### PR TITLE
[test] Fix flaky testWithValueFilter

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreScanTest.java
@@ -150,13 +150,17 @@ public class KeyValueFileStoreScanTest {
     @Test
     public void testWithValueFilter() throws Exception {
         ThreadLocalRandom random = ThreadLocalRandom.current();
-        List<KeyValue> data = generateData(100, Math.abs(random.nextInt(1000)));
+        // 0 <= hr <= 999
+        List<KeyValue> data = generateData(100, random.nextInt(1000));
         writeData(data, 0);
-        data = generateData(100, Math.abs(random.nextInt(1000)) + 1000);
+        // 1000 <= hr <= 1999
+        data = generateData(100, random.nextInt(1000) + 1000);
         writeData(data, 1);
-        data = generateData(100, Math.abs(random.nextInt(1000)) + 2000);
+        // 2000 <= hr <= 2999
+        data = generateData(100, random.nextInt(1000) + 2000);
         writeData(data, 2);
-        generateData(100, Math.abs(random.nextInt(1000)) + 3000);
+        // 3000 <= hr <= 3999
+        data = generateData(100, random.nextInt(1000) + 3000);
         Snapshot snapshot = writeData(data, 3);
 
         KeyValueFileStoreScan scan = store.newScan();
@@ -167,7 +171,7 @@ public class KeyValueFileStoreScanTest {
         scan.withSnapshot(snapshot.id());
         scan.withValueFilter(
                 new PredicateBuilder(TestKeyValueGenerator.DEFAULT_ROW_TYPE)
-                        .between(1, 1000, 2000));
+                        .between(1, 1000, 1999));
 
         List<ManifestEntry> filesFiltered = scan.plan().files();
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

```
Error:  org.apache.paimon.operation.KeyValueFileStoreScanTest.testWithValueFilter  Time elapsed: 0.154 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: 

expected: 1
 but was: 3
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
