### PR TITLE
[FLINK-26439] Introduce sequence.field to custom the order of the records

### DIFF
--- a/flink-table-store-common/src/main/java/org/apache/flink/table/store/utils/RowDataUtils.java
+++ b/flink-table-store-common/src/main/java/org/apache/flink/table/store/utils/RowDataUtils.java
@@ -43,6 +43,8 @@ import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimestampType;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -269,5 +271,13 @@ public class RowDataUtils {
             list.add(arrayData.isNullAt(i) ? null : arrayData.getString(i).toString());
         }
         return list;
+    }
+
+    public static long castToIntegral(DecimalData dec) {
+        BigDecimal bd = dec.toBigDecimal();
+        // rounding down. This is consistent with float=>int,
+        // and consistent with SQLServer, Spark.
+        bd = bd.setScale(0, RoundingMode.DOWN);
+        return bd.longValue();
     }
 }

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/CoreOptions.java
@@ -37,6 +37,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.TextElement.text;
@@ -228,6 +229,14 @@ public class CoreOptions implements Serializable {
                                     + "This changelog file keeps the order of data input and the details of data changes, "
                                     + "it can be read directly during stream reads.");
 
+    public static final ConfigOption<String> SEQUENCE_FIELD =
+            ConfigOptions.key("sequence.field")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The field that generates the sequence number for primary key table,"
+                                    + " the sequence number determines which data is the most recent.");
+
     public static final ConfigOption<LogStartupMode> LOG_SCAN =
             ConfigOptions.key("log.scan")
                     .enumType(LogStartupMode.class)
@@ -412,6 +421,10 @@ public class CoreOptions implements Serializable {
 
     public boolean enableChangelogFile() {
         return options.get(CHANGELOG_FILE);
+    }
+
+    public Optional<String> sequenceField() {
+        return options.getOptional(SEQUENCE_FIELD);
     }
 
     /** Specifies the merge engine for table with primary key. */

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValue.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/KeyValue.java
@@ -37,6 +37,8 @@ import java.util.stream.IntStream;
  */
 public class KeyValue {
 
+    public static final long UNKNOWN_SEQUENCE = -1;
+
     private RowData key;
     private long sequenceNumber;
     private RowKind valueKind;
@@ -48,7 +50,7 @@ public class KeyValue {
     }
 
     public KeyValue replace(RowData key, RowKind valueKind, RowData value) {
-        return replace(key, -1, valueKind, value);
+        return replace(key, UNKNOWN_SEQUENCE, valueKind, value);
     }
 
     public KeyValue replace(RowData key, long sequenceNumber, RowKind valueKind, RowData value) {

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/file/mergetree/MergeTreeWriter.java
@@ -119,7 +119,10 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
 
     @Override
     public void write(KeyValue kv) throws Exception {
-        long sequenceNumber = newSequenceNumber();
+        long sequenceNumber =
+                kv.sequenceNumber() == KeyValue.UNKNOWN_SEQUENCE
+                        ? newSequenceNumber()
+                        : kv.sequenceNumber();
         boolean success = memTable.put(sequenceNumber, kv.valueKind(), kv.key(), kv.value());
         if (!success) {
             flushMemory();

--- a/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/SequenceGenerator.java
+++ b/flink-table-store-core/src/main/java/org/apache/flink/table/store/table/sink/SequenceGenerator.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.store.table.sink;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.store.utils.RowDataUtils;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeDefaultVisitor;
+
+/** Generate sequence number. */
+public class SequenceGenerator {
+
+    private final int index;
+
+    private final Generator generator;
+
+    public SequenceGenerator(String field, RowType rowType) {
+        index = rowType.getFieldNames().indexOf(field);
+        if (index == -1) {
+            throw new RuntimeException(
+                    String.format(
+                            "Can not find sequence field %s in table schema: %s", field, rowType));
+        }
+        generator = rowType.getTypeAt(index).accept(new SequenceGeneratorVisitor());
+    }
+
+    public long generate(RowData row) {
+        return generator.generate(row, index);
+    }
+
+    private interface Generator {
+        long generate(RowData row, int i);
+    }
+
+    private static class SequenceGeneratorVisitor extends LogicalTypeDefaultVisitor<Generator> {
+
+        @Override
+        public Generator visit(CharType charType) {
+            return stringGenerator();
+        }
+
+        @Override
+        public Generator visit(VarCharType varCharType) {
+            return stringGenerator();
+        }
+
+        private Generator stringGenerator() {
+            return (row, i) -> Long.parseLong(row.getString(i).toString());
+        }
+
+        @Override
+        public Generator visit(DecimalType decimalType) {
+            return (row, i) ->
+                    RowDataUtils.castToIntegral(
+                            row.getDecimal(i, decimalType.getPrecision(), decimalType.getScale()));
+        }
+
+        @Override
+        public Generator visit(TinyIntType tinyIntType) {
+            return RowData::getByte;
+        }
+
+        @Override
+        public Generator visit(SmallIntType smallIntType) {
+            return RowData::getShort;
+        }
+
+        @Override
+        public Generator visit(IntType intType) {
+            return RowData::getInt;
+        }
+
+        @Override
+        public Generator visit(BigIntType bigIntType) {
+            return RowData::getLong;
+        }
+
+        @Override
+        public Generator visit(FloatType floatType) {
+            return (row, i) -> (long) row.getFloat(i);
+        }
+
+        @Override
+        public Generator visit(DoubleType doubleType) {
+            return (row, i) -> (long) row.getDouble(i);
+        }
+
+        @Override
+        public Generator visit(DateType dateType) {
+            return RowData::getInt;
+        }
+
+        @Override
+        public Generator visit(TimestampType timestampType) {
+            return (row, i) -> row.getTimestamp(i, timestampType.getPrecision()).getMillisecond();
+        }
+
+        @Override
+        public Generator visit(LocalZonedTimestampType localZonedTimestampType) {
+            return (row, i) ->
+                    row.getTimestamp(i, localZonedTimestampType.getPrecision()).getMillisecond();
+        }
+
+        @Override
+        protected Generator defaultMethod(LogicalType logicalType) {
+            throw new UnsupportedOperationException("Unsupported type: " + logicalType);
+        }
+    }
+}


### PR DESCRIPTION
In general, the order of the record can be generated directly by the store itself.
But for some cases, its order may be broken, and then a field can be specified to control the sequence number information. (For example, which one should be returned when querying multiple records of data under one primary key)