### PR TITLE
[hotfix] Fix deprecated method getRootCause() in assertj

### DIFF
--- a/paimon-flink/paimon-flink-1.16/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-1.16/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
@@ -49,14 +49,14 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
         sql("CREATE TABLE T1 (a STRING, b STRING, c STRING)");
 
         assertThatThrownBy(() -> sql("ALTER TABLE T1 SET ('bucket-key' = 'c')"))
-                .getRootCause()
+                .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Change 'bucket-key' is not supported yet.");
 
         sql(
                 "CREATE TABLE T2 (a STRING, b STRING, c STRING) WITH ('bucket' = '1', 'bucket-key' = 'c')");
         assertThatThrownBy(() -> sql("ALTER TABLE T2 RESET ('bucket-key')"))
-                .getRootCause()
+                .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Change 'bucket-key' is not supported yet.");
 
@@ -64,14 +64,14 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
         sql(
                 "CREATE TABLE T4 (a STRING, b STRING, c STRING) WITH ('merge-engine' = 'partial-update')");
         assertThatThrownBy(() -> sql("ALTER TABLE T4 RESET ('merge-engine')"))
-                .getRootCause()
+                .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Change 'merge-engine' is not supported yet.");
 
         // sequence.field is immutable
         sql("CREATE TABLE T5 (a STRING, b STRING, c STRING) WITH ('sequence.field' = 'b')");
         assertThatThrownBy(() -> sql("ALTER TABLE T5 SET ('sequence.field' = 'c')"))
-                .getRootCause()
+                .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Change 'sequence.field' is not supported yet.");
     }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/kafka/LogSystemITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/kafka/LogSystemITCase.java
@@ -195,7 +195,7 @@ public class LogSystemITCase extends KafkaTableTestBase {
                         () ->
                                 tEnv.executeSql(
                                         "INSERT INTO kafka_file_single_sink SELECT word, COUNT(*) FROM word_table GROUP BY word;"))
-                .getRootCause()
+                .rootCause()
                 .isInstanceOf(ValidationException.class)
                 .hasMessage(
                         "File store continuous reading does not support the log streaming read mode.");

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -424,14 +424,14 @@ public class CatalogTableITCase extends CatalogITCaseBase {
     public void testConflictOption() {
         assertThatThrownBy(
                         () -> sql("CREATE TABLE T (a INT) WITH ('changelog-producer' = 'input')"))
-                .getRootCause()
+                .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining(
                         "Can not set changelog-producer on table without primary keys");
 
         sql("CREATE TABLE T (a INT)");
         assertThatThrownBy(() -> sql("ALTER TABLE T SET ('changelog-producer'='input')"))
-                .getRootCause()
+                .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining(
                         "Can not set changelog-producer on table without primary keys");
@@ -449,7 +449,7 @@ public class CatalogTableITCase extends CatalogITCaseBase {
                         + "    PRIMARY KEY (dt, hh, user_id) NOT ENFORCED\n"
                         + ")");
         assertThatThrownBy(() -> sql("SHOW PARTITIONS NoPartitionTable"))
-                .getRootCause()
+                .rootCause()
                 .isInstanceOf(TableNotPartitionedException.class)
                 .hasMessage("Table default.NoPartitionTable in catalog PAIMON is not partitioned.");
 
@@ -502,7 +502,7 @@ public class CatalogTableITCase extends CatalogITCaseBase {
                         () ->
                                 sql(
                                         "ALTER TABLE PartitionTable DROP PARTITION (`dt` = '2020-10-10')"))
-                .getRootCause()
+                .rootCause()
                 .isInstanceOf(PartitionNotExistException.class)
                 .hasMessage(
                         "Partition CatalogPartitionSpec{{dt=2020-10-10}} of table default.PartitionTable in catalog PAIMON does not exist.");

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/RescaleBucketITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/RescaleBucketITCase.java
@@ -198,7 +198,7 @@ public class RescaleBucketITCase extends CatalogITCaseBase {
 
         // check write without rescale
         assertThatThrownBy(() -> batchSql("INSERT INTO %s VALUES (6)", tableName))
-                .getRootCause()
+                .rootCause()
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage(
                         "Try to write table with a new bucket num 4, but the previous bucket num is 2. "

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
@@ -852,14 +852,14 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
                 "CREATE TABLE T1 (a STRING, b STRING, c STRING) WITH ('bucket' = '1', 'bucket-key' = 'a')");
 
         assertThatThrownBy(() -> sql("ALTER TABLE T1 SET ('bucket-key' = 'c')"))
-                .getRootCause()
+                .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Change 'bucket-key' is not supported yet.");
 
         sql(
                 "CREATE TABLE T2 (a STRING, b STRING, c STRING) WITH ('bucket' = '1', 'bucket-key' = 'c')");
         assertThatThrownBy(() -> sql("ALTER TABLE T2 RESET ('bucket-key')"))
-                .getRootCause()
+                .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Change 'bucket-key' is not supported yet.");
 
@@ -867,14 +867,14 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
         sql(
                 "CREATE TABLE T4 (a STRING, b STRING, c STRING) WITH ('merge-engine' = 'partial-update')");
         assertThatThrownBy(() -> sql("ALTER TABLE T4 RESET ('merge-engine')"))
-                .getRootCause()
+                .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Change 'merge-engine' is not supported yet.");
 
         // sequence.field is immutable
         sql("CREATE TABLE T5 (a STRING, b STRING, c STRING) WITH ('sequence.field' = 'b')");
         assertThatThrownBy(() -> sql("ALTER TABLE T5 SET ('sequence.field' = 'c')"))
-                .getRootCause()
+                .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Change 'sequence.field' is not supported yet.");
     }

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadITCase.java
@@ -298,7 +298,7 @@ public class SparkReadITCase extends SparkReadTestBase {
                         () ->
                                 spark.sql(
                                         "CREATE TABLE T (a INT) TBLPROPERTIES ('changelog-producer' = 'input')"))
-                .getRootCause()
+                .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining(
                         "Can not set changelog-producer on table without primary keys");
@@ -309,7 +309,7 @@ public class SparkReadITCase extends SparkReadTestBase {
                         () ->
                                 spark.sql(
                                         "ALTER TABLE T SET TBLPROPERTIES('changelog-producer' 'input')"))
-                .getRootCause()
+                .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining(
                         "Can not set changelog-producer on table without primary keys");


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Fix deprecated method getRootCause() in assertj

<!-- Linking this pull request to the issue -->
Linked issue: close #https://github.com/apache/paimon/issues/3695

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
