### PR TITLE
[core]remove_orphan_files support dry run and optimize output

### DIFF
--- a/docs/content/flink/procedures.md
+++ b/docs/content/flink/procedures.md
@@ -169,7 +169,8 @@ All available procedures are listed below.
       <td>remove_orphan_files</td>
       <td>
          CALL [catalog.]sys.remove_orphan_files('identifier')<br/><br/>
-         CALL [catalog.]sys.remove_orphan_files('identifier', 'olderThan')
+         CALL [catalog.]sys.remove_orphan_files('identifier', 'olderThan')<br/><br/>
+         CALL [catalog.]sys.remove_orphan_files('identifier', 'olderThan', 'dryRun')
       </td>
       <td>
          To remove the orphan data files and metadata files. Arguments:
@@ -177,8 +178,11 @@ All available procedures are listed below.
             <li>olderThan: to avoid deleting newly written files, this procedure only 
                deletes orphan files older than 1 day by default. This argument can modify the interval.
             </li>
+            <li>dryRun: when true, view only orphan files, don't actually remove files. Default is false.</li>
       </td>
-      <td>CALL remove_orphan_files('default.T', '2023-10-31 12:00:00')</td>
+      <td>CALL remove_orphan_files('default.T', '2023-10-31 12:00:00')<br/><br/>
+          CALL remove_orphan_files('default.T', '2023-10-31 12:00:00', true) 
+      </td>
    </tr>
    <tr>
       <td>reset_consumer</td>

--- a/docs/content/maintenance/manage-snapshots.md
+++ b/docs/content/maintenance/manage-snapshots.md
@@ -305,7 +305,8 @@ submit a `remove_orphan_files` job to clean them:
     --warehouse <warehouse-path> \
     --database <database-name> \ 
     --table <table-name> \
-    [--older_than <timestamp>] 
+    [--older_than <timestamp>] \
+    [--dry_run <false/true>] 
 ```
 
 To avoid deleting files that are newly added by other writing jobs, this action only deletes orphan files older than

--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -119,9 +119,11 @@ This section introduce all available spark procedures about paimon.
          To remove the orphan data files and metadata files. Arguments:
             <li>table: the target table identifier. Cannot be empty.</li>
             <li>older_than: to avoid deleting newly written files, this procedure only deletes orphan files older than 1 day by default. This argument can modify the interval.</li>
+            <li>dry_run: when true, view only orphan files, don't actually remove files. Default is false.</li>
       </td>
       <td>
-          CALL sys.remove_orphan_files(table => 'default.T', older_than => '2023-10-31 12:00:00')
+          CALL sys.remove_orphan_files(table => 'default.T', older_than => '2023-10-31 12:00:00')<br/><br/>
+          CALL sys.remove_orphan_files(table => 'default.T', older_than => '2023-10-31 12:00:00', dry_run => true)
       </td>
     </tr>
     <tr>

--- a/paimon-core/src/test/java/org/apache/paimon/operation/OrphanFilesCleanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/OrphanFilesCleanTest.java
@@ -170,7 +170,7 @@ public class OrphanFilesCleanTest {
 
         // first check, nothing will be deleted because the default olderThan interval is 1 day
         OrphanFilesClean orphanFilesClean = new OrphanFilesClean(table);
-        assertThat(orphanFilesClean.clean()).isEqualTo(0);
+        assertThat(orphanFilesClean.clean().size()).isEqualTo(0);
 
         // second check
         orphanFilesClean = new OrphanFilesClean(table);
@@ -357,7 +357,7 @@ public class OrphanFilesCleanTest {
 
         // first check, nothing will be deleted because the default olderThan interval is 1 day
         OrphanFilesClean orphanFilesClean = new OrphanFilesClean(table);
-        assertThat(orphanFilesClean.clean()).isEqualTo(0);
+        assertThat(orphanFilesClean.clean().size()).isEqualTo(0);
 
         // second check
         orphanFilesClean = new OrphanFilesClean(table);
@@ -392,7 +392,7 @@ public class OrphanFilesCleanTest {
 
         OrphanFilesClean orphanFilesClean = new OrphanFilesClean(table);
         setOlderThan(orphanFilesClean);
-        assertThat(orphanFilesClean.clean()).isGreaterThan(0);
+        assertThat(orphanFilesClean.clean().size()).isGreaterThan(0);
     }
 
     private void writeData(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RemoveOrphanFilesAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RemoveOrphanFilesAction.java
@@ -18,15 +18,22 @@
 
 package org.apache.paimon.flink.action;
 
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.operation.OrphanFilesClean;
 import org.apache.paimon.table.FileStoreTable;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Action to remove the orphan data files and metadata files. */
 public class RemoveOrphanFilesAction extends TableActionBase {
+    private static final Logger LOG = LoggerFactory.getLogger(RemoveOrphanFilesAction.class);
 
     private final OrphanFilesClean orphanFilesClean;
 
@@ -49,8 +56,18 @@ public class RemoveOrphanFilesAction extends TableActionBase {
         return this;
     }
 
+    public RemoveOrphanFilesAction dryRun(Boolean dryRun) {
+        this.orphanFilesClean.dryRun(dryRun);
+        return this;
+    }
+
     @Override
     public void run() throws Exception {
-        orphanFilesClean.clean();
+        List<Path> orphanFiles = orphanFilesClean.clean();
+        String files =
+                orphanFiles.stream()
+                        .map(filePath -> filePath.toUri().getPath())
+                        .collect(Collectors.joining(", "));
+        LOG.info("orphan files: [{}]", files);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RemoveOrphanFilesActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RemoveOrphanFilesActionFactory.java
@@ -29,6 +29,7 @@ public class RemoveOrphanFilesActionFactory implements ActionFactory {
     public static final String IDENTIFIER = "remove_orphan_files";
 
     private static final String OLDER_THAN = "older_than";
+    private static final String DRY_RUN = "dry_run";
 
     @Override
     public String identifier() {
@@ -48,6 +49,10 @@ public class RemoveOrphanFilesActionFactory implements ActionFactory {
             action.olderThan(params.get(OLDER_THAN));
         }
 
+        if (params.has(DRY_RUN)) {
+            action.dryRun(Boolean.parseBoolean(params.get(DRY_RUN)));
+        }
+
         return Optional.of(action);
     }
 
@@ -60,12 +65,16 @@ public class RemoveOrphanFilesActionFactory implements ActionFactory {
         System.out.println("Syntax:");
         System.out.println(
                 "  remove_orphan_files --warehouse <warehouse_path> --database <database_name> "
-                        + "--table <table_name> [--older_than <timestamp>]");
+                        + "--table <table_name> [--older_than <timestamp>] [--dry_run <false/true>]");
 
         System.out.println();
         System.out.println(
                 "To avoid deleting newly written files, this action only deletes orphan files older than 1 day by default. "
                         + "The interval can be modified by '--older_than'. <timestamp> format: yyyy-MM-dd HH:mm:ss");
+
+        System.out.println();
+        System.out.println(
+                "When '--dry_run true', view only orphan files, don't actually remove files. Default is false.");
         System.out.println();
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
@@ -49,6 +49,12 @@ public class RemoveOrphanFilesProcedure extends ProcedureBase {
 
     public String[] call(ProcedureContext procedureContext, String tableId, String olderThan)
             throws Exception {
+        return call(procedureContext, tableId, olderThan, false);
+    }
+
+    public String[] call(
+            ProcedureContext procedureContext, String tableId, String olderThan, boolean dryRun)
+            throws Exception {
         Identifier identifier = Identifier.fromString(tableId);
         Table table = catalog.getTable(identifier);
 
@@ -62,9 +68,11 @@ public class RemoveOrphanFilesProcedure extends ProcedureBase {
             orphanFilesClean.olderThan(olderThan);
         }
 
-        int deleted = orphanFilesClean.clean();
+        orphanFilesClean.dryRun(dryRun);
 
-        return new String[] {"Deleted=" + deleted};
+        return orphanFilesClean.clean().stream()
+                .map(filePath -> filePath.toUri().getPath())
+                .toArray(String[]::new);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ActionITCaseBase.java
@@ -38,6 +38,8 @@ import org.apache.paimon.types.RowType;
 
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.config.TableConfigOptions;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -185,12 +187,13 @@ public abstract class ActionITCaseBase extends AbstractTestBase {
         }
     }
 
-    protected void callProcedure(String procedureStatement) {
+    protected CloseableIterator<Row> callProcedure(String procedureStatement) {
         // default execution mode
-        callProcedure(procedureStatement, true, false);
+        return callProcedure(procedureStatement, true, false);
     }
 
-    protected void callProcedure(String procedureStatement, boolean isStreaming, boolean dmlSync) {
+    protected CloseableIterator<Row> callProcedure(
+            String procedureStatement, boolean isStreaming, boolean dmlSync) {
         TableEnvironment tEnv;
         if (isStreaming) {
             tEnv = tableEnvironmentBuilder().streamingMode().checkpointIntervalMs(500).build();
@@ -206,6 +209,6 @@ public abstract class ActionITCaseBase extends AbstractTestBase {
                         warehouse));
         tEnv.useCatalog("PAIMON");
 
-        tEnv.executeSql(procedureStatement);
+        return tEnv.executeSql(procedureStatement).collect();
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/RemoveOrphanFilesActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/RemoveOrphanFilesActionITCase.java
@@ -19,12 +19,18 @@
 package org.apache.paimon.flink.action;
 
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.StreamWriteBuilder;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
+
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -32,6 +38,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 /** IT cases for {@link RemoveOrphanFilesAction}. */
@@ -58,6 +65,14 @@ public class RemoveOrphanFilesActionITCase extends ActionITCaseBase {
 
         writeData(rowData(1L, BinaryString.fromString("Hi")));
 
+        Path orphanFile1 = new Path(table.location(), "bucket-0/orphan_file1");
+        Path orphanFile2 = new Path(table.location(), "bucket-0/orphan_file2");
+
+        FileIO fileIO = table.fileIO();
+        fileIO.writeFileUtf8(orphanFile1, "a");
+        Thread.sleep(2000);
+        fileIO.writeFileUtf8(orphanFile2, "b");
+
         List<String> args =
                 new ArrayList<>(
                         Arrays.asList(
@@ -78,12 +93,28 @@ public class RemoveOrphanFilesActionITCase extends ActionITCaseBase {
 
         String withoutOlderThan =
                 String.format("CALL sys.remove_orphan_files('%s.%s')", database, tableName);
-        assertThatCode(() -> callProcedure(withoutOlderThan)).doesNotThrowAnyException();
+        CloseableIterator<Row> withoutOlderThanCollect = callProcedure(withoutOlderThan);
+        assertThat(ImmutableList.copyOf(withoutOlderThanCollect).size()).isEqualTo(0);
+
+        String withDryRun =
+                String.format(
+                        "CALL sys.remove_orphan_files('%s.%s', '2999-12-31 23:59:59', true)",
+                        database, tableName);
+        ImmutableList<Row> actualDryRunDeleteFile = ImmutableList.copyOf(callProcedure(withDryRun));
+        assertThat(actualDryRunDeleteFile)
+                .containsExactlyInAnyOrder(
+                        Row.of(orphanFile1.toUri().getPath()),
+                        Row.of(orphanFile2.toUri().getPath()));
 
         String withOlderThan =
                 String.format(
-                        "CALL sys.remove_orphan_files('%s.%s', '2023-12-31 23:59:59')",
+                        "CALL sys.remove_orphan_files('%s.%s', '2999-12-31 23:59:59')",
                         database, tableName);
-        assertThatCode(() -> callProcedure(withOlderThan)).doesNotThrowAnyException();
+        ImmutableList<Row> actualDeleteFile = ImmutableList.copyOf(callProcedure(withOlderThan));
+
+        assertThat(actualDeleteFile)
+                .containsExactlyInAnyOrder(
+                        Row.of(orphanFile1.toUri().getPath()),
+                        Row.of(orphanFile2.toUri().getPath()));
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedure.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.spark.procedure;
 
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.operation.OrphanFilesClean;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.utils.StringUtils;
@@ -30,7 +31,10 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.types.UTF8String;
 
+import java.util.List;
+
 import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.spark.sql.types.DataTypes.BooleanType;
 import static org.apache.spark.sql.types.DataTypes.StringType;
 
 /**
@@ -45,7 +49,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
     private static final ProcedureParameter[] PARAMETERS =
             new ProcedureParameter[] {
                 ProcedureParameter.required("table", StringType),
-                ProcedureParameter.optional("older_than", StringType)
+                ProcedureParameter.optional("older_than", StringType),
+                ProcedureParameter.optional("dry_run", BooleanType)
             };
 
     private static final StructType OUTPUT_TYPE =
@@ -72,6 +77,7 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
     public InternalRow[] call(InternalRow args) {
         Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
         String olderThan = args.isNullAt(1) ? null : args.getString(1);
+        boolean dryRun = args.isNullAt(2) ? false : args.getBoolean(2);
 
         return modifyPaimonTable(
                 tableIdent,
@@ -82,11 +88,18 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
                     if (!StringUtils.isBlank(olderThan)) {
                         orphanFilesClean.olderThan(olderThan);
                     }
+                    orphanFilesClean.dryRun(dryRun);
                     try {
-                        int deleted = orphanFilesClean.clean();
-                        return new InternalRow[] {
-                            newInternalRow(UTF8String.fromString("Deleted=" + deleted))
-                        };
+                        List<Path> orphanFiles = orphanFilesClean.clean();
+                        InternalRow[] rows = new InternalRow[orphanFiles.size()];
+                        int index = 0;
+                        for (Path filePath : orphanFiles) {
+                            rows[index] =
+                                    newInternalRow(
+                                            UTF8String.fromString(filePath.toUri().getPath()));
+                            index++;
+                        }
+                        return rows;
                     } catch (Exception e) {
                         throw new RuntimeException("Call remove_orphan_files error", e);
                     }

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedureTest.scala
@@ -49,7 +49,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
     fileIO.writeFileUtf8(orphanFile2, "b")
 
     // by default, no file deleted
-    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row("Deleted=0") :: Nil)
+    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Nil)
 
     val orphanFile2ModTime = fileIO.getFileStatus(orphanFile2).getModificationTime
     val older_than1 = DateTimeUtils.formatLocalDateTime(
@@ -60,7 +60,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
 
     checkAnswer(
       spark.sql(s"CALL sys.remove_orphan_files(table => 'T', older_than => '$older_than1')"),
-      Row("Deleted=1") :: Nil)
+      Row(orphanFile1.toUri.getPath) :: Nil)
 
     val older_than2 = DateTimeUtils.formatLocalDateTime(
       DateTimeUtils.toLocalDateTime(System.currentTimeMillis()),
@@ -68,6 +68,40 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
 
     checkAnswer(
       spark.sql(s"CALL sys.remove_orphan_files(table => 'T', older_than => '$older_than2')"),
-      Row("Deleted=1") :: Nil)
+      Row(orphanFile2.toUri.getPath) :: Nil)
+  }
+
+  test("Paimon procedure: dry run remove orphan files") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id STRING, name STRING)
+                 |USING PAIMON
+                 |TBLPROPERTIES ('primary-key'='id')
+                 |""".stripMargin)
+
+    spark.sql(s"INSERT INTO T VALUES ('1', 'a'), ('2', 'b')")
+
+    val table = loadTable("T")
+    val fileIO = table.fileIO()
+    val tablePath = table.location()
+
+    val orphanFile1 = new Path(tablePath, "bucket-0/orphan_file1")
+    val orphanFile2 = new Path(tablePath, "bucket-0/orphan_file2")
+
+    fileIO.writeFileUtf8(orphanFile1, "a")
+    Thread.sleep(2000)
+    fileIO.writeFileUtf8(orphanFile2, "b")
+
+    // by default, no file deleted
+    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Nil)
+
+    val older_than = DateTimeUtils.formatLocalDateTime(
+      DateTimeUtils.toLocalDateTime(System.currentTimeMillis()),
+      3)
+
+    checkAnswer(
+      spark.sql(
+        s"CALL sys.remove_orphan_files(table => 'T', older_than => '$older_than', dry_run => true)"),
+      Row(orphanFile1.toUri.getPath) :: Row(orphanFile2.toUri.getPath) :: Nil
+    )
   }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

1. remove_orphan_files  support dry run，similar to the iceberg
![image](https://github.com/apache/paimon/assets/11769953/91882950-30bf-4baa-b374-fd8d3f948adb)

2. The current remove_orphan_files (flink/spark) only outputs the number of deleted files after execution. I think it should output the orphan file path to be more transparent to users. as follows

remove_orphan_files procedures output in spark/flink procedures
![image](https://github.com/apache/paimon/assets/11769953/e8b84d77-4385-491f-8d4b-0b187375c523)

remove_orphan_files  action output in flink action jar
![企业微信截图_1718182610243](https://github.com/apache/paimon/assets/11769953/0ff6a643-d59d-49e1-8a76-4f9a9d02be06)


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->



<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
