### PR TITLE
[spark] Fix merge into update on source eq target condition

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/RowLevelHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/RowLevelHelper.scala
@@ -66,8 +66,8 @@ trait RowLevelHelper extends SQLConfHelper {
         case Assignment(key, value) => key == value
       }
       .exists {
-        case EqualTo(left: AttributeReference, _) =>
-          isTargetPrimaryKey(left)
+        case EqualTo(left: AttributeReference, right: AttributeReference) =>
+          isTargetPrimaryKey(left) || isTargetPrimaryKey(right)
         case Assignment(key: AttributeReference, _) =>
           isTargetPrimaryKey(key)
         case _ => false

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTestBase.scala
@@ -621,4 +621,28 @@ abstract class MergeIntoTableTestBase extends PaimonSparkTestBase {
       assert(error.contains("Only support to MergeInto table with primary keys."))
     }
   }
+
+  test(s"Paimon MergeInto: update on source eq target condition") {
+    withTable("source", "target") {
+      Seq((1, 100, "c11"), (3, 300, "c33")).toDF("a", "b", "c").createOrReplaceTempView("source")
+
+      sql(s"""
+             |CREATE TABLE target (a INT, b INT, c STRING)
+             |TBLPROPERTIES ('primary-key'='a', 'bucket'='2')
+             |""".stripMargin)
+      sql("INSERT INTO target values (1, 10, 'c1'), (2, 20, 'c2')")
+
+      sql(s"""
+             |MERGE INTO target
+             |USING source
+             |ON source.a = target.a
+             |WHEN MATCHED THEN
+             |UPDATE SET a = source.a, b = source.b, c = source.c
+             |""".stripMargin)
+
+      checkAnswer(
+        sql("SELECT * FROM target ORDER BY a, b"),
+        Row(1, 100, "c11") :: Row(2, 20, "c2") :: Nil)
+    }
+  }
 }

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTestBase.scala
@@ -628,7 +628,7 @@ abstract class MergeIntoTableTestBase extends PaimonSparkTestBase {
 
       sql(s"""
              |CREATE TABLE target (a INT, b INT, c STRING)
-             |TBLPROPERTIES ('primary-key'='a', 'bucket'='2')
+             |TBLPROPERTIES ('primary-key'='a')
              |""".stripMargin)
       sql("INSERT INTO target values (1, 10, 'c1'), (2, 20, 'c2')")
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Before on `target.a = source.a` is OK, this patch fix merge into on `source.a = target.a`, e,g

```sql
MERGE INTO target
USING source
ON source.a = target.a
WHEN MATCHED THEN
UPDATE SET a = source.a, b = source.b, c = source.c
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
