### PR TITLE
[core] Add numWriters metrics

### DIFF
--- a/docs/content/maintenance/metrics.md
+++ b/docs/content/maintenance/metrics.md
@@ -201,6 +201,11 @@ Below is lists of Paimon built-in metrics. They are summarized into types of sca
     </thead>
     <tbody>
         <tr>
+            <td>numWriters</td>
+            <td>Gauge</td>
+            <td>Number of writers in this parallelism.</td>
+        </tr>
+        <tr>
             <td>bufferPreemptCount</td>
             <td>Gauge</td>
             <td>The total number of memory preempted.</td>


### PR DESCRIPTION
### Purpose

This PR adds a `numWriters` metrics to monitor the number of active writers in each parallelism. This metric can help us determine if the memory shortage is caused by too many writers.

### Tests

* `PrimaryKeyWriterOperatorTest#testNumWritersMetric`

### API and Format

No changes in API or format.

### Documentation

Yes. Document is updated.
