### PR TITLE
[spark] Delete supports all merge engines

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -41,7 +41,7 @@ import org.apache.paimon.table.sink.CommitMessageSerializer;
 import org.apache.paimon.table.sink.CompactionTaskSerializer;
 import org.apache.paimon.table.sink.TableCommitImpl;
 import org.apache.paimon.table.source.DataSplit;
-import org.apache.paimon.table.source.InnerTableScan;
+import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.ParameterUtils;
 import org.apache.paimon.utils.SerializationUtils;
@@ -221,13 +221,13 @@ public class CompactProcedure extends BaseProcedure {
 
     private void compactAwareBucketTable(
             FileStoreTable table, @Nullable Predicate filter, JavaSparkContext javaSparkContext) {
-        InnerTableScan scan = table.newScan();
+        SnapshotReader snapshotReader = table.newSnapshotReader();
         if (filter != null) {
-            scan.withFilter(filter);
+            snapshotReader.withFilter(filter);
         }
 
         List<Pair<byte[], Integer>> partitionBuckets =
-                scan.plan().splits().stream()
+                snapshotReader.read().splits().stream()
                         .map(split -> (DataSplit) split)
                         .map(dataSplit -> Pair.of(dataSplit.partition(), dataSplit.bucket()))
                         .distinct()

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/RowLevelOp.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/RowLevelOp.scala
@@ -46,7 +46,11 @@ sealed trait RowLevelOp {
 
 case object Delete extends RowLevelOp {
 
-  override val supportedMergeEngine: Seq[MergeEngine] = Seq(MergeEngine.DEDUPLICATE)
+  override val supportedMergeEngine: Seq[MergeEngine] = Seq(
+    MergeEngine.DEDUPLICATE,
+    MergeEngine.PARTIAL_UPDATE,
+    MergeEngine.AGGREGATE,
+    MergeEngine.FIRST_ROW)
 
   override val supportAppendOnlyTable: Boolean = true
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
@@ -118,7 +118,7 @@ trait PaimonCommand extends WithFileStoreTable with ExpressionHelper {
     for (split <- candidateDataSplits) {
       if (!split.rawConvertible()) {
         throw new IllegalArgumentException(
-          "Only compacted table can generate touched files, please use 'COMPACT' procedure.");
+          "Only compacted table can generate touched files, please use 'COMPACT' procedure first.");
       }
     }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.spark.commands
 
+import org.apache.paimon.CoreOptions
+import org.apache.paimon.CoreOptions.WRITE_ONLY
 import org.apache.paimon.index.BucketAssigner
 import org.apache.paimon.spark.SparkRow
 import org.apache.paimon.spark.SparkUtils.createIOManager
@@ -32,6 +34,8 @@ import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 import org.apache.spark.sql.functions._
 
 import java.io.IOException
+import java.util.Collections
+import java.util.Collections.singletonMap
 
 import scala.collection.JavaConverters._
 
@@ -53,6 +57,10 @@ case class PaimonSparkWriter(table: FileStoreTable) {
   private lazy val serializer = new CommitMessageSerializer
 
   val writeBuilder: BatchWriteBuilder = table.newBatchWriteBuilder()
+
+  def writeOnly(): PaimonSparkWriter = {
+    PaimonSparkWriter(table.copy(singletonMap(WRITE_ONLY.key(), "true")))
+  }
 
   def write(data: Dataset[_]): Seq[CommitMessage] = {
     val sparkSession = data.sparkSession

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DeleteFromTableTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DeleteFromTableTest.scala
@@ -195,7 +195,7 @@ abstract class DeleteFromTableTestBase extends PaimonSparkTestBase {
 
           if (mergeEngine != MergeEngine.DEDUPLICATE) {
             assertThatThrownBy(() => spark.sql("DELETE FROM T WHERE id = 1"))
-              .hasMessageContaining("please use 'COMPACT' procedure")
+              .hasMessageContaining("please use 'COMPACT' procedure first")
             spark.sql("CALL sys.compact(table => 'T')")
           }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Just like DELETE append table, we can DELETE compacted partial-update & agg & first-row table using COPY ON WRITE mode too.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
