### PR TITLE
[core] Deletion Vectors mode supports lookup async

### DIFF
--- a/docs/content/primary-key-table/deletion-vectors.md
+++ b/docs/content/primary-key-table/deletion-vectors.md
@@ -45,6 +45,5 @@ By specifying `'deletion-vectors.enabled' = 'true'`, the Deletion Vectors mode c
 ## Limitation
 
 - `changelog-producer` needs to be `none` or `lookup`.
-- `changelog-producer.lookup-wait` can't be `false`.
 - `merge-engine` can't be `first-row`, because the read of first-row is already no merging, deletion vectors are not needed.
 - This mode will filter the data in level-0, so when using time travel to read `APPEND` snapshot, there will be data delay.

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -63,6 +63,12 @@ under the License.
             <td>Whether to double write to a changelog file. This changelog file keeps the details of data changes, it can be read directly during stream reads. This can be applied to tables with primary keys. <br /><br />Possible values:<ul><li>"none": No changelog file.</li><li>"input": Double write to a changelog file when flushing memory table, the changelog is from input.</li><li>"full-compaction": Generate changelog files with each full compaction.</li><li>"lookup": Generate changelog files through 'lookup' before committing the data writing.</li></ul></td>
         </tr>
         <tr>
+            <td><h5>changelog-producer.lookup-wait</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>When changelog-producer is set to LOOKUP, commit will wait for changelog generation by lookup.</td>
+        </tr>
+        <tr>
             <td><h5>changelog-producer.row-deduplicate</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -27,12 +27,6 @@ under the License.
     </thead>
     <tbody>
         <tr>
-            <td><h5>changelog-producer.lookup-wait</h5></td>
-            <td style="word-wrap: break-word;">true</td>
-            <td>Boolean</td>
-            <td>When changelog-producer is set to LOOKUP, commit will wait for changelog generation by lookup.</td>
-        </tr>
-        <tr>
             <td><h5>end-input.watermark</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Long</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1904,7 +1904,7 @@ public class CoreOptions implements Serializable {
         return options.get(RECORD_LEVEL_TIME_FIELD);
     }
 
-    public boolean waitCompaction() {
+    public boolean prepareCommitWaitCompaction() {
         return changelogProducer() == ChangelogProducer.LOOKUP
                 && options.get(CHANGELOG_PRODUCER_LOOKUP_WAIT);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1194,6 +1194,17 @@ public class CoreOptions implements Serializable {
                     .noDefaultValue()
                     .withDescription("Specifies the commit user prefix.");
 
+    public static final ConfigOption<Boolean> CHANGELOG_PRODUCER_LOOKUP_WAIT =
+            key("changelog-producer.lookup-wait")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "When "
+                                    + CoreOptions.CHANGELOG_PRODUCER.key()
+                                    + " is set to "
+                                    + ChangelogProducer.LOOKUP.name()
+                                    + ", commit will wait for changelog generation by lookup.");
+
     private final Options options;
 
     public CoreOptions(Map<String, String> options) {
@@ -1891,6 +1902,10 @@ public class CoreOptions implements Serializable {
     @Nullable
     public String recordLevelTimeField() {
         return options.get(RECORD_LEVEL_TIME_FIELD);
+    }
+
+    public boolean changelogProducerLookupWait() {
+        return options.get(CHANGELOG_PRODUCER_LOOKUP_WAIT);
     }
 
     /** Specifies the merge engine for table with primary key. */

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1904,8 +1904,9 @@ public class CoreOptions implements Serializable {
         return options.get(RECORD_LEVEL_TIME_FIELD);
     }
 
-    public boolean changelogProducerLookupWait() {
-        return options.get(CHANGELOG_PRODUCER_LOOKUP_WAIT);
+    public boolean waitCompaction() {
+        return changelogProducer() == ChangelogProducer.LOOKUP
+                && options.get(CHANGELOG_PRODUCER_LOOKUP_WAIT);
     }
 
     /** Specifies the merge engine for table with primary key. */

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -289,7 +289,7 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
         compactBefore.clear();
         compactAfter.clear();
 
-        return new CommitIncrement(dataIncrement, compactIncrement);
+        return new CommitIncrement(dataIncrement, compactIncrement, null);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/compact/CompactDeletionFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/CompactDeletionFile.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.compact;
+
+import org.apache.paimon.deletionvectors.DeletionVectorsMaintainer;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.utils.PathFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+/** Deletion File from compaction. */
+public interface CompactDeletionFile {
+
+    Optional<IndexFileMeta> getOrCompute();
+
+    CompactDeletionFile mergeOldFile(CompactDeletionFile old);
+
+    static CompactDeletionFile generateFiles(DeletionVectorsMaintainer maintainer) {
+        List<IndexFileMeta> files = maintainer.writeDeletionVectorsIndex();
+        if (files.size() > 1) {
+            throw new IllegalStateException(
+                    "Should only generate one compact deletion file, this is a bug.");
+        }
+        Optional<IndexFileMeta> deletionFile =
+                files.isEmpty() ? Optional.empty() : Optional.of(files.get(0));
+        PathFactory pathFactory = maintainer.pathFactory();
+        FileIO fileIO = maintainer.fileIO();
+        return new CompactDeletionFile() {
+            @Override
+            public Optional<IndexFileMeta> getOrCompute() {
+                return deletionFile;
+            }
+
+            @Override
+            public CompactDeletionFile mergeOldFile(CompactDeletionFile old) {
+                if (deletionFile.isPresent()) {
+                    old.getOrCompute()
+                            .map(IndexFileMeta::fileName)
+                            .map(pathFactory::toPath)
+                            .ifPresent(fileIO::deleteQuietly);
+                    return this;
+                }
+
+                // no update, just use old file
+                return old;
+            }
+
+            @Override
+            public String toString() {
+                return "GeneratedFiles-" + deletionFile;
+            }
+        };
+    }
+
+    static CompactDeletionFile lazyGeneration(DeletionVectorsMaintainer maintainer) {
+        return new CompactDeletionFile() {
+            @Override
+            public Optional<IndexFileMeta> getOrCompute() {
+                return generateFiles(maintainer).getOrCompute();
+            }
+
+            @Override
+            public CompactDeletionFile mergeOldFile(CompactDeletionFile old) {
+                return this;
+            }
+
+            @Override
+            public String toString() {
+                return "LazyGeneration";
+            }
+        };
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/compact/CompactResult.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/CompactResult.java
@@ -66,7 +66,7 @@ public class CompactResult {
         return changelog;
     }
 
-    public void setDeletionFile(CompactDeletionFile deletionFile) {
+    public void setDeletionFile(@Nullable CompactDeletionFile deletionFile) {
         this.deletionFile = deletionFile;
     }
 
@@ -81,7 +81,8 @@ public class CompactResult {
         changelog.addAll(that.changelog);
 
         if (deletionFile != null || that.deletionFile != null) {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException(
+                    "There is a bug, deletionFile can't be set before merge.");
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/compact/CompactResult.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/CompactResult.java
@@ -20,6 +20,8 @@ package org.apache.paimon.compact;
 
 import org.apache.paimon.io.DataFileMeta;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -30,6 +32,8 @@ public class CompactResult {
     private final List<DataFileMeta> before;
     private final List<DataFileMeta> after;
     private final List<DataFileMeta> changelog;
+
+    @Nullable private CompactDeletionFile deletionFile;
 
     public CompactResult() {
         this(Collections.emptyList(), Collections.emptyList());
@@ -62,9 +66,22 @@ public class CompactResult {
         return changelog;
     }
 
+    public void setDeletionFile(CompactDeletionFile deletionFile) {
+        this.deletionFile = deletionFile;
+    }
+
+    @Nullable
+    public CompactDeletionFile deletionFile() {
+        return deletionFile;
+    }
+
     public void merge(CompactResult that) {
         before.addAll(that.before);
         after.addAll(that.after);
         changelog.addAll(that.changelog);
+
+        if (deletionFile != null || that.deletionFile != null) {
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsMaintainer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsMaintainer.java
@@ -20,11 +20,9 @@ package org.apache.paimon.deletionvectors;
 
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.manifest.IndexManifestEntry;
-import org.apache.paimon.utils.PathFactory;
 
 import javax.annotation.Nullable;
 
@@ -115,12 +113,8 @@ public class DeletionVectorsMaintainer {
         return Optional.ofNullable(deletionVectors.get(fileName));
     }
 
-    public FileIO fileIO() {
-        return indexFileHandler.fileIO();
-    }
-
-    public PathFactory pathFactory() {
-        return indexFileHandler.pathFactory();
+    public IndexFileHandler indexFileHandler() {
+        return indexFileHandler;
     }
 
     @VisibleForTesting

--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsMaintainer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsMaintainer.java
@@ -20,9 +20,11 @@ package org.apache.paimon.deletionvectors;
 
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.manifest.IndexManifestEntry;
+import org.apache.paimon.utils.PathFactory;
 
 import javax.annotation.Nullable;
 
@@ -89,13 +91,12 @@ public class DeletionVectorsMaintainer {
     }
 
     /**
-     * Prepares to commit: write new deletion vectors index file if any modifications have been
-     * made.
+     * Write new deletion vectors index file if any modifications have been made.
      *
      * @return A list containing the metadata of the deletion vectors index file, or an empty list
      *     if no changes need to be committed.
      */
-    public List<IndexFileMeta> prepareCommit() {
+    public List<IndexFileMeta> writeDeletionVectorsIndex() {
         if (modified) {
             modified = false;
             return indexFileHandler.writeDeletionVectorsIndex(deletionVectors);
@@ -112,6 +113,14 @@ public class DeletionVectorsMaintainer {
      */
     public Optional<DeletionVector> deletionVectorOf(String fileName) {
         return Optional.ofNullable(deletionVectors.get(fileName));
+    }
+
+    public FileIO fileIO() {
+        return indexFileHandler.fileIO();
+    }
+
+    public PathFactory pathFactory() {
+        return indexFileHandler.pathFactory();
     }
 
     @VisibleForTesting

--- a/paimon-core/src/main/java/org/apache/paimon/index/IndexFileHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/IndexFileHandler.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.deletionvectors.DeletionVector;
 import org.apache.paimon.deletionvectors.DeletionVectorIndexFileMaintainer;
 import org.apache.paimon.deletionvectors.DeletionVectorsIndexFile;
+import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.IndexManifestFile;
@@ -63,6 +64,14 @@ public class IndexFileHandler {
         this.indexManifestFile = indexManifestFile;
         this.hashIndex = hashIndex;
         this.deletionVectorsIndex = deletionVectorsIndex;
+    }
+
+    public FileIO fileIO() {
+        return indexManifestFile.fileIO();
+    }
+
+    public PathFactory pathFactory() {
+        return pathFactory;
     }
 
     public DeletionVectorsIndexFile deletionVectorsIndex() {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -20,6 +20,7 @@ package org.apache.paimon.operation;
 
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.compact.CompactDeletionFile;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.deletionvectors.DeletionVectorsMaintainer;
 import org.apache.paimon.disk.IOManager;
@@ -200,8 +201,9 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
                 if (writerContainer.indexMaintainer != null) {
                     newIndexFiles.addAll(writerContainer.indexMaintainer.prepareCommit());
                 }
-                if (writerContainer.deletionVectorsMaintainer != null) {
-                    newIndexFiles.addAll(writerContainer.deletionVectorsMaintainer.prepareCommit());
+                CompactDeletionFile compactDeletionFile = increment.compactDeletionFile();
+                if (compactDeletionFile != null) {
+                    compactDeletionFile.getOrCompute().ifPresent(newIndexFiles::add);
                 }
                 CommitMessageImpl committable =
                         new CommitMessageImpl(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -250,7 +250,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                             ? null
                             : compactionMetrics.createReporter(partition, bucket),
                     dvMaintainer,
-                    options.waitCompaction());
+                    options.prepareCommitWaitCompaction());
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -250,7 +250,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                             ? null
                             : compactionMetrics.createReporter(partition, bucket),
                     dvMaintainer,
-                    options.changelogProducerLookupWait());
+                    options.waitCompaction());
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -249,7 +249,8 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                     compactionMetrics == null
                             ? null
                             : compactionMetrics.createReporter(partition, bucket),
-                    options.deletionVectorsEnabled());
+                    dvMaintainer,
+                    options.changelogProducerLookupWait());
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/utils/CommitIncrement.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/CommitIncrement.java
@@ -18,18 +18,26 @@
 
 package org.apache.paimon.utils;
 
+import org.apache.paimon.compact.CompactDeletionFile;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataIncrement;
+
+import javax.annotation.Nullable;
 
 /** Changes to commit. */
 public class CommitIncrement {
 
     private final DataIncrement dataIncrement;
     private final CompactIncrement compactIncrement;
+    @Nullable private final CompactDeletionFile compactDeletionFile;
 
-    public CommitIncrement(DataIncrement dataIncrement, CompactIncrement compactIncrement) {
+    public CommitIncrement(
+            DataIncrement dataIncrement,
+            CompactIncrement compactIncrement,
+            @Nullable CompactDeletionFile compactDeletionFile) {
         this.dataIncrement = dataIncrement;
         this.compactIncrement = compactIncrement;
+        this.compactDeletionFile = compactDeletionFile;
     }
 
     public DataIncrement newFilesIncrement() {
@@ -40,8 +48,13 @@ public class CommitIncrement {
         return compactIncrement;
     }
 
+    @Nullable
+    public CompactDeletionFile compactDeletionFile() {
+        return compactDeletionFile;
+    }
+
     @Override
     public String toString() {
-        return dataIncrement.toString() + "\n" + compactIncrement;
+        return dataIncrement.toString() + "\n" + compactIncrement + "\n" + compactDeletionFile;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
@@ -68,6 +68,10 @@ public class ObjectsFile<T> {
                 cache == null ? null : new ObjectsCache<>(cache, serializer, this::createIterator);
     }
 
+    public FileIO fileIO() {
+        return fileIO;
+    }
+
     public long fileSize(String fileName) {
         try {
             return fileIO.getFileSize(pathFactory.toPath(fileName));

--- a/paimon-core/src/test/java/org/apache/paimon/TestAppendFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestAppendFileStore.java
@@ -144,7 +144,7 @@ public class TestAppendFileStore extends AppendOnlyFileStore {
                 bucket,
                 DataIncrement.emptyIncrement(),
                 CompactIncrement.emptyIncrement(),
-                new IndexIncrement(dvMaintainer.prepareCommit()));
+                new IndexIncrement(dvMaintainer.writeDeletionVectorsIndex()));
     }
 
     public static TestAppendFileStore createAppendStore(

--- a/paimon-core/src/test/java/org/apache/paimon/deletionvectors/DeletionVectorsMaintainerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/deletionvectors/DeletionVectorsMaintainerTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.deletionvectors;
 
 import org.apache.paimon.catalog.PrimaryKeyTableTestBase;
+import org.apache.paimon.compact.CompactDeletionFile;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.index.IndexFileMeta;
@@ -28,10 +29,13 @@ import org.apache.paimon.io.IndexIncrement;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
+import org.apache.paimon.utils.FileIOUtils;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -61,7 +65,7 @@ public class DeletionVectorsMaintainerTest extends PrimaryKeyTableTestBase {
 
         assertThat(dvMaintainer.deletionVectorOf("f1")).isPresent();
         assertThat(dvMaintainer.deletionVectorOf("f3")).isEmpty();
-        List<IndexFileMeta> fileMetas = dvMaintainer.prepareCommit();
+        List<IndexFileMeta> fileMetas = dvMaintainer.writeDeletionVectorsIndex();
 
         Map<String, DeletionVector> deletionVectors = fileHandler.readAllDeletionVectors(fileMetas);
         assertThat(deletionVectors.get("f1").isDeleted(1)).isTrue();
@@ -83,7 +87,7 @@ public class DeletionVectorsMaintainerTest extends PrimaryKeyTableTestBase {
         deletionVector1.delete(5);
         dvMaintainer.notifyNewDeletion("f1", deletionVector1);
 
-        List<IndexFileMeta> fileMetas1 = dvMaintainer.prepareCommit();
+        List<IndexFileMeta> fileMetas1 = dvMaintainer.writeDeletionVectorsIndex();
         assertThat(fileMetas1.size()).isEqualTo(1);
         CommitMessage commitMessage =
                 new CommitMessageImpl(
@@ -104,7 +108,7 @@ public class DeletionVectorsMaintainerTest extends PrimaryKeyTableTestBase {
         deletionVector2.delete(2);
         dvMaintainer.notifyNewDeletion("f1", deletionVector2);
 
-        List<IndexFileMeta> fileMetas2 = dvMaintainer.prepareCommit();
+        List<IndexFileMeta> fileMetas2 = dvMaintainer.writeDeletionVectorsIndex();
         assertThat(fileMetas2.size()).isEqualTo(1);
         commitMessage =
                 new CommitMessageImpl(
@@ -121,5 +125,45 @@ public class DeletionVectorsMaintainerTest extends PrimaryKeyTableTestBase {
         DeletionVector deletionVector3 = dvMaintainer.deletionVectorOf("f1").get();
         assertThat(deletionVector3.isDeleted(1)).isTrue();
         assertThat(deletionVector3.isDeleted(2)).isTrue();
+    }
+
+    @Test
+    public void testCompactDeletion() throws IOException {
+        DeletionVectorsMaintainer.Factory factory =
+                new DeletionVectorsMaintainer.Factory(fileHandler);
+        DeletionVectorsMaintainer dvMaintainer =
+                factory.createOrRestore(null, BinaryRow.EMPTY_ROW, 0);
+
+        File indexDir = new File(tempPath.toFile(), "/default.db/T/index");
+
+        // test generate files
+
+        dvMaintainer.notifyNewDeletion("f1", 1);
+        CompactDeletionFile deletionFile1 = CompactDeletionFile.generateFiles(dvMaintainer);
+        assertThat(indexDir.listFiles()).hasSize(1);
+
+        dvMaintainer.notifyNewDeletion("f2", 4);
+        CompactDeletionFile deletionFile2 = CompactDeletionFile.generateFiles(dvMaintainer);
+        assertThat(indexDir.listFiles()).hasSize(2);
+
+        deletionFile2.mergeOldFile(deletionFile1);
+        assertThat(indexDir.listFiles()).hasSize(1);
+        FileIOUtils.deleteDirectory(indexDir);
+
+        // test lazyGeneration
+
+        dvMaintainer.notifyNewDeletion("f1", 3);
+        CompactDeletionFile deletionFile3 = CompactDeletionFile.lazyGeneration(dvMaintainer);
+        assertThat(indexDir.listFiles()).isNull();
+
+        dvMaintainer.notifyNewDeletion("f2", 5);
+        CompactDeletionFile deletionFile4 = CompactDeletionFile.lazyGeneration(dvMaintainer);
+        assertThat(indexDir.listFiles()).isNull();
+
+        deletionFile4.mergeOldFile(deletionFile3);
+        assertThat(indexDir.listFiles()).isNull();
+
+        deletionFile4.getOrCompute();
+        assertThat(indexDir.listFiles()).hasSize(1);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
@@ -458,6 +458,7 @@ public abstract class MergeTreeTestBase {
                 options.numSortedRunStopTrigger(),
                 new TestRewriter(),
                 null,
+                null,
                 false);
     }
 
@@ -478,6 +479,7 @@ public abstract class MergeTreeTestBase {
                     minFileSize,
                     numSortedRunStopTrigger,
                     rewriter,
+                    null,
                     null,
                     false);
         }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManagerTest.java
@@ -206,6 +206,7 @@ public class MergeTreeCompactManagerTest {
                         Integer.MAX_VALUE,
                         new TestRewriter(expectedDropDelete),
                         null,
+                        null,
                         false);
         manager.triggerCompaction(false);
         manager.getCompactionResult(true);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.flink.sink.cdc;
 
 import org.apache.paimon.catalog.Catalog;
-import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.sink.CommittableStateManager;
 import org.apache.paimon.flink.sink.Committer;
 import org.apache.paimon.flink.sink.CommitterOperator;
@@ -88,8 +87,7 @@ public class FlinkCdcMultiTableSink implements Serializable {
                         state,
                         ioManager,
                         isOverwrite,
-                        FlinkConnectorOptions.prepareCommitWaitCompaction(
-                                table.coreOptions().toConfiguration()),
+                        table.coreOptions().changelogProducerLookupWait(),
                         true,
                         memoryPoolFactory,
                         metricGroup);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
@@ -87,7 +87,7 @@ public class FlinkCdcMultiTableSink implements Serializable {
                         state,
                         ioManager,
                         isOverwrite,
-                        table.coreOptions().waitCompaction(),
+                        table.coreOptions().prepareCommitWaitCompaction(),
                         true,
                         memoryPoolFactory,
                         metricGroup);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
@@ -87,7 +87,7 @@ public class FlinkCdcMultiTableSink implements Serializable {
                         state,
                         ioManager,
                         isOverwrite,
-                        table.coreOptions().changelogProducerLookupWait(),
+                        table.coreOptions().waitCompaction(),
                         true,
                         memoryPoolFactory,
                         metricGroup);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -25,7 +25,6 @@ import org.apache.paimon.annotation.Documentation.ExcludeFromDocumentation;
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
 import org.apache.paimon.options.MemorySize;
-import org.apache.paimon.options.Options;
 import org.apache.paimon.options.description.DescribedEnum;
 import org.apache.paimon.options.description.Description;
 import org.apache.paimon.options.description.InlineElement;
@@ -36,7 +35,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.paimon.CoreOptions.DELETION_VECTORS_ENABLED;
 import static org.apache.paimon.CoreOptions.STREAMING_READ_MODE;
 import static org.apache.paimon.options.ConfigOptions.key;
 import static org.apache.paimon.options.description.TextElement.text;
@@ -147,17 +145,6 @@ public class FlinkConnectorOptions {
                                     + " is set to "
                                     + ChangelogProducer.FULL_COMPACTION.name()
                                     + ", full compaction will be constantly triggered after this interval.");
-
-    public static final ConfigOption<Boolean> CHANGELOG_PRODUCER_LOOKUP_WAIT =
-            key("changelog-producer.lookup-wait")
-                    .booleanType()
-                    .defaultValue(true)
-                    .withDescription(
-                            "When "
-                                    + CoreOptions.CHANGELOG_PRODUCER.key()
-                                    + " is set to "
-                                    + ChangelogProducer.LOOKUP.name()
-                                    + ", commit will wait for changelog generation by lookup.");
 
     public static final ConfigOption<WatermarkEmitStrategy> SCAN_WATERMARK_EMIT_STRATEGY =
             key("scan.watermark.emit.strategy")
@@ -444,20 +431,6 @@ public class FlinkConnectorOptions {
             }
         }
         return list;
-    }
-
-    public static boolean prepareCommitWaitCompaction(Options options) {
-        if (options.get(DELETION_VECTORS_ENABLED)) {
-            // DeletionVector (DV) is maintained in the compaction thread, but it needs to be
-            // read into a file during prepareCommit (write thread) to commit it.
-            // We must set waitCompaction to true so that there are no multiple threads
-            // operating DV simultaneously.
-            return true;
-        }
-
-        ChangelogProducer changelogProducer = options.get(CoreOptions.CHANGELOG_PRODUCER);
-        return changelogProducer == ChangelogProducer.LOOKUP
-                && options.get(CHANGELOG_PRODUCER_LOOKUP_WAIT);
     }
 
     /** The mode of lookup cache. */

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -102,7 +102,7 @@ public abstract class FlinkSink<T> implements Serializable {
         if (coreOptions.writeOnly()) {
             waitCompaction = false;
         } else {
-            waitCompaction = coreOptions.changelogProducerLookupWait();
+            waitCompaction = coreOptions.waitCompaction();
             int deltaCommits = -1;
             if (options.contains(FULL_COMPACTION_DELTA_COMMITS)) {
                 deltaCommits = options.get(FULL_COMPACTION_DELTA_COMMITS);
@@ -134,8 +134,7 @@ public abstract class FlinkSink<T> implements Serializable {
             }
         }
 
-        if (changelogProducer == ChangelogProducer.LOOKUP
-                && !coreOptions.changelogProducerLookupWait()) {
+        if (changelogProducer == ChangelogProducer.LOOKUP && !coreOptions.waitCompaction()) {
             return (table, commitUser, state, ioManager, memoryPool, metricGroup) -> {
                 assertNoSinkMaterializer.run();
                 return new AsyncLookupSinkWrite(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -18,9 +18,9 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.CoreOptions.ChangelogProducer;
 import org.apache.paimon.CoreOptions.TagCreationMode;
-import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
@@ -62,7 +62,6 @@ import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_COMMITTER_MEMOR
 import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_COMMITTER_OPERATOR_CHAINING;
 import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_MANAGED_WRITER_BUFFER_MEMORY;
 import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_USE_MANAGED_MEMORY;
-import static org.apache.paimon.flink.FlinkConnectorOptions.prepareCommitWaitCompaction;
 import static org.apache.paimon.flink.utils.ManagedMemoryUtils.declareManagedMemory;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
@@ -99,10 +98,11 @@ public abstract class FlinkSink<T> implements Serializable {
         Options options = table.coreOptions().toConfiguration();
         ChangelogProducer changelogProducer = table.coreOptions().changelogProducer();
         boolean waitCompaction;
-        if (table.coreOptions().writeOnly()) {
+        CoreOptions coreOptions = table.coreOptions();
+        if (coreOptions.writeOnly()) {
             waitCompaction = false;
         } else {
-            waitCompaction = prepareCommitWaitCompaction(options);
+            waitCompaction = coreOptions.changelogProducerLookupWait();
             int deltaCommits = -1;
             if (options.contains(FULL_COMPACTION_DELTA_COMMITS)) {
                 deltaCommits = options.get(FULL_COMPACTION_DELTA_COMMITS);
@@ -135,7 +135,7 @@ public abstract class FlinkSink<T> implements Serializable {
         }
 
         if (changelogProducer == ChangelogProducer.LOOKUP
-                && !options.get(FlinkConnectorOptions.CHANGELOG_PRODUCER_LOOKUP_WAIT)) {
+                && !coreOptions.changelogProducerLookupWait()) {
             return (table, commitUser, state, ioManager, memoryPool, metricGroup) -> {
                 assertNoSinkMaterializer.run();
                 return new AsyncLookupSinkWrite(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -102,7 +102,7 @@ public abstract class FlinkSink<T> implements Serializable {
         if (coreOptions.writeOnly()) {
             waitCompaction = false;
         } else {
-            waitCompaction = coreOptions.waitCompaction();
+            waitCompaction = coreOptions.prepareCommitWaitCompaction();
             int deltaCommits = -1;
             if (options.contains(FULL_COMPACTION_DELTA_COMMITS)) {
                 deltaCommits = options.get(FULL_COMPACTION_DELTA_COMMITS);
@@ -134,7 +134,8 @@ public abstract class FlinkSink<T> implements Serializable {
             }
         }
 
-        if (changelogProducer == ChangelogProducer.LOOKUP && !coreOptions.waitCompaction()) {
+        if (changelogProducer == ChangelogProducer.LOOKUP
+                && !coreOptions.prepareCommitWaitCompaction()) {
             return (table, commitUser, state, ioManager, memoryPool, metricGroup) -> {
                 assertNoSinkMaterializer.run();
                 return new AsyncLookupSinkWrite(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
@@ -240,7 +240,7 @@ public class MultiTablesStoreCompactOperator
         if (coreOptions.writeOnly()) {
             waitCompaction = false;
         } else {
-            waitCompaction = coreOptions.changelogProducerLookupWait();
+            waitCompaction = coreOptions.waitCompaction();
             int deltaCommits = -1;
             if (options.contains(FULL_COMPACTION_DELTA_COMMITS)) {
                 deltaCommits = options.get(FULL_COMPACTION_DELTA_COMMITS);
@@ -272,7 +272,7 @@ public class MultiTablesStoreCompactOperator
         }
 
         if (changelogProducer == CoreOptions.ChangelogProducer.LOOKUP
-                && !coreOptions.changelogProducerLookupWait()) {
+                && !coreOptions.waitCompaction()) {
             return (table, commitUser, state, ioManager, memoryPool, metricGroup) ->
                     new AsyncLookupSinkWrite(
                             table,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
@@ -240,7 +240,7 @@ public class MultiTablesStoreCompactOperator
         if (coreOptions.writeOnly()) {
             waitCompaction = false;
         } else {
-            waitCompaction = coreOptions.waitCompaction();
+            waitCompaction = coreOptions.prepareCommitWaitCompaction();
             int deltaCommits = -1;
             if (options.contains(FULL_COMPACTION_DELTA_COMMITS)) {
                 deltaCommits = options.get(FULL_COMPACTION_DELTA_COMMITS);
@@ -272,7 +272,7 @@ public class MultiTablesStoreCompactOperator
         }
 
         if (changelogProducer == CoreOptions.ChangelogProducer.LOOKUP
-                && !coreOptions.waitCompaction()) {
+                && !coreOptions.prepareCommitWaitCompaction()) {
             return (table, commitUser, state, ioManager, memoryPool, metricGroup) ->
                     new AsyncLookupSinkWrite(
                             table,

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -238,7 +238,7 @@ case class PaimonSparkWriter(table: FileStoreTable) {
         sdv.bucket,
         DataIncrement.emptyIncrement(),
         CompactIncrement.emptyIncrement(),
-        new IndexIncrement(maintainer.prepareCommit()))
+        new IndexIncrement(maintainer.writeDeletionVectorsIndex()))
 
       serializer.serialize(commitMessage)
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In the previous implementation, due to concurrent thread safety issues, asynchronous execution could not be enabled for the deletion vectors mode, as there were also an asynchronous compaction thread to write deletion vectors when the main thread materialize them.

We can avoid this situation by handing over the materialization of the deletion vectors to the asynchronous compaction thread. After each compaction is completed, we actively materialize the deletion vectors as a deletion file.

<!-- What is the purpose of the change -->

### Tests

`PrimaryKeyFileStoreTableITCase` already coverred this.

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

`/primary-key-table/deletion-vectors` modified.

<!-- Does this change introduce a new feature -->
