### PR TITLE
[flink] Fix lookup IndexOutOfBounds for sequence defined with projection

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/types/RowType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/RowType.java
@@ -99,6 +99,15 @@ public final class RowType extends DataType {
         return -1;
     }
 
+    public int[] getFieldIndices(List<String> projectFields) {
+        List<String> fieldNames = getFieldNames();
+        int[] projection = new int[projectFields.size()];
+        for (int i = 0; i < projection.length; i++) {
+            projection[i] = fieldNames.indexOf(projectFields.get(i));
+        }
+        return projection;
+    }
+
     public boolean containsField(String fieldName) {
         for (DataField field : fields) {
             if (field.name().equals(fieldName)) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
@@ -85,7 +85,6 @@ public abstract class FullCacheLookupTable implements LookupTable {
     private Predicate specificPartition;
 
     public FullCacheLookupTable(Context context) {
-        this.context = context;
         this.table = context.table;
         List<String> sequenceFields = new ArrayList<>();
         if (table.primaryKeys().size() > 0) {
@@ -106,6 +105,7 @@ public abstract class FullCacheLookupTable implements LookupTable {
                                 builder.field(f.name(), f.type());
                             });
             projectedType = builder.build();
+            context = context.copy(table.rowType().getFieldIndices(projectedType.getFieldNames()));
             this.userDefinedSeqComparator =
                     UserDefinedSeqComparator.create(projectedType, sequenceFields);
             this.appendUdsFieldNumber = appendUdsFieldNumber.get();
@@ -113,6 +113,8 @@ public abstract class FullCacheLookupTable implements LookupTable {
             this.userDefinedSeqComparator = null;
             this.appendUdsFieldNumber = 0;
         }
+
+        this.context = context;
 
         Options options = Options.fromMap(context.table.options());
         this.projectedType = projectedType;
@@ -353,6 +355,17 @@ public abstract class FullCacheLookupTable implements LookupTable {
             this.tempPath = tempPath;
             this.joinKey = joinKey;
             this.requiredCachedBucketIds = requiredCachedBucketIds;
+        }
+
+        public Context copy(int[] newProjection) {
+            return new Context(
+                    table,
+                    newProjection,
+                    tablePredicate,
+                    projectedPredicate,
+                    tempPath,
+                    joinKey,
+                    requiredCachedBucketIds);
         }
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
```
Caused by: java.lang.ArrayIndexOutOfBoundsException: 3
	at org.apache.paimon.utils.ProjectedRow.isNullAt(ProjectedRow.java:80)
	at RecordComparator$52.compare(Unknown Source)
	at org.apache.paimon.utils.UserDefinedSeqComparator.compare(UserDefinedSeqComparator.java:49)
	at org.apache.paimon.utils.UserDefinedSeqComparator.compare(UserDefinedSeqComparator.java:32)
	at org.apache.paimon.flink.lookup.SecondaryIndexLookupTable.refresh(SecondaryIndexLookupTable.java:88)
	at org.apache.paimon.flink.lookup.FullCacheLookupTable.refresh(FullCacheLookupTable.java:154)
	at org.apache.paimon.flink.lookup.FileStoreLookupFunction.refresh(FileStoreLookupFunction.java:299)
	at org.apache.paimon.flink.lookup.FileStoreLookupFunction.checkRefresh(FileStoreLookupFunction.java:288)
	at org.apache.paimon.flink.lookup.FileStoreLookupFunction.lookup(FileStoreLookupFunction.java:206)
	... 87 more
```

`FullCacheLookupTable` should pad sequence fields for projection.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

`LookupTableTest.testPkTableWithSequenceFieldProjection`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
