### PR TITLE
[core] Reduce small files while batch write append only table with a lot of partitions.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -227,11 +227,11 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
                 while (reader.hasNext()) {
                     sinkWriter.write(reader.next());
                 }
-            }
-
-            // remove small files
-            for (DataFileMeta file : files) {
-                fileIO.deleteQuietly(pathFactory.toPath(file.fileName()));
+            } finally {
+                // remove small files
+                for (DataFileMeta file : files) {
+                    fileIO.deleteQuietly(pathFactory.toPath(file.fileName()));
+                }
             }
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
@@ -185,19 +185,14 @@ public class AppendOnlyFileStoreWrite extends MemoryFileStoreWrite<InternalRow> 
     }
 
     public BucketFileRead bucketReader(BinaryRow partition, int bucket) {
-        return files -> {
-            try {
-                return new RecordReaderIterator<>(
+        return files ->
+                new RecordReaderIterator<>(
                         read.createReader(
                                 DataSplit.builder()
                                         .withPartition(partition)
                                         .withBucket(bucket)
                                         .withDataFiles(files)
                                         .build()));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        };
     }
 
     public AppendOnlyFileStoreWrite withBucketMode(BucketMode bucketMode) {
@@ -229,6 +224,6 @@ public class AppendOnlyFileStoreWrite extends MemoryFileStoreWrite<InternalRow> 
 
     /** Read for one bucket. */
     public interface BucketFileRead {
-        RecordReaderIterator<InternalRow> read(List<DataFileMeta> files);
+        RecordReaderIterator<InternalRow> read(List<DataFileMeta> files) throws IOException;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
@@ -227,8 +227,8 @@ public class AppendOnlyFileStoreWrite extends MemoryFileStoreWrite<InternalRow> 
         }
     }
 
+    /** Read for one bucket. */
     public interface BucketFileRead {
-
         RecordReaderIterator<InternalRow> read(List<DataFileMeta> files);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -594,6 +594,7 @@ public class AppendOnlyWriterTest {
                         AppendOnlyWriterTest.SCHEMA,
                         getMaxSequenceNumber(toCompact),
                         compactManager,
+                        null,
                         forceCompact,
                         pathFactory,
                         null,

--- a/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
@@ -79,6 +79,7 @@ public class FileFormatSuffixTest extends KeyValueFileReadWriteTest {
                         0,
                         new AppendOnlyCompactManager(
                                 null, toCompact, 4, 10, 10, null, null), // not used
+                        null,
                         false,
                         dataFilePathFactory,
                         null,


### PR DESCRIPTION

Reduce small files generation in many partitions write job of append only table.