### PR TITLE
[core] update tag metadata for the same snapshot of the same tag

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -104,14 +104,13 @@ public class TagManager {
                         ? Tag.fromSnapshotAndTagTtl(snapshot, timeRetained, LocalDateTime.now())
                                 .toJson()
                         : snapshot.toJson();
+        Path tagPath = tagPath(tagName);
 
         // update tag metadata into for the same snapshot of the same tag name.
         if (tagExists(tagName)) {
             Snapshot tagged = taggedSnapshot(tagName);
             Preconditions.checkArgument(
                     tagged.id() == snapshot.id(), "Tag name '%s' already exists.", tagName);
-
-            Path tagPath = tagPath(tagName);
             try {
                 fileIO.overwriteFileUtf8(tagPath, content);
             } catch (IOException ignored) {
@@ -121,15 +120,14 @@ public class TagManager {
                                 tagName, tagPath));
             }
         } else {
-            Path newTagPath = tagPath(tagName);
             try {
-                fileIO.writeFileUtf8(newTagPath, content);
+                fileIO.writeFileUtf8(tagPath, content);
             } catch (IOException e) {
                 throw new RuntimeException(
                         String.format(
                                 "Exception occurs when committing tag '%s' (path %s). "
                                         + "Cannot clean up because we can't determine the success.",
-                                tagName, newTagPath),
+                                tagName, tagPath),
                         e);
             }
         }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -113,11 +113,12 @@ public class TagManager {
                     tagged.id() == snapshot.id(), "Tag name '%s' already exists.", tagName);
             try {
                 fileIO.overwriteFileUtf8(tagPath, content);
-            } catch (IOException ignored) {
-                LOG.info(
+            } catch (IOException e) {
+                throw new RuntimeException(
                         String.format(
                                 "Tag already exists. Failed to update tag metadata info for tag '%s' (path %s).",
-                                tagName, tagPath));
+                                tagName, tagPath),
+                        e);
             }
         } else {
             try {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -94,26 +94,36 @@ public class TagManager {
             List<TagCallback> callbacks) {
         checkArgument(!StringUtils.isBlank(tagName), "Tag name '%s' is blank.", tagName);
 
-        // skip create tag for the same snapshot of the same name.
+        // When timeRetained is not defined, please do not write the tagCreatorTime field,
+        // as this will cause older versions (<= 0.7) of readers to be unable to read this
+        // tag.
+        // When timeRetained is defined, it is fine, because timeRetained is the new
+        // feature.
+        String content =
+                timeRetained != null
+                        ? Tag.fromSnapshotAndTagTtl(snapshot, timeRetained, LocalDateTime.now())
+                                .toJson()
+                        : snapshot.toJson();
+
+        // update tag metadata into for the same snapshot of the same tag name.
         if (tagExists(tagName)) {
             Snapshot tagged = taggedSnapshot(tagName);
             Preconditions.checkArgument(
                     tagged.id() == snapshot.id(), "Tag name '%s' already exists.", tagName);
+
+            Path tagPath = tagPath(tagName);
+            try {
+                fileIO.overwriteFileUtf8(tagPath, content);
+            } catch (IOException ignored) {
+                LOG.info(
+                        String.format(
+                                "Tag already exists. Failed to update tag metadata info for tag '%s' (path %s).",
+                                tagName, tagPath));
+            }
         } else {
             Path newTagPath = tagPath(tagName);
             try {
-                // When timeRetained is not defined, please do not write the tagCreatorTime field,
-                // as this will cause older versions (<= 0.7) of readers to be unable to read this
-                // tag.
-                // When timeRetained is defined, it is fine, because timeRetained is the new
-                // feature.
-                fileIO.writeFileUtf8(
-                        newTagPath,
-                        timeRetained != null
-                                ? Tag.fromSnapshotAndTagTtl(
-                                                snapshot, timeRetained, LocalDateTime.now())
-                                        .toJson()
-                                : snapshot.toJson());
+                fileIO.writeFileUtf8(newTagPath, content);
             } catch (IOException e) {
                 throw new RuntimeException(
                         String.format(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
When call create_tag twice for the same snapshot of the same tag, the tag medata should update.
```sql
CALL sys.create_tag(table => 'default.T', tag => 'my_tag', snapshot => 10)
CALL sys.delete_tag(table => 'default.T', tag => 'my_tag', snapshot => 10, time_retained => '1d')
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
