### PR TITLE
[core] support decouple the delta files lifecycle

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -28,6 +28,7 @@ import org.apache.paimon.manifest.ManifestFile;
 import org.apache.paimon.manifest.ManifestList;
 import org.apache.paimon.metastore.AddPartitionTagCallback;
 import org.apache.paimon.metastore.MetastoreClient;
+import org.apache.paimon.operation.ChangelogDeletion;
 import org.apache.paimon.operation.FileStoreCommitImpl;
 import org.apache.paimon.operation.PartitionExpire;
 import org.apache.paimon.operation.SnapshotDeletion;
@@ -201,8 +202,21 @@ public abstract class AbstractFileStore<T> implements FileStore<T> {
     }
 
     @Override
-    public SnapshotDeletion newSnapshotDeletion() {
+    public SnapshotDeletion newSnapshotDeletion(CoreOptions options) {
         return new SnapshotDeletion(
+                fileIO,
+                pathFactory(),
+                manifestFileFactory().create(),
+                manifestListFactory().create(),
+                newIndexFileHandler(),
+                newStatsFileHandler(),
+                options.changelogLifecycleDecoupled(),
+                options.changelogProducer() != CoreOptions.ChangelogProducer.NONE);
+    }
+
+    @Override
+    public ChangelogDeletion newChangelogDeletion(CoreOptions options) {
+        return new ChangelogDeletion(
                 fileIO,
                 pathFactory(),
                 manifestFileFactory().create(),

--- a/paimon-core/src/main/java/org/apache/paimon/FileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/FileStore.java
@@ -22,6 +22,7 @@ import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.manifest.ManifestFile;
 import org.apache.paimon.manifest.ManifestList;
+import org.apache.paimon.operation.ChangelogDeletion;
 import org.apache.paimon.operation.FileStoreCommit;
 import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.operation.FileStoreWrite;
@@ -83,7 +84,9 @@ public interface FileStore<T> extends Serializable {
 
     FileStoreCommit newCommit(String commitUser, String branchName);
 
-    SnapshotDeletion newSnapshotDeletion();
+    SnapshotDeletion newSnapshotDeletion(CoreOptions options);
+
+    ChangelogDeletion newChangelogDeletion(CoreOptions options);
 
     TagManager newTagManager();
 

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -251,7 +251,8 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
                 seqNumCounter,
                 fileCompression,
                 statsCollectors,
-                fileIndexOptions);
+                fileIndexOptions,
+                false);
     }
 
     private void trySyncLatestCompaction(boolean blocking)

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMetaSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMetaSerializer.java
@@ -21,6 +21,7 @@ package org.apache.paimon.io;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.stats.BinaryTableStats;
 import org.apache.paimon.utils.ObjectSerializer;
 
@@ -55,7 +56,8 @@ public class DataFileMetaSerializer extends ObjectSerializer<DataFileMeta> {
                 toStringArrayData(meta.extraFiles()),
                 meta.creationTime(),
                 meta.deleteRowCount().orElse(null),
-                meta.embeddedIndex());
+                meta.embeddedIndex(),
+                meta.fileSource().map(FileSource::toByteValue).orElse(null));
     }
 
     @Override
@@ -75,6 +77,7 @@ public class DataFileMetaSerializer extends ObjectSerializer<DataFileMeta> {
                 fromStringArrayData(row.getArray(11)),
                 row.getTimestamp(12, 3),
                 row.isNullAt(13) ? null : row.getLong(13),
-                row.isNullAt(14) ? null : row.getBinary(14));
+                row.isNullAt(14) ? null : row.getBinary(14),
+                row.isNullAt(15) ? null : FileSource.fromByteValue(row.getByte(15)));
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileWriter.java
@@ -28,6 +28,7 @@ import org.apache.paimon.format.FormatWriterFactory;
 import org.apache.paimon.format.TableStatsExtractor;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.stats.BinaryTableStats;
 import org.apache.paimon.stats.FieldStatsArraySerializer;
 import org.apache.paimon.types.RowType;
@@ -68,6 +69,7 @@ public class KeyValueDataFileWriter
     private long minSeqNumber = Long.MAX_VALUE;
     private long maxSeqNumber = Long.MIN_VALUE;
     private long deleteRecordCount = 0;
+    private final boolean isCompact;
 
     public KeyValueDataFileWriter(
             FileIO fileIO,
@@ -80,7 +82,8 @@ public class KeyValueDataFileWriter
             long schemaId,
             int level,
             String compression,
-            CoreOptions options) {
+            CoreOptions options,
+            boolean isCompact) {
         super(
                 fileIO,
                 factory,
@@ -100,6 +103,7 @@ public class KeyValueDataFileWriter
         this.keyStatsConverter = new FieldStatsArraySerializer(keyType);
         this.valueStatsConverter = new FieldStatsArraySerializer(valueType);
         this.keySerializer = new InternalRowSerializer(keyType);
+        this.isCompact = isCompact;
     }
 
     @Override
@@ -170,6 +174,7 @@ public class KeyValueDataFileWriter
                 level,
                 deleteRecordCount,
                 // TODO: enable file filter for primary key table (e.g. deletion table).
-                null);
+                null,
+                isCompact ? FileSource.COMPACT : FileSource.APPEND);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileWriterFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileWriterFactory.java
@@ -81,9 +81,12 @@ public class KeyValueFileWriterFactory {
         return formatContext.pathFactory(level);
     }
 
-    public RollingFileWriter<KeyValue, DataFileMeta> createRollingMergeTreeFileWriter(int level) {
+    public RollingFileWriter<KeyValue, DataFileMeta> createRollingMergeTreeFileWriter(
+            int level, boolean isCompact) {
         return new RollingFileWriter<>(
-                () -> createDataFileWriter(formatContext.pathFactory(level).newPath(), level),
+                () ->
+                        createDataFileWriter(
+                                formatContext.pathFactory(level).newPath(), level, isCompact),
                 suggestedFileSize);
     }
 
@@ -91,11 +94,11 @@ public class KeyValueFileWriterFactory {
         return new RollingFileWriter<>(
                 () ->
                         createDataFileWriter(
-                                formatContext.pathFactory(level).newChangelogPath(), level),
+                                formatContext.pathFactory(level).newChangelogPath(), level, false),
                 suggestedFileSize);
     }
 
-    private KeyValueDataFileWriter createDataFileWriter(Path path, int level) {
+    private KeyValueDataFileWriter createDataFileWriter(Path path, int level, boolean isCompact) {
         KeyValueSerializer kvSerializer = new KeyValueSerializer(keyType, valueType);
         return new KeyValueDataFileWriter(
                 fileIO,
@@ -108,7 +111,8 @@ public class KeyValueFileWriterFactory {
                 schemaId,
                 level,
                 formatContext.compression(level),
-                options);
+                options,
+                isCompact);
     }
 
     public void deleteFile(String filename, int level) {

--- a/paimon-core/src/main/java/org/apache/paimon/io/RowDataFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/RowDataFileWriter.java
@@ -24,6 +24,7 @@ import org.apache.paimon.format.FormatWriterFactory;
 import org.apache.paimon.format.TableStatsExtractor;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.statistics.FieldStatsCollector;
 import org.apache.paimon.stats.BinaryTableStats;
 import org.apache.paimon.stats.FieldStatsArraySerializer;
@@ -48,6 +49,7 @@ public class RowDataFileWriter extends StatsCollectingSingleFileWriter<InternalR
     private final LongCounter seqNumCounter;
     private final FieldStatsArraySerializer statsArraySerializer;
     @Nullable private final FileIndexWriter fileIndexWriter;
+    private final boolean isCompact;
 
     public RowDataFileWriter(
             FileIO fileIO,
@@ -59,7 +61,8 @@ public class RowDataFileWriter extends StatsCollectingSingleFileWriter<InternalR
             LongCounter seqNumCounter,
             String fileCompression,
             FieldStatsCollector.Factory[] statsCollectors,
-            FileIndexOptions fileIndexOptions) {
+            FileIndexOptions fileIndexOptions,
+            boolean isCompact) {
         super(
                 fileIO,
                 factory,
@@ -72,6 +75,7 @@ public class RowDataFileWriter extends StatsCollectingSingleFileWriter<InternalR
         this.schemaId = schemaId;
         this.seqNumCounter = seqNumCounter;
         this.statsArraySerializer = new FieldStatsArraySerializer(writeSchema);
+        this.isCompact = isCompact;
         this.fileIndexWriter =
                 FileIndexWriter.create(
                         fileIO, toFileIndexPath(path), writeSchema, fileIndexOptions);
@@ -111,6 +115,7 @@ public class RowDataFileWriter extends StatsCollectingSingleFileWriter<InternalR
                 indexResult.independentIndexFile() == null
                         ? Collections.emptyList()
                         : Collections.singletonList(indexResult.independentIndexFile()),
-                indexResult.embeddedIndexBytes());
+                indexResult.embeddedIndexBytes(),
+                isCompact ? FileSource.COMPACT : FileSource.APPEND);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/io/RowDataRollingFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/RowDataRollingFileWriter.java
@@ -40,7 +40,8 @@ public class RowDataRollingFileWriter extends RollingFileWriter<InternalRow, Dat
             LongCounter seqNumCounter,
             String fileCompression,
             FieldStatsCollector.Factory[] statsCollectors,
-            FileIndexOptions fileIndexOptions) {
+            FileIndexOptions fileIndexOptions,
+            boolean isCompact) {
         super(
                 () ->
                         new RowDataFileWriter(
@@ -57,7 +58,8 @@ public class RowDataRollingFileWriter extends RollingFileWriter<InternalRow, Dat
                                 seqNumCounter,
                                 fileCompression,
                                 statsCollectors,
-                                fileIndexOptions),
+                                fileIndexOptions,
+                                isCompact),
                 targetFileSize);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/FileSource.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/FileSource.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.manifest;
+
+/** The Source of a file. */
+public enum FileSource {
+
+    /** The file from new input. */
+    APPEND((byte) 0),
+
+    /** The file from compaction. */
+    COMPACT((byte) 1);
+
+    private final byte value;
+
+    FileSource(byte value) {
+        this.value = value;
+    }
+
+    public byte toByteValue() {
+        return value;
+    }
+
+    public static FileSource fromByteValue(byte value) {
+        switch (value) {
+            case 0:
+                return APPEND;
+            case 1:
+                return COMPACT;
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported byte value '" + value + "' for value kind.");
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntrySerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntrySerializer.java
@@ -66,6 +66,7 @@ public class ManifestEntrySerializer extends VersionedObjectSerializer<ManifestE
                                 "The current version %s is not compatible with the version %s, please recreate the table.",
                                 getVersion(), version));
             }
+
             throw new IllegalArgumentException("Unsupported version: " + version);
         }
         return new ManifestEntry(

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeWriter.java
@@ -207,7 +207,7 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
                             ? writerFactory.createRollingChangelogFileWriter(0)
                             : null;
             final RollingFileWriter<KeyValue, DataFileMeta> dataWriter =
-                    writerFactory.createRollingMergeTreeFileWriter(0);
+                    writerFactory.createRollingMergeTreeFileWriter(0, false);
 
             try {
                 writeBuffer.forEach(

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
@@ -128,7 +128,8 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
                     readerForMergeTree(sections, createMergeWrapper(outputLevel))
                             .toCloseableIterator();
             if (rewriteCompactFile) {
-                compactFileWriter = writerFactory.createRollingMergeTreeFileWriter(outputLevel);
+                compactFileWriter =
+                        writerFactory.createRollingMergeTreeFileWriter(outputLevel, true);
             }
             if (produceChangelog) {
                 changelogFileWriter = writerFactory.createRollingChangelogFileWriter(outputLevel);

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
@@ -73,7 +73,7 @@ public class MergeTreeCompactRewriter extends AbstractCompactRewriter {
     protected CompactResult rewriteCompaction(
             int outputLevel, boolean dropDelete, List<List<SortedRun>> sections) throws Exception {
         RollingFileWriter<KeyValue, DataFileMeta> writer =
-                writerFactory.createRollingMergeTreeFileWriter(outputLevel);
+                writerFactory.createRollingMergeTreeFileWriter(outputLevel, true);
         RecordReader<KeyValue> reader =
                 readerForMergeTree(sections, new ReducerMergeFunctionWrapper(mfFactory.create()));
         if (dropDelete) {

--- a/paimon-core/src/main/java/org/apache/paimon/migrate/FileMetaUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/migrate/FileMetaUtils.java
@@ -30,6 +30,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataIncrement;
+import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.statistics.FieldStatsCollector;
 import org.apache.paimon.stats.BinaryTableStats;
 import org.apache.paimon.stats.FieldStatsArraySerializer;
@@ -165,7 +166,8 @@ public class FileMetaUtils {
                 stats,
                 0,
                 0,
-                ((FileStoreTable) table).schema().id());
+                ((FileStoreTable) table).schema().id(),
+                FileSource.APPEND);
     }
 
     public static BinaryRow writePartitionValue(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
@@ -179,7 +179,9 @@ public class AppendOnlyFileStoreWrite extends MemoryFileStoreWrite<InternalRow> 
                             new LongCounter(toCompact.get(0).minSequenceNumber()),
                             fileCompression,
                             statsCollectors,
-                            fileIndexOptions);
+                            fileIndexOptions,
+                            true);
+
             try {
                 rewriter.write(bucketReader(partition, bucket).read(toCompact));
             } finally {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ChangelogDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ChangelogDeletion.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.operation;
+
+import org.apache.paimon.Changelog;
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.index.IndexFileHandler;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.manifest.IndexManifestEntry;
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.ManifestFile;
+import org.apache.paimon.manifest.ManifestFileMeta;
+import org.apache.paimon.manifest.ManifestList;
+import org.apache.paimon.stats.StatsFileHandler;
+import org.apache.paimon.utils.FileStorePathFactory;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/** Delete changelog files. */
+public class ChangelogDeletion extends FileDeletionBase<Changelog> {
+    public ChangelogDeletion(
+            FileIO fileIO,
+            FileStorePathFactory pathFactory,
+            ManifestFile manifestFile,
+            ManifestList manifestList,
+            IndexFileHandler indexFileHandler,
+            StatsFileHandler statsFileHandler) {
+        super(fileIO, pathFactory, manifestFile, manifestList, indexFileHandler, statsFileHandler);
+    }
+
+    @Override
+    public void cleanUnusedDataFiles(Changelog changelog, Predicate<ManifestEntry> skipper) {
+        if (changelog.changelogManifestList() != null) {
+            deleteAddedDataFiles(changelog.changelogManifestList());
+        }
+
+        if (manifestList.exists(changelog.deltaManifestList())) {
+            cleanUnusedDataFiles(changelog.deltaManifestList(), skipper);
+        }
+    }
+
+    @Override
+    public void cleanUnusedManifests(Changelog changelog, Set<String> skippingSet) {
+        if (changelog.changelogManifestList() != null) {
+            cleanUnusedManifestList(changelog.changelogManifestList(), skippingSet);
+        }
+
+        if (manifestList.exists(changelog.deltaManifestList())) {
+            cleanUnusedManifestList(changelog.deltaManifestList(), skippingSet);
+        }
+
+        if (manifestList.exists(changelog.baseManifestList())) {
+            cleanUnusedManifestList(changelog.baseManifestList(), skippingSet);
+        }
+
+        // the index and statics manifest list should handle by snapshot deletion.
+    }
+
+    public Set<String> manifestSkippingSet(List<Snapshot> skippingSnapshots) {
+        Set<String> skippingSet = new HashSet<>();
+
+        for (Snapshot skippingSnapshot : skippingSnapshots) {
+            // base manifests
+            if (manifestList.exists(skippingSnapshot.baseManifestList())) {
+                skippingSet.add(skippingSnapshot.baseManifestList());
+                manifestList.read(skippingSnapshot.baseManifestList()).stream()
+                        .map(ManifestFileMeta::fileName)
+                        .forEach(skippingSet::add);
+            }
+
+            // delta manifests
+            if (manifestList.exists(skippingSnapshot.deltaManifestList())) {
+                skippingSet.add(skippingSnapshot.deltaManifestList());
+                manifestList.read(skippingSnapshot.deltaManifestList()).stream()
+                        .map(ManifestFileMeta::fileName)
+                        .forEach(skippingSet::add);
+            }
+
+            // index manifests
+            String indexManifest = skippingSnapshot.indexManifest();
+            if (indexManifest != null) {
+                skippingSet.add(indexManifest);
+                indexFileHandler.readManifest(indexManifest).stream()
+                        .map(IndexManifestEntry::indexFile)
+                        .map(IndexFileMeta::fileName)
+                        .forEach(skippingSet::add);
+            }
+
+            // statistics
+            if (skippingSnapshot.statistics() != null) {
+                skippingSet.add(skippingSnapshot.statistics());
+            }
+        }
+
+        return skippingSet;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -25,6 +25,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.manifest.FileEntry;
+import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFile;
@@ -33,6 +34,8 @@ import org.apache.paimon.manifest.ManifestList;
 import org.apache.paimon.stats.StatsFileHandler;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.FileUtils;
+import org.apache.paimon.utils.Pair;
+import org.apache.paimon.utils.TagManager;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +60,7 @@ import java.util.stream.Collectors;
  * Base class for file deletion including methods for clean data files, manifest files and empty
  * data directories.
  */
-public abstract class FileDeletionBase {
+public abstract class FileDeletionBase<T extends Snapshot> {
 
     private static final Logger LOG = LoggerFactory.getLogger(FileDeletionBase.class);
 
@@ -70,6 +73,12 @@ public abstract class FileDeletionBase {
 
     protected final Map<BinaryRow, Set<Integer>> deletionBuckets;
     protected final Executor ioExecutor;
+
+    /** Used to record which tag is cached in tagged snapshots list. */
+    private int cachedTagIndex = -1;
+
+    /** Used to cache data files used by current tag. */
+    private final Map<BinaryRow, Map<Integer, Set<String>>> cachedTagDataFiles = new HashMap<>();
 
     public FileDeletionBase(
             FileIO fileIO,
@@ -95,7 +104,7 @@ public abstract class FileDeletionBase {
      * @param skipper if the test result of a data file is true, it will be skipped when deleting;
      *     else it will be deleted
      */
-    public abstract void cleanUnusedDataFiles(Snapshot snapshot, Predicate<ManifestEntry> skipper);
+    public abstract void cleanUnusedDataFiles(T snapshot, Predicate<ManifestEntry> skipper);
 
     /**
      * Clean metadata files that will not be used anymore of a snapshot, including data manifests,
@@ -104,7 +113,7 @@ public abstract class FileDeletionBase {
      * @param snapshot {@link Snapshot} that will be cleaned
      * @param skippingSet manifests that should not be deleted
      */
-    public abstract void cleanUnusedManifests(Snapshot snapshot, Set<String> skippingSet);
+    public abstract void cleanUnusedManifests(T snapshot, Set<String> skippingSet);
 
     /** Try to delete data directories that may be empty after data file deletion. */
     public void cleanDataDirectories() {
@@ -151,6 +160,105 @@ public abstract class FileDeletionBase {
                 .add(entry.bucket());
     }
 
+    public void cleanUnusedDataFiles(String manifestList, Predicate<ManifestEntry> skipper) {
+        // try read manifests
+        List<String> manifestFileNames = readManifestFileNames(tryReadManifestList(manifestList));
+        List<ManifestEntry> manifestEntries;
+        // data file path -> (original manifest entry, extra file paths)
+        Map<Path, Pair<ManifestEntry, List<Path>>> dataFileToDelete = new HashMap<>();
+        for (String manifest : manifestFileNames) {
+            try {
+                manifestEntries = manifestFile.read(manifest);
+            } catch (Exception e) {
+                // cancel deletion if any exception occurs
+                LOG.warn("Failed to read some manifest files. Cancel deletion.", e);
+                return;
+            }
+
+            getDataFileToDelete(dataFileToDelete, manifestEntries);
+        }
+
+        doCleanUnusedDataFile(dataFileToDelete, skipper);
+    }
+
+    protected void doCleanUnusedDataFile(
+            Map<Path, Pair<ManifestEntry, List<Path>>> dataFileToDelete,
+            Predicate<ManifestEntry> skipper) {
+        List<Path> actualDataFileToDelete = new ArrayList<>();
+        dataFileToDelete.forEach(
+                (path, pair) -> {
+                    ManifestEntry entry = pair.getLeft();
+                    // check whether we should skip the data file
+                    if (!skipper.test(entry)) {
+                        // delete data files
+                        actualDataFileToDelete.add(path);
+                        actualDataFileToDelete.addAll(pair.getRight());
+
+                        recordDeletionBuckets(entry);
+                    }
+                });
+        deleteFiles(actualDataFileToDelete, fileIO::deleteQuietly);
+    }
+
+    protected void getDataFileToDelete(
+            Map<Path, Pair<ManifestEntry, List<Path>>> dataFileToDelete,
+            List<ManifestEntry> dataFileEntries) {
+        // we cannot delete a data file directly when we meet a DELETE entry, because that
+        // file might be upgraded
+        for (ManifestEntry entry : dataFileEntries) {
+            Path bucketPath = pathFactory.bucketPath(entry.partition(), entry.bucket());
+            Path dataFilePath = new Path(bucketPath, entry.file().fileName());
+            switch (entry.kind()) {
+                case ADD:
+                    dataFileToDelete.remove(dataFilePath);
+                    break;
+                case DELETE:
+                    List<Path> extraFiles = new ArrayList<>(entry.file().extraFiles().size());
+                    for (String file : entry.file().extraFiles()) {
+                        extraFiles.add(new Path(bucketPath, file));
+                    }
+                    dataFileToDelete.put(dataFilePath, Pair.of(entry, extraFiles));
+                    break;
+                default:
+                    throw new UnsupportedOperationException(
+                            "Unknown value kind " + entry.kind().name());
+            }
+        }
+    }
+
+    /**
+     * Delete added file in the manifest list files. Added files marked as "ADD" in manifests.
+     *
+     * @param manifestListName name of manifest list
+     */
+    public void deleteAddedDataFiles(String manifestListName) {
+        List<String> manifestFileNames =
+                readManifestFileNames(tryReadManifestList(manifestListName));
+        for (String file : manifestFileNames) {
+            try {
+                List<ManifestEntry> manifestEntries = manifestFile.read(file);
+                deleteAddedDataFiles(manifestEntries);
+            } catch (Exception e) {
+                // We want to delete the data file, so just ignore the unavailable files
+                LOG.info("Failed to read manifest " + file + ". Ignore it.", e);
+            }
+        }
+    }
+
+    private void deleteAddedDataFiles(List<ManifestEntry> manifestEntries) {
+        List<Path> dataFileToDelete = new ArrayList<>();
+        for (ManifestEntry entry : manifestEntries) {
+            if (entry.kind() == FileKind.ADD) {
+                dataFileToDelete.add(
+                        new Path(
+                                pathFactory.bucketPath(entry.partition(), entry.bucket()),
+                                entry.file().fileName()));
+                recordDeletionBuckets(entry);
+            }
+        }
+        deleteFiles(dataFileToDelete, fileIO::deleteQuietly);
+    }
+
     public void cleanUnusedStatisticsManifests(Snapshot snapshot, Set<String> skippingSet) {
         // clean statistics
         if (snapshot.statistics() != null && !skippingSet.contains(snapshot.statistics())) {
@@ -194,14 +302,33 @@ public abstract class FileDeletionBase {
     }
 
     public void cleanUnusedManifests(
-            Snapshot snapshot, Set<String> skippingSet, boolean deleteChangelog) {
-        cleanUnusedManifestList(snapshot.baseManifestList(), skippingSet);
-        cleanUnusedManifestList(snapshot.deltaManifestList(), skippingSet);
+            Snapshot snapshot,
+            Set<String> skippingSet,
+            boolean deleteDataManifestLists,
+            boolean deleteChangelog) {
+        if (deleteDataManifestLists) {
+            cleanUnusedManifestList(snapshot.baseManifestList(), skippingSet);
+            cleanUnusedManifestList(snapshot.deltaManifestList(), skippingSet);
+        }
+
         if (deleteChangelog && snapshot.changelogManifestList() != null) {
             cleanUnusedManifestList(snapshot.changelogManifestList(), skippingSet);
         }
         cleanUnusedIndexManifests(snapshot, skippingSet);
         cleanUnusedStatisticsManifests(snapshot, skippingSet);
+    }
+
+    public Predicate<ManifestEntry> dataFileSkipper(
+            List<Snapshot> taggedSnapshots, long expiringSnapshotId) throws Exception {
+        int index = TagManager.findPreviousTag(taggedSnapshots, expiringSnapshotId);
+        // refresh tag data files
+        if (index >= 0 && cachedTagIndex != index) {
+            cachedTagIndex = index;
+            cachedTagDataFiles.clear();
+            addMergedDataFiles(cachedTagDataFiles, taggedSnapshots.get(index));
+        }
+
+        return entry -> index >= 0 && containsDataFile(cachedTagDataFiles, entry);
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/operation/SnapshotDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/SnapshotDeletion.java
@@ -20,23 +20,17 @@ package org.apache.paimon.operation;
 
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.annotation.VisibleForTesting;
-import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.index.IndexFileHandler;
-import org.apache.paimon.manifest.FileKind;
+import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFile;
 import org.apache.paimon.manifest.ManifestList;
 import org.apache.paimon.stats.StatsFileHandler;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.Pair;
-import org.apache.paimon.utils.TagManager;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,15 +38,11 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 /** Delete snapshot files. */
-public class SnapshotDeletion extends FileDeletionBase {
+public class SnapshotDeletion extends FileDeletionBase<Snapshot> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(SnapshotDeletion.class);
+    private final boolean changelogDecoupled;
 
-    /** Used to record which tag is cached in tagged snapshots list. */
-    private int cachedTagIndex = -1;
-
-    /** Used to cache data files used by current tag. */
-    private final Map<BinaryRow, Map<Integer, Set<String>>> cachedTagDataFiles = new HashMap<>();
+    private final boolean produceChangelog;
 
     public SnapshotDeletion(
             FileIO fileIO,
@@ -60,84 +50,39 @@ public class SnapshotDeletion extends FileDeletionBase {
             ManifestFile manifestFile,
             ManifestList manifestList,
             IndexFileHandler indexFileHandler,
-            StatsFileHandler statsFileHandler) {
+            StatsFileHandler statsFileHandler,
+            boolean changelogDecoupled,
+            boolean produceChangelog) {
         super(fileIO, pathFactory, manifestFile, manifestList, indexFileHandler, statsFileHandler);
+        this.produceChangelog = produceChangelog;
+        this.changelogDecoupled = changelogDecoupled;
     }
 
     @Override
     public void cleanUnusedDataFiles(Snapshot snapshot, Predicate<ManifestEntry> skipper) {
-        cleanUnusedDataFiles(snapshot.deltaManifestList(), skipper);
-    }
-
-    public void cleanUnusedDataFiles(String manifestList, Predicate<ManifestEntry> skipper) {
-        // try read manifests
-        List<String> manifestFileNames = readManifestFileNames(tryReadManifestList(manifestList));
-        List<ManifestEntry> manifestEntries;
-        // data file path -> (original manifest entry, extra file paths)
-        Map<Path, Pair<ManifestEntry, List<Path>>> dataFileToDelete = new HashMap<>();
-        for (String manifest : manifestFileNames) {
-            try {
-                manifestEntries = manifestFile.read(manifest);
-            } catch (Exception e) {
-                // cancel deletion if any exception occurs
-                LOG.warn("Failed to read some manifest files. Cancel deletion.", e);
-                return;
-            }
-
-            getDataFileToDelete(dataFileToDelete, manifestEntries);
+        if (changelogDecoupled && !produceChangelog) {
+            // Skip clean the 'APPEND' data files.If we do not have the file source information
+            // eg: the old version table file, we just skip clean this here, let it done by
+            // ExpireChangelogImpl
+            Predicate<ManifestEntry> enriched =
+                    manifestEntry ->
+                            skipper.test(manifestEntry)
+                                    || (manifestEntry.file().fileSource().orElse(FileSource.APPEND)
+                                            == FileSource.APPEND);
+            cleanUnusedDataFiles(snapshot.deltaManifestList(), enriched);
+        } else {
+            cleanUnusedDataFiles(snapshot.deltaManifestList(), skipper);
         }
-
-        doCleanUnusedDataFile(dataFileToDelete, skipper);
     }
 
     @Override
     public void cleanUnusedManifests(Snapshot snapshot, Set<String> skippingSet) {
-        cleanUnusedManifests(snapshot, skippingSet, true);
-    }
-
-    private void getDataFileToDelete(
-            Map<Path, Pair<ManifestEntry, List<Path>>> dataFileToDelete,
-            List<ManifestEntry> dataFileEntries) {
-        // we cannot delete a data file directly when we meet a DELETE entry, because that
-        // file might be upgraded
-        for (ManifestEntry entry : dataFileEntries) {
-            Path bucketPath = pathFactory.bucketPath(entry.partition(), entry.bucket());
-            Path dataFilePath = new Path(bucketPath, entry.file().fileName());
-            switch (entry.kind()) {
-                case ADD:
-                    dataFileToDelete.remove(dataFilePath);
-                    break;
-                case DELETE:
-                    List<Path> extraFiles = new ArrayList<>(entry.file().extraFiles().size());
-                    for (String file : entry.file().extraFiles()) {
-                        extraFiles.add(new Path(bucketPath, file));
-                    }
-                    dataFileToDelete.put(dataFilePath, Pair.of(entry, extraFiles));
-                    break;
-                default:
-                    throw new UnsupportedOperationException(
-                            "Unknown value kind " + entry.kind().name());
-            }
-        }
-    }
-
-    private void doCleanUnusedDataFile(
-            Map<Path, Pair<ManifestEntry, List<Path>>> dataFileToDelete,
-            Predicate<ManifestEntry> skipper) {
-        List<Path> actualDataFileToDelete = new ArrayList<>();
-        dataFileToDelete.forEach(
-                (path, pair) -> {
-                    ManifestEntry entry = pair.getLeft();
-                    // check whether we should skip the data file
-                    if (!skipper.test(entry)) {
-                        // delete data files
-                        actualDataFileToDelete.add(path);
-                        actualDataFileToDelete.addAll(pair.getRight());
-
-                        recordDeletionBuckets(entry);
-                    }
-                });
-        deleteFiles(actualDataFileToDelete, fileIO::deleteQuietly);
+        // delay clean the base and delta manifest lists when changelog decoupled enabled
+        cleanUnusedManifests(
+                snapshot,
+                skippingSet,
+                !changelogDecoupled || produceChangelog,
+                !changelogDecoupled);
     }
 
     @VisibleForTesting
@@ -145,51 +90,5 @@ public class SnapshotDeletion extends FileDeletionBase {
         Map<Path, Pair<ManifestEntry, List<Path>>> dataFileToDelete = new HashMap<>();
         getDataFileToDelete(dataFileToDelete, dataFileLog);
         doCleanUnusedDataFile(dataFileToDelete, f -> false);
-    }
-
-    /**
-     * Delete added file in the manifest list files. Added files marked as "ADD" in manifests.
-     *
-     * @param manifestListName name of manifest list
-     */
-    public void deleteAddedDataFiles(String manifestListName) {
-        List<String> manifestFileNames =
-                readManifestFileNames(tryReadManifestList(manifestListName));
-        for (String file : manifestFileNames) {
-            try {
-                List<ManifestEntry> manifestEntries = manifestFile.read(file);
-                deleteAddedDataFiles(manifestEntries);
-            } catch (Exception e) {
-                // We want to delete the data file, so just ignore the unavailable files
-                LOG.info("Failed to read manifest " + file + ". Ignore it.", e);
-            }
-        }
-    }
-
-    private void deleteAddedDataFiles(List<ManifestEntry> manifestEntries) {
-        List<Path> dataFileToDelete = new ArrayList<>();
-        for (ManifestEntry entry : manifestEntries) {
-            if (entry.kind() == FileKind.ADD) {
-                dataFileToDelete.add(
-                        new Path(
-                                pathFactory.bucketPath(entry.partition(), entry.bucket()),
-                                entry.file().fileName()));
-                recordDeletionBuckets(entry);
-            }
-        }
-        deleteFiles(dataFileToDelete, fileIO::deleteQuietly);
-    }
-
-    public Predicate<ManifestEntry> dataFileSkipper(
-            List<Snapshot> taggedSnapshots, long expiringSnapshotId) throws Exception {
-        int index = TagManager.findPreviousTag(taggedSnapshots, expiringSnapshotId);
-        // refresh tag data files
-        if (index >= 0 && cachedTagIndex != index) {
-            cachedTagIndex = index;
-            cachedTagDataFiles.clear();
-            addMergedDataFiles(cachedTagDataFiles, taggedSnapshots.get(index));
-        }
-
-        return entry -> index >= 0 && containsDataFile(cachedTagDataFiles, entry);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/TagDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/TagDeletion.java
@@ -43,7 +43,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 /** Delete tag files. */
-public class TagDeletion extends FileDeletionBase {
+public class TagDeletion extends FileDeletionBase<Snapshot> {
 
     private static final Logger LOG = LoggerFactory.getLogger(TagDeletion.class);
 
@@ -85,7 +85,7 @@ public class TagDeletion extends FileDeletionBase {
     @Override
     public void cleanUnusedManifests(Snapshot taggedSnapshot, Set<String> skippingSet) {
         // doesn't clean changelog files because they are handled by SnapshotDeletion
-        cleanUnusedManifests(taggedSnapshot, skippingSet, false);
+        cleanUnusedManifests(taggedSnapshot, skippingSet, true, false);
     }
 
     public Predicate<ManifestEntry> dataFileSkipper(Snapshot fromSnapshot) throws Exception {

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -117,23 +117,7 @@ public class SchemaValidation {
                             ChangelogProducer.LOOKUP));
         }
 
-        checkArgument(
-                options.snapshotNumRetainMin() > 0,
-                SNAPSHOT_NUM_RETAINED_MIN.key() + " should be at least 1");
-        checkArgument(
-                options.snapshotNumRetainMin() <= options.snapshotNumRetainMax(),
-                SNAPSHOT_NUM_RETAINED_MIN.key()
-                        + " should not be larger than "
-                        + SNAPSHOT_NUM_RETAINED_MAX.key());
-
-        checkArgument(
-                options.changelogNumRetainMin() > 0,
-                CHANGELOG_NUM_RETAINED_MIN.key() + " should be at least 1");
-        checkArgument(
-                options.changelogNumRetainMin() <= options.changelogNumRetainMax(),
-                CHANGELOG_NUM_RETAINED_MIN.key()
-                        + " should not be larger than "
-                        + CHANGELOG_NUM_RETAINED_MAX.key());
+        validateSnapshotAndChangelogRetainOption(options);
 
         // Get the format type here which will try to convert string value to {@Code
         // FileFormatType}. If the string value is illegal, an exception will be thrown.
@@ -188,6 +172,26 @@ public class SchemaValidation {
         if (options.deletionVectorsEnabled()) {
             validateForDeletionVectors(schema, options);
         }
+    }
+
+    public static void validateSnapshotAndChangelogRetainOption(CoreOptions options) {
+        checkArgument(
+                options.snapshotNumRetainMin() > 0,
+                SNAPSHOT_NUM_RETAINED_MIN.key() + " should be at least 1");
+        checkArgument(
+                options.snapshotNumRetainMin() <= options.snapshotNumRetainMax(),
+                SNAPSHOT_NUM_RETAINED_MIN.key()
+                        + " should not be larger than "
+                        + SNAPSHOT_NUM_RETAINED_MAX.key());
+
+        checkArgument(
+                options.changelogNumRetainMin() > 0,
+                CHANGELOG_NUM_RETAINED_MIN.key() + " should be at least 1");
+        checkArgument(
+                options.changelogNumRetainMin() <= options.changelogNumRetainMax(),
+                CHANGELOG_NUM_RETAINED_MIN.key()
+                        + " should not be larger than "
+                        + CHANGELOG_NUM_RETAINED_MAX.key());
     }
 
     private static void validateOnlyContainPrimitiveType(

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshots.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshots.java
@@ -18,17 +18,79 @@
 
 package org.apache.paimon.table;
 
+import org.apache.paimon.operation.ChangelogDeletion;
+import org.apache.paimon.operation.SnapshotDeletion;
+import org.apache.paimon.utils.SnapshotManager;
+import org.apache.paimon.utils.TagManager;
+
+import javax.annotation.Nullable;
+
 /** Expire snapshots. */
 public interface ExpireSnapshots {
 
-    ExpireSnapshots retainMax(int retainMax);
-
-    ExpireSnapshots retainMin(int retainMin);
-
-    ExpireSnapshots olderThanMills(long olderThanMills);
-
-    ExpireSnapshots maxDeletes(int maxDeletes);
-
     /** @return How many snapshots have been expired. */
     int expire();
+
+    /** Expire the snapshots and changelogs. */
+    class Expire implements ExpireSnapshots {
+
+        private @Nullable ExpireChangelogImpl expireChangelogs;
+        private final ExpireSnapshotsImpl expireSnapshots;
+
+        public Expire(
+                SnapshotManager snapshotManager,
+                SnapshotDeletion snapshotDeletion,
+                ChangelogDeletion changelogDeletion,
+                TagManager tagManager,
+                boolean cleanEmptyDirectories,
+                int snapshotRetainMax,
+                int snapshotRetainMin,
+                long snapshotTimeToRetain,
+                int changelogRetainMax,
+                int changelogRetainMin,
+                long changelogTimeToRetain,
+                int maxDeletes) {
+            boolean changelogDecoupled =
+                    changelogRetainMax > snapshotRetainMax
+                            || changelogRetainMin > snapshotRetainMin
+                            || changelogTimeToRetain > snapshotTimeToRetain;
+            this.expireSnapshots =
+                    new ExpireSnapshotsImpl(
+                            snapshotManager,
+                            snapshotDeletion,
+                            tagManager,
+                            cleanEmptyDirectories,
+                            changelogDecoupled,
+                            snapshotRetainMax,
+                            snapshotRetainMin,
+                            snapshotTimeToRetain,
+                            maxDeletes);
+            if (changelogDecoupled) {
+                this.expireChangelogs =
+                        new ExpireChangelogImpl(
+                                snapshotManager,
+                                tagManager,
+                                changelogDeletion,
+                                cleanEmptyDirectories,
+                                changelogRetainMax,
+                                changelogRetainMin,
+                                changelogTimeToRetain,
+                                maxDeletes);
+            }
+        }
+
+        public ExpireSnapshotsImpl getExpireSnapshots() {
+            return expireSnapshots;
+        }
+
+        @Override
+        public int expire() {
+            int snapshot = expireSnapshots.expire();
+            if (expireChangelogs != null) {
+                snapshot += expireChangelogs.expire();
+            }
+
+            return snapshot;
+        }
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/ReadonlyTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ReadonlyTable.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.table;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.stats.Statistics;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.sink.InnerTableCommit;
@@ -167,18 +168,10 @@ public interface ReadonlyTable extends InnerTable {
     }
 
     @Override
-    default ExpireSnapshots newExpireSnapshots() {
+    default ExpireSnapshots newExpireSnapshots(CoreOptions options) {
         throw new UnsupportedOperationException(
                 String.format(
                         "Readonly Table %s does not support expireSnapshots.",
-                        this.getClass().getSimpleName()));
-    }
-
-    @Override
-    default ExpireSnapshots newExpireChangelog() {
-        throw new UnsupportedOperationException(
-                String.format(
-                        "Readonly Table %s does not support expireChangelog.",
                         this.getClass().getSimpleName()));
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/Table.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/Table.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.table;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.annotation.Experimental;
 import org.apache.paimon.annotation.Public;
 import org.apache.paimon.stats.Statistics;
@@ -105,10 +106,7 @@ public interface Table extends Serializable {
 
     /** Manually expire snapshots, parameters can be controlled independently of table options. */
     @Experimental
-    ExpireSnapshots newExpireSnapshots();
-
-    @Experimental
-    ExpireSnapshots newExpireChangelog();
+    ExpireSnapshots newExpireSnapshots(CoreOptions options);
 
     // =============== Read & Write Operations ==================
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractInnerTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractInnerTableScan.java
@@ -122,7 +122,6 @@ public abstract class AbstractInnerTableScan implements InnerTableScan {
                 return new ContinuousFromSnapshotStartingScanner(
                         snapshotManager,
                         consumer.get().nextSnapshot(),
-                        options.changelogProducer() != ChangelogProducer.NONE,
                         options.changelogLifecycleDecoupled());
             }
         }
@@ -152,7 +151,6 @@ public abstract class AbstractInnerTableScan implements InnerTableScan {
                         ? new ContinuousFromTimestampStartingScanner(
                                 snapshotManager,
                                 startupMillis,
-                                options.changelogProducer() != ChangelogProducer.NONE,
                                 options.changelogLifecycleDecoupled())
                         : new StaticFromTimestampStartingScanner(snapshotManager, startupMillis);
             case FROM_FILE_CREATION_TIME:
@@ -164,7 +162,6 @@ public abstract class AbstractInnerTableScan implements InnerTableScan {
                             ? new ContinuousFromSnapshotStartingScanner(
                                     snapshotManager,
                                     options.scanSnapshotId(),
-                                    options.changelogProducer() != ChangelogProducer.NONE,
                                     options.changelogLifecycleDecoupled())
                             : new StaticFromSnapshotStartingScanner(
                                     snapshotManager, options.scanSnapshotId());

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerStreamTableScanImpl.java
@@ -80,10 +80,7 @@ public class InnerStreamTableScanImpl extends AbstractInnerTableScan
         this.supportStreamingReadOverwrite = supportStreamingReadOverwrite;
         this.defaultValueAssigner = defaultValueAssigner;
         this.nextSnapshotProvider =
-                new NextSnapshotFetcher(
-                        snapshotManager,
-                        options.changelogLifecycleDecoupled(),
-                        options.changelogProducer() != CoreOptions.ChangelogProducer.NONE);
+                new NextSnapshotFetcher(snapshotManager, options.changelogLifecycleDecoupled());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromSnapshotStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromSnapshotStartingScanner.java
@@ -27,18 +27,13 @@ import org.apache.paimon.utils.SnapshotManager;
  */
 public class ContinuousFromSnapshotStartingScanner extends AbstractStartingScanner {
 
-    private final boolean changelogAsFollowup;
     private final boolean changelogDecoupled;
 
     public ContinuousFromSnapshotStartingScanner(
-            SnapshotManager snapshotManager,
-            long snapshotId,
-            boolean changelogAsFollowup,
-            boolean changelogDecoupled) {
+            SnapshotManager snapshotManager, long snapshotId, boolean changelogDecoupled) {
         super(snapshotManager);
         this.startingSnapshotId = snapshotId;
         this.changelogDecoupled = changelogDecoupled;
-        this.changelogAsFollowup = changelogAsFollowup;
     }
 
     @Override
@@ -54,7 +49,7 @@ public class ContinuousFromSnapshotStartingScanner extends AbstractStartingScann
 
     private Long getEarliestId() {
         Long earliestId;
-        if (changelogAsFollowup && changelogDecoupled) {
+        if (changelogDecoupled) {
             Long earliestChangelogId = snapshotManager.earliestLongLivedChangelogId();
             earliestId =
                     earliestChangelogId == null

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScanner.java
@@ -37,13 +37,10 @@ public class ContinuousFromTimestampStartingScanner extends AbstractStartingScan
     private final boolean startFromChangelog;
 
     public ContinuousFromTimestampStartingScanner(
-            SnapshotManager snapshotManager,
-            long startupMillis,
-            boolean changelogAsFollowup,
-            boolean changelogDecoupled) {
+            SnapshotManager snapshotManager, long startupMillis, boolean changelogDecoupled) {
         super(snapshotManager);
         this.startupMillis = startupMillis;
-        this.startFromChangelog = changelogAsFollowup && changelogDecoupled;
+        this.startFromChangelog = changelogDecoupled;
         this.startingSnapshotId =
                 this.snapshotManager.earlierThanTimeMills(startupMillis, startFromChangelog);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/NextSnapshotFetcher.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/NextSnapshotFetcher.java
@@ -32,16 +32,10 @@ public class NextSnapshotFetcher {
     public static final Logger LOG = LoggerFactory.getLogger(NextSnapshotFetcher.class);
     private final SnapshotManager snapshotManager;
     private final boolean changelogDecoupled;
-    // Only support changelog as follow-up now.
-    private final boolean changelogAsFollowup;
 
-    public NextSnapshotFetcher(
-            SnapshotManager snapshotManager,
-            boolean changelogDecoupled,
-            boolean changelogAsFollowup) {
+    public NextSnapshotFetcher(SnapshotManager snapshotManager, boolean changelogDecoupled) {
         this.snapshotManager = snapshotManager;
         this.changelogDecoupled = changelogDecoupled;
-        this.changelogAsFollowup = changelogAsFollowup;
     }
 
     @Nullable
@@ -59,9 +53,7 @@ public class NextSnapshotFetcher {
             return null;
         }
 
-        if (!changelogAsFollowup
-                || !changelogDecoupled
-                || !snapshotManager.longLivedChangelogExists(nextSnapshotId)) {
+        if (!changelogDecoupled || !snapshotManager.longLivedChangelogExists(nextSnapshotId)) {
             throw new OutOfRangeException(
                     String.format(
                             "The snapshot with id %d has expired. You can: "

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -26,6 +26,8 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.IndexIncrement;
+import org.apache.paimon.manifest.FileKind;
+import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFileMeta;
@@ -46,9 +48,7 @@ import org.apache.paimon.schema.KeyValueFieldsExtractor;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.CatalogEnvironment;
-import org.apache.paimon.table.ExpireChangelogImpl;
 import org.apache.paimon.table.ExpireSnapshots;
-import org.apache.paimon.table.ExpireSnapshotsImpl;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.ScanMode;
@@ -160,44 +160,58 @@ public class TestFileStore extends KeyValueFileStore {
                 numRetainedMin,
                 numRetainedMax,
                 millisRetained,
-                snapshotExpireCleanEmptyDirectories,
-                false);
+                numRetainedMin,
+                numRetainedMax,
+                millisRetained,
+                snapshotExpireCleanEmptyDirectories);
     }
 
     public ExpireSnapshots newExpire(int numRetainedMin, int numRetainedMax, long millisRetained) {
-        return newExpire(numRetainedMin, numRetainedMax, millisRetained, true, false);
+        return newExpire(numRetainedMin, numRetainedMax, millisRetained, true);
     }
 
     public ExpireSnapshots newExpire(
-            int numRetainedMin,
-            int numRetainedMax,
-            long millisRetained,
-            boolean snapshotExpireCleanEmptyDirectories,
-            boolean changelogDecoupled) {
-        return new ExpireSnapshotsImpl(
-                        snapshotManager(),
-                        newSnapshotDeletion(),
-                        new TagManager(fileIO, options.path()),
-                        snapshotExpireCleanEmptyDirectories,
-                        changelogDecoupled)
-                .retainMax(numRetainedMax)
-                .retainMin(numRetainedMin)
-                .olderThanMills(System.currentTimeMillis() - millisRetained);
-    }
-
-    public ExpireSnapshots newChangelogExpire(
-            int numRetainedMin,
-            int numRetainedMax,
-            long millisRetained,
+            int snapshotNumRetainedMin,
+            int snapshotNumRetainedMax,
+            long snapshotMillisRetained,
+            int changelogNumRetainedMin,
+            int changelogNumRetainedMax,
+            long changelogMillisRetained,
             boolean snapshotExpireCleanEmptyDirectories) {
-        return new ExpireChangelogImpl(
-                        snapshotManager(),
-                        new TagManager(fileIO, options.path()),
-                        newSnapshotDeletion(),
-                        snapshotExpireCleanEmptyDirectories)
-                .retainMin(numRetainedMin)
-                .retainMax(numRetainedMax)
-                .olderThanMills(System.currentTimeMillis() - millisRetained);
+        Map<String, String> origin = new HashMap<>(options.toMap());
+        origin.put(
+                CoreOptions.SNAPSHOT_NUM_RETAINED_MAX.key(),
+                String.valueOf(snapshotNumRetainedMax));
+        origin.put(
+                CoreOptions.SNAPSHOT_NUM_RETAINED_MIN.key(),
+                String.valueOf(snapshotNumRetainedMin));
+        origin.put(
+                CoreOptions.SNAPSHOT_TIME_RETAINED.key(),
+                String.format("%dms", snapshotMillisRetained));
+        origin.put(
+                CoreOptions.CHANGELOG_NUM_RETAINED_MAX.key(),
+                String.valueOf(changelogNumRetainedMax));
+        origin.put(
+                CoreOptions.CHANGELOG_NUM_RETAINED_MIN.key(),
+                String.valueOf(changelogNumRetainedMin));
+        origin.put(
+                CoreOptions.CHANGELOG_TIME_RETAINED.key(),
+                String.format("%dms", changelogMillisRetained));
+
+        CoreOptions newOption = new CoreOptions(origin);
+        return new ExpireSnapshots.Expire(
+                snapshotManager(),
+                newSnapshotDeletion(newOption),
+                newChangelogDeletion(newOption),
+                new TagManager(fileIO, options.path()),
+                snapshotExpireCleanEmptyDirectories,
+                newOption.snapshotNumRetainMax(),
+                newOption.snapshotNumRetainMin(),
+                newOption.snapshotTimeRetain().toMillis(),
+                newOption.changelogNumRetainMax(),
+                newOption.changelogNumRetainMin(),
+                newOption.changelogTimeRetain().toMillis(),
+                Integer.MAX_VALUE);
     }
 
     public List<Snapshot> commitData(
@@ -608,6 +622,12 @@ public class TestFileStore extends KeyValueFileStore {
             FileStorePathFactory pathFactory,
             ManifestList manifestList) {
         Set<Path> result = new HashSet<>();
+        SchemaManager schemaManager = new SchemaManager(fileIO, snapshotManager.tablePath());
+        CoreOptions options = new CoreOptions(schemaManager.latest().get().options());
+        boolean produceChangelog =
+                options.changelogProducer() != CoreOptions.ChangelogProducer.NONE;
+        // The option from the table may not align with the expiration config
+        boolean changelogDecoupled = snapshotManager.earliestLongLivedChangelogId() != null;
 
         Path snapshotPath = snapshotManager.snapshotPath(snapshotId);
         Snapshot snapshot = Snapshot.fromPath(fileIO, snapshotPath);
@@ -635,6 +655,27 @@ public class TestFileStore extends KeyValueFileStore {
                             entry.file().fileName()));
         }
 
+        // Add 'DELETE' 'APPEND' file in snapshot
+        // These 'delete' files can be merged by the plan#splits,
+        // so it's not shown in the entries above.
+        // In other words, these files are not used (by snapshot or changelog) now,
+        // but it can only be cleaned after this snapshot expired, so we should add it to the file
+        // use list.
+        if (changelogDecoupled && !produceChangelog) {
+            entries = scan.withManifestList(snapshot.deltaManifests(manifestList)).plan().files();
+            for (ManifestEntry entry : entries) {
+                // append delete file are delayed to delete
+                if (entry.kind() == FileKind.DELETE
+                        && entry.file().fileSource().orElse(FileSource.APPEND)
+                                == FileSource.APPEND) {
+                    result.add(
+                            new Path(
+                                    pathFactory.bucketPath(entry.partition(), entry.bucket()),
+                                    entry.file().fileName()));
+                }
+            }
+        }
+
         return result;
     }
 
@@ -646,6 +687,10 @@ public class TestFileStore extends KeyValueFileStore {
             FileStorePathFactory pathFactory,
             ManifestList manifestList) {
         Set<Path> result = new HashSet<>();
+        SchemaManager schemaManager = new SchemaManager(fileIO, snapshotManager.tablePath());
+        CoreOptions options = new CoreOptions(schemaManager.latest().get().options());
+        boolean produceChangelog =
+                options.changelogProducer() != CoreOptions.ChangelogProducer.NONE;
 
         Path changelogPath = snapshotManager.longLivedChangelogPath(changelogId);
         Changelog changelog = Changelog.fromPath(fileIO, changelogPath);
@@ -654,24 +699,51 @@ public class TestFileStore extends KeyValueFileStore {
         result.add(changelogPath);
 
         // manifest lists
+        if (!produceChangelog) {
+            result.add(pathFactory.toManifestListPath(changelog.baseManifestList()));
+            result.add(pathFactory.toManifestListPath(changelog.deltaManifestList()));
+        }
         if (changelog.changelogManifestList() != null) {
             result.add(pathFactory.toManifestListPath(changelog.changelogManifestList()));
         }
 
         // manifests
-        List<ManifestFileMeta> manifests = new ArrayList<>();
-        manifests.addAll(changelog.changelogManifests(manifestList));
+        List<ManifestFileMeta> manifests =
+                new ArrayList<>(changelog.changelogManifests(manifestList));
+        if (!produceChangelog) {
+            manifests.addAll(changelog.dataManifests(manifestList));
+        }
 
         manifests.forEach(m -> result.add(pathFactory.toManifestFilePath(m.fileName())));
 
-        // data file
-        List<ManifestEntry> entries = scan.withManifestList(manifests).plan().files();
-        for (ManifestEntry entry : entries) {
-            result.add(
-                    new Path(
-                            pathFactory.bucketPath(entry.partition(), entry.bucket()),
-                            entry.file().fileName()));
+        // not all manifests contains useful data file
+        // (1) produceChangelog = 'true': data file in changelog manifests
+        // (2) produceChangelog = 'false': 'APPEND' data file in delta manifests
+
+        // delta file
+        if (!produceChangelog) {
+            for (ManifestEntry entry :
+                    scan.withManifestList(changelog.deltaManifests(manifestList)).plan().files()) {
+                if (entry.file().fileSource().orElse(FileSource.APPEND) == FileSource.APPEND) {
+                    result.add(
+                            new Path(
+                                    pathFactory.bucketPath(entry.partition(), entry.bucket()),
+                                    entry.file().fileName()));
+                }
+            }
+        } else {
+            // changelog
+            for (ManifestEntry entry :
+                    scan.withManifestList(changelog.changelogManifests(manifestList))
+                            .plan()
+                            .files()) {
+                result.add(
+                        new Path(
+                                pathFactory.bucketPath(entry.partition(), entry.bucket()),
+                                entry.file().fileName()));
+            }
         }
+
         return result;
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyTableCompactionCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyTableCompactionCoordinatorTest.java
@@ -187,6 +187,7 @@ public class AppendOnlyTableCompactionCoordinatorTest {
                 0,
                 0,
                 0L,
+                null,
                 null);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -34,6 +34,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFilePathFactory;
+import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.memory.HeapMemorySegmentPool;
 import org.apache.paimon.memory.MemoryPoolFactory;
 import org.apache.paimon.options.MemorySize;
@@ -646,6 +647,7 @@ public class AppendOnlyWriterTest {
                         }),
                 minSeq,
                 maxSeq,
-                toCompact.get(0).schemaId());
+                toCompact.get(0).schemaId(),
+                FileSource.APPEND);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/crosspartition/IndexBootstrapTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/crosspartition/IndexBootstrapTest.java
@@ -139,6 +139,7 @@ public class IndexBootstrapTest extends TableTestBase {
                                 .atZone(ZoneId.systemDefault())
                                 .toLocalDateTime()),
                 0L,
+                null,
                 null);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/io/DataFileTestDataGenerator.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/DataFileTestDataGenerator.java
@@ -162,6 +162,7 @@ public class DataFileTestDataGenerator {
                         0,
                         level,
                         kvs.stream().filter(kv -> kv.valueKind().isRetract()).count(),
+                        null,
                         null),
                 kvs);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/io/DataFileTestUtils.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/DataFileTestUtils.java
@@ -52,6 +52,7 @@ public class DataFileTestUtils {
                 Collections.emptyList(),
                 Timestamp.fromEpochMillis(100),
                 maxSeq - minSeq + 1,
+                null,
                 null);
     }
 
@@ -69,6 +70,7 @@ public class DataFileTestUtils {
                 0,
                 0,
                 0L,
+                null,
                 null);
     }
 
@@ -92,6 +94,7 @@ public class DataFileTestUtils {
                 0,
                 level,
                 deleteRowCount,
+                null,
                 null);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
@@ -101,7 +101,7 @@ public class KeyValueFileReadWriteTest {
         DataFileMetaSerializer serializer = new DataFileMetaSerializer();
 
         RollingFileWriter<KeyValue, DataFileMeta> writer =
-                writerFactory.createRollingMergeTreeFileWriter(0);
+                writerFactory.createRollingMergeTreeFileWriter(0, false);
         writer.write(CloseableIterator.fromList(data.content, kv -> {}));
         writer.close();
         List<DataFileMeta> actualMetas = writer.result();
@@ -130,7 +130,8 @@ public class KeyValueFileReadWriteTest {
                         FailingFileIO.getFailingPath(failingName, tempDir.toString()), "avro");
 
         try {
-            FileWriter<KeyValue, ?> writer = writerFactory.createRollingMergeTreeFileWriter(0);
+            FileWriter<KeyValue, ?> writer =
+                    writerFactory.createRollingMergeTreeFileWriter(0, false);
             writer.write(CloseableIterator.fromList(data.content, kv -> {}));
         } catch (Throwable e) {
             if (e.getCause() != null) {
@@ -154,7 +155,7 @@ public class KeyValueFileReadWriteTest {
         DataFileMetaSerializer serializer = new DataFileMetaSerializer();
 
         RollingFileWriter<KeyValue, DataFileMeta> writer =
-                writerFactory.createRollingMergeTreeFileWriter(0);
+                writerFactory.createRollingMergeTreeFileWriter(0, false);
         writer.write(CloseableIterator.fromList(data.content, kv -> {}));
         writer.close();
         List<DataFileMeta> actualMetas = writer.result();
@@ -192,7 +193,7 @@ public class KeyValueFileReadWriteTest {
         DataFileMetaSerializer serializer = new DataFileMetaSerializer();
 
         RollingFileWriter<KeyValue, DataFileMeta> writer =
-                writerFactory.createRollingMergeTreeFileWriter(0);
+                writerFactory.createRollingMergeTreeFileWriter(0, false);
         writer.write(CloseableIterator.fromList(data.content, kv -> {}));
         writer.close();
         List<DataFileMeta> actualMetas = writer.result();
@@ -397,7 +398,7 @@ public class KeyValueFileReadWriteTest {
         DataFileMetaSerializer serializer = new DataFileMetaSerializer();
 
         RollingFileWriter<KeyValue, DataFileMeta> writer =
-                writerFactory.createRollingMergeTreeFileWriter(0);
+                writerFactory.createRollingMergeTreeFileWriter(0, false);
         writer.write(CloseableIterator.fromList(data.content, kv -> {}));
         writer.close();
         List<DataFileMeta> actualMetas = writer.result();

--- a/paimon-core/src/test/java/org/apache/paimon/io/RollingFileWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/RollingFileWriterTest.java
@@ -89,7 +89,8 @@ public class RollingFileWriterTest {
                                         StatsCollectorFactories.createStatsFactories(
                                                 new CoreOptions(new HashMap<>()),
                                                 SCHEMA.getFieldNames()),
-                                        new FileIndexOptions()),
+                                        new FileIndexOptions(),
+                                        false),
                         TARGET_FILE_SIZE);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestCommittableSerializerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestCommittableSerializerTest.java
@@ -116,6 +116,7 @@ public class ManifestCommittableSerializerTest {
                 0,
                 level,
                 0L,
+                null,
                 null);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTestBase.java
@@ -83,8 +83,8 @@ public abstract class ManifestFileMetaTestBase {
                         Collections.emptyList(),
                         Timestamp.fromEpochMillis(200000),
                         0L, // not used
-                        null // not used
-                        ));
+                        null, // not used
+                        null));
     }
 
     protected ManifestFileMeta makeManifest(ManifestEntry... entries) {
@@ -245,6 +245,7 @@ public abstract class ManifestFileMetaTestBase {
                         0, // not used
                         0, // not used
                         0L,
+                        null,
                         null));
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/ContainsLevelsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/ContainsLevelsTest.java
@@ -206,7 +206,7 @@ public class ContainsLevelsTest {
 
     private DataFileMeta newFile(int level, KeyValue... records) throws IOException {
         RollingFileWriter<KeyValue, DataFileMeta> writer =
-                createWriterFactory().createRollingMergeTreeFileWriter(level);
+                createWriterFactory().createRollingMergeTreeFileWriter(level, false);
         for (KeyValue kv : records) {
             writer.write(kv);
         }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/LevelsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/LevelsTest.java
@@ -81,6 +81,7 @@ public class LevelsTest {
                 0,
                 level,
                 0L,
+                null,
                 null);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/LookupLevelsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/LookupLevelsTest.java
@@ -286,7 +286,7 @@ public class LookupLevelsTest {
 
     private DataFileMeta newFile(int level, KeyValue... records) throws IOException {
         RollingFileWriter<KeyValue, DataFileMeta> writer =
-                createWriterFactory().createRollingMergeTreeFileWriter(level);
+                createWriterFactory().createRollingMergeTreeFileWriter(level, false);
         for (KeyValue kv : records) {
             writer.write(kv);
         }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
@@ -608,7 +608,7 @@ public abstract class MergeTreeTestBase {
                 int outputLevel, boolean dropDelete, List<List<SortedRun>> sections)
                 throws Exception {
             RollingFileWriter<KeyValue, DataFileMeta> writer =
-                    writerFactory.createRollingMergeTreeFileWriter(outputLevel);
+                    writerFactory.createRollingMergeTreeFileWriter(outputLevel, false);
             RecordReader<KeyValue> reader =
                     MergeTreeReaders.readerForMergeTree(
                             sections,

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/IntervalPartitionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/IntervalPartitionTest.java
@@ -182,6 +182,7 @@ public class IntervalPartitionTest {
                 Collections.emptyList(),
                 Timestamp.fromEpochMillis(100000),
                 0L,
+                null,
                 null);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/UniversalCompactionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/UniversalCompactionTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.mergetree.compact;
 
 import org.apache.paimon.compact.CompactUnit;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.mergetree.LevelSortedRun;
 import org.apache.paimon.mergetree.SortedRun;
 
@@ -357,6 +358,7 @@ public class UniversalCompactionTest {
     }
 
     static DataFileMeta file(long size) {
-        return new DataFileMeta("", size, 1, null, null, null, null, 0, 0, 0, 0, 0L, null);
+        return new DataFileMeta(
+                "", size, 1, null, null, null, null, 0, 0, 0, 0, 0L, null, FileSource.APPEND);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/OrphanFilesCleanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/OrphanFilesCleanTest.java
@@ -59,6 +59,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -328,14 +330,16 @@ public class OrphanFilesCleanTest {
         assertThat(result).containsExactlyInAnyOrderElementsOf(TestPojo.formatData(data));
     }
 
-    @Test
-    public void testCleanOrphanFilesWithChangelogDecoupled() throws Exception {
+    @ValueSource(strings = {"none", "input"})
+    @ParameterizedTest(name = "changelog-producer = {0}")
+    public void testCleanOrphanFilesWithChangelogDecoupled(String changelogProducer)
+            throws Exception {
         // recreate the table with another option
         this.write.close();
         this.commit.close();
         int commitTimes = 30;
         Options options = new Options();
-        options.set(CoreOptions.CHANGELOG_PRODUCER, CoreOptions.ChangelogProducer.INPUT);
+        options.setString(CoreOptions.CHANGELOG_PRODUCER.key(), changelogProducer);
         options.set(CoreOptions.SNAPSHOT_NUM_RETAINED_MAX, 15);
         options.set(CoreOptions.CHANGELOG_NUM_RETAINED_MAX, 20);
         FileStoreTable table = createFileStoreTable(rowType, options);

--- a/paimon-core/src/test/java/org/apache/paimon/table/IndexFileExpireTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/IndexFileExpireTableTest.java
@@ -59,10 +59,13 @@ public class IndexFileExpireTableTest extends PrimaryKeyTableTestBase {
     @Test
     public void testIndexFileExpiration() throws Exception {
         prepareExpireTable();
-        ExpireSnapshotsImpl expire = (ExpireSnapshotsImpl) table.newExpireSnapshots();
 
         long indexFileSize = indexFileSize();
         long indexManifestSize = indexManifestSize();
+
+        ExpireSnapshotsImpl expire =
+                ((ExpireSnapshots.Expire) table.newExpireSnapshots(table.coreOptions()))
+                        .getExpireSnapshots();
 
         expire.expireUntil(1, 2);
         checkIndexFiles(2);
@@ -88,7 +91,9 @@ public class IndexFileExpireTableTest extends PrimaryKeyTableTestBase {
     @Test
     public void testIndexFileExpirationWithTag() throws Exception {
         prepareExpireTable();
-        ExpireSnapshotsImpl expire = (ExpireSnapshotsImpl) table.newExpireSnapshots();
+        ExpireSnapshotsImpl expire =
+                ((ExpireSnapshots.Expire) table.newExpireSnapshots(table.coreOptions()))
+                        .getExpireSnapshots();
 
         table.createTag("tag3", 3);
         table.createTag("tag5", 5);
@@ -114,7 +119,9 @@ public class IndexFileExpireTableTest extends PrimaryKeyTableTestBase {
     @Test
     public void testIndexFileExpirationWhenDeletingTag() throws Exception {
         prepareExpireTable();
-        ExpireSnapshotsImpl expire = (ExpireSnapshotsImpl) table.newExpireSnapshots();
+        ExpireSnapshotsImpl expire =
+                ((ExpireSnapshots.Expire) table.newExpireSnapshots(table.coreOptions()))
+                        .getExpireSnapshots();
 
         table.createTag("tag3", 3);
         table.createTag("tag5", 5);

--- a/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
@@ -65,6 +65,8 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.CompatibilityTestUtils;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -1456,15 +1458,15 @@ public class PrimaryKeyFileStoreTableTest extends FileStoreTableTestBase {
                                 "1|2|200|binary|varbinary|mapKey:mapVal|multiset"));
     }
 
-    @Test
-    public void testRollbackToTagWithChangelogDecoupled() throws Exception {
+    @ParameterizedTest(name = "changelog-producer = {0}")
+    @ValueSource(strings = {"none", "input"})
+    public void testRollbackToTagWithChangelogDecoupled(String changelogProducer) throws Exception {
         int commitTimes = ThreadLocalRandom.current().nextInt(100) + 6;
         FileStoreTable table =
                 createFileStoreTable(
                         options ->
-                                options.set(
-                                        CoreOptions.CHANGELOG_PRODUCER,
-                                        CoreOptions.ChangelogProducer.INPUT));
+                                options.setString(
+                                        CoreOptions.CHANGELOG_PRODUCER.key(), changelogProducer));
         prepareRollbackTable(commitTimes, table);
 
         int t1 = 1;

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/SplitGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/SplitGeneratorTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.table.source;
 
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.utils.Pair;
 
@@ -56,7 +57,8 @@ public class SplitGeneratorTest {
                 0,
                 0,
                 0L,
-                null);
+                null,
+                FileSource.APPEND);
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ContinuousFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ContinuousFileStoreITCase.java
@@ -33,6 +33,8 @@ import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -597,16 +599,18 @@ public class ContinuousFileStoreITCase extends CatalogITCaseBase {
         assertThat(iterator.collect(1)).containsExactlyInAnyOrder(Row.of(3, "c"));
     }
 
-    @Test
-    public void testScanFromChangelog() throws Exception {
+    @ParameterizedTest(name = "changelog-producer = {0}")
+    @ValueSource(strings = {"none", "input"})
+    public void testScanFromChangelog(String changelogProducer) throws Exception {
         batchSql(
                 "CREATE TABLE IF NOT EXISTS T3 (a STRING, b STRING, c STRING, PRIMARY KEY (a) NOT ENFORCED)\n"
-                        + " WITH ('changelog-producer'='input', 'bucket' = '1', \n"
+                        + " WITH ('changelog-producer'='%s', 'bucket' = '1', \n"
                         + " 'snapshot.num-retained.max' = '2',\n"
                         + " 'snapshot.num-retained.min' = '1',\n"
                         + " 'changelog.num-retained.max' = '3',\n"
                         + " 'changelog.num-retained.min' = '1'\n"
-                        + ")");
+                        + ")",
+                changelogProducer);
 
         batchSql("INSERT INTO T3 VALUES ('1', '2', '3')");
         batchSql("INSERT INTO T3 VALUES ('4', '5', '6')");

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpireSnapshotsProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpireSnapshotsProcedureITCase.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.procedure;
+
+import org.apache.paimon.flink.CatalogITCaseBase;
+import org.apache.paimon.table.FileStoreTable;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/** IT Case for {@link ExpireSnapshotsProcedure}. */
+public class ExpireSnapshotsProcedureITCase extends CatalogITCaseBase {
+
+    @Test
+    public void testExpire() throws Exception {
+        sql(
+                "CREATE TABLE T ("
+                        + " k INT,"
+                        + " v INT,"
+                        + " PRIMARY KEY (k) NOT ENFORCED"
+                        + ") WITH ("
+                        + " 'bucket' = '1'"
+                        + ")");
+        FileStoreTable table = paimonTable("T");
+
+        for (int i = 0; i < 15; i++) {
+            sql("INSERT INTO T VALUES (1, 1)");
+        }
+
+        sql("CALL sys.expire_snapshots('default.T', 10)");
+        Assertions.assertThat(
+                        table.snapshotManager()
+                                .fileIO()
+                                .exists(table.snapshotManager().changelogDirectory()))
+                .isFalse();
+
+        sql(
+                "CREATE TABLE T_1 ("
+                        + " k INT,"
+                        + " v INT,"
+                        + " PRIMARY KEY (k) NOT ENFORCED"
+                        + ") WITH ("
+                        + " 'bucket' = '1',"
+                        + " 'snapshot.num-retained.max' = '12',"
+                        + " 'changelog.num-retained.max' = '12'"
+                        + ")");
+        table = paimonTable("T_1");
+
+        for (int i = 0; i < 15; i++) {
+            sql("INSERT INTO T_1 VALUES (1, 1)");
+        }
+        Assertions.assertThat(table.snapshotManager().changelogs().hasNext()).isFalse();
+
+        sql("CALL sys.expire_snapshots('default.T_1', 10)");
+        Assertions.assertThat(table.snapshotManager().changelogs().hasNext()).isTrue();
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CompactionTaskSimpleSerializerTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CompactionTaskSimpleSerializerTest.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink.sink;
 import org.apache.paimon.append.AppendOnlyCompactionTask;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.table.sink.CompactionTaskSerializer;
 
 import org.junit.jupiter.api.Test;
@@ -76,6 +77,7 @@ public class CompactionTaskSimpleSerializerTest {
                 0,
                 0,
                 0L,
-                null);
+                null,
+                FileSource.APPEND);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitGeneratorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitGeneratorTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink.source;
 
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.stats.StatsTestUtils;
 import org.apache.paimon.table.source.DataFilePlan;
 import org.apache.paimon.table.source.DataSplit;
@@ -113,8 +114,8 @@ public class FileStoreSourceSplitGeneratorTest {
                             0, // not used
                             0, // not used
                             0L, // not used
-                            null // not used
-                            ));
+                            null, // not used
+                            FileSource.APPEND));
         }
         return DataSplit.builder()
                 .withSnapshot(1)

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitSerializerTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.source;
 
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.stats.StatsTestUtils;
 import org.apache.paimon.table.source.DataSplit;
 
@@ -86,7 +87,8 @@ public class FileStoreSourceSplitSerializerTest {
                 0,
                 level,
                 0L,
-                null);
+                null,
+                FileSource.APPEND);
     }
 
     public static FileStoreSourceSplit newSourceSplit(

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/ScanHelperTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/ScanHelperTest.scala
@@ -21,6 +21,7 @@ package org.apache.paimon.spark
 import org.apache.paimon.CoreOptions
 import org.apache.paimon.data.BinaryRow
 import org.apache.paimon.io.DataFileMeta
+import org.apache.paimon.manifest.FileSource
 import org.apache.paimon.table.source.{DataSplit, RawFile, Split}
 
 import org.junit.jupiter.api.Assertions
@@ -42,7 +43,7 @@ class ScanHelperTest extends PaimonSparkTestBase {
       0.until(fileNum).foreach {
         i =>
           val path = s"f$i.parquet"
-          files += DataFileMeta.forAppend(path, 750000, 30000, null, 0, 29999, 1)
+          files += DataFileMeta.forAppend(path, 750000, 30000, null, 0, 29999, 1, FileSource.APPEND)
 
           rawFiles += new RawFile(s"/a/b/$path", 0, 75000, "parquet", 0, 30000)
       }

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/ExpireSnapshotsProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/ExpireSnapshotsProcedureTest.scala
@@ -71,7 +71,8 @@ class ExpireSnapshotsProcedureTest extends PaimonSparkTestBase with StreamTest {
 
             // expire
             checkAnswer(
-              spark.sql("CALL paimon.sys.expire_snapshots(table => 'test.T', retain_max => 2)"),
+              spark.sql(
+                "CALL paimon.sys.expire_snapshots(table => 'test.T', retain_max => 2, retain_min => 1)"),
               Row(1) :: Nil)
 
             checkAnswer(

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
@@ -288,7 +288,7 @@ abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
     Assertions.assertEquals(2, statsFileCount(tableLocation, fileIO))
 
     // test expire statistic
-    spark.sql("CALL sys.expire_snapshots(table => 'test.T', retain_max => 1)")
+    spark.sql("CALL sys.expire_snapshots(table => 'test.T', retain_max => 1, retain_min => 1)")
     Assertions.assertEquals(1, statsFileCount(tableLocation, fileIO))
 
     val orphanStats = new Path(tableLocation, "statistics/stats-orphan-0")


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose


This PR is meant to support decouple the delta files lifecycle #2899 

The basic idea behind this is that:

- Add fileSource in `DatafileMeta` to indicate whether this file is generated as an `APPEND` or `COMPACT` file
- When expire a snapshot, if changelog is decoupled, and it's a none changelog producer, we do not clean the `APPEND` files in data file
- When expire a changelog, we do the final clean for these files
- Due to the manifest file could still be used by delta files, so the `base` and `delta` manifest file for the `none` producer are also postpone to delete

**About why we need `FileSource` in DataFileMeta**

For `none` changelog producer, only `APPEND` commits are required for stream read. In a `COMPACT` commit, some files from the compact or append could be marked as delete. We should delete the files from the compact commit and keep the files from the append commit for further stream read. So we need a flag to distinguish the file source (compact or append).

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

Introduce `FileSource` in DataFileMeta

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
