### PR TITLE
[core] Should not ignore return value of FileIO.writeFileUtf8

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
@@ -232,20 +232,11 @@ public interface FileIO extends Serializable {
      *
      * @return false if target file exists
      */
-    default boolean writeFileUtf8(Path path, String content) throws IOException {
-        if (exists(path)) {
-            return false;
-        }
-
+    default boolean tryToWriteAtomic(Path path, String content) throws IOException {
         Path tmp = path.createTempPath();
         boolean success = false;
         try {
-            try (PositionOutputStream out = newOutputStream(tmp, false)) {
-                OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
-                writer.write(content);
-                writer.flush();
-            }
-
+            writeFile(tmp, content, false);
             success = rename(tmp, path);
         } finally {
             if (!success) {
@@ -254,6 +245,14 @@ public interface FileIO extends Serializable {
         }
 
         return success;
+    }
+
+    default void writeFile(Path path, String content, boolean overwrite) throws IOException {
+        try (PositionOutputStream out = newOutputStream(path, overwrite)) {
+            OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
+            writer.write(content);
+            writer.flush();
+        }
     }
 
     /**

--- a/paimon-common/src/test/java/org/apache/paimon/fs/FileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/FileIOTest.java
@@ -76,7 +76,7 @@ public class FileIOTest {
         Path dstFile = new Path(tempDir.resolve("dst.txt").toUri());
 
         FileIO fileIO = new DummyFileIO();
-        fileIO.writeFileUtf8(srcFile, "foobar");
+        fileIO.tryToWriteAtomic(srcFile, "foobar");
 
         fileIO.copyFile(srcFile, dstFile, true);
         assertThat(fileIO.readFileUtf8(dstFile)).isEqualTo("foobar");

--- a/paimon-common/src/test/java/org/apache/paimon/fs/local/LocalFleIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/local/LocalFleIOTest.java
@@ -37,7 +37,7 @@ public class LocalFleIOTest {
         Path dstFile = new Path(tempDir.resolve("dst.txt").toUri());
 
         FileIO fileIO = new LocalFileIO();
-        fileIO.writeFileUtf8(srcFile, "foobar");
+        fileIO.tryToWriteAtomic(srcFile, "foobar");
 
         fileIO.copyFile(srcFile, dstFile, false);
         assertThat(fileIO.readFileUtf8(dstFile)).isEqualTo("foobar");

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -939,7 +939,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             Callable<Boolean> callable =
                     () -> {
                         boolean committed =
-                                fileIO.writeFileUtf8(newSnapshotPath, newSnapshot.toJson());
+                                fileIO.tryToWriteAtomic(newSnapshotPath, newSnapshot.toJson());
                         if (committed) {
                             snapshotManager.commitLatestHint(newSnapshotId);
                         }

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -474,7 +474,8 @@ public class SchemaManager implements Serializable {
     boolean commit(TableSchema newSchema) throws Exception {
         SchemaValidation.validateTableSchema(newSchema);
         Path schemaPath = toSchemaPath(newSchema.id());
-        Callable<Boolean> callable = () -> fileIO.writeFileUtf8(schemaPath, newSchema.toString());
+        Callable<Boolean> callable =
+                () -> fileIO.tryToWriteAtomic(schemaPath, newSchema.toString());
         if (lock == null) {
             return callable.call();
         }

--- a/paimon-core/src/main/java/org/apache/paimon/stats/StatsFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/StatsFile.java
@@ -54,7 +54,7 @@ public class StatsFile {
         Path path = pathFactory.newPath();
 
         try {
-            fileIO.writeFileUtf8(path, stats.toJson());
+            fileIO.writeFile(path, stats.toJson(), false);
         } catch (IOException e) {
             throw new RuntimeException("Failed to write stats file: " + path, e);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -544,9 +544,10 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
             // earliest hint
             SnapshotManager snapshotManager = snapshotManager();
             if (!snapshotManager.snapshotExists(taggedSnapshot.id())) {
-                fileIO.writeFileUtf8(
+                fileIO.writeFile(
                         snapshotManager().snapshotPath(taggedSnapshot.id()),
-                        fileIO.readFileUtf8(tagManager.tagPath(tagName)));
+                        fileIO.readFileUtf8(tagManager.tagPath(tagName)),
+                        false);
                 snapshotManager.commitEarliestHint(taggedSnapshot.id());
             }
         } catch (IOException e) {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -526,7 +526,7 @@ public class SnapshotManager implements Serializable {
     }
 
     public void commitChangelog(Changelog changelog, long id) throws IOException {
-        fileIO.writeFileUtf8(longLivedChangelogPath(id), changelog.toJson());
+        fileIO.writeFile(longLivedChangelogPath(id), changelog.toJson(), false);
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -114,7 +114,7 @@ public class TagManager {
                 // update tag metadata into for the same snapshot of the same tag name.
                 fileIO.overwriteFileUtf8(tagPath, content);
             } else {
-                fileIO.writeFileUtf8(tagPath, content);
+                fileIO.writeFile(tagPath, content, false);
             }
         } catch (IOException e) {
             throw new RuntimeException(

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogFactoryTest.java
@@ -51,7 +51,7 @@ public class CatalogFactoryTest {
     public void testNotDirectory(@TempDir java.nio.file.Path path) throws IOException {
         Path root = new Path(path.toUri().toString());
         Path warehouse = new Path(root, "warehouse");
-        LocalFileIO.create().writeFileUtf8(warehouse, "");
+        LocalFileIO.create().tryToWriteAtomic(warehouse, "");
         Options options = new Options();
         options.set(WAREHOUSE, warehouse.toString());
         assertThatThrownBy(() -> CatalogFactory.createCatalog(CatalogContext.create(options)))

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -184,11 +184,11 @@ public class ExpireSnapshotsTest {
         BinaryRow partition = gen.getPartition(gen.next());
         Path bucketPath = store.pathFactory().bucketPath(partition, 0);
         Path myDataFile = new Path(bucketPath, "myDataFile");
-        new LocalFileIO().writeFileUtf8(myDataFile, "1");
+        new LocalFileIO().tryToWriteAtomic(myDataFile, "1");
         Path extra1 = new Path(bucketPath, "extra1");
-        fileIO.writeFileUtf8(extra1, "2");
+        fileIO.tryToWriteAtomic(extra1, "2");
         Path extra2 = new Path(bucketPath, "extra2");
-        fileIO.writeFileUtf8(extra2, "3");
+        fileIO.tryToWriteAtomic(extra2, "3");
 
         // create DataFileMeta and ManifestEntry
         List<String> extraFiles = Arrays.asList("extra1", "extra2");

--- a/paimon-core/src/test/java/org/apache/paimon/operation/OrphanFilesCleanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/OrphanFilesCleanTest.java
@@ -595,7 +595,7 @@ public class OrphanFilesCleanTest {
                     fileNamePrefix.get(RANDOM.nextInt(fileNamePrefix.size())) + UUID.randomUUID();
             Path file = new Path(dir, fileName);
             if (RANDOM.nextBoolean()) {
-                fileIO.writeFileUtf8(file, "");
+                fileIO.tryToWriteAtomic(file, "");
             } else {
                 fileIO.mkdirs(file);
             }

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -73,7 +73,7 @@ public class SnapshotManagerTest {
         int firstSnapshotId = random.nextInt(1, 100);
         for (int i = 0; i < numSnapshots; i++) {
             Snapshot snapshot = createSnapshotWithMillis(firstSnapshotId + i, millis.get(i));
-            localFileIO.writeFileUtf8(
+            localFileIO.tryToWriteAtomic(
                     snapshotManager.snapshotPath(firstSnapshotId + i), snapshot.toJson());
         }
 
@@ -110,7 +110,7 @@ public class SnapshotManagerTest {
         // create 10 snapshots
         for (long i = 0; i < 10; i++) {
             Snapshot snapshot = createSnapshotWithMillis(i, millis + i * 1000);
-            localFileIO.writeFileUtf8(snapshotManager.snapshotPath(i), snapshot.toJson());
+            localFileIO.tryToWriteAtomic(snapshotManager.snapshotPath(i), snapshot.toJson());
         }
         // smaller than the second snapshot return the first snapshot
         assertThat(snapshotManager.earlierOrEqualTimeMills(millis + 999).timeMillis())
@@ -132,7 +132,7 @@ public class SnapshotManagerTest {
         // create 10 snapshots
         for (long i = 0; i < 10; i++) {
             Snapshot snapshot = createSnapshotWithMillis(i, millis, Long.MIN_VALUE);
-            localFileIO.writeFileUtf8(snapshotManager.snapshotPath(i), snapshot.toJson());
+            localFileIO.tryToWriteAtomic(snapshotManager.snapshotPath(i), snapshot.toJson());
         }
         // smaller than the second snapshot
         assertThat(snapshotManager.laterOrEqualWatermark(millis + 999)).isNull();
@@ -224,7 +224,7 @@ public class SnapshotManagerTest {
                             null,
                             null,
                             null);
-            localFileIO.writeFileUtf8(snapshotManager.snapshotPath(i), snapshot.toJson());
+            localFileIO.tryToWriteAtomic(snapshotManager.snapshotPath(i), snapshot.toJson());
         }
 
         // read all
@@ -301,13 +301,13 @@ public class SnapshotManagerTest {
         long millis = 1L;
         for (long i = 1; i <= 5; i++) {
             Changelog changelog = createChangelogWithMillis(i, millis + i * 1000);
-            localFileIO.writeFileUtf8(
+            localFileIO.tryToWriteAtomic(
                     snapshotManager.longLivedChangelogPath(i), changelog.toJson());
         }
 
         for (long i = 6; i <= 10; i++) {
             Snapshot snapshot = createSnapshotWithMillis(i, millis + i * 1000);
-            localFileIO.writeFileUtf8(snapshotManager.snapshotPath(i), snapshot.toJson());
+            localFileIO.tryToWriteAtomic(snapshotManager.snapshotPath(i), snapshot.toJson());
         }
 
         Assertions.assertThat(snapshotManager.earliestLongLivedChangelogId()).isEqualTo(1);

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedureTest.scala
@@ -44,9 +44,9 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
     val orphanFile1 = new Path(tablePath, "bucket-0/orphan_file1")
     val orphanFile2 = new Path(tablePath, "bucket-0/orphan_file2")
 
-    fileIO.writeFileUtf8(orphanFile1, "a")
+    fileIO.tryToWriteAtomic(orphanFile1, "a")
     Thread.sleep(2000)
-    fileIO.writeFileUtf8(orphanFile2, "b")
+    fileIO.tryToWriteAtomic(orphanFile2, "b")
 
     // by default, no file deleted
     checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row("Deleted=0") :: Nil)

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
@@ -300,7 +300,7 @@ abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
     Assertions.assertEquals(1, statsFileCount(tableLocation, fileIO))
 
     val orphanStats = new Path(tableLocation, "statistics/stats-orphan-0")
-    fileIO.writeFileUtf8(orphanStats, "x")
+    fileIO.tryToWriteAtomic(orphanStats, "x")
     Assertions.assertEquals(2, statsFileCount(tableLocation, fileIO))
 
     // test clean orhan statistic


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Old writeFileUtf8 should only be used by commit, others should throw exception when file existing. So this PR introduces a new writeFile.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
