### PR TITLE
[core] Fix should ignore the Long.MIN value when create TAG based on …

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagTimeExtractor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagTimeExtractor.java
@@ -56,7 +56,7 @@ public interface TagTimeExtractor {
 
         @Override
         public Optional<LocalDateTime> extract(long timeMilli, @Nullable Long watermark) {
-            if (watermark == null) {
+            if (watermark == null || watermark < 0) {
                 return Optional.empty();
             }
 

--- a/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoManagerTest.java
@@ -135,6 +135,10 @@ public class TagAutoManagerTest extends PrimaryKeyTableTestBase {
         TableCommitImpl commit = table.newCommit(commitUser).ignoreEmptyCommit(false);
         TagManager tagManager = table.store().newTagManager();
 
+        // test watermark is Long.MIN_VALUE.
+        commit.commit(new ManifestCommittable(0, Long.MIN_VALUE));
+        assertThat(tagManager.allTagNames()).isEmpty();
+
         // test first create
         commit.commit(new ManifestCommittable(0, localZoneMills("2023-07-18T12:00:09")));
         assertThat(tagManager.allTagNames()).containsOnly("2023-07-18 11");


### PR DESCRIPTION
…the watermark. 

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close https://github.com/apache/paimon/issues/3346

<!-- What is the purpose of the change -->

```
CREATE TEMPORARY TABLE testTag ( 
id STRING  
,name STRING 
,dt STRING 
,PRIMARY KEY(id, dt) NOT ENFORCED 
) PARTITIONED BY (dt) WITH ( 
,'connector' = 'paimon' 
.......
'tag.automatic-creation'='watermark',
'tag.creation-period'='hourly',
'tag.creation-delay' = '10 s', 
'tag.num-retained-max' = '90', 
)
```
When the watermark value is Long.MIN_VALUE,  the tag will be created with name `tag-1705471-09-26 16`.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
