### PR TITLE
[core] Fix that ignore-delete option is not compatible with old delete records and LocalMergeOperator

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileRecordReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileRecordReader.java
@@ -34,12 +34,18 @@ public class KeyValueDataFileRecordReader implements RecordReader<KeyValue> {
     private final RecordReader<InternalRow> reader;
     private final KeyValueSerializer serializer;
     private final int level;
+    private final boolean ignoreDelete;
 
     public KeyValueDataFileRecordReader(
-            RecordReader<InternalRow> reader, RowType keyType, RowType valueType, int level) {
+            RecordReader<InternalRow> reader,
+            RowType keyType,
+            RowType valueType,
+            int level,
+            boolean ignoreDelete) {
         this.reader = reader;
         this.serializer = new KeyValueSerializer(keyType, valueType);
         this.level = level;
+        this.ignoreDelete = ignoreDelete;
     }
 
     @Nullable
@@ -50,11 +56,15 @@ public class KeyValueDataFileRecordReader implements RecordReader<KeyValue> {
             return null;
         }
 
-        return iterator.transform(
-                internalRow ->
-                        internalRow == null
-                                ? null
-                                : serializer.fromRow(internalRow).setLevel(level));
+        RecordIterator<KeyValue> transformed =
+                iterator.transform(
+                        internalRow ->
+                                internalRow == null
+                                        ? null
+                                        : serializer.fromRow(internalRow).setLevel(level));
+        // In older version, the delete records might be written into data file even when
+        // ignore-delete configured, so the reader should also filter the delete records
+        return ignoreDelete ? transformed.filter(KeyValue::isAdd) : transformed;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileRecordReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileRecordReader.java
@@ -62,7 +62,7 @@ public class KeyValueDataFileRecordReader implements RecordReader<KeyValue> {
                                 internalRow == null
                                         ? null
                                         : serializer.fromRow(internalRow).setLevel(level));
-        // In older version, the delete records might be written into data file even when
+        // In 0.7- versions, the delete records might be written into data file even when
         // ignore-delete configured, so the reader should also filter the delete records
         return ignoreDelete ? transformed.filter(KeyValue::isAdd) : transformed;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
@@ -144,7 +144,12 @@ public class KeyValueFileReaderFactory {
                     new ApplyDeletionVectorReader<>(fileRecordReader, deletionVector.get());
         }
 
-        return new KeyValueDataFileRecordReader(fileRecordReader, keyType, valueType, level);
+        return new KeyValueDataFileRecordReader(
+                fileRecordReader,
+                keyType,
+                valueType,
+                level,
+                CoreOptions.fromMap(schema.options()).ignoreDelete());
     }
 
     public static Builder builder(

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
@@ -68,6 +68,7 @@ public class KeyValueFileReaderFactory {
     private final Map<FormatKey, BulkFormatMapping> bulkFormatMappings;
     private final BinaryRow partition;
     private final DeletionVector.Factory dvFactory;
+    private final boolean ignoreDelete;
 
     private KeyValueFileReaderFactory(
             FileIO fileIO,
@@ -91,6 +92,7 @@ public class KeyValueFileReaderFactory {
         this.partition = partition;
         this.bulkFormatMappings = new HashMap<>();
         this.dvFactory = dvFactory;
+        this.ignoreDelete = CoreOptions.fromMap(schema.options()).ignoreDelete();
     }
 
     public RecordReader<KeyValue> createRecordReader(
@@ -145,11 +147,7 @@ public class KeyValueFileReaderFactory {
         }
 
         return new KeyValueDataFileRecordReader(
-                fileRecordReader,
-                keyType,
-                valueType,
-                level,
-                CoreOptions.fromMap(schema.options()).ignoreDelete());
+                fileRecordReader, keyType, valueType, level, ignoreDelete);
     }
 
     public static Builder builder(

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -189,11 +189,6 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
         return copyInternal(dynamicOptions, false);
     }
 
-    @Override
-    public FileStoreTable internalCopyWithoutCheck(Map<String, String> dynamicOptions) {
-        return copyInternal(dynamicOptions, true);
-    }
-
     private void checkImmutability(Map<String, String> dynamicOptions) {
         Map<String, String> options = tableSchema.options();
         // check option is not immutable

--- a/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTable.java
@@ -86,9 +86,6 @@ public interface FileStoreTable extends DataTable {
     /** Doesn't change table schema even when there exists time travel scan options. */
     FileStoreTable copyWithoutTimeTravel(Map<String, String> dynamicOptions);
 
-    /** Sometimes we have to change some Immutable options to implement features. */
-    FileStoreTable internalCopyWithoutCheck(Map<String, String> dynamicOptions);
-
     /** TODO: this method is weird, old options will overwrite new options. */
     FileStoreTable copyWithLatestSchema();
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PartialUpdateITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PartialUpdateITCase.java
@@ -460,7 +460,7 @@ public class PartialUpdateITCase extends CatalogITCaseBase {
         assertThat(batchSql("SELECT * FROM ignore_delete"))
                 .containsExactlyInAnyOrder(Row.of(1, "A", null));
 
-        // force alter merge-engine and read
+        // force altering merge engine and read
         Map<String, String> newOptions = new HashMap<>();
         newOptions.put(
                 CoreOptions.MERGE_ENGINE.key(), CoreOptions.MergeEngine.PARTIAL_UPDATE.toString());

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MergeIntoActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MergeIntoActionITCase.java
@@ -130,29 +130,60 @@ public class MergeIntoActionITCase extends ActionITCaseBase {
                         changelogRow("+I", 8, "v_8", "insert", "02-29"),
                         changelogRow("+I", 11, "v_11", "insert", "02-29"),
                         changelogRow("+I", 12, "v_12", "insert", "02-29")));
-
-        if (producer == CoreOptions.ChangelogProducer.FULL_COMPACTION) {
-            // test partial update still works after action
-            testWorkWithPartialUpdate();
-        }
     }
 
-    private void testWorkWithPartialUpdate() throws Exception {
+    @Test
+    public void testWorkWithPartialUpdate() throws Exception {
+        // re-create target table with given producer
+        sEnv.executeSql("DROP TABLE T");
+        prepareTargetTable(CoreOptions.ChangelogProducer.LOOKUP);
+
+        MergeIntoActionBuilder action = new MergeIntoActionBuilder(warehouse, database, "T");
+        // here test if it works when table S is in default and qualified both
+        action.withSourceTable("default.S")
+                .withMergeCondition("T.k = S.k AND T.dt = S.dt")
+                .withMatchedUpsert(
+                        "T.v <> S.v AND S.v IS NOT NULL", "v = S.v, last_action = 'matched_upsert'")
+                .withMatchedDelete("S.v IS NULL")
+                .withNotMatchedInsert(null, "S.k, S.v, 'insert', S.dt")
+                .withNotMatchedBySourceUpsert(
+                        "dt < '02-28'", "v = v || '_nmu', last_action = 'not_matched_upsert'")
+                .withNotMatchedBySourceDelete("dt >= '02-28'");
+
+        // delete records are filtered
+        validateActionRunResult(
+                action.build(),
+                Arrays.asList(
+                        changelogRow("+U", 2, "v_2_nmu", "not_matched_upsert", "02-27"),
+                        changelogRow("+U", 3, "v_3_nmu", "not_matched_upsert", "02-27"),
+                        changelogRow("+U", 7, "Seven", "matched_upsert", "02-28"),
+                        changelogRow("+I", 8, "v_8", "insert", "02-29"),
+                        changelogRow("+I", 11, "v_11", "insert", "02-29"),
+                        changelogRow("+I", 12, "v_12", "insert", "02-29")),
+                Arrays.asList(
+                        changelogRow("+I", 1, "v_1", "creation", "02-27"),
+                        changelogRow("+I", 2, "v_2_nmu", "not_matched_upsert", "02-27"),
+                        changelogRow("+I", 3, "v_3_nmu", "not_matched_upsert", "02-27"),
+                        changelogRow("+I", 4, "v_4", "creation", "02-27"),
+                        changelogRow("+I", 5, "v_5", "creation", "02-28"),
+                        changelogRow("+I", 6, "v_6", "creation", "02-28"),
+                        changelogRow("+I", 7, "Seven", "matched_upsert", "02-28"),
+                        changelogRow("+I", 8, "v_8", "creation", "02-28"),
+                        changelogRow("+I", 8, "v_8", "insert", "02-29"),
+                        changelogRow("+I", 9, "v_9", "creation", "02-28"),
+                        changelogRow("+I", 10, "v_10", "creation", "02-28"),
+                        changelogRow("+I", 11, "v_11", "insert", "02-29"),
+                        changelogRow("+I", 12, "v_12", "insert", "02-29")));
+
+        // test partial update still works after action
         insertInto(
                 "T",
                 "(12, CAST (NULL AS STRING), '$', '02-29')",
                 "(12, 'Test', CAST (NULL AS STRING), '02-29')");
 
         testBatchRead(
-                buildSimpleQuery("T"),
-                Arrays.asList(
-                        changelogRow("+I", 1, "v_1", "creation", "02-27"),
-                        changelogRow("+U", 2, "v_2_nmu", "not_matched_upsert", "02-27"),
-                        changelogRow("+U", 3, "v_3_nmu", "not_matched_upsert", "02-27"),
-                        changelogRow("+U", 7, "Seven", "matched_upsert", "02-28"),
-                        changelogRow("+I", 8, "v_8", "insert", "02-29"),
-                        changelogRow("+I", 11, "v_11", "insert", "02-29"),
-                        changelogRow("+I", 12, "Test", "$", "02-29")));
+                "SELECT * FROM T WHERE k = 12",
+                Collections.singletonList(changelogRow("+I", 12, "Test", "$", "02-29")));
     }
 
     @ParameterizedTest(name = "in-default = {0}")
@@ -553,7 +584,7 @@ public class MergeIntoActionITCase extends ActionITCaseBase {
                             {
                                 put(CHANGELOG_PRODUCER.key(), producer.toString());
                                 // test works with partial update normally
-                                if (producer == CoreOptions.ChangelogProducer.FULL_COMPACTION) {
+                                if (producer == CoreOptions.ChangelogProducer.LOOKUP) {
                                     put(
                                             CoreOptions.MERGE_ENGINE.key(),
                                             CoreOptions.MergeEngine.PARTIAL_UPDATE.toString());

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MergeIntoActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MergeIntoActionITCase.java
@@ -139,8 +139,7 @@ public class MergeIntoActionITCase extends ActionITCaseBase {
         prepareTargetTable(CoreOptions.ChangelogProducer.LOOKUP);
 
         MergeIntoActionBuilder action = new MergeIntoActionBuilder(warehouse, database, "T");
-        // here test if it works when table S is in default and qualified both
-        action.withSourceTable("default.S")
+        action.withSourceTable("S")
                 .withMergeCondition("T.k = S.k AND T.dt = S.dt")
                 .withMatchedUpsert(
                         "T.v <> S.v AND S.v IS NOT NULL", "v = S.v, last_action = 'matched_upsert'")


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Before #3128 , the delete records can be write into data file even when `ignore-delete=true`. So if using jar built after 3128 to read old data, the merge engine might throw exception. This PR fix it by adding filter in reader.

Besides, records passed by `LocalMergeOperator` also should be filtered.

Also remove `changeIgnoreMergeEngine` in merge_into action. Because I think merge_into should also obey the constrains of merge engine. 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
