### PR TITLE
[core] Legacy files should always drop delete rows

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.table.source;
 
-import org.apache.paimon.CoreOptions;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
@@ -59,15 +58,9 @@ public final class KeyValueTableRead extends AbstractDataTableRead<KeyValue> {
             Supplier<RawFileSplitRead> batchRawReadSupplier,
             TableSchema schema) {
         super(schema);
-        boolean isLookupChangelogProducer =
-                new CoreOptions(schema.options()).changelogProducer()
-                        == CoreOptions.ChangelogProducer.LOOKUP;
         this.readProviders =
                 Arrays.asList(
-                        new RawFileSplitReadProvider(
-                                batchRawReadSupplier,
-                                isLookupChangelogProducer,
-                                this::assignValues),
+                        new RawFileSplitReadProvider(batchRawReadSupplier, this::assignValues),
                         new MergeFileSplitReadProvider(mergeReadSupplier, this::assignValues),
                         new IncrementalChangelogReadProvider(mergeReadSupplier, this::assignValues),
                         new IncrementalDiffReadProvider(mergeReadSupplier, this::assignValues));

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.table.source;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
@@ -58,9 +59,15 @@ public final class KeyValueTableRead extends AbstractDataTableRead<KeyValue> {
             Supplier<RawFileSplitRead> batchRawReadSupplier,
             TableSchema schema) {
         super(schema);
+        boolean isLookupChangelogProducer =
+                new CoreOptions(schema.options()).changelogProducer()
+                        == CoreOptions.ChangelogProducer.LOOKUP;
         this.readProviders =
                 Arrays.asList(
-                        new RawFileSplitReadProvider(batchRawReadSupplier, this::assignValues),
+                        new RawFileSplitReadProvider(
+                                batchRawReadSupplier,
+                                isLookupChangelogProducer,
+                                this::assignValues),
                         new MergeFileSplitReadProvider(mergeReadSupplier, this::assignValues),
                         new IncrementalChangelogReadProvider(mergeReadSupplier, this::assignValues),
                         new IncrementalDiffReadProvider(mergeReadSupplier, this::assignValues));


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

Old version: Previous versions of Paimon may retain -D records at the highest level for tables with changelog producer=lookup, while Paimon's old reader will filter -D once no matter what.

New version: Paimon will not retain -D data in the top-level files in the new version, and also optimizes the Reader to enter optimization logic when reading top-level data, no longer filtering -D data.

Paimon should filter out - D for old files in the case of changelog-producer=lookup, without going through optimization logic.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
