### PR TITLE
[core] Introduce record-level expire time

### DIFF
--- a/docs/content/primary-key-table/overview.md
+++ b/docs/content/primary-key-table/overview.md
@@ -69,3 +69,11 @@ To limit the number of sorted runs, we have to merge several sorted runs into on
 However, compaction is a resource intensive procedure which consumes a certain amount of CPU time and disk IO, so too frequent compaction may in turn result in slower writes. It is a trade-off between query and write performance. Paimon currently adapts a compaction strategy similar to Rocksdb's [universal compaction](https://github.com/facebook/rocksdb/wiki/Universal-Compaction).
 
 By default, when Paimon appends records to the LSM tree, it will also perform compactions as needed. Users can also choose to perform all compactions in a dedicated compaction job. See [dedicated compaction job]({{< ref "maintenance/dedicated-compaction#dedicated-compaction-job" >}}) for more info.
+
+### Record-Level expire
+
+In compaction, you can configure record-Level expire time to expire records, you should configure:
+1. `'record-level.expire-time'`: time retain for records.
+2. `'record-level.time-field'`: time field for record level expire, it should be a seconds INT.
+
+Expiration happens in compaction, and there is no strong guarantee to expire records in time.

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -474,6 +474,18 @@ This config option does not affect the default filesystem metastore.</td>
             <td>Read batch size for orc and parquet.</td>
         </tr>
         <tr>
+            <td><h5>record-level.expire-time</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>Record level expire time for primary key table, expiration happens in compaction, there is no strong guarantee to expire records in time. You must specific 'record-level.time-field' too.</td>
+        </tr>
+        <tr>
+            <td><h5>record-level.time-field</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Time field for record level expire, it should be a seconds INT.</td>
+        </tr>
+        <tr>
             <td><h5>rowkind.field</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1775,10 +1775,10 @@ public class CoreOptions implements Serializable {
         return options.get(FILE_INDEX_READ_ENABLED);
     }
 
-<<<<<<< HEAD
     public boolean deleteForceProduceChangelog() {
         return options.get(DELETION_FORCE_PRODUCE_CHANGELOG);
-=======
+    }
+
     @Nullable
     public Duration recordLevelExpireTime() {
         return options.get(RECORD_LEVEL_EXPIRE_TIME);
@@ -1787,7 +1787,6 @@ public class CoreOptions implements Serializable {
     @Nullable
     public String recordLevelTimeField() {
         return options.get(RECORD_LEVEL_TIME_FIELD);
->>>>>>> 581c6d5c7 ([core] Introduce record-level expire time)
     }
 
     /** Specifies the merge engine for table with primary key. */

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1128,6 +1128,23 @@ public class CoreOptions implements Serializable {
                     .defaultValue(1000)
                     .withDescription(
                             "The magnification of local sample for sort-compaction.The size of local sample is sink parallelism * magnification.");
+
+    public static final ConfigOption<Duration> RECORD_LEVEL_EXPIRE_TIME =
+            key("record-level.expire-time")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Record level expire time for primary key table, expiration happens in compaction, "
+                                    + "there is no strong guarantee to expire records in time. "
+                                    + "You must specific 'record-level.time-field' too.");
+
+    public static final ConfigOption<String> RECORD_LEVEL_TIME_FIELD =
+            key("record-level.time-field")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Time field for record level expire, it should be a seconds INT.");
+
     private final Options options;
 
     public CoreOptions(Map<String, String> options) {
@@ -1758,8 +1775,19 @@ public class CoreOptions implements Serializable {
         return options.get(FILE_INDEX_READ_ENABLED);
     }
 
+<<<<<<< HEAD
     public boolean deleteForceProduceChangelog() {
         return options.get(DELETION_FORCE_PRODUCE_CHANGELOG);
+=======
+    @Nullable
+    public Duration recordLevelExpireTime() {
+        return options.get(RECORD_LEVEL_EXPIRE_TIME);
+    }
+
+    @Nullable
+    public String recordLevelTimeField() {
+        return options.get(RECORD_LEVEL_TIME_FIELD);
+>>>>>>> 581c6d5c7 ([core] Introduce record-level expire time)
     }
 
     /** Specifies the merge engine for table with primary key. */

--- a/paimon-core/src/main/java/org/apache/paimon/io/FileReaderFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/FileReaderFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import org.apache.paimon.reader.RecordReader;
+
+import java.io.IOException;
+
+/** Factory to read records from file. */
+public interface FileReaderFactory<T> {
+
+    RecordReader<T> createRecordReader(DataFileMeta file) throws IOException;
+}

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
@@ -53,7 +53,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 /** Factory to create {@link RecordReader}s for reading {@link KeyValue} files. */
-public class KeyValueFileReaderFactory {
+public class KeyValueFileReaderFactory implements FileReaderFactory<KeyValue> {
 
     private final FileIO fileIO;
     private final SchemaManager schemaManager;
@@ -93,6 +93,11 @@ public class KeyValueFileReaderFactory {
         this.bulkFormatMappings = new HashMap<>();
         this.dvFactory = dvFactory;
         this.ignoreDelete = CoreOptions.fromMap(schema.options()).ignoreDelete();
+    }
+
+    @Override
+    public RecordReader<KeyValue> createRecordReader(DataFileMeta file) throws IOException {
+        return createRecordReader(file.schemaId(), file.fileName(), file.fileSize(), file.level());
     }
 
     public RecordReader<KeyValue> createRecordReader(

--- a/paimon-core/src/main/java/org/apache/paimon/io/RecordLevelExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/RecordLevelExpire.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.RowType;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** A factory to create {@link RecordReader} expires records by time. */
+public class RecordLevelExpire {
+
+    private final int timeField;
+    private final int expireTime;
+
+    @Nullable
+    public static RecordLevelExpire create(CoreOptions options, RowType rowType) {
+        Duration expireTime = options.recordLevelExpireTime();
+        if (expireTime == null) {
+            return null;
+        }
+
+        String timeField = options.recordLevelTimeField();
+        if (timeField == null) {
+            throw new IllegalArgumentException(
+                    "You should set time field for record-level expire.");
+        }
+
+        // should no project here, record level expire only works in compaction
+        int fieldIndex = rowType.getFieldIndex(timeField);
+        if (fieldIndex == -1) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Can not find time field %s for record level expire.", timeField));
+        }
+
+        DataField field = rowType.getField(timeField);
+        if (!(field.type() instanceof IntType)) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Record level time field should be INT type, but is %s.",
+                            field.type()));
+        }
+
+        return new RecordLevelExpire(fieldIndex, (int) expireTime.getSeconds());
+    }
+
+    public RecordLevelExpire(int timeField, int expireTime) {
+        this.timeField = timeField;
+        this.expireTime = expireTime;
+    }
+
+    public FileReaderFactory<KeyValue> wrap(FileReaderFactory<KeyValue> readerFactory) {
+        return file -> wrap(readerFactory.createRecordReader(file));
+    }
+
+    public RecordReader<KeyValue> wrap(RecordReader<KeyValue> reader) {
+        int currentTime = (int) (System.currentTimeMillis() / 1000);
+        return reader.filter(
+                kv -> {
+                    checkArgument(
+                            !kv.value().isNullAt(timeField),
+                            "Time field for record-level expire should not be null.");
+                    int recordTime = kv.value().getInt(timeField);
+                    return currentTime <= recordTime + expireTime;
+                });
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ChangelogMergeTreeRewriter.java
@@ -23,7 +23,7 @@ import org.apache.paimon.KeyValue;
 import org.apache.paimon.compact.CompactResult;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileMeta;
-import org.apache.paimon.io.KeyValueFileReaderFactory;
+import org.apache.paimon.io.FileReaderFactory;
 import org.apache.paimon.io.KeyValueFileWriterFactory;
 import org.apache.paimon.io.RollingFileWriter;
 import org.apache.paimon.mergetree.MergeSorter;
@@ -51,7 +51,7 @@ public abstract class ChangelogMergeTreeRewriter extends MergeTreeCompactRewrite
     public ChangelogMergeTreeRewriter(
             int maxLevel,
             MergeEngine mergeEngine,
-            KeyValueFileReaderFactory readerFactory,
+            FileReaderFactory<KeyValue> readerFactory,
             KeyValueFileWriterFactory writerFactory,
             Comparator<InternalRow> keyComparator,
             @Nullable FieldsComparator userDefinedSeqComparator,

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullChangelogMergeTreeCompactRewriter.java
@@ -23,7 +23,7 @@ import org.apache.paimon.KeyValue;
 import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileMeta;
-import org.apache.paimon.io.KeyValueFileReaderFactory;
+import org.apache.paimon.io.FileReaderFactory;
 import org.apache.paimon.io.KeyValueFileWriterFactory;
 import org.apache.paimon.mergetree.MergeSorter;
 import org.apache.paimon.mergetree.SortedRun;
@@ -48,7 +48,7 @@ public class FullChangelogMergeTreeCompactRewriter extends ChangelogMergeTreeRew
     public FullChangelogMergeTreeCompactRewriter(
             int maxLevel,
             CoreOptions.MergeEngine mergeEngine,
-            KeyValueFileReaderFactory readerFactory,
+            FileReaderFactory<KeyValue> readerFactory,
             KeyValueFileWriterFactory writerFactory,
             Comparator<InternalRow> keyComparator,
             @Nullable FieldsComparator userDefinedSeqComparator,

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupMergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupMergeTreeCompactRewriter.java
@@ -24,7 +24,7 @@ import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.deletionvectors.DeletionVectorsMaintainer;
 import org.apache.paimon.io.DataFileMeta;
-import org.apache.paimon.io.KeyValueFileReaderFactory;
+import org.apache.paimon.io.FileReaderFactory;
 import org.apache.paimon.io.KeyValueFileWriterFactory;
 import org.apache.paimon.lookup.LookupStrategy;
 import org.apache.paimon.mergetree.LookupLevels;
@@ -58,7 +58,7 @@ public class LookupMergeTreeCompactRewriter<T> extends ChangelogMergeTreeRewrite
             int maxLevel,
             MergeEngine mergeEngine,
             LookupLevels<T> lookupLevels,
-            KeyValueFileReaderFactory readerFactory,
+            FileReaderFactory<KeyValue> readerFactory,
             KeyValueFileWriterFactory writerFactory,
             Comparator<InternalRow> keyComparator,
             @Nullable FieldsComparator userDefinedSeqComparator,

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
@@ -22,7 +22,7 @@ import org.apache.paimon.KeyValue;
 import org.apache.paimon.compact.CompactResult;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileMeta;
-import org.apache.paimon.io.KeyValueFileReaderFactory;
+import org.apache.paimon.io.FileReaderFactory;
 import org.apache.paimon.io.KeyValueFileWriterFactory;
 import org.apache.paimon.io.RollingFileWriter;
 import org.apache.paimon.mergetree.DropDeleteReader;
@@ -42,7 +42,7 @@ import java.util.List;
 /** Default {@link CompactRewriter} for merge trees. */
 public class MergeTreeCompactRewriter extends AbstractCompactRewriter {
 
-    protected final KeyValueFileReaderFactory readerFactory;
+    protected final FileReaderFactory<KeyValue> readerFactory;
     protected final KeyValueFileWriterFactory writerFactory;
     protected final Comparator<InternalRow> keyComparator;
     @Nullable protected final FieldsComparator userDefinedSeqComparator;
@@ -50,7 +50,7 @@ public class MergeTreeCompactRewriter extends AbstractCompactRewriter {
     protected final MergeSorter mergeSorter;
 
     public MergeTreeCompactRewriter(
-            KeyValueFileReaderFactory readerFactory,
+            FileReaderFactory<KeyValue> readerFactory,
             KeyValueFileWriterFactory writerFactory,
             Comparator<InternalRow> keyComparator,
             @Nullable FieldsComparator userDefinedSeqComparator,

--- a/paimon-core/src/test/java/org/apache/paimon/table/RecordLevelExpireTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/RecordLevelExpireTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.PrimaryKeyTableTestBase;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.options.Options;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RecordLevelExpireTest extends PrimaryKeyTableTestBase {
+
+    @Override
+    protected Options tableOptions() {
+        Options options = new Options();
+        options.set(CoreOptions.BUCKET, 1);
+        options.set(CoreOptions.RECORD_LEVEL_EXPIRE_TIME, Duration.ofSeconds(1));
+        options.set(CoreOptions.RECORD_LEVEL_TIME_FIELD, "col1");
+        return options;
+    }
+
+    @Test
+    public void test() throws Exception {
+        writeCommit(GenericRow.of(1, 1, 1), GenericRow.of(1, 2, 2));
+
+        // can be queried
+        assertThat(query())
+                .containsExactlyInAnyOrder(GenericRow.of(1, 1, 1), GenericRow.of(1, 2, 2));
+
+        int currentSecs = (int) (System.currentTimeMillis() / 1000);
+        writeCommit(GenericRow.of(1, 3, currentSecs));
+        writeCommit(GenericRow.of(1, 4, currentSecs + 60 * 60));
+        Thread.sleep(2000);
+
+        // no compaction, can be queried
+        assertThat(query())
+                .containsExactlyInAnyOrder(
+                        GenericRow.of(1, 1, 1),
+                        GenericRow.of(1, 2, 2),
+                        GenericRow.of(1, 3, currentSecs),
+                        GenericRow.of(1, 4, currentSecs + 60 * 60));
+
+        // compact, expired
+        compact(1);
+        assertThat(query()).containsExactlyInAnyOrder(GenericRow.of(1, 4, currentSecs + 60 * 60));
+        assertThat(query(new int[] {2}))
+                .containsExactlyInAnyOrder(GenericRow.of(currentSecs + 60 * 60));
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In compaction, you can configure record-Level expire time to expire records, you should configure:
1. `'record-level.expire-time'`: time retain for records.
2. `'record-level.time-field'`: time field for record level expire, it should be a seconds INT.

Expiration happens in compaction, and there is no strong guarantee to expire records in time.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
