### PR TITLE
[hotfix] fix the spark generic catalog to execute externalCatalog() creates a new hive metastore connection instance.

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkGenericCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkGenericCatalog.java
@@ -35,7 +35,6 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.analysis.NonEmptyNamespaceException;
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalog;
-import org.apache.spark.sql.catalyst.catalog.InMemoryCatalog;
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog;
 import org.apache.spark.sql.connector.catalog.CatalogExtension;
 import org.apache.spark.sql.connector.catalog.CatalogPlugin;
@@ -236,7 +235,8 @@ public class SparkGenericCatalog extends SparkBaseCatalog implements CatalogExte
 
     @Override
     public final void initialize(String name, CaseInsensitiveStringMap options) {
-        SessionState sessionState = SparkSession.active().sessionState();
+        SparkSession sparkSession = SparkSession.active();
+        SessionState sessionState = sparkSession.sessionState();
         Configuration hadoopConf = sessionState.newHadoopConf();
         SparkConf sparkConf = new SparkConf();
         if (options.containsKey(METASTORE.key())
@@ -253,8 +253,8 @@ public class SparkGenericCatalog extends SparkBaseCatalog implements CatalogExte
                 }
             }
         }
-        if (SparkSession.active().sharedState().externalCatalog().unwrapped()
-                instanceof InMemoryCatalog) {
+        if ("in-memory"
+                .equals(sparkSession.conf().get(StaticSQLConf.CATALOG_IMPLEMENTATION().key()))) {
             LOG.warn("InMemoryCatalog here may cause bad effect.");
         }
 


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

The SparkSession.active().sharedState().externalCatalog().unwrapped() method will create a new hive metastore connection

<img width="896" alt="image" src="https://github.com/apache/paimon/assets/37063904/cc1b10be-6dec-494f-91ea-3c48b5570b7b">

<img width="874" alt="image" src="https://github.com/apache/paimon/assets/37063904/7789ecc6-1289-4094-ac6e-4954db1a4fa0">


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
