### PR TITLE
[core] Optimize lookups on Manifest's FileMeta with binary search

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFileMeta.java
@@ -285,7 +285,7 @@ public class ManifestFileMeta {
                         new FieldStatsArraySerializer(partitionType);
                 int searchResult =
                         binarySearchWithFilter(
-                                base, 0, base.size() - 1, predicate, fieldStatsArraySerializer);
+                                base, j, base.size() - 1, predicate, fieldStatsArraySerializer);
                 if (searchResult != -1) {
                     result.addAll(base.subList(0, searchResult));
                 }

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFileMeta.java
@@ -233,7 +233,7 @@ public class ManifestFileMeta {
         // 1. should trigger full compaction
 
         List<ManifestFileMeta> base = new ArrayList<>();
-        int totalManifestSize = 0;
+        long totalManifestSize = 0;
         int i = 0;
         for (; i < inputs.size(); i++) {
             ManifestFileMeta file = inputs.get(i);


### PR DESCRIPTION
### Purpose

Optimize lookups on Manifest's FileMeta with binary search.

### Tests

`ManifestFileMetaTest`

### API and Format

None.

### Documentation

None.