### PR TITLE
[core] PartitionExpire drop partitions consisitent with hms drop

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
@@ -108,10 +108,10 @@ public class PartitionExpire {
             LOG.info("Expire Partition: " + partition);
         }
         if (expired.size() > 0) {
-            commit.dropPartitions(expired, commitIdentifier);
             if (metastoreClient != null) {
                 deleteMetastorePartitions(expired);
             }
+            commit.dropPartitions(expired, commitIdentifier);
         }
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
PartitionExpire drop partition atomicity when sync to hms.
CREATE TABLE bdsp_test.paimon_mi_24(
user_id STRING COMMENT '任务用到的库',
used_table STRING COMMENT '任务用到的表',
day STRING COMMENT '按天进行分区'
)USING paimon
PARTITIONED BY (day);

insert into bdsp_test.paimon_mi_24
select 'a', 'a_table', '2024-04-22';

insert into bdsp_test.paimon_mi_24
select 'b', 'a_table', '2024-09-22';

select * from bdsp_test.paimon_mi_24 limit 10;

CALL sys.expire_partitions(table => 'bdsp_test.paimon_mi_24', expiration_time => '1 d', timestamp_formatter => 'yyyy-MM-dd');

If hive version is low which cannot compatible with paimon（such as follow），hms sync would error but paimon drop partition is ok

![1719229921801.png](https://github.com/apache/paimon/assets/10645422/8bded804-52a1-48c5-8fa1-31f597749cde)


<!-- Linking this pull request to the issue -->
Linked issue: https://github.com/apache/paimon/issues/3593

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
