### PR TITLE
[spark] SparkSql UT use version check instead of interfaces

### DIFF
--- a/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTest.scala
+++ b/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTest.scala
@@ -18,7 +18,4 @@
 
 package org.apache.paimon.spark.sql
 
-class AnalyzeTableTest extends AnalyzeTableTestBase {
-
-  override protected def supportsColStats(): Boolean = false
-}
+class AnalyzeTableTest extends AnalyzeTableTestBase {}

--- a/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTest.scala
+++ b/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTest.scala
@@ -18,6 +18,4 @@
 
 package org.apache.paimon.spark.sql
 
-class DDLWithHiveCatalogTest extends DDLWithHiveCatalogTestBase {
-  override def supportDefaultDatabaseWithSessionCatalog = false
-}
+class DDLWithHiveCatalogTest extends DDLWithHiveCatalogTestBase {}

--- a/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTest.scala
+++ b/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTest.scala
@@ -18,7 +18,4 @@
 
 package org.apache.paimon.spark.sql
 
-class AnalyzeTableTest extends AnalyzeTableTestBase {
-
-  override protected def supportsColStats(): Boolean = false
-}
+class AnalyzeTableTest extends AnalyzeTableTestBase {}

--- a/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTest.scala
+++ b/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTest.scala
@@ -18,6 +18,4 @@
 
 package org.apache.paimon.spark.sql
 
-class DDLWithHiveCatalogTest extends DDLWithHiveCatalogTestBase {
-  override def supportDefaultDatabaseWithSessionCatalog = false
-}
+class DDLWithHiveCatalogTest extends DDLWithHiveCatalogTestBase {}

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
@@ -340,7 +340,7 @@ abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
 
     val stats = getScanStatistic("SELECT * FROM T")
     Assertions.assertEquals(2L, stats.rowCount.get.longValue())
-    Assertions.assertEquals(if (supportsColStats()) 4 else 0, stats.attributeStats.size)
+    Assertions.assertEquals(if (gteqSpark3_4) 4 else 0, stats.attributeStats.size)
   }
 
   test("Paimon analyze: partition filter push down hit") {
@@ -357,14 +357,14 @@ abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
     // partition push down hit
     var sql = "SELECT * FROM T WHERE pt < 1"
     Assertions.assertEquals(
-      if (supportsColStats()) 0L else 4L,
+      if (gteqSpark3_4) 0L else 4L,
       getScanStatistic(sql).rowCount.get.longValue())
     checkAnswer(spark.sql(sql), Nil)
 
     // partition push down hit and select without it
     sql = "SELECT id FROM T WHERE pt < 1"
     Assertions.assertEquals(
-      if (supportsColStats()) 0L else 4L,
+      if (gteqSpark3_4) 0L else 4L,
       getScanStatistic(sql).rowCount.get.longValue())
     checkAnswer(spark.sql(sql), Nil)
 
@@ -388,6 +388,4 @@ abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
     relation.computeStats()
   }
 
-  /** Spark supports the use of col stats for v2 table since 3.4+. */
-  protected def supportsColStats(): Boolean = true
 }

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTestBase.scala
@@ -89,7 +89,7 @@ abstract class DDLWithHiveCatalogTestBase extends PaimonHiveTestBase {
             .config(s"spark.sql.catalog.$catalogName.defaultDatabase", dbName)
             .getOrCreate()
 
-          if (catalogName.equals(sparkCatalogName) && !supportDefaultDatabaseWithSessionCatalog) {
+          if (catalogName.equals(sparkCatalogName) && !gteqSpark3_4) {
             checkAnswer(reusedSpark.sql("show tables").select("tableName"), Nil)
             reusedSpark.sql(s"use $dbName")
           }
@@ -124,8 +124,6 @@ abstract class DDLWithHiveCatalogTestBase extends PaimonHiveTestBase {
       }
     }
   }
-
-  def supportDefaultDatabaseWithSessionCatalog = true
 
   def getDatabaseLocation(dbName: String): String = {
     spark


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

SparkSql uts use version check instead of interfaces avoid multiple methods to control test logic

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
