### PR TITLE
[core] Disable forceBufferSpill when io-manager is null.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -79,7 +79,7 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
     private final String spillCompression;
     private SinkWriter sinkWriter;
     private final SimpleColStatsCollector.Factory[] statsCollectors;
-    private final IOManager ioManager;
+    @Nullable private final IOManager ioManager;
     private final FileIndexOptions fileIndexOptions;
 
     private MemorySegmentPool memorySegmentPool;
@@ -87,7 +87,7 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
 
     public AppendOnlyWriter(
             FileIO fileIO,
-            IOManager ioManager,
+            @Nullable IOManager ioManager,
             long schemaId,
             FileFormat fileFormat,
             long targetFileSize,

--- a/paimon-core/src/main/java/org/apache/paimon/disk/RowBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/RowBuffer.java
@@ -61,7 +61,7 @@ public interface RowBuffer {
             boolean spillable,
             MemorySize maxDiskSize,
             String compression) {
-        if (spillable) {
+        if (spillable && ioManager != null) {
             return new ExternalBuffer(ioManager, memoryPool, serializer, maxDiskSize, compression);
         } else {
             return new InMemoryBuffer(memoryPool, serializer);

--- a/paimon-core/src/main/java/org/apache/paimon/disk/RowBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/RowBuffer.java
@@ -61,7 +61,7 @@ public interface RowBuffer {
             boolean spillable,
             MemorySize maxDiskSize,
             String compression) {
-        if (spillable && ioManager != null) {
+        if (spillable) {
             return new ExternalBuffer(ioManager, memoryPool, serializer, maxDiskSize, compression);
         } else {
             return new InMemoryBuffer(memoryPool, serializer);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
@@ -224,6 +224,9 @@ public class AppendOnlyFileStoreWrite extends MemoryFileStoreWrite<InternalRow> 
 
     @Override
     protected void forceBufferSpill() throws Exception {
+        if (ioManager == null) {
+            return;
+        }
         forceBufferSpill = true;
         for (Map<Integer, WriterContainer<InternalRow>> bucketWriters : writers.values()) {
             for (WriterContainer<InternalRow> writerContainer : bucketWriters.values()) {

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -26,7 +26,6 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.ChannelWithMeta;
 import org.apache.paimon.disk.ExternalBuffer;
 import org.apache.paimon.disk.IOManager;
-import org.apache.paimon.disk.InMemoryBuffer;
 import org.apache.paimon.disk.RowBuffer;
 import org.apache.paimon.fileindex.FileIndexOptions;
 import org.apache.paimon.format.FileFormat;
@@ -338,27 +337,6 @@ public class AppendOnlyWriterTest {
         Assertions.assertThat(buffer.size()).isEqualTo(100);
         Assertions.assertThat(buffer.memoryOccupancy()).isLessThanOrEqualTo(16384L);
 
-        writer.close();
-    }
-
-    @Test
-    public void testWithoutIoManager() throws Exception {
-        AppendOnlyWriter writer = createEmptyWriterWithoutIoManager(Long.MAX_VALUE, true);
-
-        // we give it a small Memory Pool, force it to spill
-        writer.setMemoryPool(new HeapMemorySegmentPool(16384L, 1024));
-
-        char[] s = new char[990];
-        Arrays.fill(s, 'a');
-
-        // set the record that much larger than the maxMemory
-        for (int j = 0; j < 100; j++) {
-            writer.write(row(j, String.valueOf(s), PART));
-        }
-
-        RowBuffer buffer = writer.getWriteBuffer();
-
-        Assertions.assertThat(buffer instanceof InMemoryBuffer).isTrue();
         writer.close();
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/operation/AppendOnlyFileStoreWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/AppendOnlyFileStoreWriteTest.java
@@ -27,6 +27,7 @@ import org.apache.paimon.data.BinaryRowWriter;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.ExternalBuffer;
+import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.io.DataFileMeta;
@@ -59,6 +60,7 @@ public class AppendOnlyFileStoreWriteTest {
         FileStoreTable table = createFileStoreTable();
 
         AppendOnlyFileStoreWrite write = (AppendOnlyFileStoreWrite) table.store().newWrite("ss");
+        write.withIOManager(IOManager.create(tempDir.toString()));
         write.withExecutionMode(false);
 
         write.write(partition(0), 0, GenericRow.of(0, 0, 0));


### PR DESCRIPTION
io-manager is null, should not invoke spill.
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
