### PR TITLE
[core] Add type and classname in TypeHandle condition when throw IllegalArgumentException

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/BinaryArrayWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BinaryArrayWriter.java
@@ -253,7 +253,12 @@ public final class BinaryArrayWriter extends AbstractBinaryWriter {
             case DOUBLE:
                 return BinaryArrayWriter::setNullDouble;
             default:
-                throw new IllegalArgumentException();
+                String msg =
+                        String.format(
+                                "type %s not support in %s",
+                                elementType.getTypeRoot().toString(),
+                                BinaryArrayWriter.class.getName());
+                throw new IllegalArgumentException(msg);
         }
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/data/BinaryWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BinaryWriter.java
@@ -209,7 +209,11 @@ public interface BinaryWriter {
                         writer.writeRow(
                                 pos, (InternalRow) value, (InternalRowSerializer) rowSerializer);
             default:
-                throw new IllegalArgumentException();
+                String msg =
+                        String.format(
+                                "type %s not support in %s",
+                                elementType.getTypeRoot().toString(), BinaryArray.class.getName());
+                throw new IllegalArgumentException(msg);
         }
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/data/InternalArray.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/InternalArray.java
@@ -131,7 +131,12 @@ public interface InternalArray extends DataGetters {
                 elementGetter = (array, pos) -> array.getRow(pos, rowFieldCount);
                 break;
             default:
-                throw new IllegalArgumentException();
+                String msg =
+                        String.format(
+                                "type %s not support in %s",
+                                elementType.getTypeRoot().toString(),
+                                InternalArray.class.getName());
+                throw new IllegalArgumentException(msg);
         }
         if (!elementType.isNullable()) {
             return elementGetter;

--- a/paimon-common/src/main/java/org/apache/paimon/data/InternalRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/InternalRow.java
@@ -222,7 +222,11 @@ public interface InternalRow extends DataGetters {
                 fieldGetter = row -> row.getRow(fieldPos, rowFieldCount);
                 break;
             default:
-                throw new IllegalArgumentException();
+                String msg =
+                        String.format(
+                                "type %s not support in %s",
+                                fieldType.getTypeRoot().toString(), InternalRow.class.getName());
+                throw new IllegalArgumentException(msg);
         }
         if (!fieldType.isNullable()) {
             return fieldGetter;

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/RowCompactedSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/RowCompactedSerializer.java
@@ -230,7 +230,11 @@ public class RowCompactedSerializer implements Serializer<InternalRow> {
                         (writer, pos, value) -> writer.writeRow((InternalRow) value, rowSerializer);
                 break;
             default:
-                throw new IllegalArgumentException();
+                String msg =
+                        String.format(
+                                "type %s not support in %s",
+                                fieldType.getTypeRoot().toString(), this.getClass().getName());
+                throw new IllegalArgumentException(msg);
         }
 
         if (!fieldType.isNullable()) {
@@ -302,7 +306,12 @@ public class RowCompactedSerializer implements Serializer<InternalRow> {
                 fieldReader = (reader, pos) -> reader.readRow(serializer);
                 break;
             default:
-                throw new IllegalArgumentException();
+                String msg =
+                        String.format(
+                                "type %s not support in %s",
+                                fieldType.getTypeRoot().toString(),
+                                RowCompactedSerializer.class.getName());
+                throw new IllegalArgumentException(msg);
         }
         if (!fieldType.isNullable()) {
             return fieldReader;

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/RowCompactedSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/RowCompactedSerializer.java
@@ -233,7 +233,8 @@ public class RowCompactedSerializer implements Serializer<InternalRow> {
                 String msg =
                         String.format(
                                 "type %s not support in %s",
-                                fieldType.getTypeRoot().toString(), this.getClass().getName());
+                                fieldType.getTypeRoot().toString(),
+                                RowCompactedSerializer.class.getName());
                 throw new IllegalArgumentException(msg);
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldBoolAndAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldBoolAndAgg.java
@@ -46,7 +46,11 @@ public class FieldBoolAndAgg extends FieldAggregator {
                     boolAnd = (boolean) accumulator && (boolean) inputField;
                     break;
                 default:
-                    throw new IllegalArgumentException();
+                    String msg =
+                            String.format(
+                                    "type %s not support in %s",
+                                    fieldType.getTypeRoot().toString(), this.getClass().getName());
+                    throw new IllegalArgumentException(msg);
             }
         }
         return boolAnd;

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldBoolOrAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldBoolOrAgg.java
@@ -46,7 +46,11 @@ public class FieldBoolOrAgg extends FieldAggregator {
                     boolOr = (boolean) accumulator || (boolean) inputField;
                     break;
                 default:
-                    throw new IllegalArgumentException();
+                    String msg =
+                            String.format(
+                                    "type %s not support in %s",
+                                    fieldType.getTypeRoot().toString(), this.getClass().getName());
+                    throw new IllegalArgumentException(msg);
             }
         }
         return boolOr;

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldCountAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldCountAgg.java
@@ -55,7 +55,11 @@ public class FieldCountAgg extends FieldAggregator {
                     count = (long) accumulator + 1L;
                     break;
                 default:
-                    throw new IllegalArgumentException();
+                    String msg =
+                            String.format(
+                                    "type %s not support in %s",
+                                    fieldType.getTypeRoot().toString(), this.getClass().getName());
+                    throw new IllegalArgumentException(msg);
             }
         }
         return count;
@@ -82,7 +86,11 @@ public class FieldCountAgg extends FieldAggregator {
                     count = (long) accumulator - 1L;
                     break;
                 default:
-                    throw new IllegalArgumentException();
+                    String msg =
+                            String.format(
+                                    "type %s not support in %s",
+                                    fieldType.getTypeRoot().toString(), this.getClass().getName());
+                    throw new IllegalArgumentException(msg);
             }
         }
         return count;

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldListaggAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldListaggAgg.java
@@ -57,7 +57,11 @@ public class FieldListaggAgg extends FieldAggregator {
                                     mergeFieldSD, BinaryString.fromString(DELIMITER), inFieldSD);
                     break;
                 default:
-                    throw new IllegalArgumentException();
+                    String msg =
+                            String.format(
+                                    "type %s not support in %s",
+                                    fieldType.getTypeRoot().toString(), this.getClass().getName());
+                    throw new IllegalArgumentException(msg);
             }
         }
         return concatenate;

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldProductAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldProductAgg.java
@@ -79,7 +79,11 @@ public class FieldProductAgg extends FieldAggregator {
                     product = (double) accumulator * (double) inputField;
                     break;
                 default:
-                    throw new IllegalArgumentException();
+                    String msg =
+                            String.format(
+                                    "type %s not support in %s",
+                                    fieldType.getTypeRoot().toString(), this.getClass().getName());
+                    throw new IllegalArgumentException(msg);
             }
         }
         return product;
@@ -124,7 +128,11 @@ public class FieldProductAgg extends FieldAggregator {
                     product = (double) accumulator / (double) inputField;
                     break;
                 default:
-                    throw new IllegalArgumentException();
+                    String msg =
+                            String.format(
+                                    "type %s not support in %s",
+                                    fieldType.getTypeRoot().toString(), this.getClass().getName());
+                    throw new IllegalArgumentException(msg);
             }
         }
         return product;

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldSumAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldSumAgg.java
@@ -78,7 +78,11 @@ public class FieldSumAgg extends FieldAggregator {
                     sum = (double) accumulator + (double) inputField;
                     break;
                 default:
-                    throw new IllegalArgumentException();
+                    String msg =
+                            String.format(
+                                    "type %s not support in %s",
+                                    fieldType.getTypeRoot().toString(), this.getClass().getName());
+                    throw new IllegalArgumentException(msg);
             }
         }
         return sum;
@@ -125,7 +129,11 @@ public class FieldSumAgg extends FieldAggregator {
                     sum = (double) accumulator - (double) inputField;
                     break;
                 default:
-                    throw new IllegalArgumentException();
+                    String msg =
+                            String.format(
+                                    "type %s not support in %s",
+                                    fieldType.getTypeRoot().toString(), this.getClass().getName());
+                    throw new IllegalArgumentException(msg);
             }
         }
         return sum;
@@ -153,7 +161,11 @@ public class FieldSumAgg extends FieldAggregator {
             case DOUBLE:
                 return -((double) value);
             default:
-                throw new IllegalArgumentException();
+                String msg =
+                        String.format(
+                                "type %s not support in %s",
+                                fieldType.getTypeRoot().toString(), this.getClass().getName());
+                throw new IllegalArgumentException(msg);
         }
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Type handle check need more details about type and classname for user dig
Currently when type not matched only throw out IllegalArgumentException without any details which is litter hard for user to dig their job，so add more detail in IllegalArgumentException maybe better.

<!-- Linking this pull request to the issue -->
Linked issue: close https://github.com/apache/paimon/issues/3697

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
