### PR TITLE
[doc] Add more previous version docs

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -70,6 +70,9 @@ pygmentsUseClasses = true
     ["master", "https://paimon.apache.org/docs/master"],
     ["stable", "https://paimon.apache.org/docs/0.8"],
     ["0.8", "https://paimon.apache.org/docs/0.8"],
+    ["0.7", "https://paimon.apache.org/docs/0.7"],
+    ["0.6", "https://paimon.apache.org/docs/0.6"],
+    ["0.5", "https://paimon.apache.org/docs/0.5"]
   ]
 
   BookSection = '/'


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

After:

Only show first 5 versions in `front page`, for the current config`range $docs := first 5 .Site.Params.PreviousDocs`

<img width="206" alt="image" src="https://github.com/apache/paimon/assets/37108074/17e0a929-adf4-4f05-9aa9-4cd1e546fb9b">

In `all versions` page we can see all version's docs:

<img width="496" alt="image" src="https://github.com/apache/paimon/assets/37108074/4db39122-c4aa-4e14-b6d2-089794db7321">


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
