### PR TITLE
[flink] Optimize watermark check in SnapshotManager which can earlier quit reduce FileIO with Filesystem

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -296,16 +296,17 @@ public class SnapshotManager implements Serializable {
         }
         Long earliestWatermark = null;
         // find the first snapshot with watermark
-        if ((earliestWatermark = snapshot(earliest).watermark()) == null) {
+        earliestWatermark = snapshot(earliest).watermark();
+        if (earliestWatermark == null || earliestWatermark == Long.MIN_VALUE) {
             while (earliest < latest) {
                 earliest++;
                 earliestWatermark = snapshot(earliest).watermark();
-                if (earliestWatermark != null) {
+                if (earliestWatermark != null && earliestWatermark != Long.MIN_VALUE) {
                     break;
                 }
             }
         }
-        if (earliestWatermark == null) {
+        if (earliestWatermark == null || earliestWatermark == Long.MIN_VALUE) {
             return null;
         }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Optimize watermark check in SnapshotManager which can earlier quit reduce FileIO with Filesystem:
we can find many watermark in snapshot could be Long.MIN firstly which should not be compute.

![1719634609775.png](https://github.com/apache/paimon/assets/10645422/16acfc2e-93f2-43a6-a879-0da58da7e605)




<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
