### PR TITLE
[parquet] Optimize parquet to use getBytesUnsafe for dictionary

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/BytesColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/BytesColumnReader.java
@@ -75,7 +75,7 @@ public class BytesColumnReader extends AbstractColumnReader<WritableBytesVector>
             int rowId, int num, WritableBytesVector column, WritableIntVector dictionaryIds) {
         for (int i = rowId; i < rowId + num; ++i) {
             if (!column.isNullAt(i)) {
-                byte[] bytes = dictionary.decodeToBinary(dictionaryIds.getInt(i)).getBytes();
+                byte[] bytes = dictionary.decodeToBinary(dictionaryIds.getInt(i)).getBytesUnsafe();
                 column.appendBytes(i, bytes, 0, bytes.length);
             }
         }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/FixedLenBytesColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/FixedLenBytesColumnReader.java
@@ -70,7 +70,7 @@ public class FixedLenBytesColumnReader<VECTOR extends WritableColumnVector>
             WritableBytesVector bytesVector = (WritableBytesVector) column;
             for (int i = 0; i < num; i++) {
                 if (runLenDecoder.readInteger() == maxDefLevel) {
-                    byte[] bytes = readDataBinary(bytesLen).getBytes();
+                    byte[] bytes = readDataBinary(bytesLen).getBytesUnsafe();
                     bytesVector.appendBytes(rowId + i, bytes, 0, bytes.length);
                 } else {
                     bytesVector.setNullAt(rowId + i);

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetDictionary.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetDictionary.java
@@ -54,7 +54,7 @@ public final class ParquetDictionary implements Dictionary {
 
     @Override
     public byte[] decodeToBinary(int id) {
-        return dictionary.decodeToBinary(id).getBytes();
+        return dictionary.decodeToBinary(id).getBytesUnsafe();
     }
 
     @Override


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Avoid copying byte arrays every time.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
