### PR TITLE
[orc] Correct ORC timestamp with local zone support

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/AbstractOrcColumnVector.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/AbstractOrcColumnVector.java
@@ -64,7 +64,11 @@ public abstract class AbstractOrcColumnVector
         } else if (vector instanceof DecimalColumnVector) {
             return new OrcDecimalColumnVector((DecimalColumnVector) vector);
         } else if (vector instanceof TimestampColumnVector) {
-            return new OrcTimestampColumnVector(vector);
+            if (dataType.getTypeRoot() == DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
+                return new OrcTimestampColumnVector(vector);
+            } else {
+                return new OrcTimestampLTZColumnVector(vector);
+            }
         } else if (vector instanceof ListColumnVector) {
             return new OrcArrayColumnVector((ListColumnVector) vector, (ArrayType) dataType);
         } else if (vector instanceof StructColumnVector) {

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/OrcTimestampLTZColumnVector.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/OrcTimestampLTZColumnVector.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.orc.reader;
+
+import org.apache.paimon.data.Timestamp;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
+
+/**
+ * This column vector is used to adapt hive's TimestampColumnVector to Paimon's
+ * TimestampColumnVector for timestamp with local time zone.
+ */
+public class OrcTimestampLTZColumnVector extends AbstractOrcColumnVector
+        implements org.apache.paimon.data.columnar.TimestampColumnVector {
+
+    private final TimestampColumnVector vector;
+
+    public OrcTimestampLTZColumnVector(ColumnVector vector) {
+        super(vector);
+        this.vector = (TimestampColumnVector) vector;
+    }
+
+    @Override
+    public Timestamp getTimestamp(int i, int precision) {
+        int index = vector.isRepeating ? 0 : i;
+        return Timestamp.fromEpochMillis(vector.time[index], vector.nanos[index] % 1_000_000);
+    }
+}

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/writer/FieldWriterFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/writer/FieldWriterFactory.java
@@ -186,8 +186,9 @@ public class FieldWriterFactory implements DataTypeVisitor<FieldWriter> {
     public FieldWriter visit(LocalZonedTimestampType localZonedTimestampType) {
         return (rowId, column, getters, columnId) -> {
             Timestamp timestamp =
-                    getters.getTimestamp(columnId, localZonedTimestampType.getPrecision())
-                            .toSQLTimestamp();
+                    Timestamp.from(
+                            getters.getTimestamp(columnId, localZonedTimestampType.getPrecision())
+                                    .toInstant());
             TimestampColumnVector vector = (TimestampColumnVector) column;
             vector.set(rowId, timestamp);
         };


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
ORC should store Epoch mills for timestamp with local zone.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
