### PR TITLE
[flink] do not throw exception when create table error in the db sync

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
@@ -215,9 +215,18 @@ public class MySqlSyncDatabaseAction extends ActionBase {
                     unmonitor(mySqlSchema);
                 }
             } catch (Catalog.TableNotExistException e) {
-                catalog.createTable(identifier, fromMySql, false);
-                table = (FileStoreTable) catalog.getTable(identifier);
-                fileStoreTables.add(table);
+                try {
+                    // TODO : add hive test case.
+                    catalog.createTable(identifier, fromMySql, false);
+                    table = (FileStoreTable) catalog.getTable(identifier);
+                    fileStoreTables.add(table);
+                } catch (Exception ex) {
+                    LOG.error(
+                            String.format(
+                                    "create table %s error in the database synchronize.",
+                                    identifier.getFullName()),
+                            ex);
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close (https://github.com/apache/incubator-paimon/issues/1764)

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
