### PR TITLE
[core] Append-Only table use zstd compression default reduce storage in parquet format

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -39,11 +39,9 @@ import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.reader.RecordReaderIterator;
 import org.apache.paimon.statistics.SimpleColStatsCollector;
 import org.apache.paimon.types.RowType;
-import org.apache.paimon.utils.CommitIncrement;
-import org.apache.paimon.utils.IOUtils;
-import org.apache.paimon.utils.LongCounter;
-import org.apache.paimon.utils.Preconditions;
-import org.apache.paimon.utils.RecordWriter;
+import org.apache.paimon.utils.*;
+
+import org.apache.orc.CompressionKind;
 
 import javax.annotation.Nullable;
 
@@ -118,7 +116,10 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
         this.compactBefore = new ArrayList<>();
         this.compactAfter = new ArrayList<>();
         this.seqNumCounter = new LongCounter(maxSequenceNumber + 1);
-        this.fileCompression = fileCompression;
+        this.fileCompression =
+                StringUtils.isBlank(fileCompression)
+                        ? CompressionKind.ZSTD.name()
+                        : fileCompression;
         this.spillCompression = spillCompression;
         this.ioManager = ioManager;
         this.statsCollectors = statsCollectors;

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -44,6 +44,7 @@ import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.LongCounter;
 import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.RecordWriter;
+import org.apache.paimon.utils.StringUtils;
 
 import org.apache.orc.CompressionKind;
 

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -39,7 +39,11 @@ import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.reader.RecordReaderIterator;
 import org.apache.paimon.statistics.SimpleColStatsCollector;
 import org.apache.paimon.types.RowType;
-import org.apache.paimon.utils.*;
+import org.apache.paimon.utils.CommitIncrement;
+import org.apache.paimon.utils.IOUtils;
+import org.apache.paimon.utils.LongCounter;
+import org.apache.paimon.utils.Preconditions;
+import org.apache.paimon.utils.RecordWriter;
 
 import org.apache.orc.CompressionKind;
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormatFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormatFactory.java
@@ -20,8 +20,8 @@ package org.apache.paimon.format.parquet;
 
 import org.apache.paimon.format.FileFormatFactory;
 import org.apache.paimon.options.Options;
-
 import org.apache.paimon.utils.StringUtils;
+
 import org.apache.parquet.hadoop.ParquetOutputFormat;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
@@ -52,7 +52,8 @@ public class ParquetFileFormatFactory implements FileFormatFactory {
         if (!options.containsKey(compression)) {
             Properties properties = new Properties();
             options.addAllToProperties(properties);
-            // Append Only table use zstd compression default and other keep snappy for parquet file format
+            // Append Only table use zstd compression default and other keep snappy for parquet file
+            // format
             if (StringUtils.isBlank(options.get(MERGE_ENGINE.key()))) {
                 properties.setProperty(compression, CompressionCodecName.ZSTD.name());
             } else {

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormatFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormatFactory.java
@@ -20,14 +20,11 @@ package org.apache.paimon.format.parquet;
 
 import org.apache.paimon.format.FileFormatFactory;
 import org.apache.paimon.options.Options;
-import org.apache.paimon.utils.StringUtils;
 
 import org.apache.parquet.hadoop.ParquetOutputFormat;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
 import java.util.Properties;
-
-import static org.apache.paimon.CoreOptions.MERGE_ENGINE;
 
 /** Factory to create {@link ParquetFileFormat}. */
 public class ParquetFileFormatFactory implements FileFormatFactory {
@@ -52,13 +49,7 @@ public class ParquetFileFormatFactory implements FileFormatFactory {
         if (!options.containsKey(compression)) {
             Properties properties = new Properties();
             options.addAllToProperties(properties);
-            // Append Only table use zstd compression default and other keep snappy for parquet file
-            // format
-            if (StringUtils.isBlank(options.get(MERGE_ENGINE.key()))) {
-                properties.setProperty(compression, CompressionCodecName.ZSTD.name());
-            } else {
-                properties.setProperty(compression, CompressionCodecName.SNAPPY.name());
-            }
+            properties.setProperty(compression, CompressionCodecName.SNAPPY.name());
             Options newOptions = new Options();
             properties.forEach((k, v) -> newOptions.setString(k.toString(), v.toString()));
             return newOptions;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

When we test append only table in stream scences, we found the condition paimon table storage is 1.3x size of hive table，this is a litter high，then we change compression from snappy(wich is default) to zstd, storage from 1.3x to 1.04x which is expected to us.
From other lake engine we also do the change and other lake engine also reduce storage and stream job is stable as the same.
So should we make the default compression in parquet to zstd?

<!-- Linking this pull request to the issue -->
Linked issue: https://github.com/apache/paimon/issues/3359

<!-- What is the purpose of the change -->


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
