### PR TITLE
[spark] Migrate should guard for file format option which may not accurate to the hive table 

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
@@ -139,9 +139,7 @@ public class HiveMigrator implements Migrator {
         boolean alreadyExist = hiveCatalog.tableExists(identifier);
 
         Preconditions.checkArgument(
-                !coreOptions
-                        .formatType()
-                        .equals(sourceHiveTable.getSd().getSerdeInfo().toString()));
+                coreOptions.formatType().equals(sourceHiveTable.getSd().getSerdeInfo().toString()));
 
         if (!alreadyExist) {
             Schema schema =

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
@@ -143,13 +143,13 @@ public class HiveMigrator implements Migrator {
         boolean alreadyExist = hiveCatalog.tableExists(identifier);
 
         // add a check for migrate when set file format in options
-        if (!StringUtils.isEmpty(options.get(FILE_FORMAT))) {
+        if (!StringUtils.isEmpty(options.get(FILE_FORMAT.key()))) {
             Preconditions.checkArgument(
-                    options.get(FILE_FORMAT)
+                    options.get(FILE_FORMAT.key())
                             .equals(parseFormat(sourceHiveTable.getSd().getSerdeInfo().toString())),
                     String.format(
                             "file.format %s need keep the same with file format %s in hive table",
-                            coreOptions.formatType(),
+                            options.get(FILE_FORMAT),
                             parseFormat(sourceHiveTable.getSd().getSerdeInfo().toString())));
         }
 

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
@@ -36,6 +36,7 @@ import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.Preconditions;
 
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -136,6 +137,12 @@ public class HiveMigrator implements Migrator {
         // create paimon table if not exists
         Identifier identifier = Identifier.create(targetDatabase, targetTable);
         boolean alreadyExist = hiveCatalog.tableExists(identifier);
+
+        Preconditions.checkArgument(
+                !coreOptions
+                        .formatType()
+                        .equals(sourceHiveTable.getSd().getSerdeInfo().toString()));
+
         if (!alreadyExist) {
             Schema schema =
                     from(

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
@@ -145,8 +145,7 @@ public class HiveMigrator implements Migrator {
         // add a check for migrate when set file format in options
         if (!StringUtils.isEmpty(options.get(FILE_FORMAT))) {
             Preconditions.checkArgument(
-                    coreOptions
-                            .formatType()
+                    options.get(FILE_FORMAT)
                             .equals(parseFormat(sourceHiveTable.getSd().getSerdeInfo().toString())),
                     String.format(
                             "file.format %s need keep the same with file format %s in hive table",

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
@@ -139,7 +139,11 @@ public class HiveMigrator implements Migrator {
         boolean alreadyExist = hiveCatalog.tableExists(identifier);
 
         Preconditions.checkArgument(
-                coreOptions.formatType().equals(sourceHiveTable.getSd().getSerdeInfo().toString()));
+                coreOptions.formatType().equals(sourceHiveTable.getSd().getSerdeInfo().toString()),
+                String.format(
+                        "file.format %s need keep the same with file format %s in hive table",
+                        coreOptions.formatType(),
+                        sourceHiveTable.getSd().getSerdeInfo().toString()));
 
         if (!alreadyExist) {
             Schema schema =

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -62,10 +62,10 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
           // If format not accurate to hive format then throw exception
           assertThrows[RuntimeException] {
             spark.sql(
-              s"CALL sys.migrate_table(source_type => 'hive', source_table => '$hiveDbName.hive_tbl', options => 'file.format=orc')")
+              s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl', options => 'file.format=orc')")
           }
           spark.sql(
-            s"CALL sys.migrate_table(source_type => 'hive', source_table => '$hiveDbName.hive_tbl', options => 'file.format=parquet')")
+            s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl', options => 'file.format=parquet')")
         }
       }
     })

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -60,10 +60,12 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
           spark.sql(s"INSERT INTO hive_tbl VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
 
           // If format not accurate to hive format then throw exception
-          assertThrows[IllegalArgumentException] {
+          assertThrows[RuntimeException] {
             spark.sql(
               s"CALL sys.migrate_file(source_type => 'hive', source_table => '$hiveDbName.hive_tbl', options => 'file.format=orc')")
           }
+          spark.sql(
+            s"CALL sys.migrate_file(source_type => 'hive', source_table => '$hiveDbName.hive_tbl', options => 'file.format=parquet')")
         }
       }
     })

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -62,10 +62,10 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
           // If format not accurate to hive format then throw exception
           assertThrows[RuntimeException] {
             spark.sql(
-              s"CALL sys.migrate_file(source_type => 'hive', source_table => '$hiveDbName.hive_tbl', options => 'file.format=orc')")
+              s"CALL sys.migrate_table(source_type => 'hive', source_table => '$hiveDbName.hive_tbl', options => 'file.format=orc')")
           }
           spark.sql(
-            s"CALL sys.migrate_file(source_type => 'hive', source_table => '$hiveDbName.hive_tbl', options => 'file.format=parquet')")
+            s"CALL sys.migrate_table(source_type => 'hive', source_table => '$hiveDbName.hive_tbl', options => 'file.format=parquet')")
         }
       }
     })

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -46,6 +46,28 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
       }
     })
 
+  Seq("parquet").foreach(
+    format => {
+      test(
+        s"Paimon migrate table procedure: migrate $format non-partitioned table to paimon table with orc file format") {
+        withTable("hive_tbl") {
+          // create hive table
+          spark.sql(s"""
+                       |CREATE TABLE hive_tbl (id STRING, name STRING, pt STRING)
+                       |USING $format
+                       |""".stripMargin)
+
+          spark.sql(s"INSERT INTO hive_tbl VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
+
+          // If format not accurate to hive format then throw exception
+          assertThrows[IllegalArgumentException] {
+            spark.sql(
+              s"CALL sys.migrate_file(source_type => 'hive', source_table => '$hiveDbName.hive_tbl', options => 'file.format=orc')")
+          }
+        }
+      }
+    })
+
   Seq("parquet", "orc", "avro").foreach(
     format => {
       test(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

1. create a hive table using parquet format named test.hive_table;
2. insert into hive table with several records;
3. CALL sys.migrate_table(source_type =>'hive', table => 'test.hive_table', options => 'file.format=orc');
4. insert into test.hive_table;
5. data file format would not all with parquet;

<!-- Linking this pull request to the issue -->
Linked issue: https://github.com/apache/paimon/issues/3494

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
