### PR TITLE
[core] Fix that FileDeletionBase#dataFileSkipper might skip tag when deleting tag

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -332,8 +332,8 @@ public abstract class FileDeletionBase<T extends Snapshot> {
                 cachedTag = previousTag.id();
                 cachedTagDataFiles.clear();
                 addMergedDataFiles(cachedTagDataFiles, previousTag);
-                return entry -> containsDataFile(cachedTagDataFiles, entry);
             }
+            return entry -> containsDataFile(cachedTagDataFiles, entry);
         }
         return entry -> false;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -75,8 +75,8 @@ public abstract class FileDeletionBase<T extends Snapshot> {
     protected final Executor ioExecutor;
     protected boolean changelogDecoupled;
 
-    /** Used to record which tag is cached in tagged snapshots list. */
-    private int cachedTagIndex = -1;
+    /** Used to record which tag is cached. */
+    private long cachedTag = 0;
 
     /** Used to cache data files used by current tag. */
     private final Map<BinaryRow, Map<Integer, Set<String>>> cachedTagDataFiles = new HashMap<>();
@@ -326,13 +326,16 @@ public abstract class FileDeletionBase<T extends Snapshot> {
             List<Snapshot> taggedSnapshots, long expiringSnapshotId) throws Exception {
         int index = TagManager.findPreviousTag(taggedSnapshots, expiringSnapshotId);
         // refresh tag data files
-        if (index >= 0 && cachedTagIndex != index) {
-            cachedTagIndex = index;
-            cachedTagDataFiles.clear();
-            addMergedDataFiles(cachedTagDataFiles, taggedSnapshots.get(index));
+        if (index >= 0) {
+            Snapshot previousTag = taggedSnapshots.get(index);
+            if (previousTag.id() != cachedTag) {
+                cachedTag = previousTag.id();
+                cachedTagDataFiles.clear();
+                addMergedDataFiles(cachedTagDataFiles, previousTag);
+                return entry -> containsDataFile(cachedTagDataFiles, entry);
+            }
         }
-
-        return entry -> index >= 0 && containsDataFile(cachedTagDataFiles, entry);
+        return entry -> false;
     }
 
     /**


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Scenario: If a stream writing job is running and expiring snapshots, and then deleting tags around the expiring snapshots, might lead to the skipping set is wrong and the reading job will throw FileNotFoundException.

The problem is，the `taggedSnapshots` may be changed. 
TODO: maybe should check delete tags.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
