### PR TITLE
[core][test] Fix unstable unit test for TagsTable

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/system/TagsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/TagsTable.java
@@ -45,6 +45,7 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.utils.DateTimeUtils;
 import org.apache.paimon.utils.IteratorRecordReader;
+import org.apache.paimon.utils.JsonSerdeUtil;
 import org.apache.paimon.utils.ProjectedRow;
 import org.apache.paimon.utils.SerializationUtils;
 import org.apache.paimon.utils.TagManager;
@@ -244,7 +245,11 @@ public class TagsTable implements ReadonlyTable {
                     Timestamp.fromLocalDateTime(
                             DateTimeUtils.toLocalDateTime(snapshot.timeMillis())),
                     snapshot.totalRecordCount(),
-                    BinaryString.fromString(branches == null ? "[]" : branches.toString()));
+                    toJson(branches));
+        }
+
+        private BinaryString toJson(Object obj) {
+            return BinaryString.fromString(JsonSerdeUtil.toFlatJson(obj));
         }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/TagsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/TagsTableTest.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import static org.apache.paimon.utils.JsonSerdeUtil.toFlatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for {@link TagsTable}. */
@@ -108,7 +109,10 @@ class TagsTableTest extends TableTestBase {
                             if (tag.equals("2023-07-17")) {
                                 return Collections.singletonList("2023-07-17-branch1");
                             } else if (tag.equals("2023-07-18")) {
-                                return Arrays.asList("2023-07-18-branch2", "2023-07-18-branch1");
+                                List<String> list =
+                                        Arrays.asList("2023-07-18-branch2", "2023-07-18-branch1");
+                                Collections.sort(list);
+                                return list;
                             } else {
                                 return new ArrayList<>();
                             }
@@ -132,7 +136,7 @@ class TagsTableTest extends TableTestBase {
                                         DateTimeUtils.toLocalDateTime(snapshot.timeMillis())),
                                 snapshot.totalRecordCount(),
                                 BinaryString.fromString(
-                                        tagBranchesFunction.apply(tagName).toString())));
+                                        toFlatJson(tagBranchesFunction.apply(tagName)))));
             }
         }
         return internalRows;


### PR DESCRIPTION
Fix unstable unit test of `TagsTableTest#testTagBranchesTable`, to ensure the order of returned `branch` list in expected rows.

<!-- What is the purpose of the change -->
### Tests
TagsTableTest#testTagBranchesTable