### PR TITLE
[flink][lookup] Support async refresh of lookup table

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -69,6 +69,12 @@ under the License.
             <td>Specific dynamic partition refresh interval for lookup, scan all partitions and obtain corresponding partition.</td>
         </tr>
         <tr>
+            <td><h5>lookup.refresh.async</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to refresh lookup table in an async thread.</td>
+        </tr>
+        <tr>
             <td><h5>partition.idle-time-to-done</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -75,6 +75,12 @@ under the License.
             <td>Whether to refresh lookup table in an async thread.</td>
         </tr>
         <tr>
+            <td><h5>lookup.refresh.async.pending-snapshot-count</h5></td>
+            <td style="word-wrap: break-word;">5</td>
+            <td>Integer</td>
+            <td>If the pending snapshot count exceeds the threshold, lookup operator will refresh the table in sync.</td>
+        </tr>
+        <tr>
             <td><h5>partition.idle-time-to-done</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -317,6 +317,13 @@ public class FlinkConnectorOptions {
                     .defaultValue(false)
                     .withDescription("Whether to refresh lookup table in an async thread.");
 
+    public static final ConfigOption<Integer> LOOKUP_REFRESH_ASYNC_PENDING_SNAPSHOT_COUNT =
+            ConfigOptions.key("lookup.refresh.async.pending-snapshot-count")
+                    .intType()
+                    .defaultValue(5)
+                    .withDescription(
+                            "If the pending snapshot count exceeds the threshold, lookup operator will refresh the table in sync.");
+
     public static final ConfigOption<Boolean> SINK_AUTO_TAG_FOR_SAVEPOINT =
             ConfigOptions.key("sink.savepoint.auto-tag")
                     .booleanType()

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -311,6 +311,12 @@ public class FlinkConnectorOptions {
                             "Specific dynamic partition refresh interval for lookup, "
                                     + "scan all partitions and obtain corresponding partition.");
 
+    public static final ConfigOption<Boolean> LOOKUP_REFRESH_ASYNC =
+            ConfigOptions.key("lookup.refresh.async")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether to refresh lookup table in an async thread.");
+
     public static final ConfigOption<Boolean> SINK_AUTO_TAG_FOR_SAVEPOINT =
             ConfigOptions.key("sink.savepoint.auto-tag")
                     .booleanType()

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
@@ -217,9 +217,23 @@ public abstract class FullCacheLookupTable implements LookupTable {
         return dropSequence;
     }
 
+    public void refresh(Iterator<InternalRow> input) throws IOException {
+        Predicate predicate = projectedPredicate();
+        while (input.hasNext()) {
+            InternalRow row = input.next();
+            if (refreshAsync) {
+                synchronized (lock) {
+                    refreshRow(row, predicate);
+                }
+            } else {
+                refreshRow(row, predicate);
+            }
+        }
+    }
+
     public abstract List<InternalRow> innerGet(InternalRow key) throws IOException;
 
-    public abstract void refresh(Iterator<InternalRow> input) throws IOException;
+    protected abstract void refreshRow(InternalRow row, Predicate predicate) throws IOException;
 
     @Nullable
     public Predicate projectedPredicate() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
@@ -33,6 +33,7 @@ import org.apache.paimon.reader.RecordReaderIterator;
 import org.apache.paimon.sort.BinaryExternalSortBuffer;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.ExecutorThreadFactory;
 import org.apache.paimon.utils.FieldsComparator;
 import org.apache.paimon.utils.FileIOUtils;
 import org.apache.paimon.utils.MutableObjectIterator;
@@ -53,11 +54,13 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.paimon.flink.FlinkConnectorOptions.LOOKUP_REFRESH_ASYNC;
+import static org.apache.paimon.flink.FlinkConnectorOptions.LOOKUP_REFRESH_ASYNC_PENDING_SNAPSHOT_COUNT;
 
 /** Lookup table of full cache. */
 public abstract class FullCacheLookupTable implements LookupTable {
@@ -74,12 +77,15 @@ public abstract class FullCacheLookupTable implements LookupTable {
     protected RocksDBStateFactory stateFactory;
     private final ExecutorService refreshExecutor;
     private final AtomicReference<Exception> cachedException;
+    private final int maxPendingSnapshotCount;
+    private final FileStoreTable table;
+    private Future<?> refreshFuture;
     private LookupStreamingReader reader;
     private Predicate specificPartition;
 
     public FullCacheLookupTable(Context context) {
         this.context = context;
-        FileStoreTable table = context.table;
+        this.table = context.table;
         List<String> sequenceFields = new ArrayList<>();
         if (table.primaryKeys().size() > 0) {
             sequenceFields = new CoreOptions(table.options()).sequenceField();
@@ -106,10 +112,20 @@ public abstract class FullCacheLookupTable implements LookupTable {
             this.userDefinedSeqComparator = null;
             this.appendUdsFieldNumber = 0;
         }
+
+        Options options = Options.fromMap(context.table.options());
         this.projectedType = projectedType;
-        this.refreshAsync = Options.fromMap(context.table.options()).get(LOOKUP_REFRESH_ASYNC);
-        this.refreshExecutor = this.refreshAsync ? Executors.newSingleThreadExecutor() : null;
+        this.refreshAsync = options.get(LOOKUP_REFRESH_ASYNC);
+        this.refreshExecutor =
+                this.refreshAsync
+                        ? Executors.newSingleThreadExecutor(
+                                new ExecutorThreadFactory(
+                                        String.format(
+                                                "%s-lookup-refresh",
+                                                Thread.currentThread().getName())))
+                        : null;
         this.cachedException = new AtomicReference<>();
+        this.maxPendingSnapshotCount = options.get(LOOKUP_REFRESH_ASYNC_PENDING_SNAPSHOT_COUNT);
     }
 
     @Override
@@ -163,23 +179,51 @@ public abstract class FullCacheLookupTable implements LookupTable {
 
     @Override
     public void refresh() throws Exception {
-        if (refreshAsync) {
-            try {
-                refreshExecutor.execute(
-                        () -> {
-                            try {
-                                doRefresh();
-                            } catch (Exception e) {
-                                LOG.error(
-                                        "Refresh lookup table {} failed", context.table.name(), e);
-                                cachedException.set(e);
-                            }
-                        });
-            } catch (RejectedExecutionException e) {
-                LOG.warn("Add refresh task for lookup table {} failed", context.table.name(), e);
+        Long latestSnapshotId = table.snapshotManager().latestSnapshotId();
+        Long nextSnapshotId = reader.nextSnapshotId();
+        if (latestSnapshotId != null
+                && nextSnapshotId != null
+                && latestSnapshotId - nextSnapshotId > maxPendingSnapshotCount) {
+            LOG.warn(
+                    "The latest snapshot id {} is much greater than the next snapshot id {} for {}}, "
+                            + "you may need to increase the parallelism of lookup operator.",
+                    latestSnapshotId,
+                    nextSnapshotId,
+                    maxPendingSnapshotCount);
+            if (refreshFuture != null) {
+                // Wait the previous refresh task to be finished.
+                refreshFuture.get();
             }
-        } else {
             doRefresh();
+        } else {
+            if (refreshAsync) {
+                Future<?> currentFuture = null;
+                try {
+                    currentFuture =
+                            refreshExecutor.submit(
+                                    () -> {
+                                        try {
+                                            doRefresh();
+                                        } catch (Exception e) {
+                                            LOG.error(
+                                                    "Refresh lookup table {} failed",
+                                                    context.table.name(),
+                                                    e);
+                                            cachedException.set(e);
+                                        }
+                                    });
+                } catch (RejectedExecutionException ignored) {
+                    LOG.warn(
+                            "Add refresh task for lookup table {} failed",
+                            context.table.name(),
+                            ignored);
+                }
+                if (currentFuture != null) {
+                    refreshFuture = currentFuture;
+                }
+            } else {
+                doRefresh();
+            }
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupStreamingReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupStreamingReader.java
@@ -144,4 +144,9 @@ public class LookupStreamingReader {
         }
         return reader;
     }
+
+    @Nullable
+    public Long nextSnapshotId() {
+        return scan.checkpoint();
+    }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/NoPrimaryKeyLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/NoPrimaryKeyLookupTable.java
@@ -74,21 +74,11 @@ public class NoPrimaryKeyLookupTable extends FullCacheLookupTable {
             throw new IllegalArgumentException(
                     "Append table does not support user defined sequence fields.");
         }
-
-        Predicate predicate = projectedPredicate();
-        while (incremental.hasNext()) {
-            InternalRow row = incremental.next();
-            if (refreshAsync) {
-                synchronized (lock) {
-                    refreshRow(row, predicate);
-                }
-            } else {
-                refreshRow(row, predicate);
-            }
-        }
+        super.refresh(incremental);
     }
 
-    private void refreshRow(InternalRow row, Predicate predicate) throws IOException {
+    @Override
+    protected void refreshRow(InternalRow row, Predicate predicate) throws IOException {
         joinKeyRow.replaceRow(row);
         if (row.getRowKind() == RowKind.INSERT || row.getRowKind() == RowKind.UPDATE_AFTER) {
             if (predicate == null || predicate.test(row)) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyLookupTable.java
@@ -33,7 +33,6 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 /** A {@link LookupTable} for primary key table. */
@@ -95,21 +94,7 @@ public class PrimaryKeyLookupTable extends FullCacheLookupTable {
     }
 
     @Override
-    public void refresh(Iterator<InternalRow> incremental) throws IOException {
-        Predicate predicate = projectedPredicate();
-        while (incremental.hasNext()) {
-            InternalRow row = incremental.next();
-            if (refreshAsync) {
-                synchronized (lock) {
-                    refreshRow(row, predicate);
-                }
-            } else {
-                refreshRow(row, predicate);
-            }
-        }
-    }
-
-    private void refreshRow(InternalRow row, Predicate predicate) throws IOException {
+    protected void refreshRow(InternalRow row, Predicate predicate) throws IOException {
         primaryKeyRow.replaceRow(row);
         if (userDefinedSeqComparator != null) {
             InternalRow previous = tableState.get(primaryKeyRow);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/SecondaryIndexLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/SecondaryIndexLookupTable.java
@@ -28,7 +28,6 @@ import org.apache.paimon.utils.TypeUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 /** A {@link LookupTable} for primary key table which provides lookup by secondary key. */
@@ -74,21 +73,7 @@ public class SecondaryIndexLookupTable extends PrimaryKeyLookupTable {
     }
 
     @Override
-    public void refresh(Iterator<InternalRow> incremental) throws IOException {
-        Predicate predicate = projectedPredicate();
-        while (incremental.hasNext()) {
-            InternalRow row = incremental.next();
-            if (refreshAsync) {
-                synchronized (lock) {
-                    refreshRow(row, predicate);
-                }
-            } else {
-                refreshRow(row, predicate);
-            }
-        }
-    }
-
-    private void refreshRow(InternalRow row, Predicate predicate) throws IOException {
+    protected void refreshRow(InternalRow row, Predicate predicate) throws IOException {
         primaryKeyRow.replaceRow(row);
 
         boolean previousFetched = false;

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/LookupTableTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/LookupTableTest.java
@@ -25,6 +25,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.JoinedRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.disk.IOManagerImpl;
+import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.lookup.FullCacheLookupTable.TableBulkLoader;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.local.LocalFileIO;
@@ -37,6 +38,9 @@ import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.table.sink.BatchTableCommit;
+import org.apache.paimon.table.sink.BatchTableWrite;
+import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
@@ -47,6 +51,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
@@ -60,6 +66,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeoutException;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -594,6 +601,59 @@ public class LookupTableTest extends TableTestBase {
         result = table.get(row(-2, 2));
         assertThat(result).hasSize(1);
         assertRow(result.get(0), 22, -2);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testPKLookupTableRefreshAsync(boolean refreshAsync) throws Exception {
+        Options options = new Options();
+        options.set(FlinkConnectorOptions.LOOKUP_REFRESH_ASYNC, refreshAsync);
+        FileStoreTable storeTable = createTable(singletonList("f0"), options);
+        FullCacheLookupTable.Context context =
+                new FullCacheLookupTable.Context(
+                        storeTable,
+                        new int[] {0, 1, 2},
+                        null,
+                        null,
+                        tempDir.toFile(),
+                        singletonList("f0"));
+        table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
+        table.open();
+
+        // Batch insert 100_000 records into table store
+        BatchWriteBuilder writeBuilder = storeTable.newBatchWriteBuilder();
+        Set<Integer> insertKeys = new HashSet<>();
+        try (BatchTableWrite write = writeBuilder.newWrite()) {
+            for (int i = 1; i <= 100_000; i++) {
+                insertKeys.add(i);
+                write.write(row(i, 11 * i, 111 * i), 0);
+            }
+            try (BatchTableCommit commit = writeBuilder.newCommit()) {
+                commit.commit(write.prepareCommit());
+            }
+        }
+
+        // Refresh lookup table
+        table.refresh();
+        Set<Integer> batchKeys = new HashSet<>();
+        long start = System.currentTimeMillis();
+        while (batchKeys.size() < 100_000) {
+            Thread.sleep(10);
+            for (int i = 1; i <= 100_000; i++) {
+                List<InternalRow> result = table.get(row(i));
+                if (!result.isEmpty()) {
+                    assertThat(result).hasSize(1);
+                    assertRow(result.get(0), i, 11 * i, 111 * i);
+                    batchKeys.add(i);
+                }
+            }
+            if (System.currentTimeMillis() - start > 30_000) {
+                throw new TimeoutException();
+            }
+        }
+        assertThat(batchKeys).isEqualTo(insertKeys);
+
+        table.close();
     }
 
     private FileStoreTable createDimTable() throws Exception {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/LookupTableTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/LookupTableTest.java
@@ -653,6 +653,19 @@ public class LookupTableTest extends TableTestBase {
         }
         assertThat(batchKeys).isEqualTo(insertKeys);
 
+        // Add 10 snapshots and refresh lookup table
+        for (int k = 0; k < 10; k++) {
+            try (BatchTableWrite write = writeBuilder.newWrite()) {
+                for (int i = 1; i <= 100; i++) {
+                    write.write(row(i, 11 * i, 111 * i), 0);
+                }
+                try (BatchTableCommit commit = writeBuilder.newCommit()) {
+                    commit.commit(write.prepareCommit());
+                }
+            }
+        }
+        table.refresh();
+
         table.close();
     }
 


### PR DESCRIPTION
### Purpose

Linked issue: close #3295 

This PR aims to add async refresh of lookup table to avoid lag in job when the lookup operator is blocked by refresh data from table store

### Tests

1. Updated existing test for refresh async in FileStoreLookupFunctionTest
2. Added LookupTableTest#testPKLookupTableRefreshAsync for refresh async

### API and Format

no

### Documentation

no
