### PR TITLE
[flink] Adjust the setMaxParallelism api call

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/service/QueryFileMonitor.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/service/QueryFileMonitor.java
@@ -142,5 +142,10 @@ public class QueryFileMonitor extends RichSourceFunction<InternalRow> {
             int bucket = row.getInt(2);
             return ChannelComputer.select(partition, bucket, numChannels);
         }
+
+        @Override
+        public String toString() {
+            return "FileMonitorChannelComputer{" + "numChannels=" + numChannels + '}';
+        }
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

`DataStreamSink#setMaxParallelism` is only available in Flink 1.18+. So for compatibility, we can replace with 

```
sink.getTransformation().setMaxParallelism(1);
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
