### PR TITLE
[pom] Bump ANTLR from 4.8 to 4.9.3

### DIFF
--- a/paimon-common/src/main/resources/META-INF/NOTICE
+++ b/paimon-common/src/main/resources/META-INF/NOTICE
@@ -10,7 +10,7 @@ This project bundles the following dependencies under the Apache Software Licens
 This project bundles the following dependencies under the BSD 3-clause license.
 You find them under licenses/LICENSE.antlr-runtime and licenses/LICENSE.janino.
 
-- org.antlr:antlr4-runtime:4.8
+- org.antlr:antlr4-runtime:4.9.3
 - org.codehaus.janino:janino:3.0.11
 - org.codehaus.janino:commons-compiler:3.0.11
 - it.unimi.dsi:fastutil:8.5.12

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@ under the License.
         <paimon.shade.guava.version>30.1.1-jre</paimon.shade.guava.version>
         <paimon.shade.caffeine.version>2.9.3</paimon.shade.caffeine.version>
         <paimon.shade.netty.version>4.1.100.Final</paimon.shade.netty.version>
-        <antlr4.version>4.8</antlr4.version>
+        <antlr4.version>4.9.3</antlr4.version>
         <hadoop.version>2.8.5</hadoop.version>
         <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
@@ -114,7 +114,6 @@ under the License.
         <kafka.version>3.2.3</kafka.version>
         <scala-maven-plugin.version>3.2.2</scala-maven-plugin.version>
         <scalatest-maven-plugin.version>2.1.0</scalatest-maven-plugin.version>
-        <antlr4-maven-plugin.version>4.8</antlr4-maven-plugin.version>
         <jsoup.version>1.15.3</jsoup.version>
         <CodeCacheSize>128m</CodeCacheSize>
         <extraJavaTestArgs>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Upgrade ANTLR from 4.8 to 4.9.3 for the reasons:

1. IDEA spark test warning for spark upgrade antlr from 4.8 to 4.9.3 since spark3.4
```
ANTLR Tool version 4.9.3 used for code generation does not match the current runtime version 4.8ANTLR Tool version 4.9.3 used for code generation does not match the current runtime version 4.8
```
Note: this warning will exist in paimon-spark3.3- after this PR, because I think just follow the newest version is ok, don't want to add mutl versions for this

2. github CI warning for antlr4-maven-plugin:4.8 not thread-safe

```
Warning:  *****************************************************************
Warning:  * Your build is requesting parallel execution, but this         *
Warning:  * project contains the following plugin(s) that have goals not  *
Warning:  * marked as thread-safe to support parallel execution.          *
Warning:  * While this /may/ work fine, please look for plugin updates    *
Warning:  * and/or request plugins be made thread-safe.                   *
Warning:  * If reporting an issue, report it against the plugin in        *
Warning:  * question, not against Apache Maven.                           *
Warning:  *****************************************************************
Warning:  The following plugins are not marked as thread-safe in Paimon : Common:
Warning:    org.antlr:antlr4-maven-plugin:4.8
Warning:  
Warning:  Enable debug to see precisely which goals are not marked as thread-safe.
Warning:  *****************************************************************
```
https://github.com/antlr/antlr4/commit/1b791a86947d0e6a28946903e10840d2cb8c7a1d: fix it since 4.9.2

3. iceberg, delta use 4.9.3

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
