### PR TITLE
[lookup] Fix NPE when FileStoreLookupFunction init empty table with dynamic partition

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/DynamicPartitionLoader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/DynamicPartitionLoader.java
@@ -53,7 +53,7 @@ public class DynamicPartitionLoader implements Serializable {
     private Comparator<InternalRow> comparator;
 
     private LocalDateTime lastRefresh;
-    private BinaryRow partition;
+    @Nullable private BinaryRow partition;
 
     private DynamicPartitionLoader(Table table, Duration refreshInterval) {
         this.table = table;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -236,6 +236,10 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
 
         boolean partitionChanged = partitionLoader.checkRefresh();
         BinaryRow partition = partitionLoader.partition();
+        if (partition == null) {
+            return null;
+        }
+
         lookupTable.specificPartitionFilter(createSpecificPartFilter(partition));
 
         if (partitionChanged && reopen) {


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Fix NPE

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
