### PR TITLE
[spark] Optimize Spark write newly dynamic bucket table

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/index/BucketAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/BucketAssigner.java
@@ -27,6 +27,10 @@ public interface BucketAssigner {
 
     void prepareCommit(long commitIdentifier);
 
+    static boolean isMyBucket(int bucket, int numAssigners, int assignId) {
+        return bucket % numAssigners == assignId % numAssigners;
+    }
+
     static int computeHashKey(int partitionHash, int keyHash, int numChannels, int numAssigners) {
         int start = Math.abs(partitionHash % numChannels);
         int id = Math.abs(keyHash % numAssigners);

--- a/paimon-core/src/main/java/org/apache/paimon/index/HashBucketAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/HashBucketAssigner.java
@@ -159,7 +159,7 @@ public class HashBucketAssigner implements BucketAssigner {
     }
 
     private boolean isMyBucket(int bucket) {
-        return bucket % numAssigners == assignId % numAssigners;
+        return BucketAssigner.isMyBucket(bucket, numAssigners, assignId);
     }
 
     private PartitionIndex loadIndex(BinaryRow partition, int partitionHash) {

--- a/paimon-core/src/main/java/org/apache/paimon/index/SimpleHashBucketAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/SimpleHashBucketAssigner.java
@@ -92,7 +92,7 @@ public class SimpleHashBucketAssigner implements BucketAssigner {
 
         private void loadNewBucket() {
             for (int i = 0; i < Short.MAX_VALUE; i++) {
-                if (i % numAssigners == assignId && !bucketInformation.containsKey(i)) {
+                if (isMyBucket(i) && !bucketInformation.containsKey(i)) {
                     currentBucket = i;
                     return;
                 }
@@ -100,5 +100,9 @@ public class SimpleHashBucketAssigner implements BucketAssigner {
             throw new RuntimeException(
                     "Can't find a suitable bucket to assign, all the bucket are assigned?");
         }
+    }
+
+    private boolean isMyBucket(int bucket) {
+        return BucketAssigner.isMyBucket(bucket, numAssigners, assignId);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/index/SimpleHashBucketAssignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/SimpleHashBucketAssignerTest.java
@@ -23,6 +23,9 @@ import org.apache.paimon.data.BinaryRow;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.apache.paimon.io.DataFileTestUtils.row;
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** Tests for {@link SimpleHashBucketAssigner}. */
 public class SimpleHashBucketAssignerTest {
 
@@ -65,5 +68,21 @@ public class SimpleHashBucketAssignerTest {
             int bucket = simpleHashBucketAssigner.assign(binaryRow, hash++);
             Assertions.assertThat(bucket).isEqualTo(0);
         }
+    }
+
+    @Test
+    public void testPartitionCopy() {
+        SimpleHashBucketAssigner assigner = new SimpleHashBucketAssigner(1, 0, 5);
+
+        BinaryRow partition = row(1);
+        assertThat(assigner.assign(partition, 0)).isEqualTo(0);
+        assertThat(assigner.assign(partition, 1)).isEqualTo(0);
+
+        partition.setInt(0, 2);
+        assertThat(assigner.assign(partition, 5)).isEqualTo(0);
+        assertThat(assigner.assign(partition, 6)).isEqualTo(0);
+
+        assertThat(assigner.currentPartitions()).contains(row(1));
+        assertThat(assigner.currentPartitions()).contains(row(2));
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkRow.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkRow.java
@@ -68,7 +68,7 @@ public class SparkRow implements InternalRow, Serializable {
 
     @Override
     public int getFieldCount() {
-        return row.size();
+        return type.getFieldCount();
     }
 
     @Override

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkTableWrite.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkTableWrite.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark;
+
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.spark.util.SparkRowUtils;
+import org.apache.paimon.table.sink.BatchTableWrite;
+import org.apache.paimon.table.sink.BatchWriteBuilder;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.sink.CommitMessageSerializer;
+import org.apache.paimon.types.RowType;
+
+import org.apache.spark.sql.Row;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/** An util class for {@link BatchTableWrite}. */
+public class SparkTableWrite implements AutoCloseable {
+
+    private final BatchTableWrite write;
+    private final IOManager ioManager;
+
+    private final RowType rowType;
+    private final int rowKindColIdx;
+
+    public SparkTableWrite(BatchWriteBuilder writeBuilder, RowType rowType, int rowKindColIdx) {
+        this.write = writeBuilder.newWrite();
+        this.rowType = rowType;
+        this.rowKindColIdx = rowKindColIdx;
+        this.ioManager = SparkUtils.createIOManager();
+        write.withIOManager(ioManager);
+    }
+
+    public void write(Row row) throws Exception {
+        write.write(toPaimonRow(row));
+    }
+
+    public void write(Row row, int bucket) throws Exception {
+        write.write(toPaimonRow(row), bucket);
+    }
+
+    public Iterator<byte[]> finish() throws Exception {
+        CommitMessageSerializer serializer = new CommitMessageSerializer();
+        List<byte[]> commitMessages = new ArrayList<>();
+        for (CommitMessage message : write.prepareCommit()) {
+            commitMessages.add(serializer.serialize(message));
+        }
+        return commitMessages.iterator();
+    }
+
+    @Override
+    public void close() throws Exception {
+        write.close();
+        ioManager.close();
+    }
+
+    private SparkRow toPaimonRow(Row row) {
+        return new SparkRow(rowType, row, SparkRowUtils.getRowKind(row, rowKindColIdx));
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/BucketProcessor.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/BucketProcessor.scala
@@ -97,16 +97,15 @@ case class DynamicBucketProcessor(
 
   def processPartition(rowIterator: Iterator[Row]): Iterator[Row] = {
     val rowPartitionKeyExtractor = new RowPartitionKeyExtractor(fileStoreTable.schema)
-    val assigner =
-      new HashBucketAssigner(
-        fileStoreTable.snapshotManager(),
-        commitUser,
-        fileStoreTable.store.newIndexFileHandler,
-        numSparkPartitions,
-        numAssigners,
-        TaskContext.getPartitionId(),
-        targetBucketRowNumber
-      )
+    val assigner = new HashBucketAssigner(
+      fileStoreTable.snapshotManager(),
+      commitUser,
+      fileStoreTable.store.newIndexFileHandler,
+      numSparkPartitions,
+      numAssigners,
+      TaskContext.getPartitionId(),
+      targetBucketRowNumber
+    )
 
     new Iterator[Row]() {
       override def hasNext: Boolean = rowIterator.hasNext

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -61,7 +61,7 @@ case class PaimonSparkWriter(table: FileStoreTable) {
     import sparkSession.implicits._
 
     val rowKindColIdx = SparkRowUtils.getFieldIndex(data.schema, ROW_KIND_COL)
-    checkArgument(
+    assert(
       rowKindColIdx == -1 || rowKindColIdx == data.schema.length - 1,
       "Row kind column should be the last field.")
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -24,7 +24,6 @@ import org.apache.paimon.spark.{SparkRow, SparkTableWrite}
 import org.apache.paimon.spark.schema.SparkSystemColumns
 import org.apache.paimon.spark.schema.SparkSystemColumns.{BUCKET_COL, ROW_KIND_COL}
 import org.apache.paimon.spark.util.SparkRowUtils
-import org.apache.paimon.spark.util.SparkRowUtils.getFieldIndex
 import org.apache.paimon.table.{BucketMode, FileStoreTable}
 import org.apache.paimon.table.sink.{BatchWriteBuilder, CommitMessage, CommitMessageSerializer, RowPartitionKeyExtractor}
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
There are currently two shuffles, which can be optimized into one.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
