### PR TITLE
[core]Committer operator memory optimization

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/manifest/FileEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/FileEntry.java
@@ -176,6 +176,15 @@ public interface FileEntry {
         return result;
     }
 
+    static Future<List<ManifestEntry>> readManifestEntry(
+            ManifestFile manifestFile, ManifestFileMeta file) {
+        Future<List<ManifestEntry>> future =
+                CompletableFuture.supplyAsync(
+                        () -> manifestFile.read(file.fileName(), file.fileSize()),
+                        FileUtils.COMMON_IO_FORK_JOIN_POOL);
+        return future;
+    }
+
     static <T extends FileEntry> void assertNoDelete(Collection<T> entries) {
         for (T entry : entries) {
             Preconditions.checkState(


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close https://github.com/apache/paimon/issues/3590

<!-- What is the purpose of the change -->
When submitting a snapshot triggers a full compaction of the manifest file, we hope to reduce the usage of the taskManager heap memory.

### Tests

<!-- List UT and IT cases to verify this change -->
Before the comparison test, fine-grained-resource-management has been enabled，The committer operator runs in a separate task manager.

Heap memory usage before optimization：

![image](https://github.com/apache/paimon/assets/20182632/21184999-26c1-43cc-994d-2d98734e0c0c)

Heap memory usage after optimization：
![image](https://github.com/apache/paimon/assets/20182632/e2106b79-0fc1-412d-8cf3-bc5713a8e780)

### API and Format
### Documentation
