### PR TITLE
[core] File index result should be able to process and/or.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexReader.java
@@ -23,84 +23,90 @@ import org.apache.paimon.predicate.FunctionVisitor;
 
 import java.util.List;
 
+import static org.apache.paimon.fileindex.FileIndexResult.REMAIN;
+
 /**
  * Read file index from serialized bytes. Return true, means we need to search this file, else means
  * needn't.
  */
-public abstract class FileIndexReader implements FunctionVisitor<Boolean> {
+public abstract class FileIndexReader implements FunctionVisitor<FileIndexResult> {
 
     @Override
-    public Boolean visitIsNotNull(FieldRef fieldRef) {
-        return true;
+    public FileIndexResult visitIsNotNull(FieldRef fieldRef) {
+        return REMAIN;
     }
 
     @Override
-    public Boolean visitIsNull(FieldRef fieldRef) {
-        return true;
+    public FileIndexResult visitIsNull(FieldRef fieldRef) {
+        return REMAIN;
     }
 
     @Override
-    public Boolean visitStartsWith(FieldRef fieldRef, Object literal) {
-        return true;
+    public FileIndexResult visitStartsWith(FieldRef fieldRef, Object literal) {
+        return REMAIN;
     }
 
     @Override
-    public Boolean visitLessThan(FieldRef fieldRef, Object literal) {
-        return true;
+    public FileIndexResult visitLessThan(FieldRef fieldRef, Object literal) {
+        return REMAIN;
     }
 
     @Override
-    public Boolean visitGreaterOrEqual(FieldRef fieldRef, Object literal) {
-        return true;
+    public FileIndexResult visitGreaterOrEqual(FieldRef fieldRef, Object literal) {
+        return REMAIN;
     }
 
     @Override
-    public Boolean visitNotEqual(FieldRef fieldRef, Object literal) {
-        return true;
+    public FileIndexResult visitNotEqual(FieldRef fieldRef, Object literal) {
+        return REMAIN;
     }
 
     @Override
-    public Boolean visitLessOrEqual(FieldRef fieldRef, Object literal) {
-        return true;
+    public FileIndexResult visitLessOrEqual(FieldRef fieldRef, Object literal) {
+        return REMAIN;
     }
 
     @Override
-    public Boolean visitEqual(FieldRef fieldRef, Object literal) {
-        return true;
+    public FileIndexResult visitEqual(FieldRef fieldRef, Object literal) {
+        return REMAIN;
     }
 
     @Override
-    public Boolean visitGreaterThan(FieldRef fieldRef, Object literal) {
-        return true;
+    public FileIndexResult visitGreaterThan(FieldRef fieldRef, Object literal) {
+        return REMAIN;
     }
 
     @Override
-    public Boolean visitIn(FieldRef fieldRef, List<Object> literals) {
+    public FileIndexResult visitIn(FieldRef fieldRef, List<Object> literals) {
+        FileIndexResult fileIndexResult = null;
         for (Object key : literals) {
-            if (visitEqual(fieldRef, key)) {
-                return true;
-            }
+            fileIndexResult =
+                    fileIndexResult == null
+                            ? visitEqual(fieldRef, key)
+                            : fileIndexResult.or(visitEqual(fieldRef, key));
         }
-        return false;
+        return fileIndexResult;
     }
 
     @Override
-    public Boolean visitNotIn(FieldRef fieldRef, List<Object> literals) {
+    public FileIndexResult visitNotIn(FieldRef fieldRef, List<Object> literals) {
+        FileIndexResult fileIndexResult = null;
         for (Object key : literals) {
-            if (visitNotEqual(fieldRef, key)) {
-                return true;
-            }
+            fileIndexResult =
+                    fileIndexResult == null
+                            ? visitNotEqual(fieldRef, key)
+                            : fileIndexResult.or(visitNotEqual(fieldRef, key));
         }
-        return false;
+        return fileIndexResult;
     }
 
     @Override
-    public Boolean visitAnd(List<Boolean> children) {
+    public FileIndexResult visitAnd(List<FileIndexResult> children) {
         throw new UnsupportedOperationException("Should not invoke this");
     }
 
     @Override
-    public Boolean visitOr(List<Boolean> children) {
+    public FileIndexResult visitOr(List<FileIndexResult> children) {
         throw new UnsupportedOperationException("Should not invoke this");
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexResult.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexResult.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex;
+
+/** File index result to decide whether filter a file. */
+public interface FileIndexResult {
+
+    FileIndexResult REMAIN =
+            new FileIndexResult() {
+                @Override
+                public boolean remain() {
+                    return true;
+                }
+
+                @Override
+                public FileIndexResult and(FileIndexResult fileIndexResult) {
+                    return fileIndexResult;
+                }
+
+                @Override
+                public FileIndexResult or(FileIndexResult fileIndexResult) {
+                    return this;
+                }
+            };
+
+    FileIndexResult SKIP =
+            new FileIndexResult() {
+                @Override
+                public boolean remain() {
+                    return false;
+                }
+
+                @Override
+                public FileIndexResult and(FileIndexResult fileIndexResult) {
+                    return this;
+                }
+
+                @Override
+                public FileIndexResult or(FileIndexResult fileIndexResult) {
+                    return fileIndexResult;
+                }
+            };
+
+    boolean remain();
+
+    FileIndexResult and(FileIndexResult fileIndexResult);
+
+    FileIndexResult or(FileIndexResult fileIndexResult);
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bloomfilter/BloomFilterFileIndex.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bloomfilter/BloomFilterFileIndex.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.fileindex.bloomfilter;
 
 import org.apache.paimon.fileindex.FileIndexReader;
+import org.apache.paimon.fileindex.FileIndexResult;
 import org.apache.paimon.fileindex.FileIndexWriter;
 import org.apache.paimon.fileindex.FileIndexer;
 import org.apache.paimon.options.Options;
@@ -28,6 +29,9 @@ import org.apache.paimon.utils.BloomFilter64;
 import org.apache.paimon.utils.BloomFilter64.BitSet;
 
 import org.apache.hadoop.util.bloom.HashFunction;
+
+import static org.apache.paimon.fileindex.FileIndexResult.REMAIN;
+import static org.apache.paimon.fileindex.FileIndexResult.SKIP;
 
 /**
  * Bloom filter for file index.
@@ -118,8 +122,8 @@ public class BloomFilterFileIndex implements FileIndexer {
         }
 
         @Override
-        public Boolean visitEqual(FieldRef fieldRef, Object key) {
-            return key == null || filter.testHash(hashFunction.hash(key));
+        public FileIndexResult visitEqual(FieldRef fieldRef, Object key) {
+            return key == null || filter.testHash(hashFunction.hash(key)) ? REMAIN : SKIP;
         }
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/empty/EmptyFileIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/empty/EmptyFileIndexReader.java
@@ -19,9 +19,12 @@
 package org.apache.paimon.fileindex.empty;
 
 import org.apache.paimon.fileindex.FileIndexReader;
+import org.apache.paimon.fileindex.FileIndexResult;
 import org.apache.paimon.predicate.FieldRef;
 
 import java.util.List;
+
+import static org.apache.paimon.fileindex.FileIndexResult.SKIP;
 
 /** Empty file index which has no writer and no serialized bytes. */
 public class EmptyFileIndexReader extends FileIndexReader {
@@ -30,42 +33,42 @@ public class EmptyFileIndexReader extends FileIndexReader {
     public static final EmptyFileIndexReader INSTANCE = new EmptyFileIndexReader();
 
     @Override
-    public Boolean visitEqual(FieldRef fieldRef, Object literal) {
-        return false;
+    public FileIndexResult visitEqual(FieldRef fieldRef, Object literal) {
+        return SKIP;
     }
 
     @Override
-    public Boolean visitIsNotNull(FieldRef fieldRef) {
-        return false;
+    public FileIndexResult visitIsNotNull(FieldRef fieldRef) {
+        return SKIP;
     }
 
     @Override
-    public Boolean visitStartsWith(FieldRef fieldRef, Object literal) {
-        return false;
+    public FileIndexResult visitStartsWith(FieldRef fieldRef, Object literal) {
+        return SKIP;
     }
 
     @Override
-    public Boolean visitLessThan(FieldRef fieldRef, Object literal) {
-        return false;
+    public FileIndexResult visitLessThan(FieldRef fieldRef, Object literal) {
+        return SKIP;
     }
 
     @Override
-    public Boolean visitGreaterOrEqual(FieldRef fieldRef, Object literal) {
-        return false;
+    public FileIndexResult visitGreaterOrEqual(FieldRef fieldRef, Object literal) {
+        return SKIP;
     }
 
     @Override
-    public Boolean visitLessOrEqual(FieldRef fieldRef, Object literal) {
-        return false;
+    public FileIndexResult visitLessOrEqual(FieldRef fieldRef, Object literal) {
+        return SKIP;
     }
 
     @Override
-    public Boolean visitGreaterThan(FieldRef fieldRef, Object literal) {
-        return false;
+    public FileIndexResult visitGreaterThan(FieldRef fieldRef, Object literal) {
+        return SKIP;
     }
 
     @Override
-    public Boolean visitIn(FieldRef fieldRef, List<Object> literals) {
-        return false;
+    public FileIndexResult visitIn(FieldRef fieldRef, List<Object> literals) {
+        return SKIP;
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/bloomfilter/BloomFilterFileIndexTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/bloomfilter/BloomFilterFileIndexTest.java
@@ -70,7 +70,7 @@ public class BloomFilterFileIndexTest {
         int num = 1000000;
         for (int i = 0; i < num; i++) {
             byte[] ra = random();
-            if (!reader.visitEqual(null, ra).remain()) {
+            if (reader.visitEqual(null, ra).remain()) {
                 errorCount++;
             }
         }

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/bloomfilter/BloomFilterFileIndexTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/bloomfilter/BloomFilterFileIndexTest.java
@@ -63,14 +63,14 @@ public class BloomFilterFileIndexTest {
         FileIndexReader reader = filter.createReader(writer.serializedBytes());
 
         for (byte[] bytes : testData) {
-            Assertions.assertThat(reader.visitEqual(null, bytes)).isTrue();
+            Assertions.assertThat(reader.visitEqual(null, bytes).remain()).isTrue();
         }
 
         int errorCount = 0;
         int num = 1000000;
         for (int i = 0; i < num; i++) {
             byte[] ra = random();
-            if (reader.visitEqual(null, ra)) {
+            if (!reader.visitEqual(null, ra).remain()) {
                 errorCount++;
             }
         }
@@ -103,14 +103,14 @@ public class BloomFilterFileIndexTest {
         FileIndexReader reader = filter.createReader(writer.serializedBytes());
 
         for (Long value : testData) {
-            Assertions.assertThat(reader.visitEqual(null, value)).isTrue();
+            Assertions.assertThat(reader.visitEqual(null, value).remain()).isTrue();
         }
 
         int errorCount = 0;
         int num = 1000000;
         for (int i = 0; i < num; i++) {
             Long ra = RANDOM.nextLong();
-            if (reader.visitEqual(null, ra)) {
+            if (reader.visitEqual(null, ra).remain()) {
                 errorCount++;
             }
         }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
@@ -311,8 +311,10 @@ public class UnawareBucketAppendOnlyTableITCase extends CatalogITCaseBase {
     public void testFileIndex() {
         batchSql(
                 "INSERT INTO index_table VALUES (1, 'a', 'AAA'), (1, 'a', 'AAA'), (2, 'c', 'BBB'), (3, 'c', 'BBB')");
+        batchSql(
+                "INSERT INTO index_table VALUES (1, 'a', 'AAA'), (1, 'a', 'AAA'), (2, 'd', 'BBB'), (3, 'd', 'BBB')");
 
-        assertThat(batchSql("SELECT * FROM index_table WHERE indexc = 'c'"))
+        assertThat(batchSql("SELECT * FROM index_table WHERE indexc = 'c' and (id = 2 or id = 3)"))
                 .containsExactlyInAnyOrder(Row.of(2, "c", "BBB"), Row.of(3, "c", "BBB"));
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

`FileIndexPredicate` return `FileIndexResult`, not `Boolean` any more.

For example, bit map index:

SQL:
```
SELECT * FROM <TABLE> WHERE a1 = 1 and a2 = 2
```

Bitmap index for a1 returns rows 1,2,3
Bitmap index for a2 returns rows 4,5,6.
Then this file could be skipped.

SQL
```
SELECT * FROM <TABLE> WHERE a1=1 or a1=2 or a1=3
```

Bitmap index for a1=1 returns rows null
Bitmap index for a1=2 return rows 1,2,3
Bitmap index for a1=3 return rows 3,4,5
Then this file should be found, and rows should be 1,2,3,4,5 (push down not implement yet)

Generally, file index implement should handle method 'or', whatever the IndexResult is produced by the file index type itself, or other kind of file index.  

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
