### PR TITLE
[cdc]Fix: When the value of entry is null, subsequent java.lang.NullPointerException is thrown

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/RecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/RecordParser.java
@@ -158,7 +158,7 @@ public abstract class RecordParser implements FlatMapFunction<String, RichCdcMul
                                                     return Objects.toString(entry.getValue());
                                                 }
                                             }
-                                            return Objects.toString(entry.getValue());
+                                            return Objects.toString(entry.getValue(), "");
                                         }));
         evalComputedColumns(rowData, paimonFieldTypes);
         return rowData;


### PR DESCRIPTION
Fix: When the value of entry is null, subsequent java.lang.NullPointerException is thrown

paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/RecordParser.java

### Purpose

When the value of entry is null, subsequent java.lang.NullPointerException is thrown


