### PR TITLE
[core] FallbackToReadSequence when readable instanceof SeekableInputStream

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/VectoredReadUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/VectoredReadUtils.java
@@ -53,8 +53,8 @@ public class VectoredReadUtils {
 
         int parallelism = readable.parallelismForVectorReads();
 
-        if (combinedRanges.size() == 1) {
-            fallbackToReadSequence(readable, sortRanges);
+        if (combinedRanges.size() == 1 && readable instanceof SeekableInputStream) {
+            fallbackToReadSequence((SeekableInputStream) readable, sortRanges);
             return;
         }
 
@@ -78,8 +78,7 @@ public class VectoredReadUtils {
     }
 
     private static void fallbackToReadSequence(
-            VectoredReadable readable, List<? extends FileRange> ranges) throws IOException {
-        SeekableInputStream in = (SeekableInputStream) readable;
+            SeekableInputStream in, List<? extends FileRange> ranges) throws IOException {
         for (FileRange range : ranges) {
             byte[] bytes = new byte[range.getLength()];
             in.seek(range.getOffset());


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Fix the flaky test `VectoredReadUtilsTest.testRandom()`

![image](https://github.com/apache/paimon/assets/37108074/95741b69-fc6c-418b-adc2-ea22a3481f31)


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
