### PR TITLE
[cdc] Handle case-insensitive in separate operator instead of record parsers

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/CdcActionCommonUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/CdcActionCommonUtils.java
@@ -190,8 +190,8 @@ public class CdcActionCommonUtils {
         checkState(
                 duplicates.isEmpty(),
                 "Table %s contains duplicate columns: %s.\n"
-                        + "Possible causes is: "
-                        + "1. computed columns or metadata columns contain duplicate field; "
+                        + "Possible causes are: "
+                        + "1. computed columns or metadata columns contain duplicate fields; "
                         + "2. the catalog is case-insensitive and the table columns duplicate after they are all converted to lower-case.",
                 tableName,
                 duplicates);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/MessageQueueSchemaUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/MessageQueueSchemaUtils.java
@@ -49,8 +49,7 @@ public class MessageQueueSchemaUtils {
         int retry = 0;
         int retryInterval = 1000;
 
-        RecordParser recordParser =
-                dataFormat.createParser(true, typeMapping, Collections.emptyList());
+        RecordParser recordParser = dataFormat.createParser(typeMapping, Collections.emptyList());
 
         while (true) {
             Optional<Schema> schema =

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
@@ -112,7 +112,7 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
     @Override
     protected FlatMapFunction<CdcSourceRecord, RichCdcMultiplexRecord> recordParse() {
         return syncJobHandler.provideRecordParser(
-                caseSensitive, Collections.emptyList(), typeMapping, metadataConverters);
+                Collections.emptyList(), typeMapping, metadataConverters);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncJobHandler.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncJobHandler.java
@@ -193,31 +193,22 @@ public class SyncJobHandler {
     }
 
     public FlatMapFunction<CdcSourceRecord, RichCdcMultiplexRecord> provideRecordParser(
-            boolean caseSensitive,
             List<ComputedColumn> computedColumns,
             TypeMapping typeMapping,
             CdcMetadataConverter[] metadataConverters) {
         switch (sourceType) {
             case MYSQL:
                 return new MySqlRecordParser(
-                        cdcSourceConfig,
-                        caseSensitive,
-                        computedColumns,
-                        typeMapping,
-                        metadataConverters);
+                        cdcSourceConfig, computedColumns, typeMapping, metadataConverters);
             case POSTGRES:
                 return new PostgresRecordParser(
-                        cdcSourceConfig,
-                        caseSensitive,
-                        computedColumns,
-                        typeMapping,
-                        metadataConverters);
+                        cdcSourceConfig, computedColumns, typeMapping, metadataConverters);
             case KAFKA:
             case PULSAR:
                 DataFormat dataFormat = provideDataFormat();
-                return dataFormat.createParser(caseSensitive, typeMapping, computedColumns);
+                return dataFormat.createParser(typeMapping, computedColumns);
             case MONGODB:
-                return new MongoDBRecordParser(caseSensitive, computedColumns, cdcSourceConfig);
+                return new MongoDBRecordParser(computedColumns, cdcSourceConfig);
             default:
                 throw new UnsupportedOperationException("Unknown source type " + sourceType);
         }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionBase.java
@@ -156,8 +156,7 @@ public abstract class SyncTableActionBase extends SynchronizationActionBase {
 
     @Override
     protected FlatMapFunction<CdcSourceRecord, RichCdcMultiplexRecord> recordParse() {
-        return syncJobHandler.provideRecordParser(
-                caseSensitive, computedColumns, typeMapping, metadataConverters);
+        return syncJobHandler.provideRecordParser(computedColumns, typeMapping, metadataConverters);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/DataFormat.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/DataFormat.java
@@ -53,13 +53,12 @@ public enum DataFormat {
      * Creates a new instance of {@link RecordParser} for this data format with the specified
      * configurations.
      *
-     * @param caseSensitive Indicates whether the parser should be case-sensitive.
      * @param computedColumns List of computed columns to be considered by the parser.
      * @return A new instance of {@link RecordParser}.
      */
     public RecordParser createParser(
-            boolean caseSensitive, TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
-        return parser.createParser(caseSensitive, typeMapping, computedColumns);
+            TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
+        return parser.createParser(typeMapping, computedColumns);
     }
 
     public static DataFormat fromConfigString(String format) {

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/RecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/RecordParser.java
@@ -51,10 +51,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.fieldNameCaseConvert;
-import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.listCaseConvert;
-import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.mapKeyCaseConvert;
-import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.recordKeyDuplicateErrMsg;
 import static org.apache.paimon.utils.JsonSerdeUtil.convertValue;
 import static org.apache.paimon.utils.JsonSerdeUtil.getNodeAs;
 import static org.apache.paimon.utils.JsonSerdeUtil.isNull;
@@ -75,15 +71,12 @@ public abstract class RecordParser
 
     protected static final String FIELD_TABLE = "table";
     protected static final String FIELD_DATABASE = "database";
-    private final boolean caseSensitive;
     protected final TypeMapping typeMapping;
     protected final List<ComputedColumn> computedColumns;
 
     protected JsonNode root;
 
-    public RecordParser(
-            boolean caseSensitive, TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
-        this.caseSensitive = caseSensitive;
+    public RecordParser(TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
         this.typeMapping = typeMapping;
         this.computedColumns = computedColumns;
     }
@@ -203,15 +196,12 @@ public abstract class RecordParser
     /** Handle case sensitivity here. */
     private RichCdcMultiplexRecord createRecord(
             RowKind rowKind, Map<String, String> data, List<DataField> paimonFields) {
-        String databaseName = getDatabaseName();
-        String tableName = getTableName();
-        paimonFields = fieldNameCaseConvert(paimonFields, caseSensitive, tableName);
-
-        data = mapKeyCaseConvert(data, caseSensitive, recordKeyDuplicateErrMsg(data));
-        List<String> primaryKeys = listCaseConvert(extractPrimaryKeys(), caseSensitive);
-
         return new RichCdcMultiplexRecord(
-                databaseName, tableName, paimonFields, primaryKeys, new CdcRecord(rowKind, data));
+                getDatabaseName(),
+                getTableName(),
+                paimonFields,
+                extractPrimaryKeys(),
+                new CdcRecord(rowKind, data));
     }
 
     protected void setRoot(CdcSourceRecord record) {

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/RecordParserFactory.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/RecordParserFactory.java
@@ -37,11 +37,9 @@ public interface RecordParserFactory {
     /**
      * Creates a new instance of {@link RecordParser} with the specified configurations.
      *
-     * @param caseSensitive Indicates whether the parser should be case-sensitive.
      * @param typeMapping Data type mapping options.
      * @param computedColumns List of computed columns to be considered by the parser.
      * @return A new instance of {@link RecordParser}.
      */
-    RecordParser createParser(
-            boolean caseSensitive, TypeMapping typeMapping, List<ComputedColumn> computedColumns);
+    RecordParser createParser(TypeMapping typeMapping, List<ComputedColumn> computedColumns);
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/canal/CanalRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/canal/CanalRecordParser.java
@@ -82,9 +82,8 @@ public class CanalRecordParser extends RecordParser {
         return !isNull(node) && node.asBoolean();
     }
 
-    public CanalRecordParser(
-            boolean caseSensitive, TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
-        super(caseSensitive, typeMapping, computedColumns);
+    public CanalRecordParser(TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
+        super(typeMapping, computedColumns);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumRecordParser.java
@@ -83,9 +83,8 @@ public class DebeziumRecordParser extends RecordParser {
     private final Map<String, String> classNames = new HashMap<>();
     private final Map<String, Map<String, String>> parameters = new HashMap<>();
 
-    public DebeziumRecordParser(
-            boolean caseSensitive, TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
-        super(caseSensitive, typeMapping, computedColumns);
+    public DebeziumRecordParser(TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
+        super(typeMapping, computedColumns);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/json/JsonRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/json/JsonRecordParser.java
@@ -36,9 +36,8 @@ import java.util.List;
  */
 public class JsonRecordParser extends RecordParser {
 
-    public JsonRecordParser(
-            boolean caseSensitive, TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
-        super(caseSensitive, typeMapping, computedColumns);
+    public JsonRecordParser(TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
+        super(typeMapping, computedColumns);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/maxwell/MaxwellRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/maxwell/MaxwellRecordParser.java
@@ -50,9 +50,8 @@ public class MaxwellRecordParser extends RecordParser {
     private static final String OP_UPDATE = "update";
     private static final String OP_DELETE = "delete";
 
-    public MaxwellRecordParser(
-            boolean caseSensitive, TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
-        super(caseSensitive, typeMapping, computedColumns);
+    public MaxwellRecordParser(TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
+        super(typeMapping, computedColumns);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/ogg/OggRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/ogg/OggRecordParser.java
@@ -58,9 +58,8 @@ public class OggRecordParser extends RecordParser {
     private static final String OP_INSERT = "I";
     private static final String OP_DELETE = "D";
 
-    public OggRecordParser(
-            boolean caseSensitive, TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
-        super(caseSensitive, typeMapping, computedColumns);
+    public OggRecordParser(TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
+        super(typeMapping, computedColumns);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBRecordParser.java
@@ -60,15 +60,10 @@ public class MongoDBRecordParser
     private static final String FIELD_NAMESPACE = "ns";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private final List<ComputedColumn> computedColumns;
-    private final boolean caseSensitive;
     private final Configuration mongodbConfig;
     private JsonNode root;
 
-    public MongoDBRecordParser(
-            boolean caseSensitive,
-            List<ComputedColumn> computedColumns,
-            Configuration mongodbConfig) {
-        this.caseSensitive = caseSensitive;
+    public MongoDBRecordParser(List<ComputedColumn> computedColumns, Configuration mongodbConfig) {
         this.computedColumns = computedColumns;
         this.mongodbConfig = mongodbConfig;
     }
@@ -81,7 +76,7 @@ public class MongoDBRecordParser
         String collection = extractString(FIELD_TABLE);
         MongoVersionStrategy versionStrategy =
                 VersionStrategyFactory.create(
-                        databaseName, collection, caseSensitive, computedColumns, mongodbConfig);
+                        databaseName, collection, computedColumns, mongodbConfig);
         versionStrategy.extractRecords(root).forEach(out::collect);
     }
 
@@ -93,7 +88,6 @@ public class MongoDBRecordParser
         static MongoVersionStrategy create(
                 String databaseName,
                 String collection,
-                boolean caseSensitive,
                 List<ComputedColumn> computedColumns,
                 Configuration mongodbConfig) {
             // TODO: When MongoDB CDC is upgraded to 2.5, uncomment the version check logic
@@ -101,7 +95,7 @@ public class MongoDBRecordParser
             //     return new Mongo6VersionStrategy(databaseName, collection, caseSensitive);
             // }
             return new Mongo4VersionStrategy(
-                    databaseName, collection, caseSensitive, computedColumns, mongodbConfig);
+                    databaseName, collection, computedColumns, mongodbConfig);
         }
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/strategy/Mongo4VersionStrategy.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/strategy/Mongo4VersionStrategy.java
@@ -34,10 +34,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.fieldNameCaseConvert;
-import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.mapKeyCaseConvert;
-import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.recordKeyDuplicateErrMsg;
-
 /**
  * Implementation class for extracting records from MongoDB versions greater than 4.x and less than
  * 6.x.
@@ -53,19 +49,16 @@ public class Mongo4VersionStrategy implements MongoVersionStrategy {
     private static final String OP_DELETE = "delete";
     private final String databaseName;
     private final String collection;
-    private final boolean caseSensitive;
     private final Configuration mongodbConfig;
     private final List<ComputedColumn> computedColumns;
 
     public Mongo4VersionStrategy(
             String databaseName,
             String collection,
-            boolean caseSensitive,
             List<ComputedColumn> computedColumns,
             Configuration mongodbConfig) {
         this.databaseName = databaseName;
         this.collection = collection;
-        this.caseSensitive = caseSensitive;
         this.mongodbConfig = mongodbConfig;
         this.computedColumns = computedColumns;
     }
@@ -133,11 +126,7 @@ public class Mongo4VersionStrategy implements MongoVersionStrategy {
         RowType.Builder rowTypeBuilder = RowType.builder();
         Map<String, String> record =
                 getExtractRow(fullDocument, rowTypeBuilder, computedColumns, mongodbConfig);
-
-        record = mapKeyCaseConvert(record, caseSensitive, recordKeyDuplicateErrMsg(record));
-
         List<DataField> fields = rowTypeBuilder.build().getFields();
-        fields = fieldNameCaseConvert(fields, caseSensitive, collection);
 
         return new RichCdcMultiplexRecord(
                 databaseName,

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CaseSensitiveUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CaseSensitiveUtils.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.cdc;
+
+import org.apache.paimon.catalog.Catalog;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.util.Collector;
+
+/** Add convert operator if the catalog is case-insensitive. */
+public class CaseSensitiveUtils {
+
+    public static DataStream<CdcRecord> cdcRecordConvert(
+            Catalog.Loader catalogLoader, DataStream<CdcRecord> input) {
+        if (caseSensitive(catalogLoader)) {
+            return input;
+        }
+
+        return input.forward()
+                .process(
+                        new ProcessFunction<CdcRecord, CdcRecord>() {
+                            @Override
+                            public void processElement(
+                                    CdcRecord record, Context ctx, Collector<CdcRecord> out) {
+                                out.collect(record.fieldNameLowerCase());
+                            }
+                        })
+                .name("Case-insensitive Convert");
+    }
+
+    public static DataStream<CdcMultiplexRecord> cdcMultiplexRecordConvert(
+            Catalog.Loader catalogLoader, DataStream<CdcMultiplexRecord> input) {
+        if (caseSensitive(catalogLoader)) {
+            return input;
+        }
+
+        return input.forward()
+                .process(
+                        new ProcessFunction<CdcMultiplexRecord, CdcMultiplexRecord>() {
+                            @Override
+                            public void processElement(
+                                    CdcMultiplexRecord record,
+                                    Context ctx,
+                                    Collector<CdcMultiplexRecord> out) {
+                                out.collect(record.fieldNameLowerCase());
+                            }
+                        })
+                .name("Case-insensitive Convert");
+    }
+
+    private static boolean caseSensitive(Catalog.Loader catalogLoader) {
+        try (Catalog catalog = catalogLoader.load()) {
+            return catalog.caseSensitive();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcMultiplexRecord.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcMultiplexRecord.java
@@ -55,6 +55,10 @@ public class CdcMultiplexRecord implements Serializable {
         return record;
     }
 
+    public CdcMultiplexRecord fieldNameLowerCase() {
+        return new CdcMultiplexRecord(databaseName, tableName, record.fieldNameLowerCase());
+    }
+
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof CdcMultiplexRecord)) {

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecord.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecord.java
@@ -23,6 +23,7 @@ import org.apache.paimon.types.RowKind;
 
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -41,11 +42,6 @@ public class CdcRecord implements Serializable {
         this.fields = fields;
     }
 
-    public CdcRecord setRowKind(RowKind kind) {
-        this.kind = kind;
-        return this;
-    }
-
     public static CdcRecord emptyRecord() {
         return new CdcRecord(RowKind.INSERT, Collections.emptyMap());
     }
@@ -56,6 +52,14 @@ public class CdcRecord implements Serializable {
 
     public Map<String, String> fields() {
         return fields;
+    }
+
+    public CdcRecord fieldNameLowerCase() {
+        Map<String, String> newFields = new HashMap<>();
+        for (Map.Entry<String, String> entry : fields.entrySet()) {
+            newFields.put(entry.getKey().toLowerCase(), entry.getValue());
+        }
+        return new CdcRecord(kind, newFields);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcSinkBuilder.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcSinkBuilder.java
@@ -110,7 +110,7 @@ public class CdcSinkBuilder<T> {
                                         new SchemaManager(dataTable.fileIO(), dataTable.location()),
                                         identifier,
                                         catalogLoader))
-                        .name("Schema Change");
+                        .name("Schema Evolution");
         schemaChangeProcessFunction.getTransformation().setParallelism(1);
         schemaChangeProcessFunction.getTransformation().setMaxParallelism(1);
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcSinkBuilder.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcSinkBuilder.java
@@ -99,6 +99,7 @@ public class CdcSinkBuilder<T> {
         SingleOutputStreamOperator<CdcRecord> parsed =
                 input.forward()
                         .process(new CdcParsingProcessFunction<>(parserFactory))
+                        .name("Side Output")
                         .setParallelism(input.getParallelism());
 
         DataStream<Void> schemaChangeProcessFunction =
@@ -108,18 +109,22 @@ public class CdcSinkBuilder<T> {
                                 new UpdatedDataFieldsProcessFunction(
                                         new SchemaManager(dataTable.fileIO(), dataTable.location()),
                                         identifier,
-                                        catalogLoader));
+                                        catalogLoader))
+                        .name("Schema Change");
         schemaChangeProcessFunction.getTransformation().setParallelism(1);
         schemaChangeProcessFunction.getTransformation().setMaxParallelism(1);
 
+        DataStream<CdcRecord> converted =
+                CaseSensitiveUtils.cdcRecordConvert(catalogLoader, parsed);
         BucketMode bucketMode = dataTable.bucketMode();
         switch (bucketMode) {
             case HASH_FIXED:
-                return buildForFixedBucket(parsed);
+                return buildForFixedBucket(converted);
             case HASH_DYNAMIC:
-                return new CdcDynamicBucketSink((FileStoreTable) table).build(parsed, parallelism);
+                return new CdcDynamicBucketSink((FileStoreTable) table)
+                        .build(converted, parallelism);
             case BUCKET_UNAWARE:
-                return buildForUnawareBucket(parsed);
+                return buildForUnawareBucket(converted);
             default:
                 throw new UnsupportedOperationException("Unsupported bucket mode: " + bucketMode);
         }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
@@ -542,11 +542,17 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
         RowType rowType =
                 RowType.of(
                         new DataType[] {
-                            DataTypes.INT().notNull(), DataTypes.VARCHAR(10), DataTypes.INT()
+                            DataTypes.INT().notNull(),
+                            DataTypes.VARCHAR(10),
+                            DataTypes.INT(),
+                            DataTypes.VARCHAR(10)
                         },
-                        new String[] {"k1", "v0", "v1"});
+                        new String[] {"k1", "v0", "v1", "v2"});
         waitForResult(
-                Arrays.asList("+I[5, five, 50]", "+I[7, seven, 70]"),
+                Arrays.asList(
+                        "+I[5, five, 50, NULL]",
+                        "+I[7, seven, 70, NULL]",
+                        "+I[8, eight, 80, added]"),
                 table,
                 rowType,
                 Collections.singletonList("k1"));

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/case-insensitive/canal-data-1.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/case-insensitive/canal-data-1.txt
@@ -18,3 +18,4 @@
 
 {"data":[{"k1":"5","v0":"five","V1":"50"}],"database":"paimon_sync_database_affix","es":1684770072000,"id":81,"isDdl":false,"mysqlType":{"k1":"INT","v0":"VARCHAR(10)","V1":"INT"},"old":null,"pkNames":["k1"],"sql":"","sqlType":{"k1":4,"v0":12,"v1":4},"table":"t1","ts":1684770072286,"type":"INSERT"}
 {"data":[{"K1":"7","v0":"seven","V1":"70"}],"database":"paimon_sync_database_affix","es":1684770073000,"id":84,"isDdl":false,"mysqlType":{"K1":"INT","v0":"VARCHAR(10)","V1":"INT"},"old":null,"pkNames":["k1"],"sql":"","sqlType":{"k1":4,"v0":12,"v1":4},"table":"t1","ts":1684770073254,"type":"INSERT"}
+{"data":[{"K1":"8","v0":"eight","V1":"80", "V2":"added"}],"database":"paimon_sync_database_affix","es":1684770074000,"id":84,"isDdl":false,"mysqlType":{"K1":"INT","v0":"VARCHAR(10)","V1":"INT","V2":"VARCHAR(10)"},"old":null,"pkNames":["k1"],"sql":"","sqlType":{"k1":4,"v0":12,"v1":4,"v2":12},"table":"t1","ts":1684770073254,"type":"INSERT"}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/mysql/sync_database_setup.sql
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/mysql/sync_database_setup.sql
@@ -191,11 +191,24 @@ CREATE TABLE test (
 );
 
 -- ################################################################################
---  MySqlSyncDatabaseActionITCase#testIgnoreCase
+--  MySqlSyncDatabaseActionITCase#testIgnoreCaseDivided
 -- ################################################################################
 
-CREATE DATABASE paimon_ignore_CASE;
-USE paimon_ignore_CASE;
+CREATE DATABASE paimon_ignore_CASE_divided;
+USE paimon_ignore_CASE_divided;
+
+CREATE TABLE T (
+    k INT,
+    UPPERCASE_V0 VARCHAR(20),
+    PRIMARY KEY (k)
+);
+
+-- ################################################################################
+--  MySqlSyncDatabaseActionITCase#testIgnoreCaseCombined
+-- ################################################################################
+
+CREATE DATABASE paimon_ignore_CASE_combined;
+USE paimon_ignore_CASE_combined;
 
 CREATE TABLE T (
     k INT,


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Currently, all record parsers have to handle `case-insensitive`. This PR want to move it to a separate operator.

Note that #2485 has already considered handle `case-insensitive` with computed columns, so this PR won't cause problems to computed columns.

<!-- What is the purpose of the change -->

### Tests
1. there are already some test cases for table sync with `case-insensitive`.
2. add `MySqlSyncDatabaseActionITCase#testIgnoreCaseCombined`
3. enhance `KafkaCanalSyncDatabaseActionITCase#testCaseInsensitive`

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
