### PR TITLE
[Flink] `expire_snapshots` procedure supports `retain_min`, `older_than` and `max_deletes`

### DIFF
--- a/docs/content/flink/procedures.md
+++ b/docs/content/flink/procedures.md
@@ -215,15 +215,28 @@ All available procedures are listed below.
    <tr>
       <td>expire_snapshots</td>
       <td>
-         -- expires snapshot<br/>
-         CALL sys.expire_snapshots('identifier', retainMax)<br/><br/>
+         -- for Flink 1.18<br/>
+         CALL sys.expire_snapshots(table, retain_max)<br/><br/>
+         -- for Flink 1.19 and later<br/>
+         CALL sys.expire_snapshots(table, retain_max, retain_min, older_than, max_deletes)<br/><br/>
       </td>
       <td>
          To expire snapshots. Argument:
-            <li>identifier: the target table identifier. Cannot be empty.</li>
-            <li>retainMax: the maximum number of completed snapshots to retain.</li>
+            <li>table: the target table identifier. Cannot be empty.</li>
+            <li>retain_max: the maximum number of completed snapshots to retain.</li>
+            <li>retain_min: the minimum number of completed snapshots to retain.</li>
+            <li>order_than: timestamp before which snapshots will be removed.</li>
+            <li>max_deletes: the maximum number of snapshots that can be deleted at once.</li>
       </td>
-      <td>CALL sys.expire_snapshots('default.T', 2)</td>
+      <td>
+         -- for Flink 1.18<br/><br/>
+         CALL sys.expire_snapshots('default.T', 2)<br/><br/>
+         -- for Flink 1.19 and later<br/><br/>
+         CALL sys.expire_snapshots(`table` => 'default.T', retain_max => 2)<br/><br/>
+         CALL sys.expire_snapshots(`table` => 'default.T', older_than => '2024-01-01 12:00:00')<br/><br/>
+         CALL sys.expire_snapshots(`table` => 'default.T', older_than => '2024-01-01 12:00:00', retain_min => 10)<br/><br/>
+         CALL sys.expire_snapshots(`table` => 'default.T', older_than => '2024-01-01 12:00:00', max_deletes => 10)<br/><br/>
+      </td>
    </tr>
    </tbody>
 </table>

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/ExpireSnapshotsProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/ExpireSnapshotsProcedure.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.procedure;
+
+import org.apache.paimon.catalog.Catalog;
+
+import org.apache.flink.table.procedure.ProcedureContext;
+
+/** A procedure to expire snapshots. */
+public class ExpireSnapshotsProcedure extends ProcedureBase {
+
+    @Override
+    public String identifier() {
+        return "expire_snapshots";
+    }
+
+    public String[] call(ProcedureContext procedureContext, String tableId, int retainMax)
+            throws Catalog.TableNotExistException {
+        return new String[] {
+            table(tableId).newExpireSnapshots().retainMax(retainMax).expire() + ""
+        };
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ExpireSnapshotsProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ExpireSnapshotsProcedure.java
@@ -19,7 +19,12 @@
 package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.table.ExpireSnapshots;
+import org.apache.paimon.utils.DateTimeUtils;
 
+import org.apache.flink.table.annotation.ArgumentHint;
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.ProcedureHint;
 import org.apache.flink.table.procedure.ProcedureContext;
 
 /** A procedure to expire snapshots. */
@@ -30,10 +35,49 @@ public class ExpireSnapshotsProcedure extends ProcedureBase {
         return "expire_snapshots";
     }
 
-    public String[] call(ProcedureContext procedureContext, String tableId, int retainMax)
+    @ProcedureHint(
+            argument = {
+                @ArgumentHint(name = "table", type = @DataTypeHint("STRING"), isOptional = false),
+                @ArgumentHint(
+                        name = "retain_max",
+                        type = @DataTypeHint("INTEGER"),
+                        isOptional = true),
+                @ArgumentHint(
+                        name = "retain_min",
+                        type = @DataTypeHint("INTEGER"),
+                        isOptional = true),
+                @ArgumentHint(
+                        name = "older_than",
+                        type = @DataTypeHint(value = "STRING"),
+                        isOptional = true),
+                @ArgumentHint(
+                        name = "max_deletes",
+                        type = @DataTypeHint("INTEGER"),
+                        isOptional = true)
+            })
+    public String[] call(
+            ProcedureContext procedureContext,
+            String tableId,
+            Integer retainMax,
+            Integer retainMin,
+            String olderThanStr,
+            Integer maxDeletes)
             throws Catalog.TableNotExistException {
-        return new String[] {
-            table(tableId).newExpireSnapshots().retainMax(retainMax).expire() + ""
-        };
+        ExpireSnapshots expireSnapshots = table(tableId).newExpireSnapshots();
+        if (retainMax != null) {
+            expireSnapshots.retainMax(retainMax);
+        }
+        if (retainMin != null) {
+            expireSnapshots.retainMin(retainMin);
+        }
+        if (olderThanStr != null) {
+            expireSnapshots.olderThanMills(
+                    DateTimeUtils.parseTimestampData(olderThanStr, 3, DateTimeUtils.LOCAL_TZ)
+                            .getMillisecond());
+        }
+        if (maxDeletes != null) {
+            expireSnapshots.maxDeletes(maxDeletes);
+        }
+        return new String[] {expireSnapshots.expire() + ""};
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpireSnapshotsProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpireSnapshotsProcedureITCase.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.procedure;
+
+import org.apache.paimon.flink.CatalogITCaseBase;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.SnapshotManager;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** IT Case for {@link ExpireSnapshotsProcedure}. */
+public class ExpireSnapshotsProcedureITCase extends CatalogITCaseBase {
+
+    @Test
+    public void testExpireSnapshotsProcedure() throws Exception {
+        sql(
+                "CREATE TABLE word_count ( word STRING PRIMARY KEY NOT ENFORCED, cnt INT)"
+                        + " WITH ( 'num-sorted-run.compaction-trigger' = '9999' )");
+        FileStoreTable table = paimonTable("word_count");
+        SnapshotManager snapshotManager = table.snapshotManager();
+
+        // initially prepare 6 snapshots, expected snapshots (1, 2, 3, 4, 5, 6)
+        for (int i = 0; i < 6; ++i) {
+            sql("INSERT INTO word_count VALUES ('" + String.valueOf(i) + "', " + i + ")");
+        }
+        checkSnapshots(snapshotManager, 1, 6);
+
+        // retain_max => 5, expected snapshots (2, 3, 4, 5, 6)
+        sql("CALL sys.expire_snapshots(`table` => 'default.word_count', retain_max => 5)");
+        checkSnapshots(snapshotManager, 2, 6);
+
+        // older_than => timestamp of snapshot 6, max_deletes => 1, expected snapshots (3, 4, 5, 6)
+        Timestamp ts6 = new Timestamp(snapshotManager.latestSnapshot().timeMillis());
+        sql(
+                "CALL sys.expire_snapshots(`table` => 'default.word_count', older_than => '"
+                        + ts6.toString()
+                        + "', max_deletes => 1)");
+        checkSnapshots(snapshotManager, 3, 6);
+
+        // older_than => timestamp of snapshot 6, retain_min => 3, expected snapshots (4, 5, 6)
+        sql(
+                "CALL sys.expire_snapshots(`table` => 'default.word_count', older_than => '"
+                        + ts6.toString()
+                        + "', retain_min => 3)");
+        checkSnapshots(snapshotManager, 4, 6);
+
+        // older_than => timestamp of snapshot 6, expected snapshots (6)
+        sql(
+                "CALL sys.expire_snapshots(`table`  => 'default.word_count', older_than => '"
+                        + ts6.toString()
+                        + "')");
+        checkSnapshots(snapshotManager, 6, 6);
+    }
+
+    private void checkSnapshots(SnapshotManager sm, int earliest, int latest) throws IOException {
+        assertThat(sm.snapshotCount()).isEqualTo(latest - earliest + 1);
+        assertThat(sm.earliestSnapshotId()).isEqualTo(earliest);
+        assertThat(sm.latestSnapshotId()).isEqualTo(latest);
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3330

<!-- What is the purpose of the change -->
Support specifying `retain_min`, `older_than` and `max_deletes` for Flink's `expire_snapshots procedure`.

### Tests

<!-- List UT and IT cases to verify this change -->
Add `ExpireSnapshotsProcedureITCase`

### API and Format

<!-- Does this change affect API or storage format -->
Signature of the `expire_snapshots` procedure for Flink 1.19 and later is changed. `expire_snapshot(table, retain_max)` with positioned arguments is no longer supported. User needs to either use named arguments, or use the full signature `expire_snapshot(table, retain_max, retain_min, older_than, max_deletes)` and pass null for arguments not needed. Flink 1.18 and earlier versions are not affected.

### Documentation

<!-- Does this change introduce a new feature -->
The Flink Procedure page is been updated.
