### PR TITLE
[core] Enable file index for map type with map-keys.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -22,6 +22,7 @@ import org.apache.paimon.annotation.Documentation;
 import org.apache.paimon.annotation.Documentation.ExcludeFromDocumentation;
 import org.apache.paimon.annotation.Documentation.Immutable;
 import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.fileindex.FileIndexCommon;
 import org.apache.paimon.fileindex.FileIndexOptions;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.fs.Path;
@@ -1782,13 +1783,17 @@ public class CoreOptions implements Serializable {
                             fileIndexOptions.computeIfAbsent(name.trim(), indexType);
                         }
                         if (!foundTarget) {
-                            throw new IllegalArgumentException(
-                                    "Wrong option in "
-                                            + key
-                                            + ", can't found column "
-                                            + cname
-                                            + " in "
-                                            + columns);
+                            if (FileIndexCommon.isNestedColumn(cname)) {
+                                fileIndexOptions.computeIfAbsent(cname, indexType);
+                            } else {
+                                throw new IllegalArgumentException(
+                                        "Wrong option in "
+                                                + key
+                                                + ", can't found column "
+                                                + cname
+                                                + " in "
+                                                + columns);
+                            }
                         }
                     }
                     fileIndexOptions.get(cname, indexType).set(opkey, entry.getValue());

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1727,66 +1727,7 @@ public class CoreOptions implements Serializable {
     }
 
     public FileIndexOptions indexColumnsOptions() {
-        String fileIndexPrefix = FILE_INDEX + ".";
-        String fileIndexColumnSuffix = "." + COLUMNS;
-
-        FileIndexOptions fileIndexOptions = new FileIndexOptions(fileIndexInManifestThreshold());
-        Map<String, String> optionMap = new HashMap<>();
-        // find the column to be indexed.
-        for (Map.Entry<String, String> entry : options.toMap().entrySet()) {
-            String key = entry.getKey();
-            if (key.startsWith(fileIndexPrefix)) {
-                // start with file-index, decode this option
-                if (key.endsWith(fileIndexColumnSuffix)) {
-                    // if end with .column, set up indexes
-                    String indexType =
-                            key.substring(
-                                    fileIndexPrefix.length(),
-                                    key.length() - fileIndexColumnSuffix.length());
-                    String[] names = entry.getValue().split(",");
-                    for (String name : names) {
-                        if (StringUtils.isBlank(name)) {
-                            throw new IllegalArgumentException(
-                                    "Wrong option in " + key + ", should not have empty column");
-                        }
-                        fileIndexOptions.computeIfAbsent(name.trim(), indexType);
-                    }
-                } else {
-                    optionMap.put(entry.getKey(), entry.getValue());
-                }
-            }
-        }
-
-        // fill out the options
-        for (Map.Entry<String, String> optionEntry : optionMap.entrySet()) {
-            String key = optionEntry.getKey();
-
-            String[] kv = key.substring(fileIndexPrefix.length()).split("\\.");
-            if (kv.length != 3) {
-                // just ignore options those are not expected
-                continue;
-            }
-            String indexType = kv[0];
-            String cname = kv[1];
-            String opkey = kv[2];
-
-            // if reaches here, must be an option.
-            if (fileIndexOptions.get(cname, indexType) == null) {
-                throw new IllegalArgumentException(
-                        "Wrong option in \""
-                                + key
-                                + "\", can't found column \""
-                                + cname
-                                + "\" in \""
-                                + fileIndexPrefix
-                                + indexType
-                                + fileIndexColumnSuffix
-                                + "\"");
-            }
-            fileIndexOptions.get(cname, indexType).set(opkey, optionEntry.getValue());
-        }
-
-        return fileIndexOptions;
+        return new FileIndexOptions(this);
     }
 
     public long fileIndexInManifestThreshold() {

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexCommon.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexCommon.java
@@ -33,9 +33,9 @@ public class FileIndexCommon {
     }
 
     public static DataType getFieldType(Map<String, DataField> fields, String columnsName) {
-        Optional<Integer> nestedIndex = FileIndexOptions.getNestedColumn(columnsName);
-        if (nestedIndex.isPresent()) {
-            return ((MapType) fields.get(columnsName.substring(0, nestedIndex.get())).type())
+        Optional<Integer> topLevelIndex = FileIndexOptions.topLevelIndexOfNested(columnsName);
+        if (topLevelIndex.isPresent()) {
+            return ((MapType) fields.get(columnsName.substring(0, topLevelIndex.get())).type())
                     .getValueType();
         } else {
             return fields.get(columnsName).type();

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexCommon.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexCommon.java
@@ -23,26 +23,22 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.MapType;
 
 import java.util.Map;
+import java.util.Optional;
 
 /** Common function of file index put here. */
 public class FileIndexCommon {
 
-    public static final String JUNCTION_SYMBOL = "##";
-
     public static String toMapKey(String mapColumnName, String keyName) {
-        return mapColumnName + JUNCTION_SYMBOL + keyName;
+        return mapColumnName + "[" + keyName + "]";
     }
 
     public static DataType getFieldType(Map<String, DataField> fields, String columnsName) {
-        int index = columnsName.indexOf(JUNCTION_SYMBOL);
-        if (index == -1) {
-            return fields.get(columnsName).type();
+        Optional<Integer> nestedIndex = FileIndexOptions.getNestedColumn(columnsName);
+        if (nestedIndex.isPresent()) {
+            return ((MapType) fields.get(columnsName.substring(0, nestedIndex.get())).type())
+                    .getValueType();
         } else {
-            return ((MapType) fields.get(columnsName.substring(0, index)).type()).getValueType();
+            return fields.get(columnsName).type();
         }
-    }
-
-    public static boolean isNestedColumn(String columnName) {
-        return columnName.contains(JUNCTION_SYMBOL);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexCommon.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexCommon.java
@@ -27,7 +27,7 @@ import java.util.Map;
 /** Common function of file index put here. */
 public class FileIndexCommon {
 
-    private static final String JUNCTION_SYMBOL = "##";
+    public static final String JUNCTION_SYMBOL = "##";
 
     public static String toMapKey(String mapColumnName, String keyName) {
         return mapColumnName + JUNCTION_SYMBOL + keyName;
@@ -40,5 +40,9 @@ public class FileIndexCommon {
         } else {
             return ((MapType) fields.get(columnsName.substring(0, index)).type()).getValueType();
         }
+    }
+
+    public static boolean isNestedColumn(String columnName) {
+        return columnName.contains(JUNCTION_SYMBOL);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexCommon.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexCommon.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex;
+
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.MapType;
+
+import java.util.Map;
+
+/** Common function of file index put here. */
+public class FileIndexCommon {
+
+    private static final String JUNCTION_SYMBOL = "##";
+
+    public static String toMapKey(String mapColumnName, String keyName) {
+        return mapColumnName + JUNCTION_SYMBOL + keyName;
+    }
+
+    public static DataType getFieldType(Map<String, DataField> fields, String columnsName) {
+        int index = columnsName.indexOf(JUNCTION_SYMBOL);
+        if (index == -1) {
+            return fields.get(columnsName).type();
+        } else {
+            return ((MapType) fields.get(columnsName.substring(0, index)).type()).getValueType();
+        }
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexFormat.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexFormat.java
@@ -288,13 +288,13 @@ public final class FileIndexFormat {
         }
 
         public FileIndexReader readColumnIndex(String columnName, String indexType) {
-
             return readColumnInputStream(columnName, indexType)
                     .map(
                             serializedBytes ->
                                     FileIndexer.create(
                                                     indexType,
-                                                    fields.get(columnName).type(),
+                                                    FileIndexCommon.getFieldType(
+                                                            fields, columnName),
                                                     new Options())
                                             .createReader(serializedBytes))
                     .orElse(null);

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexOptions.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /** Options of file index column. */
 public class FileIndexOptions {
@@ -64,6 +65,8 @@ public class FileIndexOptions {
     }
 
     public Set<Map.Entry<String, Map<String, Options>>> entrySet() {
-        return indexTypeOptions.entrySet();
+        return indexTypeOptions.entrySet().stream()
+                .filter(entry -> !entry.getKey().contains(FileIndexCommon.JUNCTION_SYMBOL))
+                .collect(Collectors.toSet());
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexPredicate.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexPredicate.java
@@ -34,6 +34,7 @@ import javax.annotation.Nullable;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -116,9 +117,10 @@ public class FileIndexPredicate implements Closeable {
     private static class FileIndexFieldPredicate implements PredicateVisitor<Boolean> {
 
         private final String columnName;
-        private final List<FileIndexReader> fileIndexReaders;
+        private final Collection<FileIndexReader> fileIndexReaders;
 
-        public FileIndexFieldPredicate(String columnName, List<FileIndexReader> fileIndexReaders) {
+        public FileIndexFieldPredicate(
+                String columnName, Collection<FileIndexReader> fileIndexReaders) {
             this.columnName = columnName;
             this.fileIndexReaders = fileIndexReaders;
         }

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexReader.java
@@ -27,55 +27,55 @@ import java.util.List;
  * Read file index from serialized bytes. Return true, means we need to search this file, else means
  * needn't.
  */
-public interface FileIndexReader extends FunctionVisitor<Boolean> {
+public abstract class FileIndexReader implements FunctionVisitor<Boolean> {
 
     @Override
-    default Boolean visitIsNotNull(FieldRef fieldRef) {
+    public Boolean visitIsNotNull(FieldRef fieldRef) {
         return true;
     }
 
     @Override
-    default Boolean visitIsNull(FieldRef fieldRef) {
+    public Boolean visitIsNull(FieldRef fieldRef) {
         return true;
     }
 
     @Override
-    default Boolean visitStartsWith(FieldRef fieldRef, Object literal) {
+    public Boolean visitStartsWith(FieldRef fieldRef, Object literal) {
         return true;
     }
 
     @Override
-    default Boolean visitLessThan(FieldRef fieldRef, Object literal) {
+    public Boolean visitLessThan(FieldRef fieldRef, Object literal) {
         return true;
     }
 
     @Override
-    default Boolean visitGreaterOrEqual(FieldRef fieldRef, Object literal) {
+    public Boolean visitGreaterOrEqual(FieldRef fieldRef, Object literal) {
         return true;
     }
 
     @Override
-    default Boolean visitNotEqual(FieldRef fieldRef, Object literal) {
+    public Boolean visitNotEqual(FieldRef fieldRef, Object literal) {
         return true;
     }
 
     @Override
-    default Boolean visitLessOrEqual(FieldRef fieldRef, Object literal) {
+    public Boolean visitLessOrEqual(FieldRef fieldRef, Object literal) {
         return true;
     }
 
     @Override
-    default Boolean visitEqual(FieldRef fieldRef, Object literal) {
+    public Boolean visitEqual(FieldRef fieldRef, Object literal) {
         return true;
     }
 
     @Override
-    default Boolean visitGreaterThan(FieldRef fieldRef, Object literal) {
+    public Boolean visitGreaterThan(FieldRef fieldRef, Object literal) {
         return true;
     }
 
     @Override
-    default Boolean visitIn(FieldRef fieldRef, List<Object> literals) {
+    public Boolean visitIn(FieldRef fieldRef, List<Object> literals) {
         for (Object key : literals) {
             if (visitEqual(fieldRef, key)) {
                 return true;
@@ -85,7 +85,7 @@ public interface FileIndexReader extends FunctionVisitor<Boolean> {
     }
 
     @Override
-    default Boolean visitNotIn(FieldRef fieldRef, List<Object> literals) {
+    public Boolean visitNotIn(FieldRef fieldRef, List<Object> literals) {
         for (Object key : literals) {
             if (visitNotEqual(fieldRef, key)) {
                 return true;
@@ -95,12 +95,12 @@ public interface FileIndexReader extends FunctionVisitor<Boolean> {
     }
 
     @Override
-    default Boolean visitAnd(List<Boolean> children) {
+    public Boolean visitAnd(List<Boolean> children) {
         throw new UnsupportedOperationException("Should not invoke this");
     }
 
     @Override
-    default Boolean visitOr(List<Boolean> children) {
+    public Boolean visitOr(List<Boolean> children) {
         throw new UnsupportedOperationException("Should not invoke this");
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexWriter.java
@@ -21,7 +21,7 @@ package org.apache.paimon.fileindex;
 /** To write file index. */
 public abstract class FileIndexWriter {
 
-    boolean empty = true;
+    private boolean empty = true;
 
     public void writeRecord(Object key) {
         if (key != null) {

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexWriter.java
@@ -19,11 +19,22 @@
 package org.apache.paimon.fileindex;
 
 /** To write file index. */
-public interface FileIndexWriter {
+public abstract class FileIndexWriter {
 
-    void write(Object key);
+    boolean empty = true;
 
-    byte[] serializedBytes();
+    public void writeRecord(Object key) {
+        if (key != null) {
+            empty = false;
+            write(key);
+        }
+    }
 
-    boolean empty();
+    public abstract void write(Object key);
+
+    public abstract byte[] serializedBytes();
+
+    public boolean empty() {
+        return empty;
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexWriter.java
@@ -24,4 +24,6 @@ public interface FileIndexWriter {
     void write(Object key);
 
     byte[] serializedBytes();
+
+    boolean empty();
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bloomfilter/BloomFilterFileIndex.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bloomfilter/BloomFilterFileIndex.java
@@ -76,6 +76,8 @@ public class BloomFilterFileIndex implements FileIndexer {
         private final BloomFilter64 filter;
         private final FastHash hashFunction;
 
+        private boolean empty = true;
+
         public Writer(DataType type, int items, double fpp) {
             this.filter = new BloomFilter64(items, fpp);
             this.hashFunction = FastHash.getHashFunction(type);
@@ -84,6 +86,7 @@ public class BloomFilterFileIndex implements FileIndexer {
         @Override
         public void write(Object key) {
             if (key != null) {
+                empty = false;
                 filter.addHash(hashFunction.hash(key));
             }
         }
@@ -99,6 +102,11 @@ public class BloomFilterFileIndex implements FileIndexer {
             serialized[3] = (byte) (numHashFunctions & 0xFF);
             filter.getBitSet().toByteArray(serialized, 4, serialized.length - 4);
             return serialized;
+        }
+
+        @Override
+        public boolean empty() {
+            return empty;
         }
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bloomfilter/BloomFilterFileIndex.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bloomfilter/BloomFilterFileIndex.java
@@ -71,12 +71,10 @@ public class BloomFilterFileIndex implements FileIndexer {
         return new Reader(dataType, serializedBytes);
     }
 
-    private static class Writer implements FileIndexWriter {
+    private static class Writer extends FileIndexWriter {
 
         private final BloomFilter64 filter;
         private final FastHash hashFunction;
-
-        private boolean empty = true;
 
         public Writer(DataType type, int items, double fpp) {
             this.filter = new BloomFilter64(items, fpp);
@@ -85,10 +83,7 @@ public class BloomFilterFileIndex implements FileIndexer {
 
         @Override
         public void write(Object key) {
-            if (key != null) {
-                empty = false;
-                filter.addHash(hashFunction.hash(key));
-            }
+            filter.addHash(hashFunction.hash(key));
         }
 
         @Override
@@ -103,14 +98,9 @@ public class BloomFilterFileIndex implements FileIndexer {
             filter.getBitSet().toByteArray(serialized, 4, serialized.length - 4);
             return serialized;
         }
-
-        @Override
-        public boolean empty() {
-            return empty;
-        }
     }
 
-    private static class Reader implements FileIndexReader {
+    private static class Reader extends FileIndexReader {
 
         private final BloomFilter64 filter;
         private final FastHash hashFunction;

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/empty/EmptyFileIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/empty/EmptyFileIndexReader.java
@@ -24,7 +24,7 @@ import org.apache.paimon.predicate.FieldRef;
 import java.util.List;
 
 /** Empty file index which has no writer and no serialized bytes. */
-public class EmptyFileIndexReader implements FileIndexReader {
+public class EmptyFileIndexReader extends FileIndexReader {
 
     /** No data in the file index, which mean this file has no related records. */
     public static final EmptyFileIndexReader INSTANCE = new EmptyFileIndexReader();

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/empty/EmptyFileIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/empty/EmptyFileIndexReader.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex.empty;
+
+import org.apache.paimon.fileindex.FileIndexReader;
+import org.apache.paimon.predicate.FieldRef;
+
+import java.util.List;
+
+/** Empty file index which has no writer and no serialized bytes. */
+public class EmptyFileIndexReader implements FileIndexReader {
+
+    /** No data in the file index, which mean this file has no related records. */
+    public static final EmptyFileIndexReader INSTANCE = new EmptyFileIndexReader();
+
+    @Override
+    public Boolean visitEqual(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitIsNotNull(FieldRef fieldRef) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitStartsWith(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitLessThan(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitGreaterOrEqual(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitLessOrEqual(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitGreaterThan(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitIn(FieldRef fieldRef, List<Object> literals) {
+        return false;
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/options/Options.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/Options.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 
 import static org.apache.paimon.options.OptionsUtils.canBePrefixMap;
 import static org.apache.paimon.options.OptionsUtils.containsPrefixMap;
@@ -92,6 +93,15 @@ public class Options implements Serializable {
 
     public synchronized String get(String key) {
         return data.get(key);
+    }
+
+    public synchronized <X extends Throwable> String getOrThrow(String key, Supplier<X> supplier)
+            throws X {
+        String value = data.get(key);
+        if (value == null) {
+            throw supplier.get();
+        }
+        return value;
     }
 
     public synchronized <T> Optional<T> getOptional(ConfigOption<T> option) {

--- a/paimon-common/src/main/java/org/apache/paimon/options/Options.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/Options.java
@@ -102,15 +102,6 @@ public class Options implements Serializable {
         return data.get(key);
     }
 
-    public synchronized <X extends Throwable> String getOrThrow(String key, Supplier<X> supplier)
-            throws X {
-        String value = data.get(key);
-        if (value == null) {
-            throw supplier.get();
-        }
-        return value;
-    }
-
     public synchronized <T> Optional<T> getOptional(ConfigOption<T> option) {
         Optional<Object> rawValue = getRawValueFromOption(option);
         Class<?> clazz = option.getClazz();

--- a/paimon-common/src/main/java/org/apache/paimon/options/Options.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/Options.java
@@ -30,7 +30,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.function.Supplier;
 
 import static org.apache.paimon.options.OptionsUtils.canBePrefixMap;
 import static org.apache.paimon.options.OptionsUtils.containsPrefixMap;

--- a/paimon-common/src/main/java/org/apache/paimon/options/Options.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/Options.java
@@ -63,6 +63,13 @@ public class Options implements Serializable {
         map.forEach(this::setString);
     }
 
+    /** Creates a new configuration that is initialized with the options of the given two maps. */
+    public Options(Map<String, String> map1, Map<String, String> map2) {
+        this();
+        map1.forEach(this::setString);
+        map2.forEach(this::setString);
+    }
+
     public static Options fromMap(Map<String, String> map) {
         return new Options(map);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/io/FileIndexWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/FileIndexWriter.java
@@ -269,32 +269,6 @@ public final class FileIndexWriter implements Closeable {
                 throw new IllegalArgumentException(
                         "Only support map data type with key field of CHAR、VARCHAR、STRING.");
             }
-
-            //            String[] nestedFields =
-            //                    options.getOrThrow(
-            //                                    NESTED_FIELDS,
-            //                                    () ->
-            //                                            new RuntimeException(
-            //                                                    "Bloom filter in map must has
-            // nested-fields option, which specify map keys to be indexed."))
-            //                            .split(",");
-            //            for (String mapKey : nestedFields) {
-            //                Options nestedOptions =
-            //                        fileIndexOptions.get(
-            //                                FileIndexCommon.toMapKey(columnName, mapKey),
-            // indexType);
-            //                indexWritersMap.put(
-            //                        mapKey,
-            //                        FileIndexer.create(
-            //                                        indexType,
-            //                                        valueType,
-            //                                        nestedOptions == null
-            //                                                ? options
-            //                                                : new Options(
-            //                                                        options.toMap(),
-            // nestedOptions.toMap()))
-            //                                .createWriter());
-            //            }
         }
 
         public void write(InternalRow row) {
@@ -318,9 +292,7 @@ public final class FileIndexWriter implements Closeable {
                     FileIndexer.create(
                                     indexType,
                                     valueType,
-                                    nestedOptions == null
-                                            ? options
-                                            : new Options(options.toMap(), nestedOptions.toMap()))
+                                    new Options(options.toMap(), nestedOptions.toMap()))
                             .createWriter());
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/io/FileIndexWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/FileIndexWriter.java
@@ -57,8 +57,7 @@ public final class FileIndexWriter implements Closeable {
     // if the filter size greater than fileIndexInManifestThreshold, we put it in file
     private final long inManifestThreshold;
 
-    //    private final List<FileIndexMaintainer> fileIndexMaintainers = new ArrayList<>();
-    private final Map<String, IndexMaintainer> mapFileIndexMaintainers = new HashMap<>();
+    private final Map<String, IndexMaintainer> indexMaintainers = new HashMap<>();
 
     private String resultFileName;
 
@@ -96,7 +95,7 @@ public final class FileIndexWriter implements Closeable {
                     }
                     MapType mapType = (MapType) field.type();
                     ((MapFileIndexMaintainer)
-                                    mapFileIndexMaintainers.computeIfAbsent(
+                                    indexMaintainers.computeIfAbsent(
                                             columnName,
                                             name ->
                                                     new MapFileIndexMaintainer(
@@ -109,7 +108,7 @@ public final class FileIndexWriter implements Closeable {
                                                             index.get(columnName))))
                             .add(entryColumn.getNestedColumnName(), typeEntry.getValue());
                 } else {
-                    mapFileIndexMaintainers.computeIfAbsent(
+                    indexMaintainers.computeIfAbsent(
                             columnName,
                             name ->
                                     new FileIndexMaintainer(
@@ -129,9 +128,7 @@ public final class FileIndexWriter implements Closeable {
     }
 
     public void write(InternalRow row) {
-        //        fileIndexMaintainers.forEach(fileIndexMaintainer ->
-        // fileIndexMaintainer.write(row));
-        mapFileIndexMaintainers
+        indexMaintainers
                 .values()
                 .forEach(mapFileIndexMaintainer -> mapFileIndexMaintainer.write(row));
     }
@@ -140,7 +137,7 @@ public final class FileIndexWriter implements Closeable {
     public void close() throws IOException {
         Map<String, Map<String, byte[]>> indexMaps = new HashMap<>();
 
-        for (IndexMaintainer indexMaintainer : mapFileIndexMaintainers.values()) {
+        for (IndexMaintainer indexMaintainer : indexMaintainers.values()) {
             Map<String, byte[]> mapBytes = indexMaintainer.serializedBytes();
             for (Map.Entry<String, byte[]> entry : mapBytes.entrySet()) {
                 indexMaps

--- a/paimon-core/src/main/java/org/apache/paimon/io/FileIndexWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/FileIndexWriter.java
@@ -93,6 +93,7 @@ public final class FileIndexWriter implements Closeable {
                                     indexType,
                                     mapType.getKeyType(),
                                     mapType.getValueType(),
+                                    fileIndexOptions,
                                     typeEntry.getValue(),
                                     index.get(columnName)));
                 } else {
@@ -240,6 +241,7 @@ public final class FileIndexWriter implements Closeable {
                 String indexType,
                 DataType keyType,
                 DataType valueType,
+                FileIndexOptions fileIndexOptions,
                 Options options,
                 int position) {
             this.columnName = columnName;
@@ -262,8 +264,19 @@ public final class FileIndexWriter implements Closeable {
                                                     "Bloom filter in map must has nested-fields option, which specify map keys to be indexed."))
                             .split(",");
             for (String mapKey : nestedFields) {
+                Options nestedOptions =
+                        fileIndexOptions.get(
+                                FileIndexCommon.toMapKey(columnName, mapKey), indexType);
                 indexWritersMap.put(
-                        mapKey, FileIndexer.create(indexType, valueType, options).createWriter());
+                        mapKey,
+                        FileIndexer.create(
+                                        indexType,
+                                        valueType,
+                                        nestedOptions == null
+                                                ? options
+                                                : new Options(
+                                                        options.toMap(), nestedOptions.toMap()))
+                                .createWriter());
             }
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/io/FileIndexWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/FileIndexWriter.java
@@ -103,7 +103,7 @@ public final class FileIndexWriter implements Closeable {
                                                             indexType,
                                                             mapType.getKeyType(),
                                                             mapType.getValueType(),
-                                                            fileIndexOptions.get(
+                                                            fileIndexOptions.getMapTopLevelOptions(
                                                                     columnName, typeEntry.getKey()),
                                                             index.get(columnName))))
                             .add(entryColumn.getNestedColumnName(), typeEntry.getValue());

--- a/paimon-core/src/main/java/org/apache/paimon/io/FileIndexWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/FileIndexWriter.java
@@ -227,7 +227,7 @@ public final class FileIndexWriter implements Closeable {
         }
 
         public void write(InternalRow row) {
-            fileIndexWriter.write(getter.getFieldOrNull(row));
+            fileIndexWriter.writeRecord(getter.getFieldOrNull(row));
         }
 
         public String getIndexType() {
@@ -282,7 +282,7 @@ public final class FileIndexWriter implements Closeable {
                 org.apache.paimon.fileindex.FileIndexWriter writer =
                         indexWritersMap.getOrDefault(key, null);
                 if (writer != null) {
-                    writer.write(valueElementGetter.getElementOrNull(valueArray, i));
+                    writer.writeRecord(valueElementGetter.getElementOrNull(valueArray, i));
                 }
             }
         }

--- a/paimon-core/src/main/java/org/apache/paimon/io/FileIndexWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/FileIndexWriter.java
@@ -227,7 +227,7 @@ public final class FileIndexWriter implements Closeable {
     /** File index writer for map data type. */
     private static class MapFileIndexMaintainer {
 
-        private static final String NESTED_FIELDS = "nested-fields";
+        private static final String NESTED_FIELDS = "map-keys";
 
         private final String columnName;
         private final String indexType;

--- a/paimon-core/src/main/java/org/apache/paimon/io/FileIndexWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/FileIndexWriter.java
@@ -308,6 +308,8 @@ public final class FileIndexWriter implements Closeable {
                         if (!v.empty()) {
                             result.put(
                                     FileIndexCommon.toMapKey(columnName, k), v.serializedBytes());
+                        } else {
+                            result.put(FileIndexCommon.toMapKey(columnName, k), null);
                         }
                     });
             return result;

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -25,6 +25,7 @@ import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.fileindex.FileIndexOptions;
 import org.apache.paimon.fileindex.bloomfilter.BloomFilterFileIndex;
 import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.Path;
@@ -66,6 +67,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.CoreOptions.FILE_INDEX_IN_MANIFEST_THRESHOLD;
 import static org.apache.paimon.table.sink.KeyAndBucketExtractor.bucket;
 import static org.apache.paimon.table.sink.KeyAndBucketExtractor.bucketKeyHashCode;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -374,32 +376,32 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                         rowType,
                         options -> {
                             options.set(
-                                    CoreOptions.FILE_INDEX
+                                    FileIndexOptions.FILE_INDEX
                                             + "."
                                             + BloomFilterFileIndex.BLOOM_FILTER
                                             + "."
                                             + CoreOptions.COLUMNS,
                                     "index_column, index_column2, index_column3");
                             options.set(
-                                    CoreOptions.FILE_INDEX
+                                    FileIndexOptions.FILE_INDEX
                                             + "."
                                             + BloomFilterFileIndex.BLOOM_FILTER
                                             + ".index_column.items",
                                     "150");
                             options.set(
-                                    CoreOptions.FILE_INDEX
+                                    FileIndexOptions.FILE_INDEX
                                             + "."
                                             + BloomFilterFileIndex.BLOOM_FILTER
                                             + ".index_column2.items",
                                     "150");
                             options.set(
-                                    CoreOptions.FILE_INDEX
+                                    FileIndexOptions.FILE_INDEX
                                             + "."
                                             + BloomFilterFileIndex.BLOOM_FILTER
                                             + ".index_column3.items",
                                     "150");
                             options.set(
-                                    CoreOptions.FILE_INDEX_IN_MANIFEST_THRESHOLD.key(), "500 B");
+                                    FILE_INDEX_IN_MANIFEST_THRESHOLD.key(), "500 B");
                         });
 
         StreamTableWrite write = table.newWrite(commitUser);
@@ -441,13 +443,13 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                         rowType,
                         options -> {
                             options.set(
-                                    CoreOptions.FILE_INDEX
+                                    FileIndexOptions.FILE_INDEX
                                             + "."
                                             + BloomFilterFileIndex.BLOOM_FILTER
                                             + "."
                                             + CoreOptions.COLUMNS,
                                     "index_column, index_column2, index_column3");
-                            options.set(CoreOptions.FILE_INDEX_IN_MANIFEST_THRESHOLD.key(), "50 B");
+                            options.set(FILE_INDEX_IN_MANIFEST_THRESHOLD.key(), "50 B");
                         });
 
         StreamTableWrite write = table.newWrite(commitUser);
@@ -499,32 +501,32 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                         rowType,
                         options -> {
                             options.set(
-                                    CoreOptions.FILE_INDEX
+                                    FileIndexOptions.FILE_INDEX
                                             + "."
                                             + BloomFilterFileIndex.BLOOM_FILTER
                                             + "."
                                             + CoreOptions.COLUMNS,
                                     "index_column, index_column2, index_column3[a], index_column3[b], index_column3[c], index_column3[d]");
                             options.set(
-                                    CoreOptions.FILE_INDEX
+                                    FileIndexOptions.FILE_INDEX
                                             + "."
                                             + BloomFilterFileIndex.BLOOM_FILTER
                                             + ".index_column.items",
                                     "150");
                             options.set(
-                                    CoreOptions.FILE_INDEX
+                                    FileIndexOptions.FILE_INDEX
                                             + "."
                                             + BloomFilterFileIndex.BLOOM_FILTER
                                             + ".index_column2.items",
                                     "150");
                             options.set(
-                                    CoreOptions.FILE_INDEX
+                                    FileIndexOptions.FILE_INDEX
                                             + "."
                                             + BloomFilterFileIndex.BLOOM_FILTER
                                             + ".index_column3.items",
                                     "150");
                             options.set(
-                                    CoreOptions.FILE_INDEX
+                                    FileIndexOptions.FILE_INDEX
                                             + "."
                                             + BloomFilterFileIndex.BLOOM_FILTER
                                             + ".index_column3[a].items",

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -25,6 +25,7 @@ import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.fileindex.FileIndexCommon;
 import org.apache.paimon.fileindex.bloomfilter.BloomFilterFileIndex;
 import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.Path;
@@ -529,6 +530,14 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                                             + BloomFilterFileIndex.BLOOM_FILTER
                                             + ".index_column3.items",
                                     "150");
+                            options.set(
+                                    CoreOptions.FILE_INDEX
+                                            + "."
+                                            + BloomFilterFileIndex.BLOOM_FILTER
+                                            + ".index_column3"
+                                            + FileIndexCommon.JUNCTION_SYMBOL
+                                            + "a.items",
+                                    "10000");
                         });
 
         StreamTableWrite write = table.newWrite(commitUser);

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -509,12 +509,6 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                                     CoreOptions.FILE_INDEX
                                             + "."
                                             + BloomFilterFileIndex.BLOOM_FILTER
-                                            + ".index_column3.map-keys",
-                                    "a,b,c,d");
-                            options.set(
-                                    CoreOptions.FILE_INDEX
-                                            + "."
-                                            + BloomFilterFileIndex.BLOOM_FILTER
                                             + ".index_column.items",
                                     "150");
                             options.set(

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -400,8 +400,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                                             + BloomFilterFileIndex.BLOOM_FILTER
                                             + ".index_column3.items",
                                     "150");
-                            options.set(
-                                    FILE_INDEX_IN_MANIFEST_THRESHOLD.key(), "500 B");
+                            options.set(FILE_INDEX_IN_MANIFEST_THRESHOLD.key(), "500 B");
                         });
 
         StreamTableWrite write = table.newWrite(commitUser);

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -25,7 +25,6 @@ import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
-import org.apache.paimon.fileindex.FileIndexCommon;
 import org.apache.paimon.fileindex.bloomfilter.BloomFilterFileIndex;
 import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.Path;
@@ -505,7 +504,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                                             + BloomFilterFileIndex.BLOOM_FILTER
                                             + "."
                                             + CoreOptions.COLUMNS,
-                                    "index_column, index_column2, index_column3");
+                                    "index_column, index_column2, index_column3[a], index_column3[b], index_column3[c], index_column3[d]");
                             options.set(
                                     CoreOptions.FILE_INDEX
                                             + "."
@@ -534,9 +533,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                                     CoreOptions.FILE_INDEX
                                             + "."
                                             + BloomFilterFileIndex.BLOOM_FILTER
-                                            + ".index_column3"
-                                            + FileIndexCommon.JUNCTION_SYMBOL
-                                            + "a.items",
+                                            + ".index_column3[a].items",
                                     "10000");
                         });
 
@@ -618,7 +615,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                         Equal.INSTANCE,
                         DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING()),
                         3,
-                        "index_column3##a",
+                        "index_column3[a]",
                         Collections.singletonList(BinaryString.fromString("I am a good girl")));
         TableScan.Plan plan = table.newScan().withFilter(predicate).plan();
         List<DataFileMeta> metas =

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -509,7 +509,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                                     CoreOptions.FILE_INDEX
                                             + "."
                                             + BloomFilterFileIndex.BLOOM_FILTER
-                                            + ".index_column3.nested-fields",
+                                            + ".index_column3.map-keys",
                                     "a,b,c,d");
                             options.set(
                                     CoreOptions.FILE_INDEX


### PR DESCRIPTION
* API
If you want to create a file index with map-keys, you need to specify.
```sql
CREATE TABLE <PAIMON_TABLE> (<COLUMN> <COLUMN_TYPE> , ...) WITH
(
"file-index.bloom-filter.columns" = "map_data[key1], map_data[key2], map_data[key3], map_data[key4]", --must
"file-index.bloom-filter.map_data.items" = "200", --optional default 1000000
"file-index.bloom-filter.map_data.fpp" = "0.1",  --optional default 0.1
"file-index.bloom-filter.map_data[key1].items" = "10000", --optional
"file-index.in-manifest-threshold" = "500 B" --optional
)
```

If you want to specify the options for specific map key, you can add an external options like:
`file-index.bloom-filter.<map_column>##<map_key>.<op_key>='<op_value>'`
clickhouse: https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree#table_engine-mergetree-data_skipping-indexes
* NOTE
1. flink sql read `select * from <table> where map_data['key1'] = 'value1'` will not push down
2. Every key in `map-keys` will generate a standalone bloom-filter, so if just need to predicate map_data['key1'] will not all map_data bloom-filter, just only map_data['key1'] bloom-filter.
3. `map-keys` refer to clickhouse "INDEX map_key_index mapKeys(map_column) TYPE bloom_filter GRANULARITY 1"
