### PR TITLE
[doc]introduce the minimum version of Maven.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can join the Paimon community on Slack. Paimon channel is in ASF Slack works
 
 ## Building
 
-JDK 8/11 is required for building the project.
+JDK 8/11 is required for building the project. Maven version >=3.3.1.
 
 - Run the `mvn clean install -DskipTests` command to build the project.
 - Run the `mvn spotless:apply` to format the project (both Java and Scala).


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
#3063 used the Maven variable ${maven.multiModuleProjectDirectory}, which was added in versions after Maven 3.3.1. Therefore, it's necessary to declare the minimum required version of Maven.