### PR TITLE
[spark] Optimize sort compact procedure by submitting job by partition

### DIFF
--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -46,7 +46,7 @@ This section introduce all available spark procedures about paimon.
             <li>where: partition predicate. Left empty for all partitions. (Can't be used together with "partitions")</li>          
             <li>order_strategy: 'order' or 'zorder' or 'hilbert' or 'none'. Left empty for 'none'.</li>
             <li>order_columns: the columns need to be sort. Left empty if 'order_strategy' is 'none'.</li>
-            <li>max_order_threads: when sort compact is used, files in one partition are grouped and submitted as a single spark job. This parameter controls the maximum number of jobs that can be submitted simultaneously. The default value is 15.</li>
+            <li>max_concurrent_jobs: when sort compact is used, files in one partition are grouped and submitted as a single spark compact job. This parameter controls the maximum number of jobs that can be submitted simultaneously. The default value is 15.</li>
       </td>
       <td>
          SET spark.sql.shuffle.partitions=10; --set the compact parallelism <br/>

--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -46,6 +46,7 @@ This section introduce all available spark procedures about paimon.
             <li>where: partition predicate. Left empty for all partitions. (Can't be used together with "partitions")</li>          
             <li>order_strategy: 'order' or 'zorder' or 'hilbert' or 'none'. Left empty for 'none'.</li>
             <li>order_columns: the columns need to be sort. Left empty if 'order_strategy' is 'none'.</li>
+            <li>max_order_threads: when sort compact is used, files in one partition are grouped and submitted as a single spark job. This parameter controls the maximum number of jobs that can be submitted simultaneously. The default value is 15.</li>
       </td>
       <td>
          SET spark.sql.shuffle.partitions=10; --set the compact parallelism <br/>

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/BaseProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/BaseProcedure.java
@@ -26,7 +26,6 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.connector.catalog.CatalogPlugin;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.Table;
@@ -109,7 +108,7 @@ abstract class BaseProcedure implements Procedure {
         }
     }
 
-    protected LogicalPlan createRelation(Identifier ident) {
+    protected DataSourceV2Relation createRelation(Identifier ident) {
         return DataSourceV2Relation.create(
                 loadSparkTable(ident), Option.apply(tableCatalog), Option.apply(ident));
     }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonSplitScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonSplitScan.scala
@@ -45,3 +45,9 @@ case class PaimonSplitScan(
       metadataColumns)
   }
 }
+
+object PaimonSplitScan {
+  def apply(table: Table, dataSplits: Array[DataSplit]): PaimonSplitScan = {
+    new PaimonSplitScan(table, dataSplits)
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -50,7 +50,7 @@ case class PaimonSparkWriter(table: FileStoreTable) {
 
   private lazy val primaryKeyCols = tableSchema.trimmedPrimaryKeys().asScala
 
-  private lazy val serializer = new CommitMessageSerializer
+  @transient private lazy val serializer = new CommitMessageSerializer
 
   val writeBuilder: BatchWriteBuilder = table.newBatchWriteBuilder()
 

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
@@ -249,14 +249,13 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
     }
   }
 
-  test("Paimon Procedure: sort compact with max_order_threads") {
+  test("Paimon Procedure: sort compact with max_concurrent_jobs") {
     Seq("order", "zorder").foreach {
       orderStrategy =>
         {
           withTable("T") {
             spark.sql(s"""
                          |CREATE TABLE T (id INT, pt STRING)
-                         |TBLPROPERTIES ('bucket'='-1')
                          |PARTITIONED BY (pt)
                          |""".stripMargin)
 
@@ -276,7 +275,7 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
 
             checkAnswer(
               spark.sql(
-                s"CALL sys.compact(table => 'T', order_strategy => '$orderStrategy', order_by => 'id', max_order_threads => 2)"),
+                s"CALL sys.compact(table => 'T', order_strategy => '$orderStrategy', order_by => 'id', max_concurrent_jobs => 2)"),
               Seq(true).toDF())
 
             val result = List(Row(1), Row(2), Row(3), Row(4)).asJava

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
@@ -30,6 +30,8 @@ import org.assertj.core.api.Assertions
 
 import java.util
 
+import scala.collection.JavaConverters._
+
 /** Test compact procedure. See [[CompactProcedure]]. */
 abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamTest {
 
@@ -247,6 +249,48 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
     }
   }
 
+  test("Paimon Procedure: sort compact with max_order_threads") {
+    Seq("order", "zorder").foreach {
+      orderStrategy =>
+        {
+          withTable("T") {
+            spark.sql(s"""
+                         |CREATE TABLE T (id INT, pt STRING)
+                         |TBLPROPERTIES ('bucket'='-1')
+                         |PARTITIONED BY (pt)
+                         |""".stripMargin)
+
+            spark.sql(s"""INSERT INTO T VALUES
+                         |(1, 'p1'), (3, 'p1'),
+                         |(1, 'p2'), (4, 'p2'),
+                         |(3, 'p3'), (2, 'p3'),
+                         |(1, 'p4'), (2, 'p4')
+                         |""".stripMargin)
+
+            spark.sql(s"""INSERT INTO T VALUES
+                         |(4, 'p1'), (2, 'p1'),
+                         |(2, 'p2'), (3, 'p2'),
+                         |(1, 'p3'), (4, 'p3'),
+                         |(3, 'p4'), (4, 'p4')
+                         |""".stripMargin)
+
+            checkAnswer(
+              spark.sql(
+                s"CALL sys.compact(table => 'T', order_strategy => '$orderStrategy', order_by => 'id', max_order_threads => 2)"),
+              Seq(true).toDF())
+
+            val result = List(Row(1), Row(2), Row(3), Row(4)).asJava
+            Seq("p1", "p2", "p3", "p4").foreach {
+              pt =>
+                Assertions
+                  .assertThat(spark.sql(s"SELECT id FROM T WHERE pt='$pt'").collect())
+                  .containsExactlyElementsOf(result)
+            }
+          }
+        }
+    }
+  }
+
   test("Paimon Procedure: compact for pk") {
     failAfter(streamingTimeout) {
       withTempDir {
@@ -433,6 +477,10 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
     assert(intercept[IllegalArgumentException] {
       spark.sql("CALL sys.compact(table => 'T', where => 'id > 1 AND pt = \"p1\"')")
     }.getMessage.contains("Only partition predicate is supported"))
+
+    assert(intercept[IllegalArgumentException] {
+      spark.sql("CALL sys.compact(table => 'T', order_strategy => 'sort', order_by => 'pt')")
+    }.getMessage.contains("order_by should not contain partition cols"))
   }
 
   test("Paimon Procedure: compact with where") {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Currently, spark sort compact will sort all the filtered data globally, and then write them by dynamic partition overwrite, which will lead to the following problems:

1. If the partition is not specified, data will be sorted globally, which is an unnecessary overhead
2. because it is a full range shuffle, small files are uncontrollable, for all reducers may contain all partitions

Therefore, this PR make a single partition as a sort compact group and then submit it to spark, a new conf ~`max_order_threads`~ `max_concurrent_jobs ` is introduced in sort compact procedure, the maximum number of concurrent job submissions, default is 15.

### Tests

Test on 1T tpc-ds, sort compact web_sales on ws_bill_customer_sk, before 233s -> after 108s, and the target file size can be controled by `spark.sql.shuffle.partitions`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
