### PR TITLE
[core] [bug] Partition should not be filtered when manifest file predicate and file itself all min/max is null

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/NullFalseLeafBinaryFunction.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/NullFalseLeafBinaryFunction.java
@@ -50,7 +50,7 @@ public abstract class NullFalseLeafBinaryFunction extends LeafFunction {
             List<Object> literals) {
         if (nullCount != null) {
             if (rowCount == nullCount || literals.get(0) == null) {
-                return rowCount == nullCount && literals.get(0) == null;
+                return false;
             }
         }
         return test(type, rowCount, min, max, nullCount, literals.get(0));

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/NullFalseLeafBinaryFunction.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/NullFalseLeafBinaryFunction.java
@@ -50,7 +50,7 @@ public abstract class NullFalseLeafBinaryFunction extends LeafFunction {
             List<Object> literals) {
         if (nullCount != null) {
             if (rowCount == nullCount || literals.get(0) == null) {
-                return false;
+                return rowCount == nullCount && literals.get(0) == null;
             }
         }
         return test(type, rowCount, min, max, nullCount, literals.get(0));

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
@@ -368,10 +368,12 @@ public class PredicateBuilder {
         for (Map.Entry<String, String> entry : map.entrySet()) {
             int idx = fieldNames.indexOf(entry.getKey());
             Object literal = TypeUtils.castFromString(entry.getValue(), rowType.getTypeAt(idx));
+            Predicate predicateTemp =
+                    literal == null ? builder.isNull(idx) : builder.equal(idx, literal);
             if (predicate == null) {
-                predicate = builder.equal(idx, literal);
+                predicate = predicateTemp;
             } else {
-                predicate = PredicateBuilder.and(predicate, builder.equal(idx, literal));
+                predicate = PredicateBuilder.and(predicate, predicateTemp);
             }
         }
         return predicate;
@@ -394,10 +396,12 @@ public class PredicateBuilder {
         PredicateBuilder builder = new PredicateBuilder(partitionType);
         Object[] literals = converter.convert(partition);
         for (int i = 0; i < literals.length; i++) {
+            Predicate predicateTemp =
+                    literals[i] == null ? builder.isNull(i) : builder.equal(i, literals[i]);
             if (predicate == null) {
-                predicate = builder.equal(i, literals[i]);
+                predicate = predicateTemp;
             } else {
-                predicate = PredicateBuilder.and(predicate, builder.equal(i, literals[i]));
+                predicate = PredicateBuilder.and(predicate, predicateTemp);
             }
         }
 

--- a/paimon-common/src/main/java/org/apache/paimon/utils/RowDataToObjectArrayConverter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/RowDataToObjectArrayConverter.java
@@ -75,7 +75,7 @@ public class RowDataToObjectArrayConverter implements Serializable {
         Object[] partitionObjects = convert(binaryRow);
         for (int i = 0; i < getArity(); i++) {
             Object o = partitionObjects[i];
-            fieldPredicates.add(builder.equal(i, o));
+            fieldPredicates.add(o == null ? builder.isNull(i) : builder.equal(i, o));
         }
         return PredicateBuilder.and(fieldPredicates);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionPredicate.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionPredicate.java
@@ -121,8 +121,11 @@ public interface PartitionPredicate {
             PredicateBuilder builder = new PredicateBuilder(partitionType);
             for (int i = 0; i < collectors.length; i++) {
                 SimpleColStats stats = collectors[i].result();
-                min[i] = builder.greaterOrEqual(i, stats.min());
-                max[i] = builder.lessOrEqual(i, stats.max());
+                Object minValue = stats.min();
+                Object maxValue = stats.max();
+
+                min[i] = minValue == null ? builder.isNull(i) : builder.greaterOrEqual(i, minValue);
+                max[i] = maxValue == null ? builder.isNull(i) : builder.lessOrEqual(i, maxValue);
             }
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
@@ -153,7 +153,9 @@ public class SnapshotReaderImpl implements SnapshotReader {
                                                         m.getValue(),
                                                         rowType.getTypeAt(index),
                                                         false);
-                                        return predicateBuilder.equal(index, value);
+                                        return value == null
+                                                ? predicateBuilder.isNull(index)
+                                                : predicateBuilder.equal(index, value);
                                     })
                             .collect(Collectors.toList());
             scan.withPartitionFilter(PredicateBuilder.and(partitionFilters));

--- a/paimon-core/src/test/java/org/apache/paimon/operation/AppendOnlyFileStoreWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/AppendOnlyFileStoreWriteTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.operation;
 
+import java.util.Collections;
+import java.util.HashMap;
 import org.apache.paimon.append.AppendOnlyWriter;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.FileSystemCatalog;
@@ -30,10 +32,12 @@ import org.apache.paimon.disk.ExternalBuffer;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.SimpleFileEntry;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
+import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.types.DataTypes;
 
 import org.assertj.core.api.Assertions;
@@ -168,6 +172,34 @@ public class AppendOnlyFileStoreWriteTest {
         BinaryRow binaryRow = new BinaryRow(1);
         BinaryRowWriter writer = new BinaryRowWriter(binaryRow);
         writer.writeInt(0, i);
+        writer.complete();
+        return binaryRow;
+    }
+
+    @Test
+    public void testScanFilterWithNullPartition() throws Exception {
+        FileStoreTable table = createFileStoreTable();
+
+        AppendOnlyFileStoreWrite write = (AppendOnlyFileStoreWrite) table.store().newWrite("ss");
+        StreamTableCommit commit = table.newStreamWriteBuilder().newCommit();
+        write.withExecutionMode(false);
+
+        for (int i = 0; i < 100; i++) {
+            write.write(nullPartition(), i, GenericRow.of(null, i, i));
+            commit.commit(i, write.prepareCommit(false, i));
+        }
+
+        BinaryRow binaryRow = nullPartition();
+        FileStoreScan scan = table.store().newScan();
+        List<SimpleFileEntry> l0 = scan.withPartitionFilter(Collections.singletonList(binaryRow)).readSimpleEntries();
+        Assertions.assertThat(l0.size()).isEqualTo(100);
+    }
+
+
+    private BinaryRow nullPartition() {
+        BinaryRow binaryRow = new BinaryRow(1);
+        BinaryRowWriter writer = new BinaryRowWriter(binaryRow);
+        writer.setNullAt(0);
         writer.complete();
         return binaryRow;
     }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/AppendOnlyFileStoreWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/AppendOnlyFileStoreWriteTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.paimon.operation;
 
-import java.util.Collections;
-import java.util.HashMap;
 import org.apache.paimon.append.AppendOnlyWriter;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.FileSystemCatalog;
@@ -44,6 +42,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -191,10 +190,10 @@ public class AppendOnlyFileStoreWriteTest {
 
         BinaryRow binaryRow = nullPartition();
         FileStoreScan scan = table.store().newScan();
-        List<SimpleFileEntry> l0 = scan.withPartitionFilter(Collections.singletonList(binaryRow)).readSimpleEntries();
+        List<SimpleFileEntry> l0 =
+                scan.withPartitionFilter(Collections.singletonList(binaryRow)).readSimpleEntries();
         Assertions.assertThat(l0.size()).isEqualTo(100);
     }
-
 
     private BinaryRow nullPartition() {
         BinaryRow binaryRow = new BinaryRow(1);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -258,9 +258,8 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         List<Predicate> predicates = new ArrayList<>();
         for (int i = 0; i < partitionKeys.size(); i++) {
             int index = fieldNames.indexOf(partitionKeys.get(i));
-            predicates.add(
-                    builder.equal(
-                            index, InternalRowUtils.get(partition, i, rowType.getTypeAt(index))));
+            Object value = InternalRowUtils.get(partition, i, rowType.getTypeAt(index));
+            predicates.add(value == null ? builder.isNull(index) : builder.equal(index, value));
         }
         return PredicateBuilder.and(predicates);
     }


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
