### PR TITLE
[core] Introduce ExpireChangelogImpl to decouple the changelog lifecycle

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -63,6 +63,24 @@ under the License.
             <td>Whether to generate -U, +U changelog for the same record. This configuration is only valid for the changelog-producer is lookup or full-compaction.</td>
         </tr>
         <tr>
+            <td><h5>changelog.num-retained.max</h5></td>
+            <td style="word-wrap: break-word;">infinite</td>
+            <td>Integer</td>
+            <td>The maximum number of completed changelog to retain. Should be greater than or equal to the minimum number.</td>
+        </tr>
+        <tr>
+            <td><h5>changelog.num-retained.min</h5></td>
+            <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
+            <td>The minimum number of completed changelog to retain. Should be greater than or equal to 1.</td>
+        </tr>
+        <tr>
+            <td><h5>changelog.time-retained</h5></td>
+            <td style="word-wrap: break-word;">1 h</td>
+            <td>Duration</td>
+            <td>The maximum time of completed changelog to retain.</td>
+        </tr>
+        <tr>
             <td><h5>commit.callback.#.param</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -191,6 +191,27 @@ public class CoreOptions implements Serializable {
                     .defaultValue(Duration.ofHours(1))
                     .withDescription("The maximum time of completed snapshots to retain.");
 
+    public static final ConfigOption<Integer> CHANGELOG_NUM_RETAINED_MIN =
+            key("changelog.num-retained.min")
+                    .intType()
+                    .defaultValue(10)
+                    .withDescription(
+                            "The minimum number of completed changelog to retain. Should be greater than or equal to 1.");
+
+    @Documentation.OverrideDefault("infinite")
+    public static final ConfigOption<Integer> CHANGELOG_NUM_RETAINED_MAX =
+            key("changelog.num-retained.max")
+                    .intType()
+                    .defaultValue(Integer.MAX_VALUE)
+                    .withDescription(
+                            "The maximum number of completed changelog to retain. Should be greater than or equal to the minimum number.");
+
+    public static final ConfigOption<Duration> CHANGELOG_TIME_RETAINED =
+            key("changelog.time-retained")
+                    .durationType()
+                    .defaultValue(Duration.ofHours(1))
+                    .withDescription("The maximum time of completed changelog to retain.");
+
     public static final ConfigOption<ExpireExecutionMode> SNAPSHOT_EXPIRE_EXECUTION_MODE =
             key("snapshot.expire.execution-mode")
                     .enumType(ExpireExecutionMode.class)
@@ -1204,6 +1225,26 @@ public class CoreOptions implements Serializable {
 
     public Duration snapshotTimeRetain() {
         return options.get(SNAPSHOT_TIME_RETAINED);
+    }
+
+    public int changelogNumRetainMin() {
+        return options.get(CHANGELOG_NUM_RETAINED_MIN);
+    }
+
+    public int changelogNumRetainMax() {
+        return options.get(CHANGELOG_NUM_RETAINED_MAX);
+    }
+
+    public Duration changelogTimeRetain() {
+        return options.get(CHANGELOG_TIME_RETAINED);
+    }
+
+    public boolean changelogLifecycleDecoupled() {
+        return changelogNumRetainMax() > snapshotNumRetainMax()
+                || options.get(CHANGELOG_TIME_RETAINED)
+                                .compareTo(options.get(SNAPSHOT_TIME_RETAINED))
+                        > 0
+                || changelogNumRetainMin() > snapshotNumRetainMin();
     }
 
     public ExpireExecutionMode snapshotExpireExecutionMode() {

--- a/paimon-core/src/main/java/org/apache/paimon/Changelog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/Changelog.java
@@ -39,7 +39,7 @@ import java.util.Map;
  */
 public class Changelog extends Snapshot {
 
-    private static final int CURRENT_VERSION = 3;
+    private static final int CURRENT_VERSION = 1;
 
     public Changelog(
             long id,

--- a/paimon-core/src/main/java/org/apache/paimon/Changelog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/Changelog.java
@@ -20,20 +20,15 @@ package org.apache.paimon;
 
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
-import org.apache.paimon.manifest.ManifestFileMeta;
-import org.apache.paimon.manifest.ManifestList;
 import org.apache.paimon.utils.JsonSerdeUtil;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
-import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 
 /**
  * The metadata of changelog. It generates from the snapshot file during expiration. So that the
@@ -42,69 +37,45 @@ import java.util.Objects;
  * <li>The changelog file. Eg: from the changelog-producer = 'input'
  * <li>The delta files in the APPEND commits when the changelog-producer = 'none'
  */
-public class Changelog {
+public class Changelog extends Snapshot {
 
-    private static final int CURRENT_VERSION = 1;
-
-    private static final String FIELD_VERSION = "version";
-    private static final String FIELD_ID = "id";
-    private static final String FIELD_SCHEMA_ID = "schemaId";
-    private static final String FIELD_DELTA_MANIFEST_LIST = "deltaManifestList";
-    private static final String FIELD_CHANGELOG_MANIFEST_LIST = "changelogManifestList";
-    private static final String FIELD_COMMIT_KIND = "commitKind";
-    private static final String FIELD_TIME_MILLIS = "timeMillis";
-    private static final String FIELD_RECORD_COUNT = "recordCount";
-    private static final String FIELD_WATERMARK = "watermark";
-
-    @JsonProperty(FIELD_VERSION)
-    private final int version;
-
-    @JsonProperty(FIELD_ID)
-    private final long id;
-
-    @JsonProperty(FIELD_SCHEMA_ID)
-    private final long schemaId;
-
-    @JsonProperty(FIELD_DELTA_MANIFEST_LIST)
-    private final String deltaManifestList;
-
-    @JsonProperty(FIELD_CHANGELOG_MANIFEST_LIST)
-    @Nullable
-    private final String changelogManifestList;
-
-    @JsonProperty(FIELD_TIME_MILLIS)
-    private final long timeMillis;
-
-    @JsonProperty(FIELD_RECORD_COUNT)
-    @Nullable
-    private final Long recordCount;
-
-    @JsonProperty(FIELD_WATERMARK)
-    @Nullable
-    private final Long watermark;
-
-    @JsonProperty(FIELD_COMMIT_KIND)
-    private Snapshot.CommitKind commitKind;
+    private static final int CURRENT_VERSION = 3;
 
     public Changelog(
             long id,
             long schemaId,
-            @Nullable String deltaManifestList,
+            String baseManifestList,
+            String deltaManifestList,
             @Nullable String changelogManifestList,
-            Snapshot.CommitKind commitKind,
+            @Nullable String indexManifest,
+            String commitUser,
+            long commitIdentifier,
+            CommitKind commitKind,
             long timeMillis,
-            Long recordCount,
-            @Nullable Long watermark) {
+            Map<Integer, Long> logOffsets,
+            @Nullable Long totalRecordCount,
+            @Nullable Long deltaRecordCount,
+            @Nullable Long changelogRecordCount,
+            @Nullable Long watermark,
+            @Nullable String statistics) {
         this(
                 CURRENT_VERSION,
                 id,
                 schemaId,
+                baseManifestList,
                 deltaManifestList,
                 changelogManifestList,
+                indexManifest,
+                commitUser,
+                commitIdentifier,
                 commitKind,
                 timeMillis,
-                recordCount,
-                watermark);
+                logOffsets,
+                totalRecordCount,
+                deltaRecordCount,
+                changelogRecordCount,
+                watermark,
+                statistics);
     }
 
     @JsonCreator
@@ -112,130 +83,38 @@ public class Changelog {
             @JsonProperty(FIELD_VERSION) @Nullable Integer version,
             @JsonProperty(FIELD_ID) long id,
             @JsonProperty(FIELD_SCHEMA_ID) long schemaId,
-            @JsonProperty(FIELD_DELTA_MANIFEST_LIST) @Nullable String deltaManifestList,
+            @JsonProperty(FIELD_BASE_MANIFEST_LIST) String baseManifestList,
+            @JsonProperty(FIELD_DELTA_MANIFEST_LIST) String deltaManifestList,
             @JsonProperty(FIELD_CHANGELOG_MANIFEST_LIST) @Nullable String changelogManifestList,
-            @JsonProperty(FIELD_COMMIT_KIND) Snapshot.CommitKind commitKind,
+            @JsonProperty(FIELD_INDEX_MANIFEST) @Nullable String indexManifest,
+            @JsonProperty(FIELD_COMMIT_USER) String commitUser,
+            @JsonProperty(FIELD_COMMIT_IDENTIFIER) long commitIdentifier,
+            @JsonProperty(FIELD_COMMIT_KIND) CommitKind commitKind,
             @JsonProperty(FIELD_TIME_MILLIS) long timeMillis,
-            @JsonProperty(FIELD_RECORD_COUNT) @Nullable Long recordCount,
-            @JsonProperty(FIELD_WATERMARK) @Nullable Long watermark) {
-        this.version = version;
-        this.id = id;
-        this.schemaId = schemaId;
-        this.deltaManifestList = deltaManifestList;
-        this.changelogManifestList = changelogManifestList;
-        this.recordCount = recordCount;
-        this.commitKind = commitKind;
-        this.timeMillis = timeMillis;
-        this.watermark = watermark;
-    }
-
-    @JsonGetter(FIELD_VERSION)
-    public int version() {
-        return version;
-    }
-
-    @JsonGetter(FIELD_ID)
-    public long id() {
-        return id;
-    }
-
-    @JsonGetter(FIELD_CHANGELOG_MANIFEST_LIST)
-    @Nullable
-    public String changelogManifestList() {
-        return changelogManifestList;
-    }
-
-    @JsonGetter(FIELD_DELTA_MANIFEST_LIST)
-    public String deltaManifestList() {
-        return deltaManifestList;
-    }
-
-    @JsonGetter(FIELD_SCHEMA_ID)
-    public long schemaId() {
-        return schemaId;
-    }
-
-    @JsonGetter(FIELD_COMMIT_KIND)
-    public Snapshot.CommitKind commitKind() {
-        return commitKind;
-    }
-
-    @JsonGetter(FIELD_TIME_MILLIS)
-    public long timeMillis() {
-        return timeMillis;
-    }
-
-    @JsonGetter(FIELD_RECORD_COUNT)
-    public Long recordCount() {
-        return recordCount;
-    }
-
-    @JsonGetter(FIELD_WATERMARK)
-    @Nullable
-    public Long watermark() {
-        return watermark;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof Changelog)) {
-            return false;
-        }
-        Changelog changelog = (Changelog) o;
-        return version == changelog.version
-                && id == changelog.id
-                && schemaId == changelog.schemaId
-                && timeMillis == changelog.timeMillis
-                && Objects.equals(deltaManifestList, changelog.deltaManifestList)
-                && Objects.equals(changelogManifestList, changelog.changelogManifestList)
-                && Objects.equals(recordCount, changelog.recordCount)
-                && Objects.equals(watermark, changelog.watermark)
-                && commitKind == changelog.commitKind;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(
+            @JsonProperty(FIELD_LOG_OFFSETS) Map<Integer, Long> logOffsets,
+            @JsonProperty(FIELD_TOTAL_RECORD_COUNT) @Nullable Long totalRecordCount,
+            @JsonProperty(FIELD_DELTA_RECORD_COUNT) @Nullable Long deltaRecordCount,
+            @JsonProperty(FIELD_CHANGELOG_RECORD_COUNT) @Nullable Long changelogRecordCount,
+            @JsonProperty(FIELD_WATERMARK) @Nullable Long watermark,
+            @JsonProperty(FIELD_STATISTICS) @Nullable String statistics) {
+        super(
                 version,
                 id,
                 schemaId,
+                baseManifestList,
                 deltaManifestList,
                 changelogManifestList,
+                indexManifest,
+                commitUser,
+                commitIdentifier,
+                commitKind,
                 timeMillis,
-                recordCount,
+                logOffsets,
+                totalRecordCount,
+                deltaRecordCount,
+                changelogRecordCount,
                 watermark,
-                commitKind);
-    }
-
-    /**
-     * Return a {@link ManifestFileMeta} for each delta manifest in this changelog.
-     *
-     * @param manifestList a {@link ManifestList} instance used for reading files at snapshot.
-     * @return a list of ManifestFileMeta.
-     */
-    public List<ManifestFileMeta> deltaManifests(ManifestList manifestList) {
-        return deltaManifestList == null
-                ? Collections.emptyList()
-                : manifestList.read(deltaManifestList);
-    }
-
-    /**
-     * Return a {@link ManifestFileMeta} for each changelog manifest in this changelog.
-     *
-     * @param manifestList a {@link ManifestList} instance used for reading files at snapshot.
-     * @return a list of ManifestFileMeta.
-     */
-    public List<ManifestFileMeta> changelogManifests(ManifestList manifestList) {
-        return changelogManifestList == null
-                ? Collections.emptyList()
-                : manifestList.read(changelogManifestList);
-    }
-
-    public String toJson() {
-        return JsonSerdeUtil.toJson(this);
+                statistics);
     }
 
     public static Changelog fromJson(String json) {

--- a/paimon-core/src/main/java/org/apache/paimon/Changelog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/Changelog.java
@@ -33,13 +33,12 @@ import java.util.Map;
 /**
  * The metadata of changelog. It generates from the snapshot file during expiration. So that the
  * changelog of the table can outlive the snapshot's lifecycle. A table's changelog can come from
- * two source:
+ * one source:
  * <li>The changelog file. Eg: from the changelog-producer = 'input'
- * <li>The delta files in the APPEND commits when the changelog-producer = 'none'
  */
 public class Changelog extends Snapshot {
 
-    private static final int CURRENT_VERSION = 1;
+    private static final int CURRENT_VERSION = Snapshot.CURRENT_VERSION;
 
     public Changelog(
             long id,

--- a/paimon-core/src/main/java/org/apache/paimon/Changelog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/Changelog.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.manifest.ManifestFileMeta;
+import org.apache.paimon.manifest.ManifestList;
+import org.apache.paimon.utils.JsonSerdeUtil;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The metadata of changelog. It generates from the snapshot file during expiration. So that the
+ * changelog of the table can outlive the snapshot's lifecycle. A table's changelog can come from
+ * two source:
+ * <li>The changelog file. Eg: from the changelog-producer = 'input'
+ * <li>The delta files in the APPEND commits when the changelog-producer = 'none'
+ */
+public class Changelog {
+
+    private static final int CURRENT_VERSION = 1;
+
+    private static final String FIELD_VERSION = "version";
+    private static final String FIELD_ID = "id";
+    private static final String FIELD_SCHEMA_ID = "schemaId";
+    private static final String FIELD_DELTA_MANIFEST_LIST = "deltaManifestList";
+    private static final String FIELD_CHANGELOG_MANIFEST_LIST = "changelogManifestList";
+    private static final String FIELD_COMMIT_KIND = "commitKind";
+    private static final String FIELD_TIME_MILLIS = "timeMillis";
+    private static final String FIELD_RECORD_COUNT = "recordCount";
+    private static final String FIELD_WATERMARK = "watermark";
+
+    @JsonProperty(FIELD_VERSION)
+    private final int version;
+
+    @JsonProperty(FIELD_ID)
+    private final long id;
+
+    @JsonProperty(FIELD_SCHEMA_ID)
+    private final long schemaId;
+
+    @JsonProperty(FIELD_DELTA_MANIFEST_LIST)
+    private final String deltaManifestList;
+
+    @JsonProperty(FIELD_CHANGELOG_MANIFEST_LIST)
+    @Nullable
+    private final String changelogManifestList;
+
+    @JsonProperty(FIELD_TIME_MILLIS)
+    private final long timeMillis;
+
+    @JsonProperty(FIELD_RECORD_COUNT)
+    @Nullable
+    private final Long recordCount;
+
+    @JsonProperty(FIELD_WATERMARK)
+    @Nullable
+    private final Long watermark;
+
+    @JsonProperty(FIELD_COMMIT_KIND)
+    private Snapshot.CommitKind commitKind;
+
+    public Changelog(
+            long id,
+            long schemaId,
+            @Nullable String deltaManifestList,
+            @Nullable String changelogManifestList,
+            Snapshot.CommitKind commitKind,
+            long timeMillis,
+            Long recordCount,
+            @Nullable Long watermark) {
+        this(
+                CURRENT_VERSION,
+                id,
+                schemaId,
+                deltaManifestList,
+                changelogManifestList,
+                commitKind,
+                timeMillis,
+                recordCount,
+                watermark);
+    }
+
+    @JsonCreator
+    public Changelog(
+            @JsonProperty(FIELD_VERSION) @Nullable Integer version,
+            @JsonProperty(FIELD_ID) long id,
+            @JsonProperty(FIELD_SCHEMA_ID) long schemaId,
+            @JsonProperty(FIELD_DELTA_MANIFEST_LIST) @Nullable String deltaManifestList,
+            @JsonProperty(FIELD_CHANGELOG_MANIFEST_LIST) @Nullable String changelogManifestList,
+            @JsonProperty(FIELD_COMMIT_KIND) Snapshot.CommitKind commitKind,
+            @JsonProperty(FIELD_TIME_MILLIS) long timeMillis,
+            @JsonProperty(FIELD_RECORD_COUNT) @Nullable Long recordCount,
+            @JsonProperty(FIELD_WATERMARK) @Nullable Long watermark) {
+        this.version = version;
+        this.id = id;
+        this.schemaId = schemaId;
+        this.deltaManifestList = deltaManifestList;
+        this.changelogManifestList = changelogManifestList;
+        this.recordCount = recordCount;
+        this.commitKind = commitKind;
+        this.timeMillis = timeMillis;
+        this.watermark = watermark;
+    }
+
+    @JsonGetter(FIELD_VERSION)
+    public int version() {
+        return version;
+    }
+
+    @JsonGetter(FIELD_ID)
+    public long id() {
+        return id;
+    }
+
+    @JsonGetter(FIELD_CHANGELOG_MANIFEST_LIST)
+    @Nullable
+    public String changelogManifestList() {
+        return changelogManifestList;
+    }
+
+    @JsonGetter(FIELD_DELTA_MANIFEST_LIST)
+    public String deltaManifestList() {
+        return deltaManifestList;
+    }
+
+    @JsonGetter(FIELD_SCHEMA_ID)
+    public long schemaId() {
+        return schemaId;
+    }
+
+    @JsonGetter(FIELD_COMMIT_KIND)
+    public Snapshot.CommitKind commitKind() {
+        return commitKind;
+    }
+
+    @JsonGetter(FIELD_TIME_MILLIS)
+    public long timeMillis() {
+        return timeMillis;
+    }
+
+    @JsonGetter(FIELD_RECORD_COUNT)
+    public Long recordCount() {
+        return recordCount;
+    }
+
+    @JsonGetter(FIELD_WATERMARK)
+    @Nullable
+    public Long watermark() {
+        return watermark;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Changelog)) {
+            return false;
+        }
+        Changelog changelog = (Changelog) o;
+        return version == changelog.version
+                && id == changelog.id
+                && schemaId == changelog.schemaId
+                && timeMillis == changelog.timeMillis
+                && Objects.equals(deltaManifestList, changelog.deltaManifestList)
+                && Objects.equals(changelogManifestList, changelog.changelogManifestList)
+                && Objects.equals(recordCount, changelog.recordCount)
+                && Objects.equals(watermark, changelog.watermark)
+                && commitKind == changelog.commitKind;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                version,
+                id,
+                schemaId,
+                deltaManifestList,
+                changelogManifestList,
+                timeMillis,
+                recordCount,
+                watermark,
+                commitKind);
+    }
+
+    /**
+     * Return a {@link ManifestFileMeta} for each delta manifest in this changelog.
+     *
+     * @param manifestList a {@link ManifestList} instance used for reading files at snapshot.
+     * @return a list of ManifestFileMeta.
+     */
+    public List<ManifestFileMeta> deltaManifests(ManifestList manifestList) {
+        return deltaManifestList == null
+                ? Collections.emptyList()
+                : manifestList.read(deltaManifestList);
+    }
+
+    /**
+     * Return a {@link ManifestFileMeta} for each changelog manifest in this changelog.
+     *
+     * @param manifestList a {@link ManifestList} instance used for reading files at snapshot.
+     * @return a list of ManifestFileMeta.
+     */
+    public List<ManifestFileMeta> changelogManifests(ManifestList manifestList) {
+        return changelogManifestList == null
+                ? Collections.emptyList()
+                : manifestList.read(changelogManifestList);
+    }
+
+    public String toJson() {
+        return JsonSerdeUtil.toJson(this);
+    }
+
+    public static Changelog fromJson(String json) {
+        return JsonSerdeUtil.fromJson(json, Changelog.class);
+    }
+
+    public static Changelog fromPath(FileIO fileIO, Path path) {
+        try {
+            String json = fileIO.readFileUtf8(path);
+            return Changelog.fromJson(json);
+        } catch (IOException e) {
+            throw new RuntimeException("Fails to read changelog from path " + path, e);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/Snapshot.java
+++ b/paimon-core/src/main/java/org/apache/paimon/Snapshot.java
@@ -69,7 +69,7 @@ public class Snapshot {
     public static final long FIRST_SNAPSHOT_ID = 1;
 
     public static final int TABLE_STORE_02_VERSION = 1;
-    private static final int CURRENT_VERSION = 3;
+    protected static final int CURRENT_VERSION = 3;
 
     protected static final String FIELD_VERSION = "version";
     protected static final String FIELD_ID = "id";

--- a/paimon-core/src/main/java/org/apache/paimon/Snapshot.java
+++ b/paimon-core/src/main/java/org/apache/paimon/Snapshot.java
@@ -71,23 +71,23 @@ public class Snapshot {
     public static final int TABLE_STORE_02_VERSION = 1;
     private static final int CURRENT_VERSION = 3;
 
-    private static final String FIELD_VERSION = "version";
-    private static final String FIELD_ID = "id";
-    private static final String FIELD_SCHEMA_ID = "schemaId";
-    private static final String FIELD_BASE_MANIFEST_LIST = "baseManifestList";
-    private static final String FIELD_DELTA_MANIFEST_LIST = "deltaManifestList";
-    private static final String FIELD_CHANGELOG_MANIFEST_LIST = "changelogManifestList";
-    private static final String FIELD_INDEX_MANIFEST = "indexManifest";
-    private static final String FIELD_COMMIT_USER = "commitUser";
-    private static final String FIELD_COMMIT_IDENTIFIER = "commitIdentifier";
-    private static final String FIELD_COMMIT_KIND = "commitKind";
-    private static final String FIELD_TIME_MILLIS = "timeMillis";
-    private static final String FIELD_LOG_OFFSETS = "logOffsets";
-    private static final String FIELD_TOTAL_RECORD_COUNT = "totalRecordCount";
-    private static final String FIELD_DELTA_RECORD_COUNT = "deltaRecordCount";
-    private static final String FIELD_CHANGELOG_RECORD_COUNT = "changelogRecordCount";
-    private static final String FIELD_WATERMARK = "watermark";
-    private static final String FIELD_STATISTICS = "statistics";
+    protected static final String FIELD_VERSION = "version";
+    protected static final String FIELD_ID = "id";
+    protected static final String FIELD_SCHEMA_ID = "schemaId";
+    protected static final String FIELD_BASE_MANIFEST_LIST = "baseManifestList";
+    protected static final String FIELD_DELTA_MANIFEST_LIST = "deltaManifestList";
+    protected static final String FIELD_CHANGELOG_MANIFEST_LIST = "changelogManifestList";
+    protected static final String FIELD_INDEX_MANIFEST = "indexManifest";
+    protected static final String FIELD_COMMIT_USER = "commitUser";
+    protected static final String FIELD_COMMIT_IDENTIFIER = "commitIdentifier";
+    protected static final String FIELD_COMMIT_KIND = "commitKind";
+    protected static final String FIELD_TIME_MILLIS = "timeMillis";
+    protected static final String FIELD_LOG_OFFSETS = "logOffsets";
+    protected static final String FIELD_TOTAL_RECORD_COUNT = "totalRecordCount";
+    protected static final String FIELD_DELTA_RECORD_COUNT = "deltaRecordCount";
+    protected static final String FIELD_CHANGELOG_RECORD_COUNT = "changelogRecordCount";
+    protected static final String FIELD_WATERMARK = "watermark";
+    protected static final String FIELD_STATISTICS = "statistics";
 
     // version of snapshot
     // null for paimon <= 0.2

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.operation;
 
+import org.apache.paimon.Changelog;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
@@ -386,6 +387,10 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
             case DELTA:
                 return snapshot.deltaManifests(manifestList);
             case CHANGELOG:
+                if (snapshot instanceof Changelog) {
+                    return snapshot.changelogManifests(manifestList);
+                }
+
                 if (snapshot.version() > Snapshot.TABLE_STORE_02_VERSION) {
                     return snapshot.changelogManifests(manifestList);
                 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.operation;
 
-import org.apache.paimon.Changelog;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
@@ -387,10 +386,6 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
             case DELTA:
                 return snapshot.deltaManifests(manifestList);
             case CHANGELOG:
-                if (snapshot instanceof Changelog) {
-                    return snapshot.changelogManifests(manifestList);
-                }
-
                 if (snapshot.version() > Snapshot.TABLE_STORE_02_VERSION) {
                     return snapshot.changelogManifests(manifestList);
                 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -151,40 +151,14 @@ public abstract class FileDeletionBase {
                 .add(entry.bucket());
     }
 
-    protected void cleanUnusedManifests(
-            Snapshot snapshot, Set<String> skippingSet, boolean deleteChangelog) {
-        // clean base and delta manifests
-        List<String> toDeleteManifests = new ArrayList<>();
-        List<ManifestFileMeta> toExpireManifests = new ArrayList<>();
-        toExpireManifests.addAll(tryReadManifestList(snapshot.baseManifestList()));
-        toExpireManifests.addAll(tryReadManifestList(snapshot.deltaManifestList()));
-        for (ManifestFileMeta manifest : toExpireManifests) {
-            String fileName = manifest.fileName();
-            if (!skippingSet.contains(fileName)) {
-                toDeleteManifests.add(fileName);
-                // to avoid other snapshots trying to delete again
-                skippingSet.add(fileName);
-            }
+    public void cleanUnusedStatisticsManifests(Snapshot snapshot, Set<String> skippingSet) {
+        // clean statistics
+        if (snapshot.statistics() != null && !skippingSet.contains(snapshot.statistics())) {
+            statsFileHandler.deleteStats(snapshot.statistics());
         }
-        deleteFiles(toDeleteManifests, manifestFile::delete);
+    }
 
-        toDeleteManifests.clear();
-        if (!skippingSet.contains(snapshot.baseManifestList())) {
-            toDeleteManifests.add(snapshot.baseManifestList());
-        }
-        if (!skippingSet.contains(snapshot.deltaManifestList())) {
-            toDeleteManifests.add(snapshot.deltaManifestList());
-        }
-        deleteFiles(toDeleteManifests, manifestList::delete);
-
-        // clean changelog manifests
-        if (deleteChangelog && snapshot.changelogManifestList() != null) {
-            deleteFiles(
-                    tryReadManifestList(snapshot.changelogManifestList()),
-                    manifest -> manifestFile.delete(manifest.fileName()));
-            manifestList.delete(snapshot.changelogManifestList());
-        }
-
+    public void cleanUnusedIndexManifests(Snapshot snapshot, Set<String> skippingSet) {
         // clean index manifests
         String indexManifest = snapshot.indexManifest();
         // check exists, it may have been deleted by other snapshots
@@ -199,11 +173,35 @@ public abstract class FileDeletionBase {
                 indexFileHandler.deleteManifest(indexManifest);
             }
         }
+    }
 
-        // clean statistics
-        if (snapshot.statistics() != null && !skippingSet.contains(snapshot.statistics())) {
-            statsFileHandler.deleteStats(snapshot.statistics());
+    public void cleanUnusedManifestList(String manifestName, Set<String> skippingSet) {
+        List<String> toDeleteManifests = new ArrayList<>();
+        List<ManifestFileMeta> toExpireManifests = tryReadManifestList(manifestName);
+        for (ManifestFileMeta manifest : toExpireManifests) {
+            String fileName = manifest.fileName();
+            if (!skippingSet.contains(fileName)) {
+                toDeleteManifests.add(fileName);
+                // to avoid other snapshots trying to delete again
+                skippingSet.add(fileName);
+            }
         }
+        if (!skippingSet.contains(manifestName)) {
+            toDeleteManifests.add(manifestName);
+        }
+
+        deleteFiles(toDeleteManifests, manifestFile::delete);
+    }
+
+    public void cleanUnusedManifests(
+            Snapshot snapshot, Set<String> skippingSet, boolean deleteChangelog) {
+        cleanUnusedManifestList(snapshot.baseManifestList(), skippingSet);
+        cleanUnusedManifestList(snapshot.deltaManifestList(), skippingSet);
+        if (deleteChangelog) {
+            cleanUnusedManifestList(snapshot.changelogManifestList(), skippingSet);
+        }
+        cleanUnusedIndexManifests(snapshot, skippingSet);
+        cleanUnusedStatisticsManifests(snapshot, skippingSet);
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/operation/SnapshotDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/SnapshotDeletion.java
@@ -66,9 +66,12 @@ public class SnapshotDeletion extends FileDeletionBase {
 
     @Override
     public void cleanUnusedDataFiles(Snapshot snapshot, Predicate<ManifestEntry> skipper) {
+        cleanUnusedDataFiles(snapshot.deltaManifestList(), skipper);
+    }
+
+    public void cleanUnusedDataFiles(String manifestList, Predicate<ManifestEntry> skipper) {
         // try read manifests
-        List<String> manifestFileNames =
-                readManifestFileNames(tryReadManifestList(snapshot.deltaManifestList()));
+        List<String> manifestFileNames = readManifestFileNames(tryReadManifestList(manifestList));
         List<ManifestEntry> manifestEntries;
         // data file path -> (original manifest entry, extra file paths)
         Map<Path, Pair<ManifestEntry, List<Path>>> dataFileToDelete = new HashMap<>();
@@ -125,6 +128,7 @@ public class SnapshotDeletion extends FileDeletionBase {
         dataFileToDelete.forEach(
                 (path, pair) -> {
                     ManifestEntry entry = pair.getLeft();
+                    System.out.println("delete: " + path);
                     // check whether we should skip the data file
                     if (!skipper.test(entry)) {
                         // delete data files

--- a/paimon-core/src/main/java/org/apache/paimon/operation/SnapshotDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/SnapshotDeletion.java
@@ -128,7 +128,6 @@ public class SnapshotDeletion extends FileDeletionBase {
         dataFileToDelete.forEach(
                 (path, pair) -> {
                     ManifestEntry entry = pair.getLeft();
-                    System.out.println("delete: " + path);
                     // check whether we should skip the data file
                     if (!skipper.test(entry)) {
                         // delete data files

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -46,7 +46,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.CoreOptions.BUCKET_KEY;
+import static org.apache.paimon.CoreOptions.CHANGELOG_NUM_RETAINED_MAX;
+import static org.apache.paimon.CoreOptions.CHANGELOG_NUM_RETAINED_MIN;
 import static org.apache.paimon.CoreOptions.CHANGELOG_PRODUCER;
+import static org.apache.paimon.CoreOptions.CHANGELOG_TIME_RETAINED;
 import static org.apache.paimon.CoreOptions.FIELDS_PREFIX;
 import static org.apache.paimon.CoreOptions.FULL_COMPACTION_DELTA_COMMITS;
 import static org.apache.paimon.CoreOptions.INCREMENTAL_BETWEEN;
@@ -58,6 +61,7 @@ import static org.apache.paimon.CoreOptions.SCAN_TAG_NAME;
 import static org.apache.paimon.CoreOptions.SCAN_TIMESTAMP_MILLIS;
 import static org.apache.paimon.CoreOptions.SNAPSHOT_NUM_RETAINED_MAX;
 import static org.apache.paimon.CoreOptions.SNAPSHOT_NUM_RETAINED_MIN;
+import static org.apache.paimon.CoreOptions.SNAPSHOT_TIME_RETAINED;
 import static org.apache.paimon.CoreOptions.STREAMING_READ_OVERWRITE;
 import static org.apache.paimon.mergetree.compact.PartialUpdateMergeFunction.SEQUENCE_GROUP;
 import static org.apache.paimon.schema.SystemColumns.KEY_FIELD_PREFIX;
@@ -119,6 +123,21 @@ public class SchemaValidation {
                 options.snapshotNumRetainMin() <= options.snapshotNumRetainMax(),
                 SNAPSHOT_NUM_RETAINED_MIN.key()
                         + " should not be larger than "
+                        + SNAPSHOT_NUM_RETAINED_MAX.key());
+        checkArgument(
+                options.changelogTimeRetain().toMillis() >= options.snapshotTimeRetain().toMillis(),
+                CHANGELOG_TIME_RETAINED.key()
+                        + " should not less than "
+                        + SNAPSHOT_TIME_RETAINED.key());
+        checkArgument(
+                options.changelogNumRetainMin() >= options.snapshotNumRetainMin(),
+                CHANGELOG_NUM_RETAINED_MIN.key()
+                        + " should not less than "
+                        + SNAPSHOT_NUM_RETAINED_MIN.key());
+        checkArgument(
+                options.changelogNumRetainMax() >= options.changelogNumRetainMax(),
+                CHANGELOG_NUM_RETAINED_MAX.key()
+                        + " should not less than "
                         + SNAPSHOT_NUM_RETAINED_MAX.key());
 
         // Get the format type here which will try to convert string value to {@Code

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -49,7 +49,6 @@ import static org.apache.paimon.CoreOptions.BUCKET_KEY;
 import static org.apache.paimon.CoreOptions.CHANGELOG_NUM_RETAINED_MAX;
 import static org.apache.paimon.CoreOptions.CHANGELOG_NUM_RETAINED_MIN;
 import static org.apache.paimon.CoreOptions.CHANGELOG_PRODUCER;
-import static org.apache.paimon.CoreOptions.CHANGELOG_TIME_RETAINED;
 import static org.apache.paimon.CoreOptions.FIELDS_PREFIX;
 import static org.apache.paimon.CoreOptions.FULL_COMPACTION_DELTA_COMMITS;
 import static org.apache.paimon.CoreOptions.INCREMENTAL_BETWEEN;
@@ -61,7 +60,6 @@ import static org.apache.paimon.CoreOptions.SCAN_TAG_NAME;
 import static org.apache.paimon.CoreOptions.SCAN_TIMESTAMP_MILLIS;
 import static org.apache.paimon.CoreOptions.SNAPSHOT_NUM_RETAINED_MAX;
 import static org.apache.paimon.CoreOptions.SNAPSHOT_NUM_RETAINED_MIN;
-import static org.apache.paimon.CoreOptions.SNAPSHOT_TIME_RETAINED;
 import static org.apache.paimon.CoreOptions.STREAMING_READ_OVERWRITE;
 import static org.apache.paimon.mergetree.compact.PartialUpdateMergeFunction.SEQUENCE_GROUP;
 import static org.apache.paimon.schema.SystemColumns.KEY_FIELD_PREFIX;
@@ -124,21 +122,15 @@ public class SchemaValidation {
                 SNAPSHOT_NUM_RETAINED_MIN.key()
                         + " should not be larger than "
                         + SNAPSHOT_NUM_RETAINED_MAX.key());
+
         checkArgument(
-                options.changelogTimeRetain().toMillis() >= options.snapshotTimeRetain().toMillis(),
-                CHANGELOG_TIME_RETAINED.key()
-                        + " should not less than "
-                        + SNAPSHOT_TIME_RETAINED.key());
+                options.changelogNumRetainMin() > 0,
+                CHANGELOG_NUM_RETAINED_MIN.key() + " should be at least 1");
         checkArgument(
-                options.changelogNumRetainMin() >= options.snapshotNumRetainMin(),
+                options.changelogNumRetainMin() <= options.changelogNumRetainMax(),
                 CHANGELOG_NUM_RETAINED_MIN.key()
-                        + " should not less than "
-                        + SNAPSHOT_NUM_RETAINED_MIN.key());
-        checkArgument(
-                options.changelogNumRetainMax() >= options.changelogNumRetainMax(),
-                CHANGELOG_NUM_RETAINED_MAX.key()
-                        + " should not less than "
-                        + SNAPSHOT_NUM_RETAINED_MAX.key());
+                        + " should not be larger than "
+                        + CHANGELOG_NUM_RETAINED_MAX.key());
 
         // Get the format type here which will try to convert string value to {@Code
         // FileFormatType}. If the string value is illegal, an exception will be thrown.

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -303,6 +303,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
     public ExpireSnapshots newExpireChangelog() {
         return new ExpireChangelogImpl(
                 snapshotManager(),
+                tagManager(),
                 store().newSnapshotDeletion(),
                 coreOptions().snapshotExpireCleanEmptyDirectories());
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -295,6 +295,15 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
                 snapshotManager(),
                 store().newSnapshotDeletion(),
                 store().newTagManager(),
+                coreOptions().snapshotExpireCleanEmptyDirectories(),
+                coreOptions().changelogLifecycleDecoupled());
+    }
+
+    @Override
+    public ExpireSnapshots newExpireChangelog() {
+        return new ExpireChangelogImpl(
+                snapshotManager(),
+                store().newSnapshotDeletion(),
                 coreOptions().snapshotExpireCleanEmptyDirectories());
     }
 
@@ -308,17 +317,27 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
         CoreOptions options = coreOptions();
         Runnable snapshotExpire = null;
         if (!options.writeOnly()) {
+            boolean changelogDecoupled = options.changelogLifecycleDecoupled();
+            ExpireSnapshots expireChangelog =
+                    newExpireChangelog()
+                            .maxDeletes(options.snapshotExpireLimit())
+                            .retainMin(options.changelogNumRetainMin())
+                            .retainMax(options.changelogNumRetainMax());
             ExpireSnapshots expireSnapshots =
                     newExpireSnapshots()
                             .retainMax(options.snapshotNumRetainMax())
                             .retainMin(options.snapshotNumRetainMin())
                             .maxDeletes(options.snapshotExpireLimit());
             long snapshotTimeRetain = options.snapshotTimeRetain().toMillis();
+            long changelogTimeRetain = options.changelogTimeRetain().toMillis();
             snapshotExpire =
-                    () ->
-                            expireSnapshots
-                                    .olderThanMills(System.currentTimeMillis() - snapshotTimeRetain)
-                                    .expire();
+                    () -> {
+                        long current = System.currentTimeMillis();
+                        expireSnapshots.olderThanMills(current - snapshotTimeRetain).expire();
+                        if (changelogDecoupled) {
+                            expireChangelog.olderThanMills(current - changelogTimeRetain).expire();
+                        }
+                    };
         }
 
         return new TableCommitImpl(

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireChangelogImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireChangelogImpl.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table;
+
+import org.apache.paimon.Changelog;
+import org.apache.paimon.consumer.ConsumerManager;
+import org.apache.paimon.operation.SnapshotDeletion;
+import org.apache.paimon.utils.SnapshotManager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.HashSet;
+
+/** Cleanup the changelog in changelog directory. */
+public class ExpireChangelogImpl implements ExpireSnapshots {
+
+    public static final Logger LOG = LoggerFactory.getLogger(ExpireChangelogImpl.class);
+
+    private final SnapshotManager snapshotManager;
+    private final ConsumerManager consumerManager;
+    private final SnapshotDeletion snapshotDeletion;
+    private final boolean cleanEmptyDirectories;
+
+    private long olderThanMills = 0;
+    public int retainMin = 1;
+    private int retainMax = Integer.MAX_VALUE;
+    private int maxDeletes = Integer.MAX_VALUE;
+
+    public ExpireChangelogImpl(
+            SnapshotManager snapshotManager,
+            SnapshotDeletion snapshotDeletion,
+            boolean cleanEmptyDirectories) {
+        this.snapshotManager = snapshotManager;
+        this.consumerManager =
+                new ConsumerManager(snapshotManager.fileIO(), snapshotManager.tablePath());
+        this.snapshotDeletion = snapshotDeletion;
+        this.cleanEmptyDirectories = cleanEmptyDirectories;
+    }
+
+    @Override
+    public ExpireChangelogImpl retainMax(int retainMax) {
+        this.retainMax = retainMax;
+        return this;
+    }
+
+    @Override
+    public ExpireChangelogImpl retainMin(int retainMin) {
+        this.retainMin = retainMin;
+        return this;
+    }
+
+    @Override
+    public ExpireChangelogImpl olderThanMills(long olderThanMills) {
+        this.olderThanMills = olderThanMills;
+        return this;
+    }
+
+    @Override
+    public ExpireChangelogImpl maxDeletes(int maxDeletes) {
+        this.maxDeletes = maxDeletes;
+        return this;
+    }
+
+    @Override
+    public int expire() {
+        Long latestSnapshotId = snapshotManager.latestSnapshotId();
+        if (latestSnapshotId == null) {
+            // no snapshot, nothing to expire
+            return 0;
+        }
+
+        Long earliestSnapshotId = snapshotManager.earliestSnapshotId();
+        if (earliestSnapshotId == null) {
+            return 0;
+        }
+
+        Long latestChangelogId = snapshotManager.latestLongLivedChangelogId();
+        if (latestChangelogId == null) {
+            return 0;
+        }
+        Long earliestChangelogId = snapshotManager.earliestLongLivedChangelogId();
+        if (earliestChangelogId == null) {
+            return 0;
+        }
+
+        // the min snapshot to retain from 'changelog.num-retained.max'
+        // (the maximum number of snapshots to retain)
+        long min = Math.max(latestSnapshotId - retainMax + 1, earliestChangelogId);
+
+        // the max exclusive snapshot to expire until
+        // protected by 'changelog.num-retained.min'
+        // (the minimum number of completed snapshots to retain)
+        long maxExclusive = latestSnapshotId - retainMin + 1;
+
+        // the snapshot being read by the consumer cannot be deleted
+        maxExclusive =
+                Math.min(maxExclusive, consumerManager.minNextSnapshot().orElse(Long.MAX_VALUE));
+
+        // protected by 'snapshot.expire.limit'
+        // (the maximum number of snapshots allowed to expire at a time)
+        maxExclusive = Math.min(maxExclusive, earliestChangelogId + maxDeletes);
+
+        // Only clean the snapshot in changelog dir
+        maxExclusive = Math.min(maxExclusive, latestChangelogId);
+
+        for (long id = min; id <= maxExclusive; id++) {
+            if (snapshotManager.longLivedChangelogExists(id)
+                    && olderThanMills <= snapshotManager.longLivedChangelog(id).timeMillis()) {
+                return expireUntil(earliestChangelogId, id);
+            }
+        }
+        return expireUntil(earliestChangelogId, maxExclusive);
+    }
+
+    public int expireUntil(long earliestId, long endExclusiveId) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Changelog expire range is [" + earliestId + ", " + endExclusiveId + ")");
+        }
+
+        for (long id = earliestId; id < endExclusiveId; id++) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Ready to delete changelog files from snapshot #" + id);
+            }
+            Changelog changelog = snapshotManager.longLivedChangelog(id);
+            // delete changelog files
+            if (changelog.changelogManifestList() != null) {
+                snapshotDeletion.deleteAddedDataFiles(changelog.changelogManifestList());
+                snapshotDeletion.cleanUnusedManifestList(
+                        changelog.changelogManifestList(), new HashSet<>());
+            }
+            if (changelog.deltaManifestList() != null) {
+                snapshotDeletion.deleteAddedDataFiles(changelog.deltaManifestList());
+                snapshotDeletion.cleanUnusedManifestList(
+                        changelog.deltaManifestList(), new HashSet<>());
+            }
+
+            snapshotManager.fileIO().deleteQuietly(snapshotManager.longLivedChangelogPath(id));
+        }
+
+        if (cleanEmptyDirectories) {
+            snapshotDeletion.cleanDataDirectories();
+        }
+        writeEarliestHintFile(endExclusiveId);
+        return (int) (endExclusiveId - earliestId);
+    }
+
+    private void writeEarliestHintFile(long earliest) {
+        try {
+            snapshotManager.commitLongLivedChangelogEarliestHint(earliest);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireChangelogImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireChangelogImpl.java
@@ -19,9 +19,7 @@
 package org.apache.paimon.table;
 
 import org.apache.paimon.Changelog;
-import org.apache.paimon.Snapshot;
 import org.apache.paimon.consumer.ConsumerManager;
-import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.operation.SnapshotDeletion;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
@@ -32,8 +30,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.HashSet;
-import java.util.List;
-import java.util.function.Predicate;
 
 /** Cleanup the changelog in changelog directory. */
 public class ExpireChangelogImpl implements ExpireSnapshots {
@@ -144,8 +140,6 @@ public class ExpireChangelogImpl implements ExpireSnapshots {
             LOG.debug("Changelog expire range is [" + earliestId + ", " + endExclusiveId + ")");
         }
 
-        List<Snapshot> taggedSnapshots = tagManager.taggedSnapshots();
-
         for (long id = earliestId; id < endExclusiveId; id++) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Ready to delete changelog files from snapshot #" + id);
@@ -156,27 +150,10 @@ public class ExpireChangelogImpl implements ExpireSnapshots {
                 snapshotDeletion.deleteAddedDataFiles(changelog.changelogManifestList());
                 snapshotDeletion.cleanUnusedManifestList(
                         changelog.changelogManifestList(), new HashSet<>());
-            } else if (changelog.deltaManifestList() != null) {
-                Predicate<ManifestEntry> skipper;
-                try {
-                    skipper = snapshotDeletion.dataFileSkipper(taggedSnapshots, id);
-                } catch (Exception e) {
-                    LOG.info(
-                            String.format(
-                                    "Skip cleaning data files of snapshot '%s' due to failed to build skipping set.",
-                                    id),
-                            e);
-                    continue;
-                }
-                snapshotDeletion.cleanUnusedDataFiles(changelog.deltaManifestList(), skipper);
-                snapshotDeletion.cleanUnusedManifestList(
-                        changelog.deltaManifestList(), new HashSet<>());
             }
 
             snapshotManager.fileIO().deleteQuietly(snapshotManager.longLivedChangelogPath(id));
         }
-
-        // List<Snapshot> taggedSnapshots = tagManager.taggedSnapshots();
 
         if (cleanEmptyDirectories) {
             snapshotDeletion.cleanDataDirectories();

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
@@ -243,7 +243,6 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
                                     snapshot.changelogRecordCount(),
                                     snapshot.watermark(),
                                     null);
-                    commitChangelog(changelog);
                     snapshotDeletion.cleanUnusedManifests(snapshot, skippingSet, false);
                 } else {
                     // no changelog
@@ -265,9 +264,9 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
                                     snapshot.changelogRecordCount(),
                                     snapshot.watermark(),
                                     snapshot.statistics());
-                    commitChangelog(changelog);
                     snapshotDeletion.cleanUnusedManifests(snapshot, skippingSet, true);
                 }
+                commitChangelog(changelog);
             } else {
                 snapshotDeletion.cleanUnusedManifests(snapshot, skippingSet, true);
             }

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
@@ -188,14 +188,7 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
                 continue;
             }
 
-            if (changelogDecoupled) {
-                if (snapshot.changelogManifestList() != null
-                        || snapshot.commitKind() != Snapshot.CommitKind.APPEND) {
-                    snapshotDeletion.cleanUnusedDataFiles(snapshot, skipper);
-                }
-            } else {
-                snapshotDeletion.cleanUnusedDataFiles(snapshot, skipper);
-            }
+            snapshotDeletion.cleanUnusedDataFiles(snapshot, skipper);
         }
 
         // delete changelog files
@@ -243,21 +236,6 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
                                     snapshot.changelogRecordCount(),
                                     snapshot.watermark());
                     snapshotDeletion.cleanUnusedManifests(snapshot, skippingSet, false);
-                } else if (snapshot.commitKind() == Snapshot.CommitKind.APPEND) {
-                    changelog =
-                            new Changelog(
-                                    id,
-                                    snapshot.schemaId(),
-                                    snapshot.deltaManifestList(),
-                                    null,
-                                    snapshot.commitKind(),
-                                    snapshot.timeMillis(),
-                                    snapshot.deltaRecordCount(),
-                                    snapshot.watermark());
-                    snapshotDeletion.cleanUnusedManifestList(
-                            snapshot.baseManifestList(), skippingSet);
-                    snapshotDeletion.cleanUnusedIndexManifests(snapshot, skippingSet);
-                    snapshotDeletion.cleanUnusedStatisticsManifests(snapshot, skippingSet);
                 } else {
                     // no changelog
                     changelog =

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
@@ -230,11 +230,19 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
                                     id,
                                     snapshot.schemaId(),
                                     null,
+                                    null,
                                     snapshot.changelogManifestList(),
+                                    null,
+                                    snapshot.commitUser(),
+                                    snapshot.commitIdentifier(),
                                     snapshot.commitKind(),
                                     snapshot.timeMillis(),
+                                    snapshot.logOffsets(),
+                                    snapshot.totalRecordCount(),
+                                    null,
                                     snapshot.changelogRecordCount(),
-                                    snapshot.watermark());
+                                    snapshot.watermark(),
+                                    null);
                     snapshotDeletion.cleanUnusedManifests(snapshot, skippingSet, false);
                 } else {
                     // no changelog
@@ -244,10 +252,18 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
                                     snapshot.schemaId(),
                                     null,
                                     null,
+                                    null,
+                                    snapshot.indexManifest(),
+                                    snapshot.commitUser(),
+                                    snapshot.commitIdentifier(),
                                     snapshot.commitKind(),
                                     snapshot.timeMillis(),
-                                    0L,
-                                    snapshot.watermark());
+                                    snapshot.logOffsets(),
+                                    snapshot.changelogRecordCount(),
+                                    snapshot.totalRecordCount(),
+                                    snapshot.changelogRecordCount(),
+                                    snapshot.watermark(),
+                                    snapshot.statistics());
                     snapshotDeletion.cleanUnusedManifests(snapshot, skippingSet, true);
                 }
                 try {

--- a/paimon-core/src/main/java/org/apache/paimon/table/ReadonlyTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ReadonlyTable.java
@@ -156,4 +156,12 @@ public interface ReadonlyTable extends InnerTable {
                         "Readonly Table %s does not support expireSnapshots.",
                         this.getClass().getSimpleName()));
     }
+
+    @Override
+    default ExpireSnapshots newExpireChangelog() {
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Readonly Table %s does not support expireChangelog.",
+                        this.getClass().getSimpleName()));
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/RollbackHelper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/RollbackHelper.java
@@ -156,9 +156,6 @@ public class RollbackHelper {
             if (changelog.changelogManifestList() != null) {
                 snapshotDeletion.deleteAddedDataFiles(changelog.changelogManifestList());
             }
-            if (changelog.deltaManifestList() != null) {
-                snapshotDeletion.deleteAddedDataFiles(changelog.deltaManifestList());
-            }
         }
 
         // delete directories

--- a/paimon-core/src/main/java/org/apache/paimon/table/Table.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/Table.java
@@ -100,6 +100,9 @@ public interface Table extends Serializable {
     @Experimental
     ExpireSnapshots newExpireSnapshots();
 
+    @Experimental
+    ExpireSnapshots newExpireChangelog();
+
     // =============== Read & Write Operations ==================
 
     /** Returns a new read builder. */

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractInnerTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractInnerTableScan.java
@@ -119,7 +119,10 @@ public abstract class AbstractInnerTableScan implements InnerTableScan {
             Optional<Consumer> consumer = consumerManager.consumer(consumerId);
             if (consumer.isPresent()) {
                 return new ContinuousFromSnapshotStartingScanner(
-                        snapshotManager, consumer.get().nextSnapshot());
+                        snapshotManager,
+                        consumer.get().nextSnapshot(),
+                        options.changelogProducer() != ChangelogProducer.NONE,
+                        options.changelogLifecycleDecoupled());
             }
         }
 
@@ -145,7 +148,11 @@ public abstract class AbstractInnerTableScan implements InnerTableScan {
             case FROM_TIMESTAMP:
                 Long startupMillis = options.scanTimestampMills();
                 return isStreaming
-                        ? new ContinuousFromTimestampStartingScanner(snapshotManager, startupMillis)
+                        ? new ContinuousFromTimestampStartingScanner(
+                                snapshotManager,
+                                startupMillis,
+                                options.changelogProducer() != ChangelogProducer.NONE,
+                                options.changelogLifecycleDecoupled())
                         : new StaticFromTimestampStartingScanner(snapshotManager, startupMillis);
             case FROM_FILE_CREATION_TIME:
                 Long fileCreationTimeMills = options.scanFileCreationTimeMills();
@@ -154,7 +161,10 @@ public abstract class AbstractInnerTableScan implements InnerTableScan {
                 if (options.scanSnapshotId() != null) {
                     return isStreaming
                             ? new ContinuousFromSnapshotStartingScanner(
-                                    snapshotManager, options.scanSnapshotId())
+                                    snapshotManager,
+                                    options.scanSnapshotId(),
+                                    options.changelogProducer() != ChangelogProducer.NONE,
+                                    options.changelogLifecycleDecoupled())
                             : new StaticFromSnapshotStartingScanner(
                                     snapshotManager, options.scanSnapshotId());
                 } else {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromSnapshotStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromSnapshotStartingScanner.java
@@ -34,12 +34,17 @@ public class ContinuousFromSnapshotStartingScanner extends AbstractStartingScann
 
     @Override
     public Result scan(SnapshotReader snapshotReader) {
-        Long earliestSnapshotId = snapshotManager.earliestLongLivedChangelogId();
-        if (earliestSnapshotId == null) {
+        Long earliestChangelogId = snapshotManager.earliestLongLivedChangelogId();
+
+        Long earliestId =
+                earliestChangelogId == null
+                        ? snapshotManager.earliestSnapshotId()
+                        : earliestChangelogId;
+        if (earliestId == null) {
             return new NoSnapshot();
         }
         // We should return the specified snapshot as next snapshot to indicate to scan delta data
         // from it. If the snapshotId < earliestSnapshotId, start from the earliest.
-        return new NextSnapshot(Math.max(startingSnapshotId, earliestSnapshotId));
+        return new NextSnapshot(Math.max(startingSnapshotId, earliestId));
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromSnapshotStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromSnapshotStartingScanner.java
@@ -34,7 +34,7 @@ public class ContinuousFromSnapshotStartingScanner extends AbstractStartingScann
 
     @Override
     public Result scan(SnapshotReader snapshotReader) {
-        Long earliestSnapshotId = snapshotManager.earliestSnapshotId();
+        Long earliestSnapshotId = snapshotManager.earliestLongLivedChangelogId();
         if (earliestSnapshotId == null) {
             return new NoSnapshot();
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromSnapshotStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromSnapshotStartingScanner.java
@@ -27,24 +27,42 @@ import org.apache.paimon.utils.SnapshotManager;
  */
 public class ContinuousFromSnapshotStartingScanner extends AbstractStartingScanner {
 
-    public ContinuousFromSnapshotStartingScanner(SnapshotManager snapshotManager, long snapshotId) {
+    private final boolean changelogAsFollowup;
+    private final boolean changelogDecoupled;
+
+    public ContinuousFromSnapshotStartingScanner(
+            SnapshotManager snapshotManager,
+            long snapshotId,
+            boolean changelogAsFollowup,
+            boolean changelogDecoupled) {
         super(snapshotManager);
         this.startingSnapshotId = snapshotId;
+        this.changelogDecoupled = changelogDecoupled;
+        this.changelogAsFollowup = changelogAsFollowup;
     }
 
     @Override
     public Result scan(SnapshotReader snapshotReader) {
-        Long earliestChangelogId = snapshotManager.earliestLongLivedChangelogId();
-
-        Long earliestId =
-                earliestChangelogId == null
-                        ? snapshotManager.earliestSnapshotId()
-                        : earliestChangelogId;
+        Long earliestId = getEarliestId();
         if (earliestId == null) {
             return new NoSnapshot();
         }
         // We should return the specified snapshot as next snapshot to indicate to scan delta data
         // from it. If the snapshotId < earliestSnapshotId, start from the earliest.
         return new NextSnapshot(Math.max(startingSnapshotId, earliestId));
+    }
+
+    private Long getEarliestId() {
+        Long earliestId;
+        if (changelogAsFollowup && changelogDecoupled) {
+            Long earliestChangelogId = snapshotManager.earliestLongLivedChangelogId();
+            earliestId =
+                    earliestChangelogId == null
+                            ? snapshotManager.earliestSnapshotId()
+                            : earliestChangelogId;
+        } else {
+            earliestId = snapshotManager.earliestSnapshotId();
+        }
+        return earliestId;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScanner.java
@@ -33,13 +33,10 @@ public class ContinuousFromTimestampStartingScanner extends AbstractStartingScan
     private static final Logger LOG =
             LoggerFactory.getLogger(ContinuousFromTimestampStartingScanner.class);
 
-    private final long startupMillis;
-
     public ContinuousFromTimestampStartingScanner(
             SnapshotManager snapshotManager, long startupMillis) {
         super(snapshotManager);
-        this.startupMillis = startupMillis;
-        this.startingSnapshotId = this.snapshotManager.earlierThanTimeMills(this.startupMillis);
+        this.startingSnapshotId = this.snapshotManager.earlierThanTimeMills(startupMillis);
     }
 
     @Override
@@ -53,7 +50,6 @@ public class ContinuousFromTimestampStartingScanner extends AbstractStartingScan
 
     @Override
     public Result scan(SnapshotReader snapshotReader) {
-        Long startingSnapshotId = snapshotManager.earlierThanTimeMills(startupMillis);
         if (startingSnapshotId == null) {
             LOG.debug("There is currently no snapshot. Waiting for snapshot generation.");
             return new NoSnapshot();

--- a/paimon-core/src/main/java/org/apache/paimon/utils/NextSnapshotFetcher.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/NextSnapshotFetcher.java
@@ -1,21 +1,19 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  Licensed to the Apache Software Foundation (ASF) under one
- *  or more contributor license agreements.  See the NOTICE file
- *  distributed with this work for additional information
- *  regarding copyright ownership.  The ASF licenses this file
- *  to you under the Apache License, Version 2.0 (the
- *  "License"); you may not use this file except in compliance
- *  with the License.  You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.paimon.utils;

--- a/paimon-core/src/main/java/org/apache/paimon/utils/NextSnapshotFetcher.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/NextSnapshotFetcher.java
@@ -1,0 +1,76 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.table.source.OutOfRangeException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+/** Fetcher for getting the next snapshot by snapshot id. */
+public class NextSnapshotFetcher {
+
+    public static final Logger LOG = LoggerFactory.getLogger(NextSnapshotFetcher.class);
+    private final SnapshotManager snapshotManager;
+    private final boolean changelogDecoupled;
+    // Only support changelog as follow-up now.
+    private final boolean changelogAsFollowup;
+
+    public NextSnapshotFetcher(
+            SnapshotManager snapshotManager,
+            boolean changelogDecoupled,
+            boolean changelogAsFollowup) {
+        this.snapshotManager = snapshotManager;
+        this.changelogDecoupled = changelogDecoupled;
+        this.changelogAsFollowup = changelogAsFollowup;
+    }
+
+    @Nullable
+    public Snapshot getNextSnapshot(long nextSnapshotId) {
+        if (snapshotManager.snapshotExists(nextSnapshotId)) {
+            return snapshotManager.snapshot(nextSnapshotId);
+        }
+
+        Long earliestSnapshotId = snapshotManager.earliestSnapshotId();
+        // No snapshot now
+        if (earliestSnapshotId == null || earliestSnapshotId <= nextSnapshotId) {
+            LOG.debug(
+                    "Next snapshot id {} does not exist, wait for the snapshot generation.",
+                    nextSnapshotId);
+            return null;
+        }
+
+        if (!changelogAsFollowup
+                || !changelogDecoupled
+                || !snapshotManager.longLivedChangelogExists(nextSnapshotId)) {
+            throw new OutOfRangeException(
+                    String.format(
+                            "The snapshot with id %d has expired. You can: "
+                                    + "1. increase the snapshot or changelog expiration time. "
+                                    + "2. use consumer-id to ensure that unconsumed snapshots will not be expired.",
+                            nextSnapshotId));
+        }
+        return snapshotManager.changelog(nextSnapshotId);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -245,10 +245,15 @@ public class SnapshotManager implements Serializable {
      * Returns the latest snapshot earlier than the timestamp mills. A non-existent snapshot may be
      * returned if all snapshots are equal to or later than the timestamp mills.
      */
-    public @Nullable Long earlierThanTimeMills(long timestampMills) {
-        Long changelogEarliest = earliestLongLivedChangelogId();
+    public @Nullable Long earlierThanTimeMills(long timestampMills, boolean startFromChangelog) {
         Long earliestSnapshot = earliestSnapshotId();
-        Long earliest = changelogEarliest == null ? earliestSnapshot : changelogEarliest;
+        Long earliest;
+        if (startFromChangelog) {
+            Long earliestChangelog = earliestLongLivedChangelogId();
+            earliest = earliestChangelog == null ? earliestSnapshot : earliestChangelog;
+        } else {
+            earliest = earliestSnapshot;
+        }
         Long latest = latestSnapshotId();
 
         if (earliest == null || latest == null) {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.utils;
 
+import org.apache.paimon.Changelog;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileStatus;
@@ -40,6 +41,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BinaryOperator;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -53,6 +55,7 @@ public class SnapshotManager implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private static final String SNAPSHOT_PREFIX = "snapshot-";
+    private static final String CHANGELOG_PREFIX = "changelog-";
     public static final String EARLIEST = "EARLIEST";
     public static final String LATEST = "LATEST";
     private static final int READ_HINT_RETRY_NUM = 3;
@@ -76,6 +79,14 @@ public class SnapshotManager implements Serializable {
 
     public Path snapshotDirectory() {
         return new Path(tablePath + "/snapshot");
+    }
+
+    public Path changelogDirectory() {
+        return new Path(tablePath + "/changelog");
+    }
+
+    public Path longLivedChangelogPath(long snapshotId) {
+        return new Path(tablePath + "/changelog/" + CHANGELOG_PREFIX + snapshotId);
     }
 
     public Path snapshotPath(long snapshotId) {
@@ -107,6 +118,15 @@ public class SnapshotManager implements Serializable {
         return snapshot(DEFAULT_MAIN_BRANCH, snapshotId);
     }
 
+    public Changelog changelog(long snapshotId) {
+        Path changelogPath = longLivedChangelogPath(snapshotId);
+        return Changelog.fromPath(fileIO, changelogPath);
+    }
+
+    public Changelog longLivedChangelog(long snapshotId) {
+        return Changelog.fromPath(fileIO, longLivedChangelogPath(snapshotId));
+    }
+
     public Snapshot snapshot(String branchName, long snapshotId) {
         Path snapshotPath = snapshotPathByBranch(branchName, snapshotId);
         return Snapshot.fromPath(fileIO, snapshotPath);
@@ -119,6 +139,17 @@ public class SnapshotManager implements Serializable {
         } catch (IOException e) {
             throw new RuntimeException(
                     "Failed to determine if snapshot #" + snapshotId + " exists in path " + path,
+                    e);
+        }
+    }
+
+    public boolean longLivedChangelogExists(long snapshotId) {
+        Path path = longLivedChangelogPath(snapshotId);
+        try {
+            return fileIO.exists(path);
+        } catch (IOException e) {
+            throw new RuntimeException(
+                    "Failed to determine if changelog #" + snapshotId + " exists in path " + path,
                     e);
         }
     }
@@ -138,7 +169,7 @@ public class SnapshotManager implements Serializable {
 
     public @Nullable Long latestSnapshotId(String branchName) {
         try {
-            return findLatest(branchName);
+            return findLatest(snapshotDirByBranch(branchName), SNAPSHOT_PREFIX, this::snapshotPath);
         } catch (IOException e) {
             throw new RuntimeException("Failed to find latest snapshot id", e);
         }
@@ -153,9 +184,31 @@ public class SnapshotManager implements Serializable {
         return earliestSnapshotId(DEFAULT_MAIN_BRANCH);
     }
 
+    public @Nullable Long earliestLongLivedChangelogId() {
+        try {
+            return findEarliest(
+                    changelogDirectory(), CHANGELOG_PREFIX, this::longLivedChangelogPath);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to find earliest changelog id", e);
+        }
+    }
+
+    public @Nullable Long latestLongLivedChangelogId() {
+        try {
+            return findLatest(changelogDirectory(), CHANGELOG_PREFIX, this::longLivedChangelogPath);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to find latest changelog id", e);
+        }
+    }
+
+    public @Nullable Long latestChangelogId() {
+        return latestSnapshotId();
+    }
+
     public @Nullable Long earliestSnapshotId(String branchName) {
         try {
-            return findEarliest(branchName);
+            return findEarliest(
+                    snapshotDirByBranch(branchName), SNAPSHOT_PREFIX, this::snapshotPath);
         } catch (IOException e) {
             throw new RuntimeException("Failed to find earliest snapshot id", e);
         }
@@ -351,6 +404,10 @@ public class SnapshotManager implements Serializable {
         return matchedSnapshots;
     }
 
+    public void commitChangelog(Changelog changelog, long id) throws IOException {
+        fileIO.writeFileUtf8(longLivedChangelogPath(id), changelog.toJson());
+    }
+
     /**
      * Traversal snapshots from latest to earliest safely, this is applied on the writer side
      * because the committer may delete obsolete snapshots, which may cause the writer to encounter
@@ -393,46 +450,45 @@ public class SnapshotManager implements Serializable {
         return null;
     }
 
-    private @Nullable Long findLatest(String branchName) throws IOException {
-        Path snapshotDir = snapshotDirByBranch(branchName);
-        if (!fileIO.exists(snapshotDir)) {
+    private @Nullable Long findLatest(Path dir, String prefix, Function<Long, Path> file)
+            throws IOException {
+        if (!fileIO.exists(dir)) {
             return null;
         }
 
-        Long snapshotId = readHint(LATEST, branchName);
+        Long snapshotId = readHint(LATEST, dir);
         if (snapshotId != null) {
             long nextSnapshot = snapshotId + 1;
             // it is the latest only there is no next one
-            if (!snapshotExists(nextSnapshot)) {
+            if (!fileIO.exists(file.apply(nextSnapshot))) {
                 return snapshotId;
             }
         }
 
-        return findByListFiles(Math::max, branchName);
+        return findByListFiles(Math::max, dir, prefix);
     }
 
-    private @Nullable Long findEarliest(String branchName) throws IOException {
-        Path snapshotDir = snapshotDirByBranch(branchName);
-        if (!fileIO.exists(snapshotDir)) {
+    private @Nullable Long findEarliest(Path dir, String prefix, Function<Long, Path> file)
+            throws IOException {
+        if (!fileIO.exists(dir)) {
             return null;
         }
 
-        Long snapshotId = readHint(EARLIEST, branchName);
+        Long snapshotId = readHint(EARLIEST, dir);
         // null and it is the earliest only it exists
-        if (snapshotId != null && snapshotExists(snapshotId)) {
+        if (snapshotId != null && fileIO.exists(file.apply(snapshotId))) {
             return snapshotId;
         }
 
-        return findByListFiles(Math::min, branchName);
+        return findByListFiles(Math::min, dir, prefix);
     }
 
     public Long readHint(String fileName) {
-        return readHint(fileName, DEFAULT_MAIN_BRANCH);
+        return readHint(fileName, snapshotDirByBranch(DEFAULT_MAIN_BRANCH));
     }
 
-    public Long readHint(String fileName, String branchName) {
-        Path snapshotDir = snapshotDirByBranch(branchName);
-        Path path = new Path(snapshotDir, fileName);
+    public Long readHint(String fileName, Path dir) {
+        Path path = new Path(dir, fileName);
         int retryNumber = 0;
         while (retryNumber++ < READ_HINT_RETRY_NUM) {
             try {
@@ -449,12 +505,9 @@ public class SnapshotManager implements Serializable {
         return null;
     }
 
-    private Long findByListFiles(BinaryOperator<Long> reducer, String branchName)
+    private Long findByListFiles(BinaryOperator<Long> reducer, Path dir, String prefix)
             throws IOException {
-        Path snapshotDir = snapshotDirByBranch(branchName);
-        return listVersionedFiles(fileIO, snapshotDir, SNAPSHOT_PREFIX)
-                .reduce(reducer)
-                .orElse(null);
+        return listVersionedFiles(fileIO, dir, prefix).reduce(reducer).orElse(null);
     }
 
     public void commitLatestHint(long snapshotId) throws IOException {
@@ -462,7 +515,15 @@ public class SnapshotManager implements Serializable {
     }
 
     public void commitLatestHint(long snapshotId, String branchName) throws IOException {
-        commitHint(snapshotId, LATEST, branchName);
+        commitHint(snapshotId, LATEST, snapshotDirByBranch(branchName));
+    }
+
+    public void commitLongLivedChangelogLatestHint(long snapshotId) throws IOException {
+        commitHint(snapshotId, LATEST, changelogDirectory());
+    }
+
+    public void commitLongLivedChangelogEarliestHint(long snapshotId) throws IOException {
+        commitHint(snapshotId, EARLIEST, changelogDirectory());
     }
 
     public void commitEarliestHint(long snapshotId) throws IOException {
@@ -470,13 +531,11 @@ public class SnapshotManager implements Serializable {
     }
 
     public void commitEarliestHint(long snapshotId, String branchName) throws IOException {
-        commitHint(snapshotId, EARLIEST, branchName);
+        commitHint(snapshotId, EARLIEST, snapshotDirByBranch(branchName));
     }
 
-    private void commitHint(long snapshotId, String fileName, String branchName)
-            throws IOException {
-        Path snapshotDir = snapshotDirByBranch(branchName);
-        Path hintFile = new Path(snapshotDir, fileName);
+    private void commitHint(long snapshotId, String fileName, Path dir) throws IOException {
+        Path hintFile = new Path(dir, fileName);
         fileIO.overwriteFileUtf8(hintFile, String.valueOf(snapshotId));
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -192,6 +192,7 @@ public class TestFileStore extends KeyValueFileStore {
             boolean snapshotExpireCleanEmptyDirectories) {
         return new ExpireChangelogImpl(
                         snapshotManager(),
+                        new TagManager(fileIO, options.path()),
                         newSnapshotDeletion(),
                         snapshotExpireCleanEmptyDirectories)
                 .retainMin(numRetainedMin)
@@ -633,11 +634,13 @@ public class TestFileStore extends KeyValueFileStore {
                             pathFactory.bucketPath(entry.partition(), entry.bucket()),
                             entry.file().fileName()));
         }
+        System.out.println("snapshot: " + snapshotId + result.toString());
+
         return result;
     }
 
     private static Set<Path> getChangelogFileInUse(
-            long snapshotId,
+            long changelogId,
             SnapshotManager snapshotManager,
             FileStoreScan scan,
             FileIO fileIO,
@@ -645,11 +648,11 @@ public class TestFileStore extends KeyValueFileStore {
             ManifestList manifestList) {
         Set<Path> result = new HashSet<>();
 
-        Path snapshotPath = snapshotManager.longLivedChangelogPath(snapshotId);
-        Changelog changelog = Changelog.fromPath(fileIO, snapshotPath);
+        Path changelogPath = snapshotManager.longLivedChangelogPath(changelogId);
+        Changelog changelog = Changelog.fromPath(fileIO, changelogPath);
 
-        // snapshot file
-        result.add(snapshotPath);
+        // changelog file
+        result.add(changelogPath);
 
         // manifest lists
         if (changelog.changelogManifestList() != null) {
@@ -675,6 +678,7 @@ public class TestFileStore extends KeyValueFileStore {
                             pathFactory.bucketPath(entry.partition(), entry.bucket()),
                             entry.file().fileName()));
         }
+        System.out.println("changelog: " + changelogId + result.toString());
         return result;
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -634,7 +634,6 @@ public class TestFileStore extends KeyValueFileStore {
                             pathFactory.bucketPath(entry.partition(), entry.bucket()),
                             entry.file().fileName()));
         }
-        System.out.println("snapshot: " + snapshotId + result.toString());
 
         return result;
     }
@@ -659,14 +658,9 @@ public class TestFileStore extends KeyValueFileStore {
             result.add(pathFactory.toManifestListPath(changelog.changelogManifestList()));
         }
 
-        if (changelog.deltaManifestList() != null) {
-            result.add(pathFactory.toManifestListPath(changelog.deltaManifestList()));
-        }
-
         // manifests
         List<ManifestFileMeta> manifests = new ArrayList<>();
         manifests.addAll(changelog.changelogManifests(manifestList));
-        manifests.addAll(changelog.deltaManifests(manifestList));
 
         manifests.forEach(m -> result.add(pathFactory.toManifestFilePath(m.fileName())));
 
@@ -678,7 +672,6 @@ public class TestFileStore extends KeyValueFileStore {
                             pathFactory.bucketPath(entry.partition(), entry.bucket()),
                             entry.file().fileName()));
         }
-        System.out.println("changelog: " + changelogId + result.toString());
         return result;
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -41,6 +41,7 @@ import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -450,7 +451,8 @@ public class ExpireSnapshotsTest {
         assertThat(actual).isEqualTo(expected);
     }
 
-    @Test
+    @RepeatedTest(10)
+    //    @Test
     public void testChangelogOutLivedSnapshot() throws Exception {
         List<KeyValue> allData = new ArrayList<>();
         List<Integer> snapshotPositions = new ArrayList<>();

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -449,4 +449,38 @@ public class ExpireSnapshotsTest {
         Map<BinaryRow, BinaryRow> actual = store.toKvMap(actualKvs);
         assertThat(actual).isEqualTo(expected);
     }
+
+    @Test
+    public void testChangelogOutLivedSnapshot() throws Exception {
+        List<KeyValue> allData = new ArrayList<>();
+        List<Integer> snapshotPositions = new ArrayList<>();
+        commit(10, allData, snapshotPositions);
+        ExpireSnapshots snapshot = store.newExpire(1, 2, Long.MAX_VALUE, true, true);
+        ExpireSnapshots changelog = store.newChangelogExpire(1, 3, Long.MAX_VALUE, true);
+        // expire twice to check for idempotence
+        snapshot.expire();
+        snapshot.expire();
+
+        int latestSnapshotId = snapshotManager.latestSnapshotId().intValue();
+        int earliestSnapshotId = snapshotManager.earliestSnapshotId().intValue();
+        int latestLongLivedChangelogId = snapshotManager.latestLongLivedChangelogId().intValue();
+        int earliestLongLivedChangelogId =
+                snapshotManager.earliestLongLivedChangelogId().intValue();
+
+        // 2 snapshot in /snapshot
+        assertThat(latestSnapshotId - earliestSnapshotId).isEqualTo(1);
+        assertThat(earliestLongLivedChangelogId).isEqualTo(1);
+        // The changelog id and snapshot id is continuous
+        assertThat(earliestSnapshotId - latestLongLivedChangelogId).isEqualTo(1);
+
+        changelog.expire();
+        changelog.expire();
+
+        assertThat(snapshotManager.latestSnapshotId().intValue()).isEqualTo(latestSnapshotId);
+        assertThat(snapshotManager.earliestSnapshotId().intValue()).isEqualTo(earliestSnapshotId);
+        assertThat(snapshotManager.latestLongLivedChangelogId())
+                .isEqualTo(snapshotManager.earliestSnapshotId() - 1);
+        assertThat(snapshotManager.earliestLongLivedChangelogId())
+                .isEqualTo(snapshotManager.earliestSnapshotId() - 1);
+    }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -41,7 +41,6 @@ import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -451,8 +450,7 @@ public class ExpireSnapshotsTest {
         assertThat(actual).isEqualTo(expected);
     }
 
-    @RepeatedTest(10)
-    //    @Test
+    @Test
     public void testChangelogOutLivedSnapshot() throws Exception {
         List<KeyValue> allData = new ArrayList<>();
         List<Integer> snapshotPositions = new ArrayList<>();

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -390,6 +390,41 @@ public class ExpireSnapshotsTest {
         store.assertCleaned();
     }
 
+    @Test
+    public void testChangelogOutLivedSnapshot() throws Exception {
+        List<KeyValue> allData = new ArrayList<>();
+        List<Integer> snapshotPositions = new ArrayList<>();
+        commit(10, allData, snapshotPositions);
+        ExpireSnapshots snapshot = store.newExpire(1, 2, Long.MAX_VALUE, true, true);
+        ExpireSnapshots changelog = store.newChangelogExpire(1, 3, Long.MAX_VALUE, true);
+        // expire twice to check for idempotence
+        snapshot.expire();
+        snapshot.expire();
+
+        int latestSnapshotId = snapshotManager.latestSnapshotId().intValue();
+        int earliestSnapshotId = snapshotManager.earliestSnapshotId().intValue();
+        int latestLongLivedChangelogId = snapshotManager.latestLongLivedChangelogId().intValue();
+        int earliestLongLivedChangelogId =
+                snapshotManager.earliestLongLivedChangelogId().intValue();
+
+        // 2 snapshot in /snapshot
+        assertThat(latestSnapshotId - earliestSnapshotId).isEqualTo(1);
+        assertThat(earliestLongLivedChangelogId).isEqualTo(1);
+        // The changelog id and snapshot id is continuous
+        assertThat(earliestSnapshotId - latestLongLivedChangelogId).isEqualTo(1);
+
+        changelog.expire();
+        changelog.expire();
+
+        assertThat(snapshotManager.latestSnapshotId().intValue()).isEqualTo(latestSnapshotId);
+        assertThat(snapshotManager.earliestSnapshotId().intValue()).isEqualTo(earliestSnapshotId);
+        assertThat(snapshotManager.latestLongLivedChangelogId())
+                .isEqualTo(snapshotManager.earliestSnapshotId() - 1);
+        assertThat(snapshotManager.earliestLongLivedChangelogId())
+                .isEqualTo(snapshotManager.earliestSnapshotId() - 1);
+        store.assertCleaned();
+    }
+
     private TestFileStore createStore() {
         ThreadLocalRandom random = ThreadLocalRandom.current();
 
@@ -448,39 +483,5 @@ public class ExpireSnapshotsTest {
         gen.sort(actualKvs);
         Map<BinaryRow, BinaryRow> actual = store.toKvMap(actualKvs);
         assertThat(actual).isEqualTo(expected);
-    }
-
-    @Test
-    public void testChangelogOutLivedSnapshot() throws Exception {
-        List<KeyValue> allData = new ArrayList<>();
-        List<Integer> snapshotPositions = new ArrayList<>();
-        commit(10, allData, snapshotPositions);
-        ExpireSnapshots snapshot = store.newExpire(1, 2, Long.MAX_VALUE, true, true);
-        ExpireSnapshots changelog = store.newChangelogExpire(1, 3, Long.MAX_VALUE, true);
-        // expire twice to check for idempotence
-        snapshot.expire();
-        snapshot.expire();
-
-        int latestSnapshotId = snapshotManager.latestSnapshotId().intValue();
-        int earliestSnapshotId = snapshotManager.earliestSnapshotId().intValue();
-        int latestLongLivedChangelogId = snapshotManager.latestLongLivedChangelogId().intValue();
-        int earliestLongLivedChangelogId =
-                snapshotManager.earliestLongLivedChangelogId().intValue();
-
-        // 2 snapshot in /snapshot
-        assertThat(latestSnapshotId - earliestSnapshotId).isEqualTo(1);
-        assertThat(earliestLongLivedChangelogId).isEqualTo(1);
-        // The changelog id and snapshot id is continuous
-        assertThat(earliestSnapshotId - latestLongLivedChangelogId).isEqualTo(1);
-
-        changelog.expire();
-        changelog.expire();
-
-        assertThat(snapshotManager.latestSnapshotId().intValue()).isEqualTo(latestSnapshotId);
-        assertThat(snapshotManager.earliestSnapshotId().intValue()).isEqualTo(earliestSnapshotId);
-        assertThat(snapshotManager.latestLongLivedChangelogId())
-                .isEqualTo(snapshotManager.earliestSnapshotId() - 1);
-        assertThat(snapshotManager.earliestLongLivedChangelogId())
-                .isEqualTo(snapshotManager.earliestSnapshotId() - 1);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
@@ -207,6 +207,7 @@ public class FileDeletionTest {
 
         // check after expiring
         store.newExpire(1, 1, Long.MAX_VALUE).expire();
+
         assertPathNotExists(fileIO, pathFactory.bucketPath(partition, 0));
         assertPathExists(fileIO, pathFactory.bucketPath(partition, 1));
     }

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -843,6 +843,8 @@ public abstract class FileStoreTableTestBase {
             Options options = new Options();
             options.set(CoreOptions.SNAPSHOT_NUM_RETAINED_MIN, 5);
             options.set(CoreOptions.SNAPSHOT_NUM_RETAINED_MAX, 5);
+            options.set(CoreOptions.CHANGELOG_NUM_RETAINED_MIN, 5);
+            options.set(CoreOptions.CHANGELOG_NUM_RETAINED_MAX, 5);
             table.copy(options.toMap()).newCommit("").expireSnapshots();
         }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -101,6 +101,8 @@ import java.util.stream.Collectors;
 
 import static org.apache.paimon.CoreOptions.BUCKET;
 import static org.apache.paimon.CoreOptions.BUCKET_KEY;
+import static org.apache.paimon.CoreOptions.CHANGELOG_NUM_RETAINED_MAX;
+import static org.apache.paimon.CoreOptions.CHANGELOG_NUM_RETAINED_MIN;
 import static org.apache.paimon.CoreOptions.COMPACTION_MAX_FILE_NUM;
 import static org.apache.paimon.CoreOptions.CONSUMER_IGNORE_PROGRESS;
 import static org.apache.paimon.CoreOptions.ExpireExecutionMode;
@@ -843,8 +845,8 @@ public abstract class FileStoreTableTestBase {
             Options options = new Options();
             options.set(CoreOptions.SNAPSHOT_NUM_RETAINED_MIN, 5);
             options.set(CoreOptions.SNAPSHOT_NUM_RETAINED_MAX, 5);
-            options.set(CoreOptions.CHANGELOG_NUM_RETAINED_MIN, 5);
-            options.set(CoreOptions.CHANGELOG_NUM_RETAINED_MAX, 5);
+            options.set(CHANGELOG_NUM_RETAINED_MIN, 5);
+            options.set(CHANGELOG_NUM_RETAINED_MAX, 5);
             table.copy(options.toMap()).newCommit("").expireSnapshots();
         }
 
@@ -1143,6 +1145,8 @@ public abstract class FileStoreTableTestBase {
         options.put(SNAPSHOT_EXPIRE_EXECUTION_MODE.key(), ExpireExecutionMode.ASYNC.toString());
         options.put(SNAPSHOT_NUM_RETAINED_MIN.key(), "1");
         options.put(SNAPSHOT_NUM_RETAINED_MAX.key(), "1");
+        options.put(CHANGELOG_NUM_RETAINED_MIN.key(), "1");
+        options.put(CHANGELOG_NUM_RETAINED_MAX.key(), "1");
         options.put(SNAPSHOT_EXPIRE_LIMIT.key(), "2");
 
         TableCommitImpl commit = table.copy(options).newCommit(commitUser);

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/StartupModeTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/StartupModeTest.java
@@ -195,10 +195,10 @@ public class StartupModeTest extends ScannerTestBase {
     @Test
     public void testTimeTravelFromExpiredSnapshot() throws Exception {
         Map<String, String> properties = new HashMap<>();
-        // retaine 2 snapshots
+        // retain 2 snapshots
         properties.put(CoreOptions.SNAPSHOT_NUM_RETAINED_MAX.key(), "2");
         properties.put(CoreOptions.SNAPSHOT_NUM_RETAINED_MIN.key(), "2");
-        // specify consume from a expired snapshot
+        // specify consume from an expired snapshot
         properties.put(CoreOptions.SCAN_SNAPSHOT_ID.key(), "1");
         initializeTable(StartupMode.FROM_SNAPSHOT, properties);
         initializeTestData(); // initialize 3 commits, expired snapshot 1

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/TableScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/TableScanTest.java
@@ -69,7 +69,7 @@ public class TableScanTest extends ScannerTestBase {
 
     @Test
     public void testPushDownLimit() throws Exception {
-        createAppenOnlyTable();
+        createAppendOnlyTable();
 
         StreamTableWrite write = table.newWrite(commitUser);
         StreamTableCommit commit = table.newCommit(commitUser);

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScannerTest.java
@@ -18,12 +18,20 @@
 
 package org.apache.paimon.table.source.snapshot;
 
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.ExpireSnapshots;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.utils.SnapshotManager;
+import org.apache.paimon.utils.TraceableFileIO;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -97,6 +105,72 @@ public class ContinuousFromTimestampStartingScannerTest extends ScannerTestBase 
                 (StartingScanner.NextSnapshot) scanner.scan(snapshotReader);
         // next snapshot
         assertThat(result.nextSnapshotId()).isEqualTo(1);
+
+        write.close();
+        commit.close();
+    }
+
+    @Test
+    public void testScanFromChangelog() throws Exception {
+        Options options = new Options();
+        options.set(CoreOptions.SNAPSHOT_NUM_RETAINED_MAX, 2);
+        options.set(CoreOptions.SNAPSHOT_NUM_RETAINED_MIN, 1);
+        FileStoreTable table =
+                createFileStoreTable(
+                        true,
+                        options,
+                        new Path(
+                                TraceableFileIO.SCHEME
+                                        + "://"
+                                        + tempDir.toString()
+                                        + "/"
+                                        + UUID.randomUUID()));
+        SnapshotManager snapshotManager = table.snapshotManager();
+        ExpireSnapshots expireSnapshots = table.newExpireSnapshots();
+        StreamTableWrite write = table.newWrite(commitUser);
+        StreamTableCommit commit = table.newCommit(commitUser);
+
+        write.write(rowData(1, 10, 100L));
+        write.write(rowData(1, 20, 200L));
+        write.write(rowData(1, 40, 400L));
+        commit.commit(0, write.prepareCommit(true, 0));
+
+        Thread.sleep(50);
+
+        write.write(rowData(1, 10, 101L));
+        write.write(rowData(1, 30, 300L));
+        write.write(rowDataWithKind(RowKind.DELETE, 1, 40, 400L));
+        commit.commit(1, write.prepareCommit(true, 1));
+
+        // wait for a little while
+        Thread.sleep(50);
+
+        write.write(rowData(1, 10, 102L));
+        write.write(rowData(1, 20, 201L));
+        commit.commit(2, write.prepareCommit(true, 2));
+
+        assertThat(snapshotManager.latestSnapshotId()).isEqualTo(3);
+        assertThat(snapshotManager.earliestLongLivedChangelogId()).isEqualTo(1);
+        assertThat(snapshotManager.earliestSnapshotId()).isEqualTo(2);
+
+        ContinuousFromTimestampStartingScanner scanner =
+                new ContinuousFromTimestampStartingScanner(
+                        snapshotManager, snapshotManager.snapshot(3).timeMillis());
+        StartingScanner.NextSnapshot result =
+                (StartingScanner.NextSnapshot) scanner.scan(snapshotReader);
+        assertThat(result.nextSnapshotId()).isEqualTo(3);
+        scanner =
+                new ContinuousFromTimestampStartingScanner(
+                        snapshotManager, snapshotManager.snapshot(2).timeMillis());
+
+        assertThat(((StartingScanner.NextSnapshot) scanner.scan(snapshotReader)).nextSnapshotId())
+                .isEqualTo(2);
+
+        scanner =
+                new ContinuousFromTimestampStartingScanner(
+                        snapshotManager, snapshotManager.changelog(1).timeMillis());
+        assertThat(((StartingScanner.NextSnapshot) scanner.scan(snapshotReader)).nextSnapshotId())
+                .isEqualTo(1);
 
         write.close();
         commit.close();

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScannerTest.java
@@ -66,7 +66,8 @@ public class ContinuousFromTimestampStartingScannerTest extends ScannerTestBase 
         long timestamp = snapshotManager.snapshot(3).timeMillis();
 
         ContinuousFromTimestampStartingScanner scanner =
-                new ContinuousFromTimestampStartingScanner(snapshotManager, timestamp);
+                new ContinuousFromTimestampStartingScanner(
+                        snapshotManager, timestamp, false, false);
         StartingScanner.NextSnapshot result =
                 (StartingScanner.NextSnapshot) scanner.scan(snapshotReader);
         assertThat(result.nextSnapshotId()).isEqualTo(3);
@@ -80,7 +81,7 @@ public class ContinuousFromTimestampStartingScannerTest extends ScannerTestBase 
         SnapshotManager snapshotManager = table.snapshotManager();
         ContinuousFromTimestampStartingScanner scanner =
                 new ContinuousFromTimestampStartingScanner(
-                        snapshotManager, System.currentTimeMillis());
+                        snapshotManager, System.currentTimeMillis(), false, false);
         assertThat(scanner.scan(snapshotReader)).isInstanceOf(StartingScanner.NoSnapshot.class);
     }
 
@@ -100,7 +101,8 @@ public class ContinuousFromTimestampStartingScannerTest extends ScannerTestBase 
         long timestamp = snapshotManager.snapshot(1).timeMillis();
 
         ContinuousFromTimestampStartingScanner scanner =
-                new ContinuousFromTimestampStartingScanner(snapshotManager, timestamp);
+                new ContinuousFromTimestampStartingScanner(
+                        snapshotManager, timestamp, false, false);
         StartingScanner.NextSnapshot result =
                 (StartingScanner.NextSnapshot) scanner.scan(snapshotReader);
         // next snapshot
@@ -155,20 +157,20 @@ public class ContinuousFromTimestampStartingScannerTest extends ScannerTestBase 
 
         ContinuousFromTimestampStartingScanner scanner =
                 new ContinuousFromTimestampStartingScanner(
-                        snapshotManager, snapshotManager.snapshot(3).timeMillis());
+                        snapshotManager, snapshotManager.snapshot(3).timeMillis(), false, false);
         StartingScanner.NextSnapshot result =
                 (StartingScanner.NextSnapshot) scanner.scan(snapshotReader);
         assertThat(result.nextSnapshotId()).isEqualTo(3);
         scanner =
                 new ContinuousFromTimestampStartingScanner(
-                        snapshotManager, snapshotManager.snapshot(2).timeMillis());
+                        snapshotManager, snapshotManager.snapshot(2).timeMillis(), false, false);
 
         assertThat(((StartingScanner.NextSnapshot) scanner.scan(snapshotReader)).nextSnapshotId())
                 .isEqualTo(2);
 
         scanner =
                 new ContinuousFromTimestampStartingScanner(
-                        snapshotManager, snapshotManager.changelog(1).timeMillis());
+                        snapshotManager, snapshotManager.changelog(1).timeMillis(), false, false);
         assertThat(((StartingScanner.NextSnapshot) scanner.scan(snapshotReader)).nextSnapshotId())
                 .isEqualTo(1);
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ScannerTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ScannerTestBase.java
@@ -85,7 +85,7 @@ public abstract class ScannerTestBase {
         snapshotReader = table.newSnapshotReader();
     }
 
-    protected void createAppenOnlyTable() throws Exception {
+    protected void createAppendOnlyTable() throws Exception {
         tempDir = Files.createTempDirectory("junit");
         tablePath = new Path(TraceableFileIO.SCHEME + "://" + tempDir.toString());
         fileIO = FileIOFinder.find(tablePath);
@@ -135,19 +135,19 @@ public abstract class ScannerTestBase {
     }
 
     protected FileStoreTable createFileStoreTable() throws Exception {
-        return createFileStoreTable(true, new Options());
+        return createFileStoreTable(true, new Options(), tablePath);
     }
 
     protected FileStoreTable createFileStoreTable(Options conf) throws Exception {
-        return createFileStoreTable(true, conf);
+        return createFileStoreTable(true, conf, tablePath);
     }
 
     protected FileStoreTable createFileStoreTable(boolean withPrimaryKeys) throws Exception {
-        return createFileStoreTable(withPrimaryKeys, new Options());
+        return createFileStoreTable(withPrimaryKeys, new Options(), tablePath);
     }
 
-    protected FileStoreTable createFileStoreTable(boolean withPrimaryKeys, Options conf)
-            throws Exception {
+    protected FileStoreTable createFileStoreTable(
+            boolean withPrimaryKeys, Options conf, Path tablePath) throws Exception {
         SchemaManager schemaManager = new SchemaManager(fileIO, tablePath);
         List<String> primaryKeys = new ArrayList<>();
         if (withPrimaryKeys) {

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -86,7 +86,7 @@ public class SnapshotManagerTest {
                 // pick a random time equal to one of the snapshots
                 time = millis.get(random.nextInt(numSnapshots));
             }
-            Long actual = snapshotManager.earlierThanTimeMills(time);
+            Long actual = snapshotManager.earlierThanTimeMills(time, false);
 
             if (millis.get(numSnapshots - 1) < time) {
                 assertThat(actual).isEqualTo(firstSnapshotId + numSnapshots - 1);

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -18,11 +18,13 @@
 
 package org.apache.paimon.utils;
 
+import org.apache.paimon.Changelog;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -141,6 +143,11 @@ public class SnapshotManagerTest {
                 null);
     }
 
+    private Changelog createChangelogWithMillis(long id, long millis) {
+        return new Changelog(
+                id, 0L, null, "changelog-list", Snapshot.CommitKind.APPEND, millis, 1L, null);
+    }
+
     @Test
     public void testTraversalSnapshotsFromLatestSafely() throws IOException, InterruptedException {
         FileIO localFileIO = LocalFileIO.create();
@@ -233,5 +240,30 @@ public class SnapshotManagerTest {
         thread.join();
 
         assertThat(exception.get()).hasMessageContaining("Fails to read snapshot from path");
+    }
+
+    @Test
+    public void testLongLivedChangelog() throws Exception {
+        FileIO localFileIO = LocalFileIO.create();
+        SnapshotManager snapshotManager =
+                new SnapshotManager(localFileIO, new Path(tempDir.toString()));
+        long millis = 1L;
+        for (long i = 1; i <= 5; i++) {
+            Changelog changelog = createChangelogWithMillis(i, millis + i * 1000);
+            localFileIO.writeFileUtf8(
+                    snapshotManager.longLivedChangelogPath(i), changelog.toJson());
+        }
+
+        for (long i = 6; i <= 10; i++) {
+            Snapshot snapshot = createSnapshotWithMillis(i, millis + i * 1000);
+            localFileIO.writeFileUtf8(snapshotManager.snapshotPath(i), snapshot.toJson());
+        }
+
+        Assertions.assertThat(snapshotManager.earliestLongLivedChangelogId()).isEqualTo(1);
+        Assertions.assertThat(snapshotManager.latestChangelogId()).isEqualTo(10);
+        Assertions.assertThat(snapshotManager.latestLongLivedChangelogId()).isEqualTo(5);
+        Assertions.assertThat(snapshotManager.earliestSnapshotId()).isEqualTo(6);
+        Assertions.assertThat(snapshotManager.latestSnapshotId()).isEqualTo(10);
+        Assertions.assertThat(snapshotManager.changelog(1)).isNotNull();
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -145,7 +145,22 @@ public class SnapshotManagerTest {
 
     private Changelog createChangelogWithMillis(long id, long millis) {
         return new Changelog(
-                id, 0L, null, "changelog-list", Snapshot.CommitKind.APPEND, millis, 1L, null);
+                id,
+                0L,
+                null,
+                null,
+                null,
+                null,
+                null,
+                0L,
+                Snapshot.CommitKind.APPEND,
+                millis,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This PR is the first step for #2899. It's mainly do the following things.

- Add `changelog` related option to define the changlog lifecycle.
- Introduce `ExpireChangelogImpl` to handle the changelog expire

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
