### PR TITLE
[cdc] Database sync supports specify partition keys and primary keys

### DIFF
--- a/docs/content/flink/cdc-ingestion/kafka-cdc.md
+++ b/docs/content/flink/cdc-ingestion/kafka-cdc.md
@@ -199,14 +199,14 @@ To use this feature through `flink run`, run the following shell command.
     [--including_tables <table-name|name-regular-expr>] \
     [--excluding_tables <table-name|name-regular-expr>] \
     [--type_mapping to-string] \
+    [--partition_keys <partition_keys>] \
+    [--primary_keys <primary-keys>] \
     [--kafka_conf <kafka-source-conf> [--kafka_conf <kafka-source-conf> ...]] \
     [--catalog_conf <paimon-catalog-conf> [--catalog_conf <paimon-catalog-conf> ...]] \
     [--table_conf <paimon-table-sink-conf> [--table_conf <paimon-table-sink-conf> ...]]
 ```
 
 {{< generated/kafka_sync_database >}}
-
-Only tables with primary keys will be synchronized.
 
 This action will build a single combined sink for all tables. For each Kafka topic's table to be synchronized, if the
 corresponding Paimon table does not exist, this action will automatically create the table, and its schema will be derived

--- a/docs/content/flink/cdc-ingestion/mongo-cdc.md
+++ b/docs/content/flink/cdc-ingestion/mongo-cdc.md
@@ -194,6 +194,8 @@ To use this feature through `flink run`, run the following shell command.
     [--table_suffix <paimon-table-suffix>] \
     [--including_tables <mongodb-table-name|name-regular-expr>] \
     [--excluding_tables <mongodb-table-name|name-regular-expr>] \
+    [--partition_keys <partition_keys>] \
+    [--primary_keys <primary-keys>] \
     [--mongodb_conf <mongodb-cdc-source-conf> [--mongodb_conf <mongodb-cdc-source-conf> ...]] \
     [--catalog_conf <paimon-catalog-conf> [--catalog_conf <paimon-catalog-conf> ...]] \
     [--table_conf <paimon-table-sink-conf> [--table_conf <paimon-table-sink-conf> ...]]

--- a/docs/content/flink/cdc-ingestion/mysql-cdc.md
+++ b/docs/content/flink/cdc-ingestion/mysql-cdc.md
@@ -137,6 +137,8 @@ To use this feature through `flink run`, run the following shell command.
     [--mode <sync-mode>] \
     [--metadata_column <metadata-column>] \
     [--type_mapping <option1,option2...>] \
+    [--partition_keys <partition_keys>] \
+    [--primary_keys <primary-keys>] \
     [--mysql_conf <mysql-cdc-source-conf> [--mysql_conf <mysql-cdc-source-conf> ...]] \
     [--catalog_conf <paimon-catalog-conf> [--catalog_conf <paimon-catalog-conf> ...]] \
     [--table_conf <paimon-table-sink-conf> [--table_conf <paimon-table-sink-conf> ...]]

--- a/docs/content/flink/cdc-ingestion/pulsar-cdc.md
+++ b/docs/content/flink/cdc-ingestion/pulsar-cdc.md
@@ -198,6 +198,8 @@ To use this feature through `flink run`, run the following shell command.
     [--including_tables <table-name|name-regular-expr>] \
     [--excluding_tables <table-name|name-regular-expr>] \
     [--type_mapping to-string] \
+    [--partition_keys <partition_keys>] \
+    [--primary_keys <primary-keys>] \
     [--pulsar_conf <pulsar-source-conf> [--pulsar_conf <pulsar-source-conf> ...]] \
     [--catalog_conf <paimon-catalog-conf> [--catalog_conf <paimon-catalog-conf> ...]] \
     [--table_conf <paimon-table-sink-conf> [--table_conf <paimon-table-sink-conf> ...]]

--- a/docs/layouts/shortcodes/generated/kafka_sync_database.html
+++ b/docs/layouts/shortcodes/generated/kafka_sync_database.html
@@ -70,6 +70,18 @@ under the License.
         </td>
     </tr>
     <tr>
+        <td><h5>--partition_keys</h5></td>
+        <td>The partition keys for Paimon table. If there are multiple partition keys, connect them with comma, for example "dt,hh,mm".
+            If the keys are not in source table, the sink table won't set partition keys.</td>
+    </tr>
+    <tr>
+        <td><h5>--primary_keys</h5></td>
+        <td>The primary keys for Paimon table. If there are multiple primary keys, connect them with comma, for example "buyer_id,seller_id".
+            If the keys are not in source table, but the source table has primary keys, the sink table will use source table's primary keys.
+            Otherwise, the sink table won't set primary keys.</td>
+    </tr>
+    <tr>
+    <tr>
         <td><h5>--kafka_conf</h5></td>
         <td>The configuration for Flink Kafka sources. Each configuration should be specified in the format `key=value`. `properties.bootstrap.servers`, `topic/topic-pattern`, `properties.group.id`,  and `value.format` are required configurations, others are optional.See its <a href="https://nightlies.apache.org/flink/flink-docs-stable/docs/connectors/table/kafka/#connector-options">document</a> for a complete list of configurations.</td>
     </tr>

--- a/docs/layouts/shortcodes/generated/mongodb_sync_database.html
+++ b/docs/layouts/shortcodes/generated/mongodb_sync_database.html
@@ -50,6 +50,17 @@ under the License.
         <td>It is used to specify which source tables are not to be synchronized. The usage is same as "--including_tables". "--excluding_tables" has higher priority than "--including_tables" if you specified both.</td>
     </tr>
     <tr>
+        <td><h5>--partition_keys</h5></td>
+        <td>The partition keys for Paimon table. If there are multiple partition keys, connect them with comma, for example "dt,hh,mm".
+            If the keys are not in source table, the sink table won't set partition keys.</td>
+    </tr>
+    <tr>
+        <td><h5>--primary_keys</h5></td>
+        <td>The primary keys for Paimon table. If there are multiple primary keys, connect them with comma, for example "buyer_id,seller_id".
+            If the keys are not in source table, but the source table has primary keys, the sink table will use source table's primary keys.
+            Otherwise, the sink table won't set primary keys.</td>
+    </tr>
+    <tr>
         <td><h5>--mongodb_conf</h5></td>
         <td>The configuration for Flink CDC MongoDB sources. Each configuration should be specified in the format "key=value". hosts, username, password, database are required configurations, others are optional. See its <a href="https://nightlies.apache.org/flink/flink-cdc-docs-release-3.0/docs/connectors/legacy-flink-cdc-sources/mongodb-cdc/#connector-options">document</a> for a complete list of configurations.</td>
     </tr>

--- a/docs/layouts/shortcodes/generated/mysql_sync_database.html
+++ b/docs/layouts/shortcodes/generated/mysql_sync_database.html
@@ -82,6 +82,17 @@ under the License.
         </td>
     </tr>
     <tr>
+        <td><h5>--partition_keys</h5></td>
+        <td>The partition keys for Paimon table. If there are multiple partition keys, connect them with comma, for example "dt,hh,mm".
+            If the keys are not in source table, the sink table won't set partition keys.</td>
+    </tr>
+    <tr>
+        <td><h5>--primary_keys</h5></td>
+        <td>The primary keys for Paimon table. If there are multiple primary keys, connect them with comma, for example "buyer_id,seller_id".
+            If the keys are not in source table, but the source table has primary keys, the sink table will use source table's primary keys.
+            Otherwise, the sink table won't set primary keys.</td>
+    </tr>
+    <tr>
         <td><h5>--mysql_conf</h5></td>
         <td>The configuration for Flink CDC MySQL sources. Each configuration should be specified in the format "key=value". hostname, username, password, database-name and table-name are required configurations, others are optional. See its <a href="https://nightlies.apache.org/flink/flink-cdc-docs-release-3.0/docs/connectors/legacy-flink-cdc-sources/mysql-cdc/#connector-options">document</a> for a complete list of configurations.</td>
     </tr>

--- a/docs/layouts/shortcodes/generated/pulsar_sync_database.html
+++ b/docs/layouts/shortcodes/generated/pulsar_sync_database.html
@@ -70,6 +70,17 @@ under the License.
         </td>
     </tr>
     <tr>
+        <td><h5>--partition_keys</h5></td>
+        <td>The partition keys for Paimon table. If there are multiple partition keys, connect them with comma, for example "dt,hh,mm".
+            If the keys are not in source table, the sink table won't set partition keys.</td>
+    </tr>
+    <tr>
+        <td><h5>--primary_keys</h5></td>
+        <td>The primary keys for Paimon table. If there are multiple primary keys, connect them with comma, for example "buyer_id,seller_id".
+            If the keys are not in source table, but the source table has primary keys, the sink table will use source table's primary keys.
+            Otherwise, the sink table won't set primary keys.</td>
+    </tr>
+    <tr>
         <td><h5>--pulsar_conf</h5></td>
         <td>The configuration for Flink Pulsar sources. Each configuration should be specified in the format `key=value`. `topic/topic-pattern`, `value.format`, `pulsar.client.serviceUrl`, `pulsar.admin.adminUrl`, and `pulsar.consumer.subscriptionName` are required configurations, others are optional.See its <a href="https://nightlies.apache.org/flink/flink-docs-stable/docs/connectors/datastream/pulsar/#source-configurable-options">document</a> for a complete list of configurations.</td>
     </tr>

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/MessageQueueSyncTableActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/MessageQueueSyncTableActionBase.java
@@ -80,6 +80,7 @@ public abstract class MessageQueueSyncTableActionBase extends SyncTableActionBas
                 retrievedSchema,
                 metadataConverters,
                 caseSensitive,
+                true,
                 false);
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
@@ -34,6 +34,7 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +50,8 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
     protected String tablePrefix = "";
     protected String tableSuffix = "";
     protected String includingTables = ".*";
+    protected List<String> partitionKeys = new ArrayList<>();
+    protected List<String> primaryKeys = new ArrayList<>();
     @Nullable protected String excludingTables;
     protected List<FileStoreTable> tables = new ArrayList<>();
 
@@ -102,6 +105,16 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
         return this;
     }
 
+    public SyncDatabaseActionBase withPartitionKeys(String... partitionKeys) {
+        this.partitionKeys.addAll(Arrays.asList(partitionKeys));
+        return this;
+    }
+
+    public SyncDatabaseActionBase withPrimaryKeys(String... primaryKeys) {
+        this.primaryKeys.addAll(Arrays.asList(primaryKeys));
+        return this;
+    }
+
     @Override
     protected void validateCaseSensitivity() {
         AbstractCatalog.validateCaseInsensitive(caseSensitive, "Database", database);
@@ -118,7 +131,8 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
     @Override
     protected EventParser.Factory<RichCdcMultiplexRecord> buildEventParserFactory() {
         NewTableSchemaBuilder schemaBuilder =
-                new NewTableSchemaBuilder(tableConfig, caseSensitive, metadataConverters);
+                new NewTableSchemaBuilder(
+                        tableConfig, caseSensitive, partitionKeys, primaryKeys, metadataConverters);
         Pattern includingPattern = Pattern.compile(includingTables);
         Pattern excludingPattern =
                 excludingTables == null ? null : Pattern.compile(excludingTables);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionFactoryBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionFactoryBase.java
@@ -26,6 +26,8 @@ import java.util.Optional;
 
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.EXCLUDING_TABLES;
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.INCLUDING_TABLES;
+import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.PARTITION_KEYS;
+import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.PRIMARY_KEYS;
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.TABLE_PREFIX;
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.TABLE_SUFFIX;
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.TYPE_MAPPING;
@@ -49,7 +51,16 @@ public abstract class SyncDatabaseActionFactoryBase<T extends SyncDatabaseAction
         action.withTablePrefix(params.get(TABLE_PREFIX))
                 .withTableSuffix(params.get(TABLE_SUFFIX))
                 .includingTables(params.get(INCLUDING_TABLES))
-                .excludingTables(params.get(EXCLUDING_TABLES));
+                .excludingTables(params.get(EXCLUDING_TABLES))
+                .withPartitionKeys();
+
+        if (params.has(PARTITION_KEYS)) {
+            action.withPartitionKeys(params.get(PARTITION_KEYS).split(","));
+        }
+
+        if (params.has(PRIMARY_KEYS)) {
+            action.withPrimaryKeys(params.get(PRIMARY_KEYS).split(","));
+        }
 
         if (params.has(TYPE_MAPPING)) {
             String[] options = params.get(TYPE_MAPPING).split(",");

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionBase.java
@@ -108,6 +108,7 @@ public abstract class SyncTableActionBase extends SynchronizationActionBase {
                 retrievedSchema,
                 metadataConverters,
                 caseSensitive,
+                true,
                 true);
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
@@ -146,13 +146,14 @@ public class MySqlSyncDatabaseAction extends SyncDatabaseActionBase {
             Schema fromMySql =
                     CdcActionCommonUtils.buildPaimonSchema(
                             identifier.getFullName(),
-                            Collections.emptyList(),
-                            Collections.emptyList(),
+                            partitionKeys,
+                            primaryKeys,
                             Collections.emptyList(),
                             tableConfig,
                             tableInfo.schema(),
                             metadataConverters,
                             caseSensitive,
+                            false,
                             true);
             try {
                 table = (FileStoreTable) catalog.getTable(identifier);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/NewTableSchemaBuilder.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/NewTableSchemaBuilder.java
@@ -67,7 +67,7 @@ public class NewTableSchemaBuilder implements Serializable {
                         Collections.emptyList(),
                         tableConfig,
                         sourceSchema,
-                        new CdcMetadataConverter[0],
+                        metadataConverters,
                         caseSensitive,
                         false,
                         true));

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/CdcActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/CdcActionITCaseBase.java
@@ -361,6 +361,8 @@ public class CdcActionITCaseBase extends ActionITCaseBase {
         @Nullable private String excludingTables;
         @Nullable private String mode;
         private final List<String> typeMappingModes = new ArrayList<>();
+        private final List<String> partitionKeys = new ArrayList<>();
+        private final List<String> primaryKeys = new ArrayList<>();
         private final List<String> metadataColumn = new ArrayList<>();
 
         public SyncDatabaseActionBuilder(Class<T> clazz, Map<String, String> sourceConfig) {
@@ -418,6 +420,16 @@ public class CdcActionITCaseBase extends ActionITCaseBase {
             return this;
         }
 
+        public SyncDatabaseActionBuilder<T> withPartitionKeys(String... partitionKeys) {
+            this.partitionKeys.addAll(Arrays.asList(partitionKeys));
+            return this;
+        }
+
+        public SyncDatabaseActionBuilder<T> withPrimaryKeys(String... primaryKeys) {
+            this.primaryKeys.addAll(Arrays.asList(primaryKeys));
+            return this;
+        }
+
         public SyncDatabaseActionBuilder<T> withMetadataColumn(List<String> metadataColumn) {
             this.metadataColumn.addAll(metadataColumn);
             return this;
@@ -446,6 +458,8 @@ public class CdcActionITCaseBase extends ActionITCaseBase {
             args.addAll(nullableToArgs("--mode", mode));
 
             args.addAll(listToArgs("--type-mapping", typeMappingModes));
+            args.addAll(listToArgs("--partition-keys", partitionKeys));
+            args.addAll(listToArgs("--primary-keys", primaryKeys));
             args.addAll(listToArgs("--metadata-column", metadataColumn));
 
             return createAction(clazz, args);

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
@@ -584,4 +584,60 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
                                         + "{databaseName=null, tableName=null, fields=[`k` STRING, `v0` STRING, `v1` STRING], "
                                         + "primaryKeys=[], cdcRecord=+I {v0=five, k=5, v1=50}}"));
     }
+
+    @Test
+    @Timeout(60)
+    public void testSpecifyKeys() throws Exception {
+        final String topic = "specify-keys";
+        createTestTopic(topic, 1, 1);
+        writeRecordsToKafka(topic, "kafka/canal/database/specify-keys/canal-data-1.txt");
+
+        Map<String, String> kafkaConfig = getBasicKafkaConfig();
+        kafkaConfig.put(VALUE_FORMAT.key(), "canal-json");
+        kafkaConfig.put(TOPIC.key(), topic);
+
+        KafkaSyncDatabaseAction action =
+                syncDatabaseActionBuilder(kafkaConfig)
+                        .withTableConfig(getBasicTableConfig())
+                        .withPartitionKeys("part")
+                        .withPrimaryKeys("k", "part")
+                        .build();
+        runActionWithDefaultEnv(action);
+
+        waitingTables("t1", "t2");
+
+        FileStoreTable table1 = getFileStoreTable("t1");
+        assertThat(table1.partitionKeys()).containsExactly("part");
+        assertThat(table1.primaryKeys()).containsExactly("k", "part");
+
+        RowType rowType1 =
+                RowType.of(
+                        new DataType[] {
+                            DataTypes.INT().notNull(),
+                            DataTypes.INT().notNull(),
+                            DataTypes.VARCHAR(10),
+                        },
+                        new String[] {"k", "part", "v1"});
+        waitForResult(
+                Collections.singletonList("+I[1, 1, A]"),
+                table1,
+                rowType1,
+                Arrays.asList("k", "part"));
+
+        FileStoreTable table2 = getFileStoreTable("t2");
+        assertThat(table2.partitionKeys()).isEmpty();
+        assertThat(table2.primaryKeys()).containsExactly("k");
+
+        RowType rowType2 =
+                RowType.of(
+                        new DataType[] {
+                            DataTypes.INT().notNull(), DataTypes.VARCHAR(10),
+                        },
+                        new String[] {"k", "v1"});
+        waitForResult(
+                Collections.singletonList("+I[1, A]"),
+                table2,
+                rowType2,
+                Collections.singletonList("k"));
+    }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
@@ -680,7 +680,9 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
                 .satisfies(
                         anyCauseMatches(
                                 IllegalArgumentException.class,
-                                "Specified primary key 'pk' does not exist in source tables or computed columns [pt, _id, v1]."));
+                                "For sink table "
+                                        + tableName
+                                        + ", not all specified primary keys '[pk]' exist in source tables or computed columns '[pt, _id, v1]'."));
     }
 
     @Test

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
@@ -695,8 +695,9 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
                 .satisfies(
                         anyCauseMatches(
                                 IllegalArgumentException.class,
-                                "Primary keys are not specified. "
-                                        + "Also, can't infer primary keys from source table schemas because "
+                                "Failed to set specified primary keys for sink table "
+                                        + tableName
+                                        + ". Also, can't infer primary keys from source table schemas because "
                                         + "source tables have no primary keys or have different primary keys."));
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresSyncTableActionITCase.java
@@ -525,8 +525,9 @@ public class PostgresSyncTableActionITCase extends PostgresActionITCaseBase {
                 .satisfies(
                         anyCauseMatches(
                                 IllegalArgumentException.class,
-                                "Primary keys are not specified. "
-                                        + "Also, can't infer primary keys from source table schemas because "
+                                "Failed to set specified primary keys for sink table "
+                                        + tableName
+                                        + ". Also, can't infer primary keys from source table schemas because "
                                         + "source tables have no primary keys or have different primary keys."));
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresSyncTableActionITCase.java
@@ -509,7 +509,9 @@ public class PostgresSyncTableActionITCase extends PostgresActionITCaseBase {
                 .satisfies(
                         anyCauseMatches(
                                 IllegalArgumentException.class,
-                                "Specified primary key 'pk' does not exist in source tables or computed columns [pt, _id, v1]."));
+                                "For sink table "
+                                        + tableName
+                                        + ", not all specified primary keys '[pk]' exist in source tables or computed columns '[pt, _id, v1]'."));
     }
 
     @Test

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/specify-keys/canal-data-1.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/specify-keys/canal-data-1.txt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{"data":[{"k":"1","part":"1","v1":"A"}],"database":"test_specify_keys","es":1684770072000,"id":81,"isDdl":false,"mysqlType":{"k":"INT","part":"INT","v1":"VARCHAR(10)"},"old":null,"pkNames":["k"],"sql":"","sqlType":{"k":4,"part":4,"v1":12},"table":"t1","ts":1684770072286,"type":"INSERT"}
+{"data":[{"k":"1","v1":"A"}],"database":"test_specify_keys","es":1684770072000,"id":81,"isDdl":false,"mysqlType":{"k":"INT","v1":"VARCHAR(10)"},"old":null,"pkNames":["k"],"sql":"","sqlType":{"k":4,"v1":12},"table":"t2","ts":1684770072286,"type":"INSERT"}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/mysql/sync_database_setup.sql
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/mysql/sync_database_setup.sql
@@ -494,3 +494,23 @@ CREATE TABLE t2 (
     v1 VARCHAR(10),
     PRIMARY KEY (k)
 );
+
+-- ################################################################################
+--  testSpecifyKeys
+-- ################################################################################
+
+CREATE DATABASE test_specify_keys;
+USE test_specify_keys;
+
+CREATE TABLE t1 (
+    k INT,
+    part INT,
+    v1 VARCHAR(10),
+    PRIMARY KEY (k)
+);
+
+CREATE TABLE t2 (
+    k INT,
+    v1 VARCHAR(10),
+    PRIMARY KEY (k)
+);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Specified keys if not exist in source table, we will try to set keys from source table or doesn't set keys.

<!-- What is the purpose of the change -->

### Tests

`MySqlSyncDatabaseActionITCase#testSpecifyKeys`
`KafkaCanalSyncDatabaseActionITCase#testSpecifyKeys`

<!-- List UT and IT cases to verify this change -->

### API and Format
<!-- Does this change affect API or storage format -->
database sync supports:
--primary-keys
--partition-keys

### Documentation

<!-- Does this change introduce a new feature -->
