### PR TITLE
[spark] MigrateTableProcedure support keep origin table and rename target paimon table

### DIFF
--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -102,6 +102,18 @@ This section introduce all available spark procedures about paimon.
       </td>
     </tr>
     <tr>
+      <td>migrate_table</td>
+      <td>
+         Migrate hive table to a paimon table. Arguments:
+            <li>source_type: the origin table's type to be migrated, such as hive. Cannot be empty.</li>
+            <li>table: name of the origin table to be migrated. Cannot be empty.</li>
+            <li>options: the table options of the paimon table to migrate.</li>
+            <li>delete_origin: whether to delete the origin table metadata from hms after migrate. Default is true</li>
+            <li>target_table: name of the target table. If not set would keep the same name with origin table</li>
+      </td>
+      <td>CALL sys.migrate_table(source_type => 'hive', table => 'default.T', options => 'file.format=parquet')</td>
+    </tr>
+    <tr>
       <td>remove_orphan_files</td>
       <td>
          To remove the orphan data files and metadata files. Arguments:

--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -108,8 +108,8 @@ This section introduce all available spark procedures about paimon.
             <li>source_type: the origin table's type to be migrated, such as hive. Cannot be empty.</li>
             <li>table: name of the origin table to be migrated. Cannot be empty.</li>
             <li>options: the table options of the paimon table to migrate.</li>
-            <li>delete_origin: whether to delete the origin table metadata from hms after migrate. Default is true</li>
-            <li>target_table: name of the target paimon table to migrate. If not set would keep the same name with origin hive table</li>
+            <li>target_table: name of the target paimon table to migrate. If not set would keep the same name with origin table</li>
+            <li>delete_origin: If had set target_table, can set delete_origin to decide whether delete the origin table metadata from hms after migrate. Default is true</li>
       </td>
       <td>CALL sys.migrate_table(source_type => 'hive', table => 'default.T', options => 'file.format=parquet')</td>
     </tr>

--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -109,7 +109,7 @@ This section introduce all available spark procedures about paimon.
             <li>table: name of the origin table to be migrated. Cannot be empty.</li>
             <li>options: the table options of the paimon table to migrate.</li>
             <li>delete_origin: whether to delete the origin table metadata from hms after migrate. Default is true</li>
-            <li>target_table: name of the target table. If not set would keep the same name with origin table</li>
+            <li>target_table: name of the target paimon table to migrate. If not set would keep the same name with origin hive table</li>
       </td>
       <td>CALL sys.migrate_table(source_type => 'hive', table => 'default.T', options => 'file.format=parquet')</td>
     </tr>

--- a/paimon-core/src/main/java/org/apache/paimon/migrate/Migrator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/migrate/Migrator.java
@@ -25,5 +25,5 @@ public interface Migrator {
 
     void renameTable(boolean ignoreIfNotExists) throws Exception;
 
-    public void deleteOriginTable(Boolean delete) throws Exception;
+    public void deleteOriginTable(boolean delete) throws Exception;
 }

--- a/paimon-core/src/main/java/org/apache/paimon/migrate/Migrator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/migrate/Migrator.java
@@ -24,4 +24,6 @@ public interface Migrator {
     void executeMigrate() throws Exception;
 
     void renameTable(boolean ignoreIfNotExists) throws Exception;
+
+    public void deleteOriginTable(Boolean delete) throws Exception;
 }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
@@ -78,6 +78,7 @@ public class HiveMigrator implements Migrator {
     private final String targetDatabase;
     private final String targetTable;
     private final Map<String, String> options;
+    private Boolean delete = true;
 
     public HiveMigrator(
             HiveCatalog hiveCatalog,
@@ -114,6 +115,11 @@ public class HiveMigrator implements Migrator {
         } catch (TException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public void deleteOriginTable(Boolean delete) {
+        this.delete = delete;
     }
 
     @Override
@@ -202,8 +208,10 @@ public class HiveMigrator implements Migrator {
             throw new RuntimeException("Migrating failed", e);
         }
 
-        // if all success, drop the origin table
-        client.dropTable(sourceDatabase, sourceTable, true, true);
+        // if all success, drop the origin table according the delete field
+        if (delete) {
+            client.dropTable(sourceDatabase, sourceTable, true, true);
+        }
     }
 
     @Override

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
@@ -118,7 +118,7 @@ public class HiveMigrator implements Migrator {
     }
 
     @Override
-    public void deleteOriginTable(Boolean delete) {
+    public void deleteOriginTable(boolean delete) {
         this.delete = delete;
     }
 

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateTableProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateTableProcedure.java
@@ -103,7 +103,6 @@ public class MigrateTableProcedure extends BaseProcedure {
                             tmpTableId.getObjectName(),
                             ParameterUtils.parseCommaSeparatedKeyValues(properties));
 
-            deleteNeed = deleteNeed && !StringUtils.isEmpty(targetTable);
             migrator.deleteOriginTable(deleteNeed);
             migrator.executeMigrate();
             if (StringUtils.isEmpty(targetTable)) {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateTableProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateTableProcedure.java
@@ -81,7 +81,7 @@ public class MigrateTableProcedure extends BaseProcedure {
         String format = args.getString(0);
         String sourceTable = args.getString(1);
         String properties = args.isNullAt(2) ? null : args.getString(2);
-        Boolean deleteNeed = args.isNullAt(3) ? true : args.getBoolean(3);
+        boolean deleteNeed = args.isNullAt(3) ? true : args.getBoolean(3);
         String targetTable = args.isNullAt(4) ? null : args.getString(4);
 
         Identifier sourceTableId = Identifier.fromString(sourceTable);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateTableProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateTableProcedure.java
@@ -24,6 +24,7 @@ import org.apache.paimon.migrate.Migrator;
 import org.apache.paimon.spark.catalog.WithPaimonCatalog;
 import org.apache.paimon.spark.utils.TableMigrationUtils;
 import org.apache.paimon.utils.ParameterUtils;
+import org.apache.paimon.utils.StringUtils;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
@@ -51,7 +52,8 @@ public class MigrateTableProcedure extends BaseProcedure {
                 ProcedureParameter.required("source_type", StringType),
                 ProcedureParameter.required("table", StringType),
                 ProcedureParameter.optional("options", StringType),
-                ProcedureParameter.optional("rename", BooleanType)
+                ProcedureParameter.optional("delete_origin", BooleanType),
+                ProcedureParameter.optional("target_table", StringType)
             };
 
     private static final StructType OUTPUT_TYPE =
@@ -79,10 +81,14 @@ public class MigrateTableProcedure extends BaseProcedure {
         String format = args.getString(0);
         String sourceTable = args.getString(1);
         String properties = args.isNullAt(2) ? null : args.getString(2);
-        Boolean rename = args.isNullAt(3) ? true : args.getBoolean(3);
+        Boolean deleteNeed = args.isNullAt(3) ? true : args.getBoolean(3);
+        String targetTable = args.isNullAt(4) ? null : args.getString(4);
 
         Identifier sourceTableId = Identifier.fromString(sourceTable);
-        Identifier tmpTableId = Identifier.fromString(sourceTable + TMP_TBL_SUFFIX);
+        Identifier tmpTableId =
+                StringUtils.isEmpty(targetTable)
+                        ? Identifier.fromString(sourceTable + TMP_TBL_SUFFIX)
+                        : Identifier.fromString(targetTable);
 
         Catalog paimonCatalog = ((WithPaimonCatalog) tableCatalog()).paimonCatalog();
 
@@ -96,8 +102,11 @@ public class MigrateTableProcedure extends BaseProcedure {
                             tmpTableId.getDatabaseName(),
                             tmpTableId.getObjectName(),
                             ParameterUtils.parseCommaSeparatedKeyValues(properties));
+
+            deleteNeed = deleteNeed && !StringUtils.isEmpty(targetTable);
+            migrator.deleteOriginTable(deleteNeed);
             migrator.executeMigrate();
-            if (rename) {
+            if (StringUtils.isEmpty(targetTable)) {
                 paimonCatalog.renameTable(tmpTableId, sourceTableId, false);
             }
         } catch (Exception e) {

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -62,11 +62,12 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
           spark.sql(
             s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl_$format', options => 'file.format=$format', target_table => '$hiveDbName.target_$format', delete_origin => false)")
 
-          checkAnswer(spark.sql(s"SELECT * FROM target_$format ORDER BY id"), Nil)
-
           checkAnswer(
-            spark.sql(s"SELECT * FROM hive_tbl_$format ORDER BY id"),
+            spark.sql(s"SELECT * FROM target_$format ORDER BY id"),
             Row("1", "a", "p1") :: Row("2", "b", "p2") :: Nil)
+
+          checkAnswer(spark.sql(s"SELECT * FROM hive_tbl_$format ORDER BY id"), Nil)
+
         }
       }
     })

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -57,7 +57,7 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
                        |USING $format
                        |""".stripMargin)
 
-          spark.sql(s"INSERT INTO l$format VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
+          spark.sql(s"INSERT INTO hive_tbl_$format VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
 
           spark.sql(
             s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl_$format', options => 'file.format=$format', target_table => '$hiveDbName.target_$format', delete_origin => false)")

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -52,7 +52,7 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
         withTable("hive_tbl_rn") {
           // create hive table
           spark.sql(s"""
-                       |CREATE TABLE hive_tbl (id STRING, name STRING, pt STRING)
+                       |CREATE TABLE hive_tbl_rn (id STRING, name STRING, pt STRING)
                        |USING $format
                        |""".stripMargin)
 

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.spark.procedure
 
-import org.apache.paimon.catalog.Catalog.TableNotExistException
 import org.apache.paimon.spark.PaimonHiveTestBase
 
 import org.apache.spark.sql.Row

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -62,9 +62,7 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
           spark.sql(
             s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl_$format', options => 'file.format=$format', target_table => '$hiveDbName.target_$format', delete_origin => false)")
 
-          checkAnswer(
-            spark.sql(s"SELECT * FROM target_$format ORDER BY id"),
-            Row("1", "a", "p1") :: Row("2", "b", "p2") :: Nil)
+          checkAnswer(spark.sql(s"SELECT * FROM target_$format ORDER BY id"), Nil)
 
           checkAnswer(
             spark.sql(s"SELECT * FROM hive_tbl_$format ORDER BY id"),

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -49,7 +49,7 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
   Seq("parquet", "orc", "avro").foreach(
     format => {
       test(
-        s"Paimon migrate table procedure: migrate $format non-partitioned table with set taget table") {
+        s"Paimon migrate table procedure: migrate $format non-partitioned table with set target table") {
         withTable("hive_tbl_rn") {
           // create hive table
           spark.sql(s"""
@@ -60,7 +60,7 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
           spark.sql(s"INSERT INTO hive_tbl_$format VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
 
           spark.sql(
-            s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl_$format', options => 'file.format=$format', target_table => '$hiveDbName.target_$format')")
+            s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl_$format', options => 'file.format=$format', target_table => '$hiveDbName.target_$format', delete_origin => false)")
 
           checkAnswer(
             spark.sql(s"SELECT * FROM $hiveDbName.hive_tbl_$format ORDER BY id"),

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -49,20 +49,20 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
     format => {
       test(
         s"Paimon migrate table procedure: migrate $format non-partitioned table with not rename") {
-        withTable("hive_tbl") {
+        withTable("hive_tbl_rn") {
           // create hive table
           spark.sql(s"""
                        |CREATE TABLE hive_tbl (id STRING, name STRING, pt STRING)
                        |USING $format
                        |""".stripMargin)
 
-          spark.sql(s"INSERT INTO hive_tbl VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
+          spark.sql(s"INSERT INTO hive_tbl_rn VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
 
           spark.sql(
-            s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl', options => 'file.format=$format', rename => false)")
+            s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl_rn', options => 'file.format=$format', rename => false)")
 
           checkAnswer(
-            spark.sql(s"SELECT * FROM hive_tbl_paimon_ ORDER BY id"),
+            spark.sql(s"SELECT * FROM hive_tbl_rn_paimon_ ORDER BY id"),
             Row("1", "a", "p1") :: Row("2", "b", "p2") :: Nil)
         }
       }

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -56,7 +56,7 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
                        |USING $format
                        |""".stripMargin)
 
-          spark.sql(s"INSERT OVERWRITE hive_tbl_rn VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
+          spark.sql(s"INSERT INTO hive_tbl_rn VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
 
           spark.sql(
             s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl_rn', options => 'file.format=$format', rename => false)")
@@ -64,6 +64,8 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
           checkAnswer(
             spark.sql(s"SELECT * FROM hive_tbl_rn_paimon_ ORDER BY id"),
             Row("1", "a", "p1") :: Row("2", "b", "p2") :: Nil)
+
+          spark.sql(s"drop table hive_tbl_rn_paimon_")
         }
       }
     })

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -57,17 +57,17 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
                        |USING $format
                        |""".stripMargin)
 
-          spark.sql(s"INSERT INTO hive_tbl_$format VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
+          spark.sql(s"INSERT INTO l$format VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
 
           spark.sql(
             s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl_$format', options => 'file.format=$format', target_table => '$hiveDbName.target_$format', delete_origin => false)")
 
           checkAnswer(
-            spark.sql(s"SELECT * FROM $hiveDbName.hive_tbl_$format ORDER BY id"),
+            spark.sql(s"SELECT * FROM target_$format ORDER BY id"),
             Row("1", "a", "p1") :: Row("2", "b", "p2") :: Nil)
 
           checkAnswer(
-            spark.sql(s"SELECT * FROM target_$format ORDER BY id"),
+            spark.sql(s"SELECT * FROM hive_tbl_$format ORDER BY id"),
             Row("1", "a", "p1") :: Row("2", "b", "p2") :: Nil)
         }
       }

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -56,7 +56,7 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
                        |USING $format
                        |""".stripMargin)
 
-          spark.sql(s"INSERT INTO hive_tbl_rn VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
+          spark.sql(s"INSERT OVERWRITE hive_tbl_rn VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
 
           spark.sql(
             s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl_rn', options => 'file.format=$format', rename => false)")

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -47,6 +47,33 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
 
   Seq("parquet", "orc", "avro").foreach(
     format => {
+      test(s"Paimon migrate table procedure: migrate $format non-partitioned table with not rename") {
+        withTable("hive_tbl") {
+          // create hive table
+          spark.sql(
+            s"""
+               |CREATE TABLE hive_tbl (id STRING, name STRING, pt STRING)
+               |USING $format
+               |""".stripMargin)
+
+          spark.sql(s"INSERT INTO hive_tbl VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
+
+          spark.sql(
+            s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl', options => 'file.format=$format', rename => false)")
+
+          checkAnswer(
+            spark.sql(s"SELECT * FROM hive_tbl ORDER BY id"),
+            Row("1", "a", "p1") :: Row("2", "b", "p2") :: Nil)
+
+          checkAnswer(
+            spark.sql(s"SELECT * FROM hive_tbl_paimon_ ORDER BY id"),
+            Row("1", "a", "p1") :: Row("2", "b", "p2") :: Nil)
+        }
+      }
+    })
+
+  Seq("parquet", "orc", "avro").foreach(
+    format => {
       test(s"Paimon migrate table procedure: migrate $format partitioned table") {
         withTable("hive_tbl") {
           // create hive table

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -62,10 +62,6 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
             s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl', options => 'file.format=$format', rename => false)")
 
           checkAnswer(
-            spark.sql(s"SELECT * FROM hive_tbl ORDER BY id"),
-            Row("1", "a", "p1") :: Row("2", "b", "p2") :: Nil)
-
-          checkAnswer(
             spark.sql(s"SELECT * FROM hive_tbl_paimon_ ORDER BY id"),
             Row("1", "a", "p1") :: Row("2", "b", "p2") :: Nil)
         }

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -47,14 +47,14 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
 
   Seq("parquet", "orc", "avro").foreach(
     format => {
-      test(s"Paimon migrate table procedure: migrate $format non-partitioned table with not rename") {
+      test(
+        s"Paimon migrate table procedure: migrate $format non-partitioned table with not rename") {
         withTable("hive_tbl") {
           // create hive table
-          spark.sql(
-            s"""
-               |CREATE TABLE hive_tbl (id STRING, name STRING, pt STRING)
-               |USING $format
-               |""".stripMargin)
+          spark.sql(s"""
+                       |CREATE TABLE hive_tbl (id STRING, name STRING, pt STRING)
+                       |USING $format
+                       |""".stripMargin)
 
           spark.sql(s"INSERT INTO hive_tbl VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

Currently MigrateTableProcedure  only support migrate table with origin name，but some conditions user not want to drop origin table in hms or want to rename a new target table name，this pr is aim to support it.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
