### PR TITLE
[flink] Support FileStoreLookupFunction to only cache required buckets

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.Filter;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -100,6 +101,16 @@ public interface ReadBuilder extends Serializable {
     ReadBuilder withPartitionFilter(Map<String, String> partitionSpec);
 
     /**
+     * Push bucket filter. Note that this method cannot be used simultaneously with {@link
+     * #withShard(int, int)}.
+     *
+     * <p>Reason: Bucket filtering and sharding are different logical mechanisms for selecting
+     * subsets of table data. Applying both methods simultaneously introduces conflicting selection
+     * criteria.
+     */
+    ReadBuilder withBucketFilter(Filter<Integer> bucketFilter);
+
+    /**
      * Apply projection to the reader.
      *
      * <p>NOTE: Nested row projection is currently not supported.
@@ -122,7 +133,14 @@ public interface ReadBuilder extends Serializable {
     /** the row number pushed down. */
     ReadBuilder withLimit(int limit);
 
-    /** Specify the shard to be read, and allocate sharded files to read records. */
+    /**
+     * Specify the shard to be read, and allocate sharded files to read records. Note that this
+     * method cannot be used simultaneously with {@link #withBucketFilter(Filter)}.
+     *
+     * <p>Reason: Sharding and bucket filtering are different logical mechanisms for selecting
+     * subsets of table data. Applying both methods simultaneously introduces conflicting selection
+     * criteria.
+     */
     ReadBuilder withShard(int indexOfThisSubtask, int numberOfParallelSubtasks);
 
     /** Create a {@link TableScan} to perform batch planning. */

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -60,6 +60,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
@@ -165,7 +166,11 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
                 try {
                     this.lookupTable =
                             PrimaryKeyPartialLookupTable.createLocalTable(
-                                    storeTable, projection, path, joinKeys);
+                                    storeTable,
+                                    projection,
+                                    path,
+                                    joinKeys,
+                                    getRequireCachedBucketIds());
                 } catch (UnsupportedOperationException ignore2) {
                 }
             }
@@ -179,7 +184,8 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
                             predicate,
                             createProjectedPredicate(projection),
                             path,
-                            joinKeys);
+                            joinKeys,
+                            getRequireCachedBucketIds());
             this.lookupTable = FullCacheLookupTable.create(context, options.get(LOOKUP_CACHE_ROWS));
         }
 
@@ -336,5 +342,18 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         Field field = runtimeContext.getClass().getDeclaredField("runtimeContext");
         field.setAccessible(true);
         return extractStreamingRuntimeContext(field.get(runtimeContext));
+    }
+
+    /**
+     * Get the set of bucket IDs that need to be cached by the current lookup join subtask.
+     *
+     * <p>The Flink Planner will distribute data to lookup join nodes based on buckets. This allows
+     * paimon to cache only the necessary buckets for each subtask, improving efficiency.
+     *
+     * @return the set of bucket IDs to be cached
+     */
+    private Set<Integer> getRequireCachedBucketIds() {
+        // TODO: Implement the method when Flink support bucket shuffle for lookup join.
+        return null;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
@@ -54,6 +54,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -146,7 +147,12 @@ public abstract class FullCacheLookupTable implements LookupTable {
     protected void bootstrap() throws Exception {
         Predicate scanPredicate =
                 PredicateBuilder.andNullable(context.tablePredicate, specificPartition);
-        this.reader = new LookupStreamingReader(context.table, context.projection, scanPredicate);
+        this.reader =
+                new LookupStreamingReader(
+                        context.table,
+                        context.projection,
+                        scanPredicate,
+                        context.requiredCachedBucketIds);
         BinaryExternalSortBuffer bulkLoadSorter =
                 RocksDBState.createBulkLoadSorter(
                         IOManager.create(context.tempPath.toString()), context.table.coreOptions());
@@ -328,6 +334,7 @@ public abstract class FullCacheLookupTable implements LookupTable {
         @Nullable public final Predicate projectedPredicate;
         public final File tempPath;
         public final List<String> joinKey;
+        public final Set<Integer> requiredCachedBucketIds;
 
         public Context(
                 FileStoreTable table,
@@ -335,13 +342,15 @@ public abstract class FullCacheLookupTable implements LookupTable {
                 @Nullable Predicate tablePredicate,
                 @Nullable Predicate projectedPredicate,
                 File tempPath,
-                List<String> joinKey) {
+                List<String> joinKey,
+                @Nullable Set<Integer> requiredCachedBucketIds) {
             this.table = table;
             this.projection = projection;
             this.tablePredicate = tablePredicate;
             this.projectedPredicate = projectedPredicate;
             this.tempPath = tempPath;
             this.joinKey = joinKey;
+            this.requiredCachedBucketIds = requiredCachedBucketIds;
         }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupStreamingReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupStreamingReader.java
@@ -45,6 +45,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.IntUnaryOperator;
 import java.util.stream.IntStream;
 
@@ -68,11 +69,22 @@ public class LookupStreamingReader {
                     CoreOptions.SCAN_TAG_NAME,
                     CoreOptions.SCAN_VERSION);
 
-    public LookupStreamingReader(Table table, int[] projection, @Nullable Predicate predicate) {
+    public LookupStreamingReader(
+            Table table,
+            int[] projection,
+            @Nullable Predicate predicate,
+            Set<Integer> requireCachedBucketIds) {
         this.table = unsetTimeTravelOptions(table);
         this.projection = projection;
         this.readBuilder =
-                this.table.newReadBuilder().withProjection(projection).withFilter(predicate);
+                this.table
+                        .newReadBuilder()
+                        .withProjection(projection)
+                        .withFilter(predicate)
+                        .withBucketFilter(
+                                requireCachedBucketIds == null
+                                        ? null
+                                        : requireCachedBucketIds::contains);
         scan = readBuilder.newStreamScan();
 
         if (predicate != null) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyPartialLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyPartialLookupTable.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import static org.apache.paimon.CoreOptions.SCAN_BOUNDED_WATERMARK;
@@ -149,9 +150,15 @@ public class PrimaryKeyPartialLookupTable implements LookupTable {
     }
 
     public static PrimaryKeyPartialLookupTable createLocalTable(
-            FileStoreTable table, int[] projection, File tempPath, List<String> joinKey) {
+            FileStoreTable table,
+            int[] projection,
+            File tempPath,
+            List<String> joinKey,
+            Set<Integer> requireCachedBucketIds) {
         return new PrimaryKeyPartialLookupTable(
-                filter -> new LocalQueryExecutor(table, projection, tempPath, filter),
+                filter ->
+                        new LocalQueryExecutor(
+                                table, projection, tempPath, filter, requireCachedBucketIds),
                 table,
                 joinKey);
     }
@@ -175,7 +182,11 @@ public class PrimaryKeyPartialLookupTable implements LookupTable {
         private final StreamTableScan scan;
 
         private LocalQueryExecutor(
-                FileStoreTable table, int[] projection, File tempPath, @Nullable Predicate filter) {
+                FileStoreTable table,
+                int[] projection,
+                File tempPath,
+                @Nullable Predicate filter,
+                Set<Integer> requireCachedBucketIds) {
             this.tableQuery =
                     table.newLocalTableQuery()
                             .withValueProjection(Projection.of(projection).toNestedIndexes())
@@ -185,7 +196,14 @@ public class PrimaryKeyPartialLookupTable implements LookupTable {
             dynamicOptions.put(STREAM_SCAN_MODE.key(), FILE_MONITOR.getValue());
             dynamicOptions.put(SCAN_BOUNDED_WATERMARK.key(), null);
             this.scan =
-                    table.copy(dynamicOptions).newReadBuilder().withFilter(filter).newStreamScan();
+                    table.copy(dynamicOptions)
+                            .newReadBuilder()
+                            .withFilter(filter)
+                            .withBucketFilter(
+                                    requireCachedBucketIds == null
+                                            ? null
+                                            : requireCachedBucketIds::contains)
+                            .newStreamScan();
         }
 
         @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/LookupTableTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/LookupTableTest.java
@@ -121,7 +121,8 @@ public class LookupTableTest extends TableTestBase {
                         null,
                         null,
                         tempDir.toFile(),
-                        singletonList("f0"));
+                        singletonList("f0"),
+                        null);
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
         table.open();
 
@@ -182,7 +183,8 @@ public class LookupTableTest extends TableTestBase {
                         null,
                         null,
                         tempDir.toFile(),
-                        singletonList("f0"));
+                        singletonList("f0"),
+                        null);
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
         table.open();
 
@@ -230,7 +232,8 @@ public class LookupTableTest extends TableTestBase {
                         null,
                         new PredicateBuilder(RowType.of(INT())).lessThan(0, 3),
                         tempDir.toFile(),
-                        singletonList("f0"));
+                        singletonList("f0"),
+                        null);
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
         table.open();
 
@@ -265,7 +268,8 @@ public class LookupTableTest extends TableTestBase {
                         null,
                         new PredicateBuilder(RowType.of(INT(), INT())).lessThan(1, 22),
                         tempDir.toFile(),
-                        singletonList("f0"));
+                        singletonList("f0"),
+                        null);
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
         table.open();
 
@@ -293,7 +297,8 @@ public class LookupTableTest extends TableTestBase {
                         null,
                         null,
                         tempDir.toFile(),
-                        singletonList("f1"));
+                        singletonList("f1"),
+                        null);
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
         table.open();
 
@@ -342,7 +347,8 @@ public class LookupTableTest extends TableTestBase {
                         null,
                         null,
                         tempDir.toFile(),
-                        singletonList("f1"));
+                        singletonList("f1"),
+                        null);
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
         table.open();
 
@@ -394,7 +400,8 @@ public class LookupTableTest extends TableTestBase {
                         null,
                         new PredicateBuilder(RowType.of(INT())).lessThan(0, 3),
                         tempDir.toFile(),
-                        singletonList("f1"));
+                        singletonList("f1"),
+                        null);
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
         table.open();
 
@@ -438,7 +445,8 @@ public class LookupTableTest extends TableTestBase {
                         null,
                         null,
                         tempDir.toFile(),
-                        singletonList("f1"));
+                        singletonList("f1"),
+                        null);
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
         table.open();
 
@@ -485,7 +493,8 @@ public class LookupTableTest extends TableTestBase {
                         null,
                         new PredicateBuilder(RowType.of(INT(), INT(), INT())).lessThan(2, 222),
                         tempDir.toFile(),
-                        singletonList("f1"));
+                        singletonList("f1"),
+                        null);
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
         table.open();
 
@@ -517,7 +526,8 @@ public class LookupTableTest extends TableTestBase {
                         dimTable,
                         new int[] {0, 1, 2},
                         tempDir.toFile(),
-                        ImmutableList.of("pk1", "pk2"));
+                        ImmutableList.of("pk1", "pk2"),
+                        null);
         table.open();
 
         List<InternalRow> result = table.get(row(1, -1));
@@ -549,7 +559,8 @@ public class LookupTableTest extends TableTestBase {
                         dimTable,
                         new int[] {2, 1},
                         tempDir.toFile(),
-                        ImmutableList.of("pk1", "pk2"));
+                        ImmutableList.of("pk1", "pk2"),
+                        null);
         table.open();
 
         // test re-open
@@ -580,7 +591,8 @@ public class LookupTableTest extends TableTestBase {
                         dimTable,
                         new int[] {2, 1},
                         tempDir.toFile(),
-                        ImmutableList.of("pk2", "pk1"));
+                        ImmutableList.of("pk2", "pk1"),
+                        null);
         table.open();
 
         // test re-open
@@ -616,7 +628,8 @@ public class LookupTableTest extends TableTestBase {
                         null,
                         null,
                         tempDir.toFile(),
-                        singletonList("f0"));
+                        singletonList("f0"),
+                        null);
         table = FullCacheLookupTable.create(context, ThreadLocalRandom.current().nextInt(2) * 10);
         table.open();
 


### PR DESCRIPTION
### Purpose

Modifies Paimon's FileStoreLookupFunction to cache only the required buckets during lookup joins.

### Documentation

no
