### PR TITLE
[spark] Integrate paimon scan metrics into spark scan

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanMetrics.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanMetrics.java
@@ -27,7 +27,7 @@ import org.apache.paimon.metrics.MetricRegistry;
 public class ScanMetrics {
 
     private static final int HISTOGRAM_WINDOW_SIZE = 100;
-    @VisibleForTesting protected static final String GROUP_NAME = "scan";
+    public static final String GROUP_NAME = "scan";
 
     private final MetricGroup metricGroup;
 
@@ -45,26 +45,22 @@ public class ScanMetrics {
 
     private ScanStats latestScan;
 
-    @VisibleForTesting static final String LAST_SCAN_DURATION = "lastScanDuration";
-    @VisibleForTesting static final String SCAN_DURATION = "scanDuration";
-    @VisibleForTesting static final String LAST_SCANNED_MANIFESTS = "lastScannedManifests";
+    public static final String LAST_SCAN_DURATION = "lastScanDuration";
+    public static final String SCAN_DURATION = "scanDuration";
+    public static final String LAST_SCANNED_MANIFESTS = "lastScannedManifests";
 
-    @VisibleForTesting
-    static final String LAST_SKIPPED_BY_PARTITION_AND_STATS = "lastSkippedByPartitionAndStats";
+    public static final String LAST_SKIPPED_BY_PARTITION_AND_STATS =
+            "lastSkippedByPartitionAndStats";
 
-    @VisibleForTesting
-    static final String LAST_SKIPPED_BY_BUCKET_AND_LEVEL_FILTER =
+    public static final String LAST_SKIPPED_BY_BUCKET_AND_LEVEL_FILTER =
             "lastSkippedByBucketAndLevelFilter";
 
-    @VisibleForTesting
-    static final String LAST_SKIPPED_BY_WHOLE_BUCKET_FILES_FILTER =
+    public static final String LAST_SKIPPED_BY_WHOLE_BUCKET_FILES_FILTER =
             "lastSkippedByWholeBucketFilesFilter";
 
-    @VisibleForTesting
-    static final String LAST_SCAN_SKIPPED_TABLE_FILES = "lastScanSkippedTableFiles";
+    public static final String LAST_SCAN_SKIPPED_TABLE_FILES = "lastScanSkippedTableFiles";
 
-    @VisibleForTesting
-    static final String LAST_SCAN_RESULTED_TABLE_FILES = "lastScanResultedTableFiles";
+    public static final String LAST_SCAN_RESULTED_TABLE_FILES = "lastScanResultedTableFiles";
 
     private void registerGenericScanMetrics() {
         metricGroup.gauge(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanStats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanStats.java
@@ -22,6 +22,7 @@ import org.apache.paimon.annotation.VisibleForTesting;
 
 /** Statistics for a scan operation. */
 public class ScanStats {
+    // the unit is milliseconds
     private final long duration;
     private final long scannedManifests;
     private final long skippedByPartitionAndStats;

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -151,7 +151,12 @@ abstract class PaimonBaseScan(
   }
 
   override def reportDriverMetrics(): Array[CustomTaskMetric] = {
-    paimonMetricsRegistry.buildSparkScanMetrics()
+    table match {
+      case _: FileStoreTable =>
+        paimonMetricsRegistry.buildSparkScanMetrics()
+      case _ =>
+        Array.empty[CustomTaskMetric]
+    }
   }
 
   override def description(): String = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonMetrics.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonMetrics.scala
@@ -19,7 +19,7 @@
 package org.apache.paimon.spark
 
 import org.apache.spark.sql.PaimonUtils
-import org.apache.spark.sql.connector.metric.{CustomAvgMetric, CustomSumMetric, CustomTaskMetric}
+import org.apache.spark.sql.connector.metric.{CustomAvgMetric, CustomMetric, CustomSumMetric, CustomTaskMetric}
 
 import java.text.DecimalFormat
 
@@ -30,6 +30,14 @@ object PaimonMetrics {
   val SPLIT_SIZE = "splitSize"
 
   val AVG_SPLIT_SIZE = "avgSplitSize"
+
+  val PLANNING_DURATION = "planningDuration"
+
+  val SCANNED_MANIFESTS = "scannedManifests"
+
+  val SKIPPED_TABLE_FILES = "skippedTableFiles"
+
+  val RESULTED_TABLE_FILES = "resultedTableFiles"
 }
 
 // paimon's task metric
@@ -122,4 +130,40 @@ case class PaimonAvgSplitSizeMetric() extends PaimonAvgMetric {
     PaimonUtils.bytesToString(average)
   }
 
+}
+
+case class PaimonPlanningDurationMetric() extends PaimonSumMetric {
+  override def name(): String = PaimonMetrics.PLANNING_DURATION
+  override def description(): String = "planing duration (ms)"
+}
+
+case class PaimonPlanningDurationTaskMetric(value: Long) extends PaimonTaskMetric {
+  override def name(): String = PaimonMetrics.PLANNING_DURATION
+}
+
+case class PaimonScannedManifestsMetric() extends PaimonSumMetric {
+  override def name(): String = PaimonMetrics.SCANNED_MANIFESTS
+  override def description(): String = "number of scanned manifests"
+}
+
+case class PaimonScannedManifestsTaskMetric(value: Long) extends PaimonTaskMetric {
+  override def name(): String = PaimonMetrics.SCANNED_MANIFESTS
+}
+
+case class PaimonSkippedTableFilesMetric() extends PaimonSumMetric {
+  override def name(): String = PaimonMetrics.SKIPPED_TABLE_FILES
+  override def description(): String = "number of skipped table files"
+}
+
+case class PaimonSkippedTableFilesTaskMetric(value: Long) extends PaimonTaskMetric {
+  override def name(): String = PaimonMetrics.SKIPPED_TABLE_FILES
+}
+
+case class PaimonResultedTableFilesMetric() extends PaimonSumMetric {
+  override def name(): String = PaimonMetrics.RESULTED_TABLE_FILES
+  override def description(): String = "number of resulted table files"
+}
+
+case class PaimonResultedTableFilesTaskMetric(value: Long) extends PaimonTaskMetric {
+  override def name(): String = PaimonMetrics.RESULTED_TABLE_FILES
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonMetrics.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonMetrics.scala
@@ -19,7 +19,7 @@
 package org.apache.paimon.spark
 
 import org.apache.spark.sql.PaimonUtils
-import org.apache.spark.sql.connector.metric.{CustomAvgMetric, CustomMetric, CustomSumMetric, CustomTaskMetric}
+import org.apache.spark.sql.connector.metric.{CustomAvgMetric, CustomSumMetric, CustomTaskMetric}
 
 import java.text.DecimalFormat
 
@@ -132,6 +132,7 @@ case class PaimonAvgSplitSizeMetric() extends PaimonAvgMetric {
 
 }
 
+// Metrics reported by driver
 case class PaimonPlanningDurationMetric() extends PaimonSumMetric {
   override def name(): String = PaimonMetrics.PLANNING_DURATION
   override def description(): String = "planing duration (ms)"

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/metric/SparkMetricRegistry.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/metric/SparkMetricRegistry.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.metric
+
+import org.apache.paimon.metrics.{Gauge, MetricGroup, MetricGroupImpl, MetricRegistry}
+import org.apache.paimon.operation.metrics.ScanMetrics
+import org.apache.paimon.spark.{PaimonPlanningDurationTaskMetric, PaimonResultedTableFilesTaskMetric, PaimonScannedManifestsTaskMetric, PaimonSkippedTableFilesTaskMetric}
+
+import org.apache.spark.sql.connector.metric.CustomTaskMetric
+
+import java.util
+
+import scala.collection.mutable
+
+case class SparkMetricRegistry() extends MetricRegistry {
+
+  private val metricGroups = mutable.Map.empty[String, MetricGroup]
+
+  override protected def createMetricGroup(
+      groupName: String,
+      variables: util.Map[String, String]): MetricGroup = {
+    val metricGroup = new MetricGroupImpl(groupName, variables)
+    metricGroups.put(groupName, metricGroup)
+    metricGroup
+  }
+
+  def buildSparkScanMetrics(): Array[CustomTaskMetric] = {
+    metricGroups.get(ScanMetrics.GROUP_NAME) match {
+      case Some(group) =>
+        val metrics = group.getMetrics
+        def gaugeLong(key: String): Long = metrics.get(key).asInstanceOf[Gauge[Long]].getValue
+        Array(
+          PaimonPlanningDurationTaskMetric(gaugeLong(ScanMetrics.LAST_SCAN_DURATION)),
+          PaimonScannedManifestsTaskMetric(gaugeLong(ScanMetrics.LAST_SCANNED_MANIFESTS)),
+          PaimonSkippedTableFilesTaskMetric(gaugeLong(ScanMetrics.LAST_SCAN_SKIPPED_TABLE_FILES)),
+          PaimonResultedTableFilesTaskMetric(gaugeLong(ScanMetrics.LAST_SCAN_RESULTED_TABLE_FILES))
+        )
+      case None =>
+        Array.empty
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Integrate paimon scan metrics into spark scan, so that we can get more information on the UI. Note: these new metrics are only available from Spark 3.4, because `reportDriverMetrics` was added in 3.4.

e.g.

```sql
select count(*) from inventory where inv_date_sk = 2450822
```

<img width="388" alt="image" src="https://github.com/apache/paimon/assets/37108074/845c127e-41a3-4d75-9254-e8c8feba2431">


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
