### PR TITLE
[core] FileStoreCommit should check append files only in recovering

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
@@ -29,7 +29,6 @@ import org.apache.paimon.utils.FileStorePathFactory;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /** Commit operation which provides commit and overwrite. */
 public interface FileStoreCommit {
@@ -39,23 +38,17 @@ public interface FileStoreCommit {
 
     FileStoreCommit ignoreEmptyCommit(boolean ignoreEmptyCommit);
 
-    /** Find out which manifest committable need to be retried when recovering from the failure. */
-    default List<ManifestCommittable> filterCommitted(List<ManifestCommittable> committableList) {
-        Set<Long> identifiers =
-                filterCommitted(
-                        committableList.stream()
-                                .map(ManifestCommittable::identifier)
-                                .collect(Collectors.toSet()));
-        return committableList.stream()
-                .filter(m -> identifiers.contains(m.identifier()))
-                .collect(Collectors.toList());
-    }
-
     /** Find out which commit identifier need to be retried when recovering from the failure. */
     Set<Long> filterCommitted(Set<Long> commitIdentifiers);
 
     /** Commit from manifest committable. */
     void commit(ManifestCommittable committable, Map<String, String> properties);
+
+    /** Commit from manifest committable with checkAppendFiles. */
+    void commit(
+            ManifestCommittable committable,
+            Map<String, String> properties,
+            boolean checkAppendFiles);
 
     /**
      * Overwrite from manifest committable and partition.

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -455,7 +455,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                                 committable.watermark(),
                                 committable.logOffsets(),
                                 Snapshot.CommitKind.COMPACT,
-                                null,
+                                mustConflictCheck(),
                                 branchName,
                                 null);
                 generatedSnapshot += 1;
@@ -551,7 +551,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 null,
                 Collections.emptyMap(),
                 Snapshot.CommitKind.ANALYZE,
-                null,
+                noConflictCheck(),
                 branchName,
                 statsFileName);
     }
@@ -720,7 +720,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     logOffsets,
                     Snapshot.CommitKind.OVERWRITE,
                     latestSnapshot,
-                    null,
+                    mustConflictCheck(),
                     branchName,
                     null)) {
                 break;
@@ -1211,16 +1211,20 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         }
     }
 
-    private interface ConflictCheck {
-
+    /** Should do conflict check. */
+    interface ConflictCheck {
         boolean shouldCheck(long latestSnapshot);
     }
 
-    private static ConflictCheck hasConflictChecked(@Nullable Long checkedLatestSnapshotId) {
+    static ConflictCheck hasConflictChecked(@Nullable Long checkedLatestSnapshotId) {
         return latestSnapshot -> !Objects.equals(latestSnapshot, checkedLatestSnapshotId);
     }
 
-    private static ConflictCheck noConflictCheck() {
+    static ConflictCheck noConflictCheck() {
         return latestSnapshot -> false;
+    }
+
+    static ConflictCheck mustConflictCheck() {
+        return latestSnapshot -> true;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/StreamTableCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/StreamTableCommit.java
@@ -22,7 +22,6 @@ import org.apache.paimon.annotation.Public;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A {@link TableCommit} for stream processing. You can use this class to commit multiple times.
@@ -32,17 +31,6 @@ import java.util.Set;
  */
 @Public
 public interface StreamTableCommit extends TableCommit {
-
-    /**
-     * Filter committed commits. Return uncommitted identifiers. This method is used for failover
-     * cases.
-     *
-     * @deprecated Use {@link StreamTableCommit#filterAndCommit} to filter and commit all {@link
-     *     CommitMessage} in question with one method call, instead of calling this method first and
-     *     then call {@link StreamTableCommit#commit}.
-     */
-    @Deprecated
-    Set<Long> filterCommitted(Set<Long> commitIdentifiers);
 
     /**
      * Create a new commit. One commit may generate up to two snapshots, one for adding new files

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
@@ -154,11 +154,6 @@ public class TableCommitImpl implements InnerTableCommit {
     }
 
     @Override
-    public Set<Long> filterCommitted(Set<Long> commitIdentifiers) {
-        return commit.filterCommitted(commitIdentifiers);
-    }
-
-    @Override
     public void commit(List<CommitMessage> commitMessages) {
         checkCommitted();
         commit(COMMIT_IDENTIFIER, commitMessages);
@@ -198,13 +193,13 @@ public class TableCommitImpl implements InnerTableCommit {
     }
 
     public void commit(ManifestCommittable committable) {
-        commitMultiple(Collections.singletonList(committable));
+        commitMultiple(Collections.singletonList(committable), false);
     }
 
-    public void commitMultiple(List<ManifestCommittable> committables) {
+    public void commitMultiple(List<ManifestCommittable> committables, boolean checkAppendFiles) {
         if (overwritePartition == null) {
             for (ManifestCommittable committable : committables) {
-                commit.commit(committable, new HashMap<>());
+                commit.commit(committable, new HashMap<>(), checkAppendFiles);
             }
             if (!committables.isEmpty()) {
                 expire(committables.get(committables.size() - 1).identifier(), expireMainExecutor);
@@ -253,7 +248,7 @@ public class TableCommitImpl implements InnerTableCommit {
                         .collect(Collectors.toList());
         if (retryCommittables.size() > 0) {
             checkFilesExistence(retryCommittables);
-            commitMultiple(retryCommittables);
+            commitMultiple(retryCommittables, true);
         }
         return retryCommittables.size();
     }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
@@ -60,6 +60,7 @@ import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.operation.FileStoreCommitImpl.mustConflictCheck;
 import static org.apache.paimon.operation.FileStoreTestUtils.assertPathExists;
 import static org.apache.paimon.operation.FileStoreTestUtils.assertPathNotExists;
 import static org.apache.paimon.operation.FileStoreTestUtils.commitData;
@@ -728,7 +729,7 @@ public class FileDeletionTest {
                         Collections.emptyMap(),
                         Snapshot.CommitKind.APPEND,
                         store.snapshotManager().latestSnapshot(),
-                        null,
+                        mustConflictCheck(),
                         DEFAULT_MAIN_BRANCH,
                         null);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/PartitionExpireTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/PartitionExpireTest.java
@@ -34,6 +34,7 @@ import org.apache.paimon.table.sink.StreamTableWrite;
 import org.apache.paimon.table.sink.TableCommitImpl;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.utils.SnapshotManager;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,10 +50,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -175,7 +174,6 @@ public class PartitionExpireTest {
         int preparedCommits = random.nextInt(20, 30);
 
         List<List<CommitMessage>> commitMessages = new ArrayList<>();
-        Set<Long> notCommitted = new HashSet<>();
         for (int i = 0; i < preparedCommits; i++) {
             // ensure the partition will be expired
             String f0 =
@@ -185,7 +183,6 @@ public class PartitionExpireTest {
             StreamTableWrite write = table.newWrite(commitUser);
             write.write(GenericRow.of(BinaryString.fromString(f0), BinaryString.fromString(f1)));
             commitMessages.add(write.prepareCommit(false, i));
-            notCommitted.add((long) i);
         }
 
         // commit a part of data and trigger partition expire
@@ -193,7 +190,6 @@ public class PartitionExpireTest {
         StreamTableCommit commit = table.newCommit(commitUser);
         for (int i = 0; i < successCommits - 2; i++) {
             commit.commit(i, commitMessages.get(i));
-            notCommitted.remove((long) i);
         }
 
         // we need two commits to trigger partition expire
@@ -208,13 +204,12 @@ public class PartitionExpireTest {
         commit.close();
         commit = table.newCommit(commitUser);
         commit.commit(successCommits - 2, commitMessages.get(successCommits - 2));
-        notCommitted.remove((long) (successCommits - 2));
         Thread.sleep(5000);
         commit.commit(successCommits - 1, commitMessages.get(successCommits - 1));
-        notCommitted.remove((long) (successCommits - 1));
 
         // check whether partition expire is triggered
-        Snapshot snapshot = table.snapshotManager().latestSnapshot();
+        SnapshotManager snapshotManager = table.snapshotManager();
+        Snapshot snapshot = snapshotManager.latestSnapshot();
         assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.OVERWRITE);
 
         // filterAndCommit
@@ -226,6 +221,10 @@ public class PartitionExpireTest {
         // no exception here
         commit.filterAndCommit(allCommits);
         commit.close();
+
+        // check commit last
+        assertThat(snapshotManager.latestSnapshot().commitIdentifier())
+                .isEqualTo(allCommits.size() - 1);
     }
 
     private List<String> read() throws IOException {

--- a/paimon-core/src/test/java/org/apache/paimon/operation/TestCommitThread.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/TestCommitThread.java
@@ -193,7 +193,8 @@ public class TestCommitThread extends Thread {
         while (true) {
             try {
                 if (shouldCheckFilter) {
-                    if (commit.filterCommitted(Collections.singletonList(committable)).isEmpty()) {
+                    if (commit.filterCommitted(Collections.singleton(committable.identifier()))
+                            .isEmpty()) {
                         break;
                     }
                 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
@@ -97,7 +97,7 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
     @Override
     public void commit(List<ManifestCommittable> committables)
             throws IOException, InterruptedException {
-        commit.commitMultiple(committables);
+        commit.commitMultiple(committables, false);
         calcNumBytesAndRecordsOut(committables);
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
https://github.com/apache/paimon/pull/301 FileStoreCommitImpl also checks for conflicts when committing append changes.

But it only for "When the job runs to checkpoint N, if the user recovers from an old checkpoint (such as checkpoint N-5), the sink of the current FTS will cause a manifest corruption because duplicate files may be committed.".

We should optimize this, normal commit will cause too much check burden.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
