### PR TITLE
[spark] Support StringEndsWith filter in SparkFilterConverter

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexReader.java
@@ -47,6 +47,11 @@ public abstract class FileIndexReader implements FunctionVisitor<FileIndexResult
     }
 
     @Override
+    public FileIndexResult visitEndsWith(FieldRef fieldRef, Object literal) {
+        return REMAIN;
+    }
+
+    @Override
     public FileIndexResult visitLessThan(FieldRef fieldRef, Object literal) {
         return REMAIN;
     }

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/empty/EmptyFileIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/empty/EmptyFileIndexReader.java
@@ -48,6 +48,11 @@ public class EmptyFileIndexReader extends FileIndexReader {
     }
 
     @Override
+    public FileIndexResult visitEndsWith(FieldRef fieldRef, Object literal) {
+        return SKIP;
+    }
+
+    @Override
     public FileIndexResult visitLessThan(FieldRef fieldRef, Object literal) {
         return SKIP;
     }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/EndsWith.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/EndsWith.java
@@ -48,11 +48,7 @@ public class EndsWith extends NullFalseLeafBinaryFunction {
             Object max,
             Long nullCount,
             Object patternLiteral) {
-        BinaryString minStr = (BinaryString) min;
-        BinaryString maxStr = (BinaryString) max;
-        BinaryString pattern = (BinaryString) patternLiteral;
-        return (minStr.endsWith(pattern) || minStr.compareTo(pattern) <= 0)
-                && (maxStr.endsWith(pattern) || maxStr.compareTo(pattern) >= 0);
+        return true;
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/EndsWith.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/EndsWith.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.predicate;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.types.DataType;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A {@link NullFalseLeafBinaryFunction} to evaluate {@code filter like '%abc' or filter like
+ * 'abc_'}.
+ */
+public class EndsWith extends NullFalseLeafBinaryFunction {
+
+    public static final EndsWith INSTANCE = new EndsWith();
+
+    private EndsWith() {}
+
+    @Override
+    public boolean test(DataType type, Object field, Object patternLiteral) {
+        BinaryString fieldString = (BinaryString) field;
+        return fieldString.endsWith((BinaryString) patternLiteral);
+    }
+
+    @Override
+    public boolean test(
+            DataType type,
+            long rowCount,
+            Object min,
+            Object max,
+            Long nullCount,
+            Object patternLiteral) {
+        BinaryString minStr = (BinaryString) min;
+        BinaryString maxStr = (BinaryString) max;
+        BinaryString pattern = (BinaryString) patternLiteral;
+        return (minStr.endsWith(pattern) || minStr.compareTo(pattern) <= 0)
+                && (maxStr.endsWith(pattern) || maxStr.compareTo(pattern) >= 0);
+    }
+
+    @Override
+    public Optional<LeafFunction> negate() {
+        return Optional.empty();
+    }
+
+    @Override
+    public <T> T visit(FunctionVisitor<T> visitor, FieldRef fieldRef, List<Object> literals) {
+        return visitor.visitEndsWith(fieldRef, literals.get(0));
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/EndsWith.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/EndsWith.java
@@ -48,8 +48,11 @@ public class EndsWith extends NullFalseLeafBinaryFunction {
             Object max,
             Long nullCount,
             Object patternLiteral) {
-        // Can not support min max test in EndsWith
-        return true;
+        BinaryString minStr = (BinaryString) min;
+        BinaryString maxStr = (BinaryString) max;
+        BinaryString pattern = (BinaryString) patternLiteral;
+        return (minStr.endsWith(pattern) || minStr.compareTo(pattern) <= 0)
+                && (maxStr.endsWith(pattern) || maxStr.compareTo(pattern) >= 0);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/EndsWith.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/EndsWith.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 
 /**
  * A {@link NullFalseLeafBinaryFunction} to evaluate {@code filter like '%abc' or filter like
- * 'abc_'}.
+ * '_abc'}.
  */
 public class EndsWith extends NullFalseLeafBinaryFunction {
 

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/EndsWith.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/EndsWith.java
@@ -48,11 +48,8 @@ public class EndsWith extends NullFalseLeafBinaryFunction {
             Object max,
             Long nullCount,
             Object patternLiteral) {
-        BinaryString minStr = (BinaryString) min;
-        BinaryString maxStr = (BinaryString) max;
-        BinaryString pattern = (BinaryString) patternLiteral;
-        return (minStr.endsWith(pattern) || minStr.compareTo(pattern) <= 0)
-                && (maxStr.endsWith(pattern) || maxStr.compareTo(pattern) >= 0);
+        // Can not support min max test in EndsWith
+        return true;
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/FunctionVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/FunctionVisitor.java
@@ -50,6 +50,8 @@ public interface FunctionVisitor<T> extends PredicateVisitor<T> {
 
     T visitStartsWith(FieldRef fieldRef, Object literal);
 
+    T visitEndsWith(FieldRef fieldRef, Object literal);
+
     T visitLessThan(FieldRef fieldRef, Object literal);
 
     T visitGreaterOrEqual(FieldRef fieldRef, Object literal);

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/OnlyPartitionKeyEqualVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/OnlyPartitionKeyEqualVisitor.java
@@ -58,6 +58,11 @@ public class OnlyPartitionKeyEqualVisitor implements FunctionVisitor<Boolean> {
     }
 
     @Override
+    public Boolean visitEndsWith(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
     public Boolean visitLessThan(FieldRef fieldRef, Object literal) {
         return false;
     }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
@@ -107,6 +107,10 @@ public class PredicateBuilder {
         return leaf(StartsWith.INSTANCE, idx, patternLiteral);
     }
 
+    public Predicate endsWith(int idx, Object patternLiteral) {
+        return leaf(EndsWith.INSTANCE, idx, patternLiteral);
+    }
+
     public Predicate leaf(NullFalseLeafBinaryFunction function, int idx, Object literal) {
         DataField field = rowType.getFields().get(idx);
         return new LeafPredicate(function, field.type(), idx, field.name(), singletonList(literal));

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
@@ -383,14 +383,14 @@ public class PredicateTest {
     @Test
     public void testEndsWith() {
         PredicateBuilder builder = new PredicateBuilder(RowType.of(new VarCharType()));
-        Predicate predicate = builder.endsWith(0, fromString("abc"));
-        GenericRow row = GenericRow.of(fromString("aabc"));
-        assertThat(predicate.test(row)).isEqualTo(true);
+        Predicate predicate = builder.endsWith(0, fromString("bcc"));
+        GenericRow row = GenericRow.of(fromString("aabbcc"));
 
-        GenericRow max = GenericRow.of(fromString("www"));
-        GenericRow min = GenericRow.of(fromString("aaa"));
+        GenericRow max = GenericRow.of(fromString("aaba"));
+        GenericRow min = GenericRow.of(fromString("aabb"));
         Integer[] nullCount = {null};
-        assertThat(predicate.test(10, min, max, new GenericArray(nullCount))).isEqualTo(true);
+        assertThat(predicate.test(row)).isEqualTo(true);
+        assertThat(predicate.test(10, min, max, new GenericArray(nullCount))).isEqualTo(false);
     }
 
     @Test

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
@@ -390,7 +390,7 @@ public class PredicateTest {
         GenericRow min = GenericRow.of(fromString("aabb"));
         Integer[] nullCount = {null};
         assertThat(predicate.test(row)).isEqualTo(true);
-        assertThat(predicate.test(10, min, max, new GenericArray(nullCount))).isEqualTo(false);
+        assertThat(predicate.test(10, min, max, new GenericArray(nullCount))).isEqualTo(true);
     }
 
     @Test

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
@@ -18,10 +18,12 @@
 
 package org.apache.paimon.predicate;
 
+import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.format.SimpleColStats;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.VarCharType;
 
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.apache.paimon.data.BinaryString.fromString;
 import static org.apache.paimon.predicate.SimpleColStatsTestUtils.test;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -375,6 +378,19 @@ public class PredicateTest {
                 .isEqualTo(false);
         assertThat(test(predicate, 1, new SimpleColStats[] {new SimpleColStats(null, null, 1L)}))
                 .isEqualTo(false);
+    }
+
+    @Test
+    public void testEndsWith() {
+        PredicateBuilder builder = new PredicateBuilder(RowType.of(new VarCharType()));
+        Predicate predicate = builder.endsWith(0, fromString("abc"));
+        GenericRow row = GenericRow.of(fromString("aabc"));
+        assertThat(predicate.test(row)).isEqualTo(true);
+
+        GenericRow max = GenericRow.of(fromString("xasxwsa"));
+        GenericRow min = GenericRow.of(fromString("aaaaa"));
+        Integer[] nullCount = {null};
+        assertThat(predicate.test(10, min, max, new GenericArray(nullCount))).isEqualTo(true);
     }
 
     @Test

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
@@ -387,8 +387,8 @@ public class PredicateTest {
         GenericRow row = GenericRow.of(fromString("aabc"));
         assertThat(predicate.test(row)).isEqualTo(true);
 
-        GenericRow max = GenericRow.of(fromString("xasxwsa"));
-        GenericRow min = GenericRow.of(fromString("aaaaa"));
+        GenericRow max = GenericRow.of(fromString("www"));
+        GenericRow min = GenericRow.of(fromString("aaa"));
         Integer[] nullCount = {null};
         assertThat(predicate.test(10, min, max, new GenericArray(nullCount))).isEqualTo(true);
     }

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/filter/OrcPredicateFunctionVisitor.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/filter/OrcPredicateFunctionVisitor.java
@@ -65,6 +65,11 @@ public class OrcPredicateFunctionVisitor
     }
 
     @Override
+    public Optional<OrcFilters.Predicate> visitEndsWith(FieldRef fieldRef, Object literal) {
+        return Optional.empty();
+    }
+
+    @Override
     public Optional<OrcFilters.Predicate> visitLessThan(FieldRef fieldRef, Object literal) {
         return convertBinary(fieldRef, literal, OrcFilters.LessThan::new);
     }

--- a/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
+++ b/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
@@ -142,6 +142,11 @@ public class ParquetFilters {
         }
 
         @Override
+        public FilterPredicate visitEndsWith(FieldRef fieldRef, Object literal) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public FilterPredicate visitIn(FieldRef fieldRef, List<Object> literals) {
             throw new UnsupportedOperationException();
         }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkFilterConverter.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkFilterConverter.java
@@ -23,7 +23,21 @@ import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 
-import org.apache.spark.sql.sources.*;
+import org.apache.spark.sql.sources.And;
+import org.apache.spark.sql.sources.EqualNullSafe;
+import org.apache.spark.sql.sources.EqualTo;
+import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.sources.GreaterThan;
+import org.apache.spark.sql.sources.GreaterThanOrEqual;
+import org.apache.spark.sql.sources.In;
+import org.apache.spark.sql.sources.IsNotNull;
+import org.apache.spark.sql.sources.IsNull;
+import org.apache.spark.sql.sources.LessThan;
+import org.apache.spark.sql.sources.LessThanOrEqual;
+import org.apache.spark.sql.sources.Not;
+import org.apache.spark.sql.sources.Or;
+import org.apache.spark.sql.sources.StringEndsWith;
+import org.apache.spark.sql.sources.StringStartsWith;
 
 import java.util.Arrays;
 import java.util.List;

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkFilterConverter.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkFilterConverter.java
@@ -23,20 +23,7 @@ import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 
-import org.apache.spark.sql.sources.And;
-import org.apache.spark.sql.sources.EqualNullSafe;
-import org.apache.spark.sql.sources.EqualTo;
-import org.apache.spark.sql.sources.Filter;
-import org.apache.spark.sql.sources.GreaterThan;
-import org.apache.spark.sql.sources.GreaterThanOrEqual;
-import org.apache.spark.sql.sources.In;
-import org.apache.spark.sql.sources.IsNotNull;
-import org.apache.spark.sql.sources.IsNull;
-import org.apache.spark.sql.sources.LessThan;
-import org.apache.spark.sql.sources.LessThanOrEqual;
-import org.apache.spark.sql.sources.Not;
-import org.apache.spark.sql.sources.Or;
-import org.apache.spark.sql.sources.StringStartsWith;
+import org.apache.spark.sql.sources.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -61,7 +48,8 @@ public class SparkFilterConverter {
                     "And",
                     "Or",
                     "Not",
-                    "StringStartsWith");
+                    "StringStartsWith",
+                    "StringEndsWith");
 
     private final RowType rowType;
     private final PredicateBuilder builder;
@@ -141,6 +129,11 @@ public class SparkFilterConverter {
             int index = fieldIndex(startsWith.attribute());
             Object literal = convertLiteral(index, startsWith.value());
             return builder.startsWith(index, literal);
+        } else if (filter instanceof StringEndsWith) {
+            StringEndsWith endsWith = (StringEndsWith) filter;
+            int index = fieldIndex(endsWith.attribute());
+            Object literal = convertLiteral(index, endsWith.value());
+            return builder.endsWith(index, literal);
         }
 
         // TODO: AlwaysTrue, AlwaysFalse

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFilterConverterTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFilterConverterTest.java
@@ -28,17 +28,7 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.VarCharType;
 
-import org.apache.spark.sql.sources.EqualNullSafe;
-import org.apache.spark.sql.sources.EqualTo;
-import org.apache.spark.sql.sources.GreaterThan;
-import org.apache.spark.sql.sources.GreaterThanOrEqual;
-import org.apache.spark.sql.sources.In;
-import org.apache.spark.sql.sources.IsNotNull;
-import org.apache.spark.sql.sources.IsNull;
-import org.apache.spark.sql.sources.LessThan;
-import org.apache.spark.sql.sources.LessThanOrEqual;
-import org.apache.spark.sql.sources.Not;
-import org.apache.spark.sql.sources.StringStartsWith;
+import org.apache.spark.sql.sources.*;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Date;
@@ -192,6 +182,11 @@ public class SparkFilterConverterTest {
 
     @Test
     public void testIgnoreFailure() {
+        testStartsWith();
+        testEndsWith();
+    }
+
+    public void testStartsWith() {
         List<DataField> dataFields = new ArrayList<>();
         dataFields.add(new DataField(0, "id", new IntType()));
         dataFields.add(new DataField(1, "name", new VarCharType(VarCharType.MAX_LENGTH)));
@@ -199,6 +194,18 @@ public class SparkFilterConverterTest {
         SparkFilterConverter converter = new SparkFilterConverter(rowType);
 
         Not not = Not.apply(StringStartsWith.apply("name", "paimon"));
+        catchThrowableOfType(() -> converter.convert(not), UnsupportedOperationException.class);
+        assertThat(converter.convertIgnoreFailure(not)).isNull();
+    }
+
+    public void testEndsWith() {
+        List<DataField> dataFields = new ArrayList<>();
+        dataFields.add(new DataField(0, "id", new IntType()));
+        dataFields.add(new DataField(1, "name", new VarCharType(VarCharType.MAX_LENGTH)));
+        RowType rowType = new RowType(dataFields);
+        SparkFilterConverter converter = new SparkFilterConverter(rowType);
+
+        Not not = Not.apply(StringEndsWith.apply("name", "paimon"));
         catchThrowableOfType(() -> converter.convert(not), UnsupportedOperationException.class);
         assertThat(converter.convertIgnoreFailure(not)).isNull();
     }

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFilterConverterTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFilterConverterTest.java
@@ -210,11 +210,6 @@ public class SparkFilterConverterTest {
 
     @Test
     public void testIgnoreFailure() {
-        testStartsWith();
-        testEndsWith();
-    }
-
-    public void testStartsWith() {
         List<DataField> dataFields = new ArrayList<>();
         dataFields.add(new DataField(0, "id", new IntType()));
         dataFields.add(new DataField(1, "name", new VarCharType(VarCharType.MAX_LENGTH)));
@@ -222,18 +217,6 @@ public class SparkFilterConverterTest {
         SparkFilterConverter converter = new SparkFilterConverter(rowType);
 
         Not not = Not.apply(StringStartsWith.apply("name", "paimon"));
-        catchThrowableOfType(() -> converter.convert(not), UnsupportedOperationException.class);
-        assertThat(converter.convertIgnoreFailure(not)).isNull();
-    }
-
-    public void testEndsWith() {
-        List<DataField> dataFields = new ArrayList<>();
-        dataFields.add(new DataField(0, "id", new IntType()));
-        dataFields.add(new DataField(1, "name", new VarCharType(VarCharType.MAX_LENGTH)));
-        RowType rowType = new RowType(dataFields);
-        SparkFilterConverter converter = new SparkFilterConverter(rowType);
-
-        Not not = Not.apply(StringEndsWith.apply("name", "paimon"));
         catchThrowableOfType(() -> converter.convert(not), UnsupportedOperationException.class);
         assertThat(converter.convertIgnoreFailure(not)).isNull();
     }

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFilterConverterTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFilterConverterTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.spark;
 
+import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -52,6 +54,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.paimon.data.BinaryString.fromString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
@@ -150,6 +153,20 @@ public class SparkFilterConverterTest {
         Predicate expectedLargeIn = builder.in(0, Arrays.asList(literals));
         Predicate actualLargeIn = converter.convert(largeIn);
         assertThat(actualLargeIn).isEqualTo(expectedLargeIn);
+
+        RowType rowType01 =
+                new RowType(Collections.singletonList(new DataField(0, "id", new VarCharType())));
+        SparkFilterConverter converter01 = new SparkFilterConverter(rowType01);
+        StringEndsWith endsWith = StringEndsWith.apply("id", "abc");
+        Predicate endsWithPre = converter01.convert(endsWith);
+        GenericRow row = GenericRow.of(fromString("aabc"));
+        GenericRow max = GenericRow.of(fromString("xasxwsa"));
+        GenericRow min = GenericRow.of(fromString("aaaaa"));
+        boolean test = endsWithPre.test(row);
+        Integer[] nullCount = {null};
+        boolean test1 = endsWithPre.test(10, min, max, new GenericArray(nullCount));
+        assertThat(test).isEqualTo(true);
+        assertThat(test1).isEqualTo(true);
     }
 
     @Test

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFilterConverterTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFilterConverterTest.java
@@ -28,7 +28,18 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.VarCharType;
 
-import org.apache.spark.sql.sources.*;
+import org.apache.spark.sql.sources.EqualNullSafe;
+import org.apache.spark.sql.sources.EqualTo;
+import org.apache.spark.sql.sources.GreaterThan;
+import org.apache.spark.sql.sources.GreaterThanOrEqual;
+import org.apache.spark.sql.sources.In;
+import org.apache.spark.sql.sources.IsNotNull;
+import org.apache.spark.sql.sources.IsNull;
+import org.apache.spark.sql.sources.LessThan;
+import org.apache.spark.sql.sources.LessThanOrEqual;
+import org.apache.spark.sql.sources.Not;
+import org.apache.spark.sql.sources.StringEndsWith;
+import org.apache.spark.sql.sources.StringStartsWith;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Date;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close https://github.com/apache/paimon/issues/3715

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
