### PR TITLE
[core] Use rawConvertible to determine whether needs to convertToRawFiles

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
@@ -109,14 +109,9 @@ public class DataTableBatchScan extends AbstractDataTableScan {
      * merged.
      */
     private long getRowCountForSplit(DataSplit split) {
-        if (split.convertToRawFiles().isPresent()) {
-            return split.convertToRawFiles().get().stream()
-                    .map(RawFile::rowCount)
-                    .reduce(Long::sum)
-                    .orElse(0L);
-        } else {
-            return 0L;
-        }
+        return split.convertToRawFiles()
+                .map(files -> files.stream().map(RawFile::rowCount).reduce(Long::sum).orElse(0L))
+                .orElse(0L);
     }
 
     @Override

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/ScanHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/ScanHelper.scala
@@ -48,7 +48,7 @@ trait ScanHelper extends Logging {
     if (splits.length < leafNodeDefaultParallelism) {
       val beforeLength = splits.length
       val (toReshuffle, reserved) = splits.partition {
-        case split: DataSplit => split.beforeFiles().isEmpty && split.convertToRawFiles.isPresent
+        case split: DataSplit => split.beforeFiles().isEmpty && split.rawConvertible()
         case _ => false
       }
       val reshuffled = reshuffleSplits0(toReshuffle.collect { case ds: DataSplit => ds })


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

#3226 Add `rawConvertible` in `DataSplit`, and remove the lazy loading mechanism.
We should use `rawConvertible` to determine whether needs to convertToRawFiles to preventing double convert

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
