### PR TITLE
[flink] support sync multiple mysql database to paimon

### DIFF
--- a/docs/content/how-to/cdc-ingestion.md
+++ b/docs/content/how-to/cdc-ingestion.md
@@ -101,7 +101,7 @@ the regular expressions.
 
 ### Synchronizing Databases
 
-By using [MySqlSyncDatabaseAction](/docs/{{< param Branch >}}/api/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction) in a Flink DataStream job or directly through `flink run`, users can synchronize the whole MySQL database into one Paimon database.
+By using [MySqlSyncDatabaseAction](/docs/{{< param Branch >}}/api/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction) in a Flink DataStream job or directly through `flink run`, users can synchronize one or multiple MySQL database into one or multiple Paimon database, if `sync-to-multiple-db` is false, all the MySQL database will be synchronize to one paimon database, and the table with same name in different database will be merged. if `sync-to-multiple-db` is true, all the MySQL database will be synchronize to multiple paimon database with the same schema as MySQL.  
 
 To use this feature through `flink run`, run the following shell command.
 
@@ -111,6 +111,7 @@ To use this feature through `flink run`, run the following shell command.
     mysql-sync-database
     --warehouse <warehouse-path> \
     --database <database-name> \
+    [--sync-to-multiple-db <true/false>] \
     [--ignore-incompatible <true/false>] \
     [--table-prefix <paimon-table-prefix>] \
     [--table-suffix <paimon-table-suffix>] \
@@ -130,6 +131,10 @@ For each MySQL table to be synchronized, if the corresponding Paimon table does 
 
 Example 1: synchronize entire database
 
+You can synchronize one or multiple mysql database to paimon, if you want to synchronize one mysql database,
+you can set the `database-name` parameter to a specific database name, if you want to synchronize multiple mysql database,
+you can set the `database-name` parameter to a regular expression.
+ 
 ```bash
 <FLINK_HOME>/bin/flink run \
     /path/to/paimon-flink-action-{{< version >}}.jar \

--- a/docs/layouts/shortcodes/generated/mysql_sync_database.html
+++ b/docs/layouts/shortcodes/generated/mysql_sync_database.html
@@ -34,6 +34,10 @@ under the License.
         <td>The database name in Paimon catalog.</td>
     </tr>
     <tr>
+        <td><h5>--sync-to-multiple-db</h5></td>
+supp        <td>It is default false, in this case, all the MySQL database will be synchronized to one paimon database, and the table with same name in different database will be merged, it is suitable for database sharding scenarios. if it is true, the parameter "--database" will be ignored, all the MySQL database will be synchronize to multiple paimon database with the same schema as MySQL, it is suitable for scenarios with a large number of databases under a database instance, which can save resources.</td>
+    </tr>
+    <tr>
         <td><h5>--ignore-incompatible</h5></td>
         <td>It is default false, in this case, if MySQL table name exists in Paimon and their schema is incompatible,an exception will be thrown. You can specify it to true explicitly to ignore the incompatible tables and exception.</td>
     </tr>
@@ -47,7 +51,7 @@ under the License.
     </tr>
     <tr>
         <td><h5>--including-tables</h5></td>
-        <td>It is used to specify which source tables are to be synchronized. You must use '|' to separate multiple tables.Because '|' is a special character, a comma is required, for example: 'a|b|c'.Regular expression is supported, for example, specifying "--including-tables test|paimon.*" means to synchronize table 'test' and all tables start with 'paimon'.</td>
+        <td>It is used to specify which source tables are to be synchronized. You must use '|' to separate multiple tables.Because '|' is a special character, a comma is required, for example: 'db1.a|db2.b|db2.c'.Regular expression is supported, for example, specifying "--including-tables db1.test|db2.paimon.*" means to synchronize table 'db1.test' and all tables start with 'db2.paimon'.</td>
     </tr>
     <tr>
         <td><h5>--excluding-tables</h5></td>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionUtils.java
@@ -211,7 +211,7 @@ public class MySqlActionUtils {
                 .username(mySqlConfig.get(MySqlSourceOptions.USERNAME))
                 .password(mySqlConfig.get(MySqlSourceOptions.PASSWORD))
                 .databaseList(databaseName)
-                .tableList(databaseName + "." + tableName);
+                .tableList(tableName);
 
         mySqlConfig.getOptional(MySqlSourceOptions.SERVER_ID).ifPresent(sourceBuilder::serverId);
         mySqlConfig

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionFactory.java
@@ -49,6 +49,7 @@ public class MySqlSyncDatabaseActionFactory implements ActionFactory {
         String warehouse = params.get("warehouse");
         String database = params.get("database");
         boolean ignoreIncompatible = Boolean.parseBoolean(params.get("ignore-incompatible"));
+        boolean syncToMultipleDB = Boolean.parseBoolean(params.get("sync-to-multiple-db"));
         String tablePrefix = params.get("table-prefix");
         String tableSuffix = params.get("table-suffix");
         String includingTables = params.get("including-tables");
@@ -79,6 +80,7 @@ public class MySqlSyncDatabaseActionFactory implements ActionFactory {
                         mySqlConfig,
                         warehouse,
                         database,
+                        syncToMultipleDB,
                         ignoreIncompatible,
                         tablePrefix,
                         tableSuffix,
@@ -94,7 +96,7 @@ public class MySqlSyncDatabaseActionFactory implements ActionFactory {
         System.out.println(
                 "Action \"mysql-sync-database\" creates a streaming job "
                         + "with a Flink MySQL CDC source and multiple Paimon table sinks "
-                        + "to synchronize a whole MySQL database into one Paimon database.\n"
+                        + "to synchronize one or multiple MySQL database into one or multiple Paimon database.\n"
                         + "Only MySQL tables with primary keys will be considered. "
                         + "Newly created MySQL tables after the job starts will not be included.");
         System.out.println();
@@ -102,6 +104,7 @@ public class MySqlSyncDatabaseActionFactory implements ActionFactory {
         System.out.println("Syntax:");
         System.out.println(
                 "  mysql-sync-database --warehouse <warehouse-path> --database <database-name> "
+                        + "[--sync-to-multiple-db <true/false>] "
                         + "[--ignore-incompatible <true/false>] "
                         + "[--table-prefix <paimon-table-prefix>] "
                         + "[--table-suffix <paimon-table-suffix>] "
@@ -111,6 +114,13 @@ public class MySqlSyncDatabaseActionFactory implements ActionFactory {
                         + "[--mysql-conf <mysql-cdc-source-conf> [--mysql-conf <mysql-cdc-source-conf> ...]] "
                         + "[--catalog-conf <paimon-catalog-conf> [--catalog-conf <paimon-catalog-conf> ...]] "
                         + "[--table-conf <paimon-table-sink-conf> [--table-conf <paimon-table-sink-conf> ...]]");
+        System.out.println();
+
+        System.out.println(
+                "--sync-to-multiple-db is default false, in this case, all the MySQL database will be synchronized to one paimon database, "
+                        + "and the table with same name in different database will be merged, it is suitable for database sharding scenarios. "
+                        + "if it is true, the parameter \"--database\" will be ignored, all the MySQL database will be synchronize to multiple "
+                        + "paimon database with the same schema as MySQL, it is suitable for scenarios with a large number of databases under a database instance, which can save resources.");
         System.out.println();
 
         System.out.println(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/EventParser.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/cdc/EventParser.java
@@ -42,6 +42,10 @@ public interface EventParser<T> {
         throw new UnsupportedOperationException("Table name is not supported in this parser.");
     }
 
+    default String parseDatabaseName() {
+        throw new UnsupportedOperationException("Database name is not supported in this parser.");
+    }
+
     /**
      * Parse new schema if this event contains schema change.
      *

--- a/paimon-flink/paimon-flink-common/src/test/resources/mysql/sync_database_setup.sql
+++ b/paimon-flink/paimon-flink-common/src/test/resources/mysql/sync_database_setup.sql
@@ -346,3 +346,45 @@ CREATE TABLE a (
     v VARCHAR(10),
     PRIMARY KEY (k)
 );
+
+
+-- ################################################################################
+--  MySqlSyncDatabaseActionITCase#testEnableSyncToMultipleDB
+--  MySqlSyncDatabaseActionITCase#testDisableSyncToMultipleDB
+-- ################################################################################
+
+CREATE DATABASE paimon_sync_database_multiple1;
+USE paimon_sync_database_multiple1;
+
+CREATE TABLE t1 (
+    k1 INT,
+    v1 VARCHAR(10),
+    PRIMARY KEY (k1)
+);
+
+CREATE TABLE t2 (
+    k2 INT,
+    v2 VARCHAR(10),
+    PRIMARY KEY (k2)
+);
+
+INSERT INTO t1 VALUES(1, 'flink');
+INSERT INTO t2 VALUES(2, 'paimon');
+
+CREATE DATABASE paimon_sync_database_multiple2;
+USE paimon_sync_database_multiple2;
+
+CREATE TABLE t1 (
+    k1 INT,
+    v1 VARCHAR(10),
+    PRIMARY KEY (k1)
+);
+
+CREATE TABLE t3 (
+    k3 INT,
+    v3 VARCHAR(10),
+    PRIMARY KEY (k3)
+);
+
+INSERT INTO t1 VALUES(3, 'three');
+INSERT INTO t3 VALUES(4, 'four');


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1238


Users can synchronize one or multiple MySQL database into one or multiple Paimon database,  It is default false, in this case, all the MySQL database will be synchronized to one paimon database, and the table with same name in different database will be merged, it is suitable for database sharding scenarios. if it is true, the parameter "--database" will be ignored, all the MySQL database will be synchronize to multiple paimon database with the same schema as MySQL before, it is suitable for scenarios with a large number of databases under a database instance, which can save resources.


for new added table in the sync database runtime , I need to get the `databaseName` and `tableName` ,otherwise the test case will be failed,  but the `druid` framework can not get the  `databaseName`, so I merge PR https://github.com/apache/incubator-paimon/pull/1621 to this PR, so we should review PR https://github.com/apache/incubator-paimon/pull/1621  first , when it is merged to master , I will rebase from the master .

### Tests

org.apache.paimon.flink.action.cdc.mysql.MySqlSyncDatabaseActionITCase

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
