### PR TITLE
[Bug] Fix the unstable testRollbackToTagWithChangelogDecoupled

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
@@ -1458,7 +1458,7 @@ public class PrimaryKeyFileStoreTableTest extends FileStoreTableTestBase {
 
     @Test
     public void testRollbackToTagWithChangelogDecoupled() throws Exception {
-        int commitTimes = ThreadLocalRandom.current().nextInt(100) + 5;
+        int commitTimes = ThreadLocalRandom.current().nextInt(100) + 6;
         FileStoreTable table =
                 createFileStoreTable(
                         options ->


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

if the commit times is 5, the changelog-1 is not expired may lead to unexpected file left.

such as
https://github.com/Aitozi/incubator-paimon/actions/runs/8590046982/job/23537660465

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
