### PR TITLE
[core] Fix duplicate primary keys in query results

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
@@ -291,9 +291,10 @@ public class SnapshotReaderImpl implements SnapshotReader {
                 for (SplitGenerator.SplitGroup splitGroup : splitGroups) {
                     List<DataFileMeta> dataFiles = splitGroup.files;
                     builder.withDataFiles(dataFiles);
-                    if (splitGroup.rawConvertible) {
-                        builder.rawFiles(convertToRawFiles(partition, bucket, dataFiles));
-                    }
+                    builder.rawFiles(
+                            splitGroup.rawConvertible
+                                    ? convertToRawFiles(partition, bucket, dataFiles)
+                                    : Collections.emptyList());
                     if (deletionVectors) {
                         builder.withDataDeletionFiles(
                                 getDeletionFiles(dataFiles, deletionIndexFile));


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #3157

<!-- What is the purpose of the change -->
Because the same builder is used in the for loop of generateSplits in SnapshotReaderImpl, if rawConvertible is true the last time, it will affect the value of the next Datasplit rawFiles. The ultimate result is the need for MergeRedier's Datasplit, as rawFiles were mistakenly set and NoMergeReader was created, resulting in duplicate data during reading

![image](https://github.com/apache/paimon/assets/40812600/5cca61ab-6c79-4fe6-bbc1-316f972e0160)


<img width="1234" alt="image" src="https://github.com/apache/paimon/assets/40812600/20fcf833-1f34-4bd6-a4e7-609ab06e95df">


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
