### PR TITLE
[doc] Update spark procedure and dynamic overwrite docs

### DIFF
--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -188,18 +188,17 @@ This section introduce all available spark procedures about paimon.
    <tr>
       <td>reset_consumer</td>
       <td>
-         -- reset the new next snapshot id in the consumer<br/>
-         CALL sys.reset_consumer('identifier', 'consumerId', nextSnapshotId)<br/><br/>
-         -- delete consumer<br/>
-         CALL sys.reset_consumer(table => 'identifier', consumerId => 'consumerId')
-      </td>
-      <td>
          To reset or delete consumer. Arguments:
             <li>identifier: the target table identifier. Cannot be empty.</li>
             <li>consumerId: consumer to be reset or deleted.</li>
             <li>nextSnapshotId (Long): the new next snapshot id of the consumer.</li>
       </td>
-      <td>CALL sys.reset_consumer(table => 'default.T', consumerId => 'myid', nextSnapshotId=> 10)</td>
+      <td>
+         -- reset the new next snapshot id in the consumer<br/>
+         CALL sys.reset_consumer(table => 'default.T', consumerId => 'myid', nextSnapshotId => 10)<br/><br/>
+         -- delete consumer<br/>
+         CALL sys.reset_consumer(table => 'default.T', consumerId => 'myid')
+      </td>
    </tr>
     </tbody>
 </table>

--- a/docs/content/spark/sql-query.md
+++ b/docs/content/spark/sql-query.md
@@ -78,11 +78,6 @@ You can also force specifying `'incremental-between-scan-mode'`.
 Requires Spark 3.2+.
 
 Paimon supports that use Spark SQL to do the incremental query that implemented by Spark Table Valued Function.
-To enable this needs these configs below:
-
-```text
---conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions
-```
 
 you can use `paimon_incremental_query` in query to extract the incremental data:
 

--- a/docs/content/spark/sql-write.md
+++ b/docs/content/spark/sql-write.md
@@ -67,8 +67,8 @@ Spark's default overwrite mode is `static` partition overwrite. To enable dynami
 For example:
 
 ```sql
-CREATE TABLE T (id INT, pt STRING) PARTITIONED BY (pt);
-INSERT INTO T VALUES (1, 'p1'), (2, 'p2')
+CREATE TABLE my_table (id INT, pt STRING) PARTITIONED BY (pt);
+INSERT INTO my_table VALUES (1, 'p1'), (2, 'p2');
 
 -- Static overwrite (Overwrite the whole table)
 INSERT OVERWRITE my_table VALUES (3, 'p1');

--- a/docs/content/spark/sql-write.md
+++ b/docs/content/spark/sql-write.md
@@ -62,25 +62,39 @@ INSERT OVERWRITE my_table PARTITION (key1 = value1, key2 = value2, ...) SELECT .
 
 ### Dynamic Overwrite
 
-Spark's default overwrite mode is static partition overwrite. To enable dynamic overwritten needs these configs below:
+Spark's default overwrite mode is `static` partition overwrite. To enable dynamic overwritten you need to set the Spark session configuration `spark.sql.sources.partitionOverwriteMode` to `dynamic`
 
-```text
---conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions
-```
-
-Note : If `spark.sql.sources.partitionOverwriteMode` is set to `dynamic` by default in Spark,
-in order to ensure that the insert overwrite function of the Paimon table can be used normally,
-`spark.sql.extensions` should be set to `org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions`.
+For example:
 
 ```sql
--- MyTable is a Partitioned Table
+CREATE TABLE T (id INT, pt STRING) PARTITIONED BY (pt);
+INSERT INTO T VALUES (1, 'p1'), (2, 'p2')
 
--- Static overwrite (Overwrite whole table)
-INSERT OVERWRITE my_table SELECT ...
+-- Static overwrite (Overwrite the whole table)
+INSERT OVERWRITE my_table VALUES (3, 'p1');
 
--- Dynamic overwrite
-                             SET spark.sql.sources.partitionOverwriteMode=dynamic;
-INSERT OVERWRITE my_table SELECT ...
+SELECT * FROM my_table;
+/*
++---+---+
+| id| pt|
++---+---+
+|  3| p1|
++---+---+
+*/
+
+-- Dynamic overwrite (Only overwrite pt='p1')
+SET spark.sql.sources.partitionOverwriteMode=dynamic;
+INSERT OVERWRITE my_table VALUES (3, 'p1');
+
+SELECT * FROM my_table;
+/*
++---+---+
+| id| pt|
++---+---+
+|  2| p2|
+|  3| p1|
++---+---+
+*/
 ```
 
 ## Truncate tables
@@ -90,12 +104,6 @@ TRUNCATE TABLE my_table;
 ```
 
 ## Updating tables
-
-To enable update needs these configs below:
-
-```text
---conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions
-```
 
 spark supports update PrimitiveType and StructType, for example:
 
@@ -118,12 +126,6 @@ UPDATE t SET s.c2 = 'a_new' WHERE s.c1 = 1;
 ```
 
 ## Deleting from table
-
-To enable delete needs these configs below:
-
-```text
---conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions
-```
 
 ```sql
 DELETE FROM my_table WHERE currency = 'UNKNOWN';


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

- Fix sheet misalignment in `procedure` doc
- Make dynamic overwrite description clearer
- Remove `spark.sql.extensions` in other pages, because this is already a necessary configuration in `quick-start` doc

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
