### PR TITLE
[core] Introduce newWriteSelector to WriteBuilder

### DIFF
--- a/docs/content/program-api/java-api.md
+++ b/docs/content/program-api/java-api.md
@@ -536,6 +536,10 @@ public class BatchWrite {
         GenericRow record2 = GenericRow.of(BinaryString.fromString("Bob"), 5);
         GenericRow record3 = GenericRow.of(BinaryString.fromString("Emily"), 18);
 
+        // If this is a distributed write, you can use writeBuilder.newWriteSelector.
+        // WriteSelector determines to which logical downstream writers a record should be written to.
+        // If it returns empty, no data distribution is required.
+
         write.write(record1);
         write.write(record2);
         write.write(record3);
@@ -656,6 +660,11 @@ public class StreamWriteTable {
             GenericRow record1 = GenericRow.of(BinaryString.fromString("Alice"), 12);
             GenericRow record2 = GenericRow.of(BinaryString.fromString("Bob"), 5);
             GenericRow record3 = GenericRow.of(BinaryString.fromString("Emily"), 18);
+
+            // If this is a distributed write, you can use writeBuilder.newWriteSelector.
+            // WriteSelector determines to which logical downstream writers a record should be written to.
+            // If it returns empty, no data distribution is required.
+
             write.write(record1);
             write.write(record2);
             write.write(record3);

--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStoreTable.java
@@ -34,6 +34,7 @@ import org.apache.paimon.table.query.LocalTableQuery;
 import org.apache.paimon.table.sink.RowKeyExtractor;
 import org.apache.paimon.table.sink.TableCommitImpl;
 import org.apache.paimon.table.sink.TableWriteImpl;
+import org.apache.paimon.table.sink.WriteSelector;
 import org.apache.paimon.table.source.DataTableScan;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.StreamDataTableScan;
@@ -260,6 +261,12 @@ public class PrivilegedFileStoreTable implements FileStoreTable {
     public InnerTableRead newRead() {
         privilegeChecker.assertCanSelect(identifier);
         return wrapped.newRead();
+    }
+
+    @Override
+    public Optional<WriteSelector> newWriteSelector() {
+        privilegeChecker.assertCanInsert(identifier);
+        return wrapped.newWriteSelector();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -41,10 +41,12 @@ import org.apache.paimon.table.sink.CallbackUtils;
 import org.apache.paimon.table.sink.CommitCallback;
 import org.apache.paimon.table.sink.DynamicBucketRowKeyExtractor;
 import org.apache.paimon.table.sink.FixedBucketRowKeyExtractor;
+import org.apache.paimon.table.sink.FixedBucketWriteSelector;
 import org.apache.paimon.table.sink.RowKeyExtractor;
 import org.apache.paimon.table.sink.RowKindGenerator;
 import org.apache.paimon.table.sink.TableCommitImpl;
 import org.apache.paimon.table.sink.UnawareBucketRowKeyExtractor;
+import org.apache.paimon.table.sink.WriteSelector;
 import org.apache.paimon.table.source.DataTableBatchScan;
 import org.apache.paimon.table.source.DataTableStreamScan;
 import org.apache.paimon.table.source.SplitGenerator;
@@ -131,6 +133,19 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
     @Override
     public BucketMode bucketMode() {
         return store().bucketMode();
+    }
+
+    @Override
+    public Optional<WriteSelector> newWriteSelector() {
+        switch (bucketMode()) {
+            case HASH_FIXED:
+                return Optional.of(new FixedBucketWriteSelector(schema()));
+            case BUCKET_UNAWARE:
+                return Optional.empty();
+            default:
+                throw new UnsupportedOperationException(
+                        "Currently, write selector does not support table mode: " + bucketMode());
+        }
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/InnerTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/InnerTable.java
@@ -24,11 +24,14 @@ import org.apache.paimon.table.sink.InnerTableCommit;
 import org.apache.paimon.table.sink.InnerTableWrite;
 import org.apache.paimon.table.sink.StreamWriteBuilder;
 import org.apache.paimon.table.sink.StreamWriteBuilderImpl;
+import org.apache.paimon.table.sink.WriteSelector;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.InnerTableScan;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.ReadBuilderImpl;
 import org.apache.paimon.table.source.StreamDataTableScan;
+
+import java.util.Optional;
 
 /** Inner table for implementation, provide newScan, newRead ... directly. */
 public interface InnerTable extends Table {
@@ -38,6 +41,8 @@ public interface InnerTable extends Table {
     StreamDataTableScan newStreamScan();
 
     InnerTableRead newRead();
+
+    Optional<WriteSelector> newWriteSelector();
 
     InnerTableWrite newWrite(String commitUser);
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/ReadonlyTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ReadonlyTable.java
@@ -23,6 +23,7 @@ import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.sink.InnerTableCommit;
 import org.apache.paimon.table.sink.InnerTableWrite;
 import org.apache.paimon.table.sink.StreamWriteBuilder;
+import org.apache.paimon.table.sink.WriteSelector;
 import org.apache.paimon.table.source.StreamDataTableScan;
 
 import java.time.Duration;
@@ -67,6 +68,14 @@ public interface ReadonlyTable extends InnerTable {
         throw new UnsupportedOperationException(
                 String.format(
                         "Readonly Table %s does not support newStreamWriteBuilder.",
+                        this.getClass().getSimpleName()));
+    }
+
+    @Override
+    default Optional<WriteSelector> newWriteSelector() {
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Readonly Table %s does not support newWriteSelector.",
                         this.getClass().getSimpleName()));
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/BatchWriteBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/BatchWriteBuilderImpl.java
@@ -25,6 +25,7 @@ import org.apache.paimon.types.RowType;
 import javax.annotation.Nullable;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static org.apache.paimon.CoreOptions.createCommitUser;
 
@@ -51,6 +52,11 @@ public class BatchWriteBuilderImpl implements BatchWriteBuilder {
     @Override
     public RowType rowType() {
         return table.rowType();
+    }
+
+    @Override
+    public Optional<WriteSelector> newWriteSelector() {
+        return table.newWriteSelector();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/FixedBucketWriteSelector.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/FixedBucketWriteSelector.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.sink;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.BucketMode;
+
+/** A {@link WriteSelector} for {@link BucketMode#HASH_FIXED} */
+public class FixedBucketWriteSelector implements WriteSelector {
+
+    private static final long serialVersionUID = 1L;
+
+    private final TableSchema schema;
+
+    private transient KeyAndBucketExtractor<InternalRow> extractor;
+
+    public FixedBucketWriteSelector(TableSchema schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public int select(InternalRow row, int numWriters) {
+        if (extractor == null) {
+            extractor = new FixedBucketRowKeyExtractor(schema);
+        }
+        extractor.setRecord(row);
+        return ChannelComputer.select(extractor.partition(), extractor.bucket(), numWriters);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/FixedBucketWriteSelector.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/FixedBucketWriteSelector.java
@@ -22,7 +22,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.BucketMode;
 
-/** A {@link WriteSelector} for {@link BucketMode#HASH_FIXED} */
+/** A {@link WriteSelector} for {@link BucketMode#HASH_FIXED}. */
 public class FixedBucketWriteSelector implements WriteSelector {
 
     private static final long serialVersionUID = 1L;

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/StreamWriteBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/StreamWriteBuilderImpl.java
@@ -22,6 +22,8 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.table.InnerTable;
 import org.apache.paimon.types.RowType;
 
+import java.util.Optional;
+
 import static org.apache.paimon.CoreOptions.createCommitUser;
 
 /** Implementation for {@link WriteBuilder}. */
@@ -46,6 +48,11 @@ public class StreamWriteBuilderImpl implements StreamWriteBuilder {
     @Override
     public RowType rowType() {
         return table.rowType();
+    }
+
+    @Override
+    public Optional<WriteSelector> newWriteSelector() {
+        return table.newWriteSelector();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/WriteBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/WriteBuilder.java
@@ -18,11 +18,13 @@
 
 package org.apache.paimon.table.sink;
 
+import org.apache.paimon.annotation.Experimental;
 import org.apache.paimon.annotation.Public;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.types.RowType;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 /**
  * An interface for building the {@link TableWrite} and {@link TableCommit}.
@@ -37,6 +39,16 @@ public interface WriteBuilder extends Serializable {
 
     /** Returns the row type of this table. */
     RowType rowType();
+
+    /**
+     * Create a {@link WriteSelector} to partition records before writers.
+     *
+     * @return empty if no data distribution is required.
+     * @throws UnsupportedOperationException if this table mode does not support building writes
+     *     through upper level APIs.
+     */
+    @Experimental
+    Optional<WriteSelector> newWriteSelector();
 
     /** Create a {@link TableWrite} to write {@link InternalRow}s. */
     TableWrite newWrite();

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/WriteSelector.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/WriteSelector.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.sink;
+
+import org.apache.paimon.data.InternalRow;
+
+import java.io.Serializable;
+
+/**
+ * The {@link WriteSelector} determines to which logical downstream writers a record should be
+ * written to.
+ */
+public interface WriteSelector extends Serializable {
+
+    /** Returns the logical writer index, to which the given record should be written. */
+    int select(InternalRow row, int numWriters);
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -80,6 +80,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
 
     @Test
+    public void testMultipleWriters() throws Exception {
+        assertThat(
+                        createFileStoreTable(options -> options.set("bucket", "-1"))
+                                .newBatchWriteBuilder()
+                                .newWriteSelector())
+                .isEmpty();
+    }
+
+    @Test
     public void testReadDeletedFiles() throws Exception {
         writeData();
         FileStoreTable table = createFileStoreTable();

--- a/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
@@ -46,6 +46,7 @@ import org.apache.paimon.table.sink.InnerTableCommit;
 import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
 import org.apache.paimon.table.sink.StreamWriteBuilder;
+import org.apache.paimon.table.sink.WriteSelector;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.ReadBuilder;
@@ -135,6 +136,19 @@ public class PrimaryKeyFileStoreTableTest extends FileStoreTableTestBase {
                     rowData.getRowKind().shortString()
                             + " "
                             + COMPATIBILITY_BATCH_ROW_TO_STRING.apply(rowData);
+
+    @Test
+    public void testMultipleWriters() throws Exception {
+        WriteSelector selector =
+                createFileStoreTable(options -> options.set("bucket", "5"))
+                        .newBatchWriteBuilder()
+                        .newWriteSelector()
+                        .orElse(null);
+        assertThat(selector).isNotNull();
+        assertThat(selector.select(rowData(1, 1, 2L), 3)).isEqualTo(1);
+        assertThat(selector.select(rowData(1, 3, 4L), 3)).isEqualTo(1);
+        assertThat(selector.select(rowData(1, 5, 6L), 3)).isEqualTo(2);
+    }
 
     @Test
     public void testAsyncReader() throws Exception {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Compute engines require the ability to write when integrating Paimon, and currently we only have one example of single point writing. We need to add an example of distributed writing.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

new Experimental API: `WriteBuilder.newWriteSelector`:
```
    /**
     * Create a {@link WriteSelector} to partition records before writers.
     *
     * @return empty if no data distribution is required.
     * @throws UnsupportedOperationException if this table mode does not support building writes
     *     through upper level APIs.
     */
    @Experimental
    Optional<WriteSelector> newWriteSelector();
```

WriteSelector:
```
/**
 * The {@link WriteSelector} determines to which logical downstream writers a record should be
 * written to.
 */
public interface WriteSelector extends Serializable {

    /** Returns the logical writer index, to which the given record should be written. */
    int select(InternalRow row, int numWriters);
}
```

### Documentation

<!-- Does this change introduce a new feature -->
