### PR TITLE
[flink] Fix multi-add conflict when two batch jobs are writing into the same partition at the same time

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
@@ -134,6 +134,9 @@ public class TableCommitImpl implements InnerTableCommit {
         if (this.forceCreatingSnapshot) {
             return true;
         }
+        if (overwritePartition != null) {
+            return true;
+        }
         return tagAutoManager != null
                 && tagAutoManager.getTagAutoCreation() != null
                 && tagAutoManager.getTagAutoCreation().forceCreatingSnapshot();
@@ -255,7 +258,7 @@ public class TableCommitImpl implements InnerTableCommit {
                         // identifier must be in increasing order
                         .sorted(Comparator.comparingLong(ManifestCommittable::identifier))
                         .collect(Collectors.toList());
-        if (!retryCommittables.isEmpty() || overwritePartition != null) {
+        if (!retryCommittables.isEmpty()) {
             checkFilesExistence(retryCommittables);
             commitMultiple(retryCommittables, checkAppendFiles);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
@@ -255,7 +255,7 @@ public class TableCommitImpl implements InnerTableCommit {
                         // identifier must be in increasing order
                         .sorted(Comparator.comparingLong(ManifestCommittable::identifier))
                         .collect(Collectors.toList());
-        if (retryCommittables.size() > 0) {
+        if (!retryCommittables.isEmpty() || overwritePartition != null) {
             checkFilesExistence(retryCommittables);
             commitMultiple(retryCommittables, checkAppendFiles);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
@@ -230,6 +230,11 @@ public class TableCommitImpl implements InnerTableCommit {
     }
 
     public int filterAndCommitMultiple(List<ManifestCommittable> committables) {
+        return filterAndCommitMultiple(committables, true);
+    }
+
+    public int filterAndCommitMultiple(
+            List<ManifestCommittable> committables, boolean checkAppendFiles) {
         Set<Long> retryIdentifiers =
                 commit.filterCommitted(
                         committables.stream()
@@ -252,7 +257,7 @@ public class TableCommitImpl implements InnerTableCommit {
                         .collect(Collectors.toList());
         if (retryCommittables.size() > 0) {
             checkFilesExistence(retryCommittables);
-            commitMultiple(retryCommittables, true);
+            commitMultiple(retryCommittables, checkAppendFiles);
         }
         return retryCommittables.size();
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
@@ -53,7 +53,12 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
      * Filter out all {@link GlobalCommitT} which have committed, and commit the remaining {@link
      * GlobalCommitT}.
      */
-    int filterAndCommit(List<GlobalCommitT> globalCommittables) throws IOException;
+    int filterAndCommit(List<GlobalCommitT> globalCommittables, boolean checkAppendFiles)
+            throws IOException;
+
+    default int filterAndCommit(List<GlobalCommitT> globalCommittables) throws IOException {
+        return filterAndCommit(globalCommittables, true);
+    }
 
     Map<Long, List<CommitT>> groupByCheckpoint(Collection<CommitT> committables);
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
@@ -156,8 +156,8 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
     @Override
     public void processWatermark(Watermark mark) throws Exception {
         super.processWatermark(mark);
-        // Do not consume END_INPUT_CHECKPOINT_ID watermark in case of batch or bounded stream
-        if (mark.getTimestamp() != END_INPUT_CHECKPOINT_ID) {
+        // Do not consume Long.MAX_VALUE watermark in case of batch or bounded stream
+        if (mark.getTimestamp() != Long.MAX_VALUE) {
             this.currentWatermark = mark.getTimestamp();
         }
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
@@ -213,9 +213,10 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
             // in the middle.
             // If the job is restarted from the commit operator, endInput will be called again, and
             // the same commit messages will be committed again.
-            // So when `endInput` is called, we must check if these commit messages are already
-            // committed.
-            committer.filterAndCommit(committables);
+            // So when `endInput` is called, we must check if the corresponding snapshot exists.
+            // However, if the snapshot does not exist, then append files must be new files. So
+            // there is no need to check for duplicated append files.
+            committer.filterAndCommit(committables, false);
         } else {
             committer.commit(committables);
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
@@ -45,6 +45,7 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
         implements OneInputStreamOperator<CommitT, CommitT>, BoundedOneInput {
 
     private static final long serialVersionUID = 1L;
+    private static final long END_INPUT_CHECKPOINT_ID = Long.MAX_VALUE;
 
     /** Record all the inputs until commit. */
     private final Deque<CommitT> inputs = new ArrayDeque<>();
@@ -155,8 +156,8 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
     @Override
     public void processWatermark(Watermark mark) throws Exception {
         super.processWatermark(mark);
-        // Do not consume Long.MAX_VALUE watermark in case of batch or bounded stream
-        if (mark.getTimestamp() != Long.MAX_VALUE) {
+        // Do not consume END_INPUT_CHECKPOINT_ID watermark in case of batch or bounded stream
+        if (mark.getTimestamp() != END_INPUT_CHECKPOINT_ID) {
             this.currentWatermark = mark.getTimestamp();
         }
     }
@@ -188,28 +189,37 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
         }
 
         pollInputs();
-        commitUpToCheckpoint(Long.MAX_VALUE);
+        commitUpToCheckpoint(END_INPUT_CHECKPOINT_ID);
     }
 
     @Override
     public void notifyCheckpointComplete(long checkpointId) throws Exception {
         super.notifyCheckpointComplete(checkpointId);
-        commitUpToCheckpoint(endInput ? Long.MAX_VALUE : checkpointId);
+        commitUpToCheckpoint(endInput ? END_INPUT_CHECKPOINT_ID : checkpointId);
     }
 
     private void commitUpToCheckpoint(long checkpointId) throws Exception {
         NavigableMap<Long, GlobalCommitT> headMap =
                 committablesPerCheckpoint.headMap(checkpointId, true);
         List<GlobalCommitT> committables = committables(headMap);
-        committer.commit(committables);
-        headMap.clear();
-
-        if (committables.isEmpty()) {
-            if (committer.forceCreatingSnapshot()) {
-                GlobalCommitT commit = toCommittables(checkpointId, Collections.emptyList());
-                committer.commit(Collections.singletonList(commit));
-            }
+        if (committables.isEmpty() && committer.forceCreatingSnapshot()) {
+            committables =
+                    Collections.singletonList(
+                            toCommittables(checkpointId, Collections.emptyList()));
         }
+
+        if (checkpointId == END_INPUT_CHECKPOINT_ID) {
+            // In new versions of Flink, if a batch job fails, it might restart from some operator
+            // in the middle.
+            // If the job is restarted from the commit operator, endInput will be called again, and
+            // the same commit messages will be committed again.
+            // So when `endInput` is called, we must check if these commit messages are already
+            // committed.
+            committer.filterAndCommit(committables);
+        } else {
+            committer.commit(committables);
+        }
+        headMap.clear();
     }
 
     @Override
@@ -240,12 +250,14 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
             List<CommitT> committables = entry.getValue();
             // To prevent the asynchronous completion of tasks with multiple concurrent bounded
             // stream inputs, which leads to some tasks passing a Committable with cp =
-            // Long.MAX_VALUE during the endInput method call of the current checkpoint, while other
-            // tasks pass a Committable with Long.MAX_VALUE during other checkpoints hence causing
-            // an error here, we have a special handling for Committables with Long.MAX_VALUE:
-            // instead of throwing an error, we merge them.
-            if (cp != null && cp == Long.MAX_VALUE && committablesPerCheckpoint.containsKey(cp)) {
-                // Merge the Long.MAX_VALUE committables here.
+            // END_INPUT_CHECKPOINT_ID during the endInput method call of the current checkpoint,
+            // while other tasks pass a Committable with END_INPUT_CHECKPOINT_ID during other
+            // checkpoints hence causing an error here, we have a special handling for Committables
+            // with END_INPUT_CHECKPOINT_ID: instead of throwing an error, we merge them.
+            if (cp != null
+                    && cp == END_INPUT_CHECKPOINT_ID
+                    && committablesPerCheckpoint.containsKey(cp)) {
+                // Merge the END_INPUT_CHECKPOINT_ID committables here.
                 GlobalCommitT commitT =
                         committer.combine(
                                 cp,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
@@ -117,8 +117,9 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
     }
 
     @Override
-    public int filterAndCommit(List<ManifestCommittable> globalCommittables) {
-        int committed = commit.filterAndCommitMultiple(globalCommittables);
+    public int filterAndCommit(
+            List<ManifestCommittable> globalCommittables, boolean checkAppendFiles) {
+        int committed = commit.filterAndCommitMultiple(globalCommittables, checkAppendFiles);
         if (partitionMarkDone != null) {
             partitionMarkDone.notifyCommittable(globalCommittables);
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
@@ -143,12 +143,15 @@ public class StoreMultiCommitter
     }
 
     @Override
-    public int filterAndCommit(List<WrappedManifestCommittable> globalCommittables)
+    public int filterAndCommit(
+            List<WrappedManifestCommittable> globalCommittables, boolean checkAppendFiles)
             throws IOException {
         int result = 0;
         for (Map.Entry<Identifier, List<ManifestCommittable>> entry :
                 groupByTable(globalCommittables).entrySet()) {
-            result += getStoreCommitter(entry.getKey()).filterAndCommit(entry.getValue());
+            result +=
+                    getStoreCommitter(entry.getKey())
+                            .filterAndCommit(entry.getValue(), checkAppendFiles);
         }
         return result;
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/util/AbstractTestBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/util/AbstractTestBase.java
@@ -118,7 +118,7 @@ public class AbstractTestBase {
         private boolean streamingMode = true;
         private Integer parallelism = null;
         private Integer checkpointIntervalMs = null;
-        private boolean allowRestart = false;
+        private int numRestarts = 0;
         private Configuration conf = new Configuration();
 
         public TableEnvironmentBuilder batchMode() {
@@ -142,12 +142,11 @@ public class AbstractTestBase {
         }
 
         public TableEnvironmentBuilder allowRestart() {
-            this.allowRestart = true;
-            return this;
+            return allowRestart(Integer.MAX_VALUE);
         }
 
-        public TableEnvironmentBuilder allowRestart(boolean allowRestart) {
-            this.allowRestart = allowRestart;
+        public TableEnvironmentBuilder allowRestart(int numRestarts) {
+            this.numRestarts = numRestarts;
             return this;
         }
 
@@ -192,7 +191,7 @@ public class AbstractTestBase {
                                 parallelism);
             }
 
-            if (allowRestart) {
+            if (numRestarts > 0) {
                 tEnv.getConfig()
                         .getConfiguration()
                         .set(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
@@ -200,7 +199,7 @@ public class AbstractTestBase {
                         .getConfiguration()
                         .set(
                                 RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS,
-                                Integer.MAX_VALUE);
+                                numRestarts);
                 tEnv.getConfig()
                         .getConfiguration()
                         .set(


### PR DESCRIPTION
### Purpose

In new versions of Flink, if a batch job fails, it might restart from some operator in the middle.

If the job is restarted from the commit operator, endInput will be called again, and the same commit messages will be committed again.

So when `endInput` is called, we must check if these commit messages are already committed.

### Tests

* IT case.

### API and Format

No changes.

### Documentation

No new feature.
