### PR TITLE
[cdc] Fix keyAndPartitions extractor result conflict if partitions or keys value is empty.

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordUtils.java
@@ -22,7 +22,6 @@ import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowKind;
-import org.apache.paimon.utils.StringUtils;
 import org.apache.paimon.utils.TypeUtils;
 
 import org.slf4j.Logger;
@@ -56,7 +55,7 @@ public class CdcRecordUtils {
         for (int i = 0; i < dataFields.size(); i++) {
             DataField dataField = dataFields.get(i);
             String fieldValue = record.fields().get(dataField.name());
-            if (!StringUtils.isEmpty(fieldValue)) {
+            if (fieldValue != null) {
                 genericRow.setField(
                         i, TypeUtils.castFromCdcValueString(fieldValue, dataField.type()));
             }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordKeyAndBucketExtractorTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordKeyAndBucketExtractorTest.java
@@ -139,6 +139,45 @@ public class CdcRecordKeyAndBucketExtractorTest {
         assertThat(actual.bucket()).isEqualTo(expected.bucket());
     }
 
+    @Test
+    public void testEmptyPartition() throws Exception {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        TableSchema schema = createTableSchema();
+        RowDataKeyAndBucketExtractor expected = new RowDataKeyAndBucketExtractor(schema);
+        CdcRecordKeyAndBucketExtractor actual = new CdcRecordKeyAndBucketExtractor(schema);
+
+        long k1 = random.nextLong();
+        int v1 = random.nextInt();
+        String k2 = UUID.randomUUID().toString();
+        String v2 = UUID.randomUUID().toString();
+
+        GenericRowData rowData =
+                GenericRowData.of(
+                        StringData.fromString(""),
+                        null,
+                        k1,
+                        v1,
+                        StringData.fromString(k2),
+                        StringData.fromString(v2));
+        expected.setRecord(rowData);
+
+        Map<String, String> fields = new HashMap<>();
+        fields.put("pt1", "");
+        fields.put("pt2", null);
+        fields.put("k1", String.valueOf(k1));
+        fields.put("v1", String.valueOf(v1));
+        fields.put("k2", k2);
+        fields.put("v2", v2);
+
+        actual.setRecord(new CdcRecord(RowKind.INSERT, fields));
+        assertThat(actual.partition()).isEqualTo(expected.partition());
+        assertThat(actual.bucket()).isEqualTo(expected.bucket());
+
+        actual.setRecord(new CdcRecord(RowKind.DELETE, fields));
+        assertThat(actual.partition()).isEqualTo(expected.partition());
+        assertThat(actual.bucket()).isEqualTo(expected.bucket());
+    }
+
     private TableSchema createTableSchema() throws Exception {
         return SchemaUtils.forceCommit(
                 new SchemaManager(LocalFileIO.create(), new Path(tempDir.toString())),


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3570 

Why causes conflict :
`CdcRecordKeyAndBucketExtractor` use `CdcRecordUtils#projectAsInsert ` to project partition and keys genericRow , the `projectAsInsert` will ignore the empty value and eventually write null into GenericRow, but `RowDataKeyAndBucketExtractor` would be not ignore empty value and write empty value into GenericRow.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
