### PR TITLE
[flink] only sync user table in the sync action

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionUtils.java
@@ -107,7 +107,9 @@ public class MySqlActionUtils {
                     String databaseName = schemas.getString("TABLE_CAT");
                     Matcher databaseMatcher = databasePattern.matcher(databaseName);
                     if (databaseMatcher.matches()) {
-                        try (ResultSet tables = metaData.getTables(databaseName, null, "%", null)) {
+                        try (ResultSet tables =
+                                metaData.getTables(
+                                        databaseName, null, "%", new String[] {"TABLE"})) {
                             while (tables.next()) {
                                 String tableName = tables.getString("TABLE_NAME");
                                 MySqlSchema mySqlSchema =


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

add table type to avoid sync `VIEW`,`SYSTEM DATABASE` like `mysql`


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
