### PR TITLE
[compaction] Refact the file scan source of combine mode for supporting unaware logic

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyCompactionTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyCompactionTask.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.append;
 
+import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
@@ -39,13 +40,22 @@ public class AppendOnlyCompactionTask {
     private final List<DataFileMeta> compactBefore;
     private final List<DataFileMeta> compactAfter;
 
+    private final Identifier tableIdentifier;
+
     public AppendOnlyCompactionTask(BinaryRow partition, List<DataFileMeta> files) {
+        this(partition, files, Identifier.EMPTY);
+    }
+
+    public AppendOnlyCompactionTask(
+            BinaryRow partition, List<DataFileMeta> files, Identifier identifier) {
+
         Preconditions.checkArgument(
                 files != null && files.size() > 1,
                 "AppendOnlyCompactionTask need more than one file input.");
         this.partition = partition;
         compactBefore = new ArrayList<>(files);
         compactAfter = new ArrayList<>();
+        this.tableIdentifier = identifier;
     }
 
     public BinaryRow partition() {
@@ -72,8 +82,12 @@ public class AppendOnlyCompactionTask {
                 compactIncrement);
     }
 
+    public Identifier tableIdentifier() {
+        return tableIdentifier;
+    }
+
     public int hashCode() {
-        return Objects.hash(partition, compactBefore, compactAfter);
+        return Objects.hash(partition, compactBefore, compactAfter, tableIdentifier);
     }
 
     @Override
@@ -88,7 +102,8 @@ public class AppendOnlyCompactionTask {
         AppendOnlyCompactionTask that = (AppendOnlyCompactionTask) o;
         return Objects.equals(partition, that.partition)
                 && Objects.equals(compactBefore, that.compactBefore)
-                && Objects.equals(compactAfter, that.compactAfter);
+                && Objects.equals(compactAfter, that.compactAfter)
+                && Objects.equals(tableIdentifier, that.tableIdentifier);
     }
 
     @Override
@@ -97,7 +112,8 @@ public class AppendOnlyCompactionTask {
                 "CompactionTask {"
                         + "partition = %s, "
                         + "compactBefore = %s, "
-                        + "compactAfter = %s}",
-                partition, compactBefore, compactAfter);
+                        + "compactAfter = %s, "
+                        + "tableIdentifier = %s}",
+                partition, compactBefore, compactAfter, tableIdentifier);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyCompactionTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyCompactionTask.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.append;
 
-import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
@@ -40,22 +39,13 @@ public class AppendOnlyCompactionTask {
     private final List<DataFileMeta> compactBefore;
     private final List<DataFileMeta> compactAfter;
 
-    private final Identifier tableIdentifier;
-
     public AppendOnlyCompactionTask(BinaryRow partition, List<DataFileMeta> files) {
-        this(partition, files, Identifier.EMPTY);
-    }
-
-    public AppendOnlyCompactionTask(
-            BinaryRow partition, List<DataFileMeta> files, Identifier identifier) {
-
         Preconditions.checkArgument(
                 files != null && files.size() > 1,
                 "AppendOnlyCompactionTask need more than one file input.");
         this.partition = partition;
         compactBefore = new ArrayList<>(files);
         compactAfter = new ArrayList<>();
-        this.tableIdentifier = identifier;
     }
 
     public BinaryRow partition() {
@@ -82,12 +72,8 @@ public class AppendOnlyCompactionTask {
                 compactIncrement);
     }
 
-    public Identifier tableIdentifier() {
-        return tableIdentifier;
-    }
-
     public int hashCode() {
-        return Objects.hash(partition, compactBefore, compactAfter, tableIdentifier);
+        return Objects.hash(partition, compactBefore, compactAfter);
     }
 
     @Override
@@ -102,8 +88,7 @@ public class AppendOnlyCompactionTask {
         AppendOnlyCompactionTask that = (AppendOnlyCompactionTask) o;
         return Objects.equals(partition, that.partition)
                 && Objects.equals(compactBefore, that.compactBefore)
-                && Objects.equals(compactAfter, that.compactAfter)
-                && Objects.equals(tableIdentifier, that.tableIdentifier);
+                && Objects.equals(compactAfter, that.compactAfter);
     }
 
     @Override
@@ -112,8 +97,7 @@ public class AppendOnlyCompactionTask {
                 "CompactionTask {"
                         + "partition = %s, "
                         + "compactBefore = %s, "
-                        + "compactAfter = %s, "
-                        + "tableIdentifier = %s}",
-                partition, compactBefore, compactAfter, tableIdentifier);
+                        + "compactAfter = %s}",
+                partition, compactBefore, compactAfter);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/append/MultiTableAppendOnlyCompactionTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/MultiTableAppendOnlyCompactionTask.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.append;
+
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.io.DataFileMeta;
+
+import java.util.List;
+import java.util.Objects;
+
+/** Compaction task for multi table . */
+public class MultiTableAppendOnlyCompactionTask extends AppendOnlyCompactionTask {
+    private final Identifier tableIdentifier;
+
+    public MultiTableAppendOnlyCompactionTask(
+            BinaryRow partition, List<DataFileMeta> files, Identifier identifier) {
+        super(partition, files);
+        this.tableIdentifier = identifier;
+    }
+
+    public Identifier tableIdentifier() {
+        return tableIdentifier;
+    }
+
+    public int hashCode() {
+        return Objects.hash(partition(), compactBefore(), compactAfter(), tableIdentifier);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MultiTableAppendOnlyCompactionTask that = (MultiTableAppendOnlyCompactionTask) o;
+        return Objects.equals(partition(), that.partition())
+                && Objects.equals(compactBefore(), that.compactBefore())
+                && Objects.equals(compactAfter(), that.compactAfter())
+                && Objects.equals(tableIdentifier, that.tableIdentifier);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Identifier.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Identifier.java
@@ -35,7 +35,6 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
  */
 @Public
 public class Identifier implements Serializable {
-    public static final Identifier EMPTY = new Identifier(null, null);
 
     private static final long serialVersionUID = 1L;
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Identifier.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Identifier.java
@@ -19,6 +19,8 @@
 package org.apache.paimon.catalog;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.StringUtils;
 
 import java.io.Serializable;
@@ -33,6 +35,7 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
  */
 @Public
 public class Identifier implements Serializable {
+    public static final Identifier EMPTY = new Identifier(null, null);
 
     private static final long serialVersionUID = 1L;
 
@@ -108,5 +111,9 @@ public class Identifier implements Serializable {
     @Override
     public String toString() {
         return "Identifier{" + "database='" + database + '\'' + ", table='" + table + '\'' + '}';
+    }
+
+    public static RowType schema() {
+        return RowType.builder().fields(DataTypes.STRING(), DataTypes.STRING()).build();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/io/IdentifierSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/IdentifierSerializer.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.utils.ObjectSerializer;
+
+/** Serializer for {@link Identifier}. */
+public class IdentifierSerializer extends ObjectSerializer<Identifier> {
+
+    public IdentifierSerializer() {
+        super(Identifier.schema());
+    }
+
+    @Override
+    public InternalRow toRow(Identifier record) {
+        return GenericRow.of(
+                BinaryString.fromString(record.getDatabaseName()),
+                BinaryString.fromString(record.getObjectName()));
+    }
+
+    @Override
+    public Identifier fromRow(InternalRow rowData) {
+        String databaseName = rowData.isNullAt(0) ? null : rowData.getString(0).toString();
+        String tableName = rowData.isNullAt(1) ? null : rowData.getString(1).toString();
+        return Identifier.create(databaseName, tableName);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/TableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/TableTestBase.java
@@ -170,6 +170,10 @@ public abstract class TableTestBase {
         catalog.createTable(identifier(), schemaDefault(), true);
     }
 
+    public void createTable(Identifier identifier) throws Exception {
+        catalog.createTable(identifier, schemaDefault(), false);
+    }
+
     protected void commitDefault(List<CommitMessage> messages) throws Exception {
         BatchTableCommit commit = getTableDefault().newBatchWriteBuilder().newCommit();
         commit.commit(messages);
@@ -177,16 +181,22 @@ public abstract class TableTestBase {
     }
 
     protected List<CommitMessage> writeDataDefault(int size, int times) throws Exception {
-        List<CommitMessage> messages = new ArrayList<>();
-        for (int i = 0; i < times; i++) {
-            messages.addAll(writeOnce(getTableDefault(), i, size));
-        }
-
-        return messages;
+        return writeData(getTableDefault(),size,times);
     }
 
+    protected List<CommitMessage> writeData(Table table, int size, int times) throws Exception {
+        List<CommitMessage> messages = new ArrayList<>();
+        for (int i = 0; i < times; i++) {
+            messages.addAll(writeOnce(table, i, size));
+        }
+        return messages;
+    }
     public FileStoreTable getTableDefault() throws Exception {
-        return (FileStoreTable) catalog.getTable(identifier());
+        return getTable(identifier());
+    }
+
+    public FileStoreTable getTable(Identifier identifier) throws Exception {
+        return (FileStoreTable) catalog.getTable(identifier);
     }
 
     private List<CommitMessage> writeOnce(Table table, int time, int size) throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/table/TableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/TableTestBase.java
@@ -181,7 +181,7 @@ public abstract class TableTestBase {
     }
 
     protected List<CommitMessage> writeDataDefault(int size, int times) throws Exception {
-        return writeData(getTableDefault(),size,times);
+        return writeData(getTableDefault(), size, times);
     }
 
     protected List<CommitMessage> writeData(Table table, int size, int times) throws Exception {
@@ -191,6 +191,7 @@ public abstract class TableTestBase {
         }
         return messages;
     }
+
     public FileStoreTable getTableDefault() throws Exception {
         return getTable(identifier());
     }

--- a/paimon-core/src/test/java/org/apache/paimon/table/sink/CompactionTaskSerializerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/sink/CompactionTaskSerializerTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.sink;
 
 import org.apache.paimon.append.AppendOnlyCompactionTask;
+import org.apache.paimon.append.MultiTableAppendOnlyCompactionTask;
 import org.apache.paimon.catalog.Identifier;
 
 import org.junit.jupiter.api.Test;
@@ -29,32 +30,32 @@ import static org.apache.paimon.manifest.ManifestCommittableSerializerTest.rando
 import static org.apache.paimon.mergetree.compact.MergeTreeCompactManagerTest.row;
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Tests for {@link CompactionTaskSerializer}. */
+/** Tests for {@link CompactionTaskSerializer} and {@link MultiTableCompactionTaskSerializer}. */
 public class CompactionTaskSerializerTest {
 
     @Test
     public void testCompactionTaskSerializer() throws IOException {
-        {
-            CompactionTaskSerializer serializer = new CompactionTaskSerializer();
-            AppendOnlyCompactionTask task =
-                    new AppendOnlyCompactionTask(row(0), randomNewFilesIncrement().newFiles());
+        CompactionTaskSerializer serializer = new CompactionTaskSerializer();
+        AppendOnlyCompactionTask task =
+                new AppendOnlyCompactionTask(row(0), randomNewFilesIncrement().newFiles());
 
-            byte[] bytes = serializer.serialize(task);
-            AppendOnlyCompactionTask task1 = serializer.deserialize(serializer.getVersion(), bytes);
-            assertThat(task).isEqualTo(task1);
-        }
+        byte[] bytes = serializer.serialize(task);
+        AppendOnlyCompactionTask task1 = serializer.deserialize(serializer.getVersion(), bytes);
+        assertThat(task).isEqualTo(task1);
+    }
 
-        {
-            CompactionTaskSerializer serializer = new CompactionTaskSerializer();
-            AppendOnlyCompactionTask task =
-                    new AppendOnlyCompactionTask(
-                            row(0),
-                            randomNewFilesIncrement().newFiles(),
-                            Identifier.create("db", "table"));
+    @Test
+    public void testMultiTableCompactionTaskSerializer() throws IOException {
+        MultiTableCompactionTaskSerializer serializer = new MultiTableCompactionTaskSerializer();
+        MultiTableAppendOnlyCompactionTask task =
+                new MultiTableAppendOnlyCompactionTask(
+                        row(0),
+                        randomNewFilesIncrement().newFiles(),
+                        Identifier.create("db", "table"));
 
-            byte[] bytes = serializer.serialize(task);
-            AppendOnlyCompactionTask task1 = serializer.deserialize(serializer.getVersion(), bytes);
-            assertThat(task).isEqualTo(task1);
-        }
+        byte[] bytes = serializer.serialize(task);
+        MultiTableAppendOnlyCompactionTask task1 =
+                serializer.deserialize(serializer.getVersion(), bytes);
+        assertThat(task).isEqualTo(task1);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/sink/CompactionTaskSerializerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/sink/CompactionTaskSerializerTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.sink;
 
 import org.apache.paimon.append.AppendOnlyCompactionTask;
+import org.apache.paimon.catalog.Identifier;
 
 import org.junit.jupiter.api.Test;
 
@@ -33,12 +34,27 @@ public class CompactionTaskSerializerTest {
 
     @Test
     public void testCompactionTaskSerializer() throws IOException {
-        CompactionTaskSerializer serializer = new CompactionTaskSerializer();
-        AppendOnlyCompactionTask task =
-                new AppendOnlyCompactionTask(row(0), randomNewFilesIncrement().newFiles());
+        {
+            CompactionTaskSerializer serializer = new CompactionTaskSerializer();
+            AppendOnlyCompactionTask task =
+                    new AppendOnlyCompactionTask(row(0), randomNewFilesIncrement().newFiles());
 
-        byte[] bytes = serializer.serialize(task);
-        AppendOnlyCompactionTask task1 = serializer.deserialize(serializer.getVersion(), bytes);
-        assertThat(task).isEqualTo(task1);
+            byte[] bytes = serializer.serialize(task);
+            AppendOnlyCompactionTask task1 = serializer.deserialize(serializer.getVersion(), bytes);
+            assertThat(task).isEqualTo(task1);
+        }
+
+        {
+            CompactionTaskSerializer serializer = new CompactionTaskSerializer();
+            AppendOnlyCompactionTask task =
+                    new AppendOnlyCompactionTask(
+                            row(0),
+                            randomNewFilesIncrement().newFiles(),
+                            Identifier.create("db", "table"));
+
+            byte[] bytes = serializer.serialize(task);
+            AppendOnlyCompactionTask task1 = serializer.deserialize(serializer.getVersion(), bytes);
+            assertThat(task).isEqualTo(task1);
+        }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/MultiAwareBucketTableScan.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/MultiAwareBucketTableScan.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.compact;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.table.BucketMode;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.StreamTableScan;
+import org.apache.paimon.table.system.BucketsTable;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.flink.utils.MultiTablesCompactorUtil.compactOptions;
+
+/**
+ * This class is responsible for implementing the scanning logic {@link MultiTableScanBase} for the
+ * table with multi bucket such as dynamic or fixed bucket table.
+ */
+public class MultiAwareBucketTableScan extends MultiTableScanBase<Tuple2<Split, String>> {
+    protected transient Map<Identifier, BucketsTable> tablesMap;
+    protected transient Map<Identifier, StreamTableScan> scansMap;
+
+    public MultiAwareBucketTableScan(
+            Catalog.Loader catalogLoader,
+            Pattern includingPattern,
+            Pattern excludingPattern,
+            Pattern databasePattern,
+            boolean isStreaming,
+            AtomicBoolean isRunning) {
+        super(
+                catalogLoader,
+                includingPattern,
+                excludingPattern,
+                databasePattern,
+                isStreaming,
+                isRunning);
+        tablesMap = new HashMap<>();
+        scansMap = new HashMap<>();
+    }
+
+    @Override
+    List<Tuple2<Split, String>> doScan() {
+        List<Tuple2<Split, String>> splits = new ArrayList<>();
+        for (Map.Entry<Identifier, StreamTableScan> entry : scansMap.entrySet()) {
+            Identifier identifier = entry.getKey();
+            StreamTableScan scan = entry.getValue();
+            splits.addAll(
+                    scan.plan().splits().stream()
+                            .map(split -> new Tuple2<>(split, identifier.getFullName()))
+                            .collect(Collectors.toList()));
+        }
+        return splits;
+    }
+
+    @Override
+    public boolean checkTableScanned(Identifier identifier) {
+        return tablesMap.containsKey(identifier);
+    }
+
+    @Override
+    public void addScanTable(FileStoreTable fileStoreTable, Identifier identifier) {
+        if (fileStoreTable.bucketMode() != BucketMode.UNAWARE) {
+            BucketsTable bucketsTable =
+                    new BucketsTable(fileStoreTable, isStreaming, identifier.getDatabaseName())
+                            .copy(compactOptions(isStreaming));
+            tablesMap.put(identifier, bucketsTable);
+            scansMap.put(identifier, bucketsTable.newReadBuilder().newStreamScan());
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/MultiTableScanBase.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/MultiTableScanBase.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.compact;
+
+import org.apache.paimon.append.MultiTableAppendOnlyCompactionTask;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.source.EndOfScanException;
+import org.apache.paimon.table.source.Split;
+
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+
+import static org.apache.paimon.flink.utils.MultiTablesCompactorUtil.shouldCompactTable;
+
+/**
+ * This class is responsible for implementing the scanning logic for the table of different type
+ * buckets during compaction.
+ *
+ * @param <T> the result of scanning file :
+ *     <ol>
+ *       <li>Tuple2<{@link Split},String> for the table with multi buckets, such as dynamic or fixed
+ *           bucket table.
+ *       <li>{@link MultiTableAppendOnlyCompactionTask} for the table witch fixed single bucket
+ *           ,such as unaware bucket table.
+ *     </ol>
+ */
+public abstract class MultiTableScanBase<T> {
+    private static final Logger LOG = LoggerFactory.getLogger(MultiTableScanBase.class);
+    protected final Pattern includingPattern;
+    protected final Pattern excludingPattern;
+    protected final Pattern databasePattern;
+
+    protected transient Catalog catalog;
+
+    protected AtomicBoolean isRunning;
+    protected boolean isStreaming;
+
+    public MultiTableScanBase(
+            Catalog.Loader catalogLoader,
+            Pattern includingPattern,
+            Pattern excludingPattern,
+            Pattern databasePattern,
+            boolean isStreaming,
+            AtomicBoolean isRunning) {
+        catalog = catalogLoader.load();
+
+        this.includingPattern = includingPattern;
+        this.excludingPattern = excludingPattern;
+        this.databasePattern = databasePattern;
+        this.isRunning = isRunning;
+        this.isStreaming = isStreaming;
+    }
+
+    protected void updateTableMap()
+            throws Catalog.DatabaseNotExistException, Catalog.TableNotExistException {
+        List<String> databases = catalog.listDatabases();
+
+        for (String databaseName : databases) {
+            if (databasePattern.matcher(databaseName).matches()) {
+                List<String> tables = catalog.listTables(databaseName);
+                for (String tableName : tables) {
+                    Identifier identifier = Identifier.create(databaseName, tableName);
+                    if (shouldCompactTable(identifier, includingPattern, excludingPattern)
+                            && (!checkTableScanned(identifier))) {
+                        Table table = catalog.getTable(identifier);
+                        if (!(table instanceof FileStoreTable)) {
+                            LOG.error(
+                                    String.format(
+                                            "Only FileStoreTable supports compact action. The table type is '%s'.",
+                                            table.getClass().getName()));
+                            continue;
+                        }
+
+                        FileStoreTable fileStoreTable = (FileStoreTable) table;
+                        addScanTable(fileStoreTable, identifier);
+                    }
+                }
+            }
+        }
+    }
+
+    public ScanResult scanTable(SourceFunction.SourceContext<T> ctx)
+            throws Catalog.TableNotExistException, Catalog.DatabaseNotExistException {
+        try {
+            if (!isRunning.get()) {
+                return ScanResult.FINISHED;
+            }
+
+            updateTableMap();
+            List<T> tasks = doScan();
+
+            tasks.forEach(ctx::collect);
+            return tasks.isEmpty() ? ScanResult.IS_EMPTY : ScanResult.IS_NON_EMPTY;
+        } catch (EndOfScanException esf) {
+            LOG.info("Catching EndOfStreamException, the stream is finished.");
+            return ScanResult.FINISHED;
+        }
+    }
+
+    abstract List<T> doScan();
+
+    /** Check if table has been scanned. */
+    abstract boolean checkTableScanned(Identifier identifier);
+
+    /** Add the scan table to the table map. */
+    abstract void addScanTable(FileStoreTable fileStoreTable, Identifier identifier);
+
+    /** the result of table scanning. */
+    public enum ScanResult {
+        FINISHED,
+        IS_EMPTY,
+        IS_NON_EMPTY
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/MultiUnawareBucketTableScan.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/MultiUnawareBucketTableScan.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.compact;
+
+import org.apache.paimon.append.AppendOnlyTableCompactionCoordinator;
+import org.apache.paimon.append.MultiTableAppendOnlyCompactionTask;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.table.BucketMode;
+import org.apache.paimon.table.FileStoreTable;
+
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+
+/**
+ * This class is responsible for implementing the scanning logic {@link MultiTableScanBase} for the
+ * table with fix single bucket such as unaware bucket table.
+ */
+public class MultiUnawareBucketTableScan
+        extends MultiTableScanBase<MultiTableAppendOnlyCompactionTask> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MultiUnawareBucketTableScan.class);
+
+    protected transient Map<Identifier, AppendOnlyTableCompactionCoordinator> tablesMap;
+
+    public MultiUnawareBucketTableScan(
+            Catalog.Loader catalogLoader,
+            Pattern includingPattern,
+            Pattern excludingPattern,
+            Pattern databasePattern,
+            boolean isStreaming,
+            AtomicBoolean isRunning) {
+        super(
+                catalogLoader,
+                includingPattern,
+                excludingPattern,
+                databasePattern,
+                isStreaming,
+                isRunning);
+        tablesMap = new HashMap<>();
+    }
+
+    @NotNull
+    @Override
+    List<MultiTableAppendOnlyCompactionTask> doScan() {
+        // do scan and plan action, emit append-only compaction tasks.
+        List<MultiTableAppendOnlyCompactionTask> tasks = new ArrayList<>();
+        for (Map.Entry<Identifier, AppendOnlyTableCompactionCoordinator> tableIdAndCoordinator :
+                tablesMap.entrySet()) {
+            Identifier tableId = tableIdAndCoordinator.getKey();
+            AppendOnlyTableCompactionCoordinator compactionCoordinator =
+                    tableIdAndCoordinator.getValue();
+            compactionCoordinator.run().stream()
+                    .map(
+                            task ->
+                                    new MultiTableAppendOnlyCompactionTask(
+                                            task.partition(), task.compactBefore(), tableId))
+                    .forEach(tasks::add);
+        }
+        return tasks;
+    }
+
+    @Override
+    public boolean checkTableScanned(Identifier identifier) {
+        return tablesMap.containsKey(identifier);
+    }
+
+    @Override
+    public void addScanTable(FileStoreTable fileStoreTable, Identifier identifier) {
+        if (fileStoreTable.bucketMode() == BucketMode.UNAWARE) {
+            tablesMap.put(
+                    identifier,
+                    new AppendOnlyTableCompactionCoordinator(fileStoreTable, isStreaming));
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/MultiUnawareBucketTableScan.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/MultiUnawareBucketTableScan.java
@@ -25,7 +25,6 @@ import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTable;
 
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +63,6 @@ public class MultiUnawareBucketTableScan
         tablesMap = new HashMap<>();
     }
 
-    @NotNull
     @Override
     List<MultiTableAppendOnlyCompactionTask> doScan() {
         // do scan and plan action, emit append-only compaction tasks.

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/UnawareBucketCompactor.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/UnawareBucketCompactor.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.compact;
+
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.append.AppendOnlyCompactionTask;
+import org.apache.paimon.flink.sink.Committable;
+import org.apache.paimon.operation.AppendOnlyFileStoreWrite;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.sink.TableCommitImpl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/** The Compactor of unaware bucket table to execute {@link AppendOnlyCompactionTask}. */
+public class UnawareBucketCompactor {
+    private final FileStoreTable table;
+    private final String commitUser;
+
+    private final transient AppendOnlyFileStoreWrite write;
+
+    protected final transient Queue<Future<CommitMessage>> result;
+
+    private final transient Supplier<ExecutorService> compactExecutorsupplier;
+
+    public UnawareBucketCompactor(
+            FileStoreTable table,
+            String commitUser,
+            Supplier<ExecutorService> lazyCompactExecutor) {
+        this.table = table;
+        this.commitUser = commitUser;
+        this.write = (AppendOnlyFileStoreWrite) table.store().newWrite(commitUser);
+        this.result = new LinkedList<>();
+        this.compactExecutorsupplier = lazyCompactExecutor;
+    }
+
+    public void processElement(AppendOnlyCompactionTask task) throws Exception {
+        result.add(compactExecutorsupplier.get().submit(() -> task.doCompact(write)));
+    }
+
+    public void close() throws Exception {
+        shutdown();
+    }
+
+    @VisibleForTesting
+    void shutdown() throws Exception {
+
+        List<CommitMessage> messages = new ArrayList<>();
+        for (Future<CommitMessage> resultFuture : result) {
+            if (!resultFuture.isDone()) {
+                // the later tasks should be stopped running
+                break;
+            }
+            try {
+                messages.add(resultFuture.get());
+            } catch (Exception exception) {
+                // exception should already be handled
+            }
+        }
+        if (messages.isEmpty()) {
+            return;
+        }
+
+        try (TableCommitImpl tableCommit = table.newCommit(commitUser)) {
+            tableCommit.abort(messages);
+        }
+    }
+
+    public List<Committable> prepareCommit(boolean waitCompaction, long checkpointId)
+            throws IOException {
+        List<CommitMessage> tempList = new ArrayList<>();
+        try {
+            while (!result.isEmpty()) {
+                Future<CommitMessage> future = result.peek();
+                if (!future.isDone() && !waitCompaction) {
+                    break;
+                }
+                result.poll();
+                tempList.add(future.get());
+            }
+            return tempList.stream()
+                    .map(s -> new Committable(checkpointId, Committable.Kind.FILE, s))
+                    .collect(Collectors.toList());
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Interrupted while waiting tasks done.", e);
+        } catch (Exception e) {
+            throw new RuntimeException("Encountered an error while do compaction", e);
+        }
+    }
+
+    public Iterable<Future<CommitMessage>> result() {
+        return result;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendOnlyMultiTableCompactionWorkerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendOnlyMultiTableCompactionWorkerOperator.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.append.AppendOnlyCompactionTask;
+import org.apache.paimon.append.MultiTableAppendOnlyCompactionTask;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.flink.compact.UnawareBucketCompactor;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.ExecutorThreadFactory;
+
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Operator to execute {@link AppendOnlyCompactionTask} passed for support compacting multi unaware
+ * bucket tables in combined mode.
+ */
+public class AppendOnlyMultiTableCompactionWorkerOperator
+        extends PrepareCommitOperator<MultiTableAppendOnlyCompactionTask, MultiTableCommittable> {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(AppendOnlyMultiTableCompactionWorkerOperator.class);
+
+    private final String commitUser;
+    private final Catalog.Loader catalogLoader;
+
+    // support multi table compaction
+    private transient Map<Identifier, UnawareBucketCompactor> compactionHelperContainer;
+
+    private transient ExecutorService lazyCompactExecutor;
+
+    private transient Catalog catalog;
+
+    public AppendOnlyMultiTableCompactionWorkerOperator(
+            Catalog.Loader catalogLoader, String commitUser, Options options) {
+        super(options);
+        this.commitUser = commitUser;
+        this.catalogLoader = catalogLoader;
+    }
+
+    @Override
+    public void open() throws Exception {
+        LOG.debug("Opened a append-only multi table compaction worker.");
+        compactionHelperContainer = new HashMap<>();
+        catalog = catalogLoader.load();
+    }
+
+    @Override
+    protected List<MultiTableCommittable> prepareCommit(boolean waitCompaction, long checkpointId)
+            throws IOException {
+        List<MultiTableCommittable> result = new ArrayList<>();
+        for (Map.Entry<Identifier, UnawareBucketCompactor> helperEntry :
+                compactionHelperContainer.entrySet()) {
+            Identifier tableId = helperEntry.getKey();
+            UnawareBucketCompactor helper = helperEntry.getValue();
+
+            for (Committable committable : helper.prepareCommit(waitCompaction, checkpointId)) {
+                result.add(
+                        new MultiTableCommittable(
+                                tableId.getDatabaseName(),
+                                tableId.getObjectName(),
+                                committable.checkpointId(),
+                                committable.kind(),
+                                committable.wrappedCommittable()));
+            }
+        }
+
+        return result;
+    }
+
+    @Override
+    public void processElement(StreamRecord<MultiTableAppendOnlyCompactionTask> element)
+            throws Exception {
+        Identifier identifier = element.getValue().tableIdentifier();
+        compactionHelperContainer
+                .computeIfAbsent(identifier, this::unwareBucketCompactionHelper)
+                .processElement(element.getValue());
+    }
+
+    private UnawareBucketCompactor unwareBucketCompactionHelper(Identifier tableId) {
+        try {
+            return new UnawareBucketCompactor(
+                    (FileStoreTable) catalog.getTable(tableId), commitUser, this::workerExecutor);
+        } catch (Catalog.TableNotExistException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ExecutorService workerExecutor() {
+        if (lazyCompactExecutor == null) {
+            lazyCompactExecutor =
+                    Executors.newSingleThreadScheduledExecutor(
+                            new ExecutorThreadFactory(
+                                    Thread.currentThread().getName()
+                                            + "-append-only-compact-worker"));
+        }
+        return lazyCompactExecutor;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (lazyCompactExecutor != null) {
+            // ignore runnable tasks in queue
+            lazyCompactExecutor.shutdownNow();
+            if (!lazyCompactExecutor.awaitTermination(120, TimeUnit.SECONDS)) {
+                LOG.warn(
+                        "Executors shutdown timeout, there may be some files aren't deleted correctly");
+            }
+
+            for (UnawareBucketCompactor helperEntry : compactionHelperContainer.values()) {
+                helperEntry.close();
+            }
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendOnlySingleTableCompactionWorkerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendOnlySingleTableCompactionWorkerOperator.java
@@ -20,12 +20,11 @@ package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.append.AppendOnlyCompactionTask;
+import org.apache.paimon.flink.compact.UnawareBucketCompactor;
 import org.apache.paimon.flink.source.BucketUnawareCompactSource;
-import org.apache.paimon.operation.AppendOnlyFileStoreWrite;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
-import org.apache.paimon.table.sink.TableCommitImpl;
 import org.apache.paimon.utils.ExecutorThreadFactory;
 
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -33,34 +32,30 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Queue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /**
  * Operator to execute {@link AppendOnlyCompactionTask} passed from {@link
- * BucketUnawareCompactSource}.
+ * BucketUnawareCompactSource} for compacting single unaware bucket tables in divided mode.
  */
-public class AppendOnlyTableCompactionWorkerOperator
+public class AppendOnlySingleTableCompactionWorkerOperator
         extends PrepareCommitOperator<AppendOnlyCompactionTask, Committable> {
 
     private static final Logger LOG =
-            LoggerFactory.getLogger(AppendOnlyTableCompactionWorkerOperator.class);
+            LoggerFactory.getLogger(AppendOnlySingleTableCompactionWorkerOperator.class);
 
     private final FileStoreTable table;
     private final String commitUser;
 
-    private transient AppendOnlyFileStoreWrite write;
-    private transient ExecutorService lazyCompactExecutor;
-    private transient Queue<Future<CommitMessage>> result;
+    private transient UnawareBucketCompactor unawareBucketCompactor;
 
-    public AppendOnlyTableCompactionWorkerOperator(FileStoreTable table, String commitUser) {
+    private transient ExecutorService lazyCompactExecutor;
+
+    public AppendOnlySingleTableCompactionWorkerOperator(FileStoreTable table, String commitUser) {
         super(Options.fromMap(table.options()));
         this.table = table;
         this.commitUser = commitUser;
@@ -68,44 +63,25 @@ public class AppendOnlyTableCompactionWorkerOperator
 
     @VisibleForTesting
     Iterable<Future<CommitMessage>> result() {
-        return result;
+        return unawareBucketCompactor.result();
     }
 
     @Override
     public void open() throws Exception {
         LOG.debug("Opened a append-only table compaction worker.");
-        this.write = (AppendOnlyFileStoreWrite) table.store().newWrite(commitUser);
-        this.result = new LinkedList<>();
+        this.unawareBucketCompactor =
+                new UnawareBucketCompactor(table, commitUser, this::workerExecutor);
     }
 
     @Override
     protected List<Committable> prepareCommit(boolean waitCompaction, long checkpointId)
             throws IOException {
-        List<CommitMessage> tempList = new ArrayList<>();
-        try {
-            while (!result.isEmpty()) {
-                Future<CommitMessage> future = result.peek();
-                if (!future.isDone() && !waitCompaction) {
-                    break;
-                }
-
-                result.poll();
-                tempList.add(future.get());
-            }
-            return tempList.stream()
-                    .map(s -> new Committable(checkpointId, Committable.Kind.FILE, s))
-                    .collect(Collectors.toList());
-        } catch (InterruptedException e) {
-            throw new RuntimeException("Interrupted while waiting tasks done.", e);
-        } catch (Exception e) {
-            throw new RuntimeException("Encountered an error while do compaction", e);
-        }
+        return this.unawareBucketCompactor.prepareCommit(waitCompaction, checkpointId);
     }
 
     @Override
     public void processElement(StreamRecord<AppendOnlyCompactionTask> element) throws Exception {
-        AppendOnlyCompactionTask task = element.getValue();
-        result.add(workerExecutor().submit(() -> task.doCompact(write)));
+        this.unawareBucketCompactor.processElement(element.getValue());
     }
 
     private ExecutorService workerExecutor() {
@@ -121,11 +97,6 @@ public class AppendOnlyTableCompactionWorkerOperator
 
     @Override
     public void close() throws Exception {
-        shutdown();
-    }
-
-    @VisibleForTesting
-    void shutdown() throws Exception {
         if (lazyCompactExecutor != null) {
             // ignore runnable tasks in queue
             lazyCompactExecutor.shutdownNow();
@@ -133,25 +104,7 @@ public class AppendOnlyTableCompactionWorkerOperator
                 LOG.warn(
                         "Executors shutdown timeout, there may be some files aren't deleted correctly");
             }
-            List<CommitMessage> messages = new ArrayList<>();
-            for (Future<CommitMessage> resultFuture : result) {
-                if (!resultFuture.isDone()) {
-                    // the later tasks should be stopped running
-                    break;
-                }
-                try {
-                    messages.add(resultFuture.get());
-                } catch (Exception exception) {
-                    // exception should already be handled
-                }
-            }
-            if (messages.isEmpty()) {
-                return;
-            }
-
-            try (TableCommitImpl tableCommit = table.newCommit(commitUser)) {
-                tableCommit.abort(messages);
-            }
+            this.unawareBucketCompactor.close();
         }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTableCompactionTaskTypeInfo.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTableCompactionTaskTypeInfo.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.append.MultiTableAppendOnlyCompactionTask;
+import org.apache.paimon.flink.VersionedSerializerWrapper;
+import org.apache.paimon.table.sink.MultiTableCompactionTaskSerializer;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.io.SimpleVersionedSerializerTypeSerializerProxy;
+
+/** Type information of {@link MultiTableAppendOnlyCompactionTask}. */
+public class MultiTableCompactionTaskTypeInfo
+        extends TypeInformation<MultiTableAppendOnlyCompactionTask> {
+    @Override
+    public boolean isBasicType() {
+        return false;
+    }
+
+    @Override
+    public boolean isTupleType() {
+        return false;
+    }
+
+    @Override
+    public int getArity() {
+        return 1;
+    }
+
+    @Override
+    public int getTotalFields() {
+        return 1;
+    }
+
+    @Override
+    public Class<MultiTableAppendOnlyCompactionTask> getTypeClass() {
+        return MultiTableAppendOnlyCompactionTask.class;
+    }
+
+    @Override
+    public boolean isKeyType() {
+        return false;
+    }
+
+    @Override
+    public TypeSerializer<MultiTableAppendOnlyCompactionTask> createSerializer(
+            ExecutionConfig executionConfig) {
+        return new SimpleVersionedSerializerTypeSerializerProxy<MultiTableAppendOnlyCompactionTask>(
+                () -> new VersionedSerializerWrapper<>(new MultiTableCompactionTaskSerializer())) {
+            @Override
+            public MultiTableAppendOnlyCompactionTask copy(
+                    MultiTableAppendOnlyCompactionTask from) {
+                return from;
+            }
+
+            @Override
+            public MultiTableAppendOnlyCompactionTask copy(
+                    MultiTableAppendOnlyCompactionTask from,
+                    MultiTableAppendOnlyCompactionTask reuse) {
+                return from;
+            }
+        };
+    }
+
+    @Override
+    public String toString() {
+        return "MultiTableAppendOnlyCompactionTask";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof MultiTableAppendOnlyCompactionTask;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    @Override
+    public boolean canEqual(Object o) {
+        return o instanceof MultiTableAppendOnlyCompactionTask;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketCompactionSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketCompactionSink.java
@@ -44,7 +44,7 @@ public class UnawareBucketCompactionSink extends FlinkSink<AppendOnlyCompactionT
     @Override
     protected OneInputStreamOperator<AppendOnlyCompactionTask, Committable> createWriteOperator(
             StoreSinkWrite.Provider writeProvider, String commitUser) {
-        return new AppendOnlyTableCompactionWorkerOperator(table, commitUser);
+        return new AppendOnlySingleTableCompactionWorkerOperator(table, commitUser);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedAwareBatchSourceFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedAwareBatchSourceFunction.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.operator;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.flink.compact.MultiAwareBucketTableScan;
+import org.apache.paimon.flink.compact.MultiTableScanBase;
+import org.apache.paimon.flink.utils.JavaTypeInfo;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.Split;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.table.data.RowData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.regex.Pattern;
+
+import static org.apache.paimon.flink.compact.MultiTableScanBase.ScanResult.FINISHED;
+import static org.apache.paimon.flink.compact.MultiTableScanBase.ScanResult.IS_EMPTY;
+
+/** It is responsible for monitoring compactor source of aware bucket table in batch mode. */
+public class CombinedAwareBatchSourceFunction
+        extends CombinedCompactorSourceFunction<Tuple2<Split, String>> {
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(CombinedAwareBatchSourceFunction.class);
+
+    private MultiTableScanBase<Tuple2<Split, String>> tableScanLogic;
+
+    public CombinedAwareBatchSourceFunction(
+            Catalog.Loader catalogLoader,
+            Pattern includingPattern,
+            Pattern excludingPattern,
+            Pattern databasePattern) {
+        super(catalogLoader, includingPattern, excludingPattern, databasePattern, false);
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        tableScanLogic =
+                new MultiAwareBucketTableScan(
+                        catalogLoader,
+                        includingPattern,
+                        excludingPattern,
+                        databasePattern,
+                        isStreaming,
+                        isRunning);
+    }
+
+    @Override
+    void scanTable() throws Exception {
+        if (isRunning.get()) {
+            MultiTableScanBase.ScanResult scanResult = tableScanLogic.scanTable(ctx);
+            if (scanResult == FINISHED) {
+                return;
+            }
+            if (scanResult == IS_EMPTY) {
+                // Currently, in the combined mode, there are two scan tasks for the table of two
+                // different bucket type (multi bucket & unaware bucket) running concurrently.
+                // There will be a situation that there is only one task compaction , therefore this
+                // should not be thrown exception here.
+                LOGGER.info("No file were collected for the table of aware-bucket");
+            }
+        }
+    }
+
+    public static DataStream<RowData> buildSource(
+            StreamExecutionEnvironment env,
+            String name,
+            TypeInformation<RowData> typeInfo,
+            Catalog.Loader catalogLoader,
+            Pattern includingPattern,
+            Pattern excludingPattern,
+            Pattern databasePattern) {
+        CombinedAwareBatchSourceFunction function =
+                new CombinedAwareBatchSourceFunction(
+                        catalogLoader, includingPattern, excludingPattern, databasePattern);
+        StreamSource<Tuple2<Split, String>, ?> sourceOperator = new StreamSource<>(function);
+        TupleTypeInfo<Tuple2<Split, String>> tupleTypeInfo =
+                new TupleTypeInfo<>(
+                        new JavaTypeInfo<>(Split.class), BasicTypeInfo.STRING_TYPE_INFO);
+        return new DataStreamSource<>(
+                        env, tupleTypeInfo, sourceOperator, false, name, Boundedness.BOUNDED)
+                .forceNonParallel()
+                .partitionCustom(
+                        (key, numPartitions) -> key % numPartitions,
+                        split -> ((DataSplit) split.f0).bucket())
+                .transform(name, typeInfo, new MultiTablesReadOperator(catalogLoader, false));
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedAwareStreamingSourceFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedAwareStreamingSourceFunction.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.operator;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.flink.compact.MultiAwareBucketTableScan;
+import org.apache.paimon.flink.compact.MultiTableScanBase;
+import org.apache.paimon.flink.utils.JavaTypeInfo;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.Split;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.table.data.RowData;
+
+import java.util.regex.Pattern;
+
+import static org.apache.paimon.flink.compact.MultiTableScanBase.ScanResult.FINISHED;
+import static org.apache.paimon.flink.compact.MultiTableScanBase.ScanResult.IS_EMPTY;
+
+/** It is responsible for monitoring compactor source of multi bucket table in stream mode. */
+public class CombinedAwareStreamingSourceFunction
+        extends CombinedCompactorSourceFunction<Tuple2<Split, String>> {
+
+    private final long monitorInterval;
+    private transient MultiTableScanBase<Tuple2<Split, String>> tableScanLogic;
+
+    public CombinedAwareStreamingSourceFunction(
+            Catalog.Loader catalogLoader,
+            Pattern includingPattern,
+            Pattern excludingPattern,
+            Pattern databasePattern,
+            long monitorInterval) {
+        super(catalogLoader, includingPattern, excludingPattern, databasePattern, true);
+        this.monitorInterval = monitorInterval;
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        tableScanLogic =
+                new MultiAwareBucketTableScan(
+                        catalogLoader,
+                        includingPattern,
+                        excludingPattern,
+                        databasePattern,
+                        isStreaming,
+                        isRunning);
+    }
+
+    @SuppressWarnings("BusyWait")
+    @Override
+    void scanTable() throws Exception {
+        while (isRunning.get()) {
+            MultiTableScanBase.ScanResult scanResult = tableScanLogic.scanTable(ctx);
+            if (scanResult == FINISHED) {
+                return;
+            }
+            if (scanResult == IS_EMPTY) {
+                Thread.sleep(monitorInterval);
+            }
+        }
+    }
+
+    public static DataStream<RowData> buildSource(
+            StreamExecutionEnvironment env,
+            String name,
+            TypeInformation<RowData> typeInfo,
+            Catalog.Loader catalogLoader,
+            Pattern includingPattern,
+            Pattern excludingPattern,
+            Pattern databasePattern,
+            long monitorInterval) {
+
+        CombinedAwareStreamingSourceFunction function =
+                new CombinedAwareStreamingSourceFunction(
+                        catalogLoader,
+                        includingPattern,
+                        excludingPattern,
+                        databasePattern,
+                        monitorInterval);
+        StreamSource<Tuple2<Split, String>, ?> sourceOperator = new StreamSource<>(function);
+        boolean isParallel = false;
+        TupleTypeInfo<Tuple2<Split, String>> tupleTypeInfo =
+                new TupleTypeInfo<>(
+                        new JavaTypeInfo<>(Split.class), BasicTypeInfo.STRING_TYPE_INFO);
+        return new DataStreamSource<>(
+                        env,
+                        tupleTypeInfo,
+                        sourceOperator,
+                        isParallel,
+                        name,
+                        Boundedness.CONTINUOUS_UNBOUNDED)
+                .forceNonParallel()
+                .partitionCustom(
+                        (key, numPartitions) -> key % numPartitions,
+                        split -> ((DataSplit) split.f0).bucket())
+                .transform(name, typeInfo, new MultiTablesReadOperator(catalogLoader, true));
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedCompactorSourceFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedCompactorSourceFunction.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.operator;
+
+import org.apache.paimon.append.AppendOnlyCompactionTask;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.table.source.Split;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+
+/**
+ * This is the single (non-parallel) monitoring task, it is responsible for:
+ *
+ * <ol>
+ *   <li>Monitoring snapshots of the Paimon table.
+ *   <li>Creating the splits {@link Split} or compaction task {@link AppendOnlyCompactionTask}
+ *       corresponding to the incremental files
+ *   <li>Assigning them to downstream tasks for further processing.
+ * </ol>
+ *
+ * <p>The splits to be read are forwarded to the downstream {@link MultiTablesReadOperator} which
+ * can have parallelism greater than one.
+ *
+ * <p>Currently, only dedicated compaction job for multi-tables rely on this monitor. This is the
+ * single (non-parallel) monitoring task, it is responsible for the new Paimon table.
+ */
+public abstract class CombinedCompactorSourceFunction<T> extends RichSourceFunction<T> {
+
+    private static final long serialVersionUID = 2L;
+
+    protected final Catalog.Loader catalogLoader;
+    protected final Pattern includingPattern;
+    protected final Pattern excludingPattern;
+    protected final Pattern databasePattern;
+    protected final boolean isStreaming;
+
+    protected transient AtomicBoolean isRunning;
+    protected transient SourceContext<T> ctx;
+
+    public CombinedCompactorSourceFunction(
+            Catalog.Loader catalogLoader,
+            Pattern includingPattern,
+            Pattern excludingPattern,
+            Pattern databasePattern,
+            boolean isStreaming) {
+        this.catalogLoader = catalogLoader;
+        this.includingPattern = includingPattern;
+        this.excludingPattern = excludingPattern;
+        this.databasePattern = databasePattern;
+        this.isStreaming = isStreaming;
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        isRunning = new AtomicBoolean(true);
+    }
+
+    @Override
+    public void run(SourceContext<T> sourceContext) throws Exception {
+        this.ctx = sourceContext;
+        scanTable();
+    }
+
+    @Override
+    public void cancel() {
+        // this is to cover the case where cancel() is called before the run()
+        if (ctx != null) {
+            synchronized (ctx.getCheckpointLock()) {
+                isRunning.set(false);
+            }
+        } else {
+            isRunning.set(false);
+        }
+    }
+
+    abstract void scanTable() throws Exception;
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedUnawareBatchSourceFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedUnawareBatchSourceFunction.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.operator;
+
+import org.apache.paimon.append.MultiTableAppendOnlyCompactionTask;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.flink.compact.MultiTableScanBase;
+import org.apache.paimon.flink.compact.MultiUnawareBucketTableScan;
+import org.apache.paimon.flink.sink.MultiTableCompactionTaskTypeInfo;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.streaming.api.transformations.PartitionTransformation;
+import org.apache.flink.streaming.runtime.partitioner.RebalancePartitioner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.regex.Pattern;
+
+import static org.apache.paimon.flink.compact.MultiTableScanBase.ScanResult.FINISHED;
+import static org.apache.paimon.flink.compact.MultiTableScanBase.ScanResult.IS_EMPTY;
+
+/**
+ * It is responsible for the batch compactor source of the table with unaware bucket in combined
+ * mode.
+ */
+public class CombinedUnawareBatchSourceFunction
+        extends CombinedCompactorSourceFunction<MultiTableAppendOnlyCompactionTask> {
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(CombinedUnawareBatchSourceFunction.class);
+    private transient MultiTableScanBase<MultiTableAppendOnlyCompactionTask> tableScanLogic;
+
+    public CombinedUnawareBatchSourceFunction(
+            Catalog.Loader catalogLoader,
+            Pattern includingPattern,
+            Pattern excludingPattern,
+            Pattern databasePattern) {
+        super(catalogLoader, includingPattern, excludingPattern, databasePattern, false);
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        tableScanLogic =
+                new MultiUnawareBucketTableScan(
+                        catalogLoader,
+                        includingPattern,
+                        excludingPattern,
+                        databasePattern,
+                        isStreaming,
+                        isRunning);
+    }
+
+    @Override
+    void scanTable() throws Exception {
+        if (isRunning.get()) {
+            MultiTableScanBase.ScanResult scanResult = tableScanLogic.scanTable(ctx);
+            if (scanResult == FINISHED) {
+                return;
+            }
+            if (scanResult == IS_EMPTY) {
+                // Currently, in the combined mode, there are two scan tasks for the table of two
+                // different bucket type (multi bucket & unaware bucket) running concurrently.
+                // There will be a situation that there is only one task compaction , therefore this
+                // should not be thrown exception here.
+                LOGGER.info("No file were collected for the table of unaware-bucket");
+            }
+        }
+    }
+
+    public static DataStream<MultiTableAppendOnlyCompactionTask> buildSource(
+            StreamExecutionEnvironment env,
+            String name,
+            Catalog.Loader catalogLoader,
+            Pattern includingPattern,
+            Pattern excludingPattern,
+            Pattern databasePattern) {
+        CombinedUnawareBatchSourceFunction function =
+                new CombinedUnawareBatchSourceFunction(
+                        catalogLoader, includingPattern, excludingPattern, databasePattern);
+        StreamSource<MultiTableAppendOnlyCompactionTask, CombinedUnawareBatchSourceFunction>
+                sourceOperator = new StreamSource<>(function);
+        MultiTableCompactionTaskTypeInfo compactionTaskTypeInfo =
+                new MultiTableCompactionTaskTypeInfo();
+
+        SingleOutputStreamOperator<MultiTableAppendOnlyCompactionTask> source =
+                new DataStreamSource<>(
+                                env,
+                                compactionTaskTypeInfo,
+                                sourceOperator,
+                                false,
+                                name,
+                                Boundedness.BOUNDED)
+                        .forceNonParallel();
+
+        PartitionTransformation<MultiTableAppendOnlyCompactionTask> transformation =
+                new PartitionTransformation<>(
+                        source.getTransformation(), new RebalancePartitioner<>());
+
+        return new DataStream<>(env, transformation);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedUnawareStreamingSourceFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedUnawareStreamingSourceFunction.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.operator;
+
+import org.apache.paimon.append.MultiTableAppendOnlyCompactionTask;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.flink.compact.MultiTableScanBase;
+import org.apache.paimon.flink.compact.MultiUnawareBucketTableScan;
+import org.apache.paimon.flink.sink.MultiTableCompactionTaskTypeInfo;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.StreamSource;
+
+import java.util.regex.Pattern;
+
+import static org.apache.paimon.flink.compact.MultiTableScanBase.ScanResult.FINISHED;
+import static org.apache.paimon.flink.compact.MultiTableScanBase.ScanResult.IS_EMPTY;
+
+/**
+ * It is responsible for monitoring compactor source in stream mode for the table of unaware bucket.
+ */
+public class CombinedUnawareStreamingSourceFunction
+        extends CombinedCompactorSourceFunction<MultiTableAppendOnlyCompactionTask> {
+    private final long monitorInterval;
+    private MultiTableScanBase<MultiTableAppendOnlyCompactionTask> tableScanLogic;
+
+    public CombinedUnawareStreamingSourceFunction(
+            Catalog.Loader catalogLoader,
+            Pattern includingPattern,
+            Pattern excludingPattern,
+            Pattern databasePattern,
+            long monitorInterval) {
+        super(catalogLoader, includingPattern, excludingPattern, databasePattern, true);
+        this.monitorInterval = monitorInterval;
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        tableScanLogic =
+                new MultiUnawareBucketTableScan(
+                        catalogLoader,
+                        includingPattern,
+                        excludingPattern,
+                        databasePattern,
+                        isStreaming,
+                        isRunning);
+    }
+
+    @SuppressWarnings("BusyWait")
+    @Override
+    void scanTable() throws Exception {
+        while (isRunning.get()) {
+            MultiTableScanBase.ScanResult scanResult = tableScanLogic.scanTable(ctx);
+            if (scanResult == FINISHED) {
+                return;
+            }
+            if (scanResult == IS_EMPTY) {
+                Thread.sleep(monitorInterval);
+            }
+        }
+    }
+
+    public static DataStream<MultiTableAppendOnlyCompactionTask> buildSource(
+            StreamExecutionEnvironment env,
+            String name,
+            Catalog.Loader catalogLoader,
+            Pattern includingPattern,
+            Pattern excludingPattern,
+            Pattern databasePattern,
+            long monitorInterval) {
+
+        CombinedUnawareStreamingSourceFunction function =
+                new CombinedUnawareStreamingSourceFunction(
+                        catalogLoader,
+                        includingPattern,
+                        excludingPattern,
+                        databasePattern,
+                        monitorInterval);
+        StreamSource<MultiTableAppendOnlyCompactionTask, CombinedUnawareStreamingSourceFunction>
+                sourceOperator = new StreamSource<>(function);
+        boolean isParallel = false;
+        MultiTableCompactionTaskTypeInfo compactionTaskTypeInfo =
+                new MultiTableCompactionTaskTypeInfo();
+        return new DataStreamSource<>(
+                        env,
+                        compactionTaskTypeInfo,
+                        sourceOperator,
+                        isParallel,
+                        name,
+                        Boundedness.CONTINUOUS_UNBOUNDED)
+                .forceNonParallel()
+                .rebalance();
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlyMultiTableCompactionWorkerOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlyMultiTableCompactionWorkerOperatorTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.paimon.append.MultiTableAppendOnlyCompactionTask;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.sink.CommitMessageImpl;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.flink.sink.AppendOnlySingleTableCompactionWorkerOperatorTest.packTask;
+
+/**
+ * test for {@link AppendOnlyMultiTableCompactionWorkerOperator}.
+ */
+public class AppendOnlyMultiTableCompactionWorkerOperatorTest extends TableTestBase {
+    private final String[] tables = {
+            "a", "b"
+    };
+    @Test
+    public void testAsyncCompactionWorks() throws Exception {
+
+        AppendOnlyMultiTableCompactionWorkerOperator workerOperator =
+                new AppendOnlyMultiTableCompactionWorkerOperator(()->catalog, "user",new Options());
+
+        List<StreamRecord<MultiTableAppendOnlyCompactionTask>> records =new ArrayList<>();
+        //create table and write
+        for (String table : tables) {
+            Identifier identifier = identifier(table);
+            createTable(identifier);
+
+            // write 200 files
+            List<CommitMessage> commitMessages = writeData(getTable(identifier), 200, 20);
+
+            packTask(commitMessages, 5).stream().map(
+                    task->new StreamRecord<>(new MultiTableAppendOnlyCompactionTask(task.partition(),task.compactBefore(),identifier))
+            ).forEach(records::add);
+        }
+
+        Assertions.assertThat(records.size()).isEqualTo(8);
+        workerOperator.open();
+
+        for (StreamRecord<MultiTableAppendOnlyCompactionTask> record : records) {
+            workerOperator.processElement(record);
+        }
+
+        List<MultiTableCommittable> committables = new ArrayList<>();
+        Long timeStart = System.currentTimeMillis();
+        long timeout = 60_000L;
+
+        Assertions.assertThatCode(
+                        () -> {
+                            while (committables.size() != 8) {
+                                committables.addAll(
+                                        workerOperator.prepareCommit(false, Long.MAX_VALUE));
+
+                                Long now = System.currentTimeMillis();
+                                if (now - timeStart > timeout && committables.size() != 8) {
+                                    throw new RuntimeException(
+                                            "Timeout waiting for compaction, maybe some error happens in "
+                                                    + AppendOnlySingleTableCompactionWorkerOperator
+                                                    .class
+                                                    .getName());
+                                }
+                                Thread.sleep(1_000L);
+                            }
+                        })
+                .doesNotThrowAnyException();
+        committables.forEach(
+                a ->
+                        Assertions.assertThat(
+                                        ((CommitMessageImpl) a.wrappedCommittable())
+                                                .compactIncrement()
+                                                .compactAfter()
+                                                .size()
+                                                == 1)
+                                .isTrue());
+        Set<String> table = committables.stream().map(MultiTableCommittable::getTable).collect(Collectors.toSet());
+        Assertions.assertThat(table).hasSameElementsAs(Arrays.asList(tables));
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlySingleTableCompactionWorkerOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlySingleTableCompactionWorkerOperatorTest.java
@@ -191,7 +191,7 @@ public class AppendOnlySingleTableCompactionWorkerOperatorTest extends TableTest
         return GenericRow.of(RANDOM.nextInt(), RANDOM.nextLong(), randomString());
     }
 
-    private List<AppendOnlyCompactionTask> packTask(List<CommitMessage> messages, int fileSize) {
+    public static List<AppendOnlyCompactionTask> packTask(List<CommitMessage> messages, int fileSize) {
         List<AppendOnlyCompactionTask> result = new ArrayList<>();
         List<DataFileMeta> metas =
                 messages.stream()

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlySingleTableCompactionWorkerOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlySingleTableCompactionWorkerOperatorTest.java
@@ -191,7 +191,8 @@ public class AppendOnlySingleTableCompactionWorkerOperatorTest extends TableTest
         return GenericRow.of(RANDOM.nextInt(), RANDOM.nextLong(), randomString());
     }
 
-    public static List<AppendOnlyCompactionTask> packTask(List<CommitMessage> messages, int fileSize) {
+    public static List<AppendOnlyCompactionTask> packTask(
+            List<CommitMessage> messages, int fileSize) {
         List<AppendOnlyCompactionTask> result = new ArrayList<>();
         List<DataFileMeta> metas =
                 messages.stream()

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlySingleTableCompactionWorkerOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlySingleTableCompactionWorkerOperatorTest.java
@@ -42,14 +42,14 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-/** Tests for {@link AppendOnlyTableCompactionWorkerOperator}. */
-public class AppendOnlyTableCompactionWorkerOperatorTest extends TableTestBase {
+/** Tests for {@link AppendOnlySingleTableCompactionWorkerOperator}. */
+public class AppendOnlySingleTableCompactionWorkerOperatorTest extends TableTestBase {
 
     @Test
     public void testAsyncCompactionWorks() throws Exception {
         createTableDefault();
-        AppendOnlyTableCompactionWorkerOperator workerOperator =
-                new AppendOnlyTableCompactionWorkerOperator(getTableDefault(), "user");
+        AppendOnlySingleTableCompactionWorkerOperator workerOperator =
+                new AppendOnlySingleTableCompactionWorkerOperator(getTableDefault(), "user");
 
         // write 200 files
         List<CommitMessage> commitMessages = writeDataDefault(200, 20);
@@ -79,7 +79,8 @@ public class AppendOnlyTableCompactionWorkerOperatorTest extends TableTestBase {
                                 if (now - timeStart > timeout && committables.size() != 4) {
                                     throw new RuntimeException(
                                             "Timeout waiting for compaction, maybe some error happens in "
-                                                    + AppendOnlyTableCompactionWorkerOperator.class
+                                                    + AppendOnlySingleTableCompactionWorkerOperator
+                                                            .class
                                                             .getName());
                                 }
                                 Thread.sleep(1_000L);
@@ -100,8 +101,8 @@ public class AppendOnlyTableCompactionWorkerOperatorTest extends TableTestBase {
     @Test
     public void testAsyncCompactionFileDeletedWhenShutdown() throws Exception {
         createTableDefault();
-        AppendOnlyTableCompactionWorkerOperator workerOperator =
-                new AppendOnlyTableCompactionWorkerOperator(getTableDefault(), "user");
+        AppendOnlySingleTableCompactionWorkerOperator workerOperator =
+                new AppendOnlySingleTableCompactionWorkerOperator(getTableDefault(), "user");
 
         // write 200 files
         List<CommitMessage> commitMessages = writeDataDefault(200, 40);
@@ -145,7 +146,7 @@ public class AppendOnlyTableCompactionWorkerOperatorTest extends TableTestBase {
         }
 
         // shut down worker operator
-        workerOperator.shutdown();
+        workerOperator.close();
 
         // wait the last runnable in thread pool to stop
         Thread.sleep(2_000);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
1. reusing the logic of scan table.
2. add scan unaware bucket table logic.
<!-- Linking this pull request to the issue -->
related issue: #2670

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
