### PR TITLE
[core] Shade roaringbitmap dependency into paimon-common

### DIFF
--- a/paimon-common/pom.xml
+++ b/paimon-common/pom.xml
@@ -135,6 +135,12 @@ under the License.
             <version>8.5.12</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.roaringbitmap</groupId>
+            <artifactId>RoaringBitmap</artifactId>
+            <version>1.0.5</version>
+        </dependency>
+
         <!-- Test -->
 
         <dependency>
@@ -266,6 +272,7 @@ under the License.
                                     <include>org.antlr:antlr4-runtime</include>
                                     <include>org.codehaus.janino:*</include>
                                     <include>it.unimi.dsi:fastutil</include>
+                                    <include>org.roaringbitmap:RoaringBitmap</include>
                                 </includes>
                             </artifactSet>
                             <filters>
@@ -277,6 +284,12 @@ under the License.
                                         <exclude>META-INF/**</exclude>
                                         <exclude>org.codehaus.commons.compiler.properties</exclude>
                                     </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.roaringbitmap:RoaringBitmap</artifact>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
                                 </filter>
                             </filters>
                             <relocations>
@@ -300,6 +313,10 @@ under the License.
                                 <relocation>
                                     <pattern>io.airlift</pattern>
                                     <shadedPattern>org.apache.paimon.shade.io.airlift</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.roaringbitmap</pattern>
+                                    <shadedPattern>org.apache.paimon.shade.org.roaringbitmap</shadedPattern>
                                 </relocation>
                             </relocations>
                             <minimizeJar>true</minimizeJar>

--- a/paimon-common/pom.xml
+++ b/paimon-common/pom.xml
@@ -285,12 +285,6 @@ under the License.
                                         <exclude>org.codehaus.commons.compiler.properties</exclude>
                                     </excludes>
                                 </filter>
-                                <filter>
-                                    <artifact>org.roaringbitmap:RoaringBitmap</artifact>
-                                    <includes>
-                                        <include>**</include>
-                                    </includes>
-                                </filter>
                             </filters>
                             <relocations>
                                 <relocation>

--- a/paimon-common/src/main/java/org/apache/paimon/utils/RoaringBitmap32.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/RoaringBitmap32.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.roaringbitmap.RoaringBitmap;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/** A compressed bitmap for 32-bit integer. */
+public class RoaringBitmap32 {
+
+    public static final int MAX_VALUE = Integer.MAX_VALUE;
+
+    private final RoaringBitmap roaringBitmap;
+
+    public RoaringBitmap32() {
+        this.roaringBitmap = new RoaringBitmap();
+    }
+
+    public void add(int x) {
+        roaringBitmap.add(x);
+    }
+
+    public boolean checkedAdd(int x) {
+        return roaringBitmap.checkedAdd(x);
+    }
+
+    public boolean contains(int x) {
+        return roaringBitmap.contains(x);
+    }
+
+    public boolean isEmpty() {
+        return roaringBitmap.isEmpty();
+    }
+
+    public void serialize(DataOutput out) throws IOException {
+        roaringBitmap.runOptimize();
+        roaringBitmap.serialize(out);
+    }
+
+    public void deserialize(DataInput in) throws IOException {
+        roaringBitmap.deserialize(in);
+    }
+}

--- a/paimon-common/src/main/resources/META-INF/NOTICE
+++ b/paimon-common/src/main/resources/META-INF/NOTICE
@@ -4,6 +4,9 @@ Copyright 2023-2024 The Apache Software Foundation
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
+This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+- org.roaringbitmap:RoaringBitmap:1.0.5
+
 This project bundles the following dependencies under the BSD 3-clause license.
 You find them under licenses/LICENSE.antlr-runtime and licenses/LICENSE.janino.
 

--- a/paimon-core/pom.xml
+++ b/paimon-core/pom.xml
@@ -33,7 +33,6 @@ under the License.
 
     <properties>
         <frocksdbjni.version>6.20.3-ververica-2.0</frocksdbjni.version>
-        <RoaringBitmap.version>1.0.1</RoaringBitmap.version>
     </properties>
 
     <dependencies>
@@ -62,12 +61,6 @@ under the License.
             <artifactId>frocksdbjni</artifactId>
             <version>${frocksdbjni.version}</version>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.roaringbitmap</groupId>
-            <artifactId>RoaringBitmap</artifactId>
-            <version>${RoaringBitmap.version}</version>
         </dependency>
 
         <!-- test dependencies -->


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

subtask of #2898

- wapper RoaringBitma in paimon-common
- Shade roaringbitmap dependency into paimon-common, paimon-common.jar, before 3.3M -> after 3.6M

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
