### PR TITLE
[core] Fix the incorrect aggregation result due to the sequence number

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/SequenceGenerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/SequenceGenerator.java
@@ -1,21 +1,19 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  Licensed to the Apache Software Foundation (ASF) under one
- *  or more contributor license agreements.  See the NOTICE file
- *  distributed with this work for additional information
- *  regarding copyright ownership.  The ASF licenses this file
- *  to you under the Apache License, Version 2.0 (the
- *  "License"); you may not use this file except in compliance
- *  with the License.  You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.paimon.mergetree;

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/SequenceGenerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/SequenceGenerator.java
@@ -40,6 +40,7 @@ import org.apache.paimon.utils.InternalRowUtils;
 
 import javax.annotation.Nullable;
 
+/** The sequence generator. */
 public class SequenceGenerator {
 
     private final int index;

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/SequenceGenerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/SequenceGenerator.java
@@ -1,0 +1,182 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.apache.paimon.mergetree;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.types.BigIntType;
+import org.apache.paimon.types.CharType;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeDefaultVisitor;
+import org.apache.paimon.types.DateType;
+import org.apache.paimon.types.DecimalType;
+import org.apache.paimon.types.DoubleType;
+import org.apache.paimon.types.FloatType;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.LocalZonedTimestampType;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.SmallIntType;
+import org.apache.paimon.types.TimestampType;
+import org.apache.paimon.types.TinyIntType;
+import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.utils.InternalRowUtils;
+
+import javax.annotation.Nullable;
+
+public class SequenceGenerator {
+
+    private final int index;
+
+    private final Generator generator;
+    private final DataType fieldType;
+
+    public SequenceGenerator(String field, RowType rowType) {
+        index = rowType.getFieldNames().indexOf(field);
+        if (index == -1) {
+            throw new RuntimeException(
+                    String.format(
+                            "Can not find sequence field %s in table schema: %s", field, rowType));
+        }
+        fieldType = rowType.getTypeAt(index);
+        generator = fieldType.accept(new SequenceGeneratorVisitor());
+    }
+
+    public SequenceGenerator(int index, DataType dataType) {
+        this.index = index;
+
+        this.fieldType = dataType;
+        if (index == -1) {
+            throw new RuntimeException(String.format("Index : %s is invalid", index));
+        }
+        generator = fieldType.accept(new SequenceGeneratorVisitor());
+    }
+
+    public int index() {
+        return index;
+    }
+
+    public DataType fieldType() {
+        return fieldType;
+    }
+
+    @Nullable
+    public Long generate(InternalRow row) {
+        return generator.generateNullable(row, index);
+    }
+
+    private interface Generator {
+        long generate(InternalRow row, int i);
+
+        @Nullable
+        default Long generateNullable(InternalRow row, int i) {
+            if (row.isNullAt(i)) {
+                return null;
+            }
+            return generate(row, i);
+        }
+    }
+
+    private static class SequenceGeneratorVisitor extends DataTypeDefaultVisitor<Generator> {
+
+        @Override
+        public Generator visit(CharType charType) {
+            return stringGenerator();
+        }
+
+        @Override
+        public Generator visit(VarCharType varCharType) {
+            return stringGenerator();
+        }
+
+        private Generator stringGenerator() {
+            return (row, i) -> Long.parseLong(row.getString(i).toString());
+        }
+
+        @Override
+        public Generator visit(DecimalType decimalType) {
+            return (row, i) ->
+                    InternalRowUtils.castToIntegral(
+                            row.getDecimal(i, decimalType.getPrecision(), decimalType.getScale()));
+        }
+
+        @Override
+        public Generator visit(TinyIntType tinyIntType) {
+            return InternalRow::getByte;
+        }
+
+        @Override
+        public Generator visit(SmallIntType smallIntType) {
+            return InternalRow::getShort;
+        }
+
+        @Override
+        public Generator visit(IntType intType) {
+            return InternalRow::getInt;
+        }
+
+        @Override
+        public Generator visit(BigIntType bigIntType) {
+            return InternalRow::getLong;
+        }
+
+        @Override
+        public Generator visit(FloatType floatType) {
+            return (row, i) -> (long) row.getFloat(i);
+        }
+
+        @Override
+        public Generator visit(DoubleType doubleType) {
+            return (row, i) -> (long) row.getDouble(i);
+        }
+
+        @Override
+        public Generator visit(DateType dateType) {
+            return InternalRow::getInt;
+        }
+
+        @Override
+        public Generator visit(TimestampType timestampType) {
+            return (row, i) -> row.getTimestamp(i, timestampType.getPrecision()).getMillisecond();
+        }
+
+        @Override
+        public Generator visit(LocalZonedTimestampType localZonedTimestampType) {
+            return (row, i) ->
+                    row.getTimestamp(i, localZonedTimestampType.getPrecision()).getMillisecond();
+        }
+
+        @Override
+        protected Generator defaultMethod(DataType dataType) {
+            throw new UnsupportedOperationException("Unsupported type: " + dataType);
+        }
+    }
+
+    /** The Seq wrapper. */
+    public static class Seq {
+        public final @Nullable SequenceGenerator generator;
+        /** Whether the sequence generator is exclusive for one column. */
+        public final boolean isExclusive;
+
+        public Seq(@Nullable SequenceGenerator generator, boolean isExclusive) {
+            this.generator = generator;
+            this.isExclusive = isExclusive;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeFunctionUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeFunctionUtils.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree.compact;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.mergetree.SequenceGenerator;
+import org.apache.paimon.mergetree.SequenceGenerator.Seq;
+import org.apache.paimon.mergetree.compact.aggregate.FieldAggregator;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.Projection;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.CoreOptions.FIELDS_PREFIX;
+import static org.apache.paimon.mergetree.compact.PartialUpdateMergeFunction.SEQUENCE_GROUP;
+
+/** Utils for merge function. */
+public class MergeFunctionUtils {
+
+    public static Map<Integer, SequenceGenerator> getSequenceGenerator(
+            CoreOptions options, List<String> fieldNames, RowType rowType) {
+        Map<Integer, SequenceGenerator> fieldSequences = new HashMap<>();
+        for (Map.Entry<String, String> entry : options.toMap().entrySet()) {
+            String k = entry.getKey();
+            String v = entry.getValue();
+            if (k.startsWith(FIELDS_PREFIX) && k.endsWith(SEQUENCE_GROUP)) {
+                String sequenceFieldName =
+                        k.substring(
+                                FIELDS_PREFIX.length() + 1,
+                                k.length() - SEQUENCE_GROUP.length() - 1);
+                SequenceGenerator sequenceGen = new SequenceGenerator(sequenceFieldName, rowType);
+                Arrays.stream(v.split(","))
+                        .map(
+                                fieldName -> {
+                                    int field = fieldNames.indexOf(fieldName);
+                                    if (field == -1) {
+                                        throw new IllegalArgumentException(
+                                                String.format(
+                                                        "Field %s can not be found in table schema",
+                                                        fieldName));
+                                    }
+                                    return field;
+                                })
+                        .forEach(
+                                field -> {
+                                    if (fieldSequences.containsKey(field)) {
+                                        throw new IllegalArgumentException(
+                                                String.format(
+                                                        "Field %s is defined repeatedly by multiple groups: %s",
+                                                        fieldNames.get(field), k));
+                                    }
+                                    fieldSequences.put(field, sequenceGen);
+                                });
+
+                // add self
+                fieldSequences.put(sequenceGen.index(), sequenceGen);
+            }
+        }
+        return fieldSequences;
+    }
+
+    public static Map<Integer, SequenceGenerator> projectSequence(
+            int[][] projection, Map<Integer, SequenceGenerator> fieldSequences) {
+        if (projection == null) {
+            return fieldSequences;
+        }
+        Map<Integer, SequenceGenerator> projectedSequences = new HashMap<>();
+        int[] projects = Projection.of(projection).toTopLevelIndexes();
+        Map<Integer, Integer> indexMap = new HashMap<>();
+        for (int i = 0; i < projects.length; i++) {
+            indexMap.put(projects[i], i);
+        }
+
+        fieldSequences.forEach(
+                (field, sequence) -> {
+                    int newField = indexMap.getOrDefault(field, -1);
+                    if (newField != -1) {
+                        int newSequenceId = indexMap.getOrDefault(sequence.index(), -1);
+                        if (newSequenceId == -1) {
+                            throw new RuntimeException(
+                                    String.format(
+                                            "Can not find new sequence field for new field. new field index is %s",
+                                            newField));
+                        } else {
+                            projectedSequences.put(
+                                    newField,
+                                    new SequenceGenerator(newSequenceId, sequence.fieldType()));
+                        }
+                    }
+                });
+        return projectedSequences;
+    }
+
+    public static Seq[] toSeq(
+            Map<Integer, SequenceGenerator> fieldSequences, FieldAggregator[] fieldAggregators) {
+        Seq[] sequences = new Seq[fieldAggregators.length];
+        for (Map.Entry<Integer, SequenceGenerator> entry : fieldSequences.entrySet()) {
+            int index = entry.getKey();
+            Seq seq;
+            if (fieldAggregators[index] != null && fieldAggregators[index].requireSequence()) {
+                // sequence for the exclusive aggregation function
+                sequences[index] = new Seq(entry.getValue(), true);
+                // The sequence field itself.
+                sequences[entry.getValue().index()] = new Seq(entry.getValue(), true);
+            } else {
+                seq = new Seq(entry.getValue(), false);
+                if (sequences[index] == null) {
+                    sequences[index] = seq;
+                }
+            }
+        }
+        return sequences;
+    }
+
+    public static Map<Integer, Set<Integer>> seqIndex2Field(
+            Map<Integer, SequenceGenerator> generators) {
+        Map<Integer, Set<Integer>> seq2Field = new HashMap<>();
+        for (Map.Entry<Integer, SequenceGenerator> entry : generators.entrySet()) {
+            int seqIndex = entry.getValue().index();
+            seq2Field.computeIfAbsent(seqIndex, k -> new HashSet<>());
+            Set<Integer> fields = seq2Field.get(seqIndex);
+            fields.add(entry.getKey());
+        }
+        return seq2Field;
+    }
+
+    /** The required sequence's aggregator can not share sequence filed. */
+    public static void validateSequence(
+            FieldAggregator[] aggregators,
+            Map<Integer, SequenceGenerator> sequences,
+            List<String> fieldNames) {
+        Map<Integer, Set<Integer>> seq2Field = seqIndex2Field(sequences);
+        for (int i = 0; i < aggregators.length; i++) {
+            FieldAggregator aggregator = aggregators[i];
+            if (aggregator != null && aggregator.requireSequence()) {
+                SequenceGenerator seqGen = sequences.get(i);
+                if (seqGen == null) {
+                    continue;
+                    // here we should allow, but for compatibility
+                }
+                int seqIndex = seqGen.index();
+                Set<Integer> values = seq2Field.get(seqIndex);
+                // remove self.
+                values.remove(seqIndex);
+                if (values.size() >= 2) {
+                    throw new RuntimeException(
+                            String.format(
+                                    "Should not share sequence field in [%s] due to %s",
+                                    values.stream()
+                                            .map(fieldNames::get)
+                                            .collect(Collectors.joining(",")),
+                                    aggregator.name()));
+                }
+            }
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregator.java
@@ -35,6 +35,7 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 /** abstract class of aggregating a field of a row. */
 public abstract class FieldAggregator implements Serializable {
     protected DataType fieldType;
+    protected Object seq;
 
     public FieldAggregator(DataType dataType) {
         this.fieldType = dataType;
@@ -146,14 +147,24 @@ public abstract class FieldAggregator implements Serializable {
         return new FieldNestedUpdateAgg(arrayType, nestedKey);
     }
 
-    abstract String name();
+    public abstract String name();
 
-    public abstract Object agg(Object accumulator, Object inputField);
+    public abstract Object agg(Object accumulator, Object inputField, Object currentSeq);
+
+    public abstract Object aggForOldSeq(Object accumulator, Object inputField, Object currentSeq);
+
+    public Object getSeq() {
+        return seq;
+    }
+
+    public boolean requireSequence() {
+        return false;
+    }
 
     /** reset the aggregator to a clean start state. */
     public void reset() {}
 
-    public Object retract(Object accumulator, Object retractField) {
+    public Object retract(Object accumulator, Object retractField, Object sequence) {
         throw new UnsupportedOperationException(
                 String.format(
                         "Aggregate function '%s' does not support retraction,"

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldBoolAndAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldBoolAndAgg.java
@@ -30,12 +30,11 @@ public class FieldBoolAndAgg extends FieldAggregator {
     }
 
     @Override
-    String name() {
+    public String name() {
         return NAME;
     }
 
-    @Override
-    public Object agg(Object accumulator, Object inputField) {
+    private Object agg(Object accumulator, Object inputField) {
         Object boolAnd;
 
         if (accumulator == null || inputField == null) {
@@ -50,5 +49,16 @@ public class FieldBoolAndAgg extends FieldAggregator {
             }
         }
         return boolAnd;
+    }
+
+    @Override
+    public Object agg(Object accumulator, Object inputField, Object currentSeq) {
+        this.seq = currentSeq;
+        return agg(accumulator, inputField);
+    }
+
+    @Override
+    public Object aggForOldSeq(Object accumulator, Object inputField, Object currentSeq) {
+        return agg(accumulator, inputField);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldBoolOrAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldBoolOrAgg.java
@@ -30,12 +30,22 @@ public class FieldBoolOrAgg extends FieldAggregator {
     }
 
     @Override
-    String name() {
+    public String name() {
         return NAME;
     }
 
     @Override
-    public Object agg(Object accumulator, Object inputField) {
+    public Object agg(Object accumulator, Object inputField, Object currentSeq) {
+        this.seq = currentSeq;
+        return agg(accumulator, inputField);
+    }
+
+    @Override
+    public Object aggForOldSeq(Object accumulator, Object inputField, Object currentSeq) {
+        return agg(accumulator, inputField);
+    }
+
+    private Object agg(Object accumulator, Object inputField) {
         Object boolOr;
 
         if (accumulator == null || inputField == null) {

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldCollectAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldCollectAgg.java
@@ -83,12 +83,22 @@ public class FieldCollectAgg extends FieldAggregator {
     }
 
     @Override
-    String name() {
+    public String name() {
         return NAME;
     }
 
     @Override
-    public Object agg(Object accumulator, Object inputField) {
+    public Object agg(Object accumulator, Object inputField, Object currentSeq) {
+        this.seq = currentSeq;
+        return agg(accumulator, inputField);
+    }
+
+    @Override
+    public Object aggForOldSeq(Object accumulator, Object inputField, Object currentSeq) {
+        return agg(accumulator, inputField);
+    }
+
+    private Object agg(Object accumulator, Object inputField) {
         if (accumulator == null && inputField == null) {
             return null;
         }
@@ -149,7 +159,8 @@ public class FieldCollectAgg extends FieldAggregator {
     }
 
     @Override
-    public Object retract(Object accumulator, Object retractField) {
+    public Object retract(Object accumulator, Object retractField, Object currentSeq) {
+        this.seq = currentSeq;
         if (accumulator == null) {
             return null;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldCountAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldCountAgg.java
@@ -30,12 +30,22 @@ public class FieldCountAgg extends FieldAggregator {
     }
 
     @Override
-    String name() {
+    public String name() {
         return NAME;
     }
 
     @Override
-    public Object agg(Object accumulator, Object inputField) {
+    public Object agg(Object accumulator, Object inputField, Object currentSeq) {
+        this.seq = currentSeq;
+        return agg(accumulator, inputField);
+    }
+
+    @Override
+    public Object aggForOldSeq(Object accumulator, Object inputField, Object currentSeq) {
+        return agg(accumulator, inputField);
+    }
+
+    private Object agg(Object accumulator, Object inputField) {
         Object count;
         if (accumulator == null || inputField == null) {
             count = (accumulator == null ? 1 : accumulator);
@@ -56,7 +66,8 @@ public class FieldCountAgg extends FieldAggregator {
     }
 
     @Override
-    public Object retract(Object accumulator, Object inputField) {
+    public Object retract(Object accumulator, Object inputField, Object sequence) {
+        this.seq = sequence;
         Object count;
         if (accumulator == null || inputField == null) {
             count = (accumulator == null ? 1 : accumulator);

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldFirstNonNullValueAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldFirstNonNullValueAgg.java
@@ -35,18 +35,35 @@ public class FieldFirstNonNullValueAgg extends FieldAggregator {
     }
 
     @Override
-    String name() {
+    public String name() {
         return NAME;
     }
 
     @Override
-    public Object agg(Object accumulator, Object inputField) {
+    public Object agg(Object accumulator, Object inputField, Object seq) {
         if (!initialized && inputField != null) {
             initialized = true;
+            this.seq = seq;
             return inputField;
         } else {
             return accumulator;
         }
+    }
+
+    @Override
+    public Object aggForOldSeq(Object accumulator, Object inputField, Object seq) {
+        if (inputField != null) {
+            initialized = true;
+            this.seq = seq;
+            return inputField;
+        } else {
+            return accumulator;
+        }
+    }
+
+    @Override
+    public boolean requireSequence() {
+        return true;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldFirstValueAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldFirstValueAgg.java
@@ -39,13 +39,26 @@ public class FieldFirstValueAgg extends FieldAggregator {
     }
 
     @Override
-    public Object agg(Object accumulator, Object inputField) {
+    public Object agg(Object accumulator, Object inputField, Object seq) {
         if (!initialized) {
-            initialized = true;
+            this.initialized = true;
+            this.seq = seq;
             return inputField;
         } else {
             return accumulator;
         }
+    }
+
+    @Override
+    public Object aggForOldSeq(Object accumulator, Object inputField, Object currentSeq) {
+        this.initialized = true;
+        this.seq = currentSeq;
+        return inputField;
+    }
+
+    @Override
+    public boolean requireSequence() {
+        return true;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldIgnoreRetractAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldIgnoreRetractAgg.java
@@ -29,13 +29,28 @@ public class FieldIgnoreRetractAgg extends FieldAggregator {
     }
 
     @Override
-    String name() {
+    public String name() {
         return aggregator.name();
     }
 
     @Override
-    public Object agg(Object accumulator, Object inputField) {
-        return aggregator.agg(accumulator, inputField);
+    public Object agg(Object accumulator, Object inputField, Object currentSeq) {
+        return aggregator.agg(accumulator, inputField, currentSeq);
+    }
+
+    @Override
+    public Object aggForOldSeq(Object accumulator, Object inputField, Object currentSeq) {
+        return aggregator.aggForOldSeq(accumulator, inputField, currentSeq);
+    }
+
+    @Override
+    public Object getSeq() {
+        return aggregator.getSeq();
+    }
+
+    @Override
+    public boolean requireSequence() {
+        return aggregator.requireSequence();
     }
 
     @Override
@@ -44,7 +59,7 @@ public class FieldIgnoreRetractAgg extends FieldAggregator {
     }
 
     @Override
-    public Object retract(Object accumulator, Object retractField) {
+    public Object retract(Object accumulator, Object retractField, Object sequence) {
         return accumulator;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldLastNonNullValueAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldLastNonNullValueAgg.java
@@ -30,17 +30,42 @@ public class FieldLastNonNullValueAgg extends FieldAggregator {
     }
 
     @Override
-    String name() {
+    public String name() {
         return NAME;
     }
 
     @Override
-    public Object agg(Object accumulator, Object inputField) {
-        return (inputField == null) ? accumulator : inputField;
+    public Object agg(Object accumulator, Object inputField, Object currentSeq) {
+        if (inputField != null) {
+            this.seq = currentSeq;
+            return inputField;
+        } else {
+            // do not forward the seq.
+            return accumulator;
+        }
     }
 
     @Override
-    public Object retract(Object accumulator, Object retractField) {
+    public Object aggForOldSeq(Object accumulator, Object inputField, Object currentSeq) {
+        if (accumulator == null) {
+            if (inputField != null) {
+                // backward the seq
+                this.seq = currentSeq;
+            }
+            return inputField;
+        } else {
+            return accumulator;
+        }
+    }
+
+    @Override
+    public boolean requireSequence() {
+        return true;
+    }
+
+    @Override
+    public Object retract(Object accumulator, Object retractField, Object currentSeq) {
+        this.seq = currentSeq;
         return retractField != null ? null : accumulator;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldLastValueAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldLastValueAgg.java
@@ -30,17 +30,24 @@ public class FieldLastValueAgg extends FieldAggregator {
     }
 
     @Override
-    String name() {
+    public String name() {
         return NAME;
     }
 
     @Override
-    public Object agg(Object accumulator, Object inputField) {
+    public Object agg(Object accumulator, Object inputField, Object currentSeq) {
+        this.seq = currentSeq;
         return inputField;
     }
 
     @Override
-    public Object retract(Object accumulator, Object retractField) {
+    public Object retract(Object accumulator, Object retractField, Object sequence) {
+        this.seq = sequence;
         return null;
+    }
+
+    @Override
+    public Object aggForOldSeq(Object accumulator, Object inputField, Object currentSeq) {
+        return accumulator;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldListaggAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldListaggAgg.java
@@ -35,12 +35,22 @@ public class FieldListaggAgg extends FieldAggregator {
     }
 
     @Override
-    String name() {
+    public String name() {
         return NAME;
     }
 
     @Override
-    public Object agg(Object accumulator, Object inputField) {
+    public Object agg(Object accumulator, Object inputField, Object currentSeq) {
+        this.seq = currentSeq;
+        return agg(accumulator, inputField);
+    }
+
+    @Override
+    public Object aggForOldSeq(Object accumulator, Object inputField, Object currentSeq) {
+        return agg(accumulator, inputField);
+    }
+
+    private Object agg(Object accumulator, Object inputField) {
         Object concatenate;
 
         if (inputField == null || accumulator == null) {

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldMaxAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldMaxAgg.java
@@ -32,12 +32,11 @@ public class FieldMaxAgg extends FieldAggregator {
     }
 
     @Override
-    String name() {
+    public String name() {
         return NAME;
     }
 
-    @Override
-    public Object agg(Object accumulator, Object inputField) {
+    private Object agg(Object accumulator, Object inputField) {
         Object max;
 
         if (accumulator == null || inputField == null) {
@@ -51,5 +50,16 @@ public class FieldMaxAgg extends FieldAggregator {
             }
         }
         return max;
+    }
+
+    @Override
+    public Object agg(Object accumulator, Object inputField, Object currentSeq) {
+        this.seq = currentSeq;
+        return agg(accumulator, inputField);
+    }
+
+    @Override
+    public Object aggForOldSeq(Object accumulator, Object inputField, Object currentSeq) {
+        return agg(accumulator, inputField);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldMergeMapAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldMergeMapAgg.java
@@ -44,12 +44,22 @@ public class FieldMergeMapAgg extends FieldAggregator {
     }
 
     @Override
-    String name() {
+    public String name() {
         return NAME;
     }
 
     @Override
-    public Object agg(Object accumulator, Object inputField) {
+    public Object agg(Object accumulator, Object inputField, Object currentSeq) {
+        this.seq = currentSeq;
+        return agg(accumulator, inputField);
+    }
+
+    @Override
+    public Object aggForOldSeq(Object accumulator, Object inputField, Object currentSeq) {
+        return agg(accumulator, inputField);
+    }
+
+    private Object agg(Object accumulator, Object inputField) {
         if (accumulator == null || inputField == null) {
             return accumulator == null ? inputField : accumulator;
         }
@@ -73,7 +83,8 @@ public class FieldMergeMapAgg extends FieldAggregator {
     }
 
     @Override
-    public Object retract(Object accumulator, Object retractField) {
+    public Object retract(Object accumulator, Object retractField, Object currentSeq) {
+        this.seq = currentSeq;
         if (accumulator == null) {
             return null;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldMinAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldMinAgg.java
@@ -32,12 +32,22 @@ public class FieldMinAgg extends FieldAggregator {
     }
 
     @Override
-    String name() {
+    public String name() {
         return NAME;
     }
 
     @Override
-    public Object agg(Object accumulator, Object inputField) {
+    public Object agg(Object accumulator, Object inputField, Object currentSeq) {
+        this.seq = currentSeq;
+        return agg(accumulator, inputField);
+    }
+
+    @Override
+    public Object aggForOldSeq(Object accumulator, Object inputField, Object currentSeq) {
+        return agg(accumulator, inputField);
+    }
+
+    private Object agg(Object accumulator, Object inputField) {
         Object min;
 
         if (accumulator == null || inputField == null) {

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldNestedUpdateAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldNestedUpdateAgg.java
@@ -65,11 +65,21 @@ public class FieldNestedUpdateAgg extends FieldAggregator {
     }
 
     @Override
-    String name() {
+    public String name() {
         return NAME;
     }
 
     @Override
+    public Object agg(Object accumulator, Object inputField, Object currentSeq) {
+        this.seq = currentSeq;
+        return agg(accumulator, inputField);
+    }
+
+    @Override
+    public Object aggForOldSeq(Object accumulator, Object inputField, Object currentSeq) {
+        return agg(inputField, accumulator);
+    }
+
     public Object agg(Object accumulator, Object inputField) {
         if (accumulator == null || inputField == null) {
             return accumulator == null ? inputField : accumulator;
@@ -100,7 +110,8 @@ public class FieldNestedUpdateAgg extends FieldAggregator {
     }
 
     @Override
-    public Object retract(Object accumulator, Object retractField) {
+    public Object retract(Object accumulator, Object retractField, Object currentSeq) {
+        this.seq = currentSeq;
         if (accumulator == null || retractField == null) {
             return accumulator;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldPrimaryKeyAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldPrimaryKeyAgg.java
@@ -30,17 +30,24 @@ public class FieldPrimaryKeyAgg extends FieldAggregator {
     }
 
     @Override
-    String name() {
+    public String name() {
         return NAME;
     }
 
     @Override
-    public Object agg(Object accumulator, Object inputField) {
+    public Object agg(Object accumulator, Object inputField, Object currentSeq) {
+        this.seq = currentSeq;
         return inputField;
     }
 
     @Override
-    public Object retract(Object accumulator, Object inputField) {
+    public Object aggForOldSeq(Object accumulator, Object inputField, Object currentSeq) {
+        return inputField;
+    }
+
+    @Override
+    public Object retract(Object accumulator, Object inputField, Object sequence) {
+        this.seq = sequence;
         return inputField;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldProductAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldProductAgg.java
@@ -35,12 +35,22 @@ public class FieldProductAgg extends FieldAggregator {
     }
 
     @Override
-    String name() {
+    public String name() {
         return NAME;
     }
 
     @Override
-    public Object agg(Object accumulator, Object inputField) {
+    public Object agg(Object accumulator, Object inputField, Object currentSeq) {
+        this.seq = currentSeq;
+        return agg(accumulator, inputField);
+    }
+
+    @Override
+    public Object aggForOldSeq(Object accumulator, Object inputField, Object currentSeq) {
+        return agg(accumulator, inputField);
+    }
+
+    private Object agg(Object accumulator, Object inputField) {
         Object product;
 
         if (accumulator == null || inputField == null) {
@@ -86,7 +96,8 @@ public class FieldProductAgg extends FieldAggregator {
     }
 
     @Override
-    public Object retract(Object accumulator, Object inputField) {
+    public Object retract(Object accumulator, Object inputField, Object sequence) {
+        this.seq = sequence;
         Object product;
 
         if (accumulator == null || inputField == null) {

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldSumAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldSumAgg.java
@@ -32,12 +32,22 @@ public class FieldSumAgg extends FieldAggregator {
     }
 
     @Override
-    String name() {
+    public String name() {
         return NAME;
     }
 
     @Override
-    public Object agg(Object accumulator, Object inputField) {
+    public Object agg(Object accumulator, Object inputField, Object currentSeq) {
+        this.seq = currentSeq;
+        return agg(accumulator, inputField);
+    }
+
+    @Override
+    public Object aggForOldSeq(Object accumulator, Object inputField, Object currentSeq) {
+        return agg(accumulator, inputField);
+    }
+
+    private Object agg(Object accumulator, Object inputField) {
         Object sum;
 
         if (accumulator == null || inputField == null) {
@@ -85,7 +95,8 @@ public class FieldSumAgg extends FieldAggregator {
     }
 
     @Override
-    public Object retract(Object accumulator, Object inputField) {
+    public Object retract(Object accumulator, Object inputField, Object sequence) {
+        this.seq = sequence;
         Object sum;
 
         if (accumulator == null || inputField == null) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyTableUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyTableUtils.java
@@ -68,11 +68,7 @@ public class PrimaryKeyTableUtils {
             case PARTIAL_UPDATE:
                 return PartialUpdateMergeFunction.factory(conf, rowType, tableSchema.primaryKeys());
             case AGGREGATE:
-                return AggregateMergeFunction.factory(
-                        conf,
-                        tableSchema.fieldNames(),
-                        rowType.getFieldTypes(),
-                        tableSchema.primaryKeys());
+                return AggregateMergeFunction.factory(conf, rowType, tableSchema.primaryKeys());
             case FIRST_ROW:
                 return FirstRowMergeFunction.factory(
                         new RowType(extractor.keyFields(tableSchema)), rowType, conf);

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/SortBufferWriteBufferTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/SortBufferWriteBufferTestBase.java
@@ -203,8 +203,9 @@ public abstract class SortBufferWriteBufferTestBase {
             options.set("fields.value.aggregate-function", "sum");
             return AggregateMergeFunction.factory(
                             options,
-                            Collections.singletonList("value"),
-                            Collections.singletonList(DataTypes.BIGINT()),
+                            new RowType(
+                                    ImmutableList.of(
+                                            new DataField(0, "value", DataTypes.BIGINT()))),
                             Collections.emptyList())
                     .create();
         }
@@ -230,8 +231,9 @@ public abstract class SortBufferWriteBufferTestBase {
             MergeFunctionFactory<KeyValue> aggMergeFunction =
                     AggregateMergeFunction.factory(
                             options,
-                            Collections.singletonList("value"),
-                            Collections.singletonList(DataTypes.BIGINT()),
+                            new RowType(
+                                    ImmutableList.of(
+                                            new DataField(0, "value", DataTypes.BIGINT()))),
                             Collections.emptyList());
             return LookupMergeFunction.wrap(
                             aggMergeFunction,

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
@@ -22,8 +22,8 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.data.InternalRow.FieldGetter;
 import org.apache.paimon.lookup.LookupStrategy;
+import org.apache.paimon.mergetree.SequenceGenerator;
 import org.apache.paimon.mergetree.compact.aggregate.AggregateMergeFunction;
 import org.apache.paimon.mergetree.compact.aggregate.FieldAggregator;
 import org.apache.paimon.mergetree.compact.aggregate.FieldSumAgg;
@@ -218,12 +218,13 @@ public class LookupChangelogMergeFunctionWrapperTest {
                         LookupMergeFunction.wrap(
                                 projection ->
                                         new AggregateMergeFunction(
-                                                new FieldGetter[] {
+                                                new InternalRow.FieldGetter[] {
                                                     row -> row.isNullAt(0) ? null : row.getInt(0)
                                                 },
                                                 new FieldAggregator[] {
                                                     new FieldSumAgg(DataTypes.INT())
-                                                }),
+                                                },
+                                                new SequenceGenerator.Seq[1]),
                                 RowType.of(DataTypes.INT()),
                                 RowType.of(DataTypes.INT())),
                         key -> null,

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunctionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunctionTest.java
@@ -324,11 +324,17 @@ public class PartialUpdateMergeFunctionTest {
     @Test
     public void testFirstValue() {
         Options options = new Options();
-        options.set("fields.f1.sequence-group", "f2,f3");
+        options.set("fields.f1.sequence-group", "f2");
         options.set("fields.f2.aggregate-function", "first_value");
-        options.set("fields.f3.aggregate-function", "last_value");
+        options.set("fields.f3.sequence-group", "f4");
+        options.set("fields.f4.aggregate-function", "last_value");
         RowType rowType =
-                RowType.of(DataTypes.INT(), DataTypes.INT(), DataTypes.INT(), DataTypes.INT());
+                RowType.of(
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT());
         MergeFunction<KeyValue> func =
                 PartialUpdateMergeFunction.factory(options, rowType, ImmutableList.of("f0"))
                         .create();
@@ -336,11 +342,11 @@ public class PartialUpdateMergeFunctionTest {
         func.reset();
 
         // f7 sequence group 2
-        add(func, 1, 1, 1, 1);
-        add(func, 1, 2, 2, 2);
-        validate(func, 1, 2, 1, 2);
-        add(func, 1, 0, 3, 3);
-        validate(func, 1, 2, 3, 2);
+        add(func, 1, 1, 1, 1, 1);
+        add(func, 1, 2, 2, 2, 2);
+        validate(func, 1, 1, 1, 2, 2);
+        add(func, 1, 0, 0, 3, 3);
+        validate(func, 1, 0, 0, 3, 3);
     }
 
     @Test
@@ -388,7 +394,7 @@ public class PartialUpdateMergeFunctionTest {
 
         // test null
         add(func, 1, 3, null, null, null, null, null, 2);
-        validate(func, 1, 3, 2, null, null, 2, 1, 2);
+        validate(func, 1, 3, 2, null, null, 2, 1, 1);
 
         // test retract
         add(func, 1, 3, 1, 1, 1, 1, 1, 3);

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -60,15 +60,15 @@ public class FieldAggregatorTest {
     @Test
     public void testFieldBoolAndAgg() {
         FieldBoolAndAgg fieldBoolAndAgg = new FieldBoolAndAgg(new BooleanType());
-        assertThat(fieldBoolAndAgg.agg(false, true)).isEqualTo(false);
-        assertThat(fieldBoolAndAgg.agg(true, true)).isEqualTo(true);
+        assertThat(fieldBoolAndAgg.agg(false, true, 1)).isEqualTo(false);
+        assertThat(fieldBoolAndAgg.agg(true, true, 1)).isEqualTo(true);
     }
 
     @Test
     public void testFieldBoolOrAgg() {
         FieldBoolOrAgg fieldBoolOrAgg = new FieldBoolOrAgg(new BooleanType());
-        assertThat(fieldBoolOrAgg.agg(false, true)).isEqualTo(true);
-        assertThat(fieldBoolOrAgg.agg(false, false)).isEqualTo(false);
+        assertThat(fieldBoolOrAgg.agg(false, true, 1)).isEqualTo(true);
+        assertThat(fieldBoolOrAgg.agg(false, false, 1)).isEqualTo(false);
     }
 
     @Test
@@ -77,11 +77,11 @@ public class FieldAggregatorTest {
                 new FieldLastNonNullValueAgg(new IntType());
         Integer accumulator = null;
         Integer inputField = 1;
-        assertThat(fieldLastNonNullValueAgg.agg(accumulator, inputField)).isEqualTo(1);
+        assertThat(fieldLastNonNullValueAgg.agg(accumulator, inputField, 1)).isEqualTo(1);
 
         accumulator = 1;
         inputField = null;
-        assertThat(fieldLastNonNullValueAgg.agg(accumulator, inputField)).isEqualTo(1);
+        assertThat(fieldLastNonNullValueAgg.agg(accumulator, inputField, 1)).isEqualTo(1);
     }
 
     @Test
@@ -89,33 +89,33 @@ public class FieldAggregatorTest {
         FieldLastValueAgg fieldLastValueAgg = new FieldLastValueAgg(new IntType());
         Integer accumulator = null;
         Integer inputField = 1;
-        assertThat(fieldLastValueAgg.agg(accumulator, inputField)).isEqualTo(1);
+        assertThat(fieldLastValueAgg.agg(accumulator, inputField, 1)).isEqualTo(1);
 
         accumulator = 1;
         inputField = null;
-        assertThat(fieldLastValueAgg.agg(accumulator, inputField)).isEqualTo(null);
+        assertThat(fieldLastValueAgg.agg(accumulator, inputField, 1)).isEqualTo(null);
     }
 
     @Test
     public void testFieldFirstValueAgg() {
         FieldFirstValueAgg fieldFirstValueAgg = new FieldFirstValueAgg(new IntType());
-        assertThat(fieldFirstValueAgg.agg(null, 1)).isEqualTo(1);
-        assertThat(fieldFirstValueAgg.agg(1, 2)).isEqualTo(1);
+        assertThat(fieldFirstValueAgg.agg(null, 1, 1)).isEqualTo(1);
+        assertThat(fieldFirstValueAgg.agg(1, 2, 1)).isEqualTo(1);
 
         fieldFirstValueAgg.reset();
-        assertThat(fieldFirstValueAgg.agg(1, 3)).isEqualTo(3);
+        assertThat(fieldFirstValueAgg.agg(1, 3, 1)).isEqualTo(3);
     }
 
     @Test
     public void testFieldFirstNonNullValueAgg() {
         FieldFirstNonNullValueAgg fieldFirstNonNullValueAgg =
                 new FieldFirstNonNullValueAgg(new IntType());
-        assertThat(fieldFirstNonNullValueAgg.agg(null, null)).isNull();
-        assertThat(fieldFirstNonNullValueAgg.agg(null, 1)).isEqualTo(1);
-        assertThat(fieldFirstNonNullValueAgg.agg(1, 2)).isEqualTo(1);
+        assertThat(fieldFirstNonNullValueAgg.agg(null, null, 1)).isNull();
+        assertThat(fieldFirstNonNullValueAgg.agg(null, 1, 1)).isEqualTo(1);
+        assertThat(fieldFirstNonNullValueAgg.agg(1, 2, 1)).isEqualTo(1);
 
         fieldFirstNonNullValueAgg.reset();
-        assertThat(fieldFirstNonNullValueAgg.agg(1, 3)).isEqualTo(3);
+        assertThat(fieldFirstNonNullValueAgg.agg(1, 3, 1)).isEqualTo(3);
     }
 
     @Test
@@ -123,7 +123,7 @@ public class FieldAggregatorTest {
         FieldListaggAgg fieldListaggAgg = new FieldListaggAgg(new VarCharType());
         BinaryString accumulator = BinaryString.fromString("user1");
         BinaryString inputField = BinaryString.fromString("user2");
-        assertThat(fieldListaggAgg.agg(accumulator, inputField).toString())
+        assertThat(fieldListaggAgg.agg(accumulator, inputField, 1).toString())
                 .isEqualTo("user1,user2");
     }
 
@@ -132,7 +132,7 @@ public class FieldAggregatorTest {
         FieldMaxAgg fieldMaxAgg = new FieldMaxAgg(new IntType());
         Integer accumulator = 1;
         Integer inputField = 10;
-        assertThat(fieldMaxAgg.agg(accumulator, inputField)).isEqualTo(10);
+        assertThat(fieldMaxAgg.agg(accumulator, inputField, 1)).isEqualTo(10);
     }
 
     @Test
@@ -140,142 +140,142 @@ public class FieldAggregatorTest {
         FieldMinAgg fieldMinAgg = new FieldMinAgg(new IntType());
         Integer accumulator = 1;
         Integer inputField = 10;
-        assertThat(fieldMinAgg.agg(accumulator, inputField)).isEqualTo(1);
+        assertThat(fieldMinAgg.agg(accumulator, inputField, 1)).isEqualTo(1);
     }
 
     @Test
     public void testFieldSumIntAgg() {
         FieldSumAgg fieldSumAgg = new FieldSumAgg(new IntType());
-        assertThat(fieldSumAgg.agg(null, 10)).isEqualTo(10);
-        assertThat(fieldSumAgg.agg(1, 10)).isEqualTo(11);
-        assertThat(fieldSumAgg.retract(10, 5)).isEqualTo(5);
-        assertThat(fieldSumAgg.retract(null, 5)).isEqualTo(-5);
+        assertThat(fieldSumAgg.agg(null, 10, 1)).isEqualTo(10);
+        assertThat(fieldSumAgg.agg(1, 10, 1)).isEqualTo(11);
+        assertThat(fieldSumAgg.retract(10, 5, 1)).isEqualTo(5);
+        assertThat(fieldSumAgg.retract(null, 5, 1)).isEqualTo(-5);
     }
 
     @Test
     public void testFieldCountIntAgg() {
         FieldCountAgg fieldCountAgg = new FieldCountAgg(new IntType());
-        assertThat(fieldCountAgg.agg(null, 10)).isEqualTo(1);
-        assertThat(fieldCountAgg.agg(1, 5)).isEqualTo(2);
-        assertThat(fieldCountAgg.agg(2, 15)).isEqualTo(3);
-        assertThat(fieldCountAgg.agg(3, 25)).isEqualTo(4);
+        assertThat(fieldCountAgg.agg(null, 10, 1)).isEqualTo(1);
+        assertThat(fieldCountAgg.agg(1, 5, 1)).isEqualTo(2);
+        assertThat(fieldCountAgg.agg(2, 15, 1)).isEqualTo(3);
+        assertThat(fieldCountAgg.agg(3, 25, 1)).isEqualTo(4);
     }
 
     @Test
     public void testFieldProductIntAgg() {
         FieldProductAgg fieldProductAgg = new FieldProductAgg(new IntType());
-        assertThat(fieldProductAgg.agg(null, 10)).isEqualTo(10);
-        assertThat(fieldProductAgg.agg(1, 10)).isEqualTo(10);
-        assertThat(fieldProductAgg.retract(10, 5)).isEqualTo(2);
-        assertThat(fieldProductAgg.retract(null, 5)).isEqualTo(5);
+        assertThat(fieldProductAgg.agg(null, 10, 1)).isEqualTo(10);
+        assertThat(fieldProductAgg.agg(1, 10, 1)).isEqualTo(10);
+        assertThat(fieldProductAgg.retract(10, 5, 1)).isEqualTo(2);
+        assertThat(fieldProductAgg.retract(null, 5, 1)).isEqualTo(5);
     }
 
     @Test
     public void testFieldSumByteAgg() {
         FieldSumAgg fieldSumAgg = new FieldSumAgg(new TinyIntType());
-        assertThat(fieldSumAgg.agg(null, (byte) 10)).isEqualTo((byte) 10);
-        assertThat(fieldSumAgg.agg((byte) 1, (byte) 10)).isEqualTo((byte) 11);
-        assertThat(fieldSumAgg.retract((byte) 10, (byte) 5)).isEqualTo((byte) 5);
-        assertThat(fieldSumAgg.retract(null, (byte) 5)).isEqualTo((byte) -5);
+        assertThat(fieldSumAgg.agg(null, (byte) 10, 1)).isEqualTo((byte) 10);
+        assertThat(fieldSumAgg.agg((byte) 1, (byte) 10, 1)).isEqualTo((byte) 11);
+        assertThat(fieldSumAgg.retract((byte) 10, (byte) 5, 1)).isEqualTo((byte) 5);
+        assertThat(fieldSumAgg.retract(null, (byte) 5, 1)).isEqualTo((byte) -5);
     }
 
     @Test
     public void testFieldProductByteAgg() {
         FieldProductAgg fieldProductAgg = new FieldProductAgg(new TinyIntType());
-        assertThat(fieldProductAgg.agg(null, (byte) 10)).isEqualTo((byte) 10);
-        assertThat(fieldProductAgg.agg((byte) 1, (byte) 10)).isEqualTo((byte) 10);
-        assertThat(fieldProductAgg.retract((byte) 10, (byte) 5)).isEqualTo((byte) 2);
-        assertThat(fieldProductAgg.retract(null, (byte) 5)).isEqualTo((byte) 5);
+        assertThat(fieldProductAgg.agg(null, (byte) 10, 1)).isEqualTo((byte) 10);
+        assertThat(fieldProductAgg.agg((byte) 1, (byte) 10, 1)).isEqualTo((byte) 10);
+        assertThat(fieldProductAgg.retract((byte) 10, (byte) 5, 1)).isEqualTo((byte) 2);
+        assertThat(fieldProductAgg.retract(null, (byte) 5, 1)).isEqualTo((byte) 5);
     }
 
     @Test
     public void testFieldProductShortAgg() {
         FieldProductAgg fieldProductAgg = new FieldProductAgg(new SmallIntType());
-        assertThat(fieldProductAgg.agg(null, (short) 10)).isEqualTo((short) 10);
-        assertThat(fieldProductAgg.agg((short) 1, (short) 10)).isEqualTo((short) 10);
-        assertThat(fieldProductAgg.retract((short) 10, (short) 5)).isEqualTo((short) 2);
-        assertThat(fieldProductAgg.retract(null, (short) 5)).isEqualTo((short) 5);
+        assertThat(fieldProductAgg.agg(null, (short) 10, 1)).isEqualTo((short) 10);
+        assertThat(fieldProductAgg.agg((short) 1, (short) 10, 1)).isEqualTo((short) 10);
+        assertThat(fieldProductAgg.retract((short) 10, (short) 5, 1)).isEqualTo((short) 2);
+        assertThat(fieldProductAgg.retract(null, (short) 5, 1)).isEqualTo((short) 5);
     }
 
     @Test
     public void testFieldSumShortAgg() {
         FieldSumAgg fieldSumAgg = new FieldSumAgg(new SmallIntType());
-        assertThat(fieldSumAgg.agg(null, (short) 10)).isEqualTo((short) 10);
-        assertThat(fieldSumAgg.agg((short) 1, (short) 10)).isEqualTo((short) 11);
-        assertThat(fieldSumAgg.retract((short) 10, (short) 5)).isEqualTo((short) 5);
-        assertThat(fieldSumAgg.retract(null, (short) 5)).isEqualTo((short) -5);
+        assertThat(fieldSumAgg.agg(null, (short) 10, 1)).isEqualTo((short) 10);
+        assertThat(fieldSumAgg.agg((short) 1, (short) 10, 1)).isEqualTo((short) 11);
+        assertThat(fieldSumAgg.retract((short) 10, (short) 5, 1)).isEqualTo((short) 5);
+        assertThat(fieldSumAgg.retract(null, (short) 5, 1)).isEqualTo((short) -5);
     }
 
     @Test
     public void testFieldSumLongAgg() {
         FieldSumAgg fieldSumAgg = new FieldSumAgg(new BigIntType());
-        assertThat(fieldSumAgg.agg(null, 10L)).isEqualTo(10L);
-        assertThat(fieldSumAgg.agg(1L, 10L)).isEqualTo(11L);
-        assertThat(fieldSumAgg.retract(10L, 5L)).isEqualTo(5L);
-        assertThat(fieldSumAgg.retract(null, 5L)).isEqualTo(-5L);
+        assertThat(fieldSumAgg.agg(null, 10L, 1)).isEqualTo(10L);
+        assertThat(fieldSumAgg.agg(1L, 10L, 1)).isEqualTo(11L);
+        assertThat(fieldSumAgg.retract(10L, 5L, 1)).isEqualTo(5L);
+        assertThat(fieldSumAgg.retract(null, 5L, 1)).isEqualTo(-5L);
     }
 
     @Test
     public void testFieldProductLongAgg() {
         FieldProductAgg fieldProductAgg = new FieldProductAgg(new BigIntType());
-        assertThat(fieldProductAgg.agg(null, 10L)).isEqualTo(10L);
-        assertThat(fieldProductAgg.agg(1L, 10L)).isEqualTo(10L);
-        assertThat(fieldProductAgg.retract(10L, 5L)).isEqualTo(2L);
-        assertThat(fieldProductAgg.retract(null, 5L)).isEqualTo(5L);
+        assertThat(fieldProductAgg.agg(null, 10L, 1)).isEqualTo(10L);
+        assertThat(fieldProductAgg.agg(1L, 10L, 1)).isEqualTo(10L);
+        assertThat(fieldProductAgg.retract(10L, 5L, 1)).isEqualTo(2L);
+        assertThat(fieldProductAgg.retract(null, 5L, 1)).isEqualTo(5L);
     }
 
     @Test
     public void testFieldProductFloatAgg() {
         FieldProductAgg fieldProductAgg = new FieldProductAgg(new FloatType());
-        assertThat(fieldProductAgg.agg(null, (float) 10)).isEqualTo((float) 10);
-        assertThat(fieldProductAgg.agg((float) 1, (float) 10)).isEqualTo((float) 10);
-        assertThat(fieldProductAgg.retract((float) 10, (float) 5)).isEqualTo((float) 2);
-        assertThat(fieldProductAgg.retract(null, (float) 5)).isEqualTo((float) 5);
+        assertThat(fieldProductAgg.agg(null, (float) 10, 1)).isEqualTo((float) 10);
+        assertThat(fieldProductAgg.agg((float) 1, (float) 10, 1)).isEqualTo((float) 10);
+        assertThat(fieldProductAgg.retract((float) 10, (float) 5, 1)).isEqualTo((float) 2);
+        assertThat(fieldProductAgg.retract(null, (float) 5, 1)).isEqualTo((float) 5);
     }
 
     @Test
     public void testFieldSumFloatAgg() {
         FieldSumAgg fieldSumAgg = new FieldSumAgg(new FloatType());
-        assertThat(fieldSumAgg.agg(null, (float) 10)).isEqualTo((float) 10);
-        assertThat(fieldSumAgg.agg((float) 1, (float) 10)).isEqualTo((float) 11);
-        assertThat(fieldSumAgg.retract((float) 10, (float) 5)).isEqualTo((float) 5);
-        assertThat(fieldSumAgg.retract(null, (float) 5)).isEqualTo((float) -5);
+        assertThat(fieldSumAgg.agg(null, (float) 10, 1)).isEqualTo((float) 10);
+        assertThat(fieldSumAgg.agg((float) 1, (float) 10, 1)).isEqualTo((float) 11);
+        assertThat(fieldSumAgg.retract((float) 10, (float) 5, 1)).isEqualTo((float) 5);
+        assertThat(fieldSumAgg.retract(null, (float) 5, 1)).isEqualTo((float) -5);
     }
 
     @Test
     public void testFieldProductDoubleAgg() {
         FieldProductAgg fieldProductAgg = new FieldProductAgg(new DoubleType());
-        assertThat(fieldProductAgg.agg(null, (double) 10)).isEqualTo((double) 10);
-        assertThat(fieldProductAgg.agg((double) 1, (double) 10)).isEqualTo((double) 10);
-        assertThat(fieldProductAgg.retract((double) 10, (double) 5)).isEqualTo((double) 2);
-        assertThat(fieldProductAgg.retract(null, (double) 5)).isEqualTo((double) 5);
+        assertThat(fieldProductAgg.agg(null, (double) 10, 1)).isEqualTo((double) 10);
+        assertThat(fieldProductAgg.agg((double) 1, (double) 10, 1)).isEqualTo((double) 10);
+        assertThat(fieldProductAgg.retract((double) 10, (double) 5, 1)).isEqualTo((double) 2);
+        assertThat(fieldProductAgg.retract(null, (double) 5, 1)).isEqualTo((double) 5);
     }
 
     @Test
     public void testFieldSumDoubleAgg() {
         FieldSumAgg fieldSumAgg = new FieldSumAgg(new DoubleType());
-        assertThat(fieldSumAgg.agg(null, (double) 10)).isEqualTo((double) 10);
-        assertThat(fieldSumAgg.agg((double) 1, (double) 10)).isEqualTo((double) 11);
-        assertThat(fieldSumAgg.retract((double) 10, (double) 5)).isEqualTo((double) 5);
-        assertThat(fieldSumAgg.retract(null, (double) 5)).isEqualTo((double) -5);
+        assertThat(fieldSumAgg.agg(null, (double) 10, 1)).isEqualTo((double) 10);
+        assertThat(fieldSumAgg.agg((double) 1, (double) 10, 1)).isEqualTo((double) 11);
+        assertThat(fieldSumAgg.retract((double) 10, (double) 5, 1)).isEqualTo((double) 5);
+        assertThat(fieldSumAgg.retract(null, (double) 5, 1)).isEqualTo((double) -5);
     }
 
     @Test
     public void testFieldProductDecimalAgg() {
         FieldProductAgg fieldProductAgg = new FieldProductAgg(new DecimalType());
-        assertThat(fieldProductAgg.agg(null, toDecimal(10))).isEqualTo(toDecimal(10));
-        assertThat(fieldProductAgg.agg(toDecimal(1), toDecimal(10))).isEqualTo(toDecimal(10));
-        assertThat(fieldProductAgg.retract(toDecimal(10), toDecimal(5))).isEqualTo(toDecimal(2));
-        assertThat(fieldProductAgg.retract(null, toDecimal(5))).isEqualTo(toDecimal(5));
+        assertThat(fieldProductAgg.agg(null, toDecimal(10), 1)).isEqualTo(toDecimal(10));
+        assertThat(fieldProductAgg.agg(toDecimal(1), toDecimal(10), 1)).isEqualTo(toDecimal(10));
+        assertThat(fieldProductAgg.retract(toDecimal(10), toDecimal(5), 1)).isEqualTo(toDecimal(2));
+        assertThat(fieldProductAgg.retract(null, toDecimal(5), 1)).isEqualTo(toDecimal(5));
     }
 
     @Test
     public void testFieldSumDecimalAgg() {
         FieldSumAgg fieldSumAgg = new FieldSumAgg(new DecimalType());
-        assertThat(fieldSumAgg.agg(null, toDecimal(10))).isEqualTo(toDecimal(10));
-        assertThat(fieldSumAgg.agg(toDecimal(1), toDecimal(10))).isEqualTo(toDecimal(11));
-        assertThat(fieldSumAgg.retract(toDecimal(10), toDecimal(5))).isEqualTo(toDecimal(5));
-        assertThat(fieldSumAgg.retract(null, toDecimal(5))).isEqualTo(toDecimal(-5));
+        assertThat(fieldSumAgg.agg(null, toDecimal(10), 1)).isEqualTo(toDecimal(10));
+        assertThat(fieldSumAgg.agg(toDecimal(1), toDecimal(10), 1)).isEqualTo(toDecimal(11));
+        assertThat(fieldSumAgg.retract(toDecimal(10), toDecimal(5), 1)).isEqualTo(toDecimal(5));
+        assertThat(fieldSumAgg.retract(null, toDecimal(5), 1)).isEqualTo(toDecimal(-5));
     }
 
     private static Decimal toDecimal(int i) {
@@ -319,7 +319,7 @@ public class FieldAggregatorTest {
                 .containsExactlyInAnyOrderElementsOf(Arrays.asList(row(0, 0, "A"), row(0, 1, "b")));
 
         current = row(0, 1, "b");
-        accumulator = (InternalArray) agg.retract(accumulator, singletonArray(current));
+        accumulator = (InternalArray) agg.retract(accumulator, singletonArray(current), 1);
         assertThat(unnest(accumulator, elementGetter))
                 .containsExactlyInAnyOrderElementsOf(Collections.singletonList(row(0, 0, "A")));
     }
@@ -349,7 +349,7 @@ public class FieldAggregatorTest {
                 .containsExactlyInAnyOrderElementsOf(Arrays.asList(row(0, 1, "B"), row(0, 1, "b")));
 
         current = row(0, 1, "b");
-        accumulator = (InternalArray) agg.retract(accumulator, singletonArray(current));
+        accumulator = (InternalArray) agg.retract(accumulator, singletonArray(current), 1);
         assertThat(unnest(accumulator, elementGetter))
                 .containsExactlyInAnyOrderElementsOf(Collections.singletonList(row(0, 1, "B")));
     }
@@ -376,16 +376,17 @@ public class FieldAggregatorTest {
         InternalArray.ElementGetter elementGetter =
                 InternalArray.createElementGetter(DataTypes.INT());
 
-        assertThat(agg.agg(null, null)).isNull();
+        assertThat(agg.agg(null, null, 1)).isNull();
 
-        result = (InternalArray) agg.agg(null, new GenericArray(new int[] {1, 1, 2}));
+        result = (InternalArray) agg.agg(null, new GenericArray(new int[] {1, 1, 2}), 1);
         assertThat(unnest(result, elementGetter)).containsExactlyInAnyOrder(1, 2);
 
         result =
                 (InternalArray)
                         agg.agg(
                                 new GenericArray(new int[] {1, 1, 2}),
-                                new GenericArray(new int[] {2, 3}));
+                                new GenericArray(new int[] {2, 3}),
+                                1);
         assertThat(unnest(result, elementGetter)).containsExactlyInAnyOrder(1, 2, 3);
     }
 
@@ -397,14 +398,14 @@ public class FieldAggregatorTest {
         InternalArray result;
         InternalArray.ElementGetter elementGetter = InternalArray.createElementGetter(rowType);
 
-        assertThat(agg.agg(null, null)).isNull();
+        assertThat(agg.agg(null, null, 1)).isNull();
 
         Object[] input1 =
                 new Object[] {
                     GenericRow.of(1, BinaryString.fromString("A")),
                     GenericRow.of(1, BinaryString.fromString("B"))
                 };
-        result = (InternalArray) agg.agg(null, new GenericArray(input1));
+        result = (InternalArray) agg.agg(null, new GenericArray(input1), 1);
         assertThat(unnest(result, elementGetter)).containsExactlyInAnyOrder(input1);
 
         Object[] input2 =
@@ -412,7 +413,7 @@ public class FieldAggregatorTest {
                     GenericRow.of(1, BinaryString.fromString("A")),
                     GenericRow.of(2, BinaryString.fromString("A"))
                 };
-        result = (InternalArray) agg.agg(new GenericArray(input1), new GenericArray(input2));
+        result = (InternalArray) agg.agg(new GenericArray(input1), new GenericArray(input2), 1);
         assertThat(unnest(result, elementGetter))
                 .containsExactlyInAnyOrder(
                         GenericRow.of(1, BinaryString.fromString("A")),
@@ -428,13 +429,13 @@ public class FieldAggregatorTest {
         InternalArray result;
         InternalArray.ElementGetter elementGetter = InternalArray.createElementGetter(arrayType);
 
-        assertThat(agg.agg(null, null)).isNull();
+        assertThat(agg.agg(null, null, 1)).isNull();
 
         Object[] input1 =
                 new Object[] {
                     new GenericArray(new Object[] {1, 1}), new GenericArray(new Object[] {1, 2})
                 };
-        result = (InternalArray) agg.agg(null, new GenericArray(input1));
+        result = (InternalArray) agg.agg(null, new GenericArray(input1), 1);
         assertThat(unnest(result, elementGetter)).containsExactlyInAnyOrder(input1);
 
         Object[] input2 =
@@ -443,7 +444,7 @@ public class FieldAggregatorTest {
                     new GenericArray(new Object[] {1, 2}),
                     new GenericArray(new Object[] {2, 1})
                 };
-        result = (InternalArray) agg.agg(new GenericArray(input1), new GenericArray(input2));
+        result = (InternalArray) agg.agg(new GenericArray(input1), new GenericArray(input2), 1);
         assertThat(unnest(result, elementGetter))
                 .containsExactlyInAnyOrder(
                         new GenericArray(new Object[] {1, 1}),
@@ -459,11 +460,11 @@ public class FieldAggregatorTest {
         InternalArray result;
         InternalArray.ElementGetter elementGetter = InternalArray.createElementGetter(mapType);
 
-        assertThat(agg.agg(null, null)).isNull();
+        assertThat(agg.agg(null, null, 1)).isNull();
 
         Object[] input1 =
                 new Object[] {new GenericMap(toMap(1, "A")), new GenericMap(toMap(1, "A", 2, "B"))};
-        result = (InternalArray) agg.agg(null, new GenericArray(input1));
+        result = (InternalArray) agg.agg(null, new GenericArray(input1), 1);
         assertThat(unnest(result, elementGetter)).containsExactlyInAnyOrder(input1);
 
         Object[] input2 =
@@ -472,7 +473,7 @@ public class FieldAggregatorTest {
                     new GenericMap(toMap(2, "B", 1, "A")),
                     new GenericMap(toMap(1, "C"))
                 };
-        result = (InternalArray) agg.agg(new GenericArray(input1), new GenericArray(input2));
+        result = (InternalArray) agg.agg(new GenericArray(input1), new GenericArray(input2), 1);
         assertThat(unnest(result, elementGetter))
                 .containsExactlyInAnyOrder(
                         new GenericMap(toMap(1, "A")),
@@ -488,16 +489,17 @@ public class FieldAggregatorTest {
         InternalArray.ElementGetter elementGetter =
                 InternalArray.createElementGetter(DataTypes.INT());
 
-        assertThat(agg.agg(null, null)).isNull();
+        assertThat(agg.agg(null, null, 1)).isNull();
 
-        result = (InternalArray) agg.agg(null, new GenericArray(new int[] {1, 1, 2}));
+        result = (InternalArray) agg.agg(null, new GenericArray(new int[] {1, 1, 2}), 1);
         assertThat(unnest(result, elementGetter)).containsExactlyInAnyOrder(1, 1, 2);
 
         result =
                 (InternalArray)
                         agg.agg(
                                 new GenericArray(new int[] {1, 1, 2}),
-                                new GenericArray(new int[] {2, 3}));
+                                new GenericArray(new int[] {2, 3}),
+                                1);
         assertThat(unnest(result, elementGetter)).containsExactlyInAnyOrder(1, 1, 2, 2, 3);
     }
 
@@ -513,7 +515,8 @@ public class FieldAggregatorTest {
                 (InternalArray)
                         agg.retract(
                                 new GenericArray(new int[] {1, 2, 3}),
-                                new GenericArray(new int[] {1}));
+                                new GenericArray(new int[] {1}),
+                                1);
         assertThat(unnest(result, elementGetter)).containsExactlyInAnyOrder(2, 3);
 
         // row type
@@ -535,7 +538,9 @@ public class FieldAggregatorTest {
         result =
                 (InternalArray)
                         agg.retract(
-                                new GenericArray(accElements), new GenericArray(retractElements));
+                                new GenericArray(accElements),
+                                new GenericArray(retractElements),
+                                1);
         assertThat(unnest(result, elementGetter))
                 .containsExactlyInAnyOrder(GenericRow.of(1, BinaryString.fromString("B")));
 
@@ -557,7 +562,9 @@ public class FieldAggregatorTest {
         result =
                 (InternalArray)
                         agg.retract(
-                                new GenericArray(accElements), new GenericArray(retractElements));
+                                new GenericArray(accElements),
+                                new GenericArray(retractElements),
+                                1);
         assertThat(unnest(result, elementGetter))
                 .containsExactlyInAnyOrder(new GenericArray(new Object[] {2, 1}));
 
@@ -577,7 +584,9 @@ public class FieldAggregatorTest {
         result =
                 (InternalArray)
                         agg.retract(
-                                new GenericArray(accElements), new GenericArray(retractElements));
+                                new GenericArray(accElements),
+                                new GenericArray(retractElements),
+                                1);
 
         assertThat(unnest(result, elementGetter))
                 .containsExactlyInAnyOrder(new GenericMap(toMap(1, "C")));
@@ -595,7 +604,8 @@ public class FieldAggregatorTest {
                 (InternalArray)
                         agg.retract(
                                 new GenericArray(new int[] {1, 1, 2, 2, 3}),
-                                new GenericArray(new int[] {1, 2, 3}));
+                                new GenericArray(new int[] {1, 2, 3}),
+                                1);
         assertThat(unnest(result, elementGetter)).containsExactlyInAnyOrder(1, 2);
 
         // row type
@@ -618,7 +628,9 @@ public class FieldAggregatorTest {
         result =
                 (InternalArray)
                         agg.retract(
-                                new GenericArray(accElements), new GenericArray(retractElements));
+                                new GenericArray(accElements),
+                                new GenericArray(retractElements),
+                                1);
         assertThat(unnest(result, elementGetter))
                 .containsExactlyInAnyOrder(
                         GenericRow.of(1, BinaryString.fromString("A")),
@@ -643,7 +655,9 @@ public class FieldAggregatorTest {
         result =
                 (InternalArray)
                         agg.retract(
-                                new GenericArray(accElements), new GenericArray(retractElements));
+                                new GenericArray(accElements),
+                                new GenericArray(retractElements),
+                                1);
         assertThat(unnest(result, elementGetter))
                 .containsExactlyInAnyOrder(
                         new GenericArray(new Object[] {1, 1}),
@@ -666,7 +680,9 @@ public class FieldAggregatorTest {
         result =
                 (InternalArray)
                         agg.retract(
-                                new GenericArray(accElements), new GenericArray(retractElements));
+                                new GenericArray(accElements),
+                                new GenericArray(retractElements),
+                                1);
 
         assertThat(unnest(result, elementGetter))
                 .containsExactlyInAnyOrder(
@@ -678,16 +694,16 @@ public class FieldAggregatorTest {
         FieldMergeMapAgg agg =
                 new FieldMergeMapAgg(DataTypes.MAP(DataTypes.INT(), DataTypes.STRING()));
 
-        assertThat(agg.agg(null, null)).isNull();
+        assertThat(agg.agg(null, null, 1)).isNull();
 
-        Object accumulator = agg.agg(null, new GenericMap(toMap(1, "A")));
+        Object accumulator = agg.agg(null, new GenericMap(toMap(1, "A")), 1);
         assertThat(toJavaMap(accumulator)).containsExactlyInAnyOrderEntriesOf(toMap(1, "A"));
 
-        accumulator = agg.agg(accumulator, new GenericMap(toMap(1, "A", 2, "B")));
+        accumulator = agg.agg(accumulator, new GenericMap(toMap(1, "A", 2, "B")), 1);
         assertThat(toJavaMap(accumulator))
                 .containsExactlyInAnyOrderEntriesOf(toMap(1, "A", 2, "B"));
 
-        accumulator = agg.agg(accumulator, new GenericMap(toMap(1, "a", 3, "c")));
+        accumulator = agg.agg(accumulator, new GenericMap(toMap(1, "a", 3, "c")), 1);
         assertThat(toJavaMap(accumulator))
                 .containsExactlyInAnyOrderEntriesOf(toMap(1, "a", 2, "B", 3, "c"));
     }
@@ -699,7 +715,8 @@ public class FieldAggregatorTest {
         Object result =
                 agg.retract(
                         new GenericMap(toMap(1, "A", 2, "B", 3, "C")),
-                        new GenericMap(toMap(1, "A", 2, "A")));
+                        new GenericMap(toMap(1, "A", 2, "A")),
+                        1);
         assertThat(toJavaMap(result)).containsExactlyInAnyOrderEntriesOf(toMap(3, "C"));
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PreAggregationITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PreAggregationITCase.java
@@ -1332,6 +1332,22 @@ public class PreAggregationITCase {
         }
 
         @Test
+        public void testAggregate() {
+            sql(
+                    "CREATE TABLE AGG ("
+                            + "k INT, a varchar, g_1 bigINT, "
+                            + " PRIMARY KEY (k) NOT ENFORCED)"
+                            + " WITH ("
+                            + "'merge-engine'='aggregation', "
+                            + "'fields.g_1.sequence-group'='a', "
+                            + "'full-compaction.delta-commits'='1');");
+            sql("INSERT INTO AGG VALUES (1, cast(null as varchar), 4)");
+            sql("INSERT INTO AGG VALUES (1, '2', 2)");
+            sql("INSERT INTO AGG VALUES (1, '3', 3)");
+            assertThat(sql("SELECT * FROM AGG")).containsExactlyInAnyOrder(Row.of(1, "3", 3L));
+        }
+
+        @Test
         @Timeout(60)
         public void testUpdateWithIgnoreRetract() throws Exception {
             sEnv.getConfig()


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3020

This pr is meant to fix the incorrect aggregation result for `first`, `first_not_null`, `last_not_null`

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
