### PR TITLE
[spark] adjust the field order of readSchema

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -53,8 +53,8 @@ abstract class PaimonBaseScan(
   private lazy val tableSchema = SparkTypeUtils.fromPaimonRowType(tableRowType)
 
   private val (tableFields, metadataFields) = {
-    val requiredFieldNames = requiredSchema.fieldNames
-    val _tableFields = tableSchema.filter(field => requiredFieldNames.contains(field.name))
+    val nameToField = tableSchema.map(field => (field.name, field)).toMap
+    val _tableFields = requiredSchema.flatMap(field => nameToField.get(field.name))
     val _metadataFields =
       requiredSchema
         .filterNot(field => tableSchema.fieldNames.contains(field.name))


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

To remove redundant projects requires the project and its child have the same output with order.
So we adjust here.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
