### PR TITLE
[doc] Document sequence.field supports fields of all data types

### DIFF
--- a/docs/content/primary-key-table/merge-engine.md
+++ b/docs/content/primary-key-table/merge-engine.md
@@ -354,8 +354,8 @@ By specifying `'merge-engine' = 'first-row'`, users can keep the first row of th
 `deduplicate` merge engine that in the `first-row` merge engine, it will generate insert only changelog.
 
 {{< hint info >}}
-1. You can not specify `sequence.field`.
+1. You can not specify [sequence.field]({{< ref "primary-key-table/sequence-rowkind#sequence-field" >}}).
 2. Not accept `DELETE` and `UPDATE_BEFORE` message. You can config `ignore-delete` to ignore these two kinds records.
-   {{< /hint >}}
+{{< /hint >}}
 
 This is of great help in replacing log deduplication in streaming computation.

--- a/docs/content/primary-key-table/sequence-rowkind.md
+++ b/docs/content/primary-key-table/sequence-rowkind.md
@@ -50,7 +50,7 @@ CREATE TABLE my_table (
 {{< /tabs >}}
 
 The record with the largest `sequence.field` value will be the last to merge, if the values are the same, the input
-order will be used to determine which one is the last one.
+order will be used to determine which one is the last one. `sequence.field` supports fields of all data types.
 
 You can define multiple fields for `sequence.field`, for example `'update_time,flag'`, multiple fields will be compared in order.
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Document sequence.field supports fields of all data types

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
