### PR TITLE
[spark] Fix drop database cascade when database with view with SparkGenericCatalog

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkGenericCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkGenericCatalog.java
@@ -134,7 +134,14 @@ public class SparkGenericCatalog extends SparkBaseCatalog implements CatalogExte
             throws NoSuchNamespaceException, NonEmptyNamespaceException {
         if (namespace.length == 1 && namespaceExists(namespace) && cascade) {
             for (Identifier table : listTables(namespace)) {
-                dropTable(table);
+                try {
+                    dropTable(table);
+                } catch (Exception e) {
+                    LOG.warn(
+                            "Failed to drop {}, fallback to use sessionCatalog to drop, for {}",
+                            table,
+                            e.getMessage());
+                }
             }
         }
         return asNamespaceCatalog().dropNamespace(namespace, cascade);

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
@@ -84,6 +84,11 @@ class PaimonSparkTestBase
     }
   }
 
+  protected def reset(): Unit = {
+    afterAll()
+    beforeAll()
+  }
+
   /** Default is paimon catalog */
   override protected def beforeEach(): Unit = {
     super.beforeAll()

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTestBase.scala
@@ -99,7 +99,9 @@ abstract class DDLWithHiveCatalogTestBase extends PaimonHiveTestBase {
         }
     }
 
+    // Since we created a new sparkContext, we need to stop it and reset the default sparkContext
     reusedSpark.stop()
+    reset()
   }
 
   test("Paimon DDL with hive catalog: drop database cascade which contains paimon table") {
@@ -111,6 +113,12 @@ abstract class DDLWithHiveCatalogTestBase extends PaimonHiveTestBase {
           spark.sql(s"CREATE DATABASE paimon_db")
           spark.sql(s"USE paimon_db")
           spark.sql(s"CREATE TABLE paimon_tbl (id int, name string, dt string) using paimon")
+          // Currently, only spark_catalog supports create other table or view
+          if (catalogName.equals(sparkCatalogName)) {
+            spark.sql(s"CREATE TABLE parquet_tbl (id int, name string, dt string) using parquet")
+            spark.sql(s"CREATE VIEW parquet_tbl_view AS SELECT * FROM parquet_tbl")
+            spark.sql(s"CREATE VIEW paimon_tbl_view AS SELECT * FROM paimon_tbl")
+          }
           spark.sql(s"USE default")
           spark.sql(s"DROP DATABASE paimon_db CASCADE")
       }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Becase `SparkGenericCatalog` doest not implement `ViewCatalog` currently, `listTables` will return views too, so dropTable(view) will raise exception, we need to fallback to use `sessionCatalog` to drop

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
