### PR TITLE
[flink] Compact procedure supports named arguments

### DIFF
--- a/docs/content/engines/flink.md
+++ b/docs/content/engines/flink.md
@@ -324,17 +324,23 @@ SELECT * FROM T;
 
 Flink 1.18 and later versions support [Call Statements](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/sql/call/), 
 which make it easier to manipulate data and metadata of Paimon table by writing SQLs instead of submitting Flink jobs.
-All available procedures are listed below. Note that when you call a procedure, you must pass all parameters in order, 
-and if you don't want to pass some parameters, you must use `''` as placeholder. For example, if you want to compact 
-table `default.t` with parallelism 4, but you don't want to specify partitions and sort strategy, the call statement 
-should be \
+
+In 1.18, the procedure only supports passing arguments by position. You must pass all arguments in order, and if you 
+don't want to pass some arguments, you must use `''` as placeholder. For example, if you want to compact table `default.t` 
+with parallelism 4, but you don't want to specify partitions and sort strategy, the call statement should be \
 `CALL sys.compact('default.t', '', '', '', 'sink.parallelism=4')`.
+
+In higher versions, the procedure supports passing arguments by name. You can pass arguments in any order and any optional 
+argument can be omitted. For the above example, the call statement is \
+``CALL sys.compact(`table` => 'default.t', options => 'sink.parallelism=4')``. 
 
 Specify partitions: we use string to represent partition filter. "," means "AND" and ";" means "OR". For example, if you want 
 to specify two partitions date=01 and date=02, you need to write 'date=01;date=02'; If you want to specify one partition 
 with date=01 and day=01, you need to write 'date=01,day=01'.
 
-table options syntax: we use string to represent table options. The format is 'key1=value1,key2=value2...'.
+Table options syntax: we use string to represent table options. The format is 'key1=value1,key2=value2...'.
+
+All available procedures are listed below.
 
 <table class="table table-bordered">
    <thead>
@@ -349,20 +355,17 @@ table options syntax: we use string to represent table options. The format is 'k
    <tr>
       <td>compact</td>
       <td>
-         CALL [catalog.]sys.compact('identifier') <br/><br/>
-         CALL [catalog.]sys.compact('identifier', 'partitions') <br/><br/>
-         CALL [catalog.]sys.compact('identifier', 'partitions', 'order_strategy', 'order_columns', 'table_options')
       </td>
       <td>
-         TO compact a table. Arguments:
-            <li>identifier: the target table identifier. Cannot be empty.</li>
-            <li>partitions: partition filter.</li>
-            <li>order_strategy: 'order' or 'zorder' or 'hilbert' or 'none'. Left empty for 'none'.</li>
-            <li>order_columns: the columns need to be sort. Left empty if 'order_strategy' is 'none'.</li>
-            <li>table_options: additional dynamic options of the table.</li>
+         To compact a table. Arguments:
+            <li>table(required): the target table identifier.</li>
+            <li>partitions(optional): partition filter.</li>
+            <li>order_strategy(optional): 'order' or 'zorder' or 'hilbert' or 'none'.</li>
+            <li>order_by(optional): the columns need to be sort. Left empty if 'order_strategy' is 'none'.</li>
+            <li>options(optional): additional dynamic options of the table.</li>
       </td>
       <td>
-         CALL sys.compact('default.T', 'p=0', 'zorder', 'a,b', 'sink.parallelism=4')
+         CALL sys.compact(`table` => 'default.T', partitions => 'p=0', order_strategy => 'zorder', order_by => 'a,b', options => 'sink.parallelism=4')
       </td>
    </tr>
    <tr>

--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/FlinkProceduresE2eTest.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/FlinkProceduresE2eTest.java
@@ -93,9 +93,16 @@ public class FlinkProceduresE2eTest extends E2eTestBase {
                 testDataSourceDdl);
 
         // execute compact procedure
+        String callStatement;
+        if (System.getProperty("test.flink.main.version").compareTo("1.18") == 0) {
+            callStatement = "CALL sys.compact('default.ts_table', 'dt=20221205;dt=20221206');";
+        } else {
+            callStatement =
+                    "CALL sys.compact(\\`table\\` => 'default.ts_table', partitions => 'dt=20221205;dt=20221206');";
+        }
+
         runSql(
-                "SET 'execution.checkpointing.interval' = '1s';\n"
-                        + "CALL sys.compact('default.ts_table', 'dt=20221205;dt=20221206');",
+                "SET 'execution.checkpointing.interval' = '1s';\n" + callStatement,
                 catalogDdl,
                 useCatalogCmd);
 

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
@@ -22,38 +22,54 @@ import org.apache.paimon.catalog.AbstractCatalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.action.CompactAction;
 import org.apache.paimon.flink.action.SortCompactAction;
+import org.apache.paimon.utils.ParameterUtils;
+import org.apache.paimon.utils.StringUtils;
 
-import org.apache.flink.table.annotation.ArgumentHint;
-import org.apache.flink.table.annotation.DataTypeHint;
-import org.apache.flink.table.annotation.ProcedureHint;
 import org.apache.flink.table.procedure.ProcedureContext;
 
 import java.util.Collections;
 import java.util.Map;
 
-import static org.apache.paimon.utils.ParameterUtils.getPartitions;
-import static org.apache.paimon.utils.ParameterUtils.parseCommaSeparatedKeyValues;
-import static org.apache.paimon.utils.StringUtils.isBlank;
-
-/** Compact procedure. */
+/**
+ * Stay compatible with 1.18 procedure which doesn't support named argument. Usage:
+ *
+ * <pre><code>
+ *  -- NOTE: use '' as placeholder for optional arguments
+ *
+ *  -- compact a table (tableId should be 'database_name.table_name')
+ *  CALL sys.compact('tableId')
+ *
+ *  -- compact specific partitions ('pt1=A,pt2=a;pt1=B,pt2=b', ...)
+ *  CALL sys.compact('tableId', 'pt1=A,pt2=a;pt1=B,pt2=b')
+ *
+ *  -- compact a table with sorting
+ *  CALL sys.compact('tableId', 'partitions', 'ORDER/ZORDER', 'col1,col2', 'sink.parallelism=6')
+ *
+ * </code></pre>
+ */
 public class CompactProcedure extends ProcedureBase {
 
     public static final String IDENTIFIER = "compact";
 
-    @ProcedureHint(
-            argument = {
-                @ArgumentHint(name = "table", type = @DataTypeHint("STRING")),
-                @ArgumentHint(
-                        name = "partitions",
-                        type = @DataTypeHint("STRING"),
-                        isOptional = true),
-                @ArgumentHint(
-                        name = "order_strategy",
-                        type = @DataTypeHint("STRING"),
-                        isOptional = true),
-                @ArgumentHint(name = "order_by", type = @DataTypeHint("STRING"), isOptional = true),
-                @ArgumentHint(name = "options", type = @DataTypeHint("STRING"), isOptional = true)
-            })
+    public String[] call(ProcedureContext procedureContext, String tableId) throws Exception {
+        return call(procedureContext, tableId, "");
+    }
+
+    public String[] call(ProcedureContext procedureContext, String tableId, String partitions)
+            throws Exception {
+        return call(procedureContext, tableId, partitions, "", "", "");
+    }
+
+    public String[] call(
+            ProcedureContext procedureContext,
+            String tableId,
+            String partitions,
+            String orderStrategy,
+            String orderByColumns)
+            throws Exception {
+        return call(procedureContext, tableId, partitions, orderStrategy, orderByColumns, "");
+    }
+
     public String[] call(
             ProcedureContext procedureContext,
             String tableId,
@@ -65,13 +81,13 @@ public class CompactProcedure extends ProcedureBase {
         String warehouse = ((AbstractCatalog) catalog).warehouse();
         Map<String, String> catalogOptions = ((AbstractCatalog) catalog).options();
         Map<String, String> tableConf =
-                isBlank(tableOptions)
+                StringUtils.isBlank(tableOptions)
                         ? Collections.emptyMap()
-                        : parseCommaSeparatedKeyValues(tableOptions);
+                        : ParameterUtils.parseCommaSeparatedKeyValues(tableOptions);
         Identifier identifier = Identifier.fromString(tableId);
         CompactAction action;
         String jobName;
-        if (isBlank(orderStrategy) && isBlank(orderByColumns)) {
+        if (orderStrategy.isEmpty() && orderByColumns.isEmpty()) {
             action =
                     new CompactAction(
                             warehouse,
@@ -80,7 +96,7 @@ public class CompactProcedure extends ProcedureBase {
                             catalogOptions,
                             tableConf);
             jobName = "Compact Job";
-        } else if (!isBlank(orderStrategy) && !isBlank(orderByColumns)) {
+        } else if (!orderStrategy.isEmpty() && !orderByColumns.isEmpty()) {
             action =
                     new SortCompactAction(
                                     warehouse,
@@ -96,8 +112,8 @@ public class CompactProcedure extends ProcedureBase {
                     "You must specify 'order strategy' and 'order by columns' both.");
         }
 
-        if (!(isBlank(partitions))) {
-            action.withPartitions(getPartitions(partitions.split(";")));
+        if (!(StringUtils.isBlank(partitions))) {
+            action.withPartitions(ParameterUtils.getPartitions(partitions.split(";")));
         }
 
         return execute(procedureContext, action, jobName);

--- a/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/procedure/ProcedurePositionalArgumentsITCase.java
+++ b/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/procedure/ProcedurePositionalArgumentsITCase.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-/** Ensure that the legacy multiply overridden CALL with positional arguments can be invoked. */
+/** Ensure that the legacy multiply overloaded CALL with positional arguments can be invoked. */
 public class ProcedurePositionalArgumentsITCase extends CatalogITCaseBase {
 
     @Test

--- a/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/procedure/ProcedurePositionalArgumentsITCase.java
+++ b/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/procedure/ProcedurePositionalArgumentsITCase.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.procedure;
+
+import org.apache.paimon.flink.CatalogITCaseBase;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/** Ensure that the legacy multiply overridden CALL with positional arguments can be invoked. */
+public class ProcedurePositionalArgumentsITCase extends CatalogITCaseBase {
+
+    @Test
+    public void testCallCompact() {
+        sql(
+                "CREATE TABLE T ("
+                        + " k INT,"
+                        + " v INT,"
+                        + " pt INT,"
+                        + " PRIMARY KEY (k, pt) NOT ENFORCED"
+                        + ") PARTITIONED BY (pt) WITH ("
+                        + " 'write-only' = 'true',"
+                        + " 'bucket' = '1'"
+                        + ")");
+
+        assertThatCode(() -> sql("CALL sys.compact('default.T')")).doesNotThrowAnyException();
+        assertThatCode(() -> sql("CALL sys.compact('default.T', 'pt=1')"))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> sql("CALL sys.compact('default.T', 'pt=1', '', '')"))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> sql("CALL sys.compact('default.T', '', '', '', 'sink.parallelism=1')"))
+                .doesNotThrowAnyException();
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogITCaseBase.java
@@ -23,7 +23,7 @@ import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.util.AbstractTestBase;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
-import org.apache.paimon.table.Table;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.utils.BlockingIterator;
 import org.apache.paimon.utils.SnapshotManager;
 
@@ -183,10 +183,11 @@ public abstract class CatalogITCaseBase extends AbstractTestBase {
         return (CatalogTable) table;
     }
 
-    protected Table paimonTable(String tableName)
+    protected FileStoreTable paimonTable(String tableName)
             throws org.apache.paimon.catalog.Catalog.TableNotExistException {
         org.apache.paimon.catalog.Catalog catalog = flinkCatalog().catalog();
-        return catalog.getTable(Identifier.create(tEnv.getCurrentDatabase(), tableName));
+        return (FileStoreTable)
+                catalog.getTable(Identifier.create(tEnv.getCurrentDatabase(), tableName));
     }
 
     private FlinkCatalog flinkCatalog() {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactActionITCase.java
@@ -43,7 +43,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ThreadLocalRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -77,11 +76,7 @@ public class CompactActionITCase extends CompactActionITCaseBase {
 
         checkLatestSnapshot(table, 2, Snapshot.CommitKind.APPEND);
 
-        if (ThreadLocalRandom.current().nextBoolean()) {
-            runAction(false);
-        } else {
-            callProcedure(false);
-        }
+        runAction(false);
 
         checkLatestSnapshot(table, 3, Snapshot.CommitKind.COMPACT);
 
@@ -126,11 +121,7 @@ public class CompactActionITCase extends CompactActionITCaseBase {
         TableScan.Plan plan = scan.plan();
         assertThat(plan.splits()).isEmpty();
 
-        if (ThreadLocalRandom.current().nextBoolean()) {
-            runAction(true);
-        } else {
-            callProcedure(true);
-        }
+        runAction(true);
 
         // first full compaction
         validateResult(
@@ -193,11 +184,7 @@ public class CompactActionITCase extends CompactActionITCaseBase {
 
         checkLatestSnapshot(table, 2, Snapshot.CommitKind.APPEND);
 
-        if (ThreadLocalRandom.current().nextBoolean()) {
-            runAction(true);
-        } else {
-            callProcedure(true);
-        }
+        runAction(true);
 
         // first compaction, snapshot will be 3
         checkFileAndRowSize(table, 3L, 30_000L, 1, 6);
@@ -234,11 +221,7 @@ public class CompactActionITCase extends CompactActionITCaseBase {
 
         checkLatestSnapshot(table, 2, Snapshot.CommitKind.APPEND);
 
-        if (ThreadLocalRandom.current().nextBoolean()) {
-            runAction(false);
-        } else {
-            callProcedure(false);
-        }
+        runAction(false);
 
         // first compaction, snapshot will be 3.
         checkFileAndRowSize(table, 3L, 0L, 1, 6);
@@ -311,14 +294,5 @@ public class CompactActionITCase extends CompactActionITCaseBase {
         } else {
             env.execute();
         }
-    }
-
-    private void callProcedure(boolean isStreaming) {
-        callProcedure(
-                String.format(
-                        "CALL sys.compact('%s.%s', '%s')",
-                        database, tableName, "dt=20221208,hh=15;dt=20221209,hh=15"),
-                isStreaming,
-                !isStreaming);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionForDynamicBucketITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionForDynamicBucketITCase.java
@@ -169,27 +169,15 @@ public class SortCompactActionForDynamicBucketITCase extends ActionITCaseBase {
     }
 
     private void zorder(List<String> columns) throws Exception {
-        if (RANDOM.nextBoolean()) {
-            createAction("zorder", columns).run();
-        } else {
-            callProcedure("zorder", columns);
-        }
+        createAction("zorder", columns).run();
     }
 
     private void hilbert(List<String> columns) throws Exception {
-        if (RANDOM.nextBoolean()) {
-            createAction("hilbert", columns).run();
-        } else {
-            callProcedure("hilbert", columns);
-        }
+        createAction("hilbert", columns).run();
     }
 
     private void order(List<String> columns) throws Exception {
-        if (RANDOM.nextBoolean()) {
-            createAction("order", columns).run();
-        } else {
-            callProcedure("order", columns);
-        }
+        createAction("order", columns).run();
     }
 
     private SortCompactAction createAction(String orderStrategy, List<String> columns) {
@@ -206,15 +194,6 @@ public class SortCompactActionForDynamicBucketITCase extends ActionITCaseBase {
                 orderStrategy,
                 "--order_by",
                 String.join(",", columns));
-    }
-
-    private void callProcedure(String orderStrategy, List<String> orderByColumns) {
-        callProcedure(
-                String.format(
-                        "CALL sys.compact('%s.%s', '', '%s', '%s')",
-                        database, tableName, orderStrategy, String.join(",", orderByColumns)),
-                false,
-                true);
     }
 
     // schema with all the basic types.

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionForUnawareBucketITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionForUnawareBucketITCase.java
@@ -332,29 +332,17 @@ public class SortCompactActionForUnawareBucketITCase extends ActionITCaseBase {
 
     private void zorder(List<String> columns) throws Exception {
         String rangeStrategy = RANDOM.nextBoolean() ? "size" : "quantity";
-        if (RANDOM.nextBoolean()) {
-            createAction("zorder", rangeStrategy, columns).run();
-        } else {
-            callProcedure("zorder", rangeStrategy, columns);
-        }
+        createAction("zorder", rangeStrategy, columns).run();
     }
 
     private void hilbert(List<String> columns) throws Exception {
         String rangeStrategy = RANDOM.nextBoolean() ? "size" : "quantity";
-        if (RANDOM.nextBoolean()) {
-            createAction("hilbert", rangeStrategy, columns).run();
-        } else {
-            callProcedure("hilbert", rangeStrategy, columns);
-        }
+        createAction("hilbert", rangeStrategy, columns).run();
     }
 
     private void order(List<String> columns) throws Exception {
         String rangeStrategy = RANDOM.nextBoolean() ? "size" : "quantity";
-        if (RANDOM.nextBoolean()) {
-            createAction("order", rangeStrategy, columns).run();
-        } else {
-            callProcedure("order", rangeStrategy, columns);
-        }
+        createAction("order", rangeStrategy, columns).run();
     }
 
     private SortCompactAction createAction(
@@ -375,20 +363,6 @@ public class SortCompactActionForUnawareBucketITCase extends ActionITCaseBase {
                 String.join(",", columns),
                 "--table_conf sort-compaction.range-strategy=" + rangeStrategy,
                 rangeStrategy);
-    }
-
-    private void callProcedure(
-            String orderStrategy, String rangeStrategy, List<String> orderByColumns) {
-        callProcedure(
-                String.format(
-                        "CALL sys.compact('%s.%s', '', '%s', '%s','sort-compaction.range-strategy=%s')",
-                        database,
-                        tableName,
-                        orderStrategy,
-                        String.join(",", orderByColumns),
-                        rangeStrategy),
-                false,
-                true);
     }
 
     private void createTable() throws Exception {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CompactProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CompactProcedureITCase.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.procedure;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.flink.CatalogITCaseBase;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.StreamTableScan;
+import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.utils.BlockingIterator;
+import org.apache.paimon.utils.SnapshotManager;
+import org.apache.paimon.utils.StringUtils;
+
+import org.apache.flink.table.api.config.TableConfigOptions;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** IT Case for {@link CompactProcedure}. */
+public class CompactProcedureITCase extends CatalogITCaseBase {
+
+    // ----------------------- Non-sort Compact -----------------------
+    @Test
+    public void testBatchCompact() throws Exception {
+        sql(
+                "CREATE TABLE T ("
+                        + " k INT,"
+                        + " v INT,"
+                        + " hh INT,"
+                        + " dt STRING,"
+                        + " PRIMARY KEY (k, dt, hh) NOT ENFORCED"
+                        + ") PARTITIONED BY (dt, hh) WITH ("
+                        + " 'write-only' = 'true',"
+                        + " 'bucket' = '1'"
+                        + ")");
+        FileStoreTable table = paimonTable("T");
+
+        sql(
+                "INSERT INTO T VALUES (1, 100, 15, '20221208'), (1, 100, 16, '20221208'), (1, 100, 15, '20221209')");
+        sql(
+                "INSERT INTO T VALUES (2, 100, 15, '20221208'), (2, 100, 16, '20221208'), (2, 100, 15, '20221209')");
+
+        checkLatestSnapshot(table, 2, Snapshot.CommitKind.APPEND);
+
+        tEnv.getConfig().set(TableConfigOptions.TABLE_DML_SYNC, true);
+        sql(
+                "CALL sys.compact(`table` => 'default.T', partitions => 'dt=20221208,hh=15;dt=20221209,hh=15')");
+
+        checkLatestSnapshot(table, 3, Snapshot.CommitKind.COMPACT);
+
+        List<DataSplit> splits = table.newSnapshotReader().read().dataSplits();
+        assertThat(splits.size()).isEqualTo(3);
+        for (DataSplit split : splits) {
+            if (split.partition().getInt(1) == 15) {
+                // compacted
+                assertThat(split.dataFiles().size()).isEqualTo(1);
+            } else {
+                // not compacted
+                assertThat(split.dataFiles().size()).isEqualTo(2);
+            }
+        }
+    }
+
+    @Test
+    public void testStreamingCompact() throws Exception {
+        sql(
+                "CREATE TABLE T ("
+                        + " k INT,"
+                        + " v INT,"
+                        + " hh INT,"
+                        + " dt STRING,"
+                        + " PRIMARY KEY (k, dt, hh) NOT ENFORCED"
+                        + ") PARTITIONED BY (dt, hh) WITH ("
+                        + " 'write-only' = 'true',"
+                        + " 'bucket' = '1',"
+                        + " 'changelog-producer' = 'full-compaction',"
+                        + " 'full-compaction.delta-commits' = '1',"
+                        + " 'continuous.discovery-interval' = '1s'"
+                        + ")");
+        FileStoreTable table = paimonTable("T");
+        BlockingIterator<Row, Row> select = streamSqlBlockIter("SELECT * FROM T");
+
+        sql(
+                "INSERT INTO T VALUES (1, 100, 15, '20221208'), (1, 100, 16, '20221208'), (1, 100, 15, '20221209')");
+        checkLatestSnapshot(table, 1, Snapshot.CommitKind.APPEND);
+
+        // no full compaction has happened, so plan should be empty
+        StreamTableScan scan = table.newReadBuilder().newStreamScan();
+        TableScan.Plan plan = scan.plan();
+        assertThat(plan.splits()).isEmpty();
+
+        // submit streaming compaction job
+        streamSqlIter(
+                        "CALL sys.compact(`table` => 'default.T', partitions => 'dt=20221208,hh=15;dt=20221209,hh=15', "
+                                + "options => 'scan.parallelism=1')")
+                .close();
+
+        // first full compaction
+        assertThat(select.collect(2))
+                .containsExactlyInAnyOrder(
+                        Row.of(1, 100, 15, "20221208"), Row.of(1, 100, 15, "20221209"));
+
+        // incremental records
+        sql(
+                "INSERT INTO T VALUES (1, 101, 15, '20221208'), (1, 101, 16, '20221208'), (1, 101, 15, '20221209')");
+
+        // second full compaction
+        assertThat(select.collect(4))
+                .containsExactlyInAnyOrder(
+                        Row.ofKind(RowKind.UPDATE_BEFORE, 1, 100, 15, "20221208"),
+                        Row.ofKind(RowKind.UPDATE_AFTER, 1, 101, 15, "20221208"),
+                        Row.ofKind(RowKind.UPDATE_BEFORE, 1, 100, 15, "20221209"),
+                        Row.ofKind(RowKind.UPDATE_AFTER, 1, 101, 15, "20221209"));
+
+        select.close();
+    }
+
+    // ----------------------- Sort Compact -----------------------
+
+    @Test
+    public void testDynamicBucketSortCompact() throws Exception {
+        sql(
+                "CREATE TABLE T ("
+                        + " f0 BIGINT PRIMARY KEY NOT ENFORCED,"
+                        + " f1 BIGINT,"
+                        + " f2 BIGINT,"
+                        + " f3 BIGINT,"
+                        + " f4 STRING"
+                        + ") WITH ("
+                        + " 'write-only' = 'true',"
+                        + " 'dynamic-bucket.target-row-num' = '100',"
+                        + " 'zorder.var-length-contribution' = '14'"
+                        + ")");
+        FileStoreTable table = paimonTable("T");
+
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        int commitTimes = 20;
+        for (int i = 0; i < commitTimes; i++) {
+            String value =
+                    IntStream.range(0, 100)
+                            .mapToObj(
+                                    in ->
+                                            String.format(
+                                                    "(%s, %s, %s, %s, '%s')",
+                                                    random.nextLong(),
+                                                    random.nextLong(),
+                                                    random.nextLong(),
+                                                    random.nextLong(),
+                                                    StringUtils.randomNumericString(14)))
+                            .collect(Collectors.joining(","));
+
+            sql("INSERT INTO T VALUES %s", value);
+        }
+        checkLatestSnapshot(table, 20, Snapshot.CommitKind.APPEND);
+
+        tEnv.getConfig().set(TableConfigOptions.TABLE_DML_SYNC, true);
+        sql(
+                "CALL sys.compact(`table` => 'default.T', order_strategy => 'zorder', order_by => 'f2,f1')");
+
+        checkLatestSnapshot(table, 21, Snapshot.CommitKind.OVERWRITE);
+    }
+
+    private void checkLatestSnapshot(
+            FileStoreTable table, long snapshotId, Snapshot.CommitKind commitKind) {
+        SnapshotManager snapshotManager = table.snapshotManager();
+        Snapshot snapshot = snapshotManager.snapshot(snapshotManager.latestSnapshotId());
+        assertThat(snapshot.id()).isEqualTo(snapshotId);
+        assertThat(snapshot.commitKind()).isEqualTo(commitKind);
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests
Migrate procedure tests from action tests.
Add test in flink-1.18 to ensure compatiblity.

<!-- List UT and IT cases to verify this change -->

### API and Format
Compact procedure supports named arguments. The names are:
table, partitions, order_strategy, order_by, options
<!-- Does this change affect API or storage format -->

### Documentation

flink -> procedures

<!-- Does this change introduce a new feature -->
