### PR TITLE
[flink] Introduce partition mark done with batch

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -81,6 +81,12 @@ under the License.
             <td>If the pending snapshot count exceeds the threshold, lookup operator will refresh the table in sync.</td>
         </tr>
         <tr>
+            <td><h5>partition.end-input-to-done</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether mark the done status to indicate that the data is ready when end input.</td>
+        </tr>
+        <tr>
             <td><h5>partition.idle-time-to-done</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -376,6 +376,13 @@ public class FlinkConnectorOptions {
                                             "Both can be configured at the same time: 'done-partition,success-file'.")
                                     .build());
 
+    public static final ConfigOption<Boolean> PARTITION_MARK_DONE_WHEN_END_INPUT =
+            ConfigOptions.key("partition.end-input-to-done")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether mark the done status to indicate that the data is ready when end input.");
+
     public static final ConfigOption<String> CLUSTERING_COLUMNS =
             key("sink.clustering.by-columns")
                     .stringType()

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
@@ -47,7 +47,8 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
             long checkpointId, long watermark, GlobalCommitT t, List<CommitT> committables);
 
     /** Commits the given {@link GlobalCommitT}. */
-    void commit(List<GlobalCommitT> globalCommittables) throws IOException, InterruptedException;
+    void commit(List<GlobalCommitT> globalCommittables, boolean endInput)
+            throws IOException, InterruptedException;
 
     /**
      * Filter out all {@link GlobalCommitT} which have committed, and commit the remaining {@link

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
@@ -201,13 +201,13 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
         NavigableMap<Long, GlobalCommitT> headMap =
                 committablesPerCheckpoint.headMap(checkpointId, true);
         List<GlobalCommitT> committables = committables(headMap);
-        committer.commit(committables);
+        committer.commit(committables, endInput);
         headMap.clear();
 
         if (committables.isEmpty()) {
             if (committer.forceCreatingSnapshot()) {
                 GlobalCommitT commit = toCommittables(checkpointId, Collections.emptyList());
-                committer.commit(Collections.singletonList(commit));
+                committer.commit(Collections.singletonList(commit), endInput);
             }
         }
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
@@ -107,12 +107,12 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
     }
 
     @Override
-    public void commit(List<ManifestCommittable> committables)
+    public void commit(List<ManifestCommittable> committables, boolean endInput)
             throws IOException, InterruptedException {
         commit.commitMultiple(committables, false);
         calcNumBytesAndRecordsOut(committables);
         if (partitionMarkDone != null) {
-            partitionMarkDone.notifyCommittable(committables);
+            partitionMarkDone.notifyCommittable(committables, endInput);
         }
     }
 
@@ -120,7 +120,7 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
     public int filterAndCommit(List<ManifestCommittable> globalCommittables) {
         int committed = commit.filterAndCommitMultiple(globalCommittables);
         if (partitionMarkDone != null) {
-            partitionMarkDone.notifyCommittable(globalCommittables);
+            partitionMarkDone.notifyCommittable(globalCommittables, false);
         }
         return committed;
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
@@ -114,7 +114,7 @@ public class StoreMultiCommitter
     }
 
     @Override
-    public void commit(List<WrappedManifestCommittable> committables)
+    public void commit(List<WrappedManifestCommittable> committables, boolean endInput)
             throws IOException, InterruptedException {
         if (committables.isEmpty()) {
             return;
@@ -130,13 +130,13 @@ public class StoreMultiCommitter
             List<ManifestCommittable> committableList = committableMap.get(entry.getKey());
             StoreCommitter committer = entry.getValue();
             if (committableList != null) {
-                committer.commit(committableList);
+                committer.commit(committableList, endInput);
             } else {
                 // try best to commit empty snapshot, but tableCommitters may not contain all tables
                 if (committer.forceCreatingSnapshot()) {
                     ManifestCommittable combine =
                             committer.combine(checkpointId, watermark, Collections.emptyList());
-                    committer.commit(Collections.singletonList(combine));
+                    committer.commit(Collections.singletonList(combine), endInput);
                 }
             }
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionMarkDoneTrigger.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionMarkDoneTrigger.java
@@ -18,50 +18,81 @@
 
 package org.apache.paimon.flink.sink.partition;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionTimeExtractor;
 import org.apache.paimon.utils.StringUtils;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.OperatorStateStore;
+import org.apache.flink.api.common.typeutils.base.ListSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
 
 import java.time.Duration;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.paimon.flink.FlinkConnectorOptions.PARTITION_IDLE_TIME_TO_DONE;
+import static org.apache.paimon.flink.FlinkConnectorOptions.PARTITION_MARK_DONE_WHEN_END_INPUT;
+import static org.apache.paimon.flink.FlinkConnectorOptions.PARTITION_TIME_INTERVAL;
 import static org.apache.paimon.utils.PartitionPathUtils.extractPartitionSpecFromPath;
 
-/** Trigger to mark partitions done. */
+/** Trigger to mark partitions done with streaming job. */
 public class PartitionMarkDoneTrigger {
+
+    private static final ListStateDescriptor<List<String>> PENDING_PARTITIONS_STATE_DESC =
+            new ListStateDescriptor<>(
+                    "mark-done-pending-partitions",
+                    new ListSerializer<>(StringSerializer.INSTANCE));
 
     private final State state;
     private final PartitionTimeExtractor timeExtractor;
-    private final long timeInterval;
-    private final long idleTime;
+    private long timeInterval;
+    private long idleTime;
+    private final boolean partitionMarkDoneWhenEndInput;
     private final Map<String, Long> pendingPartitions;
 
     public PartitionMarkDoneTrigger(
             State state,
             PartitionTimeExtractor timeExtractor,
             Duration timeInterval,
-            Duration idleTime)
+            Duration idleTime,
+            boolean partitionMarkDoneWhenEndInput)
             throws Exception {
-        this(state, timeExtractor, timeInterval, idleTime, System.currentTimeMillis());
+        this(
+                state,
+                timeExtractor,
+                timeInterval,
+                idleTime,
+                System.currentTimeMillis(),
+                partitionMarkDoneWhenEndInput);
     }
 
-    PartitionMarkDoneTrigger(
+    public PartitionMarkDoneTrigger(
             State state,
             PartitionTimeExtractor timeExtractor,
             Duration timeInterval,
             Duration idleTime,
-            long currentTimeMillis)
+            long currentTimeMillis,
+            boolean partitionMarkDoneWhenEndInput)
             throws Exception {
+        this.pendingPartitions = new HashMap<>();
         this.state = state;
         this.timeExtractor = timeExtractor;
-        this.timeInterval = timeInterval.toMillis();
-        this.idleTime = idleTime.toMillis();
-        this.pendingPartitions = new HashMap<>();
+        if (timeInterval != null) {
+            this.timeInterval = timeInterval.toMillis();
+        }
+        if (idleTime != null) {
+            this.idleTime = idleTime.toMillis();
+        }
+        this.partitionMarkDoneWhenEndInput = partitionMarkDoneWhenEndInput;
         state.restore().forEach(p -> pendingPartitions.put(p, currentTimeMillis));
     }
 
@@ -69,17 +100,23 @@ public class PartitionMarkDoneTrigger {
         notifyPartition(partition, System.currentTimeMillis());
     }
 
-    void notifyPartition(String partition, long currentTimeMillis) {
+    public void notifyPartition(String partition, long currentTimeMillis) {
         if (!StringUtils.isNullOrWhitespaceOnly(partition)) {
             this.pendingPartitions.put(partition, currentTimeMillis);
         }
     }
 
-    public List<String> donePartitions() {
-        return donePartitions(System.currentTimeMillis());
+    public List<String> donePartitions(boolean endInput) {
+        return donePartitions(endInput, System.currentTimeMillis());
     }
 
-    public List<String> donePartitions(long currentTimeMillis) {
+    public List<String> donePartitions(boolean endInput, long currentTimeMillis) {
+        if (endInput) {
+            return partitionMarkDoneWhenEndInput
+                    ? new ArrayList<>(pendingPartitions.keySet())
+                    : Collections.emptyList();
+        }
+
         List<String> needDone = new ArrayList<>();
         Iterator<Map.Entry<String, Long>> iter = pendingPartitions.entrySet().iterator();
         while (iter.hasNext()) {
@@ -110,9 +147,49 @@ public class PartitionMarkDoneTrigger {
 
     /** State to store partitions. */
     public interface State {
-
         List<String> restore() throws Exception;
 
         void update(List<String> partitions) throws Exception;
+    }
+
+    /** State to store partitions with streaming job. */
+    private static class PartitionMarkDoneTriggerState implements State {
+
+        private final boolean isRestored;
+        private final ListState<List<String>> pendingPartitionsState;
+
+        public PartitionMarkDoneTriggerState(boolean isRestored, OperatorStateStore stateStore)
+                throws Exception {
+            this.isRestored = isRestored;
+            this.pendingPartitionsState = stateStore.getListState(PENDING_PARTITIONS_STATE_DESC);
+        }
+
+        @Override
+        public List<String> restore() throws Exception {
+            List<String> pendingPartitions = new ArrayList<>();
+            if (isRestored) {
+                pendingPartitions.addAll(pendingPartitionsState.get().iterator().next());
+            }
+            return pendingPartitions;
+        }
+
+        @Override
+        public void update(List<String> partitions) throws Exception {
+            pendingPartitionsState.update(Collections.singletonList(partitions));
+        }
+    }
+
+    public static PartitionMarkDoneTrigger create(
+            CoreOptions coreOptions, boolean isRestored, OperatorStateStore stateStore)
+            throws Exception {
+        Options options = coreOptions.toConfiguration();
+        return new PartitionMarkDoneTrigger(
+                new PartitionMarkDoneTrigger.PartitionMarkDoneTriggerState(isRestored, stateStore),
+                new PartitionTimeExtractor(
+                        coreOptions.partitionTimestampPattern(),
+                        coreOptions.partitionTimestampFormatter()),
+                options.get(PARTITION_TIME_INTERVAL),
+                options.get(PARTITION_IDLE_TIME_TO_DONE),
+                options.get(PARTITION_MARK_DONE_WHEN_END_INPUT));
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkBatchJobPartitionMarkdoneITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkBatchJobPartitionMarkdoneITCase.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.flink.sink.FlinkSinkBuilder;
+import org.apache.paimon.flink.sink.partition.SuccessFile;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.runtime.typeutils.InternalSerializers;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+import org.apache.flink.types.Row;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.CoreOptions.BUCKET;
+import static org.apache.paimon.CoreOptions.BUCKET_KEY;
+import static org.apache.paimon.CoreOptions.FILE_FORMAT;
+import static org.apache.paimon.CoreOptions.PATH;
+import static org.apache.paimon.flink.LogicalTypeConversion.toDataType;
+import static org.apache.paimon.utils.FailingFileIO.retryArtificialException;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** ITCase for partition mark done with flink batch job. */
+@ExtendWith(ParameterizedTestExtension.class)
+public class FlinkBatchJobPartitionMarkdoneITCase extends CatalogITCaseBase {
+
+    private static final RowType TABLE_TYPE =
+            new RowType(
+                    Arrays.asList(
+                            new RowType.RowField("v", new IntType()),
+                            new RowType.RowField("p", new VarCharType(10)),
+                            // rename key
+                            new RowType.RowField("_k", new IntType())));
+
+    private static final List<RowData> SOURCE_DATA =
+            Arrays.asList(
+                    wrap(GenericRowData.of(0, StringData.fromString("p1"), 1)),
+                    wrap(GenericRowData.of(0, StringData.fromString("p1"), 2)),
+                    wrap(GenericRowData.of(0, StringData.fromString("p1"), 1)),
+                    wrap(GenericRowData.of(5, StringData.fromString("p1"), 1)),
+                    wrap(GenericRowData.of(6, StringData.fromString("p2"), 1)),
+                    wrap(GenericRowData.of(3, StringData.fromString("p2"), 5)),
+                    wrap(GenericRowData.of(5, StringData.fromString("p2"), 1)));
+
+    private static SerializableRowData wrap(RowData row) {
+        return new SerializableRowData(row, InternalSerializers.create(TABLE_TYPE));
+    }
+
+    private final StreamExecutionEnvironment env;
+
+    public FlinkBatchJobPartitionMarkdoneITCase() {
+        this.env = streamExecutionEnvironmentBuilder().batchMode().parallelism(2).build();
+    }
+
+    @Parameters(name = "isBatch-{0}")
+    public static List<Boolean> getVarSeg() {
+        return Arrays.asList(true, false);
+    }
+
+    protected List<String> ddl() {
+        return Collections.singletonList(
+                "CREATE TABLE IF NOT EXISTS T ("
+                        + "v INT, "
+                        + "p STRING, "
+                        + "_k INT, "
+                        + "PRIMARY KEY (_k) NOT ENFORCED"
+                        + ") PARTITIONED BY (p) WITH ()");
+    }
+
+    public void validateResult(FileStoreTable table) throws Exception {
+        LocalFileIO fileIO = new LocalFileIO();
+        Path successPath1 = new Path(table.location(), "p=p1/_SUCCESS");
+        SuccessFile successFile1 = SuccessFile.safelyFromPath(fileIO, successPath1);
+        assertThat(successFile1).isNotNull();
+
+        Path successPath2 = new Path(table.location(), "p=p2/_SUCCESS");
+        SuccessFile successFile2 = SuccessFile.safelyFromPath(fileIO, successPath2);
+        assertThat(successFile2).isNotNull();
+    }
+
+    @TestTemplate
+    public void testFlinkBatchJobPartitionMarkdoneBySQL() throws Exception {
+        batchSql(
+                "INSERT INTO T /*+ OPTIONS('partition.end-input-to-done'= 'true') */ VALUES (0, 'p1', 1), (0, 'p2', 2)");
+
+        validateResult(paimonTable("T"));
+    }
+
+    @TestTemplate
+    public void testFlinkBatchJobPartitionMarkdone() throws Exception {
+        FileStoreTable table = buildFileStoreTable(new int[] {1}, new int[] {1, 2});
+
+        // write
+        DataStreamSource<RowData> source =
+                env.fromCollection(SOURCE_DATA, InternalTypeInfo.of(TABLE_TYPE));
+        DataStream<Row> input =
+                source.map(
+                                (MapFunction<RowData, Row>)
+                                        r ->
+                                                Row.of(
+                                                        r.getInt(0),
+                                                        r.getString(1).toString(),
+                                                        r.getInt(2)))
+                        .setParallelism(source.getParallelism());
+        DataType inputType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("v", DataTypes.INT()),
+                        DataTypes.FIELD("p", DataTypes.STRING()),
+                        DataTypes.FIELD("_k", DataTypes.INT()));
+        new FlinkSinkBuilder(table).forRow(input, inputType).build();
+        env.execute();
+
+        validateResult(table);
+    }
+
+    private FileStoreTable buildFileStoreTable(int[] partitions, int[] primaryKey)
+            throws Exception {
+        Options options = new Options();
+        options.set(BUCKET, 3);
+        options.set(PATH, getTempDirPath());
+        options.set(FILE_FORMAT, CoreOptions.FILE_FORMAT_AVRO);
+        options.set(FlinkConnectorOptions.PARTITION_MARK_DONE_WHEN_END_INPUT.key(), "true");
+
+        Path tablePath = new CoreOptions(options.toMap()).path();
+        if (primaryKey.length == 0) {
+            options.set(BUCKET_KEY, "_k");
+        }
+        Schema schema =
+                new Schema(
+                        toDataType(TABLE_TYPE).getFields(),
+                        Arrays.stream(partitions)
+                                .mapToObj(i -> TABLE_TYPE.getFieldNames().get(i))
+                                .collect(Collectors.toList()),
+                        Arrays.stream(primaryKey)
+                                .mapToObj(i -> TABLE_TYPE.getFieldNames().get(i))
+                                .collect(Collectors.toList()),
+                        options.toMap(),
+                        "");
+        return retryArtificialException(
+                () -> {
+                    new SchemaManager(LocalFileIO.create(), tablePath).createTable(schema);
+                    return FileStoreTableFactory.create(LocalFileIO.create(), options);
+                });
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
@@ -563,7 +563,7 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
         StoreCommitter committer =
                 new StoreCommitter(
                         table, commit, Committer.createContext("", metricGroup, true, false, null));
-        committer.commit(Collections.singletonList(manifestCommittable));
+        committer.commit(Collections.singletonList(manifestCommittable), false);
         CommitterMetrics metrics = committer.getCommitterMetrics();
         assertThat(metrics.getNumBytesOutCounter().getCount()).isEqualTo(293);
         assertThat(metrics.getNumRecordsOutCounter().getCount()).isEqualTo(2);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Base on https://github.com/apache/paimon/pull/3317

This PR is intended to support a mechanism for marking a partition as finished and subsequently pulling up offline scheduling jobs with flink batch job.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
