### PR TITLE
[parquet] Optimize parquet to use getBytesUnsafe in FixedLenBytesColumnReader

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/FixedLenBytesColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/FixedLenBytesColumnReader.java
@@ -102,7 +102,7 @@ public class FixedLenBytesColumnReader<VECTOR extends WritableColumnVector>
             WritableBytesVector bytesVector = (WritableBytesVector) column;
             for (int i = rowId; i < rowId + num; ++i) {
                 if (!bytesVector.isNullAt(i)) {
-                    byte[] v = dictionary.decodeToBinary(dictionaryIds.getInt(i)).getBytes();
+                    byte[] v = dictionary.decodeToBinary(dictionaryIds.getInt(i)).getBytesUnsafe();
                     bytesVector.appendBytes(i, v, 0, v.length);
                 }
             }


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

Optimize parquet to use getBytesUnsafe in FixedLenBytesColumnReader

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
