### PR TITLE
[compaction]Add local sample config for sort compaction

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -564,10 +564,10 @@ This config option does not affect the default filesystem metastore.</td>
             <td>In watermarking, if a source remains idle beyond the specified timeout duration, it triggers snapshot advancement and facilitates tag creation.</td>
         </tr>
         <tr>
-            <td><h5>sort-compaction.local-sample.size</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
+            <td><h5>sort-compaction.local-sample.magnification</h5></td>
+            <td style="word-wrap: break-word;">1000</td>
             <td>Integer</td>
-            <td>The size of local sample for sort-compaction.By default,the value is the sink parallelism * 1000.</td>
+            <td>The magnification of local sample for sort-compaction.The size of local sample is sink parallelism * magnification.</td>
         </tr>
         <tr>
             <td><h5>sort-compaction.range-strategy</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -564,12 +564,6 @@ This config option does not affect the default filesystem metastore.</td>
             <td>In watermarking, if a source remains idle beyond the specified timeout duration, it triggers snapshot advancement and facilitates tag creation.</td>
         </tr>
         <tr>
-            <td><h5>sort-compaction.global-sample.size</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Integer</td>
-            <td>The size of global sample for sort-compaction.By default,the value is the sink parallelism * 1000.</td>
-        </tr>
-        <tr>
             <td><h5>sort-compaction.local-sample.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
@@ -581,12 +575,6 @@ This config option does not affect the default filesystem metastore.</td>
             <td><p>Enum</p></td>
             <td>The range strategy of sort compaction, the default value is quantity.
 If the data size allocated for the sorting task is uneven,which may lead to performance bottlenecks, the config can be set to size.<br /><br />Possible values:<ul><li>"SIZE"</li><li>"QUANTITY"</li></ul></td>
-        </tr>
-        <tr>
-            <td><h5>sort-compaction.range.size</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Integer</td>
-            <td>The range for sort-compaction.By default,the value is the sink parallelism * 10.</td>
         </tr>
         <tr>
             <td><h5>sort-engine</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -564,11 +564,29 @@ This config option does not affect the default filesystem metastore.</td>
             <td>In watermarking, if a source remains idle beyond the specified timeout duration, it triggers snapshot advancement and facilitates tag creation.</td>
         </tr>
         <tr>
+            <td><h5>sort-compaction.global-sample.size</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>The size of global sample for sort-compaction.By default,the value is the sink parallelism * 1000.</td>
+        </tr>
+        <tr>
+            <td><h5>sort-compaction.local-sample.size</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>The size of local sample for sort-compaction.By default,the value is the sink parallelism * 1000.</td>
+        </tr>
+        <tr>
             <td><h5>sort-compaction.range-strategy</h5></td>
             <td style="word-wrap: break-word;">QUANTITY</td>
             <td><p>Enum</p></td>
             <td>The range strategy of sort compaction, the default value is quantity.
 If the data size allocated for the sorting task is uneven,which may lead to performance bottlenecks, the config can be set to size.<br /><br />Possible values:<ul><li>"SIZE"</li><li>"QUANTITY"</li></ul></td>
+        </tr>
+        <tr>
+            <td><h5>sort-compaction.range.size</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>The range for sort-compaction.By default,the value is the sink parallelism * 10.</td>
         </tr>
         <tr>
             <td><h5>sort-engine</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1056,12 +1056,12 @@ public class CoreOptions implements Serializable {
                                     + "If the data size allocated for the sorting task is uneven,which may lead to performance bottlenecks, "
                                     + "the config can be set to size.");
 
-    public static final ConfigOption<Integer> SORT_COMPACTION_LOCAL_SAMPLE_SIZE =
-            key("sort-compaction.local-sample.size")
+    public static final ConfigOption<Integer> SORT_COMPACTION_SAMPLE_MAGNIFICATION =
+            key("sort-compaction.local-sample.magnification")
                     .intType()
-                    .noDefaultValue()
+                    .defaultValue(1000)
                     .withDescription(
-                            "The size of local sample for sort-compaction.By default,the value is the sink parallelism * 1000.");
+                            "The magnification of local sample for sort-compaction.The size of local sample is sink parallelism * magnification.");
     private final Options options;
 
     public CoreOptions(Map<String, String> options) {
@@ -1132,8 +1132,8 @@ public class CoreOptions implements Serializable {
         return options.get(SORT_RANG_STRATEGY) == RangeStrategy.SIZE;
     }
 
-    public Optional<Integer> getLocalSampleSize() {
-        return options.getOptional(SORT_COMPACTION_LOCAL_SAMPLE_SIZE);
+    public Integer getLocalSampleMagnification() {
+        return options.get(SORT_COMPACTION_SAMPLE_MAGNIFICATION);
     }
 
     public static FileFormat createFileFormat(

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1061,21 +1061,21 @@ public class CoreOptions implements Serializable {
                     .intType()
                     .noDefaultValue()
                     .withDescription(
-                            "The size of local sample for sort-compaction.By default,the value is the sink parallelism * 1000");
+                            "The size of local sample for sort-compaction.By default,the value is the sink parallelism * 1000.");
 
     public static final ConfigOption<Integer> SORT_COMPACTION_GLOBAL_SAMPLE_SIZE =
             key("sort-compaction.global-sample.size")
                     .intType()
                     .noDefaultValue()
                     .withDescription(
-                            "the size of global sample for sort-compaction.By default,the value is the sink parallelism * 1000");
+                            "The size of global sample for sort-compaction.By default,the value is the sink parallelism * 1000.");
 
     public static final ConfigOption<Integer> SORT_RANGE =
             key("sort-compaction.range.size")
                     .intType()
                     .noDefaultValue()
                     .withDescription(
-                            "The range for sort-compaction.By default,the value is the sink parallelism * 10");
+                            "The range for sort-compaction.By default,the value is the sink parallelism * 10.");
 
     private final Options options;
 

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1056,6 +1056,27 @@ public class CoreOptions implements Serializable {
                                     + "If the data size allocated for the sorting task is uneven,which may lead to performance bottlenecks, "
                                     + "the config can be set to size.");
 
+    public static final ConfigOption<Integer> SORT_COMPACTION_LOCAL_SAMPLE_SIZE =
+            key("sort-compaction.local-sample.size")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The size of local sample for sort-compaction.By default,the value is the sink parallelism * 1000");
+
+    public static final ConfigOption<Integer> SORT_COMPACTION_GLOBAL_SAMPLE_SIZE =
+            key("sort-compaction.global-sample.size")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "the size of global sample for sort-compaction.By default,the value is the sink parallelism * 1000");
+
+    public static final ConfigOption<Integer> SORT_RANGE =
+            key("sort-compaction.range.size")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The range for sort-compaction.By default,the value is the sink parallelism * 10");
+
     private final Options options;
 
     public CoreOptions(Map<String, String> options) {
@@ -1124,6 +1145,18 @@ public class CoreOptions implements Serializable {
 
     public boolean sortBySize() {
         return options.get(SORT_RANG_STRATEGY) == RangeStrategy.SIZE;
+    }
+
+    public Optional<Integer> getLocalSampleSize() {
+        return options.getOptional(SORT_COMPACTION_LOCAL_SAMPLE_SIZE);
+    }
+
+    public Optional<Integer> getGlobalSampleSize() {
+        return options.getOptional(SORT_COMPACTION_GLOBAL_SAMPLE_SIZE);
+    }
+
+    public Optional<Integer> getSortRange() {
+        return options.getOptional(SORT_RANGE);
     }
 
     public static FileFormat createFileFormat(

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1062,21 +1062,6 @@ public class CoreOptions implements Serializable {
                     .noDefaultValue()
                     .withDescription(
                             "The size of local sample for sort-compaction.By default,the value is the sink parallelism * 1000.");
-
-    public static final ConfigOption<Integer> SORT_COMPACTION_GLOBAL_SAMPLE_SIZE =
-            key("sort-compaction.global-sample.size")
-                    .intType()
-                    .noDefaultValue()
-                    .withDescription(
-                            "The size of global sample for sort-compaction.By default,the value is the sink parallelism * 1000.");
-
-    public static final ConfigOption<Integer> SORT_RANGE =
-            key("sort-compaction.range.size")
-                    .intType()
-                    .noDefaultValue()
-                    .withDescription(
-                            "The range for sort-compaction.By default,the value is the sink parallelism * 10.");
-
     private final Options options;
 
     public CoreOptions(Map<String, String> options) {
@@ -1149,14 +1134,6 @@ public class CoreOptions implements Serializable {
 
     public Optional<Integer> getLocalSampleSize() {
         return options.getOptional(SORT_COMPACTION_LOCAL_SAMPLE_SIZE);
-    }
-
-    public Optional<Integer> getGlobalSampleSize() {
-        return options.getOptional(SORT_COMPACTION_GLOBAL_SAMPLE_SIZE);
-    }
-
-    public Optional<Integer> getSortRange() {
-        return options.getOptional(SORT_RANGE);
     }
 
     public static FileFormat createFileFormat(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/shuffle/RangeShuffle.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/shuffle/RangeShuffle.java
@@ -96,7 +96,8 @@ public class RangeShuffle {
             DataStream<Tuple2<T, RowData>> inputDataStream,
             SerializableSupplier<Comparator<T>> keyComparator,
             TypeInformation<T> keyTypeInformation,
-            int sampleSize,
+            int localSampleSize,
+            int globalSampleSize,
             int rangeNum,
             int outParallelism,
             RowType valueRowType,
@@ -116,7 +117,7 @@ public class RangeShuffle {
                 new OneInputTransformation<>(
                         keyInput,
                         "LOCAL SAMPLE",
-                        new LocalSampleOperator<>(sampleSize),
+                        new LocalSampleOperator<>(localSampleSize),
                         new TupleTypeInfo<>(
                                 BasicTypeInfo.DOUBLE_TYPE_INFO,
                                 keyTypeInformation,
@@ -128,7 +129,7 @@ public class RangeShuffle {
                 new OneInputTransformation<>(
                         localSample,
                         "GLOBAL SAMPLE",
-                        new GlobalSampleOperator<>(sampleSize, keyComparator, rangeNum),
+                        new GlobalSampleOperator<>(globalSampleSize, keyComparator, rangeNum),
                         new ListTypeInfo<>(keyTypeInformation),
                         1);
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/SortUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/SortUtils.java
@@ -99,18 +99,17 @@ public class SortUtils {
                     "The adaptive batch scheduler is not supported. Please set the sink parallelism using the key: "
                             + FlinkConnectorOptions.SINK_PARALLELISM.key());
         }
-        final int localSampleSize =
-                options.getLocalSampleSize().orElseGet(() -> sinkParallelism * 1000);
-        final int globalSampleSize = sinkParallelism * 1000;
-        final int rangeNum = sinkParallelism * 10;
-
-        if (localSampleSize < 20) {
+        int localSampleMagnification = options.getLocalSampleMagnification();
+        if (localSampleMagnification < 20) {
             throw new IllegalArgumentException(
                     String.format(
-                            "the config %s=%d is set too small,greater than or equal to 20 is needed.",
-                            CoreOptions.SORT_COMPACTION_LOCAL_SAMPLE_SIZE.key(), localSampleSize));
+                            "the config '%s=%d' should not be set too small,greater than or equal to 20 is needed.",
+                            CoreOptions.SORT_COMPACTION_SAMPLE_MAGNIFICATION.key(),
+                            localSampleMagnification));
         }
-
+        final int localSampleSize = sinkParallelism * localSampleMagnification;
+        final int globalSampleSize = sinkParallelism * 1000;
+        final int rangeNum = sinkParallelism * 10;
         int keyFieldCount = sortKeyType.getFieldCount();
         int valueFieldCount = valueRowType.getFieldCount();
         final int[] valueProjectionMap = new int[valueFieldCount];

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/SortUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/SortUtils.java
@@ -99,8 +99,11 @@ public class SortUtils {
                     "The adaptive batch scheduler is not supported. Please set the sink parallelism using the key: "
                             + FlinkConnectorOptions.SINK_PARALLELISM.key());
         }
-        final int sampleSize = sinkParallelism * 1000;
-        final int rangeNum = sinkParallelism * 10;
+        final int localSampleSize =
+                options.getLocalSampleSize().orElseGet(() -> sinkParallelism * 1000);
+        final int globalSampleSize =
+                options.getGlobalSampleSize().orElseGet(() -> sinkParallelism * 1000);
+        final int rangeNum = options.getSortRange().orElseGet(() -> sinkParallelism * 10);
 
         int keyFieldCount = sortKeyType.getFieldCount();
         int valueFieldCount = valueRowType.getFieldCount();
@@ -144,7 +147,8 @@ public class SortUtils {
                         inputWithKey,
                         shuffleKeyComparator,
                         keyTypeInformation,
-                        sampleSize,
+                        localSampleSize,
+                        globalSampleSize,
                         rangeNum,
                         sinkParallelism,
                         valueRowType,

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionForUnawareBucketITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionForUnawareBucketITCase.java
@@ -393,7 +393,8 @@ public class SortCompactActionForUnawareBucketITCase extends ActionITCaseBase {
         prepareData(300, 1);
         {
             ArrayList<String> extraCompactionConfig =
-                    Lists.newArrayList("--table_conf", "sort-compaction.local-sample.size=1");
+                    Lists.newArrayList(
+                            "--table_conf", "sort-compaction.local-sample.magnification=1");
             Assertions.assertThatCode(
                             () -> {
                                 createAction(
@@ -407,7 +408,7 @@ public class SortCompactActionForUnawareBucketITCase extends ActionITCaseBase {
                                         .run();
                             })
                     .hasMessage(
-                            "the config sort-compaction.local-sample.size=1 is set too small,greater than or equal to 20 is needed.");
+                            "the config 'sort-compaction.local-sample.magnification=1' should not be set too small,greater than or equal to 20 is needed.");
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionForUnawareBucketITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionForUnawareBucketITCase.java
@@ -389,40 +389,11 @@ public class SortCompactActionForUnawareBucketITCase extends ActionITCaseBase {
     }
 
     @Test
-    public void testSampleConfig() throws Exception {
+    public void testvalidSampleConfig() throws Exception {
         prepareData(300, 1);
-
         {
             ArrayList<String> extraCompactionConfig =
-                    Lists.newArrayList(
-                            "--table_conf",
-                            "sort-compaction.range.size=100",
-                            "--table_conf",
-                            "sort-compaction.global-sample.size=10");
-            Assertions.assertThatCode(
-                            () -> {
-                                createAction(
-                                                "order",
-                                                "size",
-                                                Arrays.asList(
-                                                        "f0", "f1", "f2", "f3", "f4", "f5", "f6",
-                                                        "f7", "f8", "f9", "f10", "f11", "f12",
-                                                        "f13", "f14", "f15"),
-                                                extraCompactionConfig)
-                                        .run();
-                            })
-                    .hasMessage("The global sample size 10 should be greater than rangeNum 100.");
-        }
-
-        {
-            ArrayList<String> extraCompactionConfig =
-                    Lists.newArrayList(
-                            "--table_conf",
-                            "sort-compaction.local-sample.size=1",
-                            "--table_conf",
-                            "sort-compaction.global-sample.size=100",
-                            "--table_conf",
-                            "sink.parallelism=3");
+                    Lists.newArrayList("--table_conf", "sort-compaction.local-sample.size=1");
             Assertions.assertThatCode(
                             () -> {
                                 createAction(
@@ -436,7 +407,7 @@ public class SortCompactActionForUnawareBucketITCase extends ActionITCaseBase {
                                         .run();
                             })
                     .hasMessage(
-                            "The sum size 3 of local sample must be greater than the global sample 100.");
+                            "the config sort-compaction.local-sample.size=1 is set too small,greater than or equal to 20 is needed.");
         }
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Add local sample config for sort compaction . It' helpful for the sort compaction task with large parallelism,which sampling may lead to a performance bottleneck.
