### PR TITLE
[core] optimize the first row merge engine

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FirstRowMergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FirstRowMergeFunction.java
@@ -34,6 +34,7 @@ public class FirstRowMergeFunction implements MergeFunction<KeyValue> {
     private final InternalRowSerializer keySerializer;
     private final InternalRowSerializer valueSerializer;
     private KeyValue first;
+    public boolean containsHighLevel;
 
     protected FirstRowMergeFunction(RowType keyType, RowType valueType) {
         this.keySerializer = new InternalRowSerializer(keyType);
@@ -43,6 +44,7 @@ public class FirstRowMergeFunction implements MergeFunction<KeyValue> {
     @Override
     public void reset() {
         this.first = null;
+        this.containsHighLevel = false;
     }
 
     @Override
@@ -53,6 +55,9 @@ public class FirstRowMergeFunction implements MergeFunction<KeyValue> {
                         + "You can config 'ignore-delete' to ignore the DELETE/UPDATE_BEFORE records.");
         if (first == null) {
             this.first = kv.copy(keySerializer, valueSerializer);
+        }
+        if (kv.level() > 0) {
+            containsHighLevel = true;
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FirstRowMergeFunctionWrapper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FirstRowMergeFunctionWrapper.java
@@ -56,6 +56,11 @@ public class FirstRowMergeFunctionWrapper implements MergeFunctionWrapper<Change
     public ChangelogResult getResult() {
         reusedResult.reset();
         KeyValue result = mergeFunction.getResult();
+        if (mergeFunction.containsHighLevel) {
+            reusedResult.setResult(result);
+            return reusedResult;
+        }
+
         if (contains.test(result.key())) {
             // empty
             return reusedResult;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

If we meet high level key during the compact, we could avoid lookup the key in high level in this turn. 

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
