### PR TITLE
[core] Remove static LOCAL_TZ

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/DateTimeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/DateTimeUtils.java
@@ -64,9 +64,6 @@ public class DateTimeUtils {
     /** The UTC time zone. */
     public static final TimeZone UTC_ZONE = TimeZone.getTimeZone("UTC");
 
-    /** The local time zone. */
-    public static final TimeZone LOCAL_TZ = TimeZone.getDefault();
-
     private static final DateTimeFormatter DEFAULT_TIMESTAMP_FORMATTER =
             new DateTimeFormatterBuilder()
                     .appendPattern("yyyy-[MM][M]-[dd][d]")
@@ -83,7 +80,7 @@ public class DateTimeUtils {
     public static java.sql.Date toSQLDate(int v) {
         // note that, in this case, can't handle Daylight Saving Time
         final long t = v * MILLIS_PER_DAY;
-        return new java.sql.Date(t - LOCAL_TZ.getOffset(t));
+        return new java.sql.Date(t - TimeZone.getDefault().getOffset(t));
     }
 
     /**
@@ -92,7 +89,7 @@ public class DateTimeUtils {
      */
     public static java.sql.Time toSQLTime(int v) {
         // note that, in this case, can't handle Daylight Saving Time
-        return new java.sql.Time(v - LOCAL_TZ.getOffset(v));
+        return new java.sql.Time(v - TimeZone.getDefault().getOffset(v));
     }
 
     /**
@@ -100,7 +97,7 @@ public class DateTimeUtils {
      * internal representation (int).
      */
     public static int toInternal(java.sql.Date date) {
-        long ts = date.getTime() + LOCAL_TZ.getOffset(date.getTime());
+        long ts = date.getTime() + TimeZone.getDefault().getOffset(date.getTime());
         return (int) (ts / MILLIS_PER_DAY);
     }
 
@@ -111,12 +108,12 @@ public class DateTimeUtils {
      * <p>Converse of {@link #toSQLTime(int)}.
      */
     public static int toInternal(java.sql.Time time) {
-        long ts = time.getTime() + LOCAL_TZ.getOffset(time.getTime());
+        long ts = time.getTime() + TimeZone.getDefault().getOffset(time.getTime());
         return (int) (ts % MILLIS_PER_DAY);
     }
 
     public static Timestamp toInternal(long millis, int nanos) {
-        return Timestamp.fromEpochMillis(millis + LOCAL_TZ.getOffset(millis), nanos);
+        return Timestamp.fromEpochMillis(millis + TimeZone.getDefault().getOffset(millis), nanos);
     }
 
     public static int toInternal(LocalDate date) {

--- a/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.types.DataTypeChecks.getNestedTypes;
@@ -147,7 +148,7 @@ public class TypeUtils {
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
                 LocalZonedTimestampType localZonedTimestampType = (LocalZonedTimestampType) type;
                 return BinaryStringUtils.toTimestamp(
-                        str, localZonedTimestampType.getPrecision(), DateTimeUtils.LOCAL_TZ);
+                        str, localZonedTimestampType.getPrecision(), TimeZone.getDefault());
             case ARRAY:
                 ArrayType arrayType = (ArrayType) type;
                 DataType elementType = arrayType.getElementType();

--- a/paimon-common/src/test/java/org/apache/paimon/utils/DateTimeUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/DateTimeUtilsTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -79,6 +80,23 @@ public class DateTimeUtilsTest {
             Timestamp t1 = Timestamp.fromSQLTimestamp(timestamp);
             Timestamp t2 = DateTimeUtils.toInternal(timestamp.getTime(), nanos);
             assertThat(t1).isEqualTo(t2);
+        }
+    }
+
+    @Test
+    public void testToInternalWithChangedTimeZone() {
+        TimeZone timeZone = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+            java.sql.Timestamp ts = java.sql.Timestamp.valueOf("2024-06-01 00:00:00");
+            Timestamp ts1 = DateTimeUtils.toInternal(ts.getTime(), ts.getNanos());
+            assertThat(ts1.toString()).isEqualTo("2024-06-01T00:00");
+
+            TimeZone.setDefault(TimeZone.getTimeZone("Asia/Shanghai"));
+            Timestamp ts2 = DateTimeUtils.toInternal(ts.getTime(), ts.getNanos());
+            assertThat(ts2.toString()).isEqualTo("2024-06-01T08:00");
+        } finally {
+            TimeZone.setDefault(timeZone);
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/casting/DateToTimestampCastRule.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/DateToTimestampCastRule.java
@@ -23,6 +23,8 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.utils.DateTimeUtils;
 
+import java.util.TimeZone;
+
 /**
  * {@link DataTypeRoot#DATE} to {@link DataTypeRoot#TIMESTAMP_WITHOUT_TIME_ZONE}/{@link
  * DataTypeRoot#TIMESTAMP_WITH_LOCAL_TIME_ZONE} cast rule.
@@ -48,7 +50,7 @@ class DateToTimestampCastRule extends AbstractCastRule<Number, Timestamp> {
         } else if (targetType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
             return value ->
                     DateTimeUtils.dateToTimestampWithLocalZone(
-                            value.intValue(), DateTimeUtils.LOCAL_TZ);
+                            value.intValue(), TimeZone.getDefault());
         }
         return null;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/casting/StringToTimestampCastRule.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/StringToTimestampCastRule.java
@@ -25,7 +25,8 @@ import org.apache.paimon.types.DataTypeChecks;
 import org.apache.paimon.types.DataTypeFamily;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.utils.BinaryStringUtils;
-import org.apache.paimon.utils.DateTimeUtils;
+
+import java.util.TimeZone;
 
 /** {@link DataTypeFamily#CHARACTER_STRING} to {@link DataTypeFamily#TIMESTAMP} cast rule. */
 class StringToTimestampCastRule extends AbstractCastRule<BinaryString, Timestamp> {
@@ -47,7 +48,7 @@ class StringToTimestampCastRule extends AbstractCastRule<BinaryString, Timestamp
             return value -> BinaryStringUtils.toTimestamp(value, targetPrecision);
         } else if (targetType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
             return value ->
-                    BinaryStringUtils.toTimestamp(value, targetPrecision, DateTimeUtils.LOCAL_TZ);
+                    BinaryStringUtils.toTimestamp(value, targetPrecision, TimeZone.getDefault());
         }
         return null;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/casting/TimeToTimestampCastRule.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/TimeToTimestampCastRule.java
@@ -23,6 +23,8 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.utils.DateTimeUtils;
 
+import java.util.TimeZone;
+
 /**
  * {@link DataTypeRoot#TIME_WITHOUT_TIME_ZONE} to {@link
  * DataTypeRoot#TIMESTAMP_WITHOUT_TIME_ZONE}/{@link DataTypeRoot#TIMESTAMP_WITH_LOCAL_TIME_ZONE}
@@ -48,7 +50,7 @@ class TimeToTimestampCastRule extends AbstractCastRule<Number, Timestamp> {
         } else if (targetType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
             return value ->
                     DateTimeUtils.timeToTimestampWithLocalZone(
-                            value.intValue(), DateTimeUtils.LOCAL_TZ);
+                            value.intValue(), TimeZone.getDefault());
         }
         return null;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToDateCastRule.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToDateCastRule.java
@@ -23,6 +23,8 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.utils.DateTimeUtils;
 
+import java.util.TimeZone;
+
 /**
  * {@link DataTypeRoot#TIMESTAMP_WITHOUT_TIME_ZONE}/{@link
  * DataTypeRoot#TIMESTAMP_WITH_LOCAL_TIME_ZONE} to {@link DataTypeRoot#DATE}.
@@ -46,7 +48,7 @@ class TimestampToDateCastRule extends AbstractCastRule<Timestamp, Number> {
             return value -> (int) (value.getMillisecond() / DateTimeUtils.MILLIS_PER_DAY);
         } else if (inputType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
             return value ->
-                    DateTimeUtils.timestampWithLocalZoneToDate(value, DateTimeUtils.LOCAL_TZ);
+                    DateTimeUtils.timestampWithLocalZoneToDate(value, TimeZone.getDefault());
         }
         return null;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToStringCastRule.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToStringCastRule.java
@@ -48,7 +48,7 @@ class TimestampToStringCastRule extends AbstractCastRule<Timestamp, BinaryString
         final int precision = DataTypeChecks.getPrecision(inputType);
         TimeZone timeZone =
                 inputType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
-                        ? DateTimeUtils.LOCAL_TZ
+                        ? TimeZone.getDefault()
                         : DateTimeUtils.UTC_ZONE;
         return value ->
                 BinaryString.fromString(DateTimeUtils.formatTimestamp(value, timeZone, precision));

--- a/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToTimeCastRule.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToTimeCastRule.java
@@ -23,6 +23,8 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.utils.DateTimeUtils;
 
+import java.util.TimeZone;
+
 /**
  * {@link DataTypeRoot#TIMESTAMP_WITHOUT_TIME_ZONE}/{@link
  * DataTypeRoot#TIMESTAMP_WITH_LOCAL_TIME_ZONE} to {@link DataTypeRoot#TIME_WITHOUT_TIME_ZONE}.
@@ -46,7 +48,7 @@ class TimestampToTimeCastRule extends AbstractCastRule<Timestamp, Number> {
             return value -> (int) (value.getMillisecond() % DateTimeUtils.MILLIS_PER_DAY);
         } else if (inputType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
             return value ->
-                    DateTimeUtils.timestampWithLocalZoneToTime(value, DateTimeUtils.LOCAL_TZ);
+                    DateTimeUtils.timestampWithLocalZoneToTime(value, TimeZone.getDefault());
         }
         return null;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToTimestampCastRule.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToTimestampCastRule.java
@@ -24,6 +24,7 @@ import org.apache.paimon.types.DataTypeChecks;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.utils.DateTimeUtils;
 
+import java.util.TimeZone;
 import java.util.function.Function;
 
 /**
@@ -57,13 +58,13 @@ class TimestampToTimestampCastRule extends AbstractCastRule<Timestamp, Timestamp
             operand =
                     value ->
                             DateTimeUtils.timestampToTimestampWithLocalZone(
-                                    value, DateTimeUtils.LOCAL_TZ);
+                                    value, TimeZone.getDefault());
         } else if (inputType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
                 && targetType.is(DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
             operand =
                     value ->
                             DateTimeUtils.timestampWithLocalZoneToTimestamp(
-                                    value, DateTimeUtils.LOCAL_TZ);
+                                    value, TimeZone.getDefault());
         } else {
             operand = value -> value;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -52,6 +52,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -113,7 +114,7 @@ public class OrphanFilesClean {
     public OrphanFilesClean olderThan(String timestamp) {
         // The FileStatus#getModificationTime returns milliseconds
         this.olderThanMillis =
-                DateTimeUtils.parseTimestampData(timestamp, 3, DateTimeUtils.LOCAL_TZ)
+                DateTimeUtils.parseTimestampData(timestamp, 3, TimeZone.getDefault())
                         .getMillisecond();
         return this;
     }

--- a/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -41,6 +41,8 @@ import org.apache.paimon.utils.DecimalUtils;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.TimeZone;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -264,7 +266,7 @@ public class CastExecutorTest {
                 CastExecutors.resolve(new LocalZonedTimestampType(5), VarCharType.STRING_TYPE),
                 timestamp,
                 BinaryString.fromString(
-                        DateTimeUtils.formatTimestamp(timestamp, DateTimeUtils.LOCAL_TZ, 5)));
+                        DateTimeUtils.formatTimestamp(timestamp, TimeZone.getDefault(), 5)));
     }
 
     @Test
@@ -470,7 +472,7 @@ public class CastExecutorTest {
         compareCastResult(
                 CastExecutors.resolve(new VarCharType(25), new LocalZonedTimestampType(3)),
                 BinaryString.fromString(date),
-                DateTimeUtils.parseTimestampData(date, 3, DateTimeUtils.LOCAL_TZ));
+                DateTimeUtils.parseTimestampData(date, 3, TimeZone.getDefault()));
     }
 
     @Test
@@ -547,7 +549,7 @@ public class CastExecutorTest {
                 CastExecutors.resolve(new TimestampType(3), new LocalZonedTimestampType(3)),
                 timestamp,
                 DateTimeUtils.timestampToTimestampWithLocalZone(
-                        Timestamp.fromEpochMillis(mills), DateTimeUtils.LOCAL_TZ));
+                        Timestamp.fromEpochMillis(mills), TimeZone.getDefault()));
 
         // timestamp_ltz(5) to timestamp(2)
         compareCastResult(
@@ -555,20 +557,20 @@ public class CastExecutorTest {
                 timestamp,
                 DateTimeUtils.truncate(
                         DateTimeUtils.timestampWithLocalZoneToTimestamp(
-                                Timestamp.fromEpochMillis(mills), DateTimeUtils.LOCAL_TZ),
+                                Timestamp.fromEpochMillis(mills), TimeZone.getDefault()),
                         2));
 
         // timestamp_ltz to date
         compareCastResult(
                 CastExecutors.resolve(new LocalZonedTimestampType(5), new DateType()),
                 Timestamp.fromEpochMillis(mills),
-                DateTimeUtils.timestampWithLocalZoneToDate(timestamp, DateTimeUtils.LOCAL_TZ));
+                DateTimeUtils.timestampWithLocalZoneToDate(timestamp, TimeZone.getDefault()));
 
         // timestamp_ltz to time
         compareCastResult(
                 CastExecutors.resolve(new LocalZonedTimestampType(5), new TimeType(2)),
                 Timestamp.fromEpochMillis(mills),
-                DateTimeUtils.timestampWithLocalZoneToTime(timestamp, DateTimeUtils.LOCAL_TZ));
+                DateTimeUtils.timestampWithLocalZoneToTime(timestamp, TimeZone.getDefault()));
     }
 
     @Test
@@ -582,7 +584,7 @@ public class CastExecutorTest {
         compareCastResult(
                 CastExecutors.resolve(new DateType(), new LocalZonedTimestampType(5)),
                 DateTimeUtils.parseDate(date),
-                DateTimeUtils.parseTimestampData(date, 3, DateTimeUtils.LOCAL_TZ));
+                DateTimeUtils.parseTimestampData(date, 3, TimeZone.getDefault()));
     }
 
     @Test

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/CdcMetadataConverter.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/CdcMetadataConverter.java
@@ -28,6 +28,7 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import io.debezium.connector.AbstractSourceInfo;
 
 import java.io.Serializable;
+import java.util.TimeZone;
 
 /**
  * A functional interface for converting CDC metadata.
@@ -116,7 +117,7 @@ public interface CdcMetadataConverter extends Serializable {
             return DateTimeUtils.formatTimestamp(
                     Timestamp.fromEpochMillis(
                             source.get(AbstractSourceInfo.TIMESTAMP_KEY).asLong()),
-                    DateTimeUtils.LOCAL_TZ,
+                    TimeZone.getDefault(),
                     3);
         }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ExpireSnapshotsProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ExpireSnapshotsProcedure.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.annotation.ProcedureHint;
 import org.apache.flink.table.procedure.ProcedureContext;
 
 import java.time.Duration;
+import java.util.TimeZone;
 
 /** A procedure to expire snapshots. */
 public class ExpireSnapshotsProcedure extends ProcedureBase {
@@ -79,7 +80,7 @@ public class ExpireSnapshotsProcedure extends ProcedureBase {
                     Duration.ofMillis(
                             System.currentTimeMillis()
                                     - DateTimeUtils.parseTimestampData(
-                                                    olderThanStr, 3, DateTimeUtils.LOCAL_TZ)
+                                                    olderThanStr, 3, TimeZone.getDefault())
                                             .getMillisecond()));
         }
         if (maxDeletes != null) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
@@ -30,6 +30,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.testutils.assertj.PaimonAssertions.anyCauseMatches;
@@ -344,7 +345,7 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
                                         DateTimeUtils.formatTimestamp(
                                                 DateTimeUtils.parseTimestampData(
                                                         "1970-01-01 00:00:04.001", 3),
-                                                DateTimeUtils.LOCAL_TZ,
+                                                TimeZone.getDefault(),
                                                 3))
                                 + "]");
     }
@@ -451,7 +452,7 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
                                 + DateTimeUtils.timestampToTimestampWithLocalZone(
                                                 DateTimeUtils.parseTimestampData(
                                                         "2022-12-12 00:30:00.123456", 3),
-                                                DateTimeUtils.LOCAL_TZ)
+                                                TimeZone.getDefault())
                                         .toLocalDateTime()
                                         .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
                                 + "Z"
@@ -506,7 +507,7 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
                                 + DateTimeUtils.timestampToTimestampWithLocalZone(
                                                 DateTimeUtils.parseTimestampData(
                                                         "2022-12-02 09:00:00.123456", 6),
-                                                DateTimeUtils.LOCAL_TZ)
+                                                TimeZone.getDefault())
                                         .toLocalDateTime()
                                         .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
                                 + "Z, "
@@ -514,7 +515,7 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
                                 + DateTimeUtils.timestampWithLocalZoneToTimestamp(
                                                 DateTimeUtils.parseTimestampData(
                                                         "1970-01-01 00:00:04.001", 3),
-                                                DateTimeUtils.LOCAL_TZ)
+                                                TimeZone.getDefault())
                                         .toLocalDateTime()
                                         .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
                                 + "]");
@@ -540,7 +541,7 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
                         "+I[2022-12-12T00:00, "
                                 + DateTimeUtils.timestampToTimestampWithLocalZone(
                                                 DateTimeUtils.parseTimestampData("2022-12-11", 6),
-                                                DateTimeUtils.LOCAL_TZ)
+                                                TimeZone.getDefault())
                                         .toLocalDateTime()
                                         .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
                                 + "Z"


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

`TimeZone.getDefault()` can't be static final, otherwise we will not be able to react to time zone changes

However, worried about performance degradation of timestamp

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
