### PR TITLE
[flink] Fix the illegal usage of flink.shaded.guava31 dependency in TableSortInfo

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/TableSortInfo.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/TableSortInfo.java
@@ -24,8 +24,8 @@ import org.apache.paimon.flink.sorter.TableSorter.OrderType;
 import java.util.Collections;
 import java.util.List;
 
-import static org.apache.flink.shaded.guava31.com.google.common.base.Preconditions.checkArgument;
-import static org.apache.flink.shaded.guava31.com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
 /**
  * {@link TableSortInfo} is used to indicate the configuration details for table data sorting. This

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -182,6 +182,13 @@ This file is based on the checkstyle file of Apache Beam.
 			<property name="illegalPattern" value="true"/>
 			<property name="message" value="Use com.fasterxml.jackson instead of jettison."/>
 		</module>
+		<!-- forbid the use of flink.shaded.guava31.com.google.common -->
+		<module name="Regexp">
+			<property name="format" value="import static org\.apache\.flink\.shaded\.guava31\.com\.google\.common\.base\.Preconditions"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Paimon's Preconditions instead of Guava's Preconditions"/>
+		</module>
 
 		<!-- Enforce Java-style array declarations -->
 		<module name="ArrayTypeStyle"/>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Fix the illegal usage of flink.shaded.guava31 dependency in TableSortInfo

### Tests

no

### API and Format

no

### Documentation

no
