### PR TITLE
[core] Close writer after commit identifier of snapshot is strictly larger than last modified identifier

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -213,10 +213,13 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
                 result.add(committable);
 
                 if (committable.isEmpty()) {
-                    // Condition 1: There is no more record waiting to be committed.
+                    // Condition 1: There is no more record waiting to be committed. Note that the
+                    // condition is < (instead of <=), because each commit identifier may have
+                    // multiple snapshots. We must make sure all snapshots of this identifier are
+                    // committed.
                     // Condition 2: No compaction is in progress. That is, no more changelog will be
                     // produced.
-                    if (writerContainer.lastModifiedCommitIdentifier <= latestCommittedIdentifier
+                    if (writerContainer.lastModifiedCommitIdentifier < latestCommittedIdentifier
                             && !writerContainer.writer.isCompacting()) {
                         // Clear writer if no update, and if its latest modification has committed.
                         //


### PR DESCRIPTION
### Purpose

Currently in `AbstractFileStoreWrite`, we use `writerContainer.lastModifiedCommitIdentifier <= latestCommittedIdentifier` to check that there is no more record waiting to be committed for this writer.

However, each commit identifier may have multiple snapshots (for example, one APPEND snapshot and one COMPACT snapshot). If the commit is slow, writer might be closed and re-opened between the APPEND snapshot and the COMPACT snapshot, thus causing commit conflicts in the future.

To ensure that all snapshots of this identifier are committed, the correct condition should be `writerContainer.lastModifiedCommitIdentifier < latestCommittedIdentifier`.

### Tests

* `TableWriteTest#testWaitAllSnapshotsOfSpecificIdentifier`

### API and Format

Not affected.

### Documentation

No new feature.
