### PR TITLE
[Bug] Fix the race condition in OrphanFilesClean

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -476,8 +476,10 @@ public class OrphanFilesClean {
                     .forEach(
                             p -> {
                                 deleteFileOrDirQuietly(p);
-                                deleteFiles.add(p);
-                                deletedFilesNum++;
+                                synchronized (this) {
+                                    deleteFiles.add(p);
+                                    deletedFilesNum++;
+                                }
                             });
         }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

The `parallelStream` will run in multi thread, it will lead to unstable results of assert delete files number.

This should can resolve the unstable `OrphanFilesCleanTest.testCleanOrphanFilesWithChangelogDecoupled` such as https://github.com/apache/paimon/actions/runs/8587139001/job/23530395569

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
