### PR TITLE
[test] Exclude orc dependency to avoid test fails in IDEA

### DIFF
--- a/paimon-format/pom.xml
+++ b/paimon-format/pom.xml
@@ -74,6 +74,10 @@ under the License.
                     <artifactId>avro</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.orc</groupId>
+                    <artifactId>orc-core</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
As far as I know, `FileStoreLookupFunctionTest` will throws `NoSuchMethodError` in IDEA currently.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
