### PR TITLE
[core] Unify FileRecordReader and reduce file access

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreRead.java
@@ -23,10 +23,11 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FileFormatDiscover;
 import org.apache.paimon.format.FormatKey;
+import org.apache.paimon.format.FormatReaderContext;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFilePathFactory;
-import org.apache.paimon.io.RowDataFileRecordReader;
+import org.apache.paimon.io.FileRecordReader;
 import org.apache.paimon.mergetree.compact.ConcatRecordReader;
 import org.apache.paimon.partition.PartitionUtils;
 import org.apache.paimon.predicate.Predicate;
@@ -174,11 +175,12 @@ public class AppendOnlyFileStoreRead implements FileStoreRead<InternalRow> {
             final BinaryRow partition = split.partition();
             suppliers.add(
                     () ->
-                            new RowDataFileRecordReader(
-                                    fileIO,
-                                    dataFilePathFactory.toPath(file.fileName()),
-                                    file.fileSize(),
+                            new FileRecordReader(
                                     bulkFormatMapping.getReaderFactory(),
+                                    new FormatReaderContext(
+                                            fileIO,
+                                            dataFilePathFactory.toPath(file.fileName()),
+                                            file.fileSize()),
                                     bulkFormatMapping.getIndexMapping(),
                                     bulkFormatMapping.getCastMapping(),
                                     PartitionUtils.create(

--- a/paimon-core/src/main/java/org/apache/paimon/utils/FileUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/FileUtils.java
@@ -134,10 +134,14 @@ public class FileUtils {
     public static RecordReader<InternalRow> createFormatReader(
             FileIO fileIO, FormatReaderFactory format, Path file, @Nullable Long fileSize)
             throws IOException {
-        checkExists(fileIO, file);
-        if (fileSize == null) {
-            fileSize = fileIO.getFileSize(file);
+        try {
+            if (fileSize == null) {
+                fileSize = fileIO.getFileSize(file);
+            }
+            return format.createReader(new FormatReaderContext(fileIO, file, fileSize));
+        } catch (Exception e) {
+            checkExists(fileIO, file);
+            throw e;
         }
-        return format.createReader(new FormatReaderContext(fileIO, file, fileSize));
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
1. KeyValueDataFileRecordReader should just use FileRecordReader.
2. FileUtils.checkExists should just in exception path to reduce file access.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
