### PR TITLE
[spark] Fix HiveMigrator hive api version compatible issue

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -399,7 +399,6 @@ public class HiveCatalog extends AbstractCatalog {
                         convertToPropertiesPrefixKey(tableSchema.options(), HIVE_PREFIX));
         try {
             updateHmsTable(table, identifier, tableSchema);
-            table.getSd().unsetLocation();
             client.createTable(table);
         } catch (Exception e) {
             Path path = getDataTableLocation(identifier);

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -399,6 +399,7 @@ public class HiveCatalog extends AbstractCatalog {
                         convertToPropertiesPrefixKey(tableSchema.options(), HIVE_PREFIX));
         try {
             updateHmsTable(table, identifier, tableSchema);
+            table.getSd().unsetLocation();
             client.createTable(table);
         } catch (Exception e) {
             Path path = getDataTableLocation(identifier);

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
@@ -224,8 +224,13 @@ public class HiveMigrator implements Migrator {
 
     private void checkPrimaryKey() throws Exception {
         PrimaryKeysRequest primaryKeysRequest = new PrimaryKeysRequest(sourceDatabase, sourceTable);
-        if (!client.getPrimaryKeys(primaryKeysRequest).isEmpty()) {
-            throw new IllegalArgumentException("Can't migrate primary key table yet.");
+        try {
+            if (!client.getPrimaryKeys(primaryKeysRequest).isEmpty()) {
+                throw new IllegalArgumentException("Can't migrate primary key table yet.");
+            }
+        } catch (Exception e) {
+            LOG.warn(
+                    "Your Hive version is low which not support get_primary_keys, skip primary key check firstly!");
         }
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

<!-- Linking this pull request to the issue -->
Linked issue: https://github.com/apache/paimon/issues/3380

<!-- What is the purpose of the change -->

Fix HiveMigrator hive api version compatible issue

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
