### PR TITLE
[spark] Support timestamp_ntz

### DIFF
--- a/docs/content/spark/quick-start.md
+++ b/docs/content/spark/quick-start.md
@@ -330,3 +330,11 @@ All Spark's data types are available in package `org.apache.spark.sql.types`.
     </tr>
     </tbody>
 </table>
+
+{{< hint warning >}}
+Due to the previous design, in Spark3.3 and below, Paimon will map both Paimon's TimestampType and LocalZonedTimestamp to Spark's TimestampType, and only correctly handle with TimestampType.
+
+Therefore, when using Spark3.3 and below, reads Paimon table with LocalZonedTimestamp type written by other engines, such as Flink, the query result of LocalZonedTimestamp type will have time zone offset, which needs to be adjusted manually.
+
+When using Spark3.4 and above, all timestamp types can be parsed correctly.
+{{< /hint >}}

--- a/docs/content/spark/quick-start.md
+++ b/docs/content/spark/quick-start.md
@@ -310,7 +310,12 @@ All Spark's data types are available in package `org.apache.spark.sql.types`.
     </tr>
     <tr>
       <td><code>TimestampType</code></td>
-      <td><code>TimestampType</code>, <code>LocalZonedTimestamp</code></td>
+      <td><code>LocalZonedTimestamp</code></td>
+      <td>true</td>
+    </tr>
+    <tr>
+      <td><code>TimestampNTZType(Spark3.4+)</code></td>
+      <td><code>TimestampType</code></td>
       <td>true</td>
     </tr>
     <tr>

--- a/paimon-common/src/main/java/org/apache/paimon/utils/DateTimeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/DateTimeUtils.java
@@ -116,6 +116,10 @@ public class DateTimeUtils {
         return Timestamp.fromEpochMillis(millis + TimeZone.getDefault().getOffset(millis), nanos);
     }
 
+    public static Timestamp toInternalUTC(long millis, int nanos) {
+        return Timestamp.fromEpochMillis(millis + UTC_ZONE.getOffset(millis), nanos);
+    }
+
     public static int toInternal(LocalDate date) {
         return ymdToUnixDate(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
     }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/DateTimeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/DateTimeUtils.java
@@ -116,10 +116,6 @@ public class DateTimeUtils {
         return Timestamp.fromEpochMillis(millis + TimeZone.getDefault().getOffset(millis), nanos);
     }
 
-    public static Timestamp toInternalUTC(long millis, int nanos) {
-        return Timestamp.fromEpochMillis(millis + UTC_ZONE.getOffset(millis), nanos);
-    }
-
     public static int toInternal(LocalDate date) {
         return ymdToUnixDate(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
     }

--- a/paimon-spark/paimon-spark-3.1/src/main/scala/org/apache/paimon/spark/util/shim/TypeUtils.scala
+++ b/paimon-spark/paimon-spark-3.1/src/main/scala/org/apache/paimon/spark/util/shim/TypeUtils.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.util.shim
+
+object TypeUtils {
+
+  // Since Spark 3.3 and below do not support timestamp ntz, treat Paimon TimestampType as Spark TimestampType
+  def treatPaimonTimestampTypeAsSparkTimestampType(): Boolean = true
+}

--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/util/shim/TypeUtils.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/util/shim/TypeUtils.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.util.shim
+
+object TypeUtils {
+
+  // Since Spark 3.3 and below do not support timestamp ntz, treat Paimon TimestampType as Spark TimestampType
+  def treatPaimonTimestampTypeAsSparkTimestampType(): Boolean = true
+}

--- a/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/util/shim/TypeUtils.scala
+++ b/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/util/shim/TypeUtils.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.util.shim
+
+object TypeUtils {
+
+  // Since Spark 3.3 and below do not support timestamp ntz, treat Paimon TimestampType as Spark TimestampType
+  def treatPaimonTimestampTypeAsSparkTimestampType(): Boolean = true
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkInternalRow.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkInternalRow.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.spark.util.shim.TypeUtils;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataType;
@@ -283,7 +284,11 @@ public class SparkInternalRow extends org.apache.spark.sql.catalyst.InternalRow 
     }
 
     public static long fromPaimon(Timestamp timestamp) {
-        return DateTimeUtils.fromJavaTimestamp(timestamp.toSQLTimestamp());
+        if (TypeUtils.treatPaimonTimestampTypeAsSparkTimestampType()) {
+            return DateTimeUtils.fromJavaTimestamp(timestamp.toSQLTimestamp());
+        } else {
+            return timestamp.toMicros();
+        }
     }
 
     public static ArrayData fromPaimon(InternalArray array, ArrayType arrayType) {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkRow.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkRow.java
@@ -175,12 +175,17 @@ public class SparkRow implements InternalRow, Serializable {
             if (TypeUtils.treatPaimonTimestampTypeAsSparkTimestampType()) {
                 return Timestamp.fromSQLTimestamp(ts);
             } else {
-                return DateTimeUtils.toInternalUTC(ts.getTime(), ts.getNanos());
+                return Timestamp.fromInstant(ts.toInstant());
             }
         } else if (object instanceof java.time.Instant) {
-            LocalDateTime localDateTime =
-                    LocalDateTime.ofInstant((Instant) object, ZoneId.systemDefault());
-            return Timestamp.fromLocalDateTime(localDateTime);
+            Instant instant = (Instant) object;
+            if (TypeUtils.treatPaimonTimestampTypeAsSparkTimestampType()) {
+                LocalDateTime localDateTime =
+                        LocalDateTime.ofInstant((Instant) object, ZoneId.systemDefault());
+                return Timestamp.fromLocalDateTime(localDateTime);
+            } else {
+                return Timestamp.fromInstant(instant);
+            }
         } else {
             return Timestamp.fromLocalDateTime((LocalDateTime) object);
         }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/shim/TypeUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/shim/TypeUtils.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.util.shim
+
+object TypeUtils {
+
+  def treatPaimonTimestampTypeAsSparkTimestampType(): Boolean = false
+}

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkTypeTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkTypeTest.java
@@ -65,7 +65,8 @@ public class SparkTypeTest {
                     .field("smallint", DataTypes.SMALLINT())
                     .field("bigint", DataTypes.BIGINT())
                     .field("bytes", DataTypes.BYTES())
-                    .field("timestamp", DataTypes.TIMESTAMP())
+                    .field("timestamp", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE())
+                    .field("timestamp_ntz", DataTypes.TIMESTAMP())
                     .field("date", DataTypes.DATE())
                     .field("decimal", DataTypes.DECIMAL(2, 2))
                     .field("decimal2", DataTypes.DECIMAL(38, 2))
@@ -95,6 +96,7 @@ public class SparkTypeTest {
                         + "StructField(bigint,LongType,true),"
                         + "StructField(bytes,BinaryType,true),"
                         + "StructField(timestamp,TimestampType,true),"
+                        + "StructField(timestamp_ntz,TimestampNTZType,true),"
                         + "StructField(date,DateType,true),"
                         + "StructField(decimal,DecimalType(2,2),true),"
                         + "StructField(decimal2,DecimalType(38,2),true),"

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
@@ -36,6 +36,7 @@ import org.scalactic.source.Position
 import org.scalatest.Tag
 
 import java.io.File
+import java.util.TimeZone
 
 import scala.util.Random
 
@@ -99,6 +100,18 @@ class PaimonSparkTestBase
 
   protected def withTempDirs(f: (File, File) => Unit): Unit = {
     withTempDir(file1 => withTempDir(file2 => f(file1, file2)))
+  }
+
+  protected def withTimeZone(timeZone: String)(f: => Unit): Unit = {
+    withSQLConf("spark.sql.session.timeZone" -> timeZone) {
+      val originTimeZone = TimeZone.getDefault
+      try {
+        TimeZone.setDefault(TimeZone.getTimeZone(timeZone))
+        f
+      } finally {
+        TimeZone.setDefault(originTimeZone)
+      }
+    }
   }
 
   override def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
@@ -198,17 +198,15 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
                 withTable("paimon_tbl") {
                   // Spark support create table with timestamp_ntz since 3.4
                   if (gteqSpark3_4) {
-                    spark.sql(
-                      s"""
-                         |CREATE TABLE paimon_tbl (id int, binary BINARY, ts timestamp, ts_ntz timestamp_ntz)
-                         |USING paimon
-                         |TBLPROPERTIES ('file.format'='$format')
-                         |""".stripMargin)
+                    sql(s"""
+                           |CREATE TABLE paimon_tbl (id int, binary BINARY, ts timestamp, ts_ntz timestamp_ntz)
+                           |USING paimon
+                           |TBLPROPERTIES ('file.format'='$format')
+                           |""".stripMargin)
 
-                    spark.sql(
-                      s"INSERT INTO paimon_tbl VALUES (1, binary('b'), timestamp'2024-01-01 00:00:00', timestamp_ntz'2024-01-01 00:00:00')")
+                    sql(s"INSERT INTO paimon_tbl VALUES (1, binary('b'), timestamp'2024-01-01 00:00:00', timestamp_ntz'2024-01-01 00:00:00')")
                     checkAnswer(
-                      spark.sql(s"SELECT ts, ts_ntz FROM paimon_tbl"),
+                      sql(s"SELECT ts, ts_ntz FROM paimon_tbl"),
                       Row(
                         if (datetimeJava8APIEnabled)
                           Timestamp.valueOf("2024-01-01 00:00:00").toInstant
@@ -222,7 +220,7 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
                       // todo: fix with orc
                       if (format != "orc")
                         checkAnswer(
-                          spark.sql(s"SELECT ts, ts_ntz FROM paimon_tbl"),
+                          sql(s"SELECT ts, ts_ntz FROM paimon_tbl"),
                           Row(
                             if (datetimeJava8APIEnabled)
                               Timestamp.valueOf("2023-12-31 16:00:00").toInstant
@@ -232,16 +230,15 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
                         )
                     }
                   } else {
-                    spark.sql(s"""
-                                 |CREATE TABLE paimon_tbl (id int, binary BINARY, ts timestamp)
-                                 |USING paimon
-                                 |TBLPROPERTIES ('file.format'='$format')
-                                 |""".stripMargin)
+                    sql(s"""
+                           |CREATE TABLE paimon_tbl (id int, binary BINARY, ts timestamp)
+                           |USING paimon
+                           |TBLPROPERTIES ('file.format'='$format')
+                           |""".stripMargin)
 
-                    spark.sql(
-                      s"INSERT INTO paimon_tbl VALUES (1, binary('b'), timestamp'2024-01-01 00:00:00')")
+                    sql(s"INSERT INTO paimon_tbl VALUES (1, binary('b'), timestamp'2024-01-01 00:00:00')")
                     checkAnswer(
-                      spark.sql(s"SELECT ts FROM paimon_tbl"),
+                      sql(s"SELECT ts FROM paimon_tbl"),
                       Row(
                         if (datetimeJava8APIEnabled)
                           Timestamp.valueOf("2024-01-01 00:00:00").toInstant
@@ -254,7 +251,7 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
                       // todo: fix with orc
                       if (format != "orc") {
                         checkAnswer(
-                          spark.sql(s"SELECT ts FROM paimon_tbl"),
+                          sql(s"SELECT ts FROM paimon_tbl"),
                           Row(
                             if (datetimeJava8APIEnabled)
                               Timestamp.valueOf("2024-01-01 00:00:00").toInstant
@@ -279,11 +276,11 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
           .column("ts_ntz", DataTypes.TIMESTAMP())
           .build
         catalog.createTable(identifier, schema, false)
-        spark.sql(
+        sql(
           s"INSERT INTO paimon_tbl VALUES (timestamp'2024-01-01 00:00:00', timestamp_ntz'2024-01-01 00:00:00')")
 
         checkAnswer(
-          spark.sql(s"SELECT ts, ts_ntz FROM paimon_tbl"),
+          sql(s"SELECT ts, ts_ntz FROM paimon_tbl"),
           Row(
             Timestamp.valueOf("2024-01-01 00:00:00"),
             if (gteqSpark3_4) LocalDateTime.parse("2024-01-01T00:00:00")
@@ -294,7 +291,7 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
         // change time zone to UTC
         withTimeZone("UTC") {
           checkAnswer(
-            spark.sql(s"SELECT ts, ts_ntz FROM paimon_tbl"),
+            sql(s"SELECT ts, ts_ntz FROM paimon_tbl"),
             Row(
               // For Spark 3.3 and below, time zone conversion is not supported,
               // see TypeUtils.treatPaimonTimestampTypeAsSparkTimestampType
@@ -302,7 +299,7 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
               else Timestamp.valueOf("2024-01-01 00:00:00"),
               if (gteqSpark3_4) LocalDateTime.parse("2024-01-01T00:00:00")
               else Timestamp.valueOf("2024-01-01 00:00:00")
-            ) :: Nil
+            )
           )
         }
       }
@@ -318,21 +315,19 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
           withTable("paimon_tbl") {
             // Spark support create table with timestamp_ntz since 3.4
             if (gteqSpark3_4) {
-              spark.sql(s"""
-                           |CREATE TABLE paimon_tbl (ts timestamp, ts_ntz timestamp_ntz)
-                           |USING paimon
-                           |""".stripMargin)
-
-              spark.sql(s"""
-                           |INSERT INTO paimon_tbl VALUES
-                           |(timestamp'2024-01-01 00:00:00', timestamp_ntz'2024-01-01 00:00:00'),
-                           |(timestamp'2024-01-02 00:00:00', timestamp_ntz'2024-01-02 00:00:00'),
-                           |(timestamp'2024-01-03 00:00:00', timestamp_ntz'2024-01-03 00:00:00')
-                           |""".stripMargin)
+              sql(s"""
+                     |CREATE TABLE paimon_tbl (ts timestamp, ts_ntz timestamp_ntz)
+                     |USING paimon
+                     |""".stripMargin)
+              sql(
+                s"INSERT INTO paimon_tbl VALUES (timestamp'2024-01-01 00:00:00', timestamp_ntz'2024-01-01 00:00:00')")
+              sql(
+                s"INSERT INTO paimon_tbl VALUES (timestamp'2024-01-02 00:00:00', timestamp_ntz'2024-01-02 00:00:00')")
+              sql(
+                s"INSERT INTO paimon_tbl VALUES (timestamp'2024-01-03 00:00:00', timestamp_ntz'2024-01-03 00:00:00')")
 
               checkAnswer(
-                spark.sql(
-                  s"SELECT * FROM paimon_tbl where ts_ntz = timestamp_ntz'2024-01-01 00:00:00'"),
+                sql(s"SELECT * FROM paimon_tbl where ts_ntz = timestamp_ntz'2024-01-01 00:00:00'"),
                 Row(
                   if (datetimeJava8APIEnabled)
                     Timestamp.valueOf("2024-01-01 00:00:00").toInstant
@@ -342,7 +337,7 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
               )
 
               checkAnswer(
-                spark.sql(s"SELECT * FROM paimon_tbl where ts > timestamp'2024-01-02 00:00:00'"),
+                sql(s"SELECT * FROM paimon_tbl where ts > timestamp'2024-01-02 00:00:00'"),
                 Row(
                   if (datetimeJava8APIEnabled)
                     Timestamp.valueOf("2024-01-03 00:00:00").toInstant
@@ -351,19 +346,16 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
                 )
               )
             } else {
-              spark.sql(s"""
-                           |CREATE TABLE paimon_tbl (ts timestamp)
-                           |USING paimon
-                           |""".stripMargin)
-              spark.sql(s"""
-                           |INSERT INTO paimon_tbl VALUES
-                           |timestamp'2024-01-01 00:00:00',
-                           |timestamp'2024-01-02 00:00:00',
-                           |timestamp'2024-01-03 00:00:00'
-                           |""".stripMargin)
+              sql(s"""
+                     |CREATE TABLE paimon_tbl (ts timestamp)
+                     |USING paimon
+                     |""".stripMargin)
+              sql(s"INSERT INTO paimon_tbl VALUES (timestamp'2024-01-01 00:00:00')")
+              sql(s"INSERT INTO paimon_tbl VALUES (timestamp'2024-01-02 00:00:00')")
+              sql(s"INSERT INTO paimon_tbl VALUES (timestamp'2024-01-03 00:00:00')")
 
               checkAnswer(
-                spark.sql(s"SELECT * FROM paimon_tbl where ts = timestamp'2024-01-01 00:00:00'"),
+                sql(s"SELECT * FROM paimon_tbl where ts = timestamp'2024-01-01 00:00:00'"),
                 Row(
                   if (datetimeJava8APIEnabled)
                     Timestamp.valueOf("2024-01-01 00:00:00").toInstant


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Spark support timestamp_ntz since spark3.4, paimon can support it. And there were problems with timestamp between paimon and spark types before, the following is the correct result after modification

| Spark Data Type | Paimon Data Type | Atomic Type |
|----------|----------|----------|
| TimestampType    | LocalZonedTimestamp   | true   |
| TimestampNTZType (spark3.4+)   | TimestampType   | true   |


### Compatibility

For spark3.3 and below, we still treat paimon TimestampType as spark TimestampType

For spark3.4+, everything goes well

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation



