### PR TITLE
[cdc]Fixed When the order of the same field differs, it is considered a schema change.

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/RichEventParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/RichEventParser.java
@@ -45,12 +45,27 @@ public class RichEventParser implements EventParser<RichCdcRecord> {
                 .forEach(
                         dataField -> {
                             DataField previous = previousDataFields.get(dataField.name());
-                            if (!Objects.equals(previous, dataField)) {
+                            // When the order of the same field is different, its ID may also be
+                            // different,
+                            // so the comparison should not include the ID.
+                            if (!dataFieldEqualsIgnoreId(previous, dataField)) {
                                 previousDataFields.put(dataField.name(), dataField);
                                 change.add(dataField);
                             }
                         });
         return change;
+    }
+
+    private boolean dataFieldEqualsIgnoreId(DataField dataField1, DataField dataField2) {
+        if (dataField1 == dataField2) {
+            return true;
+        } else if (dataField1 != null && dataField2 != null) {
+            return Objects.equals(dataField1.name(), dataField2.name())
+                    && Objects.equals(dataField1.type(), dataField2.type())
+                    && Objects.equals(dataField1.description(), dataField2.description());
+        } else {
+            return false;
+        }
     }
 
     @Override


### PR DESCRIPTION
… a schema change.

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

When the order of the same field varies, it is regarded as a schema change. Consequently, the Schema Evolution node receives a large volume of records, impacting performance.

So when comparing, it's necessary to ignore the ID of the field.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
