### PR TITLE
[flink][flink-cdc] Improve the compatibility of getting kafka-cdc precision and scale

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlTypeUtils.java
@@ -381,19 +381,13 @@ public class MySqlTypeUtils {
         if (typeName.contains(LEFT_BRACKETS)
                 && typeName.contains(RIGHT_BRACKETS)
                 && isScaleType(typeName)) {
-            return Integer.parseInt(
-                    typeName.substring(typeName.indexOf(LEFT_BRACKETS) + 1, typeName.indexOf(COMMA))
-                            .trim());
+            return capturePrecision(typeName);
         } else if ((typeName.contains(LEFT_BRACKETS)
                 && typeName.contains(RIGHT_BRACKETS)
                 && !isScaleType(typeName)
                 && !isEnumType(typeName)
                 && !isSetType(typeName))) {
-            return Integer.parseInt(
-                    typeName.substring(
-                                    typeName.indexOf(LEFT_BRACKETS) + 1,
-                                    typeName.indexOf(RIGHT_BRACKETS))
-                            .trim());
+            return capturePrecision(typeName);
         } else {
             // when missing precision of the decimal, we
             // use the max precision to avoid parse error
@@ -401,14 +395,27 @@ public class MySqlTypeUtils {
         }
     }
 
+    public static int capturePrecision(String typeName) {
+        return Integer.parseInt(
+                typeName.substring(
+                                typeName.indexOf(LEFT_BRACKETS) + 1,
+                                typeName.contains(COMMA)
+                                        ? typeName.indexOf(COMMA)
+                                        : typeName.indexOf(RIGHT_BRACKETS))
+                        .trim());
+    }
+
     public static int getScale(String typeName) {
         if (typeName.contains(LEFT_BRACKETS)
                 && typeName.contains(RIGHT_BRACKETS)
                 && isScaleType(typeName)) {
-            return Integer.parseInt(
-                    typeName.substring(
-                                    typeName.indexOf(COMMA) + 1, typeName.indexOf(RIGHT_BRACKETS))
-                            .trim());
+            return typeName.contains(COMMA)
+                    ? Integer.parseInt(
+                            typeName.substring(
+                                            typeName.indexOf(COMMA) + 1,
+                                            typeName.indexOf(RIGHT_BRACKETS))
+                                    .trim())
+                    : 0;
         } else {
             // When missing scale of the decimal, we
             // use the max scale to avoid parse error


### PR DESCRIPTION
Purpose
Fixed the problem that when using kafka-cdc for data synchronization, when the field type of the data source is float(10,2) or double(8), an exception message will appear when getPrecision and getScale: just like … :java.lang.NumberFormatException: For input string: "10,2", or java.lang.NumberFormatException: For input string: "DOUBLE(8" ...

Tests
API and Format
Documentation