### PR TITLE
[core] Read deletion indexes at once to reduce file IO in splits generation

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorIndexFileMaintainer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorIndexFileMaintainer.java
@@ -52,7 +52,7 @@ public class DeletionVectorIndexFileMaintainer {
                         .map(deletionFile -> new Path(deletionFile.path()).getName())
                         .distinct()
                         .collect(Collectors.toList());
-        indexFileHandler.scan().stream()
+        indexFileHandler.scanEntries().stream()
                 .filter(
                         indexManifestEntry ->
                                 touchedIndexFileNames.contains(

--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsMaintainer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsMaintainer.java
@@ -148,7 +148,8 @@ public class DeletionVectorsMaintainer {
             List<IndexFileMeta> indexFiles =
                     snapshotId == null
                             ? Collections.emptyList()
-                            : handler.scan(snapshotId, DELETION_VECTORS_INDEX, partition).stream()
+                            : handler.scanEntries(snapshotId, DELETION_VECTORS_INDEX, partition)
+                                    .stream()
                                     .map(IndexManifestEntry::indexFile)
                                     .collect(Collectors.toList());
             Map<String, DeletionVector> deletionVectors =

--- a/paimon-core/src/main/java/org/apache/paimon/index/PartitionIndex.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/PartitionIndex.java
@@ -111,7 +111,7 @@ public class PartitionIndex {
             long targetBucketRowNumber,
             IntPredicate loadFilter,
             IntPredicate bucketFilter) {
-        List<IndexManifestEntry> files = indexFileHandler.scan(HASH_INDEX, partition);
+        List<IndexManifestEntry> files = indexFileHandler.scanEntries(HASH_INDEX, partition);
         Int2ShortHashMap.Builder mapBuilder = Int2ShortHashMap.builder();
         Map<Integer, Long> buckets = new HashMap<>();
         for (IndexManifestEntry file : files) {

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -725,7 +725,7 @@ public class FileStoreCommitTest {
 
         // assert part1
         List<IndexManifestEntry> part1Index =
-                indexFileHandler.scan(snapshot.id(), HASH_INDEX, part1);
+                indexFileHandler.scanEntries(snapshot.id(), HASH_INDEX, part1);
         assertThat(part1Index.size()).isEqualTo(2);
 
         IndexManifestEntry indexManifestEntry =
@@ -740,7 +740,7 @@ public class FileStoreCommitTest {
 
         // assert part2
         List<IndexManifestEntry> part2Index =
-                indexFileHandler.scan(snapshot.id(), HASH_INDEX, part2);
+                indexFileHandler.scanEntries(snapshot.id(), HASH_INDEX, part2);
         assertThat(part2Index.size()).isEqualTo(1);
         assertThat(part2Index.get(0).bucket()).isEqualTo(2);
         assertThat(indexFileHandler.readHashIndexList(part2Index.get(0).indexFile()))
@@ -752,7 +752,7 @@ public class FileStoreCommitTest {
         snapshot = store.snapshotManager().latestSnapshot();
 
         // assert update part1
-        part1Index = indexFileHandler.scan(snapshot.id(), HASH_INDEX, part1);
+        part1Index = indexFileHandler.scanEntries(snapshot.id(), HASH_INDEX, part1);
         assertThat(part1Index.size()).isEqualTo(2);
 
         indexManifestEntry =

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/DynamicBucketTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/DynamicBucketTableITCase.java
@@ -122,7 +122,7 @@ public class DynamicBucketTableITCase extends CatalogITCaseBase {
         IndexFileHandler indexFileHandler = table.store().newIndexFileHandler();
         List<BinaryRow> partitions = table.newScan().listPartitions();
         List<IndexManifestEntry> entries = new ArrayList<>();
-        partitions.forEach(p -> entries.addAll(indexFileHandler.scan(HASH_INDEX, p)));
+        partitions.forEach(p -> entries.addAll(indexFileHandler.scanEntries(HASH_INDEX, p)));
 
         Long records =
                 entries.stream().map(entry -> entry.indexFile().rowCount()).reduce(Long::sum).get();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

 Read deletion indexes at once to reduce file IO in splits generation

### Tests

Test on tpcds q23a

before
```shell
grep FsStats spark-thrift-server.log | grep web_sales | wc
   7437   81807 1770826
```

after
```shell
grep FsStats spark-thrift-server.log | grep web_sales | wc
     67     737   16257
```


### Documentation

<!-- Does this change introduce a new feature -->
