### PR TITLE
[spark] Exclude orc-core from spark-core_2.12 dependency

### DIFF
--- a/paimon-spark/paimon-spark-3.1/pom.xml
+++ b/paimon-spark/paimon-spark-3.1/pom.xml
@@ -76,6 +76,10 @@ under the License.
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-slf4j2-impl</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.orc</groupId>
+                    <artifactId>orc-core</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/paimon-spark/paimon-spark-3.3/pom.xml
+++ b/paimon-spark/paimon-spark-3.3/pom.xml
@@ -76,6 +76,10 @@ under the License.
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-slf4j2-impl</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.orc</groupId>
+                    <artifactId>orc-core</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/paimon-spark/paimon-spark-3.4/pom.xml
+++ b/paimon-spark/paimon-spark-3.4/pom.xml
@@ -76,6 +76,10 @@ under the License.
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-slf4j2-impl</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.orc</groupId>
+                    <artifactId>orc-core</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/paimon-spark/paimon-spark-3.5/pom.xml
+++ b/paimon-spark/paimon-spark-3.5/pom.xml
@@ -76,6 +76,10 @@ under the License.
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-slf4j2-impl</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.orc</groupId>
+                    <artifactId>orc-core</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/paimon-spark/paimon-spark-common/pom.xml
+++ b/paimon-spark/paimon-spark-common/pom.xml
@@ -130,6 +130,10 @@ under the License.
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.orc</groupId>
+                    <artifactId>orc-core</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

For test failure in IDEA
```
An exception or error caused a run to abort: COMPRESSION_ZSTD_LEVEL 
java.lang.NoSuchFieldError: COMPRESSION_ZSTD_LEVEL
	at org.apache.paimon.format.orc.OrcFileFormat.getOrcProperties(OrcFileFormat.java:153)
	at org.apache.paimon.format.orc.OrcFileFormat.<init>(OrcFileFormat.java:74)
	at org.apache.paimon.format.orc.OrcFileFormatFactory.create(OrcFileFormatFactory.java:35)
	at org.apache.paimon.format.orc.OrcFileFormatFactory.create(OrcFileFormatFactory.java:24)
	at org.apache.paimon.format.FileFormat.fromIdentifier(FileFormat.java:99)
	at org.apache.paimon.format.FileFormat.fromIdentifier(FileFormat.java:84)
	at org.apache.paimon.format.FileFormat.fromIdentifier(FileFormat.java:79)
	at org.apache.paimon.schema.SchemaValidation.validateTableSchema(SchemaValidation.java:142)
	at org.apache.paimon.schema.SchemaManager.commit(SchemaManager.java:475)
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
