### PR TITLE
[common] Minor refactor PredicateBuilder to avoid potential stack overflow

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
@@ -156,9 +156,7 @@ public class PredicateBuilder {
         if (predicates.size() == 1) {
             return predicates.get(0);
         }
-        return predicates.stream()
-                .reduce((a, b) -> new CompoundPredicate(And.INSTANCE, Arrays.asList(a, b)))
-                .get();
+        return new CompoundPredicate(And.INSTANCE, predicates);
     }
 
     @Nullable
@@ -184,9 +182,7 @@ public class PredicateBuilder {
         Preconditions.checkArgument(
                 predicates.size() > 0,
                 "There must be at least 1 inner predicate to construct an OR predicate");
-        return predicates.stream()
-                .reduce((a, b) -> new CompoundPredicate(Or.INSTANCE, Arrays.asList(a, b)))
-                .get();
+        return new CompoundPredicate(Or.INSTANCE, predicates);
     }
 
     public static List<Predicate> splitAnd(@Nullable Predicate predicate) {

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
@@ -615,14 +615,13 @@ public class PredicateTest {
         PredicateBuilder builder6 = new PredicateBuilder(RowType.of(new IntType()));
         Predicate p6 = builder6.in(0, Arrays.asList(1, null, 3, 4));
         assertThat(p6.toString())
-                .isEqualTo(
-                        "Or([Or([Or([Equal(f0, 1), Equal(f0, null)]), Equal(f0, 3)]), Equal(f0, 4)])");
+                .isEqualTo("Or([Equal(f0, 1), Equal(f0, null), Equal(f0, 3), Equal(f0, 4)])");
 
         PredicateBuilder builder7 = new PredicateBuilder(RowType.of(new IntType()));
         Predicate p7 = builder7.notIn(0, Arrays.asList(1, null, 3, 4));
         assertThat(p7.toString())
                 .isEqualTo(
-                        "And([And([And([NotEqual(f0, 1), NotEqual(f0, null)]), NotEqual(f0, 3)]), NotEqual(f0, 4)])");
+                        "And([NotEqual(f0, 1), NotEqual(f0, null), NotEqual(f0, 3), NotEqual(f0, 4)])");
 
         PredicateBuilder builder8 = new PredicateBuilder(RowType.of(new IntType()));
         List<Object> literals = new ArrayList<>();

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/filter/OrcPredicateFunctionVisitor.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/filter/OrcPredicateFunctionVisitor.java
@@ -122,30 +122,25 @@ public class OrcPredicateFunctionVisitor
 
     @Override
     public Optional<OrcFilters.Predicate> visitAnd(List<Optional<OrcFilters.Predicate>> children) {
-        if (children.size() != 2) {
-            throw new RuntimeException("Illegal and children: " + children.size());
-        }
-
-        Optional<OrcFilters.Predicate> c1 = children.get(0);
-        if (!c1.isPresent()) {
-            return Optional.empty();
-        }
-        Optional<OrcFilters.Predicate> c2 = children.get(1);
-        return c2.map(value -> new OrcFilters.And(c1.get(), value));
+        OrcFilters.Predicate[] predicates = predicates(children);
+        return predicates.length == 0
+                ? Optional.empty()
+                : Optional.of(new OrcFilters.And(predicates));
     }
 
     @Override
     public Optional<OrcFilters.Predicate> visitOr(List<Optional<OrcFilters.Predicate>> children) {
-        if (children.size() != 2) {
-            throw new RuntimeException("Illegal or children: " + children.size());
-        }
+        OrcFilters.Predicate[] predicates = predicates(children);
+        return predicates.length == 0
+                ? Optional.empty()
+                : Optional.of(new OrcFilters.Or(predicates));
+    }
 
-        Optional<OrcFilters.Predicate> c1 = children.get(0);
-        if (!c1.isPresent()) {
-            return Optional.empty();
-        }
-        Optional<OrcFilters.Predicate> c2 = children.get(1);
-        return c2.map(value -> new OrcFilters.Or(c1.get(), value));
+    private OrcFilters.Predicate[] predicates(List<Optional<OrcFilters.Predicate>> children) {
+        return children.stream()
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .toArray(OrcFilters.Predicate[]::new);
     }
 
     private Optional<OrcFilters.Predicate> convertBinary(

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/filter/OrcFilterConverterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/filter/OrcFilterConverterTest.java
@@ -74,9 +74,8 @@ public class OrcFilterConverterTest {
         test(
                 builder.in(0, Arrays.asList(1L, 2L, 3L)),
                 new OrcFilters.Or(
-                        new OrcFilters.Or(
-                                new OrcFilters.Equals("long1", PredicateLeaf.Type.LONG, 1),
-                                new OrcFilters.Equals("long1", PredicateLeaf.Type.LONG, 2)),
+                        new OrcFilters.Equals("long1", PredicateLeaf.Type.LONG, 1),
+                        new OrcFilters.Equals("long1", PredicateLeaf.Type.LONG, 2),
                         new OrcFilters.Equals("long1", PredicateLeaf.Type.LONG, 3)),
                 true);
 
@@ -91,12 +90,10 @@ public class OrcFilterConverterTest {
         test(
                 builder.notIn(0, Arrays.asList(1L, 2L, 3L)),
                 new OrcFilters.And(
-                        new OrcFilters.And(
-                                new OrcFilters.Not(
-                                        new OrcFilters.Equals("long1", PredicateLeaf.Type.LONG, 1)),
-                                new OrcFilters.Not(
-                                        new OrcFilters.Equals(
-                                                "long1", PredicateLeaf.Type.LONG, 2))),
+                        new OrcFilters.Not(
+                                new OrcFilters.Equals("long1", PredicateLeaf.Type.LONG, 1)),
+                        new OrcFilters.Not(
+                                new OrcFilters.Equals("long1", PredicateLeaf.Type.LONG, 2)),
                         new OrcFilters.Not(
                                 new OrcFilters.Equals("long1", PredicateLeaf.Type.LONG, 3))),
                 true);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The case is the upstream data changes too many partitions, make the `Predicate` too deep, then error is:
```
Caused by: java.lang.RuntimeException: java.lang.StackOverflowError
	at org.apache.paimon.manifest.ManifestFileMeta.merge(ManifestFileMeta.java:178)
	at org.apache.paimon.operation.FileStoreCommitImpl.tryCommitOnce(FileStoreCommitImpl.java:808)
	... 27 more
Caused by: java.lang.StackOverflowError
	at org.apache.paimon.predicate.CompoundPredicate.test(CompoundPredicate.java:59)
	at org.apache.paimon.predicate.Or.test(Or.java:55)
	at org.apache.paimon.predicate.CompoundPredicate.test(CompoundPredicate.java:59)
	...
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
