### PR TITLE
[core] add commit.force-expire option

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -87,6 +87,12 @@ under the License.
             <td>Whether to force create snapshot on commit.</td>
         </tr>
         <tr>
+            <td><h5>commit.force-expire</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to force a expiration before commit.</td>
+        </tr>
+        <tr>
             <td><h5>compaction.max-size-amplification-percent</h5></td>
             <td style="word-wrap: break-word;">200</td>
             <td>Integer</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -378,6 +378,12 @@ public class CoreOptions implements Serializable {
                     .defaultValue(MemorySize.ofMebiBytes(128))
                     .withDescription("Target size of a file.");
 
+    public static final ConfigOption<Boolean> FORCE_EXPIRE =
+            key("commit.force-expire")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether to force a expiration before commit.");
+
     public static final ConfigOption<Integer> NUM_SORTED_RUNS_COMPACTION_TRIGGER =
             key("num-sorted-run.compaction-trigger")
                     .intType()
@@ -1351,6 +1357,10 @@ public class CoreOptions implements Serializable {
 
     public boolean commitForceCompact() {
         return options.get(COMMIT_FORCE_COMPACT);
+    }
+
+    public boolean forceExpire() {
+        return options.get(FORCE_EXPIRE);
     }
 
     public int maxSizeAmplificationPercent() {

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -320,8 +320,12 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
                 store().newCommit(commitUser, branchName),
                 createCommitCallbacks(),
                 snapshotExpire,
-                options.writeOnly() ? null : store().newPartitionExpire(commitUser),
-                options.writeOnly() ? null : store().newTagCreationManager(),
+                options.writeOnly() && !options.forceExpire()
+                        ? null
+                        : store().newPartitionExpire(commitUser),
+                options.writeOnly() && !options.forceExpire()
+                        ? null
+                        : store().newTagCreationManager(),
                 catalogEnvironment.lockFactory().create(),
                 CoreOptions.fromMap(options()).consumerExpireTime(),
                 new ConsumerManager(fileIO, path),


### PR DESCRIPTION
### Purpose

Linked issue: close #2967 

Sort compact only supports write-only mode, during which expiration operations are not performed. When users write data in write-only mode and use sort compact for sorting and merging, expired deletion cannot be executed. This PR add an option to force expiration.
