### PR TITLE
[hotfix] Fix deprecated methods `all()`, `getContainerIpAddress()`, `PulsarContainer()`, `getLivenessCheckPorts()`, `optionallyMapResourceParameterAsVolume()` in `paimon-flink-cdc`

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionITCaseBase.java
@@ -202,7 +202,7 @@ public abstract class KafkaActionITCaseBase extends CdcActionITCaseBase {
                             .filter(listing -> !listing.isInternal())
                             .map(TopicListing::name)
                             .collect(Collectors.toList());
-            return adminClient.describeTopics(topics).all().get();
+            return adminClient.describeTopics(topics).allTopicNames().get();
         } catch (Exception e) {
             throw new RuntimeException("Failed to list Kafka topics", e);
         }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBContainer.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBContainer.java
@@ -185,11 +185,10 @@ public class MongoDBContainer extends org.testcontainers.containers.MongoDBConta
     }
 
     public String getConnectionString() {
-        return String.format(
-                "mongodb://%s:%d", getContainerIpAddress(), getMappedPort(MONGODB_PORT));
+        return String.format("mongodb://%s:%d", getHost(), getMappedPort(MONGODB_PORT));
     }
 
     public String getHostAndPort() {
-        return String.format("%s:%s", getContainerIpAddress(), getMappedPort(MONGODB_PORT));
+        return String.format("%s:%s", getHost(), getMappedPort(MONGODB_PORT));
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlContainer.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlContainer.java
@@ -54,18 +54,18 @@ public class MySqlContainer extends JdbcDatabaseContainer {
     }
 
     @Override
-    protected Set<Integer> getLivenessCheckPorts() {
+    public Set<Integer> getLivenessCheckPortNumbers() {
         return new HashSet<>(getMappedPort(MYSQL_PORT));
     }
 
     @Override
     protected void configure() {
         optionallyMapResourceParameterAsVolume(
-                MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, "/etc/mysql/", "mysql-default-conf");
+                MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, "/etc/mysql/", "mysql-default-conf", null);
 
         if (parameters.containsKey(SETUP_SQL_PARAM_NAME)) {
             optionallyMapResourceParameterAsVolume(
-                    SETUP_SQL_PARAM_NAME, "/docker-entrypoint-initdb.d/", "N/A");
+                    SETUP_SQL_PARAM_NAME, "/docker-entrypoint-initdb.d/", "N/A", null);
         }
 
         addEnv("MYSQL_DATABASE", databaseName);

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresContainer.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresContainer.java
@@ -34,7 +34,7 @@ public class PostgresContainer
     protected void configure() {
         if (parameters.containsKey(SETUP_SQL_PARAM_NAME)) {
             optionallyMapResourceParameterAsVolume(
-                    SETUP_SQL_PARAM_NAME, "/docker-entrypoint-initdb.d/", "N/A");
+                    SETUP_SQL_PARAM_NAME, "/docker-entrypoint-initdb.d/", "N/A", null);
         }
         super.configure();
     }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/pulsar/PulsarActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/pulsar/PulsarActionITCaseBase.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PulsarContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.io.File;
 import java.io.IOException;
@@ -75,6 +76,8 @@ public class PulsarActionITCaseBase extends CdcActionITCaseBase {
     private static final Network NETWORK = Network.newNetwork();
     private static final String INTER_CONTAINER_PULSAR_ALIAS = "pulsar";
 
+    public static final String IMAGE = "apachepulsar/pulsar";
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     private PulsarAdmin admin;
@@ -87,7 +90,7 @@ public class PulsarActionITCaseBase extends CdcActionITCaseBase {
 
     private static PulsarContainerExtension createPulsarContainerExtension() {
         PulsarContainerExtension container =
-                new PulsarContainerExtension("3.0.0") {
+                new PulsarContainerExtension(DockerImageName.parse(IMAGE + ":" + "3.0.0")) {
                     @Override
                     protected void doStart() {
                         super.doStart();
@@ -284,8 +287,8 @@ public class PulsarActionITCaseBase extends CdcActionITCaseBase {
     /** Pulsar container extension for junit5. */
     private static class PulsarContainerExtension extends PulsarContainer
             implements BeforeAllCallback, AfterAllCallback {
-        private PulsarContainerExtension(String pulsarVersion) {
-            super(pulsarVersion);
+        private PulsarContainerExtension(DockerImageName dockerImageName) {
+            super(dockerImageName);
         }
 
         @Override

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/kafka/KafkaTableTestBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/kafka/KafkaTableTestBase.java
@@ -218,7 +218,7 @@ public abstract class KafkaTableTestBase extends AbstractTestBase {
                             .map(TopicListing::name)
                             .collect(Collectors.toList());
 
-            return adminClient.describeTopics(topics).all().get();
+            return adminClient.describeTopics(topics).allTopicNames().get();
         } catch (Exception e) {
             throw new RuntimeException("Failed to list Kafka topics", e);
         }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Fix deprecated method `all()`, `getContainerIpAddress()`, `PulsarContainer()`, `getLivenessCheckPorts()`, `optionallyMapResourceParameterAsVolume()` in `paimon-flink-cdc`
<!-- Linking this pull request to the issue -->
Linked issue: close #3705

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
