### PR TITLE
[improve] extract field in value that already contains in key

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -485,6 +485,12 @@ This config option does not affect the default filesystem metastore.</td>
             <td>Target size of a source split when scanning a bucket.</td>
         </tr>
         <tr>
+            <td><h5>storage.thin.mode</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Enable storage thin mode to avoid duplicate columns store.</td>
+        </tr>
+        <tr>
             <td><h5>streaming-read-mode</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td><p>Enum</p></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -833,6 +833,12 @@ public class CoreOptions implements Serializable {
                                     + " the value should be the user configured local time zone. The option value is either a full name"
                                     + " such as 'America/Los_Angeles', or a custom timezone id such as 'GMT-08:00'.");
 
+    public static final ConfigOption<Boolean> STORAGE_THIN_MODE =
+            key("storage.thin.mode")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Enable storage thin mode to avoid duplicate columns store.");
+
     private final Options options;
 
     public CoreOptions(Map<String, String> options) {
@@ -1205,6 +1211,10 @@ public class CoreOptions implements Serializable {
 
     public String sinkWatermarkTimeZone() {
         return options.get(SINK_WATERMARK_TIME_ZONE);
+    }
+
+    public boolean thinMode() {
+        return options.get(STORAGE_THIN_MODE);
     }
 
     public Map<String, String> getFieldDefaultValues() {

--- a/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
@@ -25,6 +25,7 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.statistics.FieldStatsCollector;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.ArrayUtils;
 
 import javax.annotation.Nullable;
 
@@ -60,7 +61,12 @@ public abstract class FileFormat {
             RowType type, int[][] projection, @Nullable List<Predicate> filters);
 
     /** Create a {@link FormatWriterFactory} from the type. */
-    public abstract FormatWriterFactory createWriterFactory(RowType type);
+    public abstract FormatWriterFactory createWriterFactory(RowType type, int[] projection);
+
+    public FormatWriterFactory createWriterFactory(RowType rowType) {
+        return createWriterFactory(
+                rowType, ArrayUtils.selfIncrementIntArray(rowType.getFieldCount()));
+    }
 
     /** Validate data field type supported or not. */
     public abstract void validateDataFields(RowType rowType);

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ArrayUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ArrayUtils.java
@@ -354,4 +354,18 @@ public class ArrayUtils {
         }
         return result;
     }
+
+    /**
+     * This method returns a self-incremental int array.
+     *
+     * @param length the array length
+     * @return the self-incremental int array
+     */
+    public static int[] selfIncrementIntArray(int length) {
+        int[] array = new int[length];
+        for (int i = 0; i < length; i++) {
+            array[i] = i;
+        }
+        return array;
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileWriter.java
@@ -89,7 +89,8 @@ public class KeyValueDataFileWriter
                 tableStatsExtractor,
                 compression,
                 StatsCollectorFactories.createStatsFactories(
-                        options, KeyValue.schema(keyType, valueType).getFieldNames()));
+                        options, KeyValue.schema(keyType, valueType).getFieldNames()),
+                options.thinMode());
 
         this.keyType = keyType;
         this.valueType = valueType;

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileWriterFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileWriterFactory.java
@@ -165,7 +165,7 @@ public class KeyValueFileWriterFactory {
         public KeyValueFileWriterFactory build(
                 BinaryRow partition, int bucket, CoreOptions options) {
             RowType fileRowType = KeyValue.schema(keyType, valueType);
-            RowType storageRowType = RowTypeUtils.toStorageRowType(fileRowType);
+            RowType storageRowType = RowTypeUtils.toStorageRowType(fileRowType, options.thinMode());
             WriteFormatContext context =
                     new WriteFormatContext(
                             partition,

--- a/paimon-core/src/main/java/org/apache/paimon/io/RowDataFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/RowDataFileWriter.java
@@ -63,7 +63,8 @@ public class RowDataFileWriter extends StatsCollectingSingleFileWriter<InternalR
                 writeSchema,
                 tableStatsExtractor,
                 fileCompression,
-                statsCollectors);
+                statsCollectors,
+                false);
         this.schemaId = schemaId;
         this.seqNumCounter = seqNumCounter;
         this.statsArraySerializer = new FieldStatsArraySerializer(writeSchema);

--- a/paimon-core/src/main/java/org/apache/paimon/io/StatsCollectingSingleFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/StatsCollectingSingleFileWriter.java
@@ -56,13 +56,14 @@ public abstract class StatsCollectingSingleFileWriter<T, R> extends SingleFileWr
             RowType writeSchema,
             @Nullable TableStatsExtractor tableStatsExtractor,
             String compression,
-            FieldStatsCollector.Factory[] statsCollectors) {
+            FieldStatsCollector.Factory[] statsCollectors,
+            boolean thinMode) {
         super(fileIO, factory, path, converter, compression);
         this.tableStatsExtractor = tableStatsExtractor;
         if (this.tableStatsExtractor == null) {
             this.tableStatsCollector = new TableStatsCollector(writeSchema, statsCollectors);
         }
-        RowType storageSchema = RowTypeUtils.toStorageRowType(writeSchema);
+        RowType storageSchema = RowTypeUtils.toStorageRowType(writeSchema, thinMode);
         projection = RowTypeUtils.projectionRowTypeWithKeyPrefix(storageSchema, writeSchema);
         Preconditions.checkArgument(
                 statsCollectors.length == writeSchema.getFieldCount(),

--- a/paimon-core/src/main/java/org/apache/paimon/utils/BulkFormatMapping.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/BulkFormatMapping.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.utils;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.casting.CastFieldGetter;
 import org.apache.paimon.format.FileFormatDiscover;
@@ -107,7 +108,10 @@ public class BulkFormatMapping {
             RowType keyType = new RowType(dataKeyFields);
             RowType valueType = new RowType(dataValueFields);
             RowType expectedReadRowType = KeyValue.schema(keyType, valueType);
-            RowType storageRowType = RowTypeUtils.toStorageRowType(expectedReadRowType);
+            RowType storageRowType =
+                    RowTypeUtils.toStorageRowType(
+                            expectedReadRowType,
+                            CoreOptions.fromMap(dataSchema.options()).thinMode());
 
             int[][] dataKeyProjection =
                     SchemaEvolutionUtil.createDataProjection(

--- a/paimon-core/src/main/java/org/apache/paimon/utils/RowTypeUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/RowTypeUtils.java
@@ -28,7 +28,12 @@ import static org.apache.paimon.schema.SystemColumns.KEY_FIELD_PREFIX;
 
 /** Utils to convert table schema RowType to real storage RowType. */
 public class RowTypeUtils {
-    public static RowType toStorageRowType(RowType keyWithValue) {
+
+    public static RowType toStorageRowType(RowType keyWithValue, boolean thinMode) {
+        if (!thinMode) {
+            return keyWithValue;
+        }
+
         List<String> fields = keyWithValue.getFieldNames();
 
         List<DataField> dataFields = keyWithValue.getFields();

--- a/paimon-core/src/main/java/org/apache/paimon/utils/RowTypeUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/RowTypeUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.schema.SystemColumns.KEY_FIELD_PREFIX;
+
+/** Utils to convert table schema RowType to real storage RowType. */
+public class RowTypeUtils {
+    public static RowType toStorageRowType(RowType keyWithValue) {
+        List<String> fields = keyWithValue.getFieldNames();
+
+        List<DataField> dataFields = keyWithValue.getFields();
+
+        return new RowType(
+                dataFields.stream()
+                        .filter(a -> !fields.contains(KEY_FIELD_PREFIX + a.name()))
+                        .collect(Collectors.toList()));
+    }
+
+    public static int[] projectionRowTypeWithKeyPrefix(RowType source, RowType expected) {
+        int[] projection = new int[expected.getFieldCount()];
+
+        List<String> expectedFields = expected.getFieldNames();
+        List<String> sourceFields = source.getFieldNames();
+
+        for (int i = 0; i < projection.length; i++) {
+            String exField = expectedFields.get(i);
+            int index = sourceFields.indexOf(exField);
+            if (index == -1) {
+                index = sourceFields.indexOf(KEY_FIELD_PREFIX + exField);
+            }
+
+            projection[i] = index;
+        }
+        return projection;
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/TestKeyValueGenerator.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestKeyValueGenerator.java
@@ -53,6 +53,7 @@ import java.util.stream.Collectors;
 import static org.apache.paimon.TestKeyValueGenerator.GeneratorMode.MULTI_PARTITIONED;
 import static org.apache.paimon.TestKeyValueGenerator.GeneratorMode.NON_PARTITIONED;
 import static org.apache.paimon.TestKeyValueGenerator.GeneratorMode.SINGLE_PARTITIONED;
+import static org.apache.paimon.schema.SystemColumns.KEY_FIELD_PREFIX;
 
 /** Random {@link KeyValue} generator. */
 public class TestKeyValueGenerator {
@@ -116,7 +117,7 @@ public class TestKeyValueGenerator {
     public static final RowType KEY_TYPE =
             RowType.of(
                     new DataType[] {new IntType(false), new BigIntType(false)},
-                    new String[] {"key_shopId", "key_orderId"});
+                    new String[] {KEY_FIELD_PREFIX + "shopId", KEY_FIELD_PREFIX + "orderId"});
 
     public static final InternalRowSerializer DEFAULT_ROW_SERIALIZER =
             new InternalRowSerializer(DEFAULT_ROW_TYPE);
@@ -276,7 +277,7 @@ public class TestKeyValueGenerator {
     public static List<String> getPrimaryKeys(GeneratorMode mode) {
         List<String> trimmedPk =
                 KEY_TYPE.getFieldNames().stream()
-                        .map(f -> f.replaceFirst("key_", ""))
+                        .map(f -> f.replaceFirst(KEY_FIELD_PREFIX, ""))
                         .collect(Collectors.toList());
         if (mode != NON_PARTITIONED) {
             trimmedPk = new ArrayList<>(trimmedPk);
@@ -385,7 +386,13 @@ public class TestKeyValueGenerator {
         public List<DataField> keyFields(TableSchema schema) {
             return schema.fields().stream()
                     .filter(f -> KEY_NAME_LIST.contains(f.name()))
-                    .map(f -> new DataField(f.id(), "key_" + f.name(), f.type(), f.description()))
+                    .map(
+                            f ->
+                                    new DataField(
+                                            f.id(),
+                                            KEY_FIELD_PREFIX + f.name(),
+                                            f.type(),
+                                            f.description()))
                     .collect(Collectors.toList());
         }
 

--- a/paimon-core/src/test/java/org/apache/paimon/format/FileStatsExtractingAvroFormat.java
+++ b/paimon-core/src/test/java/org/apache/paimon/format/FileStatsExtractingAvroFormat.java
@@ -46,8 +46,8 @@ public class FileStatsExtractingAvroFormat extends FileFormat {
     }
 
     @Override
-    public FormatWriterFactory createWriterFactory(RowType type) {
-        return avro.createWriterFactory(type);
+    public FormatWriterFactory createWriterFactory(RowType type, int[] projection) {
+        return avro.createWriterFactory(type, projection);
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/format/FlushingFileFormat.java
+++ b/paimon-core/src/test/java/org/apache/paimon/format/FlushingFileFormat.java
@@ -46,10 +46,10 @@ public class FlushingFileFormat extends FileFormat {
     }
 
     @Override
-    public FormatWriterFactory createWriterFactory(RowType type) {
+    public FormatWriterFactory createWriterFactory(RowType type, int[] projection) {
         return (PositionOutputStream, level) -> {
             FormatWriter wrapped =
-                    format.createWriterFactory(type)
+                    format.createWriterFactory(type, projection)
                             .create(
                                     PositionOutputStream,
                                     CoreOptions.FILE_COMPRESSION.defaultValue());

--- a/paimon-core/src/test/java/org/apache/paimon/format/ThinModeReadWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/format/ThinModeReadWriteTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format;
+
+import org.apache.paimon.data.Decimal;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.manifest.FileKind;
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.AbstractFileStoreTable;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.types.DataTypes;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+
+/** This class test the compatibility and effectiveness of storage thin mode. */
+public class ThinModeReadWriteTest extends TableTestBase {
+
+    private Table createTable(String format, Boolean thinMode) throws Exception {
+        catalog.createTable(identifier(), schema(format, thinMode), true);
+        return catalog.getTable(identifier());
+    }
+
+    private Schema schema(String format, Boolean thinMode) {
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.column("f0", DataTypes.INT());
+        schemaBuilder.column("f1", DataTypes.INT());
+        schemaBuilder.column("f2", DataTypes.SMALLINT());
+        schemaBuilder.column("f3", DataTypes.STRING());
+        schemaBuilder.column("f4", DataTypes.DOUBLE());
+        schemaBuilder.column("f5", DataTypes.CHAR(100));
+        schemaBuilder.column("f6", DataTypes.VARCHAR(100));
+        schemaBuilder.column("f7", DataTypes.BOOLEAN());
+        schemaBuilder.column("f8", DataTypes.INT());
+        schemaBuilder.column("f9", DataTypes.TIME());
+        schemaBuilder.column("f10", DataTypes.TIMESTAMP());
+        schemaBuilder.column("f11", DataTypes.DECIMAL(10, 2));
+        schemaBuilder.column("f12", DataTypes.BYTES());
+        schemaBuilder.column("f13", DataTypes.FLOAT());
+        schemaBuilder.column("f14", DataTypes.BINARY(100));
+        schemaBuilder.column("f15", DataTypes.VARBINARY(100));
+        schemaBuilder.primaryKey(
+                "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11", "f12",
+                "f13");
+        schemaBuilder.option("bucket", "1");
+        schemaBuilder.option("bucket-key", "f1");
+        schemaBuilder.option("file.format", format);
+        schemaBuilder.option("storage.thin.mode", thinMode.toString());
+        return schemaBuilder.build();
+    }
+
+    @Test
+    public void testThinModeWorks() throws Exception {
+
+        InternalRow[] datas = datas(200000);
+
+        Table table = createTable("orc", true);
+        write(table, datas);
+
+        long size1 = tableSize(table);
+        dropTableDefault();
+
+        table = createTable("orc", false);
+        write(table, datas);
+        long size2 = tableSize(table);
+        dropTableDefault();
+
+        Assertions.assertThat(size2).isGreaterThan(size1);
+    }
+
+    @Test
+    public void testAllFormatReadWrite() throws Exception {
+        testFormat("orc");
+        testFormat("parquet");
+        testFormat("avro");
+    }
+
+    private void testFormat(String format) throws Exception {
+        testReadWrite(format, true, true);
+        testReadWrite(format, true, false);
+        testReadWrite(format, false, true);
+        testReadWrite(format, false, false);
+    }
+
+    private void testReadWrite(String format, boolean writeThin, boolean readThin)
+            throws Exception {
+        Table tableWrite = createTable(format, writeThin);
+        Table tableRead = setThinMode(tableWrite, readThin);
+
+        InternalRow[] datas = datas(2000);
+
+        write(tableWrite, datas);
+
+        List<InternalRow> readed = read(tableRead);
+
+        Assertions.assertThat(readed).containsExactlyInAnyOrder(datas);
+        dropTableDefault();
+    }
+
+    private Table setThinMode(Table table, Boolean flag) {
+        return table.copy(
+                new HashMap() {
+                    {
+                        put("storage.thin.mode", flag.toString());
+                    }
+                });
+    }
+
+    InternalRow[] datas(int i) {
+        InternalRow[] arrays = new InternalRow[i];
+        for (int j = 0; j < i; j++) {
+            arrays[j] = data();
+        }
+        return arrays;
+    }
+
+    protected InternalRow data() {
+        return GenericRow.of(
+                RANDOM.nextInt(),
+                RANDOM.nextInt(),
+                (short) RANDOM.nextInt(),
+                randomString(),
+                RANDOM.nextDouble(),
+                randomString(),
+                randomString(),
+                RANDOM.nextBoolean(),
+                RANDOM.nextInt(),
+                RANDOM.nextInt(),
+                Timestamp.now(),
+                Decimal.zero(10, 2),
+                randomBytes(),
+                (float) RANDOM.nextDouble(),
+                randomBytes(),
+                randomBytes());
+    }
+
+    public static long tableSize(Table table) throws Exception {
+        long count = 0;
+        List<ManifestEntry> files =
+                ((AbstractFileStoreTable) table).store().newScan().plan().files(FileKind.ADD);
+        for (ManifestEntry file : files) {
+            count += file.file().fileSize();
+        }
+
+        return count;
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
@@ -86,6 +86,11 @@ public class KeyValueFileReadWriteTest {
     }
 
     @RepeatedTest(10)
+    public void testWriteAndReadDataFileWithStatsCollectingRollingFileOrc() throws Exception {
+        testWriteAndReadDataFileImpl("orc");
+    }
+
+    @RepeatedTest(10)
     public void testWriteAndReadDataFileWithFileExtractingRollingFile() throws Exception {
         testWriteAndReadDataFileImpl("avro-extract");
     }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreReadTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreReadTest.java
@@ -59,6 +59,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.paimon.schema.SystemColumns.KEY_FIELD_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link KeyValueFileStoreRead}. */
@@ -272,7 +273,11 @@ public class KeyValueFileStoreReadTest {
                                 ? Collections.emptyList()
                                 : Stream.concat(
                                                 keyType.getFieldNames().stream()
-                                                        .map(field -> field.replace("key_", "")),
+                                                        .map(
+                                                                field ->
+                                                                        field.replace(
+                                                                                KEY_FIELD_PREFIX,
+                                                                                "")),
                                                 partitionType.getFieldNames().stream())
                                         .collect(Collectors.toList()),
                         Collections.emptyMap(),

--- a/paimon-core/src/test/java/org/apache/paimon/table/TableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/TableTestBase.java
@@ -151,6 +151,10 @@ public abstract class TableTestBase {
         return catalog.getTable(identifier());
     }
 
+    public void dropTableDefault() throws Exception {
+        catalog.dropTable(identifier(), true);
+    }
+
     private List<CommitMessage> writeOnce(Table table, int time, int size) throws Exception {
         StreamWriteBuilder builder = table.newStreamWriteBuilder();
         builder.withCommitUser(commitUser);

--- a/paimon-format/src/main/java/org/apache/paimon/format/avro/AvroFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/avro/AvroFileFormat.java
@@ -68,8 +68,8 @@ public class AvroFileFormat extends FileFormat {
     }
 
     @Override
-    public FormatWriterFactory createWriterFactory(RowType type) {
-        return new RowAvroWriterFactory(type, formatOptions.get(AVRO_OUTPUT_CODEC));
+    public FormatWriterFactory createWriterFactory(RowType type, int[] projection) {
+        return new RowAvroWriterFactory(type, formatOptions.get(AVRO_OUTPUT_CODEC), projection);
     }
 
     @Override
@@ -85,12 +85,13 @@ public class AvroFileFormat extends FileFormat {
 
         private final AvroWriterFactory<InternalRow> factory;
 
-        private RowAvroWriterFactory(RowType rowType, String codec) {
+        private RowAvroWriterFactory(RowType rowType, String codec, int[] projection) {
             this.factory =
                     new AvroWriterFactory<>(
                             out -> {
                                 Schema schema = AvroSchemaConverter.convertToSchema(rowType);
-                                AvroRowDatumWriter datumWriter = new AvroRowDatumWriter(rowType);
+                                AvroRowDatumWriter datumWriter =
+                                        new AvroRowDatumWriter(rowType, projection);
                                 DataFileWriter<InternalRow> dataFileWriter =
                                         new DataFileWriter<>(datumWriter);
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/avro/AvroRowDatumWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/avro/AvroRowDatumWriter.java
@@ -32,12 +32,14 @@ import java.io.IOException;
 public class AvroRowDatumWriter implements DatumWriter<InternalRow> {
 
     private final RowType rowType;
+    private final int[] projection;
 
     private RowWriter writer;
     private boolean isUnion;
 
-    public AvroRowDatumWriter(RowType rowType) {
+    public AvroRowDatumWriter(RowType rowType, int[] projection) {
         this.rowType = rowType;
+        this.projection = projection;
     }
 
     @Override
@@ -47,7 +49,9 @@ public class AvroRowDatumWriter implements DatumWriter<InternalRow> {
             this.isUnion = true;
             schema = schema.getTypes().get(1);
         }
-        this.writer = new FieldWriterFactory().createRowWriter(schema, rowType.getFieldTypes());
+        this.writer =
+                new FieldWriterFactory()
+                        .createRowWriter(schema, rowType.getFieldTypes(), projection);
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormat.java
@@ -131,13 +131,13 @@ public class OrcFileFormat extends FileFormat {
      * @return The factory of the writer
      */
     @Override
-    public FormatWriterFactory createWriterFactory(RowType type) {
+    public FormatWriterFactory createWriterFactory(RowType type, int[] projection) {
         DataType refinedType = refineDataType(type);
         DataType[] orcTypes = getFieldTypes(refinedType).toArray(new DataType[0]);
 
         TypeDescription typeDescription = OrcSplitReaderUtil.toOrcType(refinedType);
         Vectorizer<InternalRow> vectorizer =
-                new RowDataVectorizer(typeDescription.toString(), orcTypes);
+                new RowDataVectorizer(typeDescription.toString(), orcTypes, projection);
 
         return new OrcWriterFactory(vectorizer, orcProperties, writerConf);
     }

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcReaderFactory.java
@@ -122,8 +122,9 @@ public class OrcReaderFactory implements FormatReaderFactory {
         // create and initialize the row batch
         ColumnVector[] vectors = new ColumnVector[selectedFields.length];
         for (int i = 0; i < vectors.length; i++) {
-            String name = tableFieldNames.get(selectedFields[i]);
-            DataType type = tableFieldTypes.get(selectedFields[i]);
+            int dataIndex = selectedFields[i];
+            String name = tableFieldNames.get(dataIndex);
+            DataType type = tableFieldTypes.get(dataIndex);
             vectors[i] = createPaimonVector(orcBatch.cols[tableFieldNames.indexOf(name)], type);
         }
         return new OrcReaderBatch(orcBatch, new VectorizedColumnBatch(vectors), recycler);

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcWriterFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcWriterFactory.java
@@ -55,6 +55,7 @@ public class OrcWriterFactory implements FormatWriterFactory {
 
     private OrcFile.WriterOptions writerOptions;
     private final CoreOptions coreOptions;
+    private int[] projection;
 
     /**
      * Creates a new OrcBulkWriterFactory using the provided Vectorizer implementation.
@@ -97,6 +98,7 @@ public class OrcWriterFactory implements FormatWriterFactory {
             confMap.put(entry.getKey(), entry.getValue());
         }
         coreOptions = new CoreOptions(this.confMap);
+        this.projection = projection;
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/writer/RowDataVectorizer.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/writer/RowDataVectorizer.java
@@ -29,6 +29,7 @@ import org.apache.paimon.types.LocalZonedTimestampType;
 import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.TimestampType;
+import org.apache.paimon.utils.ArrayUtils;
 
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
@@ -48,17 +49,23 @@ import java.sql.Timestamp;
 public class RowDataVectorizer extends Vectorizer<InternalRow> {
 
     private final DataType[] fieldTypes;
+    private final int[] projection;
 
     public RowDataVectorizer(String schema, DataType[] fieldTypes) {
+        this(schema, fieldTypes, ArrayUtils.selfIncrementIntArray(fieldTypes.length));
+    }
+
+    public RowDataVectorizer(String schema, DataType[] fieldTypes, int[] projection) {
         super(schema);
         this.fieldTypes = fieldTypes;
+        this.projection = projection;
     }
 
     @Override
     public void vectorize(InternalRow row, VectorizedRowBatch batch) {
         int rowId = batch.size++;
-        for (int i = 0; i < row.getFieldCount(); ++i) {
-            setColumn(rowId, batch.cols[i], fieldTypes[i], row, i);
+        for (int i = 0; i < fieldTypes.length; ++i) {
+            setColumn(rowId, batch.cols[i], fieldTypes[i], row, projection[i]);
         }
     }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
@@ -61,10 +61,10 @@ public class ParquetFileFormat extends FileFormat {
     }
 
     @Override
-    public FormatWriterFactory createWriterFactory(RowType type) {
+    public FormatWriterFactory createWriterFactory(RowType type, int[] projection) {
         return new ParquetWriterFactory(
                 new RowDataParquetBuilder(
-                        type, getParquetConfiguration(formatContext.formatOptions())));
+                        type, getParquetConfiguration(formatContext.formatOptions()), projection));
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/ParquetRowDataBuilder.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/ParquetRowDataBuilder.java
@@ -37,10 +37,12 @@ public class ParquetRowDataBuilder
         extends ParquetWriter.Builder<InternalRow, ParquetRowDataBuilder> {
 
     private final RowType rowType;
+    private final int[] projection;
 
-    public ParquetRowDataBuilder(OutputFile path, RowType rowType) {
+    public ParquetRowDataBuilder(OutputFile path, RowType rowType, int[] projection) {
         super(path);
         this.rowType = rowType;
+        this.projection = projection;
     }
 
     @Override
@@ -66,7 +68,7 @@ public class ParquetRowDataBuilder
 
         @Override
         public void prepareForWrite(RecordConsumer recordConsumer) {
-            this.writer = new ParquetRowDataWriter(recordConsumer, rowType, schema);
+            this.writer = new ParquetRowDataWriter(recordConsumer, rowType, schema, projection);
         }
 
         @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/RowDataParquetBuilder.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/RowDataParquetBuilder.java
@@ -21,6 +21,7 @@ package org.apache.paimon.format.parquet.writer;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.ArrayUtils;
 
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.hadoop.ParquetOutputFormat;
@@ -37,17 +38,23 @@ public class RowDataParquetBuilder implements ParquetBuilder<InternalRow> {
 
     private final RowType rowType;
     private final Options conf;
+    private final int[] projection;
 
     public RowDataParquetBuilder(RowType rowType, Options conf) {
+        this(rowType, conf, ArrayUtils.selfIncrementIntArray(rowType.getFieldCount()));
+    }
+
+    public RowDataParquetBuilder(RowType rowType, Options conf, int[] projection) {
         this.rowType = rowType;
         this.conf = conf;
+        this.projection = projection;
     }
 
     @Override
     public ParquetWriter<InternalRow> createWriter(OutputFile out, String compression)
             throws IOException {
 
-        return new ParquetRowDataBuilder(out, rowType)
+        return new ParquetRowDataBuilder(out, rowType, projection)
                 .withCompressionCodec(CompressionCodecName.fromConf(getCompression(compression)))
                 .withRowGroupSize(
                         conf.getLong(


### PR DESCRIPTION
The key-value storage (in primary-key table) are redundant.
Now, the format of a row is:   _KEY_a, _KEY_b, _FIELD_SEQUENCE, _ROW_KIND, a, b, c, d, e, f, g
The column "a" and "b" have double restored. A optimization is:
<pre>
convert    _KEY_a, _KEY_b, _FIELD_SEQUENCE, _ROW_KIND, a, b, c, d, e, f, g

to         _KEY_a, _KEY_b, _FIELD_SEQUENCE, _ROW_KIND, c, d, e, f, g
</pre>

While reading, we find the `a`, `b` from key and fill them to value.

This PR is not complete, unit tests and compatibility test will need to be done.
