### PR TITLE
[common] Use Paimon's FileIO to access hadoop-conf-dir with scheme

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/HadoopUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/HadoopUtils.java
@@ -103,7 +103,7 @@ public class HadoopUtils {
         }
 
         for (String possibleHadoopConfPath : possibleHadoopConfPaths) {
-            if (possibleHadoopConfPath != null) {
+            if (!StringUtils.isNullOrWhitespaceOnly(possibleHadoopConfPath)) {
                 foundHadoopConfiguration =
                         addHadoopConfIfFound(result, possibleHadoopConfPath, options);
             }
@@ -111,7 +111,7 @@ public class HadoopUtils {
 
         // Approach 2: Paimon Catalog Option
         final String hadoopConfigPath = options.getString(PATH_HADOOP_CONFIG, null);
-        if (hadoopConfigPath != null && loader.loadOption()) {
+        if (!StringUtils.isNullOrWhitespaceOnly(hadoopConfigPath) && loader.loadOption()) {
             LOG.debug(
                     "Searching Hadoop configuration files in Paimon config: {}", hadoopConfigPath);
             foundHadoopConfiguration =
@@ -121,7 +121,7 @@ public class HadoopUtils {
 
         // Approach 3: HADOOP_CONF_DIR environment variable
         String hadoopConfDir = System.getenv(HADOOP_CONF_ENV);
-        if (hadoopConfDir != null && loader.loadEnv()) {
+        if (!StringUtils.isNullOrWhitespaceOnly(hadoopConfDir) && loader.loadEnv()) {
             LOG.debug("Searching Hadoop configuration files in HADOOP_CONF_DIR: {}", hadoopConfDir);
             foundHadoopConfiguration =
                     addHadoopConfIfFound(result, hadoopConfDir, options)

--- a/paimon-common/src/test/java/org/apache/paimon/utils/HadoopUtilsITCase.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/HadoopUtilsITCase.java
@@ -53,6 +53,7 @@ public class HadoopUtilsITCase {
         assertThat(conf.get("paimon.test.key")).isEqualTo("test.value");
     }
 
+    /** {@link FileIOLoader} for this test. */
     public static class TestFileIOLoader implements FileIOLoader {
 
         private static final String SCHEME = "hadoop-utils-test-file-io";

--- a/paimon-common/src/test/java/org/apache/paimon/utils/HadoopUtilsITCase.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/HadoopUtilsITCase.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.FileIOLoader;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.options.Options;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link HadoopUtils}. */
+public class HadoopUtilsITCase {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    @Test
+    public void testHadoopConfDirWithScheme() throws Exception {
+        LocalFileIO.create()
+                .overwriteFileUtf8(
+                        new Path(tempDir.toString(), "core-site.xml"),
+                        "<property>\n"
+                                + "  <name>paimon.test.key</name>\n"
+                                + "  <value>test.value</value>\n"
+                                + "</property>");
+
+        Options options = new Options();
+        options.set(
+                HadoopUtils.PATH_HADOOP_CONFIG,
+                TestFileIOLoader.SCHEME + "://" + tempDir.toString());
+        Configuration conf = HadoopUtils.getHadoopConfiguration(options);
+        assertThat(conf.get("paimon.test.key")).isEqualTo("test.value");
+    }
+
+    public static class TestFileIOLoader implements FileIOLoader {
+
+        private static final String SCHEME = "hadoop-utils-test-file-io";
+
+        @Override
+        public String getScheme() {
+            return SCHEME;
+        }
+
+        @Override
+        public FileIO load(Path path) {
+            return LocalFileIO.create();
+        }
+    }
+}

--- a/paimon-common/src/test/resources/META-INF/services/org.apache.paimon.fs.FileIOLoader
+++ b/paimon-common/src/test/resources/META-INF/services/org.apache.paimon.fs.FileIOLoader
@@ -14,3 +14,4 @@
 # limitations under the License.
 
 org.apache.paimon.fs.RequireOptionsFileIOLoader
+org.apache.paimon.utils.HadoopUtilsITCase$TestFileIOLoader


### PR DESCRIPTION
### Purpose

Currently `hadoop-conf-dir` only supports local path. This PR uses Paimon's FileIO to access `hadoop-conf-dir` with scheme.

### Tests

* Unit test.

### API and Format

No changes.

### Documentation

No new feature.
