### PR TITLE
[core] Skip pushing down partition filter to file reader

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
@@ -357,6 +357,16 @@ public class PredicateBuilder {
         }
     }
 
+    public static List<Predicate> excludePredicateWithFields(
+            @Nullable List<Predicate> predicates, Set<String> fields) {
+        if (predicates == null || predicates.isEmpty() || fields.isEmpty()) {
+            return predicates;
+        }
+        return predicates.stream()
+                .filter(f -> !containsFields(f, fields))
+                .collect(Collectors.toList());
+    }
+
     @Nullable
     public static Predicate partition(
             Map<String, String> map, RowType rowType, String defaultPartValue) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Skip pushing down partition filter to file reader,  for the reasons:

- The partition filters have been applied to the splits generation, so pushing them to file has little effect.
- In some scenarios, the data file may not contain partition fields (such as migrate table, or our internal implementation that does not write partition fields). Then, if we push down the partition filter to the parquet reader, we will obtain no data. (The reason behind this is that parquet reader will treat all non-existent fields ​​as null, and if we push down `is not null`, reader will reject everything).

e.g. `SELECT * FROM migrate_tbl WHERE pt = 1` always return nothing

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
