### PR TITLE
[core] Add support of sequence field in first row

### DIFF
--- a/docs/content/primary-key-table/merge-engine.md
+++ b/docs/content/primary-key-table/merge-engine.md
@@ -322,13 +322,13 @@ is an empty map instead of `+I[1->A]`
 
 ## First Row
 
-By specifying `'merge-engine' = 'first-row'`, users can keep the first row of the same primary key. It differs from the
-`deduplicate` merge engine that in the `first-row` merge engine, it will generate insert only changelog.
+By specifying `'merge-engine' = 'first-row'`, users can keep the first row of the same primary key. You can use the first row merge engine with or without setting `sequence.field`.
+When the sequence field is set, it retains the first row in a user-defined order and may generate an UPDATE_BEFORE message to adjust the outcome.
+If the sequence field is not set, it keeps the first row in natural order, resulting in only an INSERT message being created.
 
 {{< hint info >}}
 1. `first-row` merge engine must be used together with `lookup` [changelog producer]({{< ref "primary-key-table/changelog-producer" >}}).
-2. You can not specify `sequence.field`.
-3. Not accept `DELETE` and `UPDATE_BEFORE` message. You can config `ignore-delete` to ignore these two kinds records.
+2. Not accept `DELETE` and `UPDATE_BEFORE` message. You can config `ignore-delete` to ignore these two kinds records.
    {{< /hint >}}
 
 This is of great help in replacing log deduplication in streaming computation.

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1314,6 +1314,10 @@ public class CoreOptions implements Serializable {
         return options.get(MERGE_ENGINE);
     }
 
+    public boolean noDupKeysOverLevel0() {
+        return mergeEngine() == MergeEngine.FIRST_ROW && sequenceField().isEmpty();
+    }
+
     public boolean ignoreDelete() {
         return options.get(IGNORE_DELETE);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -242,7 +242,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                 options.scanManifestParallelism(),
                 branchName,
                 options.deletionVectorsEnabled(),
-                options.mergeEngine());
+                options.noDupKeysOverLevel0());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/UnOrderedFirstRowMergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/UnOrderedFirstRowMergeFunction.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree.compact;
+
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.types.RowType;
+
+import javax.annotation.Nullable;
+
+/**
+ * This class is the same as FirstRowMergeFunction, but it is specifically for merging unordered
+ * input.
+ */
+public class UnOrderedFirstRowMergeFunction extends FirstRowMergeFunction {
+    protected UnOrderedFirstRowMergeFunction(RowType keyType, RowType valueType) {
+        super(keyType, valueType);
+    }
+
+    public static MergeFunctionFactory<KeyValue> factory(RowType keyType, RowType valueType) {
+        return new UnOrderedFirstRowMergeFunction.Factory(keyType, valueType);
+    }
+
+    private static class Factory implements MergeFunctionFactory<KeyValue> {
+
+        private static final long serialVersionUID = 1L;
+        private final RowType keyType;
+        private final RowType valueType;
+
+        public Factory(RowType keyType, RowType valueType) {
+            this.keyType = keyType;
+            this.valueType = valueType;
+        }
+
+        @Override
+        public MergeFunction<KeyValue> create(@Nullable int[][] projection) {
+            return new UnOrderedFirstRowMergeFunction(keyType, valueType);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/UnOrderedFirstRowMergeFunctionWrapper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/UnOrderedFirstRowMergeFunctionWrapper.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree.compact;
+
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.codegen.RecordEqualiser;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.deletionvectors.DeletionVectorsMaintainer;
+import org.apache.paimon.lookup.LookupStrategy;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.utils.UserDefinedSeqComparator;
+
+import javax.annotation.Nullable;
+
+import java.util.function.Function;
+
+/** Wrapper for {@link MergeFunction}s to produce changelog by lookup for first row. */
+public class UnOrderedFirstRowMergeFunctionWrapper<T>
+        extends LookupChangelogMergeFunctionWrapper<T> {
+
+    private final KeyValue reusedBefore = new KeyValue();
+    private final KeyValue reusedAfter = new KeyValue();
+
+    public UnOrderedFirstRowMergeFunctionWrapper(
+            MergeFunctionFactory<KeyValue> mergeFunctionFactory,
+            Function<InternalRow, T> lookup,
+            RecordEqualiser valueEqualiser,
+            boolean changelogRowDeduplicate,
+            LookupStrategy lookupStrategy,
+            @Nullable DeletionVectorsMaintainer deletionVectorsMaintainer,
+            @Nullable UserDefinedSeqComparator userDefinedSeqComparator) {
+        super(
+                mergeFunctionFactory,
+                lookup,
+                valueEqualiser,
+                changelogRowDeduplicate,
+                lookupStrategy,
+                deletionVectorsMaintainer,
+                userDefinedSeqComparator);
+    }
+
+    @Override
+    protected void setChangelog(
+            @Nullable KeyValue before, KeyValue after, ChangelogResult reusedResult) {
+        if (after.level() == 0) {
+            if (before == null) {
+                reusedResult.addChangelog(after);
+            } else {
+                reusedResult
+                        .addChangelog(replace(reusedBefore, RowKind.UPDATE_BEFORE, before))
+                        .addChangelog(replace(reusedAfter, RowKind.UPDATE_AFTER, after));
+            }
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreScan.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.operation;
 
-import org.apache.paimon.CoreOptions.MergeEngine;
 import org.apache.paimon.KeyValueFileStore;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFile;
@@ -37,8 +36,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.apache.paimon.CoreOptions.MergeEngine.FIRST_ROW;
-
 /** {@link FileStoreScan} for {@link KeyValueFileStore}. */
 public class KeyValueFileStoreScan extends AbstractFileStoreScan {
 
@@ -48,7 +45,7 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
     private Predicate keyFilter;
     private Predicate valueFilter;
     private final boolean deletionVectorsEnabled;
-    private final MergeEngine mergeEngine;
+    private final boolean noDupKeysOverLevel0;
 
     public KeyValueFileStoreScan(
             RowType partitionType,
@@ -64,7 +61,7 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
             Integer scanManifestParallelism,
             String branchName,
             boolean deletionVectorsEnabled,
-            MergeEngine mergeEngine) {
+            boolean noDupKeysOverLevel0) {
         super(
                 partitionType,
                 bucketFilter,
@@ -86,7 +83,7 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
                         sid -> keyValueFieldsExtractor.valueFields(scanTableSchema(sid)),
                         schema.id());
         this.deletionVectorsEnabled = deletionVectorsEnabled;
-        this.mergeEngine = mergeEngine;
+        this.noDupKeysOverLevel0 = noDupKeysOverLevel0;
     }
 
     public KeyValueFileStoreScan withKeyFilter(Predicate predicate) {
@@ -106,7 +103,7 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
         Predicate filter = null;
         FieldStatsArraySerializer serializer = null;
         BinaryTableStats stats = null;
-        if ((deletionVectorsEnabled || mergeEngine == FIRST_ROW)
+        if ((deletionVectorsEnabled || noDupKeysOverLevel0)
                 && entry.level() > 0
                 && valueFilter != null) {
             filter = valueFilter;

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -473,8 +473,9 @@ public class SchemaValidation {
                 "Deletion vectors mode is only supported for none or lookup changelog producer now.");
 
         checkArgument(
-                !options.mergeEngine().equals(MergeEngine.FIRST_ROW),
-                "First row merge engine does not need deletion vectors because there is no deletion of old data in this merge engine.");
+                !options.mergeEngine().equals(MergeEngine.FIRST_ROW)
+                        || !options.sequenceField().isEmpty(),
+                "First row merge engine without sequence field does not need deletion vectors because there is no deletion of old data in this merge engine.");
     }
 
     private static void validateSequenceField(TableSchema schema, CoreOptions options) {
@@ -501,11 +502,6 @@ public class SchemaValidation {
                                 "Sequence field '%s' is defined repeatedly.",
                                 field);
                     });
-
-            if (options.mergeEngine() == MergeEngine.FIRST_ROW) {
-                throw new IllegalArgumentException(
-                        "Do not support use sequence field on FIRST_MERGE merge engine.");
-            }
 
             if (schema.crossPartitionUpdate()) {
                 throw new IllegalArgumentException(

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
@@ -120,7 +120,7 @@ class PrimaryKeyFileStoreTable extends AbstractFileStoreTable {
                 options.splitTargetSize(),
                 options.splitOpenFileCost(),
                 options.deletionVectorsEnabled(),
-                options.mergeEngine());
+                options.noDupKeysOverLevel0());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyTableUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyTableUtils.java
@@ -24,6 +24,7 @@ import org.apache.paimon.mergetree.compact.DeduplicateMergeFunction;
 import org.apache.paimon.mergetree.compact.FirstRowMergeFunction;
 import org.apache.paimon.mergetree.compact.MergeFunctionFactory;
 import org.apache.paimon.mergetree.compact.PartialUpdateMergeFunction;
+import org.apache.paimon.mergetree.compact.UnOrderedFirstRowMergeFunction;
 import org.apache.paimon.mergetree.compact.aggregate.AggregateMergeFunction;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.KeyValueFieldsExtractor;
@@ -74,8 +75,13 @@ public class PrimaryKeyTableUtils {
                         rowType.getFieldTypes(),
                         tableSchema.primaryKeys());
             case FIRST_ROW:
-                return FirstRowMergeFunction.factory(
-                        new RowType(extractor.keyFields(tableSchema)), rowType);
+                if (options.sequenceField().isEmpty()) {
+                    return FirstRowMergeFunction.factory(
+                            new RowType(extractor.keyFields(tableSchema)), rowType);
+                } else {
+                    return UnOrderedFirstRowMergeFunction.factory(
+                            new RowType(extractor.keyFields(tableSchema)), rowType);
+                }
             default:
                 throw new UnsupportedOperationException("Unsupported merge engine: " + mergeEngine);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/MergeTreeSplitGenerator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/MergeTreeSplitGenerator.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.table.source;
 
-import org.apache.paimon.CoreOptions.MergeEngine;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.mergetree.SortedRun;
@@ -32,8 +31,6 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.apache.paimon.CoreOptions.MergeEngine.FIRST_ROW;
-
 /** Merge tree implementation of {@link SplitGenerator}. */
 public class MergeTreeSplitGenerator implements SplitGenerator {
 
@@ -45,19 +42,19 @@ public class MergeTreeSplitGenerator implements SplitGenerator {
 
     private final boolean deletionVectorsEnabled;
 
-    private final MergeEngine mergeEngine;
+    private final boolean noDupKeysOverLevel0;
 
     public MergeTreeSplitGenerator(
             Comparator<InternalRow> keyComparator,
             long targetSplitSize,
             long openFileCost,
             boolean deletionVectorsEnabled,
-            MergeEngine mergeEngine) {
+            boolean noDupKeysOverLevel0) {
         this.keyComparator = keyComparator;
         this.targetSplitSize = targetSplitSize;
         this.openFileCost = openFileCost;
         this.deletionVectorsEnabled = deletionVectorsEnabled;
-        this.mergeEngine = mergeEngine;
+        this.noDupKeysOverLevel0 = noDupKeysOverLevel0;
     }
 
     @Override
@@ -67,7 +64,7 @@ public class MergeTreeSplitGenerator implements SplitGenerator {
         boolean oneLevel =
                 files.stream().map(DataFileMeta::level).collect(Collectors.toSet()).size() == 1;
 
-        if (rawConvertible && (deletionVectorsEnabled || mergeEngine == FIRST_ROW || oneLevel)) {
+        if (rawConvertible && (deletionVectorsEnabled || noDupKeysOverLevel0 || oneLevel)) {
             Function<DataFileMeta, Long> weightFunc =
                     file -> Math.max(file.fileSize(), openFileCost);
             return BinPacking.packForOrdered(files, weightFunc, targetSplitSize).stream()

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/SortMergeReaderTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/SortMergeReaderTestBase.java
@@ -129,8 +129,7 @@ public abstract class SortMergeReaderTestBase extends CombiningRecordReaderTestB
         protected MergeFunction<KeyValue> createMergeFunction() {
             RowType keyType = new RowType(Lists.list(new DataField(0, "f0", new IntType())));
             RowType valueType = new RowType(Lists.list(new DataField(1, "f1", new BigIntType())));
-            return new LookupMergeFunction(
-                    new FirstRowMergeFunction(keyType, valueType), keyType, valueType);
+            return new FirstRowMergeFunction(keyType, valueType);
         }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/schema/TableSchemaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/TableSchemaTest.java
@@ -150,12 +150,6 @@ public class TableSchemaTest {
         assertThatThrownBy(() -> validateTableSchema(schema))
                 .hasMessageContaining("Sequence field 'f3' is defined repeatedly.");
 
-        options.put(SEQUENCE_FIELD.key(), "f3");
-        options.put(MERGE_ENGINE.key(), CoreOptions.MergeEngine.FIRST_ROW.toString());
-        assertThatThrownBy(() -> validateTableSchema(schema))
-                .hasMessageContaining(
-                        "Do not support use sequence field on FIRST_MERGE merge engine.");
-
         options.put(FIELDS_PREFIX + ".f3." + AGG_FUNCTION, "max");
         assertThatThrownBy(() -> validateTableSchema(schema))
                 .hasMessageContaining("Should not define aggregation on sequence field: 'f3'.");

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/SplitGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/SplitGeneratorTest.java
@@ -31,8 +31,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.apache.paimon.CoreOptions.MergeEngine.DEDUPLICATE;
-import static org.apache.paimon.CoreOptions.MergeEngine.FIRST_ROW;
 import static org.apache.paimon.data.BinaryRow.EMPTY_ROW;
 import static org.apache.paimon.io.DataFileTestUtils.fromMinMax;
 import static org.apache.paimon.io.DataFileTestUtils.newFile;
@@ -113,14 +111,14 @@ public class SplitGeneratorTest {
         Comparator<InternalRow> comparator = Comparator.comparingInt(o -> o.getInt(0));
         assertThat(
                         toNames(
-                                new MergeTreeSplitGenerator(comparator, 100, 2, false, DEDUPLICATE)
+                                new MergeTreeSplitGenerator(comparator, 100, 2, false, false)
                                         .splitForBatch(files)))
                 .containsExactlyInAnyOrder(
                         Arrays.asList("1", "2", "4", "3", "5"), Collections.singletonList("6"));
 
         assertThat(
                         toNames(
-                                new MergeTreeSplitGenerator(comparator, 100, 30, false, DEDUPLICATE)
+                                new MergeTreeSplitGenerator(comparator, 100, 30, false, false)
                                         .splitForBatch(files)))
                 .containsExactlyInAnyOrder(
                         Arrays.asList("1", "2", "4", "3"),
@@ -132,7 +130,7 @@ public class SplitGeneratorTest {
     public void testSplitRawConvertible() {
         Comparator<InternalRow> comparator = Comparator.comparingInt(o -> o.getInt(0));
         MergeTreeSplitGenerator mergeTreeSplitGenerator =
-                new MergeTreeSplitGenerator(comparator, 100, 2, false, DEDUPLICATE);
+                new MergeTreeSplitGenerator(comparator, 100, 2, false, false);
 
         // When level0 exists, should not be rawConvertible
         List<DataFileMeta> files1 =
@@ -161,13 +159,13 @@ public class SplitGeneratorTest {
 
         // Not all in one level but with deletion vectors enabled, should be rawConvertible
         MergeTreeSplitGenerator splitGeneratorWithDVEnabled =
-                new MergeTreeSplitGenerator(comparator, 100, 2, true, DEDUPLICATE);
+                new MergeTreeSplitGenerator(comparator, 100, 2, true, false);
         assertThat(toNamesAndRawConvertible(splitGeneratorWithDVEnabled.splitForBatch(files4)))
                 .containsExactlyInAnyOrder(Pair.of(Arrays.asList("1", "2"), true));
 
         // Not all in one level but with first row merge engine, should be rawConvertible
         MergeTreeSplitGenerator splitGeneratorWithFirstRow =
-                new MergeTreeSplitGenerator(comparator, 100, 2, false, FIRST_ROW);
+                new MergeTreeSplitGenerator(comparator, 100, 2, false, true);
         assertThat(toNamesAndRawConvertible(splitGeneratorWithFirstRow.splitForBatch(files4)))
                 .containsExactlyInAnyOrder(Pair.of(Arrays.asList("1", "2"), true));
 
@@ -190,7 +188,7 @@ public class SplitGeneratorTest {
     public void testMergeTreeSplitRawConvertible() {
         Comparator<InternalRow> comparator = Comparator.comparingInt(o -> o.getInt(0));
         MergeTreeSplitGenerator mergeTreeSplitGenerator =
-                new MergeTreeSplitGenerator(comparator, 100, 2, false, DEDUPLICATE);
+                new MergeTreeSplitGenerator(comparator, 100, 2, false, false);
 
         List<DataFileMeta> files =
                 Arrays.asList(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

This PR is meant to support set `sequence.field` for first row. For example, user may want to keep the first row in Eventtime semantics (Otherwise, the result may not correct). In this mode, we will generate UB message to retract old value.

Also support generating deletion vector for first row with sequence field.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
