### PR TITLE
[parquet] ParquetSchemaConverter supports required fields

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/ParquetRowDataWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/ParquetRowDataWriter.java
@@ -59,8 +59,7 @@ public class ParquetRowDataWriter {
 
     public ParquetRowDataWriter(RecordConsumer recordConsumer, RowType rowType, GroupType schema) {
         this.recordConsumer = recordConsumer;
-
-        rowWriter = new RowWriter(rowType, schema);
+        this.rowWriter = new RowWriter(rowType, schema);
     }
 
     /**
@@ -427,6 +426,11 @@ public class ParquetRowDataWriter {
                         recordConsumer.startField(keyName, 0);
                         keyWriter.write(keyArray, i);
                         recordConsumer.endField(keyName, 0);
+                    } else {
+                        throw new IllegalArgumentException(
+                                "Parquet does not support null keys in maps. "
+                                        + "See https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#maps "
+                                        + "for more details.");
                     }
 
                     if (!valueArray.isNullAt(i)) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Cherry-pick https://github.com/apache/flink/pull/24956

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
