### PR TITLE
[parquet] Parquet supports column index filter

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
@@ -106,7 +106,8 @@ public class ParquetReaderFactory implements FormatReaderFactory {
         Pool<ParquetReaderBatch> poolOfBatches =
                 createPoolOfBatches(context.filePath(), requestedSchema);
 
-        return new ParquetReader(reader, requestedSchema, reader.getRecordCount(), poolOfBatches);
+        return new ParquetReader(
+                reader, requestedSchema, reader.getFilteredRecordCount(), poolOfBatches);
     }
 
     private void setReadOptions(ParquetReadOptions.Builder builder) {
@@ -325,7 +326,7 @@ public class ParquetReaderFactory implements FormatReaderFactory {
         }
 
         private void readNextRowGroup() throws IOException {
-            PageReadStore pages = reader.readNextRowGroup();
+            PageReadStore pages = reader.readNextFilteredRowGroup();
             if (pages == null) {
                 throw new IOException(
                         "expecting more rows but reached last block. Read "

--- a/paimon-format/src/test/java/org/apache/paimon/format/avro/AvroFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/avro/AvroFormatReadWriteTest.java
@@ -19,9 +19,8 @@
 package org.apache.paimon.format.avro;
 
 import org.apache.paimon.format.FileFormat;
-import org.apache.paimon.format.FileFormatFactory;
+import org.apache.paimon.format.FileFormatFactory.FormatContext;
 import org.apache.paimon.format.FormatReadWriteTest;
-import org.apache.paimon.options.Options;
 
 /** An avro {@link FormatReadWriteTest}. */
 public class AvroFormatReadWriteTest extends FormatReadWriteTest {
@@ -31,7 +30,12 @@ public class AvroFormatReadWriteTest extends FormatReadWriteTest {
     }
 
     @Override
-    protected FileFormat fileFormat() {
-        return new AvroFileFormat(new FileFormatFactory.FormatContext(new Options(), 1024));
+    protected boolean notSupportFilterPushDown() {
+        return true;
+    }
+
+    @Override
+    protected FileFormat fileFormat(FormatContext context) {
+        return new AvroFileFormat(context);
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFormatReadWriteTest.java
@@ -21,7 +21,6 @@ package org.apache.paimon.format.orc;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.format.FileFormatFactory;
 import org.apache.paimon.format.FormatReadWriteTest;
-import org.apache.paimon.options.Options;
 
 /** An orc {@link FormatReadWriteTest}. */
 public class OrcFormatReadWriteTest extends FormatReadWriteTest {
@@ -31,7 +30,7 @@ public class OrcFormatReadWriteTest extends FormatReadWriteTest {
     }
 
     @Override
-    protected FileFormat fileFormat() {
-        return new OrcFileFormat(new FileFormatFactory.FormatContext(new Options(), 1024));
+    protected FileFormat fileFormat(FileFormatFactory.FormatContext context) {
+        return new OrcFileFormat(context);
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
@@ -72,11 +72,12 @@ public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
         PositionOutputStream out = fileIO.newOutputStream(file, false);
         FormatWriter writer = format.createWriterFactory(rowType).create(out, "zstd");
         ThreadLocalRandom rnd = ThreadLocalRandom.current();
-        for (int i = 0; i < 10_000; i++) {
+        int batchSize = 10_000;
+        for (int i = 0; i < batchSize; i++) {
             int value = rnd.nextInt(100);
             writer.addElement(GenericRow.of(value, (long) value));
         }
-        for (int i = 0; i < 10_000; i++) {
+        for (int i = 0; i < batchSize; i++) {
             int value = rnd.nextInt(100, 500);
             writer.addElement(GenericRow.of(value, (long) value));
         }
@@ -93,6 +94,6 @@ public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
         List<InternalRow> result = new ArrayList<>();
         reader.forEachRemaining(row -> result.add(serializer.copy(row)));
 
-        assertThat(result.size()).isLessThan(10_000);
+        assertThat(result.size()).isLessThan(batchSize * 2);
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
@@ -18,10 +18,31 @@
 
 package org.apache.paimon.format.parquet;
 
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.format.FileFormat;
-import org.apache.paimon.format.FileFormatFactory;
+import org.apache.paimon.format.FileFormatFactory.FormatContext;
 import org.apache.paimon.format.FormatReadWriteTest;
+import org.apache.paimon.format.FormatReaderContext;
+import org.apache.paimon.format.FormatWriter;
+import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** A parquet {@link FormatReadWriteTest}. */
 public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
@@ -36,7 +57,42 @@ public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
     }
 
     @Override
-    protected FileFormat fileFormat() {
-        return new ParquetFileFormat(new FileFormatFactory.FormatContext(new Options(), 1024));
+    protected FileFormat fileFormat(FormatContext context) {
+        return new ParquetFileFormat(context);
+    }
+
+    @Test
+    public void testColumnIndexFilterPushDown() throws IOException {
+        Options options = new Options();
+        options.set("page.size", "64");
+        FormatContext context = new FormatContext(options, 1024);
+        FileFormat format = fileFormat(context);
+        RowType rowType = DataTypes.ROW(DataTypes.INT().notNull(), DataTypes.BIGINT());
+        InternalRowSerializer serializer = new InternalRowSerializer(rowType);
+        PositionOutputStream out = fileIO.newOutputStream(file, false);
+        FormatWriter writer = format.createWriterFactory(rowType).create(out, "zstd");
+        ThreadLocalRandom rnd = ThreadLocalRandom.current();
+        for (int i = 0; i < 10_000; i++) {
+            int value = rnd.nextInt(100);
+            writer.addElement(GenericRow.of(value, (long) value));
+        }
+        for (int i = 0; i < 10_000; i++) {
+            int value = rnd.nextInt(100, 500);
+            writer.addElement(GenericRow.of(value, (long) value));
+        }
+        writer.flush();
+        writer.finish();
+        out.close();
+
+        PredicateBuilder predicateBuilder = new PredicateBuilder(rowType);
+        List<Predicate> filters = Collections.singletonList(predicateBuilder.equal(0, 2));
+        RecordReader<InternalRow> reader =
+                format.createReaderFactory(rowType, filters)
+                        .createReader(
+                                new FormatReaderContext(fileIO, file, fileIO.getFileSize(file)));
+        List<InternalRow> result = new ArrayList<>();
+        reader.forEachRemaining(row -> result.add(serializer.copy(row)));
+
+        assertThat(result.size()).isLessThan(10_000);
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
- Use column index filter api in parquet reader.
- Add tests.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
