### PR TITLE
[core] Optimize snapshots table when specific snapshot id

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/LeafPredicateExtractor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/LeafPredicateExtractor.java
@@ -25,7 +25,7 @@ import java.util.Map;
 /** Extract leaf predicate for field names. */
 public class LeafPredicateExtractor implements PredicateVisitor<Map<String, LeafPredicate>> {
 
-    public static final LeafPredicateExtractor INSTANT = new LeafPredicateExtractor();
+    public static final LeafPredicateExtractor INSTANCE = new LeafPredicateExtractor();
 
     @Override
     public Map<String, LeafPredicate> visit(LeafPredicate predicate) {

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/LeafPredicateExtractor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/LeafPredicateExtractor.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.predicate;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Extract leaf predicate for field names. */
+public class LeafPredicateExtractor implements PredicateVisitor<Map<String, LeafPredicate>> {
+
+    public static final LeafPredicateExtractor INSTANT = new LeafPredicateExtractor();
+
+    @Override
+    public Map<String, LeafPredicate> visit(LeafPredicate predicate) {
+        return Collections.singletonMap(predicate.fieldName(), predicate);
+    }
+
+    @Override
+    public Map<String, LeafPredicate> visit(CompoundPredicate predicate) {
+        if (predicate.function() instanceof And) {
+            Map<String, LeafPredicate> leafPredicates = new HashMap<>();
+            predicate.children().stream().map(p -> p.visit(this)).forEach(leafPredicates::putAll);
+            return leafPredicates;
+        }
+        return Collections.emptyMap();
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/FilesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/FilesTable.java
@@ -167,7 +167,7 @@ public class FilesTable implements ReadonlyTable {
             }
 
             Map<String, LeafPredicate> leafPredicates =
-                    pushdown.visit(LeafPredicateExtractor.INSTANT);
+                    pushdown.visit(LeafPredicateExtractor.INSTANCE);
             this.partitionPredicate = leafPredicates.get("partition");
             this.bucketPredicate = leafPredicates.get("bucket");
             this.levelPredicate = leafPredicates.get("level");

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/FilesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/FilesTable.java
@@ -28,8 +28,8 @@ import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFilePathFactory;
 import org.apache.paimon.predicate.Equal;
 import org.apache.paimon.predicate.LeafPredicate;
+import org.apache.paimon.predicate.LeafPredicateExtractor;
 import org.apache.paimon.predicate.Predicate;
-import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
@@ -162,25 +162,15 @@ public class FilesTable implements ReadonlyTable {
 
         @Override
         public InnerTableScan withFilter(Predicate pushdown) {
-            List<Predicate> predicates = PredicateBuilder.splitAnd(pushdown);
-            for (Predicate predicate : predicates) {
-                if (predicate instanceof LeafPredicate) {
-                    LeafPredicate leaf = (LeafPredicate) predicate;
-                    switch (leaf.fieldName()) {
-                        case "partition":
-                            this.partitionPredicate = leaf;
-                            break;
-                        case "bucket":
-                            this.bucketPredicate = leaf;
-                            break;
-                        case "level":
-                            this.levelPredicate = leaf;
-                            break;
-                        default:
-                            break;
-                    }
-                }
+            if (pushdown == null) {
+                return this;
             }
+
+            Map<String, LeafPredicate> leafPredicates =
+                    pushdown.visit(LeafPredicateExtractor.INSTANT);
+            this.partitionPredicate = leafPredicates.get("partition");
+            this.bucketPredicate = leafPredicates.get("bucket");
+            this.levelPredicate = leafPredicates.get("level");
             return this;
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SnapshotsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SnapshotsTable.java
@@ -207,7 +207,7 @@ public class SnapshotsTable implements ReadonlyTable {
 
             LeafPredicate snapshotPred =
                     predicate.visit(LeafPredicateExtractor.INSTANT).get("snapshot_id");
-            if (snapshotPred.function() instanceof Equal) {
+            if (snapshotPred != null && snapshotPred.function() instanceof Equal) {
                 specificSnapshot = (Long) snapshotPred.literals().get(0);
             }
             return this;

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SnapshotsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SnapshotsTable.java
@@ -206,7 +206,7 @@ public class SnapshotsTable implements ReadonlyTable {
             }
 
             LeafPredicate snapshotPred =
-                    predicate.visit(LeafPredicateExtractor.INSTANT).get("snapshot_id");
+                    predicate.visit(LeafPredicateExtractor.INSTANCE).get("snapshot_id");
             if (snapshotPred != null && snapshotPred.function() instanceof Equal) {
                 specificSnapshot = (Long) snapshotPred.literals().get(0);
             }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -68,6 +68,11 @@ public class CatalogTableITCase extends CatalogITCaseBase {
 
         result =
                 sql(
+                        "SELECT snapshot_id, schema_id, commit_kind FROM T$snapshots WHERE schema_id = 0");
+        assertThat(result).containsExactly(Row.of(1L, 0L, "APPEND"), Row.of(2L, 0L, "APPEND"));
+
+        result =
+                sql(
                         "SELECT snapshot_id, schema_id, commit_kind FROM T$snapshots WHERE snapshot_id = 2");
         assertThat(result).containsExactly(Row.of(2L, 0L, "APPEND"));
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -64,9 +64,12 @@ public class CatalogTableITCase extends CatalogITCaseBase {
         sql("INSERT INTO T VALUES (3, 4)");
 
         List<Row> result = sql("SELECT snapshot_id, schema_id, commit_kind FROM T$snapshots");
-
-        // check correctness and sequence snapshots.
         assertThat(result).containsExactly(Row.of(1L, 0L, "APPEND"), Row.of(2L, 0L, "APPEND"));
+
+        result =
+                sql(
+                        "SELECT snapshot_id, schema_id, commit_kind FROM T$snapshots WHERE snapshot_id = 2");
+        assertThat(result).containsExactly(Row.of(2L, 0L, "APPEND"));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
1. Extract a class: LeafPredicateExtractor
2. Handle push down for snapshots table.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
