### PR TITLE
[core] Adjust VectoredReadable to better read performance

### DIFF
--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/TableReadBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/TableReadBenchmark.java
@@ -94,6 +94,19 @@ public class TableReadBenchmark extends TableBenchmark {
          */
     }
 
+    @Test
+    public void testOrcReadProjection1() throws Exception {
+        innerTestProjection(
+                Collections.singletonMap("orc", prepareData(orc(), "orc")), new int[] {10});
+        /*
+         * OpenJDK 64-Bit Server VM 1.8.0_292-b10 on Mac OS X 10.16
+         * Apple M1 Pro
+         * read:                            Best/Avg Time(ms)    Row Rate(K/s)      Per Row(ns)   Relative
+         * ------------------------------------------------------------------------------------------------
+         * OPERATORTEST_read_read-orc            716 /  728           4187.4            238.8       1.0X
+         */
+    }
+
     private Options orc() {
         Options options = new Options();
         options.set(CoreOptions.FILE_FORMAT, CoreOptions.FILE_FORMAT_ORC);

--- a/paimon-common/src/main/java/org/apache/paimon/fs/VectoredReadUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/VectoredReadUtils.java
@@ -19,18 +19,16 @@
 package org.apache.paimon.fs;
 
 import org.apache.paimon.utils.BlockingExecutor;
+import org.apache.paimon.utils.IOUtils;
 
 import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.paimon.fs.FileIOUtils.IO_THREAD_POOL;
-import static org.apache.paimon.fs.FileRange.createFileRange;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /* This file is based on source code from the Hadoop Project (http://hadoop.apache.org/), licensed by the Apache
@@ -46,26 +44,36 @@ public class VectoredReadUtils {
             return;
         }
 
+        List<? extends FileRange> sortRanges = validateAndSortRanges(ranges);
         List<CombinedRange> combinedRanges =
-                mergeSortedRanges(validateAndSortRanges(ranges), readable.minSeekForVectorReads());
+                mergeSortedRanges(sortRanges, readable.minSeekForVectorReads());
 
         int parallelism = readable.parallelismForVectorReads();
+
+        if (combinedRanges.size() == 1) {
+            fallbackToReadSequence(readable, sortRanges);
+            return;
+        }
+
         BlockingExecutor executor = new BlockingExecutor(IO_THREAD_POOL, parallelism);
-        long batchSize = readable.batchSizeForVectorReads();
         for (CombinedRange combinedRange : combinedRanges) {
             if (combinedRange.underlying.size() == 1) {
                 FileRange fileRange = combinedRange.underlying.get(0);
                 executor.submit(() -> readSingleRange(readable, fileRange));
             } else {
-                List<FileRange> splitBatches = combinedRange.splitBatches(batchSize, parallelism);
-                splitBatches.forEach(
-                        range -> executor.submit(() -> readSingleRange(readable, range)));
-                List<CompletableFuture<byte[]>> futures =
-                        splitBatches.stream().map(FileRange::getData).collect(Collectors.toList());
-                CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[0]))
-                        .thenAcceptAsync(
-                                unused -> copyToFileRanges(combinedRange, futures), IO_THREAD_POOL);
+                executor.submit(() -> readCombinedRange(readable, combinedRange));
             }
+        }
+    }
+
+    private static void fallbackToReadSequence(
+            VectoredReadable readable, List<? extends FileRange> ranges) throws IOException {
+        SeekableInputStream in = (SeekableInputStream) readable;
+        for (FileRange range : ranges) {
+            byte[] bytes = new byte[range.getLength()];
+            in.seek(range.getOffset());
+            IOUtils.readFully(in, bytes);
+            range.getData().complete(bytes);
         }
     }
 
@@ -85,42 +93,27 @@ public class VectoredReadUtils {
         }
     }
 
-    private static void copyToFileRanges(
-            CombinedRange combinedRange, List<CompletableFuture<byte[]>> futures) {
-        List<byte[]> segments = new ArrayList<>(futures.size());
-        for (CompletableFuture<byte[]> future : futures) {
-            segments.add(future.join());
-        }
-        long offset = combinedRange.offset;
-        for (FileRange fileRange : combinedRange.underlying) {
-            byte[] buffer = new byte[fileRange.getLength()];
-            copyMultiBytesToBytes(
-                    segments,
-                    (int) (fileRange.getOffset() - offset),
-                    buffer,
-                    fileRange.getLength());
-            fileRange.getData().complete(buffer);
-        }
-    }
+    private static void readCombinedRange(VectoredReadable readable, CombinedRange combinedRange) {
+        try {
+            long position = combinedRange.offset;
+            int length = combinedRange.length;
 
-    private static void copyMultiBytesToBytes(
-            List<byte[]> segments, int offset, byte[] bytes, int numBytes) {
-        int remainSize = numBytes;
-        for (byte[] segment : segments) {
-            int remain = segment.length - offset;
-            if (remain > 0) {
-                int nCopy = Math.min(remain, remainSize);
-                System.arraycopy(segment, offset, bytes, numBytes - remainSize, nCopy);
-                remainSize -= nCopy;
-                // next new segment.
-                offset = 0;
-                if (remainSize == 0) {
-                    return;
+            byte[] total = new byte[length];
+            readable.preadFully(position, total, 0, length);
+
+            for (FileRange child : combinedRange.underlying) {
+                byte[] buffer = new byte[child.getLength()];
+                System.arraycopy(
+                        total, (int) (child.getOffset() - position), buffer, 0, child.getLength());
+                child.getData().complete(buffer);
+            }
+        } catch (Exception ex) {
+            // complete exception all the underlying ranges which have not already
+            // finished.
+            for (FileRange child : combinedRange.underlying) {
+                if (!child.getData().isDone()) {
+                    child.getData().completeExceptionally(ex);
                 }
-            } else {
-                // remain is negative, let's advance to next segment
-                // now the offset = offset - segmentSize (-remain)
-                offset = -remain;
             }
         }
     }
@@ -212,30 +205,6 @@ public class VectoredReadUtils {
             this.length = (int) (newEnd - offset);
             append(other);
             return true;
-        }
-
-        private List<FileRange> splitBatches(long batchSize, int parallelism) {
-            long expectedSize = Math.max(batchSize, (length / parallelism) + 1);
-            List<FileRange> splitBatches = new ArrayList<>();
-            long offset = this.offset;
-            long end = offset + length;
-
-            // split only when remain size exceeds twice the batchSize to avoid small File IO
-            long minRemain = Math.max(expectedSize, batchSize * 2);
-
-            while (true) {
-                if (end < offset + minRemain) {
-                    int currentLen = (int) (end - offset);
-                    if (currentLen > 0) {
-                        splitBatches.add(createFileRange(offset, currentLen));
-                    }
-                    break;
-                } else {
-                    splitBatches.add(createFileRange(offset, (int) expectedSize));
-                    offset += expectedSize;
-                }
-            }
-            return splitBatches;
         }
 
         @Override

--- a/paimon-common/src/main/java/org/apache/paimon/fs/VectoredReadable.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/VectoredReadable.java
@@ -59,7 +59,7 @@ public interface VectoredReadable {
 
     /** The batch size of data read by a single parallelism. */
     default int batchSizeForVectorReads() {
-        return 2 * 1024 * 1024;
+        return 4 * 1024 * 1024;
     }
 
     /** The read parallelism for vector reads. */

--- a/paimon-common/src/main/java/org/apache/paimon/fs/VectoredReadable.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/VectoredReadable.java
@@ -54,7 +54,7 @@ public interface VectoredReadable {
 
     /** The smallest reasonable seek. */
     default int minSeekForVectorReads() {
-        return 1024 * 1024;
+        return 128 * 1024;
     }
 
     /** The read parallelism for vector reads. */

--- a/paimon-common/src/main/java/org/apache/paimon/fs/VectoredReadable.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/VectoredReadable.java
@@ -54,11 +54,6 @@ public interface VectoredReadable {
 
     /** The smallest reasonable seek. */
     default int minSeekForVectorReads() {
-        return 256 * 1024;
-    }
-
-    /** The batch size of data read by a single parallelism. */
-    default int batchSizeForVectorReads() {
         return 1024 * 1024;
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/fs/VectoredReadable.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/VectoredReadable.java
@@ -54,7 +54,12 @@ public interface VectoredReadable {
 
     /** The smallest reasonable seek. */
     default int minSeekForVectorReads() {
-        return 128 * 1024;
+        return 256 * 1024;
+    }
+
+    /** The batch size of data read by a single parallelism. */
+    default int batchSizeForVectorReads() {
+        return 2 * 1024 * 1024;
     }
 
     /** The read parallelism for vector reads. */

--- a/paimon-common/src/test/java/org/apache/paimon/fs/VectoredReadUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/VectoredReadUtilsTest.java
@@ -46,11 +46,6 @@ class VectoredReadUtilsTest {
                     }
 
                     @Override
-                    public int batchSizeForVectorReads() {
-                        return 1000;
-                    }
-
-                    @Override
                     public int pread(long position, byte[] buffer, int offset, int length)
                             throws IOException {
                         boolean returnAll = random.nextBoolean();

--- a/paimon-common/src/test/java/org/apache/paimon/fs/VectoredReadUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/VectoredReadUtilsTest.java
@@ -46,6 +46,11 @@ class VectoredReadUtilsTest {
                     }
 
                     @Override
+                    public int batchSizeForVectorReads() {
+                        return 1000;
+                    }
+
+                    @Override
                     public int pread(long position, byte[] buffer, int offset, int length)
                             throws IOException {
                         boolean returnAll = random.nextBoolean();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
For continuous disk data, if multiple threads are started to read, the performance will be worse than sequential reading.

So the strategy has been adjusted here to ensure that continuous data is read by a single thread as much as possible.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
