### PR TITLE
[dep] Remove Hdfs client dependency

### DIFF
--- a/paimon-benchmark/paimon-micro-benchmarks/pom.xml
+++ b/paimon-benchmark/paimon-micro-benchmarks/pom.xml
@@ -61,12 +61,6 @@ under the License.
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-hdfs-client</artifactId>
-            <version>${hadoop.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
             <exclusions>

--- a/paimon-common/src/main/java/org/apache/paimon/utils/HadoopUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/HadoopUtils.java
@@ -24,7 +24,6 @@ import org.apache.paimon.options.description.DescribedEnum;
 import org.apache.paimon.options.description.InlineElement;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,11 +54,7 @@ public class HadoopUtils {
     public static final String PATH_HADOOP_CONFIG = "hadoop-conf-dir";
 
     public static Configuration getHadoopConfiguration(Options options) {
-
-        // Instantiate an HdfsConfiguration to load the hdfs-site.xml and hdfs-default.xml
-        // from the classpath
-
-        Configuration result = new HdfsConfiguration();
+        Configuration result = new Configuration();
         boolean foundHadoopConfiguration = false;
 
         // We need to load both core-site.xml and hdfs-site.xml to determine the default fs path and
@@ -193,5 +188,11 @@ public class HadoopUtils {
         public InlineElement getDescription() {
             return text(description);
         }
+    }
+
+    static {
+        // load the hdfs-site.xml and hdfs-default.xml from the classpath
+        Configuration.addDefaultResource("hdfs-default.xml");
+        Configuration.addDefaultResource("hdfs-site.xml");
     }
 }

--- a/paimon-core/pom.xml
+++ b/paimon-core/pom.xml
@@ -111,27 +111,6 @@ under the License.
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-hdfs-client</artifactId>
-            <version>${hadoop.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.avro</groupId>
-                    <artifactId>avro</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
             <version>${hadoop.version}</version>
             <scope>test</scope>

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogFactoryTest.java
@@ -24,7 +24,6 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.table.TableType;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -80,7 +79,6 @@ public class CatalogFactoryTest {
         options.set("hadoop.dfs.replication", replication);
         Configuration conf = CatalogContext.create(options).hadoopConf();
 
-        assertThat(conf).isInstanceOf(HdfsConfiguration.class);
         assertThat(conf.get("fs.defaultFS")).isEqualTo(defaultFS);
         assertThat(conf.get("dfs.replication")).isEqualTo(replication);
     }

--- a/paimon-flink/pom.xml
+++ b/paimon-flink/pom.xml
@@ -65,13 +65,6 @@ under the License.
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-hdfs-client</artifactId>
-            <version>${hadoop.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
             <scope>provided</scope>

--- a/paimon-service/paimon-service-runtime/pom.xml
+++ b/paimon-service/paimon-service-runtime/pom.xml
@@ -116,27 +116,6 @@ under the License.
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-hdfs-client</artifactId>
-            <version>${hadoop.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.avro</groupId>
-                    <artifactId>avro</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
             <version>${hadoop.version}</version>
             <scope>test</scope>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
We don't need to rely on hdfs client jar, we can just load hdfs-default.xml and hdfs-site.xml.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
