### PR TITLE
[hive] HiveStoreMetaClient drop table need clear filesystem dir

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -363,7 +363,7 @@ public class HiveCatalog extends AbstractCatalog {
                 .orElseThrow(() -> new TableNotExistException(identifier));
     }
 
-    private boolean usingExternalTable() {
+    public boolean usingExternalTable() {
         TableType tableType =
                 OptionsUtils.convertToEnum(
                         hiveConf.get(TABLE_TYPE.key(), TableType.MANAGED.toString()),

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
@@ -209,9 +209,22 @@ public class HiveMigrator implements Migrator {
             throw new RuntimeException("Migrating failed", e);
         }
 
-        // if all success, drop the origin table according the delete field
+        // if all success, drop the origin table according the deleted field
         if (delete) {
             client.dropTable(sourceDatabase, sourceTable, true, true);
+
+            if (hiveCatalog.usingExternalTable()) {
+                return;
+            }
+
+            Path path = hiveCatalog.getDataTableLocation(identifier);
+            try {
+                if (fileIO.exists(path)) {
+                    fileIO.deleteDirectoryQuietly(path);
+                }
+            } catch (Exception e) {
+                LOG.error("Delete directory[{}] fail for table {}", path, identifier, e);
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Delete table dir from filesystem due to recreate table may not expect for older schema file in dir.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
