### PR TITLE
[spark]Support get full table name include database

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -211,7 +211,7 @@ public class SparkCatalog extends SparkBaseCatalog {
     @Override
     public SparkTable loadTable(Identifier ident) throws NoSuchTableException {
         try {
-            return new SparkTable(load(ident));
+            return new SparkTable(load(ident), toIdentifier(ident).getDatabaseName());
         } catch (Catalog.TableNotExistException e) {
             throw new NoSuchTableException(ident);
         }
@@ -224,7 +224,8 @@ public class SparkCatalog extends SparkBaseCatalog {
         Table table = loadPaimonTable(ident);
         LOG.info("Time travel to version '{}'.", version);
         return new SparkTable(
-                table.copy(Collections.singletonMap(CoreOptions.SCAN_VERSION.key(), version)));
+                table.copy(Collections.singletonMap(CoreOptions.SCAN_VERSION.key(), version)),
+                toIdentifier(ident).getDatabaseName());
     }
 
     /**
@@ -241,7 +242,7 @@ public class SparkCatalog extends SparkBaseCatalog {
         LOG.info("Time travel target timestamp is {} milliseconds.", timestamp);
 
         Options option = new Options().set(CoreOptions.SCAN_TIMESTAMP_MILLIS, timestamp);
-        return new SparkTable(table.copy(option.toMap()));
+        return new SparkTable(table.copy(option.toMap()), toIdentifier(ident).getDatabaseName());
     }
 
     private Table loadPaimonTable(Identifier ident) throws NoSuchTableException {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkTable.scala
@@ -35,7 +35,7 @@ import java.util.{Collections, EnumSet => JEnumSet, HashMap => JHashMap, Map => 
 import scala.collection.JavaConverters._
 
 /** A spark [[org.apache.spark.sql.connector.catalog.Table]] for paimon. */
-case class SparkTable(table: Table)
+case class SparkTable(table: Table, db: String = null)
   extends org.apache.spark.sql.connector.catalog.Table
   with SupportsRead
   with SupportsWrite
@@ -44,7 +44,7 @@ case class SparkTable(table: Table)
 
   def getTable: Table = table
 
-  override def name: String = table.name
+  override def name: String = if (db == null) table.name() else (db + "." + table.name)
 
   override lazy val schema: StructType = SparkTypeUtils.fromPaimonRowType(table.rowType)
 

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
@@ -120,7 +120,7 @@ class PaimonSparkTestBase
   }
 
   protected def createRelationV2(tableName: String): LogicalPlan = {
-    val sparkTable = new SparkTable(loadTable(tableName))
+    val sparkTable = new SparkTable(loadTable(tableName), dbName0)
     DataSourceV2Relation.create(
       sparkTable,
       Some(spark.sessionState.catalogManager.currentCatalog),

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/PaimonPushDownTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/PaimonPushDownTest.scala
@@ -177,7 +177,7 @@ class PaimonPushDownTest extends PaimonSparkTestBase {
   }
 
   private def getScanBuilder(tableName: String = "T"): ScanBuilder = {
-    new SparkTable(loadTable(tableName))
+    new SparkTable(loadTable(tableName), dbName0)
       .newScanBuilder(CaseInsensitiveStringMap.empty())
   }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Support get full table name include database
ranger spark auth plugin check auth error

![image](https://github.com/apache/paimon/assets/59957056/68d7e3fa-4949-4312-a2b8-f5995aa60fc3)

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
