### PR TITLE
[spark] use cachedRelation.output to build OutputMap in MergePaimonScalarSubqueriers

### DIFF
--- a/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueriers.scala
+++ b/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueriers.scala
@@ -36,7 +36,7 @@ object MergePaimonScalarSubqueriers extends MergePaimonScalarSubqueriersBase {
             DataSourceV2ScanRelation(
               cachedRelation,
               cachedScan: PaimonScan,
-              cachedOutput,
+              _,
               cachedPartitioning)) =>
         checkIdenticalPlans(newRelation, cachedRelation).flatMap {
           outputMap =>
@@ -46,7 +46,7 @@ object MergePaimonScalarSubqueriers extends MergePaimonScalarSubqueriersBase {
                   val mergedAttributes = mergedScan
                     .readSchema()
                     .map(f => AttributeReference(f.name, f.dataType, f.nullable, f.metadata)())
-                  val cachedOutputNameMap = cachedOutput.map(a => a.name -> a).toMap
+                  val cachedOutputNameMap = cachedRelation.output.map(a => a.name -> a).toMap
                   val mergedOutput =
                     mergedAttributes.map(a => cachedOutputNameMap.getOrElse(a.name, a))
                   val newV2ScanRelation = DataSourceV2ScanRelation(

--- a/paimon-spark/paimon-spark-3.4/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueriers.scala
+++ b/paimon-spark/paimon-spark-3.4/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueriers.scala
@@ -41,7 +41,7 @@ object MergePaimonScalarSubqueriers extends MergePaimonScalarSubqueriersBase {
             DataSourceV2ScanRelation(
               cachedRelation,
               cachedScan: PaimonScan,
-              cachedOutput,
+              _,
               cachedPartitioning,
               cacheOrdering)) =>
         checkIdenticalPlans(newRelation, cachedRelation).flatMap {
@@ -57,7 +57,7 @@ object MergePaimonScalarSubqueriers extends MergePaimonScalarSubqueriersBase {
                   val mergedAttributes = mergedScan
                     .readSchema()
                     .map(f => AttributeReference(f.name, f.dataType, f.nullable, f.metadata)())
-                  val cachedOutputNameMap = cachedOutput.map(a => a.name -> a).toMap
+                  val cachedOutputNameMap = cachedRelation.output.map(a => a.name -> a).toMap
                   val mergedOutput =
                     mergedAttributes.map(a => cachedOutputNameMap.getOrElse(a.name, a))
                   val newV2ScanRelation = DataSourceV2ScanRelation(

--- a/paimon-spark/paimon-spark-3.5/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueriers.scala
+++ b/paimon-spark/paimon-spark-3.5/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueriers.scala
@@ -41,7 +41,7 @@ object MergePaimonScalarSubqueriers extends MergePaimonScalarSubqueriersBase {
             DataSourceV2ScanRelation(
               cachedRelation,
               cachedScan: PaimonScan,
-              cachedOutput,
+              _,
               cachedPartitioning,
               cacheOrdering)) =>
         checkIdenticalPlans(newRelation, cachedRelation).flatMap {
@@ -57,7 +57,7 @@ object MergePaimonScalarSubqueriers extends MergePaimonScalarSubqueriersBase {
                   val mergedAttributes = mergedScan
                     .readSchema()
                     .map(f => AttributeReference(f.name, f.dataType, f.nullable, f.metadata)())
-                  val cachedOutputNameMap = cachedOutput.map(a => a.name -> a).toMap
+                  val cachedOutputNameMap = cachedRelation.output.map(a => a.name -> a).toMap
                   val mergedOutput =
                     mergedAttributes.map(a => cachedOutputNameMap.getOrElse(a.name, a))
                   val newV2ScanRelation = DataSourceV2ScanRelation(

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueriersBase.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueriersBase.scala
@@ -88,7 +88,7 @@ trait MergePaimonScalarSubqueriersBase extends Rule[LogicalPlan] with PredicateH
     val newPlan = removeReferences(planWithReferences, cache)
     val subqueryCTEs = cache.filter(_.merged).map(_.plan.asInstanceOf[CTERelationDef])
     if (subqueryCTEs.nonEmpty) {
-      WithCTE(newPlan, subqueryCTEs.toSeq)
+      WithCTE(newPlan, subqueryCTEs)
     } else {
       newPlan
     }
@@ -130,12 +130,12 @@ trait MergePaimonScalarSubqueriersBase extends Rule[LogicalPlan] with PredicateH
                 } else {
                   header.attributes
                 }
-                cache(subqueryIndex) = Header(newHeaderAttributes, mergedPlan, true)
+                cache(subqueryIndex) = Header(newHeaderAttributes, mergedPlan, merged = true)
                 subqueryIndex -> headerIndex
             })
       })
       .getOrElse {
-        cache += Header(Seq(output), plan, false)
+        cache += Header(Seq(output), plan, merged = false)
         cache.length - 1 -> 0
       }
   }
@@ -292,7 +292,7 @@ trait MergePaimonScalarSubqueriersBase extends Rule[LogicalPlan] with PredicateH
       plan)
   }
 
-  protected def mapAttributes[T <: Expression](expr: T, outputMap: AttributeMap[Attribute]) = {
+  protected def mapAttributes[T <: Expression](expr: T, outputMap: AttributeMap[Attribute]): T = {
     expr.transform { case a: Attribute => outputMap.getOrElse(a, a) }.asInstanceOf[T]
   }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

use cachedRelation.output to build OutputMap in MergePaimonScalarSubqueriers

before
```
=== Applying Rule org.apache.paimon.spark.catalyst.optimizer.MergePaimonScalarSubqueriers ===
!Project [CASE WHEN (scalar-subquery#0 [] > 74129) THEN scalar-subquery#1 [] ELSE scalar-subquery#2 [] END AS bucket1#3, CASE WHEN (scalar-subquery#4 [] > 122840) THEN scalar-subquery#5 [] ELSE scalar-subquery#6 [] END AS bucket2#7, CASE WHEN (scalar-subquery#8 [] > 56580) THEN scalar-subquery#9 [] ELSE scalar-subquery#10 [] END AS bucket3#11, CASE WHEN (scalar-subquery#12 [] > 10097) THEN scalar-subquery#13 [] ELSE scalar-subquery#14 [] END AS bucket4#15, CASE WHEN (scalar-subquery#16 [] > 165306) THEN scalar-subquery#17 [] ELSE scalar-subquery#18 [] END AS bucket5#19]   WithCTE
!:  :- Aggregate [count(1) AS count(1)#47L]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        :- CTERelationDef 0, true
!:  :  +- Project                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  :  +- Project [named_struct(count(1), count(1)#47L, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#72, avg(ss_net_paid), avg(ss_net_paid)#97) AS mergedValue#521]
!:  :     +- Filter ((isnotnull(ss_quantity#33) AND (ss_quantity#33 >= 1)) AND (ss_quantity#33 <= 20))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             :     +- Aggregate [count(1) AS count(1)#47L, cast((avg(UnscaledValue(ss_ext_discount_amt#457)) / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#72, cast((avg(UnscaledValue(ss_net_paid#464)) / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#97]
!:  :        +- RelationV2[ss_quantity#33] store_sales                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             :        +- Project [ss_ext_discount_amt#457, ss_net_paid#464]
!:  :  +- Project [ss_ext_discount_amt#62]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         :              +- RelationV2[ss_quantity#33, ss_ext_discount_amt#457, ss_net_paid#464] store_sales
```

after
```
=== Applying Rule org.apache.paimon.spark.catalyst.optimizer.MergePaimonScalarSubqueriers ===
!Project [CASE WHEN (scalar-subquery#0 [] > 74129) THEN scalar-subquery#1 [] ELSE scalar-subquery#2 [] END AS bucket1#3, CASE WHEN (scalar-subquery#4 [] > 122840) THEN scalar-subquery#5 [] ELSE scalar-subquery#6 [] END AS bucket2#7, CASE WHEN (scalar-subquery#8 [] > 56580) THEN scalar-subquery#9 [] ELSE scalar-subquery#10 [] END AS bucket3#11, CASE WHEN (scalar-subquery#12 [] > 10097) THEN scalar-subquery#13 [] ELSE scalar-subquery#14 [] END AS bucket4#15, CASE WHEN (scalar-subquery#16 [] > 165306) THEN scalar-subquery#17 [] ELSE scalar-subquery#18 [] END AS bucket5#19]   WithCTE
!:  :- Aggregate [count(1) AS count(1)#47L]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        :- CTERelationDef 0, true
!:  :  +- Project                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  :  +- Project [named_struct(count(1), count(1)#47L, avg(ss_ext_discount_amt), avg(ss_ext_discount_amt)#72, avg(ss_net_paid), avg(ss_net_paid)#97) AS mergedValue#521]
!:  :     +- Filter ((isnotnull(ss_quantity#33) AND (ss_quantity#33 >= 1)) AND (ss_quantity#33 <= 20))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             :     +- Aggregate [count(1) AS count(1)#47L, cast((avg(UnscaledValue(ss_ext_discount_amt#37)) / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#72, cast((avg(UnscaledValue(ss_net_paid#43)) / 100.0) as decimal(11,6)) AS avg(ss_net_paid)#97]
!:  :        +- RelationV2[ss_quantity#33] store_sales                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             :        +- Project [ss_ext_discount_amt#37, ss_net_paid#43]
!:  :- Aggregate [cast((avg(UnscaledValue(ss_ext_discount_amt#62)) / 100.0) as decimal(11,6)) AS avg(ss_ext_discount_amt)#72]                                                                                                                                                                                                                                                                                                                                                                                                                                                                      :           +- Filter ((isnotnull(ss_quantity#33) AND (ss_quantity#33 >= 1)) AND (ss_quantity#33 <= 20))
!:  :  +- Project [ss_ext_discount_amt#62]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         :              +- RelationV2[ss_quantity#33, ss_ext_discount_amt#37, ss_net_paid#43] store_sales
```


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
