### PR TITLE
[PAIMON-3219][Flink] support create database with properties when inner catalog supports.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -249,6 +249,14 @@ public interface Catalog extends AutoCloseable {
         return true;
     }
 
+    /**
+     * Return a boolean that indicates whether this catalog supports create database with
+     * properties.
+     */
+    default boolean supportDatabaseProperties() {
+        return false;
+    }
+
     /** Exception for trying to drop on a database that is not empty. */
     class DatabaseNotEmptyException extends Exception {
         private static final String MSG = "Database %s is not empty.";

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
@@ -353,6 +353,11 @@ public class JdbcCatalog extends AbstractCatalog {
         return Optional.of(new JdbcCatalogLockContext(connections, catalogKey, options));
     }
 
+    @Override
+    public boolean supportDatabaseProperties() {
+        return true;
+    }
+
     private Lock lock(Identifier identifier) {
         if (!lockEnabled()) {
             return new Lock.EmptyLock();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -191,22 +191,23 @@ public class FlinkCatalog extends AbstractCatalog {
     @Override
     public void createDatabase(String name, CatalogDatabase database, boolean ignoreIfExists)
             throws DatabaseAlreadyExistException, CatalogException {
-        // todo: flink hive catalog support create db with props
-        if (database != null) {
-            if (database.getProperties().size() > 0) {
-                throw new UnsupportedOperationException(
-                        "Create database with properties is unsupported.");
-            }
-
-            if (database.getDescription().isPresent()
-                    && !database.getDescription().get().equals("")) {
-                throw new UnsupportedOperationException(
-                        "Create database with description is unsupported.");
-            }
-        }
-
         try {
-            catalog.createDatabase(name, ignoreIfExists);
+            if (database != null) {
+                if (database.getProperties().size() > 0 && !catalog.supportDatabaseProperties()) {
+                    throw new UnsupportedOperationException(
+                            "Create database with properties is unsupported.");
+                }
+
+                if (database.getDescription().isPresent()
+                        && !database.getDescription().get().equals("")) {
+                    throw new UnsupportedOperationException(
+                            "Create database with description is unsupported.");
+                }
+
+                catalog.createDatabase(name, ignoreIfExists, database.getProperties());
+            } else {
+                catalog.createDatabase(name, ignoreIfExists);
+            }
         } catch (Catalog.DatabaseAlreadyExistException e) {
             throw new DatabaseAlreadyExistException(getName(), e.database());
         }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -236,6 +236,11 @@ public class HiveCatalog extends AbstractCatalog {
         }
     }
 
+    @Override
+    public boolean supportDatabaseProperties() {
+        return true;
+    }
+
     private Database convertToHiveDatabase(String name, Map<String, String> properties) {
         Database database = new Database();
         database.setName(name);


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3219 

Flink catalog doesn't support create database with properties, but jdbc and hive catalog actually support that. So this pr is to support create database with properties when inner catalog supports.

<!-- What is the purpose of the change -->

### Tests

cover by existing test.

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
