### PR TITLE
[cdc]Add more checker for the timestamp type.

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunctionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunctionBase.java
@@ -63,6 +63,9 @@ public abstract class UpdatedDataFieldsProcessFunctionBase<I, O> extends Process
 
     private static final List<DataTypeRoot> DECIMAL_TYPES = Arrays.asList(DataTypeRoot.DECIMAL);
 
+    private static final List<DataTypeRoot> TIMESTAMP_TYPES =
+            Arrays.asList(DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE);
+
     protected UpdatedDataFieldsProcessFunctionBase(Catalog.Loader catalogLoader) {
         this.catalogLoader = catalogLoader;
     }
@@ -172,6 +175,14 @@ public abstract class UpdatedDataFieldsProcessFunctionBase<I, O> extends Process
                             && DataTypeChecks.getScale(newType) <= DataTypeChecks.getScale(oldType)
                     ? ConvertAction.IGNORE
                     : ConvertAction.CONVERT;
+        }
+
+        oldIdx = TIMESTAMP_TYPES.indexOf(oldType.getTypeRoot());
+        newIdx = TIMESTAMP_TYPES.indexOf(newType.getTypeRoot());
+        if (oldIdx >= 0 && newIdx >= 0) {
+            return DataTypeChecks.getPrecision(oldType) <= DataTypeChecks.getPrecision(newType)
+                    ? ConvertAction.CONVERT
+                    : ConvertAction.IGNORE;
         }
 
         return ConvertAction.EXCEPTION;

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunctionBaseTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunctionBaseTest.java
@@ -22,6 +22,7 @@ import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.SmallIntType;
+import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.VarCharType;
 
 import org.junit.Assert;
@@ -75,6 +76,24 @@ public class UpdatedDataFieldsProcessFunctionBaseTest {
         Assert.assertEquals(
                 UpdatedDataFieldsProcessFunctionBase.ConvertAction.CONVERT, convertAction);
         convertAction = UpdatedDataFieldsProcessFunctionBase.canConvert(oldType, smallerRangeType);
+
+        Assert.assertEquals(
+                UpdatedDataFieldsProcessFunctionBase.ConvertAction.IGNORE, convertAction);
+    }
+
+    @Test
+    public void testCanConvertTimestamp() {
+        TimestampType oldType = new TimestampType(true, 3);
+        TimestampType biggerLengthTimestamp = new TimestampType(true, 5);
+        TimestampType smallerLengthTimestamp = new TimestampType(true, 2);
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction = null;
+        convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(oldType, biggerLengthTimestamp);
+        Assert.assertEquals(
+                UpdatedDataFieldsProcessFunctionBase.ConvertAction.CONVERT, convertAction);
+        convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(oldType, smallerLengthTimestamp);
 
         Assert.assertEquals(
                 UpdatedDataFieldsProcessFunctionBase.ConvertAction.IGNORE, convertAction);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
schemaCompatible checks support timestamp types

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
