### PR TITLE
[flink] ignore expiration check interval of partition in batch mode.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
@@ -368,4 +368,10 @@ public class TableCommitImpl implements InnerTableCommit {
     public ExecutorService getExpireMainExecutor() {
         return expireMainExecutor;
     }
+
+    public void ignoreExpireCheckInterval() {
+        if (partitionExpire != null) {
+            partitionExpire.ignoreExpireCheckInterval();
+        }
+    }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
@@ -60,4 +60,7 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
         Committer<CommitT, GlobalCommitT> create(
                 String commitUser, OperatorMetricGroup metricGroup);
     }
+
+    /** Ignore the expiration check interval. */
+    void ignoreExpireCheckInterval();
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
@@ -144,6 +144,10 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
         }
 
         pollInputs();
+
+        LOG.info("Reach end input, ignore the expiration check interval of partition.");
+        committer.ignoreExpireCheckInterval();
+
         commitUpToCheckpoint(Long.MAX_VALUE);
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
@@ -151,4 +151,9 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
     private static long calcTotalFileRowCount(List<DataFileMeta> files) {
         return files.stream().mapToLong(DataFileMeta::rowCount).reduce(Long::sum).orElse(0);
     }
+
+    @Override
+    public void ignoreExpireCheckInterval() {
+        commit.ignoreExpireCheckInterval();
+    }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
@@ -59,6 +59,7 @@ public class StoreMultiCommitter
 
     // compact job needs set "write-only" of a table to false
     private final boolean isCompactJob;
+    private boolean ignoreExpireCheckInterval = false;
 
     public StoreMultiCommitter(
             Catalog.Loader catalogLoader,
@@ -211,6 +212,10 @@ public class StoreMultiCommitter
             tableCommitters.put(tableId, committer);
         }
 
+        if (ignoreExpireCheckInterval) {
+            committer.ignoreExpireCheckInterval();
+        }
+
         return committer;
     }
 
@@ -219,5 +224,10 @@ public class StoreMultiCommitter
         for (StoreCommitter committer : tableCommitters.values()) {
             committer.close();
         }
+    }
+
+    @Override
+    public void ignoreExpireCheckInterval() {
+        this.ignoreExpireCheckInterval = true;
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2969

<!-- What is the purpose of the change -->
If the execution time of a batch job is short, and it's less than the interval for partition expiration checks, the partition expiration operations will not be executed. This PR aims to ignore partition expiration check interval for batch job.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
