### PR TITLE
[core] Revert branchs in TagsTable

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/table/system/TagsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/TagsTableTest.java
@@ -26,7 +26,6 @@ import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.table.Table;
 import org.apache.paimon.table.TableTestBase;
 import org.apache.paimon.table.sink.TableCommitImpl;
 import org.apache.paimon.tag.Tag;
@@ -40,10 +39,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -87,38 +83,12 @@ class TagsTableTest extends TableTestBase {
 
     @Test
     void testTagsTable() throws Exception {
-        List<InternalRow> expectRow =
-                getExceptedResult(
-                        key -> {
-                            return new ArrayList<>();
-                        });
+        List<InternalRow> expectRow = getExceptedResult();
         List<InternalRow> result = read(tagsTable);
         assertThat(result).containsExactlyElementsOf(expectRow);
     }
 
-    @Test
-    void testTagBranchesTable() throws Exception {
-        Table table = catalog.getTable(identifier(tableName));
-        table.createBranch("2023-07-17-branch1", "2023-07-17");
-        table.createBranch("2023-07-18-branch1", "2023-07-18");
-        table.createBranch("2023-07-18-branch2", "2023-07-18");
-        List<InternalRow> expectRow =
-                getExceptedResult(
-                        tag -> {
-                            if (tag.equals("2023-07-17")) {
-                                return Collections.singletonList("2023-07-17-branch1");
-                            } else if (tag.equals("2023-07-18")) {
-                                return Arrays.asList("2023-07-18-branch1", "2023-07-18-branch2");
-                            } else {
-                                return new ArrayList<>();
-                            }
-                        });
-        List<InternalRow> result = read(tagsTable);
-        assertThat(result).containsExactlyElementsOf(expectRow);
-    }
-
-    private List<InternalRow> getExceptedResult(
-            Function<String, List<String>> tagBranchesFunction) {
+    private List<InternalRow> getExceptedResult() {
         List<InternalRow> internalRows = new ArrayList<>();
         for (Pair<Tag, String> snapshot : tagManager.tagObjects()) {
             Tag tag = snapshot.getKey();
@@ -131,7 +101,6 @@ class TagsTableTest extends TableTestBase {
                             Timestamp.fromLocalDateTime(
                                     DateTimeUtils.toLocalDateTime(tag.timeMillis())),
                             tag.totalRecordCount(),
-                            BinaryString.fromString(tagBranchesFunction.apply(tagName).toString()),
                             tag.getTagCreateTime() == null
                                     ? null
                                     : Timestamp.fromLocalDateTime(tag.getTagCreateTime()),


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Revert #2754

`TagsTableTest.testTagBranchesTable` is an unstable case where the order of branches is uncertain.

The underlying reason is that we already have branches table, which should not be recalculated in the Tags table, forming redundant information.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
