### PR TITLE
[core] Add an expiration strategy that comparing with partition updat…

### DIFF
--- a/docs/content/flink/expire-partition.md
+++ b/docs/content/flink/expire-partition.md
@@ -29,7 +29,7 @@ under the License.
 You can set `partition.expiration-time` when creating a partitioned table. Paimon streaming sink will periodically check
 the status of partitions and delete expired partitions according to time.
 
-How to determine whether a partition has expired: compare the time extracted from the partition with the current
+How to determine whether a partition has expired: compare the time extracted from the partition or the last update time of the partition with the current
 time to see if survival time has exceeded the `partition.expiration-time`.
 
 {{< hint info >}}
@@ -42,8 +42,9 @@ An example for single partition field:
 ```sql
 CREATE TABLE t (...) PARTITIONED BY (dt) WITH (
     'partition.expiration-time' = '7 d',
-    'partition.expiration-check-interval' = '1 d',
-    'partition.timestamp-formatter' = 'yyyyMMdd'
+    'partition.expiration-check-interval' = '1 d', -- this is required in `values-time` strategy.
+    'partition.timestamp-formatter' = 'yyyyMMdd'   -- this is required in `values-time` strategy.
+    -- ,'partition.expiration-strategy' = 'update-time'
 );
 ```
 
@@ -69,6 +70,17 @@ More options:
     </tr>
     </thead>
     <tbody>
+        <tr>
+            <td><h5>partition.expiration-strategy</h5></td>
+            <td style="word-wrap: break-word;">values-time</td>
+            <td>String</td>
+            <td>
+                Specifies the expiration strategy for partition expiration. 
+                Possible values:
+                <li>values-time: The strategy compares the time extracted from the partition value with the current time.</li>
+                <li>update-time: The strategy compares the last update time of the partition with the current time.</li>
+            </td>
+        </tr>
         <tr>
             <td><h5>partition.expiration-check-interval</h5></td>
             <td style="word-wrap: break-word;">1 h</td>

--- a/docs/content/flink/expire-partition.md
+++ b/docs/content/flink/expire-partition.md
@@ -29,8 +29,17 @@ under the License.
 You can set `partition.expiration-time` when creating a partitioned table. Paimon streaming sink will periodically check
 the status of partitions and delete expired partitions according to time.
 
-How to determine whether a partition has expired: compare the time extracted from the partition or the last update time of the partition with the current
-time to see if survival time has exceeded the `partition.expiration-time`.
+How to determine whether a partition has expired: you can set `partition.expiration-strategy` when creating a partitioned table,
+this strategy determines how to extract the partition time and compare it with the current time to see if survival time
+has exceeded the `partition.expiration-time`. Expiration strategy supported values are:
+
+- `values-time` : The strategy compares the time extracted from the partition value with the current time,
+this strategy as the default.
+- `update-time` : The strategy compares the last update time of the partition with the current time. 
+What is the scenario for this strategy:
+   - Your partition value is non-date formatted.
+   - You only want to keep data that has been updated in the last n days/months/years.
+   - Data initialization imports a large amount of historical data.
 
 {{< hint info >}}
 __Note:__ After the partition expires, it is logically deleted and the latest snapshot cannot query its data. But the
@@ -39,13 +48,32 @@ See [Expire Snapshots]({{< ref "/maintenance/manage-snapshots#expire-snapshots" 
 {{< /hint >}}
 
 An example for single partition field:
+
+`values-time` strategy.
 ```sql
 CREATE TABLE t (...) PARTITIONED BY (dt) WITH (
     'partition.expiration-time' = '7 d',
-    'partition.expiration-check-interval' = '1 d', -- this is required in `values-time` strategy.
+    'partition.expiration-check-interval' = '1 d',
     'partition.timestamp-formatter' = 'yyyyMMdd'   -- this is required in `values-time` strategy.
-    -- ,'partition.expiration-strategy' = 'update-time'
+    'partition.expiration-strategy' = 'values-time' 
 );
+-- Let's say now the date is 2024-07-09，so before the date of 2024-07-02 will expire.
+insert into t values('pk', '2024-07-01');
+```
+
+`update-time` strategy.
+```sql
+CREATE TABLE t (...) PARTITIONED BY (dt) WITH (
+    'partition.expiration-time' = '7 d',
+    'partition.expiration-check-interval' = '1 d',
+    'partition.expiration-strategy' = 'update-time'
+);
+
+-- The last update time of the partition is now, so it will not expire.
+insert into t values('pk', '2024-01-01');
+-- Support non-date formatted partition.
+insert into t values('pk', 'par-1'); 
+
 ```
 
 An example for multiple partition fields:

--- a/docs/content/flink/procedures.md
+++ b/docs/content/flink/procedures.md
@@ -251,19 +251,20 @@ All available procedures are listed below.
 <tr>
       <td>expire_partitions</td>
       <td>
-         CALL sys.expire_partitions(table, expiration_time, timestamp_formatter)<br/><br/>
+         CALL sys.expire_partitions(table, expiration_time, timestamp_formatter, expire_strategy)<br/><br/>
       </td>
       <td>
          To expire partitions. Argument:
             <li>table: the target table identifier. Cannot be empty.</li>
             <li>expiration_time: the expiration interval of a partition. A partition will be expired if it‘s lifetime is over this value. Partition time is extracted from the partition value.</li>
             <li>timestamp_formatter: the formatter to format timestamp from string.</li>
+            <li>expire_strategy: the expiration strategy for partition expiration.</li>
       </td>
       <td>
          -- for Flink 1.18<br/><br/>
-         CALL sys.expire_partitions('default.T', '1 d', 'yyyy-MM-dd')<br/><br/>
+         CALL sys.expire_partitions('default.T', '1 d', 'yyyy-MM-dd', 'values-time')<br/><br/>
          -- for Flink 1.19 and later<br/><br/>
-         CALL sys.expire_partitions(`table` => 'default.T', expiration_time => '1 d', timestamp_formatter => 'yyyy-MM-dd')<br/><br/>
+         CALL sys.expire_partitions(`table` => 'default.T', expiration_time => '1 d', timestamp_formatter => 'yyyy-MM-dd', expire_strategy => 'values-time')<br/><br/>
       </td>
    </tr>
     <tr>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -486,6 +486,12 @@ This config option does not affect the default filesystem metastore.</td>
             <td>The default partition name in case the dynamic partition column value is null/empty string.</td>
         </tr>
         <tr>
+            <td><h5>partition.expiration-strategy</h5></td>
+            <td style="word-wrap: break-word;">values-time</td>
+            <td>String</td>
+            <td>Specifies the expiration strategy for partition expiration.<br />Possible values:<ul><li>values-time: A partition expiration policy that compares the time extracted from the partition value with the current time.</li></ul><ul><li>update-time: A partition expiration policy that compares the last update time of the partition with the current time.</li></ul><br /><br />Possible values:<ul><li>"values-time": The strategy compares the time extracted from the partition value with the current time.</li><li>"update-time": The strategy compares the last update time of the partition with the current time.</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>partition.expiration-check-interval</h5></td>
             <td style="word-wrap: break-word;">1 h</td>
             <td>Duration</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -681,6 +681,26 @@ public class CoreOptions implements Serializable {
                             "Whether only overwrite dynamic partition when overwriting a partitioned table with "
                                     + "dynamic partition columns. Works only when the table has partition keys.");
 
+    public static final ConfigOption<PartitionExpireStrategy> PARTITION_EXPIRATION_STRATEGY =
+            key("partition.expiration-strategy")
+                    .enumType(PartitionExpireStrategy.class)
+                    .defaultValue(PartitionExpireStrategy.VALUES_TIME)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Specifies the expiration strategy for partition expiration.")
+                                    .linebreak()
+                                    .text("Possible values:")
+                                    .list(
+                                            text(
+                                                    PartitionExpireStrategy.VALUES_TIME.value
+                                                            + ": A partition expiration policy that compares the time extracted from the partition value with the current time."))
+                                    .list(
+                                            text(
+                                                    PartitionExpireStrategy.UPDATE_TIME.value
+                                                            + ": A partition expiration policy that compares the last update time of the partition with the current time."))
+                                    .build());
+
     public static final ConfigOption<Duration> PARTITION_EXPIRATION_TIME =
             key("partition.expiration-time")
                     .durationType()
@@ -1765,6 +1785,10 @@ public class CoreOptions implements Serializable {
         return options.get(PARTITION_EXPIRATION_CHECK_INTERVAL);
     }
 
+    public PartitionExpireStrategy partitionExpireStrategy() {
+        return options.get(PARTITION_EXPIRATION_STRATEGY);
+    }
+
     public String partitionTimestampFormatter() {
         return options.get(PARTITION_TIMESTAMP_FORMATTER);
     }
@@ -2481,6 +2505,36 @@ public class CoreOptions implements Serializable {
         private final String description;
 
         ConsumerMode(String value, String description) {
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return text(description);
+        }
+    }
+
+    /** Specifies the expiration strategy for partition expiration. */
+    public enum PartitionExpireStrategy implements DescribedEnum {
+        VALUES_TIME(
+                "values-time",
+                "The strategy compares the time extracted from the partition value with the current time."),
+
+        UPDATE_TIME(
+                "update-time",
+                "The strategy compares the last update time of the partition with the current time.");
+
+        private final String value;
+
+        private final String description;
+
+        PartitionExpireStrategy(String value, String description) {
             this.value = value;
             this.description = description;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -34,6 +34,7 @@ import org.apache.paimon.operation.PartitionExpire;
 import org.apache.paimon.operation.SnapshotDeletion;
 import org.apache.paimon.operation.TagDeletion;
 import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.partition.PartitionExpireStrategy;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.service.ServiceManager;
@@ -264,11 +265,9 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
         }
 
         return new PartitionExpire(
-                partitionType(),
                 partitionExpireTime,
                 options.partitionExpireCheckInterval(),
-                options.partitionTimestampPattern(),
-                options.partitionTimestampFormatter(),
+                PartitionExpireStrategy.createPartitionExpireStrategy(options, partitionType()),
                 newScan(),
                 newCommit(commitUser),
                 metastoreClient);

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionExpireStrategy.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionExpireStrategy.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.partition;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.manifest.PartitionEntry;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.RowDataToObjectArrayConverter;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Strategy for partition expiration. */
+public abstract class PartitionExpireStrategy {
+
+    public List<String> partitionKeys;
+    public CoreOptions options;
+    public RowDataToObjectArrayConverter toObjectArrayConverter;
+
+    public PartitionExpireStrategy(CoreOptions options, RowType partitionType) {
+        this.options = options;
+        this.toObjectArrayConverter = new RowDataToObjectArrayConverter(partitionType);
+        this.partitionKeys = partitionType.getFieldNames();
+    }
+
+    public Map<String, String> toPartitionString(Object[] array) {
+        Map<String, String> map = new LinkedHashMap<>();
+        for (int i = 0; i < partitionKeys.size(); i++) {
+            map.put(partitionKeys.get(i), array[i].toString());
+        }
+        return map;
+    }
+
+    public Object[] convertPartition(BinaryRow partition) {
+        return toObjectArrayConverter.convert(partition);
+    }
+
+    public abstract PartitionPredicate createPartitionPredicate(LocalDateTime expirationTime);
+
+    /**
+     * We need to filter the partition based on the complete information of the partition rather
+     * than on a file-by-file filter under the partition, such as the last update time of the
+     * partition.
+     */
+    public abstract List<PartitionEntry> filterPartitionEntry(
+            List<PartitionEntry> partitionEntries, LocalDateTime expirationTime);
+
+    public static PartitionExpireStrategy createPartitionExpireStrategy(
+            CoreOptions options, RowType partitionType) {
+
+        switch (options.partitionExpireStrategy()) {
+            case UPDATE_TIME:
+                return new PartitionUpdateTimeExpireStrategy(options, partitionType);
+            case VALUES_TIME:
+            default:
+                return new PartitionValuesTimeExpireStrategy(options, partitionType);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionTimeExtractor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionTimeExtractor.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.partition;
 
+import org.apache.paimon.CoreOptions;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,15 +114,18 @@ public class PartitionTimeExtractor {
             }
             dateTime = toLocalDateTime(timestampString, this.formatter);
         } catch (Exception e) {
-            String paritionInfos =
+            String partitionInfos =
                     IntStream.range(0, partitionKeys.size())
                             .mapToObj(i -> partitionKeys.get(i) + ":" + partitionValues.get(i))
                             .collect(Collectors.joining(","));
             LOG.warn(
-                    "Partition {} can't be extract datetime to expire."
+                    "Partition {} can't uses '{}' formatter to extract datetime to expire."
                             + " Please check the partition expiration configuration or"
-                            + " manually delete the partition using the drop-partition command.",
-                    paritionInfos);
+                            + " manually delete the partition using the drop-partition command or"
+                            + " use 'update-time' expiration strategy by set {}, the strategy support non-date formatted partition.",
+                    partitionInfos,
+                    this.formatter,
+                    CoreOptions.PARTITION_EXPIRATION_STRATEGY.key());
         }
         return dateTime;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionUpdateTimeExpireStrategy.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionUpdateTimeExpireStrategy.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.partition;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalArray;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.manifest.PartitionEntry;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.DateTimeUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A partition expiration policy that compares the last update time of the partition to the current
+ * time.
+ */
+public class PartitionUpdateTimeExpireStrategy extends PartitionExpireStrategy {
+
+    public PartitionUpdateTimeExpireStrategy(CoreOptions options, RowType partitionType) {
+        super(options, partitionType);
+    }
+
+    @Override
+    public PartitionPredicate createPartitionPredicate(LocalDateTime expirationTime) {
+        return new PartitionUpdateTimePredicate(expirationTime);
+    }
+
+    @Override
+    public List<PartitionEntry> filterPartitionEntry(
+            List<PartitionEntry> partitionEntries, LocalDateTime expirationTime) {
+        return partitionEntries.stream()
+                .filter(
+                        partitionEntry ->
+                                expirationTime.isAfter(
+                                        DateTimeUtils.toLocalDateTime(
+                                                partitionEntry.lastFileCreationTime())))
+                .collect(Collectors.toList());
+    }
+
+    /** Use the partition's last update time to compare with the current time. */
+    private class PartitionUpdateTimePredicate implements PartitionPredicate {
+
+        private PartitionUpdateTimePredicate(LocalDateTime ignore) {}
+
+        // Always expired, we need to aggregate all partition files creation time and then filter
+        // it.
+        @Override
+        public boolean test(BinaryRow part) {
+            return true;
+        }
+
+        @Override
+        public boolean test(
+                long rowCount,
+                InternalRow minValues,
+                InternalRow maxValues,
+                InternalArray nullCounts) {
+            return true;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionValuesTimeExpireStrategy.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionValuesTimeExpireStrategy.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.partition;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalArray;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.manifest.PartitionEntry;
+import org.apache.paimon.types.RowType;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A partition expiration policy that compare the time extracted from the partition with the current
+ * time.
+ */
+public class PartitionValuesTimeExpireStrategy extends PartitionExpireStrategy {
+
+    private final PartitionTimeExtractor timeExtractor;
+
+    public PartitionValuesTimeExpireStrategy(CoreOptions options, RowType partitionType) {
+        super(options, partitionType);
+        String timePattern = options.partitionTimestampPattern();
+        String timeFormatter = options.partitionTimestampFormatter();
+        this.timeExtractor = new PartitionTimeExtractor(timePattern, timeFormatter);
+    }
+
+    @Override
+    public PartitionPredicate createPartitionPredicate(LocalDateTime expirationTime) {
+        return new PartitionValuesTimePredicate(expirationTime);
+    }
+
+    @Override
+    public List<PartitionEntry> filterPartitionEntry(
+            List<PartitionEntry> partitionEntries, LocalDateTime expirationTime) {
+        return partitionEntries;
+    }
+
+    /** The expired partition predicate uses the date-format value of the partition. */
+    private class PartitionValuesTimePredicate implements PartitionPredicate {
+
+        private final LocalDateTime expireDateTime;
+
+        private PartitionValuesTimePredicate(LocalDateTime expireDateTime) {
+            this.expireDateTime = expireDateTime;
+        }
+
+        @Override
+        public boolean test(BinaryRow partition) {
+            Object[] array = toObjectArrayConverter.convert(partition);
+            LocalDateTime partTime = timeExtractor.extract(partitionKeys, Arrays.asList(array));
+            return partTime != null && expireDateTime.isAfter(partTime);
+        }
+
+        @Override
+        public boolean test(
+                long rowCount,
+                InternalRow minValues,
+                InternalRow maxValues,
+                InternalArray nullCounts) {
+            return true;
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/procedure/ProcedurePositionalArgumentsITCase.java
+++ b/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/procedure/ProcedurePositionalArgumentsITCase.java
@@ -74,7 +74,7 @@ public class ProcedurePositionalArgumentsITCase extends CatalogITCaseBase {
         sql("INSERT INTO T VALUES ('1', '2024-06-01')");
         sql("INSERT INTO T VALUES ('2', '9024-06-01')");
         assertThat(read(table)).containsExactlyInAnyOrder("1:2024-06-01", "2:9024-06-01");
-        sql("CALL sys.expire_partitions('default.T', '1 d', 'yyyy-MM-dd')");
+        sql("CALL sys.expire_partitions('default.T', '1 d', 'yyyy-MM-dd', 'values-time')");
         assertThat(read(table)).containsExactlyInAnyOrder("2:9024-06-01");
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ActionFactory.java
@@ -55,6 +55,7 @@ public interface ActionFactory extends Factory {
     String PARTITION = "partition";
     String EXPIRATIONTIME = "expiration_time";
     String TIMESTAMPFORMATTER = "timestamp_formatter";
+    String EXPIRE_STRATEGY = "expire_strategy";
 
     Optional<Action> create(MultipleParameterToolAdapter params);
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpirePartitionsActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpirePartitionsActionFactory.java
@@ -41,6 +41,7 @@ public class ExpirePartitionsActionFactory implements ActionFactory {
         checkRequiredArgument(params, TIMESTAMPFORMATTER);
         String expirationTime = params.get(EXPIRATIONTIME);
         String timestampFormatter = params.get(TIMESTAMPFORMATTER);
+        String expireStrategy = params.get(EXPIRE_STRATEGY);
 
         Map<String, String> catalogConfig = optionalConfigMap(params, CATALOG_CONF);
 
@@ -51,7 +52,8 @@ public class ExpirePartitionsActionFactory implements ActionFactory {
                         tablePath.f2,
                         catalogConfig,
                         expirationTime,
-                        timestampFormatter));
+                        timestampFormatter,
+                        expireStrategy));
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpirePartitionsProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpirePartitionsProcedureITCase.java
@@ -46,16 +46,26 @@ public class ExpirePartitionsProcedureITCase extends CatalogITCaseBase {
                         + " 'bucket' = '1'"
                         + ")");
         FileStoreTable table = paimonTable("T");
+
         sql("INSERT INTO T VALUES ('1', '2024-06-01')");
-        // Never expire.
-        sql("INSERT INTO T VALUES ('2', '9024-06-01')");
+        // This partition never expires.
+        sql("INSERT INTO T VALUES ('Never-expire', '9999-09-09')");
         Function<InternalRow, String> consumerReadResult =
                 (InternalRow row) -> row.getString(0) + ":" + row.getString(1);
+
         assertThat(read(table, consumerReadResult))
-                .containsExactlyInAnyOrder("1:2024-06-01", "2:9024-06-01");
-        sql(
-                "CALL sys.expire_partitions(`table` => 'default.T', expiration_time => '1 d', timestamp_formatter => 'yyyy-MM-dd')");
-        assertThat(read(table, consumerReadResult)).containsExactlyInAnyOrder("2:9024-06-01");
+                .containsExactlyInAnyOrder("1:2024-06-01", "Never-expire:9999-09-09");
+
+        assertThat(
+                        callExpirePartitions(
+                                "CALL sys.expire_partitions("
+                                        + "`table` => 'default.T'"
+                                        + ", expiration_time => '1 d'"
+                                        + ", timestamp_formatter => 'yyyy-MM-dd')"))
+                .containsExactlyInAnyOrder("dt=2024-06-01");
+
+        assertThat(read(table, consumerReadResult))
+                .containsExactlyInAnyOrder("Never-expire:9999-09-09");
     }
 
     @Test
@@ -71,37 +81,227 @@ public class ExpirePartitionsProcedureITCase extends CatalogITCaseBase {
                         + ")");
         FileStoreTable table = paimonTable("T");
         // Test there are no expired partitions.
-        List<String> result =
-                sql(
-                                "CALL sys.expire_partitions(`table` => 'default.T', expiration_time => '1 d', timestamp_formatter => 'yyyy-MM-dd')")
-                        .stream()
-                        .map(row -> row.getField(0).toString())
-                        .collect(Collectors.toList());
-        assertThat(result).containsExactlyInAnyOrder("No expired partitions.");
+        assertThat(
+                        callExpirePartitions(
+                                "CALL sys.expire_partitions("
+                                        + "`table` => 'default.T'"
+                                        + ", expiration_time => '1 d'"
+                                        + ", timestamp_formatter => 'yyyy-MM-dd')"))
+                .containsExactlyInAnyOrder("No expired partitions.");
 
         sql("INSERT INTO T VALUES ('1', '2024-06-01', '01:00')");
         sql("INSERT INTO T VALUES ('2', '2024-06-02', '02:00')");
-        // Never expire.
-        sql("INSERT INTO T VALUES ('3', '9024-06-01', '03:00')");
+        // This partition never expires.
+        sql("INSERT INTO T VALUES ('Never-expire', '9999-09-09', '99:99')");
 
         Function<InternalRow, String> consumerReadResult =
                 (InternalRow row) ->
                         row.getString(0) + ":" + row.getString(1) + ":" + row.getString(2);
         assertThat(read(table, consumerReadResult))
                 .containsExactlyInAnyOrder(
-                        "1:2024-06-01:01:00", "2:2024-06-02:02:00", "3:9024-06-01:03:00");
+                        "1:2024-06-01:01:00",
+                        "2:2024-06-02:02:00",
+                        "Never-expire:9999-09-09:99:99");
 
-        result =
-                sql(
-                                "CALL sys.expire_partitions(`table` => 'default.T', expiration_time => '1 d', timestamp_formatter => 'yyyy-MM-dd')")
-                        .stream()
-                        .map(row -> row.getField(0).toString())
-                        .collect(Collectors.toList());
         // Show a list of expired partitions.
-        assertThat(result)
+        assertThat(
+                        callExpirePartitions(
+                                "CALL sys.expire_partitions("
+                                        + "`table` => 'default.T'"
+                                        + ", expiration_time => '1 d'"
+                                        + ", timestamp_formatter => 'yyyy-MM-dd')"))
                 .containsExactlyInAnyOrder("dt=2024-06-01, hm=01:00", "dt=2024-06-02, hm=02:00");
 
-        assertThat(read(table, consumerReadResult)).containsExactlyInAnyOrder("3:9024-06-01:03:00");
+        assertThat(read(table, consumerReadResult))
+                .containsExactlyInAnyOrder("Never-expire:9999-09-09:99:99");
+    }
+
+    @Test
+    public void testPartitionExpireValuesTimeStrategy() throws Exception {
+        sql(
+                "CREATE TABLE T ("
+                        + " k STRING,"
+                        + " dt STRING,"
+                        + " PRIMARY KEY (k, dt) NOT ENFORCED"
+                        + ") PARTITIONED BY (dt) WITH ("
+                        + " 'bucket' = '1'"
+                        + ")");
+        FileStoreTable table = paimonTable("T");
+        Function<InternalRow, String> consumerReadResult =
+                (InternalRow row) -> row.getString(0) + ":" + row.getString(1);
+
+        sql("INSERT INTO T VALUES ('HXH', '2024-06-01')");
+        // This partition never expires.
+        sql("INSERT INTO T VALUES ('Never-expire', '9999-09-09')");
+
+        assertThat(read(table, consumerReadResult))
+                .containsExactlyInAnyOrder("HXH:2024-06-01", "Never-expire:9999-09-09");
+
+        assertThat(
+                        callExpirePartitions(
+                                "CALL sys.expire_partitions(`table` => 'default.T',"
+                                        + " expiration_time => '1 d',"
+                                        + " timestamp_formatter => 'yyyy-MM-dd',"
+                                        + " expire_strategy => 'values-time')"))
+                .containsExactlyInAnyOrder("dt=2024-06-01");
+
+        assertThat(read(table, consumerReadResult))
+                .containsExactlyInAnyOrder("Never-expire:9999-09-09");
+    }
+
+    @Test
+    public void testPartitionExpireUpdateTimeStrategy() throws Exception {
+        sql(
+                "CREATE TABLE T ("
+                        + " k STRING,"
+                        + " dt STRING,"
+                        + " hm STRING,"
+                        + " PRIMARY KEY (k, dt, hm) NOT ENFORCED"
+                        + ") PARTITIONED BY (dt, hm) WITH ("
+                        + " 'bucket' = '1'"
+                        + ")");
+        FileStoreTable table = paimonTable("T");
+        Function<InternalRow, String> consumerReadResult =
+                (InternalRow row) ->
+                        row.getString(0) + ":" + row.getString(1) + ":" + row.getString(2);
+
+        // This partition will expire.
+        sql("INSERT INTO T VALUES ('Max-Date', '9999-09-09', '99:99')");
+        // Waiting for partition 'pt=9999-09-09, hm=99:99' to expire.
+        Thread.sleep(2500);
+        sql("INSERT INTO T VALUES ('HXH', '2024-06-01', '01:00')");
+        sql("INSERT INTO T VALUES ('HXH', '2024-06-01', '02:00')");
+
+        // Partitions that are updated within 2 second would be retained.
+        assertThat(
+                        callExpirePartitions(
+                                "CALL sys.expire_partitions("
+                                        + "`table` => 'default.T'"
+                                        + ",expiration_time => '2 s'"
+                                        + ",expire_strategy => 'update-time')"))
+                .containsExactlyInAnyOrder("dt=9999-09-09, hm=99:99");
+
+        assertThat(read(table, consumerReadResult))
+                .containsExactlyInAnyOrder("HXH:2024-06-01:01:00", "HXH:2024-06-01:02:00");
+
+        // Waiting for all partitions to expire.
+        Thread.sleep(1500);
+        // All partition will expire.
+        assertThat(
+                        callExpirePartitions(
+                                "CALL sys.expire_partitions("
+                                        + "`table` => 'default.T',"
+                                        + " expiration_time => '1 s',"
+                                        + " expire_strategy => 'update-time')"))
+                .containsExactlyInAnyOrder("dt=2024-06-01, hm=01:00", "dt=2024-06-01, hm=02:00");
+
+        assertThat(read(table, consumerReadResult)).isEmpty();
+    }
+
+    @Test
+    public void testPartitionExpireUpdateTimeStrategyInOnePartition() throws Exception {
+        sql(
+                "CREATE TABLE T ("
+                        + " k STRING,"
+                        + " dt STRING,"
+                        + " hm STRING,"
+                        + " PRIMARY KEY (k, dt, hm) NOT ENFORCED"
+                        + ") PARTITIONED BY (dt, hm) WITH ("
+                        + " 'bucket' = '1'"
+                        + ")");
+        FileStoreTable table = paimonTable("T");
+        Function<InternalRow, String> consumerReadResult =
+                (InternalRow row) ->
+                        row.getString(0) + ":" + row.getString(1) + ":" + row.getString(2);
+
+        // This partition will not expire.
+        sql("INSERT INTO T VALUES ('HXH', '2024-06-01', '01:00')");
+        // Waiting for partitions 'pt=2024-06-01, hm=01:00' to expire.
+        Thread.sleep(2500);
+        // Updating the same partition data will update partition last update time, then this
+        // partition will not expire.
+        sql("INSERT INTO T VALUES ('HXH', '2024-06-01', '01:00')");
+
+        // Partitions that are updated within 2 second would be retained,in this case no expired
+        // partitions.
+        assertThat(
+                        callExpirePartitions(
+                                "CALL sys.expire_partitions("
+                                        + "`table` => 'default.T',"
+                                        + " expiration_time => '2 s',"
+                                        + " expire_strategy => 'update-time')"))
+                .containsExactlyInAnyOrder("No expired partitions.");
+
+        assertThat(read(table, consumerReadResult))
+                .containsExactlyInAnyOrder("HXH:2024-06-01:01:00");
+
+        // Waiting for all partitions to expire.
+        Thread.sleep(1500);
+
+        // The partition 'dt=2024-06-01, hm=01:00' will expire.
+        assertThat(
+                        callExpirePartitions(
+                                "CALL sys.expire_partitions("
+                                        + "`table` => 'default.T',"
+                                        + " expiration_time => '1 s',"
+                                        + " expire_strategy => 'update-time')"))
+                .containsExactlyInAnyOrder("dt=2024-06-01, hm=01:00");
+
+        assertThat(read(table, consumerReadResult)).isEmpty();
+    }
+
+    @Test
+    public void testPartitionExpireWithNonDateFormatPartition() throws Exception {
+        sql(
+                "CREATE TABLE T ("
+                        + " k STRING,"
+                        + " dt STRING,"
+                        + " hm STRING,"
+                        + " PRIMARY KEY (k, dt, hm) NOT ENFORCED"
+                        + ") PARTITIONED BY (dt, hm) WITH ("
+                        + " 'bucket' = '1'"
+                        + ")");
+        FileStoreTable table = paimonTable("T");
+        Function<InternalRow, String> consumerReadResult =
+                (InternalRow row) ->
+                        row.getString(0) + ":" + row.getString(1) + ":" + row.getString(2);
+        // This partition will expire.
+        sql("INSERT INTO T VALUES ('HXH', 'pt-1', 'hm-1')");
+        Thread.sleep(2500);
+        sql("INSERT INTO T VALUES ('HXH', 'pt-2', 'hm-2')");
+        sql("INSERT INTO T VALUES ('HXH', 'pt-3', 'hm-3')");
+
+        // Only update-time strategy support non date format partition to expire.
+        assertThat(
+                        callExpirePartitions(
+                                "CALL sys.expire_partitions("
+                                        + "`table` => 'default.T',"
+                                        + " expiration_time => '2 s',"
+                                        + " expire_strategy => 'update-time')"))
+                .containsExactlyInAnyOrder("dt=pt-1, hm=hm-1");
+
+        assertThat(read(table, consumerReadResult))
+                .containsExactlyInAnyOrder("HXH:pt-2:hm-2", "HXH:pt-3:hm-3");
+
+        // Waiting for all partitions to expire.
+        Thread.sleep(1500);
+
+        assertThat(
+                        callExpirePartitions(
+                                "CALL sys.expire_partitions("
+                                        + "`table` => 'default.T',"
+                                        + " expiration_time => '1 s',"
+                                        + " expire_strategy => 'update-time')"))
+                .containsExactlyInAnyOrder("dt=pt-2, hm=hm-2", "dt=pt-3, hm=hm-3");
+
+        assertThat(read(table, consumerReadResult)).isEmpty();
+    }
+
+    /** Return a list of expired partitions. */
+    public List<String> callExpirePartitions(String callSql) {
+        return sql(callSql).stream()
+                .map(row -> row.getField(0).toString())
+                .collect(Collectors.toList());
     }
 
     private List<String> read(

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/ExpirePartitionsProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/ExpirePartitionsProcedureTest.scala
@@ -59,12 +59,12 @@ class ExpirePartitionsProcedureTest extends PaimonSparkTestBase with StreamTest 
             inputData.addData(("a", "2024-06-01"))
             stream.processAllAvailable()
 
-            // snapshot-2
-            inputData.addData(("b", "9024-06-01"))
+            // This partition never expires.
+            inputData.addData(("Never-expire", "9999-09-09"))
             stream.processAllAvailable()
 
-            checkAnswer(query(), Row("a", "2024-06-01") :: Row("b", "9024-06-01") :: Nil)
-            // expire
+            checkAnswer(query(), Row("a", "2024-06-01") :: Row("Never-expire", "9999-09-09") :: Nil)
+            // call expire_partitions.
             checkAnswer(
               spark.sql(
                 "CALL paimon.sys.expire_partitions(table => 'test.T', expiration_time => '1 d'" +
@@ -72,7 +72,7 @@ class ExpirePartitionsProcedureTest extends PaimonSparkTestBase with StreamTest 
               Row("pt=2024-06-01") :: Nil
             )
 
-            checkAnswer(query(), Row("b", "9024-06-01") :: Nil)
+            checkAnswer(query(), Row("Never-expire", "9999-09-09") :: Nil)
 
           } finally {
             stream.stop()
@@ -122,25 +122,281 @@ class ExpirePartitionsProcedureTest extends PaimonSparkTestBase with StreamTest 
             inputData.addData(("b", "2024-06-02", "02:00"))
             stream.processAllAvailable()
             // snapshot-3, never expires.
-            inputData.addData(("c", "9024-06-03", "03:00"))
+            inputData.addData(("Never-expire", "9999-09-09", "99:99"))
             stream.processAllAvailable()
 
             checkAnswer(
               query(),
               Row("a", "2024-06-01", "01:00") :: Row("b", "2024-06-02", "02:00") :: Row(
-                "c",
-                "9024-06-03",
-                "03:00") :: Nil)
+                "Never-expire",
+                "9999-09-09",
+                "99:99") :: Nil)
 
-            // expire
+            // Show a list of expired partitions.
             checkAnswer(
               spark.sql(
-                "CALL paimon.sys.expire_partitions(table => 'test.T', expiration_time => '1 d'" +
+                "CALL paimon.sys.expire_partitions(table => 'test.T'" +
+                  ", expiration_time => '1 d'" +
                   ", timestamp_formatter => 'yyyy-MM-dd')"),
               Row("pt=2024-06-01, hm=01:00") :: Row("pt=2024-06-02, hm=02:00") :: Nil
             )
 
-            checkAnswer(query(), Row("c", "9024-06-03", "03:00") :: Nil)
+            checkAnswer(query(), Row("Never-expire", "9999-09-09", "99:99") :: Nil)
+
+          } finally {
+            stream.stop()
+          }
+      }
+    }
+  }
+
+  test("Paimon Procedure: expire partitions with values-time strategy.") {
+    failAfter(streamingTimeout) {
+      withTempDir {
+        checkpointDir =>
+          spark.sql(s"""
+                       |CREATE TABLE T (k STRING, pt STRING)
+                       |TBLPROPERTIES ('primary-key'='k,pt', 'bucket'='1')
+                       | PARTITIONED BY (pt)
+                       |""".stripMargin)
+          val location = loadTable("T").location().toString
+
+          val inputData = MemoryStream[(String, String)]
+          val stream = inputData
+            .toDS()
+            .toDF("k", "pt")
+            .writeStream
+            .option("checkpointLocation", checkpointDir.getCanonicalPath)
+            .foreachBatch {
+              (batch: Dataset[Row], _: Long) =>
+                batch.write.format("paimon").mode("append").save(location)
+            }
+            .start()
+
+          val query = () => spark.sql("SELECT * FROM T")
+
+          try {
+            // snapshot-1
+            inputData.addData(("HXH", "2024-06-01"))
+            stream.processAllAvailable()
+
+            // Never expire.
+            inputData.addData(("Never-expire", "9999-09-09"))
+            stream.processAllAvailable()
+
+            checkAnswer(
+              query(),
+              Row("HXH", "2024-06-01") :: Row("Never-expire", "9999-09-09") :: Nil)
+            // expire
+            checkAnswer(
+              spark.sql(
+                "CALL paimon.sys.expire_partitions(table => 'test.T'," +
+                  " expiration_time => '1 d'" +
+                  ", timestamp_formatter => 'yyyy-MM-dd'" +
+                  ",expire_strategy => 'values-time')"),
+              Row("pt=2024-06-01") :: Nil
+            )
+
+            checkAnswer(query(), Row("Never-expire", "9999-09-09") :: Nil)
+
+          } finally {
+            stream.stop()
+          }
+      }
+    }
+  }
+
+  test("Paimon Procedure: expire partitions with update-time strategy.") {
+    failAfter(streamingTimeout) {
+      withTempDir {
+        checkpointDir =>
+          spark.sql(s"""
+                       |CREATE TABLE T (k STRING, pt STRING)
+                       |TBLPROPERTIES ('primary-key'='k,pt', 'bucket'='1')
+                       | PARTITIONED BY (pt)
+                       |""".stripMargin)
+          val location = loadTable("T").location().toString
+
+          val inputData = MemoryStream[(String, String)]
+          val stream = inputData
+            .toDS()
+            .toDF("k", "pt")
+            .writeStream
+            .option("checkpointLocation", checkpointDir.getCanonicalPath)
+            .foreachBatch {
+              (batch: Dataset[Row], _: Long) =>
+                batch.write.format("paimon").mode("append").save(location)
+            }
+            .start()
+
+          val query = () => spark.sql("SELECT * FROM T")
+
+          try {
+            // This partition will expire.
+            inputData.addData(("HXH", "9999-09-09"))
+            stream.processAllAvailable()
+            // Waiting for partition 'pt=9999-09-09' to expire.
+            Thread.sleep(2500L)
+            // snapshot-2
+            inputData.addData(("HXH", "2024-06-01"))
+            stream.processAllAvailable()
+
+            // Partitions that are updated within 2 second would be retained.
+            checkAnswer(
+              spark.sql(
+                "CALL paimon.sys.expire_partitions(" +
+                  "table => 'test.T'," +
+                  " expiration_time => '2 s'" +
+                  ",expire_strategy => 'update-time')"),
+              Row("pt=9999-09-09") :: Nil
+            )
+
+            checkAnswer(query(), Row("HXH", "2024-06-01") :: Nil)
+
+            // Waiting for all partitions to expire.
+            Thread.sleep(1500)
+            // All partition will expire.
+            checkAnswer(
+              spark.sql(
+                "CALL paimon.sys.expire_partitions(" +
+                  "table => 'test.T'," +
+                  " expiration_time => '1 s'" +
+                  ",expire_strategy => 'update-time')"),
+              Row("pt=2024-06-01") :: Nil
+            )
+
+            checkAnswer(query(), Nil)
+
+          } finally {
+            stream.stop()
+          }
+      }
+    }
+  }
+
+  test("Paimon Procedure: expire partitions with update-time strategy in same partition.") {
+    failAfter(streamingTimeout) {
+      withTempDir {
+        checkpointDir =>
+          spark.sql(s"""
+                       |CREATE TABLE T (k STRING, pt STRING, hm STRING)
+                       |TBLPROPERTIES ('primary-key'='k,pt,hm', 'bucket'='1')
+                       | PARTITIONED BY (pt,hm)
+                       |""".stripMargin)
+          val location = loadTable("T").location().toString
+
+          val inputData = MemoryStream[(String, String, String)]
+          val stream = inputData
+            .toDS()
+            .toDF("k", "pt", "hm")
+            .writeStream
+            .option("checkpointLocation", checkpointDir.getCanonicalPath)
+            .foreachBatch {
+              (batch: Dataset[Row], _: Long) =>
+                batch.write.format("paimon").mode("append").save(location)
+            }
+            .start()
+
+          val query = () => spark.sql("SELECT * FROM T")
+
+          try {
+            // This partition will not expire.
+            inputData.addData(("HXH", "2024-06-01", "01:00"))
+            stream.processAllAvailable()
+            // Waiting for 'pt=9999-09-09, hm=99:99' partitions to expire.
+            Thread.sleep(2500L)
+            // Updating the same partition data will update partition last update time, then this partition will not expire.
+            inputData.addData(("HXH", "2024-06-01", "01:00"))
+            stream.processAllAvailable()
+
+            // The last update time of the 'pt=9999-09-09, hm=99:99' partition is updated so the partition would not expire.
+            checkAnswer(
+              spark.sql(
+                "CALL paimon.sys.expire_partitions(table => 'test.T'," +
+                  " expiration_time => '2 s'" +
+                  ",expire_strategy => 'update-time')"),
+              Row("No expired partitions.") :: Nil
+            )
+
+            checkAnswer(query(), Row("HXH", "2024-06-01", "01:00") :: Nil)
+            // Waiting for all partitions to expire.
+            Thread.sleep(1500)
+
+            // The partition 'dt=2024-06-01, hm=01:00' will expire.
+            checkAnswer(
+              spark.sql(
+                "CALL paimon.sys.expire_partitions(table => 'test.T'," +
+                  " expiration_time => '1 s'" +
+                  ",expire_strategy => 'update-time')"),
+              Row("pt=2024-06-01, hm=01:00") :: Nil
+            )
+
+            checkAnswer(query(), Nil)
+
+          } finally {
+            stream.stop()
+          }
+      }
+    }
+  }
+
+  test("Paimon Procedure: expire partitions with non-date format partition.") {
+    failAfter(streamingTimeout) {
+      withTempDir {
+        checkpointDir =>
+          spark.sql(s"""
+                       |CREATE TABLE T (k STRING, pt STRING)
+                       |TBLPROPERTIES ('primary-key'='k,pt', 'bucket'='1')
+                       | PARTITIONED BY (pt)
+                       |""".stripMargin)
+          val location = loadTable("T").location().toString
+
+          val inputData = MemoryStream[(String, String)]
+          val stream = inputData
+            .toDS()
+            .toDF("k", "pt")
+            .writeStream
+            .option("checkpointLocation", checkpointDir.getCanonicalPath)
+            .foreachBatch {
+              (batch: Dataset[Row], _: Long) =>
+                batch.write.format("paimon").mode("append").save(location)
+            }
+            .start()
+
+          val query = () => spark.sql("SELECT * FROM T")
+
+          try {
+            // This partition will expire.
+            inputData.addData(("HXH", "pt-1"))
+            stream.processAllAvailable()
+            Thread.sleep(2500L)
+            // snapshot-2
+            inputData.addData(("HXH", "pt-2"))
+            stream.processAllAvailable()
+
+            // Only update-time strategy support non date format partition to expire.
+            checkAnswer(
+              spark.sql(
+                "CALL paimon.sys.expire_partitions(table => 'test.T'," +
+                  " expiration_time => '2 s'" +
+                  ",expire_strategy => 'update-time')"),
+              Row("pt=pt-1") :: Nil
+            )
+
+            checkAnswer(query(), Row("HXH", "pt-2") :: Nil)
+
+            // Waiting for all partitions to expire.
+            Thread.sleep(1500)
+            // call expire_partitions.
+            checkAnswer(
+              spark.sql(
+                "CALL paimon.sys.expire_partitions(table => 'test.T'," +
+                  " expiration_time => '1 s'" +
+                  ",expire_strategy => 'update-time')"),
+              Row("pt=pt-2") :: Nil
+            )
+
+            checkAnswer(query(), Nil)
 
           } finally {
             stream.stop()


### PR DESCRIPTION
…e time.

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Add an expiration strategy that comparing with partition update time.

Using `partition.expiration-strategy` option to specifies the expiration strategy for partition expiration.

Possible values: 

VALUES-TIME  (default): A partition expiration policy that compares the time extracted from the partition value with the current time.

UPDATE-TIME :  A partition expiration policy that compares the last update time of the partition with the current time.

What is the value of this feature ：

- If your partition value is not date formatted, you can use `UPDATE-TIME` as your partition expiration policy.

- If you only want to keep data that has been updated in the last n days/months/years, you can use `UPDATE-TIME` as your partition expiration policy.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
