### PR TITLE
[core] fix when cleaning up a manifest, the name of the manifest is null

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -197,7 +197,7 @@ public abstract class FileDeletionBase {
             Snapshot snapshot, Set<String> skippingSet, boolean deleteChangelog) {
         cleanUnusedManifestList(snapshot.baseManifestList(), skippingSet);
         cleanUnusedManifestList(snapshot.deltaManifestList(), skippingSet);
-        if (deleteChangelog) {
+        if (deleteChangelog && snapshot.changelogManifestList() != null) {
             cleanUnusedManifestList(snapshot.changelogManifestList(), skippingSet);
         }
         cleanUnusedIndexManifests(snapshot, skippingSet);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3195

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
