### PR TITLE
[core] Fix that FileDeletionBase#dataFileSkipper might skip tag when …

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/SnapshotDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/SnapshotDeletion.java
@@ -48,8 +48,8 @@ public class SnapshotDeletion extends FileDeletionBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(SnapshotDeletion.class);
 
-    /** Used to record which tag is cached in tagged snapshots list. */
-    private int cachedTagIndex = -1;
+    /** Used to record which tag is cached. */
+    private long cachedTag = 0;
 
     /** Used to cache data files used by current tag. */
     private final Map<BinaryRow, Map<Integer, Set<String>>> cachedTagDataFiles = new HashMap<>();
@@ -184,12 +184,15 @@ public class SnapshotDeletion extends FileDeletionBase {
             List<Snapshot> taggedSnapshots, long expiringSnapshotId) throws Exception {
         int index = TagManager.findPreviousTag(taggedSnapshots, expiringSnapshotId);
         // refresh tag data files
-        if (index >= 0 && cachedTagIndex != index) {
-            cachedTagIndex = index;
-            cachedTagDataFiles.clear();
-            addMergedDataFiles(cachedTagDataFiles, taggedSnapshots.get(index));
+        if (index >= 0) {
+            Snapshot previousTag = taggedSnapshots.get(index);
+            if (previousTag.id() != cachedTag) {
+                cachedTag = previousTag.id();
+                cachedTagDataFiles.clear();
+                addMergedDataFiles(cachedTagDataFiles, previousTag);
+            }
+            return entry -> containsDataFile(cachedTagDataFiles, entry);
         }
-
-        return entry -> index >= 0 && containsDataFile(cachedTagDataFiles, entry);
+        return entry -> false;
     }
 }


### PR DESCRIPTION
Purpose
The problem is，the taggedSnapshots may be changed.

This PR refers to [#3650](https://github.com/apache/paimon/pull/3650) on the master branch to modify the 0.8 branch.


Tests
API and Format
Documentation