### PR TITLE
[core] Fix the expired partition sync to metastore

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -258,8 +258,7 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
         MetastoreClient.Factory metastoreClientFactory =
                 catalogEnvironment.metastoreClientFactory();
         MetastoreClient metastoreClient = null;
-        if (options.partitionedTableInMetastore()
-                && metastoreClientFactory != null) {
+        if (options.partitionedTableInMetastore() && metastoreClientFactory != null) {
             metastoreClient = metastoreClientFactory.create();
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -255,6 +255,13 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
             return null;
         }
 
+        MetastoreClient.Factory metastoreClientFactory = catalogEnvironment.metastoreClientFactory();
+        MetastoreClient metastoreClient = null;
+        if (options.partitionedTableInMetastore()
+                && metastoreClientFactory != null){
+            metastoreClient = metastoreClientFactory.create();
+        }
+
         return new PartitionExpire(
                 partitionType(),
                 partitionExpireTime,
@@ -262,7 +269,8 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 options.partitionTimestampPattern(),
                 options.partitionTimestampFormatter(),
                 newScan(),
-                newCommit(commitUser));
+                newCommit(commitUser),
+                metastoreClient);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -258,7 +258,8 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
         MetastoreClient.Factory metastoreClientFactory =
                 catalogEnvironment.metastoreClientFactory();
         MetastoreClient metastoreClient = null;
-        if (options.partitionedTableInMetastore() && metastoreClientFactory != null) {
+        if (options.partitionedTableInMetastore()
+                && metastoreClientFactory != null) {
             metastoreClient = metastoreClientFactory.create();
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -255,10 +255,10 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
             return null;
         }
 
-        MetastoreClient.Factory metastoreClientFactory = catalogEnvironment.metastoreClientFactory();
+        MetastoreClient.Factory metastoreClientFactory =
+                catalogEnvironment.metastoreClientFactory();
         MetastoreClient metastoreClient = null;
-        if (options.partitionedTableInMetastore()
-                && metastoreClientFactory != null) {
+        if (options.partitionedTableInMetastore() && metastoreClientFactory != null) {
             metastoreClient = metastoreClientFactory.create();
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -258,7 +258,7 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
         MetastoreClient.Factory metastoreClientFactory = catalogEnvironment.metastoreClientFactory();
         MetastoreClient metastoreClient = null;
         if (options.partitionedTableInMetastore()
-                && metastoreClientFactory != null){
+                && metastoreClientFactory != null) {
             metastoreClient = metastoreClientFactory.create();
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
@@ -109,12 +109,12 @@ public class PartitionExpire {
         if (expired.size() > 0) {
             commit.dropPartitions(expired, commitIdentifier);
             if (metastoreClient != null) {
-                deleteMetaStorePartition(expired);
+                deleteMetaStorePartitions(expired);
             }
         }
     }
 
-    private void deleteMetaStorePartition(List<Map<String, String>> partitions) {
+    private void deleteMetaStorePartitions(List<Map<String, String>> partitions) {
         if (metastoreClient != null) {
             partitions.forEach(partition -> {
                 try {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
@@ -117,13 +117,14 @@ public class PartitionExpire {
 
     private void deleteMetastorePartitions(List<Map<String, String>> partitions) {
         if (metastoreClient != null) {
-            partitions.forEach(partition -> {
-                try {
-                    metastoreClient.deletePartition(new LinkedHashMap<>(partition));
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            });
+            partitions.forEach(
+                    partition -> {
+                        try {
+                            metastoreClient.deletePartition(new LinkedHashMap<>(partition));
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
@@ -109,12 +109,12 @@ public class PartitionExpire {
         if (expired.size() > 0) {
             commit.dropPartitions(expired, commitIdentifier);
             if (metastoreClient != null) {
-                deleteMetaStorePartitions(expired);
+                deleteMetastorePartitions(expired);
             }
         }
     }
 
-    private void deleteMetaStorePartitions(List<Map<String, String>> partitions) {
+    private void deleteMetastorePartitions(List<Map<String, String>> partitions) {
         if (metastoreClient != null) {
             partitions.forEach(partition -> {
                 try {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ExpirePartitionsProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ExpirePartitionsProcedure.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.FileStore;
 import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.metastore.MetastoreClient;
 import org.apache.paimon.operation.PartitionExpire;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.utils.TimeUtils;
@@ -30,6 +31,7 @@ import org.apache.flink.table.annotation.ProcedureHint;
 import org.apache.flink.table.procedure.ProcedureContext;
 
 import java.time.Duration;
+import java.util.Optional;
 
 /** A procedure to expire partitions. */
 public class ExpirePartitionsProcedure extends ProcedureBase {
@@ -60,7 +62,13 @@ public class ExpirePartitionsProcedure extends ProcedureBase {
                         null,
                         timestampFormatter,
                         fileStore.newScan(),
-                        fileStore.newCommit(""));
+                        fileStore.newCommit(""),
+                        Optional.ofNullable(
+                                        fileStoreTable
+                                                .catalogEnvironment()
+                                                .metastoreClientFactory())
+                                .map(MetastoreClient.Factory::create)
+                                .orElse(null));
         partitionExpire.expire(Long.MAX_VALUE);
         return new String[] {};
     }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -1269,10 +1269,8 @@ public abstract class HiveCatalogITCaseBase {
                         "CALL sys.expire_partitions(`table` => 'default.students', expiration_time => '1 d', timestamp_formatter => 'yyyy-MM-dd')")
                 .await();
 
-        List<String> nonPartitionedTableResult = hiveShell.executeQuery("SHOW PARTITIONS students");
-        assertThat(nonPartitionedTableResult.contains("2024-06-15")).isTrue();
-        assertThat(nonPartitionedTableResult.contains("9998-06-15")).isFalse();
-        assertThat(nonPartitionedTableResult.contains("9999-06-15")).isFalse();
+        assertThat(hiveShell.executeQuery("SHOW PARTITIONS students"))
+                .containsExactlyInAnyOrder("dt=2024-06-15");
     }
 
     /** Prepare to update a paimon table with a custom path in the paimon file system. */

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -1269,7 +1269,7 @@ public abstract class HiveCatalogITCaseBase {
                         "CALL sys.expire_partitions(`table` => 'default.students', expiration_time => '1 d', timestamp_formatter => 'yyyy-MM-dd')")
                 .await();
 
-        assertThat(hiveShell.executeQuery("SHOW PARTITIONS students"))
+        assertThat(hiveShell.executeQuery("show partitions students"))
                 .containsExactlyInAnyOrder("dt=2024-06-15");
     }
 

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -1249,6 +1249,24 @@ public abstract class HiveCatalogITCaseBase {
     @Test
     public void testExpiredPartitionsSyncToMetastore() throws Exception {
         // Use flink to create a partitioned table and write data, hive read.
+        path = folder.newFolder().toURI().toString();
+        EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
+        tEnv = TableEnvironmentImpl.create(settings);
+        tEnv.executeSql(
+                        "create catalog my_hive with (\n"
+                                + "  'type' = 'paimon',\n"
+                                + "  'metastore' = 'hive',\n"
+                                + "  'uri' = '',\n"
+                                + "  'warehouse' = '"
+                                + path
+                                + "',\n"
+                                + "  'metastore.client.class' = '"
+                                + HiveCatalogITCaseBase.class.getName()
+                                + "'\n"
+                                + ");")
+                .await();
+        tEnv.executeSql("USE CATALOG my_hive").await();
+        // Use flink to create a partitioned table and write data, hive read.
         tEnv.executeSql(
                         "create table students\n"
                                 + "(id string\n"
@@ -1269,6 +1287,7 @@ public abstract class HiveCatalogITCaseBase {
                         "CALL sys.expire_partitions(`table` => 'default.students', expiration_time => '1 d', timestamp_formatter => 'yyyy-MM-dd')")
                 .await();
 
+        hiveShell.execute("use default");
         assertThat(hiveShell.executeQuery("show partitions students"))
                 .containsExactlyInAnyOrder("dt=2024-06-15");
     }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -1251,7 +1251,7 @@ public abstract class HiveCatalogITCaseBase {
         // Use flink to create a partitioned table and write data, hive read.
         tEnv.executeSql(
                         "create table students\n"
-                                + "(id decimal(20,0)\n"
+                                + "(id string\n"
                                 + ",dt string\n"
                                 + ",PRIMARY KEY(id,dt) NOT ENFORCED\n"
                                 + ") PARTITIONED BY (dt)\n"

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -1246,6 +1246,35 @@ public abstract class HiveCatalogITCaseBase {
                 .containsExactlyInAnyOrder("dt=2020-01-02/hh=09", "dt=2020-01-03/hh=10");
     }
 
+    @Test
+    public void testExpiredPartitionsSyncToMetastore() throws Exception {
+        // Use flink to create a partitioned table and write data, hive read.
+        tEnv.executeSql(
+                        "create table students\n"
+                                + "(id decimal(20,0)\n"
+                                + ",dt string\n"
+                                + ",PRIMARY KEY(id,dt) NOT ENFORCED\n"
+                                + ") PARTITIONED BY (dt)\n"
+                                + "WITH (\n"
+                                + "'bucket' = '-1',\n"
+                                + "'file.format' = 'parquet',\n"
+                                + "'metastore.partitioned-table' = 'true'\n"
+                                + ");")
+                .await();
+        tEnv.executeSql("insert into students values('1', '2024-06-15')").await();
+        tEnv.executeSql("insert into students values('1', '9998-06-15')").await();
+        tEnv.executeSql("insert into students values('1', '9999-06-15')").await();
+
+        tEnv.executeSql(
+                        "CALL sys.expire_partitions(`table` => 'default.students', expiration_time => '1 d', timestamp_formatter => 'yyyy-MM-dd')")
+                .await();
+
+        List<String> nonPartitionedTableResult = hiveShell.executeQuery("SHOW PARTITIONS students");
+        assertThat(nonPartitionedTableResult.contains("2024-06-15")).isTrue();
+        assertThat(nonPartitionedTableResult.contains("9998-06-15")).isFalse();
+        assertThat(nonPartitionedTableResult.contains("9999-06-15")).isFalse();
+    }
+
     /** Prepare to update a paimon table with a custom path in the paimon file system. */
     private void alterTableInFileSystem(TableEnvironment tEnv) throws Exception {
         tEnv.executeSql(

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/ExpirePartitionsProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/ExpirePartitionsProcedure.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.spark.procedure;
 
 import org.apache.paimon.FileStore;
+import org.apache.paimon.metastore.MetastoreClient;
 import org.apache.paimon.operation.PartitionExpire;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.utils.TimeUtils;
@@ -32,6 +33,7 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import static org.apache.spark.sql.types.DataTypes.StringType;
 
@@ -83,7 +85,13 @@ public class ExpirePartitionsProcedure extends BaseProcedure {
                                     null,
                                     timestampFormatter,
                                     fileStore.newScan(),
-                                    fileStore.newCommit(""));
+                                    fileStore.newCommit(""),
+                                    Optional.ofNullable(
+                                                    fileStoreTable
+                                                            .catalogEnvironment()
+                                                            .metastoreClientFactory())
+                                            .map(MetastoreClient.Factory::create)
+                                            .orElse(null));
                     partitionExpire.expire(Long.MAX_VALUE);
                     InternalRow outputRow = newInternalRow(true);
                     return new InternalRow[] {outputRow};


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close [When metastore.partitioned-table is enabled, the partition information in hms will not be deleted after the expired partition is automatically deleted.](https://github.com/apache/paimon/issues/3514)

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
