### PR TITLE
[core] Introduce RawFileSplitRead to accelerate batch read for primary key table

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/LazyField.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/LazyField.java
@@ -16,23 +16,33 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.operation;
+package org.apache.paimon.utils;
 
-import org.apache.paimon.predicate.Predicate;
-import org.apache.paimon.reader.RecordReader;
-import org.apache.paimon.table.source.DataSplit;
+import java.util.function.Supplier;
 
-import java.io.IOException;
+/** A class to lazy initialized field. */
+public class LazyField<T> {
 
-/**
- * Read operation which provides {@link RecordReader} creation.
- *
- * @param <T> type of record to read.
- */
-public interface FileStoreRead<T> {
+    private final Supplier<T> supplier;
 
-    FileStoreRead<T> withFilter(Predicate predicate);
+    private boolean initialized;
+    private T value;
 
-    /** Create a {@link RecordReader} from split. */
-    RecordReader<T> createReader(DataSplit split) throws IOException;
+    public LazyField(Supplier<T> supplier) {
+        this.supplier = supplier;
+    }
+
+    public T get() {
+        if (!initialized) {
+            T t = supplier.get();
+            value = t;
+            initialized = true;
+            return t;
+        }
+        return value;
+    }
+
+    public boolean initialized() {
+        return initialized;
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
@@ -22,9 +22,9 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FileFormatDiscover;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.manifest.ManifestCacheFilter;
-import org.apache.paimon.operation.AppendOnlyFileStoreRead;
 import org.apache.paimon.operation.AppendOnlyFileStoreScan;
 import org.apache.paimon.operation.AppendOnlyFileStoreWrite;
+import org.apache.paimon.operation.RawFileSplitRead;
 import org.apache.paimon.operation.ScanBucketFilter;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.schema.SchemaManager;
@@ -79,8 +79,8 @@ public class AppendOnlyFileStore extends AbstractFileStore<InternalRow> {
     }
 
     @Override
-    public AppendOnlyFileStoreRead newRead() {
-        return new AppendOnlyFileStoreRead(
+    public RawFileSplitRead newRead() {
+        return new RawFileSplitRead(
                 fileIO,
                 schemaManager,
                 schema,

--- a/paimon-core/src/main/java/org/apache/paimon/FileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/FileStore.java
@@ -23,11 +23,11 @@ import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.manifest.ManifestFile;
 import org.apache.paimon.manifest.ManifestList;
 import org.apache.paimon.operation.FileStoreCommit;
-import org.apache.paimon.operation.FileStoreRead;
 import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.operation.FileStoreWrite;
 import org.apache.paimon.operation.PartitionExpire;
 import org.apache.paimon.operation.SnapshotDeletion;
+import org.apache.paimon.operation.SplitRead;
 import org.apache.paimon.operation.TagDeletion;
 import org.apache.paimon.service.ServiceManager;
 import org.apache.paimon.stats.StatsFileHandler;
@@ -73,7 +73,7 @@ public interface FileStore<T> extends Serializable {
 
     StatsFileHandler newStatsFileHandler();
 
-    FileStoreRead<T> newRead();
+    SplitRead<T> newRead();
 
     FileStoreWrite<T> newWrite(String commitUser);
 

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -28,9 +28,10 @@ import org.apache.paimon.index.IndexMaintainer;
 import org.apache.paimon.io.KeyValueFileReaderFactory;
 import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.mergetree.compact.MergeFunctionFactory;
-import org.apache.paimon.operation.KeyValueFileStoreRead;
 import org.apache.paimon.operation.KeyValueFileStoreScan;
 import org.apache.paimon.operation.KeyValueFileStoreWrite;
+import org.apache.paimon.operation.MergeFileSplitRead;
+import org.apache.paimon.operation.RawFileSplitRead;
 import org.apache.paimon.operation.ScanBucketFilter;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.schema.KeyValueFieldsExtractor;
@@ -119,8 +120,8 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
     }
 
     @Override
-    public KeyValueFileStoreRead newRead() {
-        return new KeyValueFileStoreRead(
+    public MergeFileSplitRead newRead() {
+        return new MergeFileSplitRead(
                 options,
                 schema,
                 keyType,
@@ -128,6 +129,16 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                 newKeyComparator(),
                 mfFactory,
                 newReaderFactoryBuilder());
+    }
+
+    public RawFileSplitRead newBatchRawFileRead() {
+        return new RawFileSplitRead(
+                fileIO,
+                schemaManager,
+                schema,
+                valueType,
+                FileFormatDiscover.of(options),
+                pathFactory());
     }
 
     public KeyValueFileReaderFactory.Builder newReaderFactoryBuilder() {

--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/ApplyDeletionVectorReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/ApplyDeletionVectorReader.java
@@ -24,7 +24,6 @@ import org.apache.paimon.reader.RecordReader;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.Optional;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
@@ -38,18 +37,6 @@ public class ApplyDeletionVectorReader<T> implements RecordReader<T> {
     public ApplyDeletionVectorReader(RecordReader<T> reader, DeletionVector deletionVector) {
         this.reader = reader;
         this.deletionVector = deletionVector;
-    }
-
-    public static <T> RecordReader<T> create(RecordReader<T> reader, Optional<DeletionVector> dv) {
-        return create(reader, dv.orElse(null));
-    }
-
-    public static <T> RecordReader<T> create(RecordReader<T> reader, @Nullable DeletionVector dv) {
-        if (dv == null) {
-            return reader;
-        }
-
-        return new ApplyDeletionVectorReader<>(reader, dv);
     }
 
     @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
@@ -59,7 +59,7 @@ import static org.apache.paimon.io.DataFileMeta.getMaxSequenceNumber;
 public class AppendOnlyFileStoreWrite extends MemoryFileStoreWrite<InternalRow> {
 
     private final FileIO fileIO;
-    private final AppendOnlyFileStoreRead read;
+    private final RawFileSplitRead read;
     private final long schemaId;
     private final RowType rowType;
     private final FileFormat fileFormat;
@@ -81,7 +81,7 @@ public class AppendOnlyFileStoreWrite extends MemoryFileStoreWrite<InternalRow> 
 
     public AppendOnlyFileStoreWrite(
             FileIO fileIO,
-            AppendOnlyFileStoreRead read,
+            RawFileSplitRead read,
             long schemaId,
             String commitUser,
             RowType rowType,

--- a/paimon-core/src/main/java/org/apache/paimon/operation/SplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/SplitRead.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.operation;
+
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.table.source.DataSplit;
+
+import java.io.IOException;
+
+/**
+ * Read operation which provides {@link RecordReader} creation.
+ *
+ * @param <T> type of record to read.
+ */
+public interface SplitRead<T> {
+
+    SplitRead<T> withFilter(Predicate predicate);
+
+    /** Create a {@link RecordReader} from split. */
+    RecordReader<T> createReader(DataSplit split) throws IOException;
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -24,11 +24,11 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.ManifestCacheFilter;
-import org.apache.paimon.operation.AppendOnlyFileStoreRead;
 import org.apache.paimon.operation.AppendOnlyFileStoreScan;
 import org.apache.paimon.operation.AppendOnlyFileStoreWrite;
 import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.operation.Lock;
+import org.apache.paimon.operation.RawFileSplitRead;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.TableSchema;
@@ -112,8 +112,14 @@ class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
 
     @Override
     public InnerTableRead newRead() {
-        AppendOnlyFileStoreRead read = store().newRead();
-        return new AbstractDataTableRead<InternalRow>(read, schema()) {
+        RawFileSplitRead read = store().newRead();
+        return new AbstractDataTableRead<InternalRow>(schema()) {
+
+            @Override
+            protected InnerTableRead innerWithFilter(Predicate predicate) {
+                read.withFilter(predicate);
+                return this;
+            }
 
             @Override
             public void projection(int[][] projection) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
@@ -32,7 +32,6 @@ import org.apache.paimon.operation.KeyValueFileStoreScan;
 import org.apache.paimon.operation.Lock;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
-import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.KeyValueFieldsExtractor;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.query.LocalTableQuery;
@@ -42,7 +41,6 @@ import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.KeyValueTableRead;
 import org.apache.paimon.table.source.MergeTreeSplitGenerator;
 import org.apache.paimon.table.source.SplitGenerator;
-import org.apache.paimon.table.source.ValueContentRowDataRecordIterator;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
 
@@ -157,25 +155,8 @@ class PrimaryKeyFileStoreTable extends AbstractFileStoreTable {
 
     @Override
     public InnerTableRead newRead() {
-        return new KeyValueTableRead(store().newRead(), schema()) {
-
-            @Override
-            public void projection(int[][] projection) {
-                read.withValueProjection(projection);
-            }
-
-            @Override
-            protected RecordReader.RecordIterator<InternalRow> rowDataRecordIteratorFromKv(
-                    RecordReader.RecordIterator<KeyValue> kvRecordIterator) {
-                return new ValueContentRowDataRecordIterator(kvRecordIterator);
-            }
-
-            @Override
-            public InnerTableRead forceKeepDelete() {
-                read.forceKeepDelete();
-                return this;
-            }
-        };
+        return new KeyValueTableRead(
+                () -> store().newRead(), () -> store().newBatchRawFileRead(), schema());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
@@ -21,7 +21,6 @@ package org.apache.paimon.table.source;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.operation.DefaultValueAssigner;
-import org.apache.paimon.operation.FileStoreRead;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateProjectionConverter;
 import org.apache.paimon.reader.RecordReader;
@@ -34,15 +33,13 @@ import java.util.Optional;
 /** A {@link InnerTableRead} for data table. */
 public abstract class AbstractDataTableRead<T> implements InnerTableRead {
 
-    private final FileStoreRead<T> fileStoreRead;
     private final DefaultValueAssigner defaultValueAssigner;
 
     private int[][] projection;
     private boolean executeFilter = false;
     private Predicate predicate;
 
-    public AbstractDataTableRead(FileStoreRead<T> fileStoreRead, TableSchema schema) {
-        this.fileStoreRead = fileStoreRead;
+    public AbstractDataTableRead(TableSchema schema) {
         this.defaultValueAssigner = schema == null ? null : DefaultValueAssigner.create(schema);
     }
 
@@ -61,9 +58,10 @@ public abstract class AbstractDataTableRead<T> implements InnerTableRead {
         if (defaultValueAssigner != null) {
             predicate = defaultValueAssigner.handlePredicate(predicate);
         }
-        fileStoreRead.withFilter(predicate);
-        return this;
+        return innerWithFilter(predicate);
     }
+
+    protected abstract InnerTableRead innerWithFilter(Predicate predicate);
 
     @Override
     public TableRead executeFilter() {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
@@ -117,7 +117,7 @@ public final class KeyValueTableRead extends AbstractDataTableRead<KeyValue> {
     @Override
     public RecordReader<InternalRow> reader(Split split) throws IOException {
         DataSplit dataSplit = (DataSplit) split;
-        if (!dataSplit.isStreaming() && split.convertToRawFiles().isPresent()) {
+        if (!forceKeepDelete && !dataSplit.isStreaming() && split.convertToRawFiles().isPresent()) {
             return batchRawRead.get().createReader(dataSplit);
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
@@ -21,61 +21,120 @@ package org.apache.paimon.table.source;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
-import org.apache.paimon.operation.KeyValueFileStoreRead;
+import org.apache.paimon.operation.MergeFileSplitRead;
+import org.apache.paimon.operation.RawFileSplitRead;
+import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.utils.LazyField;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.function.Supplier;
 
 /**
- * An abstraction layer above {@link KeyValueFileStoreRead} to provide reading of {@link
- * InternalRow}.
+ * An abstraction layer above {@link MergeFileSplitRead} to provide reading of {@link InternalRow}.
  */
-public abstract class KeyValueTableRead extends AbstractDataTableRead<KeyValue> {
+public final class KeyValueTableRead extends AbstractDataTableRead<KeyValue> {
 
-    protected final KeyValueFileStoreRead read;
+    private final LazyField<MergeFileSplitRead> mergeRead;
+    private final LazyField<RawFileSplitRead> batchRawRead;
 
-    protected KeyValueTableRead(KeyValueFileStoreRead read, TableSchema schema) {
-        super(read, schema);
-        // We don't need any key fields, the columns that need to be read are already included in
-        // the value
-        this.read = read.withKeyProjection(new int[0][]);
+    private int[][] projection = null;
+    private boolean forceKeepDelete = false;
+    private Predicate predicate = null;
+    private IOManager ioManager = null;
+
+    public KeyValueTableRead(
+            Supplier<MergeFileSplitRead> mergeReadSupplier,
+            Supplier<RawFileSplitRead> batchRawReadSupplier,
+            TableSchema schema) {
+        super(schema);
+        this.mergeRead = new LazyField<>(() -> createMergeRead(mergeReadSupplier));
+        this.batchRawRead = new LazyField<>(() -> createBatchRawRead(batchRawReadSupplier));
+    }
+
+    private MergeFileSplitRead createMergeRead(Supplier<MergeFileSplitRead> readSupplier) {
+        MergeFileSplitRead read =
+                readSupplier
+                        .get()
+                        .withKeyProjection(new int[0][])
+                        .withValueProjection(projection)
+                        .withFilter(predicate)
+                        .withIOManager(ioManager);
+        if (forceKeepDelete) {
+            read = read.forceKeepDelete();
+        }
+        return read;
+    }
+
+    private RawFileSplitRead createBatchRawRead(Supplier<RawFileSplitRead> readSupplier) {
+        return readSupplier.get().withProjection(projection).withFilter(predicate);
     }
 
     @Override
-    public TableRead withIOManager(IOManager ioManager) {
-        read.withIOManager(ioManager);
+    public void projection(int[][] projection) {
+        if (mergeRead.initialized()) {
+            mergeRead.get().withValueProjection(projection);
+        }
+        if (batchRawRead.initialized()) {
+            batchRawRead.get().withProjection(projection);
+        }
+        this.projection = projection;
+    }
+
+    @Override
+    public InnerTableRead forceKeepDelete() {
+        if (mergeRead.initialized()) {
+            mergeRead.get().forceKeepDelete();
+        }
+        this.forceKeepDelete = true;
         return this;
     }
 
     @Override
-    public final RecordReader<InternalRow> reader(Split split) throws IOException {
-        return new RowDataRecordReader(read.createReader((DataSplit) split));
+    protected InnerTableRead innerWithFilter(Predicate predicate) {
+        if (mergeRead.initialized()) {
+            mergeRead.get().withFilter(predicate);
+        }
+        if (batchRawRead.initialized()) {
+            batchRawRead.get().withFilter(predicate);
+        }
+        this.predicate = predicate;
+        return this;
     }
 
-    protected abstract RecordReader.RecordIterator<InternalRow> rowDataRecordIteratorFromKv(
-            RecordReader.RecordIterator<KeyValue> kvRecordIterator);
+    @Override
+    public TableRead withIOManager(IOManager ioManager) {
+        if (mergeRead.initialized()) {
+            mergeRead.get().withIOManager(ioManager);
+        }
+        this.ioManager = ioManager;
+        return this;
+    }
 
-    private class RowDataRecordReader implements RecordReader<InternalRow> {
-
-        private final RecordReader<KeyValue> wrapped;
-
-        private RowDataRecordReader(RecordReader<KeyValue> wrapped) {
-            this.wrapped = wrapped;
+    @Override
+    public RecordReader<InternalRow> reader(Split split) throws IOException {
+        DataSplit dataSplit = (DataSplit) split;
+        if (!forceKeepDelete && !dataSplit.isStreaming() && split.convertToRawFiles().isPresent()) {
+            return batchRawRead.get().createReader(dataSplit);
         }
 
-        @Nullable
-        @Override
-        public RecordIterator<InternalRow> readBatch() throws IOException {
-            RecordIterator<KeyValue> batch = wrapped.readBatch();
-            return batch == null ? null : rowDataRecordIteratorFromKv(batch);
-        }
+        RecordReader<KeyValue> reader = mergeRead.get().createReader(dataSplit);
+        return new RecordReader<InternalRow>() {
 
-        @Override
-        public void close() throws IOException {
-            wrapped.close();
-        }
+            @Nullable
+            @Override
+            public RecordIterator<InternalRow> readBatch() throws IOException {
+                RecordIterator<KeyValue> batch = reader.readBatch();
+                return batch == null ? null : new ValueContentRowDataRecordIterator(batch);
+            }
+
+            @Override
+            public void close() throws IOException {
+                reader.close();
+            }
+        };
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
@@ -117,7 +117,7 @@ public final class KeyValueTableRead extends AbstractDataTableRead<KeyValue> {
     @Override
     public RecordReader<InternalRow> reader(Split split) throws IOException {
         DataSplit dataSplit = (DataSplit) split;
-        if (!forceKeepDelete && !dataSplit.isStreaming() && split.convertToRawFiles().isPresent()) {
+        if (!dataSplit.isStreaming() && split.convertToRawFiles().isPresent()) {
             return batchRawRead.get().createReader(dataSplit);
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/TableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/TableRead.java
@@ -22,7 +22,7 @@ import org.apache.paimon.annotation.Public;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.mergetree.compact.ConcatRecordReader;
-import org.apache.paimon.operation.FileStoreRead;
+import org.apache.paimon.operation.SplitRead;
 import org.apache.paimon.reader.RecordReader;
 
 import java.io.IOException;
@@ -30,7 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * An abstraction layer above {@link FileStoreRead} to provide reading of {@link InternalRow}.
+ * An abstraction layer above {@link SplitRead} to provide reading of {@link InternalRow}.
  *
  * @since 0.4.0
  */

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -36,9 +36,9 @@ import org.apache.paimon.mergetree.compact.MergeFunctionFactory;
 import org.apache.paimon.operation.AbstractFileStoreWrite;
 import org.apache.paimon.operation.FileStoreCommit;
 import org.apache.paimon.operation.FileStoreCommitImpl;
-import org.apache.paimon.operation.FileStoreRead;
 import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.operation.Lock;
+import org.apache.paimon.operation.SplitRead;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.reader.RecordReaderIterator;
@@ -426,7 +426,7 @@ public class TestFileStore extends KeyValueFileStore {
         }
 
         List<KeyValue> kvs = new ArrayList<>();
-        FileStoreRead<KeyValue> read = newRead();
+        SplitRead<KeyValue> read = newRead();
         for (Map.Entry<BinaryRow, Map<Integer, List<DataFileMeta>>> entryWithPartition :
                 filesPerPartitionAndBucket.entrySet()) {
             for (Map.Entry<Integer, List<DataFileMeta>> entryWithBucket :

--- a/paimon-core/src/test/java/org/apache/paimon/operation/MergeFileSplitReadTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/MergeFileSplitReadTest.java
@@ -65,8 +65,8 @@ import java.util.stream.Stream;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Tests for {@link KeyValueFileStoreRead}. */
-public class KeyValueFileStoreReadTest {
+/** Tests for {@link MergeFileSplitRead}. */
+public class MergeFileSplitReadTest {
 
     @TempDir java.nio.file.Path tempDir;
 
@@ -226,7 +226,7 @@ public class KeyValueFileStoreReadTest {
         Map<BinaryRow, List<ManifestEntry>> filesGroupedByPartition =
                 scan.withSnapshot(snapshotId).plan().files().stream()
                         .collect(Collectors.groupingBy(ManifestEntry::partition));
-        KeyValueFileStoreRead read = store.newRead();
+        MergeFileSplitRead read = store.newRead();
         if (keyProjection != null) {
             read.withKeyProjection(keyProjection);
         }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MergeIntoActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MergeIntoActionITCase.java
@@ -124,9 +124,9 @@ public class MergeIntoActionITCase extends ActionITCaseBase {
                 expected,
                 Arrays.asList(
                         changelogRow("+I", 1, "v_1", "creation", "02-27"),
-                        changelogRow("+U", 2, "v_2_nmu", "not_matched_upsert", "02-27"),
-                        changelogRow("+U", 3, "v_3_nmu", "not_matched_upsert", "02-27"),
-                        changelogRow("+U", 7, "Seven", "matched_upsert", "02-28"),
+                        changelogRow("+I", 2, "v_2_nmu", "not_matched_upsert", "02-27"),
+                        changelogRow("+I", 3, "v_3_nmu", "not_matched_upsert", "02-27"),
+                        changelogRow("+I", 7, "Seven", "matched_upsert", "02-28"),
                         changelogRow("+I", 8, "v_8", "insert", "02-29"),
                         changelogRow("+I", 11, "v_11", "insert", "02-29"),
                         changelogRow("+I", 12, "v_12", "insert", "02-29")));

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
@@ -25,6 +25,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FileFormat;
+import org.apache.paimon.format.FileFormatDiscover;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.io.DataFileMeta;
@@ -32,16 +33,15 @@ import org.apache.paimon.io.KeyValueFileReaderFactory;
 import org.apache.paimon.memory.HeapMemorySegmentPool;
 import org.apache.paimon.memory.MemoryOwner;
 import org.apache.paimon.mergetree.compact.DeduplicateMergeFunction;
-import org.apache.paimon.operation.KeyValueFileStoreRead;
 import org.apache.paimon.operation.KeyValueFileStoreWrite;
+import org.apache.paimon.operation.MergeFileSplitRead;
+import org.apache.paimon.operation.RawFileSplitRead;
 import org.apache.paimon.options.Options;
-import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.KeyValueFieldsExtractor;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.source.KeyValueTableRead;
 import org.apache.paimon.table.source.TableRead;
-import org.apache.paimon.table.source.ValueContentRowDataRecordIterator;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.IntType;
@@ -60,7 +60,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.function.Function;
 
 import static java.util.Collections.singletonList;
 
@@ -110,20 +109,13 @@ public class TestChangelogDataReadWrite {
     }
 
     public TableRead createReadWithKey() {
-        return createRead(ValueContentRowDataRecordIterator::new);
-    }
-
-    private TableRead createRead(
-            Function<
-                            RecordReader.RecordIterator<KeyValue>,
-                            RecordReader.RecordIterator<InternalRow>>
-                    rowDataIteratorCreator) {
         SchemaManager schemaManager = new SchemaManager(LocalFileIO.create(), tablePath);
         CoreOptions options = new CoreOptions(new HashMap<>());
-        KeyValueFileStoreRead read =
-                new KeyValueFileStoreRead(
+        TableSchema schema = schemaManager.schema(0);
+        MergeFileSplitRead read =
+                new MergeFileSplitRead(
                         options,
-                        schemaManager.schema(0),
+                        schema,
                         KEY_TYPE,
                         VALUE_TYPE,
                         COMPARATOR,
@@ -131,26 +123,22 @@ public class TestChangelogDataReadWrite {
                         KeyValueFileReaderFactory.builder(
                                 LocalFileIO.create(),
                                 schemaManager,
-                                schemaManager.schema(0),
+                                schema,
                                 KEY_TYPE,
                                 VALUE_TYPE,
                                 ignore -> avro,
                                 pathFactory,
                                 EXTRACTOR,
                                 options));
-        return new KeyValueTableRead(read, null) {
-
-            @Override
-            public void projection(int[][] projection) {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            protected RecordReader.RecordIterator<InternalRow> rowDataRecordIteratorFromKv(
-                    RecordReader.RecordIterator<KeyValue> kvRecordIterator) {
-                return rowDataIteratorCreator.apply(kvRecordIterator);
-            }
-        };
+        RawFileSplitRead rawFileRead =
+                new RawFileSplitRead(
+                        LocalFileIO.create(),
+                        schemaManager,
+                        schema,
+                        VALUE_TYPE,
+                        FileFormatDiscover.of(options),
+                        pathFactory);
+        return new KeyValueTableRead(() -> read, () -> rawFileRead, null);
     }
 
     public List<DataFileMeta> writeFiles(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/util/ReadWriteTableTestUtil.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/util/ReadWriteTableTestUtil.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
 
 import javax.annotation.Nullable;
@@ -261,13 +262,26 @@ public class ReadWriteTableTestUtil {
         CloseableIterator<Row> resultItr = bEnv.executeSql(query).collect();
         try (BlockingIterator<Row, Row> iterator = BlockingIterator.of(resultItr)) {
             if (!expected.isEmpty()) {
-                assertThat(
-                                iterator.collect(
-                                        expected.size(), TIME_OUT.getSize(), TIME_OUT.getUnit()))
-                        .containsExactlyInAnyOrderElementsOf(expected);
+                List<Row> result =
+                        iterator.collect(expected.size(), TIME_OUT.getSize(), TIME_OUT.getUnit());
+                assertThat(toInsertOnlyRows(result))
+                        .containsExactlyInAnyOrderElementsOf(toInsertOnlyRows(expected));
             }
             assertThat(resultItr.hasNext()).isFalse();
         }
+    }
+
+    private static List<Row> toInsertOnlyRows(List<Row> rows) {
+        List<Row> result = new ArrayList<>();
+        for (Row row : rows) {
+            assertThat(row.getKind()).isIn(RowKind.INSERT, RowKind.UPDATE_AFTER);
+            Row newRow = new Row(row.getArity());
+            for (int i = 0; i < row.getArity(); i++) {
+                newRow.setField(i, row.getField(i));
+            }
+            result.add(newRow);
+        }
+        return result;
     }
 
     public static BlockingIterator<Row, Row> testStreamingRead(String query, List<Row> expected)


### PR DESCRIPTION

### Purpose

<!-- Linking this pull request to the issue -->
`KeyValueFileStoreRead` is an implementation for `KeyValueFileStore`, this class handle LSM merging and changelog row kind things, it will force reading fields such as sequence and row_kind. For `COUNT(*)` querying, it is slow.

If in batch mode and reading raw files, it is recommended to use `RawFileSplitRead`.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
