### PR TITLE
[snapshot] Optimize watermark check in SnapshotManager which can reduce FileIO with Filesystem

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -291,7 +291,9 @@ public class SnapshotManager implements Serializable {
     public @Nullable Snapshot laterOrEqualWatermark(long watermark) {
         Long earliest = earliestSnapshotId();
         Long latest = latestSnapshotId();
-        if (earliest == null || latest == null) {
+        // If latest == Long.MIN_VALUE don't need next binary search for watermark
+        // which can reduce IO cost with snapshot
+        if (earliest == null || latest == null || latest == Long.MIN_VALUE) {
             return null;
         }
         Long earliestWatermark = null;

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -293,7 +293,7 @@ public class SnapshotManager implements Serializable {
         Long latest = latestSnapshotId();
         // If latest == Long.MIN_VALUE don't need next binary search for watermark
         // which can reduce IO cost with snapshot
-        if (earliest == null || latest == null || latest == Long.MIN_VALUE) {
+        if (earliest == null || latest == null || snapshot(latest).watermark() == Long.MIN_VALUE) {
             return null;
         }
         Long earliestWatermark = null;

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -123,6 +123,21 @@ public class SnapshotManagerTest {
                 .isEqualTo(millis + 1000);
     }
 
+    @Test
+    public void testlaterOrEqualWatermark() throws IOException {
+        long millis = Long.MIN_VALUE;
+        FileIO localFileIO = LocalFileIO.create();
+        SnapshotManager snapshotManager =
+                new SnapshotManager(localFileIO, new Path(tempDir.toString()));
+        // create 10 snapshots
+        for (long i = 0; i < 10; i++) {
+            Snapshot snapshot = createSnapshotWithMillis(i, millis);
+            localFileIO.writeFileUtf8(snapshotManager.snapshotPath(i), snapshot.toJson());
+        }
+        // smaller than the second snapshot
+        assertThat(snapshotManager.laterOrEqualWatermark(millis + 999)).isNull();
+    }
+
     private Snapshot createSnapshotWithMillis(long id, long millis) {
         return new Snapshot(
                 id,

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -131,7 +131,7 @@ public class SnapshotManagerTest {
                 new SnapshotManager(localFileIO, new Path(tempDir.toString()));
         // create 10 snapshots
         for (long i = 0; i < 10; i++) {
-            Snapshot snapshot = createSnapshotWithMillis(i, millis);
+            Snapshot snapshot = createSnapshotWithMillis(i, millis, Long.MIN_VALUE);
             localFileIO.writeFileUtf8(snapshotManager.snapshotPath(i), snapshot.toJson());
         }
         // smaller than the second snapshot
@@ -155,6 +155,26 @@ public class SnapshotManagerTest {
                 null,
                 null,
                 null,
+                null);
+    }
+
+    private Snapshot createSnapshotWithMillis(long id, long millis, long watermark) {
+        return new Snapshot(
+                id,
+                0L,
+                null,
+                null,
+                null,
+                null,
+                null,
+                0L,
+                Snapshot.CommitKind.APPEND,
+                millis,
+                null,
+                null,
+                null,
+                null,
+                watermark,
                 null);
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Optimize watermark check in SnapshotManager which can earlier quit reduce FileIO with Filesystem:
we can find many watermark in snapshot could be Long.MIN firstly which should not be compute.
![1719634609775.png](https://github.com/apache/paimon/assets/10645422/805526b4-be10-4b8c-bacb-a70d26c7de71)



<!-- Linking this pull request to the issue -->
Linked issue: close https://github.com/apache/paimon/issues/3637

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
