### PR TITLE
[spark] Avoid unnecessary get splits in spark scan

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -92,7 +92,7 @@ abstract class PaimonBaseScan(
     _readBuilder
   }
 
-  def getOriginSplits: Array[Split] = {
+  private def getOriginSplits: Array[Split] = {
     readBuilder
       .newScan()
       .asInstanceOf[InnerTableScan]

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -19,6 +19,7 @@
 package org.apache.paimon.spark
 
 import org.apache.paimon.{stats, CoreOptions}
+import org.apache.paimon.annotation.VisibleForTesting
 import org.apache.paimon.predicate.{Predicate, PredicateBuilder}
 import org.apache.paimon.spark.metric.SparkMetricRegistry
 import org.apache.paimon.spark.schema.PaimonMetadataColumn
@@ -92,7 +93,8 @@ abstract class PaimonBaseScan(
     _readBuilder
   }
 
-  private def getOriginSplits: Array[Split] = {
+  @VisibleForTesting
+  def getOriginSplits: Array[Split] = {
     readBuilder
       .newScan()
       .asInstanceOf[InnerTableScan]

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonInputPartition.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonInputPartition.scala
@@ -22,7 +22,11 @@ import org.apache.paimon.table.source.Split
 
 import org.apache.spark.sql.connector.read.InputPartition
 
-case class PaimonInputPartition(splits: Seq[Split]) extends InputPartition {}
+case class PaimonInputPartition(splits: Seq[Split]) extends InputPartition {
+  def rowCount(): Long = {
+    splits.map(_.rowCount()).sum
+  }
+}
 
 object PaimonInputPartition {
   def apply(split: Split): PaimonInputPartition = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonStatistics.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonStatistics.scala
@@ -34,7 +34,7 @@ import scala.collection.JavaConverters._
 
 case class PaimonStatistics[T <: PaimonBaseScan](scan: T) extends Statistics {
 
-  private lazy val rowCount: Long = scan.getOriginSplits.map(_.rowCount).sum
+  private lazy val rowCount: Long = scan.getInputPartitions.map(_.rowCount()).sum
 
   private lazy val scannedTotalSize: Long = rowCount * scan.readSchema().defaultSize
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Avoid unnecessary get splits in spark scan

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
