### PR TITLE
[test] Remove unreachable code in `PaimonSourceTest` class

### DIFF
--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonSourceTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonSourceTest.scala
@@ -746,8 +746,6 @@ class PaimonSourceTest extends PaimonSparkTestBase with StreamTest {
           mergedData += (row._1 -> row._2)
         case false =>
           unmergedData += row
-        case _ =>
-          throw new IllegalArgumentException("Please provide write mode explicitly.")
       }
     }
 
@@ -759,8 +757,6 @@ class PaimonSourceTest extends PaimonSparkTestBase with StreamTest {
           (mergedData.toArray[(Int, String)].map(toRow), latestChanges.map(toRow))
         case false =>
           (unmergedData.sorted.toArray.map(toRow), latestChanges.map(toRow))
-        case _ =>
-          throw new IllegalArgumentException("Please provide write mode explicitly.")
       }
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Remove unreachable code in `PaimonSourceTest` class, cause that `hasPk` is scala's `Boolean` type, the value can only be `true` or `false`, so code `case _ =>` will never be accessed.

<!-- Linking this pull request to the issue -->
Linked issue: close #3710

<!-- What is the purpose of the change -->

### Tests
Passed test cases in `PaimonSourceTest`.
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
