### PR TITLE
[hive] Reuse table StorageDescriptor info

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -509,12 +509,12 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     private void updateHmsTable(Table table, Identifier identifier, TableSchema schema) {
-        StorageDescriptor sd = new StorageDescriptor();
+        StorageDescriptor sd = table.getSd() != null ? table.getSd() : new StorageDescriptor();
 
         sd.setInputFormat(INPUT_FORMAT_CLASS_NAME);
         sd.setOutputFormat(OUTPUT_FORMAT_CLASS_NAME);
 
-        SerDeInfo serDeInfo = new SerDeInfo();
+        SerDeInfo serDeInfo = sd.getSerdeInfo() != null ? sd.getSerdeInfo() : new SerDeInfo();
         serDeInfo.setParameters(new HashMap<>());
         serDeInfo.setSerializationLib(SERDE_CLASS_NAME);
         sd.setSerdeInfo(serDeInfo);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- What is the purpose of the change -->
When we perform alter table operation, `updateHmsTable` method called will lose some StorageDescriptor infos like `bucketCols` variable. It's value changes from empty to null. This will cause an npe exception if we depend on this variable. Actually, there is no need to recreate new StorageDescriptor and SerDeInfo objects when we alter table. Just reuse previous objects and modify them as needed.

call `updateHmsTable` before:

![before](https://github.com/Askwang/images/blob/main/sd-reuse-before.png?raw=true)

call `updateHmsTable` after:

![after](https://github.com/Askwang/images/blob/main/sd-reuse-after.png?raw=true)

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
