### PR TITLE
[core] Introduce DeletionVectorIndexFileWriter

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -195,6 +195,12 @@ under the License.
             <td>Whether to enable deletion vectors mode. In this mode, index files containing deletion vectors are generated when data is written, which marks the data for deletion. During read operations, by applying these index files, merging can be avoided.</td>
         </tr>
         <tr>
+            <td><h5>deletion-vector.index-file.target-size</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>The target size of deletion vector index file.</td>
+        </tr>
+        <tr>
             <td><h5>dynamic-bucket.assigner-parallelism</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1113,6 +1113,12 @@ public class CoreOptions implements Serializable {
                                     + " vectors are generated when data is written, which marks the data for deletion."
                                     + " During read operations, by applying these index files, merging can be avoided.");
 
+    public static final ConfigOption<MemorySize> DELETION_VECTOR_INDEX_FILE_TARGET_SIZE =
+            key("deletion-vector.index-file.target-size")
+                    .memoryType()
+                    .defaultValue(MemorySize.ofMebiBytes(2))
+                    .withDescription("The target size of deletion vector index file.");
+
     public static final ConfigOption<Boolean> DELETION_FORCE_PRODUCE_CHANGELOG =
             key("delete.force-produce-changelog")
                     .booleanType()
@@ -1814,6 +1820,10 @@ public class CoreOptions implements Serializable {
 
     public boolean deletionVectorsEnabled() {
         return options.get(DELETION_VECTORS_ENABLED);
+    }
+
+    public MemorySize deletionVectorIndexFileTargetSize() {
+        return options.get(DELETION_VECTOR_INDEX_FILE_TARGET_SIZE);
     }
 
     public FileIndexOptions indexColumnsOptions() {

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -146,7 +146,11 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 pathFactory().indexFileFactory(),
                 indexManifestFileFactory().create(),
                 new HashIndexFile(fileIO, pathFactory().indexFileFactory()),
-                new DeletionVectorsIndexFile(fileIO, pathFactory().indexFileFactory()));
+                new DeletionVectorsIndexFile(
+                        fileIO,
+                        pathFactory().indexFileFactory(),
+                        bucketMode(),
+                        options.deletionVectorIndexFileTargetSize()));
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorIndexFileMaintainer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorIndexFileMaintainer.java
@@ -95,16 +95,19 @@ public class DeletionVectorIndexFileMaintainer {
                 Map<String, DeletionFile> dataFileToDeletionFiles =
                         indexFileToDeletionFiles.get(indexFile);
                 if (!dataFileToDeletionFiles.isEmpty()) {
-                    IndexFileMeta newIndexFile =
+                    List<IndexFileMeta> newIndexFiles =
                             indexFileHandler.writeDeletionVectorsIndex(
                                     deletionVectorsIndexFile.readDeletionVector(
                                             dataFileToDeletionFiles));
-                    newIndexEntries.add(
-                            new IndexManifestEntry(
-                                    FileKind.ADD,
-                                    oldEntry.partition(),
-                                    oldEntry.bucket(),
-                                    newIndexFile));
+                    newIndexFiles.forEach(
+                            newIndexFile -> {
+                                newIndexEntries.add(
+                                        new IndexManifestEntry(
+                                                FileKind.ADD,
+                                                oldEntry.partition(),
+                                                oldEntry.bucket(),
+                                                newIndexFile));
+                            });
                 }
 
                 // mark the touched index file as removed.

--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorIndexFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorIndexFileWriter.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.deletionvectors;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.table.BucketMode;
+import org.apache.paimon.utils.Pair;
+import org.apache.paimon.utils.PathFactory;
+import org.apache.paimon.utils.Preconditions;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.paimon.deletionvectors.DeletionVectorsIndexFile.DELETION_VECTORS_INDEX;
+import static org.apache.paimon.deletionvectors.DeletionVectorsIndexFile.VERSION_ID_V1;
+import static org.apache.paimon.deletionvectors.DeletionVectorsIndexFile.calculateChecksum;
+
+public class DeletionVectorIndexFileWriter {
+
+    private final PathFactory indexPathFactory;
+    private final FileIO fileIO;
+    private final boolean isWrittenToMulitFiles;
+    private final long targetSizeInBytes;
+
+    private boolean written = false;
+
+    private long writtenSizeInBytes = 0L;
+
+    public DeletionVectorIndexFileWriter(
+            FileIO fileIO,
+            PathFactory pathFactory,
+            BucketMode bucketMode,
+            MemorySize targetSizePerIndexFile) {
+        this.indexPathFactory = pathFactory;
+        this.fileIO = fileIO;
+        this.isWrittenToMulitFiles = BucketMode.BUCKET_UNAWARE == bucketMode;
+        this.targetSizeInBytes = targetSizePerIndexFile.getBytes();
+    }
+
+    public List<IndexFileMeta> write(Map<String, DeletionVector> input) throws IOException {
+        List<IndexFileMeta> result = new ArrayList<>();
+        SingleIndexFileWriter writer = createWriter();
+
+        for (Map.Entry<String, DeletionVector> entry : input.entrySet()) {
+            String dataFile = entry.getKey();
+            byte[] valueBytes = entry.getValue().serializeToBytes();
+            int currentSize = valueBytes.length;
+
+            if (isWrittenToMulitFiles
+                    && written
+                    && writtenSizeInBytes + currentSize > targetSizeInBytes) {
+                result.add(writer.closeWriter());
+                writer = createWriter();
+            }
+
+            writer.write(dataFile, valueBytes);
+            written = true;
+            writtenSizeInBytes += currentSize;
+        }
+        result.add(writer.closeWriter());
+        return result;
+    }
+
+    private SingleIndexFileWriter createWriter() throws IOException {
+        written = false;
+        writtenSizeInBytes = 0L;
+        return new SingleIndexFileWriter(fileIO, indexPathFactory.newPath());
+    }
+
+    static class SingleIndexFileWriter {
+        private final FileIO fileIO;
+
+        private final Path path;
+
+        private final DataOutputStream dataOutputStream;
+
+        private final LinkedHashMap<String, Pair<Integer, Integer>> dvRanges;
+
+        public SingleIndexFileWriter(FileIO fileIO, Path path) throws IOException {
+            this.fileIO = fileIO;
+            this.path = path;
+            this.dataOutputStream = new DataOutputStream(fileIO.newOutputStream(path, true));
+            dataOutputStream.writeByte(VERSION_ID_V1);
+            this.dvRanges = new LinkedHashMap<>();
+        }
+
+        public long write(String key, byte[] data) throws IOException {
+            Preconditions.checkNotNull(dataOutputStream);
+            int size = data.length;
+
+            dvRanges.put(key, Pair.of(dataOutputStream.size(), size));
+            dataOutputStream.writeInt(size);
+            dataOutputStream.write(data);
+            dataOutputStream.writeInt(calculateChecksum(data));
+            return size;
+        }
+
+        public IndexFileMeta closeWriter() throws IOException {
+            dataOutputStream.close();
+            return new IndexFileMeta(
+                    DELETION_VECTORS_INDEX,
+                    path.getName(),
+                    fileIO.getFileSize(path),
+                    dvRanges.size(),
+                    dvRanges);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsIndexFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsIndexFile.java
@@ -23,17 +23,19 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.SeekableInputStream;
 import org.apache.paimon.index.IndexFile;
 import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.source.DeletionFile;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.PathFactory;
 
 import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.zip.CRC32;
 
@@ -46,8 +48,17 @@ public class DeletionVectorsIndexFile extends IndexFile {
     public static final String DELETION_VECTORS_INDEX = "DELETION_VECTORS";
     public static final byte VERSION_ID_V1 = 1;
 
-    public DeletionVectorsIndexFile(FileIO fileIO, PathFactory pathFactory) {
+    private final BucketMode bucketMode;
+    private final MemorySize targetSizePerIndexFile;
+
+    public DeletionVectorsIndexFile(
+            FileIO fileIO,
+            PathFactory pathFactory,
+            BucketMode bucketMode,
+            MemorySize targetSizePerIndexFile) {
         super(fileIO, pathFactory);
+        this.bucketMode = bucketMode;
+        this.targetSizePerIndexFile = targetSizePerIndexFile;
     }
 
     /**
@@ -85,6 +96,12 @@ public class DeletionVectorsIndexFile extends IndexFile {
         return deletionVectors;
     }
 
+    public Map<String, DeletionVector> readAllDeletionVectors(List<IndexFileMeta> indexFiles) {
+        Map<String, DeletionVector> deletionVectors = new HashMap<>();
+        indexFiles.forEach(indexFile -> deletionVectors.putAll(readAllDeletionVectors(indexFile)));
+        return deletionVectors;
+    }
+
     /** Reads deletion vectors from a list of DeletionFile which belong to a same index file. */
     public Map<String, DeletionVector> readDeletionVector(
             Map<String, DeletionFile> dataFileToDeletionFiles) {
@@ -111,33 +128,6 @@ public class DeletionVectorsIndexFile extends IndexFile {
     }
 
     /**
-     * Reads a single deletion vector from the specified file.
-     *
-     * @param fileName The name of the file from which to read the deletion vector.
-     * @param deletionVectorRange A Pair specifying the range (start position and size) within the
-     *     file where the deletion vector data is located.
-     * @return The DeletionVector object read from the specified range in the file.
-     * @throws UncheckedIOException If an I/O error occurs while reading from the file.
-     */
-    public DeletionVector readDeletionVector(
-            String fileName, Pair<Integer, Integer> deletionVectorRange) {
-        Path filePath = pathFactory.toPath(fileName);
-        try (SeekableInputStream inputStream = fileIO.newInputStream(filePath)) {
-            checkVersion(inputStream);
-            inputStream.seek(deletionVectorRange.getLeft());
-            DataInputStream dataInputStream = new DataInputStream(inputStream);
-            return readDeletionVector(dataInputStream, deletionVectorRange.getRight());
-        } catch (Exception e) {
-            throw new RuntimeException(
-                    "Unable to read deletion vector from file: "
-                            + filePath
-                            + ", deletionVectorRange: "
-                            + deletionVectorRange,
-                    e);
-        }
-    }
-
-    /**
      * Write deletion vectors to a new file, the format of this file can be referenced at: <a
      * href="https://cwiki.apache.org/confluence/x/Tws4EQ">PIP-16</a>.
      *
@@ -149,28 +139,18 @@ public class DeletionVectorsIndexFile extends IndexFile {
      *     data is located.
      * @throws UncheckedIOException If an I/O error occurs while writing to the file.
      */
-    public Pair<String, LinkedHashMap<String, Pair<Integer, Integer>>> write(
-            Map<String, DeletionVector> input) {
-        int size = input.size();
-        LinkedHashMap<String, Pair<Integer, Integer>> deletionVectorRanges =
-                new LinkedHashMap<>(size);
-        Path path = pathFactory.newPath();
-        try (DataOutputStream dataOutputStream =
-                new DataOutputStream(fileIO.newOutputStream(path, true))) {
-            dataOutputStream.writeByte(VERSION_ID_V1);
-            for (Map.Entry<String, DeletionVector> entry : input.entrySet()) {
-                String key = entry.getKey();
-                byte[] valueBytes = entry.getValue().serializeToBytes();
-                deletionVectorRanges.put(key, Pair.of(dataOutputStream.size(), valueBytes.length));
-                dataOutputStream.writeInt(valueBytes.length);
-                dataOutputStream.write(valueBytes);
-                dataOutputStream.writeInt(calculateChecksum(valueBytes));
-            }
+    public List<IndexFileMeta> write(Map<String, DeletionVector> input) {
+        try {
+            DeletionVectorIndexFileWriter writer =
+                    new DeletionVectorIndexFileWriter(
+                            this.fileIO,
+                            this.pathFactory,
+                            this.bucketMode,
+                            this.targetSizePerIndexFile);
+            return writer.write(input);
         } catch (IOException e) {
-            throw new RuntimeException(
-                    "Unable to write deletion vectors to file: " + path.getName(), e);
+            throw new RuntimeException("Failed to write deletion vectors.", e);
         }
-        return Pair.of(path.getName(), deletionVectorRanges);
     }
 
     private void checkVersion(InputStream in) throws IOException {
@@ -213,7 +193,7 @@ public class DeletionVectorsIndexFile extends IndexFile {
         }
     }
 
-    private int calculateChecksum(byte[] bytes) {
+    public static int calculateChecksum(byte[] bytes) {
         CRC32 crc = new CRC32();
         crc.update(bytes);
         return (int) crc.getValue();

--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsMaintainer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsMaintainer.java
@@ -97,9 +97,8 @@ public class DeletionVectorsMaintainer {
      */
     public List<IndexFileMeta> prepareCommit() {
         if (modified) {
-            IndexFileMeta entry = indexFileHandler.writeDeletionVectorsIndex(deletionVectors);
             modified = false;
-            return Collections.singletonList(entry);
+            return indexFileHandler.writeDeletionVectorsIndex(deletionVectors);
         }
         return Collections.emptyList();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/index/IndexFileHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/IndexFileHandler.java
@@ -27,17 +27,12 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.IndexManifestFile;
 import org.apache.paimon.table.source.DeletionFile;
-import org.apache.paimon.utils.IntIterator;
-import org.apache.paimon.utils.Pair;
-import org.apache.paimon.utils.PathFactory;
-import org.apache.paimon.utils.SnapshotManager;
+import org.apache.paimon.utils.*;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -193,25 +188,16 @@ public class IndexFileHandler {
     }
 
     public Map<String, DeletionVector> readAllDeletionVectors(List<IndexFileMeta> fileMetas) {
-        Map<String, DeletionVector> deletionVectors = new HashMap<>();
         for (IndexFileMeta indexFile : fileMetas) {
-            if (!indexFile.indexType().equals(DELETION_VECTORS_INDEX)) {
-                throw new IllegalArgumentException(
-                        "Input file is not deletion vectors index " + indexFile.indexType());
-            }
-            deletionVectors.putAll(deletionVectorsIndex.readAllDeletionVectors(indexFile));
+            Preconditions.checkArgument(
+                    indexFile.indexType().equals(DELETION_VECTORS_INDEX),
+                    "Input file is not deletion vectors index " + indexFile.indexType());
         }
-        return deletionVectors;
+        return deletionVectorsIndex.readAllDeletionVectors(fileMetas);
     }
 
-    public IndexFileMeta writeDeletionVectorsIndex(Map<String, DeletionVector> deletionVectors) {
-        Pair<String, LinkedHashMap<String, Pair<Integer, Integer>>> pair =
-                deletionVectorsIndex.write(deletionVectors);
-        return new IndexFileMeta(
-                DELETION_VECTORS_INDEX,
-                pair.getLeft(),
-                deletionVectorsIndex.fileSize(pair.getLeft()),
-                deletionVectors.size(),
-                pair.getRight());
+    public List<IndexFileMeta> writeDeletionVectorsIndex(
+            Map<String, DeletionVector> deletionVectors) {
+        return deletionVectorsIndex.write(deletionVectors);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/deletionvectors/DeletionVectorsIndexFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/deletionvectors/DeletionVectorsIndexFileTest.java
@@ -21,23 +21,25 @@ package org.apache.paimon.deletionvectors;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.index.IndexFileMeta;
-import org.apache.paimon.utils.Pair;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.utils.PathFactory;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.util.HashMap;
-import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 
-import static org.apache.paimon.deletionvectors.DeletionVectorsIndexFile.DELETION_VECTORS_INDEX;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link DeletionVectorsIndexFile}. */
 public class DeletionVectorsIndexFileTest {
+
+    private static MemorySize DEFAULT_TARGET_SIZE_PER_INDEX_FILE = MemorySize.parse("2MB");
     @TempDir java.nio.file.Path tempPath;
 
     @Test
@@ -45,7 +47,11 @@ public class DeletionVectorsIndexFileTest {
         PathFactory pathFactory = getPathFactory();
 
         DeletionVectorsIndexFile deletionVectorsIndexFile =
-                new DeletionVectorsIndexFile(LocalFileIO.create(), pathFactory);
+                new DeletionVectorsIndexFile(
+                        LocalFileIO.create(),
+                        pathFactory,
+                        BucketMode.HASH_FIXED,
+                        DEFAULT_TARGET_SIZE_PER_INDEX_FILE);
 
         // write
         HashMap<String, DeletionVector> deleteMap = new HashMap<>();
@@ -62,27 +68,18 @@ public class DeletionVectorsIndexFileTest {
         index3.delete(3);
         deleteMap.put("file33.parquet", index3);
 
-        Pair<String, LinkedHashMap<String, Pair<Integer, Integer>>> pair =
-                deletionVectorsIndexFile.write(deleteMap);
-        String fileName = pair.getLeft();
-        LinkedHashMap<String, Pair<Integer, Integer>> deletionVectorRanges = pair.getRight();
+        List<IndexFileMeta> indexFiles = deletionVectorsIndexFile.write(deleteMap);
+        assertThat(indexFiles.size()).isEqualTo(1);
 
         // read
-        IndexFileMeta indexFileMeta =
-                new IndexFileMeta(DELETION_VECTORS_INDEX, fileName, 0L, 0L, deletionVectorRanges);
+        String fileName = indexFiles.get(0).fileName();
         Map<String, DeletionVector> actualDeleteMap =
-                deletionVectorsIndexFile.readAllDeletionVectors(indexFileMeta);
+                deletionVectorsIndexFile.readAllDeletionVectors(indexFiles);
         assertThat(actualDeleteMap.get("file1.parquet").isDeleted(1)).isTrue();
         assertThat(actualDeleteMap.get("file1.parquet").isDeleted(2)).isFalse();
         assertThat(actualDeleteMap.get("file2.parquet").isDeleted(2)).isTrue();
         assertThat(actualDeleteMap.get("file2.parquet").isDeleted(3)).isTrue();
         assertThat(actualDeleteMap.get("file33.parquet").isDeleted(3)).isTrue();
-
-        DeletionVector file1DeletionVector =
-                deletionVectorsIndexFile.readDeletionVector(
-                        fileName, deletionVectorRanges.get("file1.parquet"));
-        assertThat(file1DeletionVector.isDeleted(1)).isTrue();
-        assertThat(file1DeletionVector.isDeleted(2)).isFalse();
 
         // delete
         deletionVectorsIndexFile.delete(fileName);
@@ -93,7 +90,11 @@ public class DeletionVectorsIndexFileTest {
     public void testReadDvIndexWithCopiousDv() {
         PathFactory pathFactory = getPathFactory();
         DeletionVectorsIndexFile deletionVectorsIndexFile =
-                new DeletionVectorsIndexFile(LocalFileIO.create(), pathFactory);
+                new DeletionVectorsIndexFile(
+                        LocalFileIO.create(),
+                        pathFactory,
+                        BucketMode.HASH_FIXED,
+                        DEFAULT_TARGET_SIZE_PER_INDEX_FILE);
 
         // write
         Random random = new Random();
@@ -104,14 +105,11 @@ public class DeletionVectorsIndexFileTest {
             deleteMap.put(String.format("file%s.parquet", i), index);
         }
 
-        Pair<String, LinkedHashMap<String, Pair<Integer, Integer>>> pair =
-                deletionVectorsIndexFile.write(deleteMap);
-
         // read
-        IndexFileMeta indexFileMeta =
-                new IndexFileMeta(DELETION_VECTORS_INDEX, pair.getLeft(), 0L, 0L, pair.getRight());
+        List<IndexFileMeta> indexFiles = deletionVectorsIndexFile.write(deleteMap);
+        assertThat(indexFiles.size()).isEqualTo(1);
         Map<String, DeletionVector> dvs =
-                deletionVectorsIndexFile.readAllDeletionVectors(indexFileMeta);
+                deletionVectorsIndexFile.readAllDeletionVectors(indexFiles);
         assertThat(dvs.size()).isEqualTo(100000);
     }
 
@@ -119,26 +117,90 @@ public class DeletionVectorsIndexFileTest {
     public void testReadDvIndexWithEnormousDv() {
         PathFactory pathFactory = getPathFactory();
         DeletionVectorsIndexFile deletionVectorsIndexFile =
-                new DeletionVectorsIndexFile(LocalFileIO.create(), pathFactory);
+                new DeletionVectorsIndexFile(
+                        LocalFileIO.create(),
+                        pathFactory,
+                        BucketMode.HASH_FIXED,
+                        DEFAULT_TARGET_SIZE_PER_INDEX_FILE);
 
         // write
         Random random = new Random();
-        HashMap<String, DeletionVector> deleteMap = new HashMap<>();
-        BitmapDeletionVector index = new BitmapDeletionVector();
-        // dv index's size is about 20M
-        for (int i = 0; i < 10000000; i++) {
-            index.delete(random.nextInt(Integer.MAX_VALUE));
+        Map<String, DeletionVector> fileToDV = new HashMap<>();
+        Map<String, Long> fileToCardinality = new HashMap<>();
+        for (int i = 0; i < 5; i++) {
+            BitmapDeletionVector index = new BitmapDeletionVector();
+            // the size of dv index file is about 20M
+            for (int j = 0; j < 10000000; j++) {
+                index.delete(random.nextInt(Integer.MAX_VALUE));
+            }
+            fileToCardinality.put("f" + i, index.getCardinality());
+            fileToDV.put("f" + i, index);
         }
-        deleteMap.put("largeFile.parquet", index);
-        Pair<String, LinkedHashMap<String, Pair<Integer, Integer>>> pair =
-                deletionVectorsIndexFile.write(deleteMap);
+        List<IndexFileMeta> indexFiles = deletionVectorsIndexFile.write(fileToDV);
 
         // read
-        IndexFileMeta indexFileMeta =
-                new IndexFileMeta(DELETION_VECTORS_INDEX, pair.getLeft(), 0L, 0L, pair.getRight());
+        assertThat(indexFiles.size()).isEqualTo(1);
         Map<String, DeletionVector> dvs =
-                deletionVectorsIndexFile.readAllDeletionVectors(indexFileMeta);
-        assertThat(dvs.size()).isEqualTo(1);
+                deletionVectorsIndexFile.readAllDeletionVectors(indexFiles);
+        assertThat(dvs.size()).isEqualTo(5);
+        for (String file : dvs.keySet()) {
+            assertThat(dvs.get(file).getCardinality()).isEqualTo(fileToCardinality.get(file));
+        }
+    }
+
+    @Test
+    public void testWriteDVIndexWithUnawareBucket() {
+        PathFactory pathFactory = getPathFactory();
+        DeletionVectorsIndexFile deletionVectorsIndexFile =
+                new DeletionVectorsIndexFile(
+                        LocalFileIO.create(),
+                        pathFactory,
+                        BucketMode.BUCKET_UNAWARE,
+                        DEFAULT_TARGET_SIZE_PER_INDEX_FILE);
+
+        // write1
+        Random random = new Random();
+        Map<String, DeletionVector> fileToDV = new HashMap<>();
+        Map<String, Long> fileToCardinality = new HashMap<>();
+        for (int i = 0; i < 5; i++) {
+            BitmapDeletionVector index = new BitmapDeletionVector();
+            // the size of dv index file is about 1.7M
+            for (int j = 0; j < 750000; j++) {
+                index.delete(random.nextInt(Integer.MAX_VALUE));
+            }
+            fileToCardinality.put("f" + i, index.getCardinality());
+            fileToDV.put("f" + i, index);
+        }
+        List<IndexFileMeta> indexFiles = deletionVectorsIndexFile.write(fileToDV);
+
+        // assert 1
+        assertThat(indexFiles.size()).isEqualTo(5);
+        Map<String, DeletionVector> dvs =
+                deletionVectorsIndexFile.readAllDeletionVectors(indexFiles);
+        for (String file : dvs.keySet()) {
+            assertThat(dvs.get(file).getCardinality()).isEqualTo(fileToCardinality.get(file));
+        }
+
+        // write2
+        fileToDV.clear();
+        fileToCardinality.clear();
+        for (int i = 0; i < 10; i++) {
+            BitmapDeletionVector index = new BitmapDeletionVector();
+            // the size of dv index file is about 0.42M
+            for (int j = 0; j < 100000; j++) {
+                index.delete(random.nextInt(Integer.MAX_VALUE));
+            }
+            fileToCardinality.put("f" + i, index.getCardinality());
+            fileToDV.put("f" + i, index);
+        }
+        indexFiles = deletionVectorsIndexFile.write(fileToDV);
+
+        // assert 2
+        assertThat(indexFiles.size()).isGreaterThan(1);
+        dvs = deletionVectorsIndexFile.readAllDeletionVectors(indexFiles);
+        for (String file : dvs.keySet()) {
+            assertThat(dvs.get(file).getCardinality()).isEqualTo(fileToCardinality.get(file));
+        }
     }
 
     private PathFactory getPathFactory() {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

to support merge and write multi deletion vector within same partition and bucket to one index file.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
