### PR TITLE
[spark] Fix can not set bucket number in HiveMigrator

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
@@ -246,7 +246,9 @@ public class HiveMigrator implements Migrator {
             List<FieldSchema> partitionFields,
             Map<String, String> hiveTableOptions) {
         HashMap<String, String> paimonOptions = new HashMap<>(this.options);
-        paimonOptions.put(CoreOptions.BUCKET.key(), "-1");
+        if (!paimonOptions.containsKey(CoreOptions.BUCKET.key())) {
+            paimonOptions.put(CoreOptions.BUCKET.key(), "-1");
+        }
         // for compatible with hive comment system
         if (hiveTableOptions.get("comment") != null) {
             paimonOptions.put("hive.comment", hiveTableOptions.get("comment"));


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

Fix can not set bucket number in HiveMigrator，currently in MigrateTableProcedure can only set bucket = -1, user cannot set bucekts，the pr is aim to fix it.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
