### PR TITLE
[pom] Add maven compiler args to optimize deprecation related logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -775,6 +775,7 @@ under the License.
                         <compilerArgs>
                             <!-- Prevents recompilation due to missing package-info.class, see MCOMPILER-205 -->
                             <arg>-Xpkginfo:always</arg>
+                            <arg>-Xlint:deprecation</arg>
                         </compilerArgs>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Add a `<arg>-Xlint:deprecation</arg>` arg for `maven-compiler-plugin` to optimizing deprecation related messages in build logs.
<!-- Linking this pull request to the issue -->
Linked issue: close #3702

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation
This helps us to discover which deprecation APIs are still being called by `Paimon`.
<!-- Does this change introduce a new feature -->
