### PR TITLE
[ci] Use hugo v0.124.1 to build documents

### DIFF
--- a/.github/workflows/docs-tests.yml
+++ b/.github/workflows/docs-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.124.1'
           extended: true
 
       - name: Build

--- a/docs/content/flink/action-jars.md
+++ b/docs/content/flink/action-jars.md
@@ -26,7 +26,7 @@ under the License.
 
 # Action Jars
 
-After the Flink Local Cluster has been started, you can execute the action jar by using the following command
+After the Flink Local Cluster has been started, you can execute the action jar by using the following command.
 
 ```
 <FLINK_HOME>/bin/flink run \
@@ -35,7 +35,7 @@ After the Flink Local Cluster has been started, you can execute the action jar b
  <args>
 ``` 
 
-The following command will used to compact a table
+The following command is used to compact a table.
 
 ```
 <FLINK_HOME>/bin/flink run \


### PR DESCRIPTION
Hugo removes google analytics support in the latest version. To avoid breaking the CI, we should specify an older version of hugo.