### PR TITLE
[flink] fix BranchesTable column created_from_tag and created_from_snapshot should be nullable.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/system/BranchesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/BranchesTable.java
@@ -71,8 +71,8 @@ public class BranchesTable implements ReadonlyTable {
                             new DataField(
                                     0, "branch_name", SerializationUtils.newStringType(false)),
                             new DataField(
-                                    1, "created_from_tag", SerializationUtils.newStringType(false)),
-                            new DataField(2, "created_from_snapshot", new BigIntType(false)),
+                                    1, "created_from_tag", SerializationUtils.newStringType(true)),
+                            new DataField(2, "created_from_snapshot", new BigIntType(true)),
                             new DataField(3, "create_time", new TimestampType(false, 3))));
 
     private final FileIO fileIO;


### PR DESCRIPTION

### Purpose

When we create a empty branch，created_from_tag and created_from_snapshot should be null.If isnullable is false and use sql 'select * form xxx$branches' query,it will throw a exception:

Caused by: org.apache.flink.table.api.TableException: Column 'created_from_tag' is NOT NULL, however, a null value is being written into it. You can set job configuration 'table.exec.sink.not-null-enforcer'='DROP' to suppress this exception and drop such records silently.
	at org.apache.flink.table.runtime.operators.sink.ConstraintEnforcer.processNotNullConstraint(ConstraintEnforcer.java:261)
	at org.apache.flink.table.runtime.operators.sink.ConstraintEnforcer.processElement(ConstraintEnforcer.java:241)
	at org.apache.flink.streaming.runtime.tasks.ChainingOutput.pushToOperator(ChainingOutput.java:108)
	at org.apache.flink.streaming.runtime.tasks.ChainingOutput.collect(ChainingOutput.java:77)
	at org.apache.flink.streaming.runtime.tasks.ChainingOutput.collect(ChainingOutput.java:39)
	at org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask$AsyncDataOutputToOutput.emitRecord(SourceOperatorStreamTask.java:309)
	at org.apache.flink.streaming.api.operators.source.NoOpTimestampsAndWatermarks$TimestampsOnlyOutput.collect(NoOpTimestampsAndWatermarks.java:98)
	at org.apache.paimon.flink.source.FlinkRecordsWithSplitIds.emitRecord(FlinkRecordsWithSplitIds.java:134)
	at org.apache.paimon.flink.source.FileStoreSourceReader.lambda$new$1(FileStoreSourceReader.java:60)
	at org.apache.flink.connector.base.source.reader.SourceReaderBase.pollNext(SourceReaderBase.java:160)
	at org.apache.flink.streaming.api.operators.SourceOperator.emitNext(SourceOperator.java:419)
	at org.apache.flink.streaming.runtime.io.StreamTaskSourceInput.emitNext(StreamTaskSourceInput.java:68)
	at org.apache.flink.streaming.runtime.io.StreamOneInputProcessor.processInput(StreamOneInputProcessor.java:65)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.processInput(StreamTask.java:562)
	at org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor.runMailboxLoop(MailboxProcessor.java:231)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.runMailboxLoop(StreamTask.java:858)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.invoke(StreamTask.java:807)
	at org.apache.flink.runtime.taskmanager.Task.runWithSystemExitMonitoring(Task.java:953)
	at org.apache.flink.runtime.taskmanager.Task.restoreAndInvoke(Task.java:932)
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format


### Documentation

