### PR TITLE
[flink][flink-cdc] Add FLOAT type adaptation to HAVE_SCALE_LIST

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
@@ -382,7 +382,11 @@ public class MySqlTypeUtils {
                 && typeName.contains(RIGHT_BRACKETS)
                 && isScaleType(typeName)) {
             return Integer.parseInt(
-                    typeName.substring(typeName.indexOf(LEFT_BRACKETS) + 1, typeName.indexOf(COMMA))
+                    typeName.substring(
+                                    typeName.indexOf(LEFT_BRACKETS) + 1,
+                                    typeName.contains(COMMA)
+                                            ? typeName.indexOf(COMMA)
+                                            : typeName.indexOf(RIGHT_BRACKETS))
                             .trim());
         } else if ((typeName.contains(LEFT_BRACKETS)
                 && typeName.contains(RIGHT_BRACKETS)

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
@@ -409,10 +409,13 @@ public class MySqlTypeUtils {
         if (typeName.contains(LEFT_BRACKETS)
                 && typeName.contains(RIGHT_BRACKETS)
                 && isScaleType(typeName)) {
-            return Integer.parseInt(
-                    typeName.substring(
-                                    typeName.indexOf(COMMA) + 1, typeName.indexOf(RIGHT_BRACKETS))
-                            .trim());
+            return typeName.contains(COMMA)
+                    ? Integer.parseInt(
+                            typeName.substring(
+                                            typeName.indexOf(COMMA) + 1,
+                                            typeName.indexOf(RIGHT_BRACKETS))
+                                    .trim())
+                    : 0;
         } else {
             // When missing scale of the decimal, we
             // use the max scale to avoid parse error

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
@@ -138,7 +138,7 @@ public class MySqlTypeUtils {
     private static final String COMMA = ",";
 
     private static final List<String> HAVE_SCALE_LIST =
-            Arrays.asList(DECIMAL, NUMERIC, DOUBLE, REAL, FIXED);
+            Arrays.asList(DECIMAL, NUMERIC, DOUBLE, REAL, FIXED, FLOAT);
     private static final List<String> MAP_TO_DECIMAL_TYPES =
             Arrays.asList(
                     NUMERIC,


### PR DESCRIPTION
### Purpose

Fixed the problem that when using cdc for data synchronization, when the field type of the data source is float, an exception message will appear during synchronization: just like … :java.lang.NumberFormatException: For input string: "10,2"

### Tests

### API and Format

### Documentation

