### PR TITLE
[flink] Introduce partition mark done

### DIFF
--- a/docs/content/flink/sql-write.md
+++ b/docs/content/flink/sql-write.md
@@ -206,3 +206,33 @@ DELETE FROM my_table WHERE currency = 'UNKNOWN';
 {{< /tab >}}
 
 {{< /tabs >}}
+
+## Partition Mark Done
+
+For partitioned tables, each partition may need to be scheduled to trigger downstream batch computation. Therefore,
+it is necessary to choose this timing to indicate that it is ready for scheduling and to minimize the amount of data
+drift during scheduling. We call this process: "Partition Mark Done".
+
+Example to mark done:
+```sql
+CREATE TABLE my_partitioned_table (
+    f0 INT,
+    f1 INT,
+    f2 INT,
+    ...
+    dt STRING
+) PARTITIONED BY (dt) WITH (
+    'partition.timestamp-formatter'='yyyyMMdd',
+    'partition.timestamp-pattern'='$dt',
+    'partition.time-interval'='1 d',
+    'partition.idle-time-to-done'='15 m'
+);
+```
+
+1. Firstly, you need to define the time parser of the partition and the time interval between partitions in order to
+   determine when the partition can be properly marked done.
+2. Secondly, you need to define idle-time, which determines how long it takes for the partition to have no new data,
+   and then it will be marked as done.
+3. Thirdly, by default, partition mark done will create _SUCCESS file, the content of _SUCCESS file is a json, contains
+   `creationTime` and `modificationTime`, they can help you understand if there is any delayed data. You can also
+   configure other actions.

--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -69,6 +69,24 @@ under the License.
             <td>Specific dynamic partition refresh interval for lookup, scan all partitions and obtain corresponding partition.</td>
         </tr>
         <tr>
+            <td><h5>partition.idle-time-to-done</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>Set a time duration when a partition has no new data after this time duration, mark the done status to indicate that the data is ready.</td>
+        </tr>
+        <tr>
+            <td><h5>partition.mark-done-action</h5></td>
+            <td style="word-wrap: break-word;">"success-file"</td>
+            <td>String</td>
+            <td>Action to mark a partition done is to notify the downstream application that the partition has finished writing, the partition is ready to be read.<br />1. 'success-file': add '_success' file to directory.<br />2. 'done-partition': add 'xxx.done' partition to metastore.<br />Both can be configured at the same time: 'done-partition,success-file'.</td>
+        </tr>
+        <tr>
+            <td><h5>partition.time-interval</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>You can specify time interval for partition, for example, daily partition is '1 d', hourly partition is '1 h'.</td>
+        </tr>
+        <tr>
             <td><h5>scan.infer-parallelism</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/paimon-common/src/main/java/org/apache/paimon/utils/IOUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/IOUtils.java
@@ -21,10 +21,13 @@ package org.apache.paimon.utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 import static java.util.Arrays.asList;
 
@@ -123,6 +126,17 @@ public final class IOUtils {
             toRead -= ret;
             off += ret;
         }
+    }
+
+    public static String readUTF8Fully(final InputStream in) throws IOException {
+        BufferedReader reader =
+                new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+        StringBuilder builder = new StringBuilder();
+        String line;
+        while ((line = reader.readLine()) != null) {
+            builder.append(line);
+        }
+        return builder.toString();
     }
 
     // ------------------------------------------------------------------------

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionTimeExtractor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionTimeExtractor.java
@@ -34,6 +34,8 @@ import java.time.format.DateTimeParseException;
 import java.time.format.ResolverStyle;
 import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -90,7 +92,11 @@ public class PartitionTimeExtractor {
         this.formatter = formatter;
     }
 
-    public LocalDateTime extract(List<String> partitionKeys, List<Object> partitionValues) {
+    public LocalDateTime extract(LinkedHashMap<String, String> spec) {
+        return extract(new ArrayList<>(spec.keySet()), new ArrayList<>(spec.values()));
+    }
+
+    public LocalDateTime extract(List<String> partitionKeys, List<?> partitionValues) {
         LocalDateTime dateTime = null;
         try {
             String timestampString;

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
@@ -153,7 +153,7 @@ public class FlinkCdcMultiTableSink implements Serializable {
         // commit new files list even if they're empty.
         // Otherwise we can't tell if the commit is successful after
         // a restart.
-        return (user, metricGroup) -> new StoreMultiCommitter(catalogLoader, user, metricGroup);
+        return context -> new StoreMultiCommitter(catalogLoader, context);
     }
 
     protected CommittableStateManager<WrappedManifestCommittable> createCommittableStateManager() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -339,6 +339,41 @@ public class FlinkConnectorOptions {
                     .withDescription(
                             "Allow sink committer and writer operator to be chained together");
 
+    public static final ConfigOption<Duration> PARTITION_IDLE_TIME_TO_DONE =
+            key("partition.idle-time-to-done")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Set a time duration when a partition has no new data after this time duration, "
+                                    + "mark the done status to indicate that the data is ready.");
+
+    public static final ConfigOption<Duration> PARTITION_TIME_INTERVAL =
+            key("partition.time-interval")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "You can specify time interval for partition, for example, "
+                                    + "daily partition is '1 d', hourly partition is '1 h'.");
+
+    public static final ConfigOption<String> PARTITION_MARK_DONE_ACTION =
+            key("partition.mark-done-action")
+                    .stringType()
+                    .defaultValue("success-file")
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Action to mark a partition done is to notify the downstream application that the partition"
+                                                    + " has finished writing, the partition is ready to be read.")
+                                    .linebreak()
+                                    .text("1. 'success-file': add '_success' file to directory.")
+                                    .linebreak()
+                                    .text(
+                                            "2. 'done-partition': add 'xxx.done' partition to metastore.")
+                                    .linebreak()
+                                    .text(
+                                            "Both can be configured at the same time: 'done-partition,success-file'.")
+                                    .build());
+
     public static List<ConfigOption<?>> getOptions() {
         final Field[] fields = FlinkConnectorOptions.class.getFields();
         final List<ConfigOption<?>> list = new ArrayList<>(fields.length);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
@@ -18,7 +18,10 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.flink.api.common.state.OperatorStateStore;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -57,7 +60,55 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
     /** Factory to create {@link Committer}. */
     interface Factory<CommitT, GlobalCommitT> extends Serializable {
 
-        Committer<CommitT, GlobalCommitT> create(
-                String commitUser, OperatorMetricGroup metricGroup);
+        Committer<CommitT, GlobalCommitT> create(Context context);
+    }
+
+    /** Context to create {@link Committer}. */
+    interface Context {
+
+        String commitUser();
+
+        @Nullable
+        OperatorMetricGroup metricGroup();
+
+        boolean streamingCheckpointEnabled();
+
+        boolean isRestored();
+
+        OperatorStateStore stateStore();
+    }
+
+    static Context createContext(
+            String commitUser,
+            @Nullable OperatorMetricGroup metricGroup,
+            boolean streamingCheckpointEnabled,
+            boolean isRestored,
+            OperatorStateStore stateStore) {
+        return new Committer.Context() {
+            @Override
+            public String commitUser() {
+                return commitUser;
+            }
+
+            @Override
+            public OperatorMetricGroup metricGroup() {
+                return metricGroup;
+            }
+
+            @Override
+            public boolean streamingCheckpointEnabled() {
+                return streamingCheckpointEnabled;
+            }
+
+            @Override
+            public boolean isRestored() {
+                return isRestored;
+            }
+
+            @Override
+            public OperatorStateStore stateStore() {
+                return stateStore;
+            }
+        };
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
@@ -119,7 +119,14 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
                 StateUtils.getSingleValueFromState(
                         context, "commit_user_state", String.class, initialCommitUser);
         // parallelism of commit operator is always 1, so commitUser will never be null
-        committer = committerFactory.create(commitUser, getMetricGroup());
+        committer =
+                committerFactory.create(
+                        Committer.createContext(
+                                commitUser,
+                                getMetricGroup(),
+                                streamingCheckpointEnabled,
+                                context.isRestored(),
+                                context.getOperatorStateStore()));
 
         committableStateManager.initializeState(context, committer);
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSink.java
@@ -40,9 +40,8 @@ public class CompactorSink extends FlinkSink<RowData> {
     }
 
     @Override
-    protected Committer.Factory<Committable, ManifestCommittable> createCommitterFactory(
-            boolean streamingCheckpointEnabled) {
-        return (user, metricGroup) -> new StoreCommitter(table.newCommit(user), metricGroup);
+    protected Committer.Factory<Committable, ManifestCommittable> createCommitterFactory() {
+        return context -> new StoreCommitter(table, table.newCommit(context.commitUser()), context);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -233,7 +233,7 @@ public abstract class FlinkSink<T> implements Serializable {
                         true,
                         options.get(SINK_COMMITTER_OPERATOR_CHAINING),
                         commitUser,
-                        createCommitterFactory(streamingCheckpointEnabled),
+                        createCommitterFactory(),
                         createCommittableStateManager());
         if (options.get(SINK_AUTO_TAG_FOR_SAVEPOINT)) {
             committerOperator =
@@ -310,8 +310,7 @@ public abstract class FlinkSink<T> implements Serializable {
     protected abstract OneInputStreamOperator<T, Committable> createWriteOperator(
             StoreSinkWrite.Provider writeProvider, String commitUser);
 
-    protected abstract Committer.Factory<Committable, ManifestCommittable> createCommitterFactory(
-            boolean streamingCheckpointEnabled);
+    protected abstract Committer.Factory<Committable, ManifestCommittable> createCommitterFactory();
 
     protected abstract CommittableStateManager<ManifestCommittable> createCommittableStateManager();
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkWriteSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkWriteSink.java
@@ -40,18 +40,18 @@ public abstract class FlinkWriteSink<T> extends FlinkSink<T> {
     }
 
     @Override
-    protected Committer.Factory<Committable, ManifestCommittable> createCommitterFactory(
-            boolean streamingCheckpointEnabled) {
+    protected Committer.Factory<Committable, ManifestCommittable> createCommitterFactory() {
         // If checkpoint is enabled for streaming job, we have to
         // commit new files list even if they're empty.
         // Otherwise we can't tell if the commit is successful after
         // a restart.
-        return (user, metricGroup) ->
+        return context ->
                 new StoreCommitter(
-                        table.newCommit(user)
+                        table,
+                        table.newCommit(context.commitUser())
                                 .withOverwrite(overwritePartition)
-                                .ignoreEmptyCommit(!streamingCheckpointEnabled),
-                        metricGroup);
+                                .ignoreEmptyCommit(!context.streamingCheckpointEnabled()),
+                        context);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesCompactorSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesCompactorSink.java
@@ -153,8 +153,7 @@ public class MultiTablesCompactorSink implements Serializable {
             createCommitterFactory() {
         Map<String, String> dynamicOptions = options.toMap();
         dynamicOptions.put(CoreOptions.WRITE_ONLY.key(), "false");
-        return (user, metricGroup) ->
-                new StoreMultiCommitter(catalogLoader, user, metricGroup, true, dynamicOptions);
+        return context -> new StoreMultiCommitter(catalogLoader, context, true, dynamicOptions);
     }
 
     protected CommittableStateManager<WrappedManifestCommittable> createCommittableStateManager() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketCompactionSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketCompactionSink.java
@@ -48,9 +48,8 @@ public class UnawareBucketCompactionSink extends FlinkSink<AppendOnlyCompactionT
     }
 
     @Override
-    protected Committer.Factory<Committable, ManifestCommittable> createCommitterFactory(
-            boolean streamingCheckpointEnabled) {
-        return (s, metricGroup) -> new StoreCommitter(table.newCommit(s), metricGroup);
+    protected Committer.Factory<Committable, ManifestCommittable> createCommitterFactory() {
+        return context -> new StoreCommitter(table, table.newCommit(context.commitUser()), context);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/AddDonePartitionAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/AddDonePartitionAction.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.partition;
+
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.metastore.MetastoreClient;
+
+import org.apache.paimon.shade.guava30.com.google.common.collect.Iterators;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map.Entry;
+
+import static org.apache.paimon.utils.PartitionPathUtils.extractPartitionSpecFromPath;
+
+/** A {@link PartitionMarkDoneAction} which add ".done" partition. */
+public class AddDonePartitionAction implements PartitionMarkDoneAction {
+
+    private final MetastoreClient metastoreClient;
+
+    public AddDonePartitionAction(MetastoreClient metastoreClient) {
+        this.metastoreClient = metastoreClient;
+    }
+
+    @Override
+    public void markDone(String partition) throws Exception {
+        LinkedHashMap<String, String> doneSpec = extractPartitionSpecFromPath(new Path(partition));
+        Entry<String, String> lastField = tailEntry(doneSpec);
+        doneSpec.put(lastField.getKey(), lastField.getValue() + ".done");
+        metastoreClient.addPartition(doneSpec);
+    }
+
+    private Entry<String, String> tailEntry(LinkedHashMap<String, String> partitionSpec) {
+        return Iterators.getLast(partitionSpec.entrySet().iterator());
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            metastoreClient.close();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionMarkDone.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionMarkDone.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.partition;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.manifest.ManifestCommittable;
+import org.apache.paimon.metastore.MetastoreClient;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.partition.PartitionTimeExtractor;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.utils.RowDataPartitionComputer;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.OperatorStateStore;
+import org.apache.flink.api.common.typeutils.base.ListSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.table.utils.PartitionPathUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.CoreOptions.METASTORE_PARTITIONED_TABLE;
+import static org.apache.paimon.flink.FlinkConnectorOptions.PARTITION_IDLE_TIME_TO_DONE;
+import static org.apache.paimon.flink.FlinkConnectorOptions.PARTITION_MARK_DONE_ACTION;
+import static org.apache.paimon.flink.FlinkConnectorOptions.PARTITION_TIME_INTERVAL;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.Preconditions.checkNotNull;
+
+/** Mark partition done. */
+public class PartitionMarkDone implements Closeable {
+
+    private static final ListStateDescriptor<List<String>> PENDING_PARTITIONS_STATE_DESC =
+            new ListStateDescriptor<>(
+                    "mark-done-pending-partitions",
+                    new ListSerializer<>(StringSerializer.INSTANCE));
+
+    private final RowDataPartitionComputer partitionComputer;
+    private final PartitionMarkDoneTrigger trigger;
+    private final List<PartitionMarkDoneAction> actions;
+
+    @Nullable
+    public static PartitionMarkDone create(
+            boolean isStreaming,
+            boolean isRestored,
+            OperatorStateStore stateStore,
+            FileStoreTable table)
+            throws Exception {
+        if (!isStreaming) {
+            return null;
+        }
+
+        List<String> partitionKeys = table.partitionKeys();
+        if (partitionKeys.isEmpty()) {
+            return null;
+        }
+
+        CoreOptions coreOptions = table.coreOptions();
+        Options options = coreOptions.toConfiguration();
+
+        Duration idleToDone = options.get(PARTITION_IDLE_TIME_TO_DONE);
+        if (idleToDone == null) {
+            return null;
+        }
+
+        MetastoreClient.Factory metastoreClientFactory =
+                table.catalogEnvironment().metastoreClientFactory();
+        checkNotNull(
+                metastoreClientFactory, "Cannot mark done partition for table without metastore.");
+        checkArgument(
+                coreOptions.partitionedTableInMetastore(),
+                "Table should enable %s",
+                METASTORE_PARTITIONED_TABLE.key());
+
+        RowDataPartitionComputer partitionComputer =
+                new RowDataPartitionComputer(
+                        coreOptions.partitionDefaultName(),
+                        table.schema().logicalPartitionType(),
+                        partitionKeys.toArray(new String[0]));
+
+        PartitionMarkDoneTrigger trigger =
+                new PartitionMarkDoneTrigger(
+                        new PartitionMarkDoneTriggerState(isRestored, stateStore),
+                        new PartitionTimeExtractor(
+                                coreOptions.partitionTimestampPattern(),
+                                coreOptions.partitionTimestampFormatter()),
+                        options.get(PARTITION_TIME_INTERVAL),
+                        idleToDone);
+
+        List<PartitionMarkDoneAction> actions =
+                Arrays.asList(options.get(PARTITION_MARK_DONE_ACTION).split(",")).stream()
+                        .map(
+                                action -> {
+                                    switch (action) {
+                                        case "success-file":
+                                            return new SuccessFileMarkDoneAction(
+                                                    table.fileIO(), table.location());
+                                        case "done-partition":
+                                            return new AddDonePartitionAction(
+                                                    metastoreClientFactory.create());
+                                        default:
+                                            throw new UnsupportedOperationException(action);
+                                    }
+                                })
+                        .collect(Collectors.toList());
+
+        return new PartitionMarkDone(partitionComputer, trigger, actions);
+    }
+
+    public PartitionMarkDone(
+            RowDataPartitionComputer partitionComputer,
+            PartitionMarkDoneTrigger trigger,
+            List<PartitionMarkDoneAction> actions) {
+        this.partitionComputer = partitionComputer;
+        this.trigger = trigger;
+        this.actions = actions;
+    }
+
+    public void notifyCommittable(List<ManifestCommittable> committables) {
+        Set<BinaryRow> partitions = new HashSet<>();
+        for (ManifestCommittable committable : committables) {
+            committable.fileCommittables().stream()
+                    .map(CommitMessage::partition)
+                    .forEach(partitions::add);
+        }
+
+        partitions.stream()
+                .map(partitionComputer::generatePartValues)
+                .map(PartitionPathUtils::generatePartitionPath)
+                .forEach(trigger::notifyPartition);
+
+        for (String partition : trigger.donePartitions()) {
+            try {
+                for (PartitionMarkDoneAction action : actions) {
+                    action.markDone(partition);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public void snapshotState() throws Exception {
+        trigger.snapshotState();
+    }
+
+    @Override
+    public void close() throws IOException {
+        for (PartitionMarkDoneAction action : actions) {
+            action.close();
+        }
+    }
+
+    private static class PartitionMarkDoneTriggerState implements PartitionMarkDoneTrigger.State {
+
+        private final boolean isRestored;
+        private final ListState<List<String>> pendingPartitionsState;
+
+        private PartitionMarkDoneTriggerState(boolean isRestored, OperatorStateStore stateStore)
+                throws Exception {
+            this.isRestored = isRestored;
+            this.pendingPartitionsState = stateStore.getListState(PENDING_PARTITIONS_STATE_DESC);
+        }
+
+        @Override
+        public List<String> restore() throws Exception {
+            List<String> pendingPartitions = new ArrayList<>();
+            if (isRestored) {
+                pendingPartitions.addAll(pendingPartitionsState.get().iterator().next());
+            }
+            return pendingPartitions;
+        }
+
+        @Override
+        public void update(List<String> partitions) throws Exception {
+            pendingPartitionsState.update(Collections.singletonList(partitions));
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionMarkDoneAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionMarkDoneAction.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.partition;
+
+import java.io.Closeable;
+
+/** Action to mark partitions done. */
+public interface PartitionMarkDoneAction extends Closeable {
+
+    void markDone(String partition) throws Exception;
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionMarkDoneTrigger.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionMarkDoneTrigger.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.partition;
+
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.partition.PartitionTimeExtractor;
+import org.apache.paimon.utils.StringUtils;
+
+import java.time.Duration;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.paimon.utils.PartitionPathUtils.extractPartitionSpecFromPath;
+
+/** Trigger to mark partitions done. */
+public class PartitionMarkDoneTrigger {
+
+    private final State state;
+    private final PartitionTimeExtractor timeExtractor;
+    private final long timeInternal;
+    private final long idleTime;
+    private final Map<String, Long> pendingPartitions;
+
+    public PartitionMarkDoneTrigger(
+            State state,
+            PartitionTimeExtractor timeExtractor,
+            Duration timeInternal,
+            Duration idleTime)
+            throws Exception {
+        this(state, timeExtractor, timeInternal, idleTime, System.currentTimeMillis());
+    }
+
+    PartitionMarkDoneTrigger(
+            State state,
+            PartitionTimeExtractor timeExtractor,
+            Duration timeInternal,
+            Duration idleTime,
+            long currentTimeMillis)
+            throws Exception {
+        this.state = state;
+        this.timeExtractor = timeExtractor;
+        this.timeInternal = timeInternal.toMillis();
+        this.idleTime = idleTime.toMillis();
+        this.pendingPartitions = new HashMap<>();
+        state.restore().forEach(p -> pendingPartitions.put(p, currentTimeMillis));
+    }
+
+    public void notifyPartition(String partition) {
+        notifyPartition(partition, System.currentTimeMillis());
+    }
+
+    void notifyPartition(String partition, long currentTimeMillis) {
+        if (!StringUtils.isNullOrWhitespaceOnly(partition)) {
+            this.pendingPartitions.put(partition, currentTimeMillis);
+        }
+    }
+
+    public List<String> donePartitions() {
+        return donePartitions(System.currentTimeMillis());
+    }
+
+    public List<String> donePartitions(long currentTimeMillis) {
+        List<String> needDone = new ArrayList<>();
+        Iterator<Map.Entry<String, Long>> iter = pendingPartitions.entrySet().iterator();
+        while (iter.hasNext()) {
+            Map.Entry<String, Long> entry = iter.next();
+            String partition = entry.getKey();
+
+            long lastUpdateTime = entry.getValue();
+            long partitionStartTime =
+                    timeExtractor
+                            .extract(extractPartitionSpecFromPath(new Path(partition)))
+                            .atZone(ZoneId.systemDefault())
+                            .toInstant()
+                            .toEpochMilli();
+            long partitionEndTime = partitionStartTime + timeInternal;
+            lastUpdateTime = Math.max(lastUpdateTime, partitionEndTime);
+
+            if (currentTimeMillis - lastUpdateTime > idleTime) {
+                needDone.add(partition);
+                iter.remove();
+            }
+        }
+        return needDone;
+    }
+
+    public void snapshotState() throws Exception {
+        state.update(new ArrayList<>(pendingPartitions.keySet()));
+    }
+
+    /** State to store partitions. */
+    public interface State {
+
+        List<String> restore() throws Exception;
+
+        void update(List<String> partitions) throws Exception;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/SuccessFile.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/SuccessFile.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.partition;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.utils.JsonSerdeUtil;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Objects;
+
+/** Json represents a success file. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SuccessFile {
+
+    private static final String FIELD_CREATION_TIME = "creationTime";
+    private static final String FIELD_MODIFICATION_TIME = "modificationTime";
+
+    @JsonProperty(FIELD_CREATION_TIME)
+    private final long creationTime;
+
+    @JsonProperty(FIELD_MODIFICATION_TIME)
+    private final long modificationTime;
+
+    @JsonCreator
+    public SuccessFile(
+            @JsonProperty(FIELD_CREATION_TIME) long creationTime,
+            @JsonProperty(FIELD_MODIFICATION_TIME) long modificationTime) {
+        this.creationTime = creationTime;
+        this.modificationTime = modificationTime;
+    }
+
+    @JsonGetter(FIELD_CREATION_TIME)
+    public long creationTime() {
+        return creationTime;
+    }
+
+    @JsonGetter(FIELD_MODIFICATION_TIME)
+    public long modificationTime() {
+        return modificationTime;
+    }
+
+    public SuccessFile updateModificationTime(long modificationTime) {
+        return new SuccessFile(creationTime, modificationTime);
+    }
+
+    public String toJson() {
+        return JsonSerdeUtil.toJson(this);
+    }
+
+    public static SuccessFile fromJson(String json) {
+        return JsonSerdeUtil.fromJson(json, SuccessFile.class);
+    }
+
+    @Nullable
+    public static SuccessFile safelyFromPath(FileIO fileIO, Path path) throws IOException {
+        try {
+            String json = fileIO.readFileUtf8(path);
+            return SuccessFile.fromJson(json);
+        } catch (FileNotFoundException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SuccessFile that = (SuccessFile) o;
+        return creationTime == that.creationTime && modificationTime == that.modificationTime;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(creationTime, modificationTime);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/SuccessFileMarkDoneAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/SuccessFileMarkDoneAction.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.partition;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+
+/** A {@link PartitionMarkDoneAction} which create "_SUCCESS" file. */
+public class SuccessFileMarkDoneAction implements PartitionMarkDoneAction {
+
+    public static final String SUCCESS_FILE_NAME = "_SUCCESS";
+
+    private final FileIO fileIO;
+    private final Path tablePath;
+
+    public SuccessFileMarkDoneAction(FileIO fileIO, Path tablePath) {
+        this.fileIO = fileIO;
+        this.tablePath = tablePath;
+    }
+
+    @Override
+    public void markDone(String partition) throws Exception {
+        Path partitionPath = new Path(tablePath, partition);
+        Path successPath = new Path(partitionPath, SUCCESS_FILE_NAME);
+
+        long currentTime = System.currentTimeMillis();
+        SuccessFile successFile = SuccessFile.safelyFromPath(fileIO, successPath);
+        if (successFile == null) {
+            successFile = new SuccessFile(currentTime, currentTime);
+        } else {
+            successFile = successFile.updateModificationTime(currentTime);
+        }
+        fileIO.overwriteFileUtf8(successPath, successFile.toJson());
+    }
+
+    @Override
+    public void close() {}
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
@@ -561,7 +561,9 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
 
         StreamTableCommit commit = table.newCommit(initialCommitUser);
         OperatorMetricGroup metricGroup = UnregisteredMetricsGroup.createOperatorMetricGroup();
-        StoreCommitter committer = new StoreCommitter(commit, metricGroup);
+        StoreCommitter committer =
+                new StoreCommitter(
+                        table, commit, Committer.createContext("", metricGroup, true, false, null));
         committer.commit(Collections.singletonList(manifestCommittable));
         CommitterMetrics metrics = committer.getCommitterMetrics();
         assertThat(metrics.getNumBytesOutCounter().getCount()).isEqualTo(285);
@@ -728,10 +730,13 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
                 true,
                 true,
                 commitUser == null ? initialCommitUser : commitUser,
-                (user, metricGroup) ->
+                context ->
                         new StoreCommitter(
-                                table.newStreamWriteBuilder().withCommitUser(user).newCommit(),
-                                metricGroup),
+                                table,
+                                table.newStreamWriteBuilder()
+                                        .withCommitUser(context.commitUser())
+                                        .newCommit(),
+                                context),
                 committableStateManager);
     }
 
@@ -745,10 +750,13 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
                 true,
                 true,
                 commitUser == null ? initialCommitUser : commitUser,
-                (user, metricGroup) ->
+                context ->
                         new StoreCommitter(
-                                table.newStreamWriteBuilder().withCommitUser(user).newCommit(),
-                                metricGroup),
+                                table,
+                                table.newStreamWriteBuilder()
+                                        .withCommitUser(context.commitUser())
+                                        .newCommit(),
+                                context),
                 committableStateManager) {
             @Override
             public void initializeState(StateInitializationContext context) throws Exception {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreMultiCommitterTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreMultiCommitterTest.java
@@ -642,9 +642,7 @@ class StoreMultiCommitterTest {
                         false,
                         true,
                         initialCommitUser,
-                        (user, metricGroup) ->
-                                new StoreMultiCommitter(
-                                        catalogLoader, initialCommitUser, metricGroup),
+                        context -> new StoreMultiCommitter(catalogLoader, context),
                         new RestoreAndFailCommittableStateManager<>(
                                 () ->
                                         new VersionedSerializerWrapper<>(
@@ -660,9 +658,7 @@ class StoreMultiCommitterTest {
                         false,
                         true,
                         initialCommitUser,
-                        (user, metricGroup) ->
-                                new StoreMultiCommitter(
-                                        catalogLoader, initialCommitUser, metricGroup),
+                        context -> new StoreMultiCommitter(catalogLoader, context),
                         new CommittableStateManager<WrappedManifestCommittable>() {
                             @Override
                             public void initializeState(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/AddDonePartitionActionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/AddDonePartitionActionTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.partition;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.metastore.MetastoreClient;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.apache.paimon.utils.PartitionPathUtils.generatePartitionPath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AddDonePartitionActionTest {
+
+    @Test
+    public void test() throws Exception {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        Set<String> donePartitions = new HashSet<>();
+        MetastoreClient metastoreClient =
+                new MetastoreClient() {
+                    @Override
+                    public void addPartition(BinaryRow partition) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public void addPartition(LinkedHashMap<String, String> partitionSpec) {
+                        donePartitions.add(generatePartitionPath(partitionSpec));
+                    }
+
+                    @Override
+                    public void deletePartition(LinkedHashMap<String, String> partitionSpec) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public void close() throws Exception {
+                        closed.set(true);
+                    }
+                };
+
+        AddDonePartitionAction action = new AddDonePartitionAction(metastoreClient);
+
+        // test normal
+        action.markDone("dt=20201202");
+        assertThat(donePartitions).containsExactlyInAnyOrder("dt=20201202.done/");
+
+        // test multiple partition fields
+        action.markDone("dt=20201202/hour=02");
+        assertThat(donePartitions)
+                .containsExactlyInAnyOrder("dt=20201202.done/", "dt=20201202/hour=02.done/");
+
+        action.close();
+        assertThat(closed).isTrue();
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/PartitionMarkDoneTriggerTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/PartitionMarkDoneTriggerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.partition;
+
+import org.apache.paimon.partition.PartitionTimeExtractor;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PartitionMarkDoneTriggerTest {
+
+    @Test
+    public void test() throws Exception {
+        List<String> pendingPartitions = new ArrayList<>();
+        PartitionMarkDoneTrigger.State state =
+                new PartitionMarkDoneTrigger.State() {
+                    @Override
+                    public List<String> restore() {
+                        return new ArrayList<>(pendingPartitions);
+                    }
+
+                    @Override
+                    public void update(List<String> partitions) {
+                        pendingPartitions.clear();
+                        pendingPartitions.addAll(partitions);
+                    }
+                };
+
+        PartitionTimeExtractor extractor = new PartitionTimeExtractor("$dt", "yyyy-MM-dd");
+        Duration timeInternal = Duration.ofDays(1);
+        Duration idleTime = Duration.ofMinutes(15);
+        PartitionMarkDoneTrigger trigger =
+                new PartitionMarkDoneTrigger(
+                        state, extractor, timeInternal, idleTime, toEpochMillis("2024-02-01"));
+
+        // test not reach partition end + idle time
+        trigger.notifyPartition("dt=2024-02-02", toEpochMillis("2024-02-01"));
+        List<String> partitions = trigger.donePartitions(toEpochMillis("2024-02-03"));
+        assertThat(partitions).isEmpty();
+
+        // test state
+        assertThat(pendingPartitions).isEmpty();
+        trigger.snapshotState();
+        assertThat(pendingPartitions).containsOnly("dt=2024-02-02");
+
+        // test trigger
+        partitions = trigger.donePartitions(toEpochMillis("2024-02-03") + idleTime.toMillis());
+        assertThat(partitions).isEmpty();
+        partitions = trigger.donePartitions(toEpochMillis("2024-02-03") + idleTime.toMillis() + 1);
+        assertThat(partitions).containsOnly("dt=2024-02-02");
+
+        // test state
+        trigger.snapshotState();
+        assertThat(pendingPartitions).isEmpty();
+
+        // test refresh
+        trigger.notifyPartition("dt=2024-02-03", toEpochMillis("2024-02-03"));
+        trigger.notifyPartition("dt=2024-02-03", toEpochMillis("2024-02-04") + idleTime.toMillis());
+        partitions = trigger.donePartitions(toEpochMillis("2024-02-04") + idleTime.toMillis() + 1);
+        assertThat(partitions).isEmpty();
+        partitions =
+                trigger.donePartitions(toEpochMillis("2024-02-04") + 2 * idleTime.toMillis() + 1);
+        assertThat(partitions).containsOnly("dt=2024-02-03");
+
+        // test restore
+        pendingPartitions.add("dt=2024-02-04");
+        trigger =
+                new PartitionMarkDoneTrigger(
+                        state, extractor, timeInternal, idleTime, toEpochMillis("2024-02-06"));
+        partitions = trigger.donePartitions(toEpochMillis("2024-02-06"));
+        assertThat(partitions).isEmpty();
+        partitions = trigger.donePartitions(toEpochMillis("2024-02-06") + idleTime.toMillis() + 1);
+        assertThat(partitions).containsOnly("dt=2024-02-04");
+    }
+
+    private long toEpochMillis(String dt) {
+        return LocalDateTime.of(LocalDate.parse(dt), LocalTime.MIN)
+                .atZone(ZoneId.systemDefault())
+                .toInstant()
+                .toEpochMilli();
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/SuccessFileMarkDoneActionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/SuccessFileMarkDoneActionTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.partition;
+
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SuccessFileMarkDoneActionTest {
+
+    @TempDir
+    java.nio.file.Path temp;
+
+    @Test
+    public void test() throws Exception {
+        LocalFileIO fileIO = new LocalFileIO();
+        Path path = new Path(temp.toUri());
+        SuccessFileMarkDoneAction action = new SuccessFileMarkDoneAction(fileIO, path);
+        Path successPath = new Path(path, "dt=20240513/_SUCCESS");
+
+        action.markDone("dt=20240513");
+        SuccessFile successFile1 = SuccessFile.safelyFromPath(fileIO, successPath);
+        assertThat(successFile1).isNotNull();
+
+        Thread.sleep(100);
+        action.markDone("dt=20240513");
+        SuccessFile successFile2 = SuccessFile.safelyFromPath(fileIO, successPath);
+        assertThat(successFile2).isNotNull();
+
+        assertThat(successFile1.creationTime() == successFile2.creationTime()).isTrue();
+        assertThat(successFile1.modificationTime() < successFile2.modificationTime()).isTrue();
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/SuccessFileMarkDoneActionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/SuccessFileMarkDoneActionTest.java
@@ -28,8 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class SuccessFileMarkDoneActionTest {
 
-    @TempDir
-    java.nio.file.Path temp;
+    @TempDir java.nio.file.Path temp;
 
     @Test
     public void test() throws Exception {

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -27,7 +27,6 @@ import org.apache.paimon.hive.annotation.Minio;
 import org.apache.paimon.hive.runner.PaimonEmbeddedHiveRunner;
 import org.apache.paimon.privilege.NoPrivilegeException;
 import org.apache.paimon.s3.MinioTestContainer;
-import org.apache.paimon.utils.FileUtils;
 import org.apache.paimon.utils.IOUtils;
 
 import com.klarna.hiverunner.HiveShell;
@@ -57,13 +56,10 @@ import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.Statement;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

This PR is intended to support a mechanism for marking a partition as finished and subsequently pulling up offline scheduling jobs.

Unlike Flink's Filesystem (which came from my younger self), this uses a "mark partition as finished if there is no new data for a certain amount of time" approach, which is currently only supported for system time, but can be extended to include a watermark approach.

Another question is how to mark the end of the partition, there are several options:
1. create a xx.done partition
2. create a _SUCCESS file
3. or other

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

For partitioned tables, each partition may need to be scheduled to trigger downstream batch computation. Therefore,
it is necessary to choose this timing to indicate that it is ready for scheduling and to minimize the amount of data
drift during scheduling. We call this process: "Partition Mark Done".

Example to mark done:
```sql
CREATE TABLE my_partitioned_table (
    f0 INT,
    f1 INT,
    f2 INT,
    ...
    dt STRING
) PARTITIONED BY (dt) WITH (
    'partition.timestamp-formatter'='yyyyMMdd',
    'partition.timestamp-pattern'='$dt',
    'partition.time-interval'='1 d',
    'partition.idle-time-to-done'='15 m'
);
```

1. Firstly, you need to define the time parser of the partition and the time interval between partitions in order to
   determine when the partition can be properly marked done.
2. Secondly, you need to define idle-time, which determines how long it takes for the partition to have no new data,
   and then it will be marked as done.
3. Thirdly, by default, partition mark done will create _SUCCESS file, the content of _SUCCESS file is a json, contains
   `creationTime` and `modificationTime`, they can help you understand if there is any delayed data. You can also
   configure other actions.
