### PR TITLE
[flink] Fix re-open for FullCacheLookupTable implementations

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
@@ -200,7 +200,7 @@ public abstract class FullCacheLookupTable implements LookupTable {
         void finish() throws IOException;
     }
 
-    static FullCacheLookupTable create(Context context, long lruCacheSize) throws IOException {
+    static FullCacheLookupTable create(Context context, long lruCacheSize) {
         List<String> primaryKeys = context.table.primaryKeys();
         if (primaryKeys.isEmpty()) {
             return new NoPrimaryKeyLookupTable(context, lruCacheSize);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/NoPrimaryKeyLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/NoPrimaryKeyLookupTable.java
@@ -42,7 +42,7 @@ public class NoPrimaryKeyLookupTable extends FullCacheLookupTable {
 
     private RocksDBListState<InternalRow, InternalRow> state;
 
-    public NoPrimaryKeyLookupTable(Context context, long lruCacheSize) throws IOException {
+    public NoPrimaryKeyLookupTable(Context context, long lruCacheSize) {
         super(context);
         this.lruCacheSize = lruCacheSize;
         List<String> fieldNames = projectedType.getFieldNames();
@@ -52,6 +52,7 @@ public class NoPrimaryKeyLookupTable extends FullCacheLookupTable {
 
     @Override
     public void open() throws Exception {
+        openStateFactory();
         this.state =
                 stateFactory.listState(
                         "join-key-index",
@@ -59,7 +60,7 @@ public class NoPrimaryKeyLookupTable extends FullCacheLookupTable {
                                 TypeUtils.project(projectedType, joinKeyRow.indexMapping())),
                         InternalSerializers.create(projectedType),
                         lruCacheSize);
-        super.open();
+        bootstrap();
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyLookupTable.java
@@ -47,8 +47,7 @@ public class PrimaryKeyLookupTable extends FullCacheLookupTable {
 
     protected RocksDBValueState<InternalRow, InternalRow> tableState;
 
-    public PrimaryKeyLookupTable(Context context, long lruCacheSize, List<String> joinKey)
-            throws IOException {
+    public PrimaryKeyLookupTable(Context context, long lruCacheSize, List<String> joinKey) {
         super(context);
         this.lruCacheSize = lruCacheSize;
         List<String> fieldNames = projectedType.getFieldNames();
@@ -71,6 +70,12 @@ public class PrimaryKeyLookupTable extends FullCacheLookupTable {
 
     @Override
     public void open() throws Exception {
+        openStateFactory();
+        createTableState();
+        bootstrap();
+    }
+
+    protected void createTableState() throws IOException {
         this.tableState =
                 stateFactory.valueState(
                         "table",
@@ -78,7 +83,6 @@ public class PrimaryKeyLookupTable extends FullCacheLookupTable {
                                 TypeUtils.project(projectedType, primaryKeyRow.indexMapping())),
                         InternalSerializers.create(projectedType),
                         lruCacheSize);
-        super.open();
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/SecondaryIndexLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/SecondaryIndexLookupTable.java
@@ -47,6 +47,8 @@ public class SecondaryIndexLookupTable extends PrimaryKeyLookupTable {
 
     @Override
     public void open() throws Exception {
+        openStateFactory();
+        createTableState();
         this.indexState =
                 stateFactory.setState(
                         "sec-index",
@@ -55,7 +57,7 @@ public class SecondaryIndexLookupTable extends PrimaryKeyLookupTable {
                         InternalSerializers.create(
                                 TypeUtils.project(projectedType, primaryKeyRow.indexMapping())),
                         lruCacheSize);
-        super.open();
+        bootstrap();
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/SecondaryIndexLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/SecondaryIndexLookupTable.java
@@ -38,7 +38,7 @@ public class SecondaryIndexLookupTable extends PrimaryKeyLookupTable {
 
     private RocksDBSetState<InternalRow, InternalRow> indexState;
 
-    public SecondaryIndexLookupTable(Context context, long lruCacheSize) throws IOException {
+    public SecondaryIndexLookupTable(Context context, long lruCacheSize) {
         super(context, lruCacheSize / 2, context.table.primaryKeys());
         List<String> fieldNames = projectedType.getFieldNames();
         int[] secKeyMapping = context.joinKey.stream().mapToInt(fieldNames::indexOf).toArray();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/LookupTableTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/LookupTableTest.java
@@ -118,6 +118,10 @@ public class LookupTableTest extends TableTestBase {
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
         table.open();
 
+        // test re-open
+        table.close();
+        table.open();
+
         // test bulk load error
         {
             TableBulkLoader bulkLoader = table.createBulkLoader();
@@ -175,6 +179,10 @@ public class LookupTableTest extends TableTestBase {
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
         table.open();
 
+        // test re-open
+        table.close();
+        table.open();
+
         List<Pair<byte[], byte[]>> records = new ArrayList<>();
         for (int i = 1; i <= 10; i++) {
             InternalRow row = row(i, 11 * i, 111 * i);
@@ -219,6 +227,10 @@ public class LookupTableTest extends TableTestBase {
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
         table.open();
 
+        // test re-open
+        table.close();
+        table.open();
+
         table.refresh(singletonList(row(1, 11, 111)).iterator());
         List<InternalRow> result = table.get(row(1));
         assertThat(result).hasSize(1);
@@ -250,6 +262,10 @@ public class LookupTableTest extends TableTestBase {
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
         table.open();
 
+        // test re-open
+        table.close();
+        table.open();
+
         table.refresh(singletonList(row(1, 11, 111)).iterator());
         List<InternalRow> result = table.get(row(1));
         assertThat(result).hasSize(1);
@@ -272,6 +288,10 @@ public class LookupTableTest extends TableTestBase {
                         tempDir.toFile(),
                         singletonList("f1"));
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
+        table.open();
+
+        // test re-open
+        table.close();
         table.open();
 
         // test bulk load 100_000 records
@@ -317,6 +337,10 @@ public class LookupTableTest extends TableTestBase {
                         tempDir.toFile(),
                         singletonList("f1"));
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
+        table.open();
+
+        // test re-open
+        table.close();
         table.open();
 
         List<Pair<byte[], byte[]>> records = new ArrayList<>();
@@ -367,6 +391,10 @@ public class LookupTableTest extends TableTestBase {
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
         table.open();
 
+        // test re-open
+        table.close();
+        table.open();
+
         table.refresh(singletonList(row(1, 11, 111)).iterator());
         List<InternalRow> result = table.get(row(11));
         assertThat(result).hasSize(1);
@@ -405,6 +433,10 @@ public class LookupTableTest extends TableTestBase {
                         tempDir.toFile(),
                         singletonList("f1"));
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
+        table.open();
+
+        // test re-open
+        table.close();
         table.open();
 
         // test bulk load 100_000 records
@@ -448,6 +480,10 @@ public class LookupTableTest extends TableTestBase {
                         tempDir.toFile(),
                         singletonList("f1"));
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
+        table.open();
+
+        // test re-open
+        table.close();
         table.open();
 
         table.refresh(singletonList(row(1, 11, 333)).iterator());
@@ -508,6 +544,11 @@ public class LookupTableTest extends TableTestBase {
                         tempDir.toFile(),
                         ImmutableList.of("pk1", "pk2"));
         table.open();
+
+        // test re-open
+        table.close();
+        table.open();
+
         List<InternalRow> result = table.get(row(1, -1));
         assertThat(result).hasSize(0);
 
@@ -533,6 +574,10 @@ public class LookupTableTest extends TableTestBase {
                         new int[] {2, 1},
                         tempDir.toFile(),
                         ImmutableList.of("pk2", "pk1"));
+        table.open();
+
+        // test re-open
+        table.close();
         table.open();
 
         List<InternalRow> result = table.get(row(-1, 1));


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Open `RocksDBStateFactory` should in `FullCacheLookupTable.open`, otherwise there will be NPE.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
