### PR TITLE
[core] Expose VectorizedRecordIterator to accelerate append table read

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarRow.java
@@ -25,7 +25,6 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
-import org.apache.paimon.data.columnar.BytesColumnVector.Bytes;
 import org.apache.paimon.types.RowKind;
 
 import java.io.Serializable;
@@ -56,6 +55,10 @@ public final class ColumnarRow implements InternalRow, DataSetters, Serializable
     public void setVectorizedColumnBatch(VectorizedColumnBatch vectorizedColumnBatch) {
         this.vectorizedColumnBatch = vectorizedColumnBatch;
         this.rowId = 0;
+    }
+
+    public VectorizedColumnBatch batch() {
+        return vectorizedColumnBatch;
     }
 
     public void setRowId(int rowId) {
@@ -119,8 +122,7 @@ public final class ColumnarRow implements InternalRow, DataSetters, Serializable
 
     @Override
     public BinaryString getString(int pos) {
-        Bytes byteArray = vectorizedColumnBatch.getByteArray(rowId, pos);
-        return BinaryString.fromBytes(byteArray.data, byteArray.offset, byteArray.len);
+        return vectorizedColumnBatch.getString(rowId, pos);
     }
 
     @Override
@@ -135,14 +137,7 @@ public final class ColumnarRow implements InternalRow, DataSetters, Serializable
 
     @Override
     public byte[] getBinary(int pos) {
-        Bytes byteArray = vectorizedColumnBatch.getByteArray(rowId, pos);
-        if (byteArray.len == byteArray.data.length) {
-            return byteArray.data;
-        } else {
-            byte[] ret = new byte[byteArray.len];
-            System.arraycopy(byteArray.data, byteArray.offset, ret, 0, byteArray.len);
-            return ret;
-        }
+        return vectorizedColumnBatch.getBinary(rowId, pos);
     }
 
     @Override
@@ -220,10 +215,6 @@ public final class ColumnarRow implements InternalRow, DataSetters, Serializable
     public int hashCode() {
         throw new UnsupportedOperationException(
                 "ColumnarRowData do not support hashCode, please hash fields one by one!");
-    }
-
-    VectorizedColumnBatch vectorizedColumnBatch() {
-        return vectorizedColumnBatch;
     }
 
     public ColumnarRow copy(ColumnVector[] vectors) {

--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarRowIterator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarRowIterator.java
@@ -51,10 +51,6 @@ public class ColumnarRowIterator extends RecyclableIterator<InternalRow>
         this.recycler = recycler;
     }
 
-    /**
-     * Reset the number of rows in the vectorized batch, the start position in this batch and the
-     * global position.
-     */
     public void reset(long nextFilePos) {
         this.num = row.batch().getNumRows();
         this.nextPos = 0;

--- a/paimon-common/src/main/java/org/apache/paimon/reader/VectorizedRecordIterator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/reader/VectorizedRecordIterator.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.reader;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.columnar.VectorizedColumnBatch;
+
+/** Wrap {@link RecordReader.RecordIterator} to support returning batch directly. */
+public interface VectorizedRecordIterator extends RecordReader.RecordIterator<InternalRow> {
+
+    VectorizedColumnBatch batch();
+}

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcReaderFactory.java
@@ -183,9 +183,8 @@ public class OrcReaderFactory implements FormatReaderFactory {
                 VectorizedRowBatch orcBatch, long rowNumber) {
             // no copying from the ORC column vectors to the Paimon columns vectors necessary,
             // because they point to the same data arrays internally design
-            int batchSize = orcBatch.size;
-            paimonColumnBatch.setNumRows(batchSize);
-            result.reset(batchSize, rowNumber);
+            paimonColumnBatch.setNumRows(orcBatch.size);
+            result.reset(rowNumber);
             return result;
         }
     }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
@@ -399,7 +399,7 @@ public class ParquetReaderFactory implements FormatReaderFactory {
         }
 
         public RecordIterator<InternalRow> convertAndGetIterator(long rowNumber) {
-            result.reset(columnarBatch.getNumRows(), rowNumber);
+            result.reset(rowNumber);
             return result;
         }
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

For the integration of computing engines, if the computing engine can perceive that the returned iterator is a columnar batch, then the computing engine has more opportunities to accelerate computation.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
