### PR TITLE
[flink] Add merge-engine check when executing row level batch update and delete

### DIFF
--- a/docs/content/primary-key-table/merge-engine.md
+++ b/docs/content/primary-key-table/merge-engine.md
@@ -34,6 +34,12 @@ result in strange behavior. When the input is out of order, we recommend that yo
 [Sequence Field]({{< ref "primary-key-table/sequence-rowkind#sequence-field" >}}) to correct disorder.
 {{< /hint >}}
 
+{{< hint info >}}
+Some compute engines support row level update and delete in batch mode but not all merge engines support them.
+- Support batch update merge engines: `deduplicate` and `first-row`.
+- Support batch delete merge engines: `deduplicate`.
+{{< /hint >}}
+
 ## Deduplicate
 
 `deduplicate` merge engine is the default merge engine. Paimon will only keep the latest record and throw away other records with the same primary keys.

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1692,20 +1692,28 @@ public class CoreOptions implements Serializable {
 
     /** Specifies the merge engine for table with primary key. */
     public enum MergeEngine implements DescribedEnum {
-        DEDUPLICATE("deduplicate", "De-duplicate and keep the last row."),
+        DEDUPLICATE("deduplicate", "De-duplicate and keep the last row.", true, true),
 
-        PARTIAL_UPDATE("partial-update", "Partial update non-null fields."),
+        PARTIAL_UPDATE("partial-update", "Partial update non-null fields.", false, false),
 
-        AGGREGATE("aggregation", "Aggregate fields with same primary key."),
+        AGGREGATE("aggregation", "Aggregate fields with same primary key.", false, false),
 
-        FIRST_ROW("first-row", "De-duplicate and keep the first row.");
+        FIRST_ROW("first-row", "De-duplicate and keep the first row.", true, false);
 
         private final String value;
         private final String description;
+        private final boolean supportBatchUpdate;
+        private final boolean supportBatchDelete;
 
-        MergeEngine(String value, String description) {
+        MergeEngine(
+                String value,
+                String description,
+                boolean supportBatchUpdate,
+                boolean supportBatchDelete) {
             this.value = value;
             this.description = description;
+            this.supportBatchUpdate = supportBatchUpdate;
+            this.supportBatchDelete = supportBatchDelete;
         }
 
         @Override
@@ -1716,6 +1724,26 @@ public class CoreOptions implements Serializable {
         @Override
         public InlineElement getDescription() {
             return text(description);
+        }
+
+        public boolean supportBatchUpdate() {
+            return supportBatchUpdate;
+        }
+
+        public boolean supportBatchDelete() {
+            return supportBatchDelete;
+        }
+
+        public static List<MergeEngine> supportBatchUpdateEngines() {
+            return Arrays.stream(MergeEngine.values())
+                    .filter(MergeEngine::supportBatchUpdate)
+                    .collect(Collectors.toList());
+        }
+
+        public static List<MergeEngine> supportBatchDeleteEngines() {
+            return Arrays.stream(MergeEngine.values())
+                    .filter(MergeEngine::supportBatchDelete)
+                    .collect(Collectors.toList());
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MergeIntoAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MergeIntoAction.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.action;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.flink.LogicalTypeConversion;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
@@ -96,11 +97,11 @@ public class MergeIntoAction extends TableActionBase {
     private String mergeCondition;
 
     // actions to be taken
-    boolean matchedUpsert;
-    boolean notMatchedUpsert;
-    boolean matchedDelete;
-    boolean notMatchedDelete;
-    boolean insert;
+    private boolean matchedUpsert;
+    private boolean notMatchedUpsert;
+    private boolean matchedDelete;
+    private boolean notMatchedDelete;
+    private boolean insert;
 
     // upsert
     @Nullable String matchedUpsertCondition;
@@ -213,6 +214,49 @@ public class MergeIntoAction extends TableActionBase {
         this.notMatchedInsertCondition = notMatchedInsertCondition;
         this.notMatchedInsertValues = notMatchedInsertValues;
         return this;
+    }
+
+    public void validate() {
+        if (!matchedUpsert && !notMatchedUpsert && !matchedDelete && !notMatchedDelete && !insert) {
+            throw new IllegalArgumentException(
+                    "Must specify at least one merge action. Run 'merge_into --help' for help.");
+        }
+
+        CoreOptions.MergeEngine mergeEngine = CoreOptions.fromMap(table.options()).mergeEngine();
+        if ((matchedUpsert || notMatchedUpsert) && !mergeEngine.supportBatchUpdate()) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "merge-into is executed in batch mode, and you have set matched_upsert or not_matched_by_source_upsert."
+                                    + " But merge engine %s can not support batch update. Support batch update merge engines are: %s.",
+                            mergeEngine, CoreOptions.MergeEngine.supportBatchUpdateEngines()));
+        }
+
+        if ((matchedDelete || notMatchedDelete) && !mergeEngine.supportBatchDelete()) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "merge-into is executed in batch mode, and you have set matched_delete or not_matched_by_source_delete."
+                                    + " But merge engine %s can not support batch delete. Support batch delete merge engines are: %s.",
+                            mergeEngine, CoreOptions.MergeEngine.supportBatchDeleteEngines()));
+        }
+
+        if ((matchedUpsert && matchedDelete)
+                && (matchedUpsertCondition == null || matchedDeleteCondition == null)) {
+            throw new IllegalArgumentException(
+                    "If both matched-upsert and matched-delete actions are present, their conditions must both be present too.");
+        }
+
+        if ((notMatchedUpsert && notMatchedDelete)
+                && (notMatchedBySourceUpsertCondition == null
+                        || notMatchedBySourceDeleteCondition == null)) {
+            throw new IllegalArgumentException(
+                    "If both not-matched-by-source-upsert and not-matched-by--source-delete actions are present, "
+                            + "their conditions must both be present too.\n");
+        }
+
+        if (notMatchedBySourceUpsertSet != null && notMatchedBySourceUpsertSet.equals("*")) {
+            throw new IllegalArgumentException(
+                    "The '*' cannot be used in not_matched_by_source_upsert_set");
+        }
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MergeIntoActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MergeIntoActionFactory.java
@@ -112,7 +112,7 @@ public class MergeIntoActionFactory implements ActionFactory {
                     params.get(NOT_MATCHED_INSERT_VALUES));
         }
 
-        validate(action);
+        action.validate();
 
         return Optional.of(action);
     }
@@ -201,37 +201,5 @@ public class MergeIntoActionFactory implements ActionFactory {
                         + "             --matched_upsert_set \"v = S.v\"");
         System.out.println(
                 "  It will find matched rows of target table that meet condition (T.k = S.k), then update T.v with S.v where (T.v <> S.v).");
-    }
-
-    public static void validate(MergeIntoAction action) {
-        if (!action.matchedUpsert
-                && !action.notMatchedUpsert
-                && !action.matchedDelete
-                && !action.notMatchedDelete
-                && !action.insert) {
-            throw new IllegalArgumentException(
-                    "Must specify at least one merge action. Run 'merge_into --help' for help.");
-        }
-
-        if ((action.matchedUpsert && action.matchedDelete)
-                && (action.matchedUpsertCondition == null
-                        || action.matchedDeleteCondition == null)) {
-            throw new IllegalArgumentException(
-                    "If both matched-upsert and matched-delete actions are present, their conditions must both be present too.");
-        }
-
-        if ((action.notMatchedUpsert && action.notMatchedDelete)
-                && (action.notMatchedBySourceUpsertCondition == null
-                        || action.notMatchedBySourceDeleteCondition == null)) {
-            throw new IllegalArgumentException(
-                    "If both not-matched-by-source-upsert and not-matched-by--source-delete actions are present, "
-                            + "their conditions must both be present too.\n");
-        }
-
-        if (action.notMatchedBySourceUpsertSet != null
-                && action.notMatchedBySourceUpsertSet.equals("*")) {
-            throw new IllegalArgumentException(
-                    "The '*' cannot be used in not_matched_by_source_upsert_set");
-        }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MergeIntoProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MergeIntoProcedure.java
@@ -21,7 +21,6 @@ package org.apache.paimon.flink.procedure;
 import org.apache.paimon.catalog.AbstractCatalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.action.MergeIntoAction;
-import org.apache.paimon.flink.action.MergeIntoActionFactory;
 
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -222,7 +221,7 @@ public class MergeIntoProcedure extends ProcedureBase {
         }
 
         action.withStreamExecutionEnvironment(procedureContext.getExecutionEnvironment());
-        MergeIntoActionFactory.validate(action);
+        action.validate();
 
         DataStream<RowData> dataStream = action.buildDataStream();
         TableResult tableResult = action.batchSink(dataStream);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MergeIntoActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MergeIntoActionITCase.java
@@ -132,59 +132,6 @@ public class MergeIntoActionITCase extends ActionITCaseBase {
                         changelogRow("+I", 12, "v_12", "insert", "02-29")));
     }
 
-    @Test
-    public void testWorkWithPartialUpdate() throws Exception {
-        // re-create target table with given producer
-        sEnv.executeSql("DROP TABLE T");
-        prepareTargetTable(CoreOptions.ChangelogProducer.LOOKUP);
-
-        MergeIntoActionBuilder action = new MergeIntoActionBuilder(warehouse, database, "T");
-        action.withSourceTable("S")
-                .withMergeCondition("T.k = S.k AND T.dt = S.dt")
-                .withMatchedUpsert(
-                        "T.v <> S.v AND S.v IS NOT NULL", "v = S.v, last_action = 'matched_upsert'")
-                .withMatchedDelete("S.v IS NULL")
-                .withNotMatchedInsert(null, "S.k, S.v, 'insert', S.dt")
-                .withNotMatchedBySourceUpsert(
-                        "dt < '02-28'", "v = v || '_nmu', last_action = 'not_matched_upsert'")
-                .withNotMatchedBySourceDelete("dt >= '02-28'");
-
-        // delete records are filtered
-        validateActionRunResult(
-                action.build(),
-                Arrays.asList(
-                        changelogRow("+U", 2, "v_2_nmu", "not_matched_upsert", "02-27"),
-                        changelogRow("+U", 3, "v_3_nmu", "not_matched_upsert", "02-27"),
-                        changelogRow("+U", 7, "Seven", "matched_upsert", "02-28"),
-                        changelogRow("+I", 8, "v_8", "insert", "02-29"),
-                        changelogRow("+I", 11, "v_11", "insert", "02-29"),
-                        changelogRow("+I", 12, "v_12", "insert", "02-29")),
-                Arrays.asList(
-                        changelogRow("+I", 1, "v_1", "creation", "02-27"),
-                        changelogRow("+I", 2, "v_2_nmu", "not_matched_upsert", "02-27"),
-                        changelogRow("+I", 3, "v_3_nmu", "not_matched_upsert", "02-27"),
-                        changelogRow("+I", 4, "v_4", "creation", "02-27"),
-                        changelogRow("+I", 5, "v_5", "creation", "02-28"),
-                        changelogRow("+I", 6, "v_6", "creation", "02-28"),
-                        changelogRow("+I", 7, "Seven", "matched_upsert", "02-28"),
-                        changelogRow("+I", 8, "v_8", "creation", "02-28"),
-                        changelogRow("+I", 8, "v_8", "insert", "02-29"),
-                        changelogRow("+I", 9, "v_9", "creation", "02-28"),
-                        changelogRow("+I", 10, "v_10", "creation", "02-28"),
-                        changelogRow("+I", 11, "v_11", "insert", "02-29"),
-                        changelogRow("+I", 12, "v_12", "insert", "02-29")));
-
-        // test partial update still works after action
-        insertInto(
-                "T",
-                "(12, CAST (NULL AS STRING), '$', '02-29')",
-                "(12, 'Test', CAST (NULL AS STRING), '02-29')");
-
-        testBatchRead(
-                "SELECT * FROM T WHERE k = 12",
-                Collections.singletonList(changelogRow("+I", 12, "Test", "$", "02-29")));
-    }
-
     @ParameterizedTest(name = "in-default = {0}")
     @ValueSource(booleans = {true, false})
     public void testTargetAlias(boolean inDefault) throws Exception {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

1. partial-update and aggregate should not accept batch update because there is no UB and the aggregate result will be wrong.

2. It's not very clear about how to handle row level batch delete with partial update currently. Doris just delete the record. But it's not easy to delete the record because #3128   and  #3139 .

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->
Support batch update merge engines: `deduplicate` and `first-row`.
Support batch delete merge engines: `deduplicate`.

### Documentation

<!-- Does this change introduce a new feature -->
