### PR TITLE
[core] Support Numberic type to FieldCountAgg

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldCountAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldCountAgg.java
@@ -42,6 +42,12 @@ public class FieldCountAgg extends FieldAggregator {
         } else {
             // ordered by type root definition
             switch (fieldType.getTypeRoot()) {
+                case TINYINT:
+                    count = (byte) ((byte) accumulator + 1);
+                    break;
+                case SMALLINT:
+                    count = (short) ((short) accumulator + 1);
+                    break;
                 case INTEGER:
                     count = (int) accumulator + 1;
                     break;
@@ -63,6 +69,12 @@ public class FieldCountAgg extends FieldAggregator {
         } else {
             // ordered by type root definition
             switch (fieldType.getTypeRoot()) {
+                case TINYINT:
+                    count = (byte) ((byte) accumulator - 1);
+                    break;
+                case SMALLINT:
+                    count = (short) ((short) accumulator - 1);
+                    break;
                 case INTEGER:
                     count = (int) accumulator - 1;
                     break;

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -154,12 +154,33 @@ public class FieldAggregatorTest {
 
     @Test
     public void testFieldCountIntAgg() {
-        FieldCountAgg fieldCountAgg = new FieldCountAgg(new IntType());
-        assertThat(fieldCountAgg.agg(null, null)).isEqualTo(0);
-        assertThat(fieldCountAgg.agg(1, null)).isEqualTo(1);
-        assertThat(fieldCountAgg.agg(null, 15)).isEqualTo(1);
-        assertThat(fieldCountAgg.agg(1, 0)).isEqualTo(2);
-        assertThat(fieldCountAgg.agg(3, 6)).isEqualTo(4);
+        FieldCountAgg fieldCountAggInt = new FieldCountAgg(new IntType());
+        assertThat(fieldCountAggInt.agg(null, null)).isEqualTo(0);
+        assertThat(fieldCountAggInt.agg(1, null)).isEqualTo(1);
+        assertThat(fieldCountAggInt.agg(null, 15)).isEqualTo(1);
+        assertThat(fieldCountAggInt.agg(1, 0)).isEqualTo(2);
+        assertThat(fieldCountAggInt.agg(3, 6)).isEqualTo(4);
+
+        FieldCountAgg fieldCountAggLong = new FieldCountAgg(new BigIntType());
+        assertThat(fieldCountAggLong.agg(null, null)).isEqualTo(0);
+        assertThat(fieldCountAggLong.agg((long) 1, null)).isEqualTo((long) 1);
+        assertThat(fieldCountAggLong.agg(null, (long) 15)).isEqualTo(1);
+        assertThat(fieldCountAggLong.agg((long) 1, 0)).isEqualTo((long) 2);
+        assertThat(fieldCountAggLong.agg((long) 3, (long) 6)).isEqualTo((long) 4);
+
+        FieldCountAgg fieldCountAggByte = new FieldCountAgg(new TinyIntType());
+        assertThat(fieldCountAggByte.agg(null, null)).isEqualTo(0);
+        assertThat(fieldCountAggByte.agg((byte) 1, null)).isEqualTo((byte) 1);
+        assertThat(fieldCountAggByte.agg(null, (byte) 15)).isEqualTo(1);
+        assertThat(fieldCountAggByte.agg((byte) 1, 0)).isEqualTo((byte) 2);
+        assertThat(fieldCountAggByte.agg((byte) 3, (byte) 6)).isEqualTo((byte) 4);
+
+        FieldCountAgg fieldCountAggShort = new FieldCountAgg(new SmallIntType());
+        assertThat(fieldCountAggShort.agg(null, null)).isEqualTo(0);
+        assertThat(fieldCountAggShort.agg((short) 1, null)).isEqualTo((short) 1);
+        assertThat(fieldCountAggShort.agg(null, (short) 15)).isEqualTo(1);
+        assertThat(fieldCountAggShort.agg((short) 1, 0)).isEqualTo((short) 2);
+        assertThat(fieldCountAggShort.agg((short) 3, (short) 6)).isEqualTo((short) 4);
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

FieldCountAgg support FieldType with numberic field type， follow up https://github.com/apache/paimon/pull/3536

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
