### PR TITLE
[flink] Fix source numRecordsIn metrics

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceReader.java
@@ -57,7 +57,8 @@ public class FileStoreSourceReader
                         new FileStoreSourceSplitReader(
                                 tableRead, RecordLimiter.create(limit), metrics),
                 (element, output, state) ->
-                        FlinkRecordsWithSplitIds.emitRecord(element, output, state, metrics),
+                        FlinkRecordsWithSplitIds.emitRecord(
+                                readerContext, element, output, state, metrics),
                 readerContext.getConfiguration(),
                 readerContext);
         this.ioManager = ioManager;
@@ -77,7 +78,8 @@ public class FileStoreSourceReader
                         new FileStoreSourceSplitReader(
                                 tableRead, RecordLimiter.create(limit), metrics),
                 (element, output, state) ->
-                        FlinkRecordsWithSplitIds.emitRecord(element, output, state, metrics),
+                        FlinkRecordsWithSplitIds.emitRecord(
+                                readerContext, element, output, state, metrics),
                 readerContext.getConfiguration(),
                 readerContext);
         this.ioManager = ioManager;

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FlinkRecordsWithSplitIdsTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FlinkRecordsWithSplitIdsTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connector.file.src.util.ArrayResultIterator;
 import org.apache.flink.connector.file.src.util.CheckpointedPosition;
 import org.apache.flink.connector.file.src.util.SingletonResultIterator;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -64,7 +65,11 @@ public class FlinkRecordsWithSplitIdsTest {
         BulkFormat.RecordIterator<RowData> iterator = records.nextRecordFromSplit();
         assertThat(iterator).isNotNull();
         FlinkRecordsWithSplitIds.emitRecord(
-                iterator, output, state, new FileStoreSourceReaderMetrics(new DummyMetricGroup()));
+                new TestingReaderContext(),
+                iterator,
+                output,
+                state,
+                new FileStoreSourceReaderMetrics(new DummyMetricGroup()));
         assertThat(output.getEmittedRecords()).containsExactly(rows);
         assertThat(state.recordsToSkip()).isEqualTo(2);
         assertThat(records.nextRecordFromSplit()).isNull();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/SourceMetricsITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/SourceMetricsITCase.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source;
+
+import org.apache.paimon.flink.util.MiniClusterWithClientExtension;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.metrics.groups.OperatorMetricGroup;
+import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.runtime.testutils.InMemoryReporter;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Metrics related IT cases for Paimon Flink source. */
+public class SourceMetricsITCase {
+
+    private static final int DEFAULT_PARALLELISM = 4;
+    private static final InMemoryReporter reporter = InMemoryReporter.createWithRetainedMetrics();
+
+    @RegisterExtension
+    protected static final MiniClusterWithClientExtension MINI_CLUSTER_EXTENSION =
+            new MiniClusterWithClientExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(DEFAULT_PARALLELISM)
+                            .setConfiguration(reporter.addToConfiguration(new Configuration()))
+                            .build());
+
+    @TempDir protected static Path tempPath;
+
+    @AfterEach
+    public final void cleanupRunningJobs() throws Exception {
+        ClusterClient<?> clusterClient = MINI_CLUSTER_EXTENSION.createRestClusterClient();
+        for (JobStatusMessage path : clusterClient.listJobs().get()) {
+            if (!path.getJobState().isTerminalState()) {
+                try {
+                    clusterClient.cancel(path.getJobId()).get();
+                } catch (Exception ignored) {
+                    // ignore exceptions when cancelling dangling jobs
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testNumRecordsIn() throws Exception {
+        TableEnvironment tEnv =
+                TableEnvironment.create(EnvironmentSettings.newInstance().inBatchMode().build());
+        tEnv.executeSql(
+                "CREATE CATALOG mycat WITH ( 'type' = 'paimon', 'warehouse' = '"
+                        + tempPath
+                        + "' )");
+        tEnv.executeSql("USE CATALOG mycat");
+        tEnv.executeSql("CREATE TABLE T ( k INT, v INT, PRIMARY KEY (k) NOT ENFORCED )");
+        tEnv.executeSql("INSERT INTO T VALUES (1, 10), (2, 20), (3, 30)").await();
+        tEnv.executeSql(
+                "CREATE TEMPORARY TABLE B ( k INT, v INT ) WITH ( 'connector' = 'blackhole' )");
+        TableResult tableResult = tEnv.executeSql("INSERT INTO B SELECT * FROM T");
+        JobClient client = tableResult.getJobClient().get();
+        JobID jobId = client.getJobID();
+        tableResult.await();
+
+        for (OperatorMetricGroup group : reporter.findOperatorMetricGroups(jobId, "Source: T")) {
+            assertThat(group.getIOMetricGroup().getNumRecordsInCounter().getCount()).isEqualTo(3);
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/SourceMetricsITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/SourceMetricsITCase.java
@@ -55,7 +55,7 @@ public class SourceMetricsITCase {
                             .setConfiguration(reporter.addToConfiguration(new Configuration()))
                             .build());
 
-    @TempDir protected static Path tempPath;
+    @TempDir Path tempPath;
 
     @AfterEach
     public final void cleanupRunningJobs() throws Exception {


### PR DESCRIPTION
### Purpose

FLIP-27 source has a default implementation of `numRecordsIn` metrics. However this metrics only count the number of batches Paimon source produces, not the number of records.

This PR fixes the metrics by increasing the counter before emitting data to source output.

### Tests

* `SourceMetricsITCase#testNumRecordsIn`

### API and Format

No API changes.

### Documentation

No new feature.
