### PR TITLE
[flink] support to infer parallelism for system table

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/AbstractFlinkTableFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/AbstractFlinkTableFactory.java
@@ -100,7 +100,10 @@ public abstract class AbstractFlinkTableFactory
                         == RuntimeExecutionMode.STREAMING;
         if (origin instanceof SystemCatalogTable) {
             return new PushedTableSource(
-                    new SystemTableSource(((SystemCatalogTable) origin).table(), isStreamingMode));
+                    new SystemTableSource(
+                            ((SystemCatalogTable) origin).table(),
+                            isStreamingMode,
+                            context.getObjectIdentifier()));
         } else {
             Table table = buildPaimonTable(context);
             if (table instanceof FileStoreTable) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/DataTableSourceTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/DataTableSourceTest.java
@@ -31,10 +31,15 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.sink.InnerTableWrite;
 import org.apache.paimon.table.sink.TableCommitImpl;
+import org.apache.paimon.table.system.ReadOptimizedTable;
 import org.apache.paimon.types.DataTypes;
 
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.catalog.ObjectIdentifier;
@@ -47,6 +52,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.paimon.options.OptionsUtils.PAIMON_PREFIX;
@@ -55,35 +61,12 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 /** Tests for {@link DataTableSource}. */
 class DataTableSourceTest {
 
-    @Test
-    void testInferScanParallelism(@TempDir java.nio.file.Path path) throws Exception {
-        FileIO fileIO = LocalFileIO.create();
-        Path tablePath = new Path(path.toString());
-        SchemaManager schemaManager = new SchemaManager(fileIO, tablePath);
-        TableSchema tableSchema =
-                schemaManager.createTable(
-                        Schema.newBuilder()
-                                .column("a", DataTypes.INT())
-                                .column("b", DataTypes.BIGINT())
-                                .option("bucket", "1")
-                                .build());
-        FileStoreTable fileStoreTable =
-                FileStoreTableFactory.create(fileIO, tablePath, tableSchema);
-        InnerTableWrite writer = fileStoreTable.newWrite("test");
-        TableCommitImpl commit = fileStoreTable.newCommit("test");
-        writer.write(GenericRow.of(1, 2L));
-        writer.write(GenericRow.of(3, 4L));
-        writer.write(GenericRow.of(5, 6L));
-        writer.write(GenericRow.of(7, 8L));
-        writer.write(GenericRow.of(9, 10L));
-        writer.write(GenericRow.of(11, 12L));
-        writer.write(GenericRow.of(13, 14L));
-        writer.write(GenericRow.of(15, 16L));
-        writer.write(GenericRow.of(17, 18L));
-        commit.commit(writer.prepareCommit());
+    @TempDir java.nio.file.Path path;
 
-        commit.close();
-        writer.close();
+    @Test
+    void testInferScanParallelism() throws Exception {
+        FileStoreTable fileStoreTable = createTable(ImmutableMap.of("bucket", "1"));
+        writeData(fileStoreTable);
 
         DataTableSource tableSource =
                 new DataTableSource(
@@ -92,28 +75,7 @@ class DataTableSourceTest {
                         true,
                         null,
                         null);
-        PaimonDataStreamScanProvider runtimeProvider =
-                (PaimonDataStreamScanProvider)
-                        tableSource.getScanRuntimeProvider(
-                                new ScanTableSource.ScanContext() {
-                                    @Override
-                                    public <T> TypeInformation<T> createTypeInformation(
-                                            DataType dataType) {
-                                        throw new UnsupportedOperationException();
-                                    }
-
-                                    @Override
-                                    public <T> TypeInformation<T> createTypeInformation(
-                                            LogicalType logicalType) {
-                                        throw new UnsupportedOperationException();
-                                    }
-
-                                    @Override
-                                    public DynamicTableSource.DataStructureConverter
-                                            createDataStructureConverter(DataType dataType) {
-                                        throw new UnsupportedOperationException();
-                                    }
-                                });
+        PaimonDataStreamScanProvider runtimeProvider = runtimeProvider(tableSource);
         StreamExecutionEnvironment sEnv1 = StreamExecutionEnvironment.createLocalEnvironment();
         DataStream<RowData> sourceStream1 =
                 runtimeProvider.produceDataStream(s -> Optional.empty(), sEnv1);
@@ -133,5 +95,90 @@ class DataTableSourceTest {
         // The default parallelism is not 1
         assertThat(sourceStream2.getParallelism()).isNotEqualTo(1);
         assertThat(sourceStream2.getParallelism()).isEqualTo(sEnv2.getParallelism());
+    }
+
+    @Test
+    public void testInferStreamParallelism() throws Exception {
+        FileStoreTable fileStoreTable = createTable(ImmutableMap.of("bucket", "-1"));
+
+        DataTableSource tableSource =
+                new DataTableSource(
+                        ObjectIdentifier.of("cat", "db", "table"),
+                        fileStoreTable,
+                        true,
+                        null,
+                        null);
+        PaimonDataStreamScanProvider runtimeProvider = runtimeProvider(tableSource);
+
+        StreamExecutionEnvironment sEnv1 = StreamExecutionEnvironment.createLocalEnvironment();
+        DataStream<RowData> sourceStream1 =
+                runtimeProvider.produceDataStream(s -> Optional.empty(), sEnv1);
+        // parallelism = 1 for table with -1 bucket.
+        assertThat(sourceStream1.getParallelism()).isEqualTo(1);
+    }
+
+    @Test
+    public void testSystemTableParallelism() throws Exception {
+        FileStoreTable fileStoreTable =
+                createTable(ImmutableMap.of("bucket", "1", "scan.parallelism", "3"));
+
+        ReadOptimizedTable ro = new ReadOptimizedTable(fileStoreTable);
+
+        SystemTableSource tableSource =
+                new SystemTableSource(ro, false, ObjectIdentifier.of("cat", "db", "table"));
+        PaimonDataStreamScanProvider runtimeProvider = runtimeProvider(tableSource);
+
+        Configuration configuration = new Configuration();
+        configuration.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
+        StreamExecutionEnvironment sEnv1 = StreamExecutionEnvironment.createLocalEnvironment();
+        DataStream<RowData> sourceStream1 =
+                runtimeProvider.produceDataStream(s -> Optional.empty(), sEnv1);
+        assertThat(sourceStream1.getParallelism()).isEqualTo(3);
+    }
+
+    private PaimonDataStreamScanProvider runtimeProvider(FlinkTableSource tableSource) {
+        return (PaimonDataStreamScanProvider)
+                tableSource.getScanRuntimeProvider(
+                        new ScanTableSource.ScanContext() {
+                            @Override
+                            public <T> TypeInformation<T> createTypeInformation(DataType dataType) {
+                                throw new UnsupportedOperationException();
+                            }
+
+                            @Override
+                            public <T> TypeInformation<T> createTypeInformation(
+                                    LogicalType logicalType) {
+                                throw new UnsupportedOperationException();
+                            }
+
+                            @Override
+                            public DynamicTableSource.DataStructureConverter
+                                    createDataStructureConverter(DataType dataType) {
+                                throw new UnsupportedOperationException();
+                            }
+                        });
+    }
+
+    private FileStoreTable createTable(Map<String, String> options) throws Exception {
+        FileIO fileIO = LocalFileIO.create();
+        Path tablePath = new Path(path.toString());
+        SchemaManager schemaManager = new SchemaManager(fileIO, tablePath);
+        TableSchema tableSchema =
+                schemaManager.createTable(
+                        Schema.newBuilder()
+                                .column("a", DataTypes.INT())
+                                .column("b", DataTypes.BIGINT())
+                                .options(options)
+                                .build());
+        return FileStoreTableFactory.create(fileIO, tablePath, tableSchema);
+    }
+
+    private void writeData(FileStoreTable table) throws Exception {
+        InnerTableWrite writer = table.newWrite("test");
+        TableCommitImpl commit = table.newCommit("test");
+        writer.write(GenericRow.of(1, 2L));
+        commit.commit(writer.prepareCommit());
+        commit.close();
+        writer.close();
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Currently, the `scan.parallelism` and `scan.infer-parallelism` is not work for system table.  We should implement this because we have `ro` / `audit_log` table

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
