### PR TITLE
[core] Use parallelismBatchIterable to reduce memory cost

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -203,7 +203,8 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 newKeyComparator(),
                 options.branch(),
                 newStatsFileHandler(),
-                bucketMode());
+                bucketMode(),
+                options.scanManifestParallelism());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -120,6 +120,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
     private final boolean dynamicPartitionOverwrite;
     @Nullable private final Comparator<InternalRow> keyComparator;
     private final String branchName;
+    @Nullable private final Integer manifestReadParallelism;
 
     @Nullable private Lock lock;
     private boolean ignoreEmptyCommit;
@@ -150,7 +151,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             @Nullable Comparator<InternalRow> keyComparator,
             String branchName,
             StatsFileHandler statsFileHandler,
-            BucketMode bucketMode) {
+            BucketMode bucketMode,
+            @Nullable Integer manifestReadParallelism) {
         this.fileIO = fileIO;
         this.schemaManager = schemaManager;
         this.commitUser = commitUser;
@@ -169,6 +171,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         this.dynamicPartitionOverwrite = dynamicPartitionOverwrite;
         this.keyComparator = keyComparator;
         this.branchName = branchName;
+        this.manifestReadParallelism = manifestReadParallelism;
 
         this.lock = null;
         this.ignoreEmptyCommit = true;
@@ -845,7 +848,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                             manifestTargetSize.getBytes(),
                             manifestMergeMinCount,
                             manifestFullCompactionSize.getBytes(),
-                            partitionType));
+                            partitionType,
+                            manifestReadParallelism));
             previousChangesListName = manifestList.write(newMetas);
 
             // the added records subtract the deleted records from

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ScanParallelExecutor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ScanParallelExecutor.java
@@ -42,9 +42,8 @@ public class ScanParallelExecutor {
     // reduce memory usage by batch iterable process, the cached result in memory will be queueSize
     public static <T, U> Iterable<T> parallelismBatchIterable(
             Function<List<U>, List<T>> processor, List<U> input, @Nullable Integer queueSize) {
-        ForkJoinPool poolCandidate = COMMON_IO_FORK_JOIN_POOL;
         if (queueSize == null) {
-            queueSize = poolCandidate.getParallelism();
+            queueSize = COMMON_IO_FORK_JOIN_POOL.getParallelism();
         } else if (queueSize <= 0) {
             throw new NegativeArraySizeException("queue size should not be negetive");
         }
@@ -73,7 +72,7 @@ public class ScanParallelExecutor {
 
                     private void advanceIfNeeded() {
                         while ((activeList == null || index >= activeList.size())
-                                && stack.size() > 0) {
+                                && !stack.isEmpty()) {
                             // reset index
                             index = 0;
                             try {

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTest.java
@@ -72,7 +72,7 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         // no trigger Full Compaction
         List<ManifestFileMeta> actual =
                 ManifestFileMeta.merge(
-                        input, manifestFile, 500, 3, Long.MAX_VALUE, getPartitionType());
+                        input, manifestFile, 500, 3, Long.MAX_VALUE, getPartitionType(), null);
         assertThat(actual).hasSameSizeAs(expected);
 
         // these two manifest files are merged from the input
@@ -110,7 +110,8 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
                     500,
                     3,
                     fullCompactionThreshold,
-                    getPartitionType());
+                    getPartitionType(),
+                    null);
         } catch (Throwable e) {
             assertThat(e).hasRootCauseExactlyInstanceOf(FailingFileIO.ArtificialException.class);
             // old files should be kept untouched, while new files should be cleaned up
@@ -142,7 +143,7 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         addDeltaManifests(input, true);
         // trigger full compaction
         List<ManifestFileMeta> merged =
-                ManifestFileMeta.merge(input, manifestFile, 500, 3, 200, getPartitionType());
+                ManifestFileMeta.merge(input, manifestFile, 500, 3, 200, getPartitionType(), null);
 
         // 1st Manifest don't need to Merge
         assertSameContent(input.get(0), merged.get(0), manifestFile);
@@ -158,7 +159,7 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         List<ManifestFileMeta> input = createBaseManifestFileMetas(true);
 
         List<ManifestFileMeta> merged =
-                ManifestFileMeta.merge(input, manifestFile, 500, 3, 200, getPartitionType());
+                ManifestFileMeta.merge(input, manifestFile, 500, 3, 200, getPartitionType(), null);
 
         assertEquivalentEntries(input, merged);
         assertThat(merged).hasSameElementsAs(input);
@@ -170,7 +171,7 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         input1.add(delta);
 
         List<ManifestFileMeta> merged1 =
-                ManifestFileMeta.merge(input1, manifestFile, 500, 3, 200, getPartitionType());
+                ManifestFileMeta.merge(input1, manifestFile, 500, 3, 200, getPartitionType(), null);
 
         assertThat(base).hasSameElementsAs(merged1);
         assertEquivalentEntries(input1, merged1);
@@ -181,7 +182,7 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         List<ManifestFileMeta> input = new ArrayList<>();
         addDeltaManifests(input, true);
         List<ManifestFileMeta> merged =
-                ManifestFileMeta.merge(input, manifestFile, 500, 3, 200, getPartitionType());
+                ManifestFileMeta.merge(input, manifestFile, 500, 3, 200, getPartitionType(), null);
         assertEquivalentEntries(input, merged);
     }
 
@@ -207,7 +208,7 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         input.add(makeManifest(makeEntry(true, "G")));
 
         List<ManifestFileMeta> merged =
-                ManifestFileMeta.merge(input, manifestFile, 500, 3, 200, getPartitionType());
+                ManifestFileMeta.merge(input, manifestFile, 500, 3, 200, getPartitionType(), null);
         assertEquivalentEntries(input, merged);
     }
 
@@ -239,7 +240,13 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         List<ManifestFileMeta> newMetas2 = new ArrayList<>();
         Optional<List<ManifestFileMeta>> fullCompacted =
                 ManifestFileMeta.tryFullCompaction(
-                        input, newMetas2, manifestFile, 500, Long.MAX_VALUE, getPartitionType());
+                        input,
+                        newMetas2,
+                        manifestFile,
+                        500,
+                        Long.MAX_VALUE,
+                        getPartitionType(),
+                        null);
         assertThat(fullCompacted).isEmpty();
         assertThat(newMetas2).isEmpty();
 
@@ -247,7 +254,7 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         List<ManifestFileMeta> newMetas3 = new ArrayList<>();
         List<ManifestFileMeta> merged =
                 ManifestFileMeta.tryFullCompaction(
-                                input, newMetas3, manifestFile, 500, 100, getPartitionType())
+                                input, newMetas3, manifestFile, 500, 100, getPartitionType(), null)
                         .get();
 
         List<String> entryFileNameExptected = new ArrayList<>();
@@ -272,7 +279,7 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         List<ManifestFileMeta> newMetas = new ArrayList<>();
         List<ManifestFileMeta> mergedManifest =
                 ManifestFileMeta.tryFullCompaction(
-                                input, newMetas, manifestFile, 500, 100, getPartitionType())
+                                input, newMetas, manifestFile, 500, 100, getPartitionType(), null)
                         .get();
 
         List<String> expected = Lists.newArrayList("ADD-C2", "ADD-D2", "ADD-G");

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/NoPartitionManifestFileMetaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/NoPartitionManifestFileMetaTest.java
@@ -46,7 +46,7 @@ public class NoPartitionManifestFileMetaTest extends ManifestFileMetaTestBase {
         addDeltaManifests(input, false);
 
         List<ManifestFileMeta> merged =
-                ManifestFileMeta.merge(input, manifestFile, 500, 3, 200, getPartitionType());
+                ManifestFileMeta.merge(input, manifestFile, 500, 3, 200, getPartitionType(), null);
         assertEquivalentEntries(input, merged);
 
         // the first one is not deleted, it should not be merged


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This closes #3590

The `ScanParallelExecutor.parallelismBatchIterable` is designed to do parallelly execution with memory control, and the parallelism is controlled by `scan.manifest.parallelism`. 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
