### PR TITLE
[flink] Close refresh executor before lookup table is closed

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
@@ -299,12 +299,12 @@ public abstract class FullCacheLookupTable implements LookupTable {
     @Override
     public void close() throws IOException {
         try {
-            stateFactory.close();
-            FileIOUtils.deleteDirectory(context.tempPath);
-        } finally {
             if (refreshExecutor != null) {
                 refreshExecutor.shutdown();
             }
+        } finally {
+            stateFactory.close();
+            FileIOUtils.deleteDirectory(context.tempPath);
         }
     }
 


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx

Close refresh executor before lookup table is closed to avoid writing data into invalid directory

### Tests

### API and Format

no

### Documentation

no
