### PR TITLE
[SECURITY] Upgrade protobuf-java and commons-compress version to fix CVE

### DIFF
--- a/paimon-format/pom.xml
+++ b/paimon-format/pom.xml
@@ -89,6 +89,10 @@ under the License.
                     <groupId>com.google.protobuf</groupId>
                     <artifactId>protobuf-java</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/paimon-format/pom.xml
+++ b/paimon-format/pom.xml
@@ -39,7 +39,7 @@ under the License.
         <commons.lang3.version>3.12.0</commons.lang3.version>
         <zstd-jni.version>1.5.5-11</zstd-jni.version>
         <storage-api.version>2.8.1</storage-api.version>
-        <protobuf-java.version>3.17.3</protobuf-java.version>
+        <protobuf-java.version>3.19.6</protobuf-java.version>
     </properties>
 
     <dependencies>

--- a/paimon-format/src/main/resources/META-INF/NOTICE
+++ b/paimon-format/src/main/resources/META-INF/NOTICE
@@ -17,7 +17,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.14.2
 - com.fasterxml.jackson.core:jackson-databind:2.14.2
 - com.fasterxml.jackson.core:jackson-annotations:2.14.2
-- org.apache.commons:commons-compress:1.4.1
+- org.apache.commons:commons-compress:1.21
 
 - org.apache.parquet:parquet-hadoop:1.13.1
 - org.apache.parquet:parquet-column:1.13.1
@@ -31,6 +31,6 @@ This project bundles the following dependencies under the BSD license.
 You find it under licenses/LICENSE.protobuf, licenses/LICENSE.zstd-jni
 and licenses/LICENSE.threeten-extra
 
-- com.google.protobuf:protobuf-java:3.17.3
+- com.google.protobuf:protobuf-java:3.19.6
 - com.github.luben:zstd-jni:1.5.5-11
 - org.threeten:threeten-extra:1.7.1

--- a/paimon-format/src/main/resources/META-INF/NOTICE
+++ b/paimon-format/src/main/resources/META-INF/NOTICE
@@ -17,7 +17,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.14.2
 - com.fasterxml.jackson.core:jackson-databind:2.14.2
 - com.fasterxml.jackson.core:jackson-annotations:2.14.2
-- org.apache.commons:commons-compress:1.21
+- org.apache.commons:commons-compress:1.22
 
 - org.apache.parquet:parquet-hadoop:1.13.1
 - org.apache.parquet:parquet-column:1.13.1


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
| LIBRARY                            | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION               | TITLE                                                                 |
|------------------------------------|------------------|----------|-------------------|-----------------------------|-----------------------------------------------------------------------|
| com.google.protobuf:protobuf-java  | CVE-2022-3171    | HIGH     | 3.17.3            | 3.16.3, 3.19.6, 3.20.3, 3.21.7 | protobuf-java: timeout in parser leads to DoS <br> -->[avd.aquasec.com/nvd/cve-2022-3171](https://avd.aquasec.com/nvd/cve-2022-3171) |
|                                    | CVE-2022-3509    | HIGH     |                   | 3.21.7, 3.20.3, 3.19.6, 3.16.3 | Protobuf Java vulnerable to Uncontrolled Resource Consumption <br> -->[avd.aquasec.com/nvd/cve-2022-3509](https://avd.aquasec.com/nvd/cve-2022-3509) |
|                                    | CVE-2022-3510    | HIGH     |                   |                             | Protobuf Java vulnerable to Uncontrolled Resource Consumption <br> -->[avd.aquasec.com/nvd/cve-2022-3510](https://avd.aquasec.com/nvd/cve-2022-3510) |
| org.apache.commons:commons-compress| CVE-2021-35515   | HIGH     | 1.4.1             | 1.21                        | apache-commons-compress: infinite loop when reading a specially crafted 7Z archive <br> -->[avd.aquasec.com/nvd/cve-2021-35515](https://avd.aquasec.com/nvd/cve-2021-35515) |
|                                    | CVE-2021-35516   | HIGH     |                   |                             | apache-commons-compress: excessive memory allocation when reading a specially crafted 7Z archive <br> -->[avd.aquasec.com/nvd/cve-2021-35516](https://avd.aquasec.com/nvd/cve-2021-35516) |
|                                    | CVE-2021-35517   | HIGH     |                   |                             | apache-commons-compress: excessive memory allocation when reading a specially crafted TAR archive <br> -->[avd.aquasec.com/nvd/cve-2021-35517](https://avd.aquasec.com/nvd/cve-2021-35517) |
|                                    | CVE-2021-36090   | HIGH     |                   |                             | apache-commons-compress: excessive memory allocation when reading a specially crafted ZIP archive <br> -->[avd.aquasec.com/nvd/cve-2021-36090](https://avd.aquasec.com/nvd/cve-2021-36090) |
|                                    | CVE-2018-11771   | MEDIUM   |                   | 1.18                        | apache-commons-compress: ZipArchiveInputStream.read() fails to identify correct EOF allowing for DoS via crafted... <br> -->[avd.aquasec.com/nvd/cve-2018-11771](https://avd.aquasec.com/nvd/cve-2018-11771) |


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
