### PR TITLE
[hive] Exclude org.pentaho and org.glassfish:javax.el dependencies from Hive modules

### DIFF
--- a/paimon-hive/paimon-hive-connector-2.3/pom.xml
+++ b/paimon-hive/paimon-hive-connector-2.3/pom.xml
@@ -143,6 +143,10 @@ under the License.
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.pentaho</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -353,6 +357,10 @@ under the License.
                     <groupId>org.jamon</groupId>
                     <artifactId>jamon-runtime</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.pentaho</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -414,6 +422,10 @@ under the License.
                     <groupId>org.jamon</groupId>
                     <artifactId>jamon-runtime</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.pentaho</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -445,7 +457,7 @@ under the License.
                 </exclusion>
                 <exclusion>
                     <groupId>org.pentaho</groupId>
-                    <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -500,7 +512,6 @@ under the License.
                     <groupId>org.apache.orc</groupId>
                     <artifactId>orc-core</artifactId>
                 </exclusion>
-                <!-- this dependency cannot be fetched from central maven repository anymore -->
                 <exclusion>
                     <groupId>org.pentaho</groupId>
                     <artifactId>*</artifactId>

--- a/paimon-hive/paimon-hive-connector-3.1/pom.xml
+++ b/paimon-hive/paimon-hive-connector-3.1/pom.xml
@@ -157,6 +157,10 @@ under the License.
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.pentaho</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -367,6 +371,14 @@ under the License.
                     <groupId>org.jamon</groupId>
                     <artifactId>jamon-runtime</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.pentaho</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>javax.el</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -428,6 +440,10 @@ under the License.
                     <groupId>org.jamon</groupId>
                     <artifactId>jamon-runtime</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.pentaho</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -459,7 +475,7 @@ under the License.
                 </exclusion>
                 <exclusion>
                     <groupId>org.pentaho</groupId>
-                    <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -514,7 +530,6 @@ under the License.
                     <groupId>org.apache.orc</groupId>
                     <artifactId>orc-core</artifactId>
                 </exclusion>
-                <!-- this dependency cannot be fetched from central maven repository anymore -->
                 <exclusion>
                     <groupId>org.pentaho</groupId>
                     <artifactId>*</artifactId>

--- a/paimon-hive/paimon-hive-connector-common/pom.xml
+++ b/paimon-hive/paimon-hive-connector-common/pom.xml
@@ -60,6 +60,10 @@ under the License.
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.pentaho</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -346,6 +350,10 @@ under the License.
                     <groupId>org.jamon</groupId>
                     <artifactId>jamon-runtime</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.pentaho</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -407,6 +415,10 @@ under the License.
                     <groupId>org.jamon</groupId>
                     <artifactId>jamon-runtime</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.pentaho</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -438,7 +450,7 @@ under the License.
                 </exclusion>
                 <exclusion>
                     <groupId>org.pentaho</groupId>
-                    <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -493,7 +505,6 @@ under the License.
                     <groupId>org.apache.orc</groupId>
                     <artifactId>orc-core</artifactId>
                 </exclusion>
-                <!-- this dependency cannot be fetched from central maven repository anymore -->
                 <exclusion>
                     <groupId>org.pentaho</groupId>
                     <artifactId>*</artifactId>


### PR DESCRIPTION
### Purpose

These dependencies are failing [website builds](https://github.com/apache/incubator-paimon-website/actions/runs/4562497707/jobs/8049792393). Some users also cannot download these dependencies.

### Tests

N/A

### API and Format 

N/A

### Documentation

N/A
