### PR TITLE
[Flink] Disable statistics for source if the predications are all value filters

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -171,6 +171,12 @@ under the License.
             <td>If the new snapshot has not been generated when the checkpoint starts to trigger, the enumerator will block the checkpoint and wait for the new snapshot. Set the maximum waiting time to avoid infinite waiting, if timeout, the checkpoint will fail. Note that it should be set smaller than the checkpoint timeout.</td>
         </tr>
         <tr>
+            <td><h5>source.value-filter-statistics.disable</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>If true, the source will not report statistics when there are filters but all the filters are value filtering.</td>
+        </tr>
+        <tr>
             <td><h5>unaware-bucket.compaction.parallelism</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/kafka/KafkaLogStoreFactoryTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/kafka/KafkaLogStoreFactoryTest.java
@@ -24,6 +24,7 @@ import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.log.LogStoreTableFactory;
 import org.apache.paimon.flink.sink.FlinkTableSink;
 import org.apache.paimon.flink.source.DataTableSource;
+import org.apache.paimon.flink.source.statistics.TestingDynamicTableFactoryContext;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.options.Options;
@@ -119,7 +120,12 @@ public class KafkaLogStoreFactoryTest {
 
         ObjectIdentifier identifier = ObjectIdentifier.of("c", "d", "t");
         DataTableSource source =
-                new DataTableSource(identifier, table, true, null, new KafkaLogStoreFactory());
+                new DataTableSource(
+                        identifier,
+                        table,
+                        true,
+                        TestingDynamicTableFactoryContext.builder().build(),
+                        new KafkaLogStoreFactory());
         assertThat(source.getChangelogMode()).isEqualTo(ChangelogMode.upsert());
 
         FlinkTableSink sink = new FlinkTableSink(identifier, table, null, null);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -268,6 +268,13 @@ public class FlinkConnectorOptions {
                     .withDescription(
                             "If the new snapshot has not been generated when the checkpoint starts to trigger, the enumerator will block the checkpoint and wait for the new snapshot. Set the maximum waiting time to avoid infinite waiting, if timeout, the checkpoint will fail. Note that it should be set smaller than the checkpoint timeout.");
 
+    public static final ConfigOption<Boolean> SOURCE_VALUE_FILTER_STATISTICS_DISABLE =
+            ConfigOptions.key("source.value-filter-statistics.disable")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "If true, the source will not report statistics when there are filters but all the filters are value filtering.");
+
     public static final ConfigOption<Boolean> LOOKUP_ASYNC =
             ConfigOptions.key("lookup.async")
                     .booleanType()

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ChangelogModeTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ChangelogModeTest.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.flink.sink.FlinkTableSink;
 import org.apache.paimon.flink.source.DataTableSource;
+import org.apache.paimon.flink.source.statistics.TestingDynamicTableFactoryContext;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.options.Options;
@@ -66,8 +67,13 @@ public class ChangelogModeTest {
                                 options.toMap(),
                                 ""));
         FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), path);
-
-        DataTableSource source = new DataTableSource(identifier, table, true, null, null);
+        DataTableSource source =
+                new DataTableSource(
+                        identifier,
+                        table,
+                        true,
+                        TestingDynamicTableFactoryContext.builder().build(),
+                        null);
         assertThat(source.getChangelogMode()).isEqualTo(expectSource);
 
         FlinkTableSink sink = new FlinkTableSink(identifier, table, null, null);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FlinkTableSourceTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FlinkTableSourceTest.java
@@ -20,6 +20,7 @@
 
 package org.apache.paimon.flink.source;
 
+import org.apache.paimon.flink.source.statistics.TestingDynamicTableFactoryContext;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
@@ -56,7 +57,11 @@ public class FlinkTableSourceTest extends TableTestBase {
         Table table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath, tableSchema);
         FlinkTableSource tableSource =
                 new DataTableSource(
-                        ObjectIdentifier.of("catalog1", "db1", "T"), table, false, null, null);
+                        ObjectIdentifier.of("catalog1", "db1", "T"),
+                        table,
+                        false,
+                        TestingDynamicTableFactoryContext.builder().build(),
+                        null);
 
         // col1 = 1
         List<ResolvedExpression> filters = ImmutableList.of(col1Equal1());
@@ -79,7 +84,11 @@ public class FlinkTableSourceTest extends TableTestBase {
         Table table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath, tableSchema);
         FlinkTableSource tableSource =
                 new DataTableSource(
-                        ObjectIdentifier.of("catalog1", "db1", "T"), table, false, null, null);
+                        ObjectIdentifier.of("catalog1", "db1", "T"),
+                        table,
+                        false,
+                        TestingDynamicTableFactoryContext.builder().build(),
+                        null);
 
         // col1 = 1 && p1 = 1 => [p1 = 1]
         List<ResolvedExpression> filters = ImmutableList.of(col1Equal1(), p1Equal1());

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/statistics/AppendOnlyTableStatisticsTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/statistics/AppendOnlyTableStatisticsTest.java
@@ -36,7 +36,8 @@ public class AppendOnlyTableStatisticsTest extends FileStoreTableStatisticsTestB
         conf.set(CoreOptions.BUCKET, 1);
         TableSchema tableSchema =
                 new SchemaManager(LocalFileIO.create(), tablePath)
-                        .createTable(schemaBuilder().partitionKeys("pt").build());
+                        .createTable(
+                                schemaBuilder().partitionKeys("pt").options(conf.toMap()).build());
         return FileStoreTableFactory.create(LocalFileIO.create(), tablePath, tableSchema);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/statistics/FileStoreTableStatisticsTestBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/statistics/FileStoreTableStatisticsTestBase.java
@@ -37,7 +37,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.plan.stats.TableStats;
 import org.assertj.core.api.Assertions;
-import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -148,7 +147,6 @@ public abstract class FileStoreTableStatisticsTestBase {
     }
 
     @Test
-    @Ignore
     public void testTableFilterValueDisableStatistics() throws Exception {
         FileStoreTable table = writeData();
         PredicateBuilder builder = new PredicateBuilder(table.schema().logicalRowType());

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/statistics/PrimaryKeyTableStatisticsTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/statistics/PrimaryKeyTableStatisticsTest.java
@@ -45,7 +45,7 @@ public class PrimaryKeyTableStatisticsTest extends FileStoreTableStatisticsTestB
                         identifier,
                         table,
                         false,
-                        null,
+                        TestingDynamicTableFactoryContext.builder().build(),
                         null,
                         builder.greaterThan(2, 500L),
                         null,
@@ -64,7 +64,11 @@ public class PrimaryKeyTableStatisticsTest extends FileStoreTableStatisticsTestB
         TableSchema tableSchema =
                 new SchemaManager(LocalFileIO.create(), tablePath)
                         .createTable(
-                                schemaBuilder().partitionKeys("pt").primaryKey("pt", "a").build());
+                                schemaBuilder()
+                                        .partitionKeys("pt")
+                                        .primaryKey("pt", "a")
+                                        .options(conf.toMap())
+                                        .build());
         return FileStoreTableFactory.create(LocalFileIO.create(), tablePath, tableSchema);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/statistics/TestingDynamicTableFactoryContext.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/statistics/TestingDynamicTableFactoryContext.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.statistics;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.factories.DynamicTableFactory;
+
+/** Dynamic table factory context implementation for testing. */
+public class TestingDynamicTableFactoryContext implements DynamicTableFactory.Context {
+    private final TableConfig configuration;
+
+    private TestingDynamicTableFactoryContext(Configuration configuration) {
+        this.configuration = TableConfig.getDefault();
+        this.configuration.addConfiguration(configuration);
+    }
+
+    @Override
+    public ObjectIdentifier getObjectIdentifier() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ResolvedCatalogTable getCatalogTable() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ReadableConfig getConfiguration() {
+        return configuration;
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isTemporary() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static TestingTableFactoryContextBuilder builder() {
+        return new TestingTableFactoryContextBuilder();
+    }
+
+    /** Builder for dynamic table factory context. */
+    public static class TestingTableFactoryContextBuilder {
+        private final Configuration configuration = new Configuration();
+
+        public TestingTableFactoryContextBuilder configuration(Configuration configuration) {
+            this.configuration.addAll(configuration);
+            return this;
+        }
+
+        public TestingDynamicTableFactoryContext build() {
+            return new TestingDynamicTableFactoryContext(configuration);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2185 

### Tests
DataTableSourceTest#testCheckAllValuePredication
FileStoreTableStatisticsTestBase#testTableFilterValueDisableStatistics

Below is the tpch test result:
Env: JM 64 core; TM 16 core，8 slot per tm; Paimon 0.5 x Flink 1.17
Table options: No partitions; The left is under configuration: `source.value-filter-statistics.disable = true`; The right is under configuration: `source.value-filter-statistics.disable = false`

<!DOCTYPE html>
query / lantency （ms） | source.value-filter-statistics.disable = true | source.value-filter-statistics.disable = false
-- | -- | --
1 | **7300** | 14745
2 | **13768** | 14179
3 | **9323** | 9490
4 | **5957** | 6091
5 | **13720** | 133810
6 | **3849** | 4664
7 | **25553** | 31348
8 | **22970** | 23417
9 | **26187** | 26653
10 | **10630** | 33056
11 | 9491 | **9062**
12 | **7741** | 40244
13 | **8082** | 8291
14 | **5829** | 9153
15 | **6515** | 6922
16 | 8650 | **8515**
17 | **13995** | 38186
18 | **15374** | 17667
19 | 7780 | **3305**
20 | 11588 | **11195**
21 | **14273** | 15423
22 | **7920** | 8090

As we can see, most of the queries are more efficient with `source.value-filter-statistics.disable = true` than the opposite, especially the query 5, with the help of statistics disabled, the query can be run into 2 mins and never timeout.

