### PR TITLE
[core] FileStoreWrite.State should get max sequence number from RecordWriter instead of from data files

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -174,6 +174,11 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
     }
 
     @Override
+    public long maxSequenceNumber() {
+        return seqNumCounter.getValue() - 1;
+    }
+
+    @Override
     public CommitIncrement prepareCommit(boolean waitCompaction) throws Exception {
         flush(false, false);
         trySyncLatestCompaction(waitCompaction || forceCompact);

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeWriter.java
@@ -183,6 +183,11 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
     }
 
     @Override
+    public long maxSequenceNumber() {
+        return newSequenceNumber - 1;
+    }
+
+    @Override
     public long memoryOccupancy() {
         return writeBuffer.memoryOccupancy();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -52,6 +52,8 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static org.apache.paimon.io.DataFileMeta.getMaxSequenceNumber;
+
 /**
  * Base {@link FileStoreWrite} implementation.
  *
@@ -297,6 +299,7 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
                                 writerContainer.baseSnapshotId,
                                 writerContainer.lastModifiedCommitIdentifier,
                                 dataFiles,
+                                writerContainer.writer.maxSequenceNumber(),
                                 writerContainer.indexMaintainer,
                                 writerContainer.deletionVectorsMaintainer,
                                 increment));
@@ -317,6 +320,7 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
                             state.partition,
                             state.bucket,
                             state.dataFiles,
+                            state.maxSequenceNumber,
                             state.commitIncrement,
                             compactExecutor(),
                             state.deletionVectorsMaintainer);
@@ -382,6 +386,7 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
                         partition.copy(),
                         bucket,
                         restoreFiles,
+                        getMaxSequenceNumber(restoreFiles),
                         null,
                         compactExecutor(),
                         deletionVectorsMaintainer);
@@ -432,6 +437,7 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
             BinaryRow partition,
             int bucket,
             List<DataFileMeta> restoreFiles,
+            long restoredMaxSeqNumber,
             @Nullable CommitIncrement restoreIncrement,
             ExecutorService compactExecutor,
             @Nullable DeletionVectorsMaintainer deletionVectorsMaintainer);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
@@ -54,8 +54,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
-import static org.apache.paimon.io.DataFileMeta.getMaxSequenceNumber;
-
 /** {@link FileStoreWrite} for {@link AppendOnlyFileStore}. */
 public class AppendOnlyFileStoreWrite extends MemoryFileStoreWrite<InternalRow> {
 
@@ -119,12 +117,12 @@ public class AppendOnlyFileStoreWrite extends MemoryFileStoreWrite<InternalRow> 
             BinaryRow partition,
             int bucket,
             List<DataFileMeta> restoredFiles,
+            long restoredMaxSeqNumber,
             @Nullable CommitIncrement restoreIncrement,
             ExecutorService compactExecutor,
             @Nullable DeletionVectorsMaintainer ignore) {
         // let writer and compact manager hold the same reference
         // and make restore files mutable to update
-        long maxSequenceNumber = getMaxSequenceNumber(restoredFiles);
         DataFilePathFactory factory = pathFactory.createDataFilePathFactory(partition, bucket);
         CompactManager compactManager =
                 skipCompaction
@@ -147,7 +145,7 @@ public class AppendOnlyFileStoreWrite extends MemoryFileStoreWrite<InternalRow> 
                 fileFormat,
                 targetFileSize,
                 rowType,
-                maxSequenceNumber,
+                restoredMaxSeqNumber,
                 compactManager,
                 bucketReader(partition, bucket),
                 commitForceCompact,

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
@@ -146,6 +146,7 @@ public interface FileStoreWrite<T> extends Restorable<List<FileStoreWrite.State<
         protected final long baseSnapshotId;
         protected final long lastModifiedCommitIdentifier;
         protected final List<DataFileMeta> dataFiles;
+        protected final long maxSequenceNumber;
         @Nullable protected final IndexMaintainer<T> indexMaintainer;
         @Nullable protected final DeletionVectorsMaintainer deletionVectorsMaintainer;
         protected final CommitIncrement commitIncrement;
@@ -156,6 +157,7 @@ public interface FileStoreWrite<T> extends Restorable<List<FileStoreWrite.State<
                 long baseSnapshotId,
                 long lastModifiedCommitIdentifier,
                 Collection<DataFileMeta> dataFiles,
+                long maxSequenceNumber,
                 @Nullable IndexMaintainer<T> indexMaintainer,
                 @Nullable DeletionVectorsMaintainer deletionVectorsMaintainer,
                 CommitIncrement commitIncrement) {
@@ -164,6 +166,7 @@ public interface FileStoreWrite<T> extends Restorable<List<FileStoreWrite.State<
             this.baseSnapshotId = baseSnapshotId;
             this.lastModifiedCommitIdentifier = lastModifiedCommitIdentifier;
             this.dataFiles = new ArrayList<>(dataFiles);
+            this.maxSequenceNumber = maxSequenceNumber;
             this.indexMaintainer = indexMaintainer;
             this.deletionVectorsMaintainer = deletionVectorsMaintainer;
             this.commitIncrement = commitIncrement;
@@ -172,12 +175,13 @@ public interface FileStoreWrite<T> extends Restorable<List<FileStoreWrite.State<
         @Override
         public String toString() {
             return String.format(
-                    "{%s, %d, %d, %d, %s, %s,  %s, %s}",
+                    "{%s, %d, %d, %d, %s, %d, %s, %s, %s}",
                     partition,
                     bucket,
                     baseSnapshotId,
                     lastModifiedCommitIdentifier,
                     dataFiles,
+                    maxSequenceNumber,
                     indexMaintainer,
                     deletionVectorsMaintainer,
                     commitIncrement);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -84,7 +84,6 @@ import java.util.function.Supplier;
 import static org.apache.paimon.CoreOptions.ChangelogProducer.FULL_COMPACTION;
 import static org.apache.paimon.CoreOptions.MergeEngine.DEDUPLICATE;
 import static org.apache.paimon.CoreOptions.MergeEngine.FIRST_ROW;
-import static org.apache.paimon.io.DataFileMeta.getMaxSequenceNumber;
 import static org.apache.paimon.lookup.LookupStoreFactory.bfGenerator;
 
 /** {@link FileStoreWrite} for {@link KeyValueFileStore}. */
@@ -168,6 +167,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
             BinaryRow partition,
             int bucket,
             List<DataFileMeta> restoreFiles,
+            long restoredMaxSeqNumber,
             @Nullable CommitIncrement restoreIncrement,
             ExecutorService compactExecutor,
             @Nullable DeletionVectorsMaintainer dvMaintainer) {
@@ -204,7 +204,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                 options.spillCompression(),
                 ioManager,
                 compactManager,
-                getMaxSequenceNumber(restoreFiles),
+                restoredMaxSeqNumber,
                 keyComparator,
                 mfFactory.create(),
                 writerFactory,

--- a/paimon-core/src/main/java/org/apache/paimon/utils/RecordWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/RecordWriter.java
@@ -53,6 +53,9 @@ public interface RecordWriter<T> {
     /** Get all data files maintained by this writer. */
     Collection<DataFileMeta> dataFiles();
 
+    /** Get max sequence number of records written by this writer. */
+    long maxSequenceNumber();
+
     /**
      * Prepare for a commit.
      *

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/mysql/sync_table_setup.sql
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/mysql/sync_table_setup.sql
@@ -420,3 +420,14 @@ USE invalid_alter_bucket;
 CREATE TABLE t (
     k INT PRIMARY KEY
 );
+
+-- ################################################################################
+--  testInvalidAlterBucket
+-- ################################################################################
+
+CREATE DATABASE write_only_and_schema_evolution;
+USE write_only_and_schema_evolution;
+CREATE TABLE t (
+    k INT PRIMARY KEY,
+    v1 VARCHAR(10)
+);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Currently, `AbstractFileStoreWrite#createWriterContainer` get max sequence number from restored data files. But if write-only is true, the restored data files are empty, which leads to a wrong sequence number.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
