### PR TITLE
[spark] SparkHilbertUDF hilbertCurvePosBytes classnotfound fix

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/sort/hilbert/HilbertIndexer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sort/hilbert/HilbertIndexer.java
@@ -295,7 +295,7 @@ public class HilbertIndexer implements Serializable {
         }
     }
 
-    private byte[] hilbertCurvePosBytes(Long[] points) {
+    public static byte[] hilbertCurvePosBytes(Long[] points) {
         long[] data = Arrays.stream(points).mapToLong(Long::longValue).toArray();
         HilbertCurve hilbertCurve = HilbertCurve.bits(BITS_NUM).dimensions(points.length);
         BigInteger index = hilbertCurve.index(data);

--- a/paimon-spark/paimon-spark-common/pom.xml
+++ b/paimon-spark/paimon-spark-common/pom.xml
@@ -53,11 +53,6 @@ under the License.
             <artifactId>scala-compiler</artifactId>
             <version>${scala.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.github.davidmoten</groupId>
-            <artifactId>hilbert-curve</artifactId>
-            <version>0.2.2</version>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/sort/SparkHilbertUDF.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/sort/SparkHilbertUDF.java
@@ -51,8 +51,6 @@ import scala.collection.Seq;
 public class SparkHilbertUDF implements Serializable {
     private static final long PRIMITIVE_EMPTY = Long.MAX_VALUE;
 
-    private static final int BITS_NUM = 63;
-
     SparkHilbertUDF() {}
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/sort/SparkHilbertUDF.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/sort/SparkHilbertUDF.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.spark.sort;
 
+import org.apache.paimon.sort.hilbert.HilbertIndexer;
 import org.apache.paimon.utils.ConvertBinaryUtil;
 
 import org.apache.spark.sql.Column;
@@ -37,14 +38,11 @@ import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.TimestampType;
-import org.davidmoten.hilbert.HilbertCurve;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.List;
 
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
@@ -62,11 +60,9 @@ public class SparkHilbertUDF implements Serializable {
     }
 
     byte[] hilbertCurvePosBytes(Seq<Long> points) {
-        List<Long> longs = JavaConverters.seqAsJavaList(points);
-        long[] data = longs.stream().mapToLong(Long::longValue).toArray();
-        HilbertCurve hilbertCurve = HilbertCurve.bits(BITS_NUM).dimensions(points.size());
-        BigInteger index = hilbertCurve.index(data);
-        return ConvertBinaryUtil.paddingToNByte(index.toByteArray(), BITS_NUM);
+        Long[] longs = JavaConverters.seqAsJavaList(points).stream().toArray(Long[]::new);
+        byte[] bytes = HilbertIndexer.hilbertCurvePosBytes(longs);
+        return bytes;
     }
 
     private UserDefinedFunction tinyToOrderedLongUDF() {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

SparkHilbertUDF hilbertCurvePosBytes classnotfound fix，due to this changes https://github.com/apache/paimon/pull/3251 

<!-- Linking this pull request to the issue -->
Linked issue: https://github.com/apache/paimon/issues/3416
before fix
![1716896508556.png](https://github.com/apache/paimon/assets/10645422/6bdce2f8-9dd2-4672-b6c4-e3e6422448b2)

![1716896540029.png](https://github.com/apache/paimon/assets/10645422/a0fd8c11-4bcd-41c2-a629-b93437b3a88a)



after fix
![1716896200378.png](https://github.com/apache/paimon/assets/10645422/7b939f85-38d7-40f9-87b1-2d43c542cb5a)



<!-- What is the purpose of the change -->


<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
