### PR TITLE
[cdc] Update the latest dynamic options to the table schema file when synchronizing an existing paimon table using the cdc action.

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionBase.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.flink.action.cdc;
 
-import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.AbstractCatalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.FlinkConnectorOptions;
@@ -124,6 +123,8 @@ public abstract class SyncTableActionBase extends SynchronizationActionBase {
         if (catalog.tableExists(identifier)) {
             fileStoreTable = (FileStoreTable) catalog.getTable(identifier);
             fileStoreTable = copyOptionsWithoutBucket(fileStoreTable);
+            // Update the latest options to schema
+            toOptionsChange(identifier, fileStoreTable.options());
             try {
                 Schema retrievedSchema = retrieveSchema();
                 computedColumns =
@@ -206,11 +207,6 @@ public abstract class SyncTableActionBase extends SynchronizationActionBase {
                     String.join(",", primaryKeys),
                     String.join(",", actualPrimaryKeys));
         }
-    }
-
-    @VisibleForTesting
-    public FileStoreTable fileStoreTable() {
-        return fileStoreTable;
     }
 
     /** Custom exception to indicate issues with schema retrieval. */

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
@@ -161,6 +161,8 @@ public class MySqlSyncDatabaseAction extends SyncDatabaseActionBase {
                 if (shouldMonitorTable(table.schema(), fromMySql, errMsg)) {
                     tables.add(table);
                     monitoredTables.addAll(tableInfo.identifiers());
+                    // Update the latest options to schema
+                    toOptionsChange(identifier, table.options());
                 } else {
                     excludedTables.addAll(tableInfo.identifiers());
                 }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/CdcActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/CdcActionITCaseBase.java
@@ -46,12 +46,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -150,6 +145,34 @@ public class CdcActionITCaseBase extends ActionITCaseBase {
             if (sortedExpected.equals(sortedActual)) {
                 break;
             }
+            Thread.sleep(1000);
+        }
+    }
+
+    protected void waitForOptions(Map<String, String> expected, FileStoreTable table)
+            throws Exception {
+
+        // wait for table options to become our expected options
+        Map<String, String> expectedOptions = new HashMap<>(expected);
+        expectedOptions.put("path", table.options().get("path"));
+        while (true) {
+            if (table.options().size() == expectedOptions.size()) {
+                boolean result =
+                        table.options().entrySet().stream()
+                                .allMatch(
+                                        entry -> {
+                                            Object key = entry.getKey();
+                                            Object value1 = entry.getValue();
+                                            Object value2 = expectedOptions.get(key);
+                                            return expectedOptions.containsKey(key)
+                                                    && Objects.equals(value1, value2);
+                                        });
+                if (result) {
+                    break;
+                }
+            }
+
+            table = table.copyWithLatestSchema();
             Thread.sleep(1000);
         }
     }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/CdcActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/CdcActionITCaseBase.java
@@ -46,7 +46,13 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSchemaITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaSchemaITCase.java
@@ -109,8 +109,9 @@ public class KafkaSchemaITCase extends KafkaActionITCaseBase {
         KafkaSyncTableAction action2 =
                 syncTableActionBuilder(kafkaConfig).withTableConfig(tableConfig).build();
         runActionWithDefaultEnv(action2);
-        Map<String, String> dynamicOptions = action2.fileStoreTable().options();
-        assertThat(dynamicOptions).containsAllEntriesOf(tableConfig).containsKey("path");
+
+        FileStoreTable table = getFileStoreTable(tableName);
+        waitForOptions(tableConfig, table);
     }
 
     @Test

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBSyncTableActionITCase.java
@@ -199,8 +199,9 @@ public class MongoDBSyncTableActionITCase extends MongoDBActionITCaseBase {
         MongoDBSyncTableAction action2 =
                 syncTableActionBuilder(mongodbConfig).withTableConfig(tableConfig).build();
         runActionWithDefaultEnv(action2);
-        Map<String, String> dynamicOptions = action2.fileStoreTable().options();
-        assertThat(dynamicOptions).containsAllEntriesOf(tableConfig);
+
+        FileStoreTable table = getFileStoreTable(tableName);
+        waitForOptions(tableConfig, table);
     }
 
     @Test

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
@@ -1093,8 +1093,8 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
                         .build();
         runActionWithDefaultEnv(action2);
 
-        Map<String, String> dynamicOptions = action2.fileStoreTable().options();
-        assertThat(dynamicOptions).containsAllEntriesOf(tableConfig);
+        FileStoreTable table = getFileStoreTable();
+        waitForOptions(tableConfig, table);
     }
 
     @Test
@@ -1274,6 +1274,8 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
                         .build();
 
         assertThatCode(action::build).doesNotThrowAnyException();
-        assertThat(action.fileStoreTable().options().get(BUCKET.key())).isEqualTo("1");
+
+        FileStoreTable table = getFileStoreTable();
+        waitForOptions(Collections.singletonMap(BUCKET.key(), "1"), table);
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresSyncTableActionITCase.java
@@ -722,8 +722,8 @@ public class PostgresSyncTableActionITCase extends PostgresActionITCaseBase {
                         .build();
         runActionWithDefaultEnv(action2);
 
-        Map<String, String> dynamicOptions = action2.fileStoreTable().options();
-        assertThat(dynamicOptions).containsAllEntriesOf(tableConfig);
+        FileStoreTable table = getFileStoreTable();
+        waitForOptions(tableConfig, table);
     }
 
     @Test


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
When using cdc action to synchronize the existing paimon table, the latest dynamic options are not updated to the table schema file.

You can first create a paimon table, start a cdc action and configure several new options. After the action is started, check the latest schema of the table. The latest schema of the table does not have the latest options.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
