### PR TITLE
[core] Introduce scan-ignore-delete for streaming read

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -540,6 +540,12 @@ This config option does not affect the default filesystem metastore.</td>
             <td>The field that generates the row kind for primary key table, the row kind determines which data is '+I', '-U', '+U' or '-D'.</td>
         </tr>
         <tr>
+            <td><h5>scan-ignore-delete</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to ignore delete records when read changelog in streaming mode.</td>
+        </tr>
+        <tr>
             <td><h5>scan.bounded.watermark</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Long</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -321,6 +321,13 @@ public class CoreOptions implements Serializable {
                             "partial-update.ignore-delete")
                     .withDescription("Whether to ignore delete records.");
 
+    public static final ConfigOption<Boolean> SCAN_IGNORE_DELETE =
+            key("scan-ignore-delete")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to ignore delete records when read changelog in streaming mode.");
+
     public static final ConfigOption<SortEngine> SORT_ENGINE =
             key("sort-engine")
                     .enumType(SortEngine.class)
@@ -1465,6 +1472,10 @@ public class CoreOptions implements Serializable {
 
     public boolean ignoreDelete() {
         return options.get(IGNORE_DELETE);
+    }
+
+    public boolean scanIgnoreDelete() {
+        return options.get(SCAN_IGNORE_DELETE);
     }
 
     public SortEngine sortEngine() {

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
@@ -153,7 +153,10 @@ class PrimaryKeyFileStoreTable extends AbstractFileStoreTable {
     @Override
     public InnerTableRead newRead() {
         return new KeyValueTableRead(
-                () -> store().newRead(), () -> store().newBatchRawFileRead(), schema());
+                () -> store().newRead(),
+                () -> store().newBatchRawFileRead(),
+                schema(),
+                coreOptions().scanIgnoreDelete());
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
@@ -139,7 +139,7 @@ public class TestChangelogDataReadWrite {
                         FileFormatDiscover.of(options),
                         pathFactory,
                         options.fileIndexReadEnabled());
-        return new KeyValueTableRead(() -> read, () -> rawFileRead, null);
+        return new KeyValueTableRead(() -> read, () -> rawFileRead, null, false);
     }
 
     public List<DataFileMeta> writeFiles(


### PR DESCRIPTION
### Purpose

Linked issue: close #3677 

Introduce scan-ignore-delete for streaming read

### Tests

1. Added test unit PrimaryKeyFileStoreTableITCase#testLookupChangelogIgnoreDelete

### API and Format

no

### Documentation

no
