### PR TITLE
[core] Local disk spill compression uses zstd

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -270,7 +270,7 @@ under the License.
             <td><h5>file.compression</h5></td>
             <td style="word-wrap: break-word;">"zstd"</td>
             <td>String</td>
-            <td>Default file compression. For faster read and write, it is recommended to use LZ4.</td>
+            <td>Default file compression. For faster read and write, it is recommended to use zstd.</td>
         </tr>
         <tr>
             <td><h5>file.compression.per.level</h5></td>
@@ -359,9 +359,9 @@ Mainly to resolve data skew on primary keys. We recommend starting with 64 mb wh
         </tr>
         <tr>
             <td><h5>lookup.cache-spill-compression</h5></td>
-            <td style="word-wrap: break-word;">"lz4"</td>
+            <td style="word-wrap: break-word;">"zstd"</td>
             <td>String</td>
-            <td>Spill compression for lookup cache, currently none, lz4, lzo and zstd are supported.</td>
+            <td>Spill compression for lookup cache, currently zstd, none, lz4 and lzo are supported.</td>
         </tr>
         <tr>
             <td><h5>lookup.cache.bloom.filter.enabled</h5></td>
@@ -486,16 +486,16 @@ This config option does not affect the default filesystem metastore.</td>
             <td>The default partition name in case the dynamic partition column value is null/empty string.</td>
         </tr>
         <tr>
-            <td><h5>partition.expiration-strategy</h5></td>
-            <td style="word-wrap: break-word;">values-time</td>
-            <td>String</td>
-            <td>Specifies the expiration strategy for partition expiration.<br />Possible values:<ul><li>values-time: A partition expiration policy that compares the time extracted from the partition value with the current time.</li></ul><ul><li>update-time: A partition expiration policy that compares the last update time of the partition with the current time.</li></ul><br /><br />Possible values:<ul><li>"values-time": The strategy compares the time extracted from the partition value with the current time.</li><li>"update-time": The strategy compares the last update time of the partition with the current time.</li></ul></td>
-        </tr>
-        <tr>
             <td><h5>partition.expiration-check-interval</h5></td>
             <td style="word-wrap: break-word;">1 h</td>
             <td>Duration</td>
             <td>The check interval of partition expiration.</td>
+        </tr>
+        <tr>
+            <td><h5>partition.expiration-strategy</h5></td>
+            <td style="word-wrap: break-word;">values-time</td>
+            <td><p>Enum</p></td>
+            <td>Specifies the expiration strategy for partition expiration.<br />Possible values:<ul><li>values-time: A partition expiration policy that compares the time extracted from the partition value with the current time.</li></ul><ul><li>update-time: A partition expiration policy that compares the last update time of the partition with the current time.</li></ul><br /><br />Possible values:<ul><li>"values-time": The strategy compares the time extracted from the partition value with the current time.</li><li>"update-time": The strategy compares the last update time of the partition with the current time.</li></ul></td>
         </tr>
         <tr>
             <td><h5>partition.expiration-time</h5></td>
@@ -710,9 +710,9 @@ If the data size allocated for the sorting task is uneven,which may lead to perf
         </tr>
         <tr>
             <td><h5>spill-compression</h5></td>
-            <td style="word-wrap: break-word;">"LZ4"</td>
+            <td style="word-wrap: break-word;">"zstd"</td>
             <td>String</td>
-            <td>Compression for spill, currently lz4, lzo and zstd are supported.</td>
+            <td>Compression for spill, currently zstd, lzo and zstd are supported.</td>
         </tr>
         <tr>
             <td><h5>streaming-read-mode</h5></td>

--- a/paimon-common/pom.xml
+++ b/paimon-common/pom.xml
@@ -64,6 +64,12 @@ under the License.
             <version>${lz4.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+            <version>${zstd-jni.version}</version>
+        </dependency>
+
         <!-- Java compiler -->
         <dependency>
             <groupId>org.codehaus.janino</groupId>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -157,7 +157,7 @@ public class CoreOptions implements Serializable {
                     .stringType()
                     .defaultValue("zstd")
                     .withDescription(
-                            "Default file compression. For faster read and write, it is recommended to use LZ4.");
+                            "Default file compression. For faster read and write, it is recommended to use zstd.");
 
     public static final ConfigOption<Integer> FILE_COMPRESSION_ZSTD_LEVEL =
             key("file.compression.zstd-level")
@@ -344,9 +344,9 @@ public class CoreOptions implements Serializable {
     public static final ConfigOption<String> SPILL_COMPRESSION =
             key("spill-compression")
                     .stringType()
-                    .defaultValue("LZ4")
+                    .defaultValue("zstd")
                     .withDescription(
-                            "Compression for spill, currently lz4, lzo and zstd are supported.");
+                            "Compression for spill, currently zstd, lzo and zstd are supported.");
 
     public static final ConfigOption<Boolean> WRITE_ONLY =
             key("write-only")
@@ -814,9 +814,9 @@ public class CoreOptions implements Serializable {
     public static final ConfigOption<String> LOOKUP_CACHE_SPILL_COMPRESSION =
             key("lookup.cache-spill-compression")
                     .stringType()
-                    .defaultValue("lz4")
+                    .defaultValue("zstd")
                     .withDescription(
-                            "Spill compression for lookup cache, currently none, lz4, lzo and zstd are supported.");
+                            "Spill compression for lookup cache, currently zstd, none, lz4 and lzo are supported.");
 
     public static final ConfigOption<MemorySize> LOOKUP_CACHE_MAX_MEMORY_SIZE =
             key("lookup.cache-max-memory-size")

--- a/paimon-common/src/main/java/org/apache/paimon/compression/BlockCompressionFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/compression/BlockCompressionFactory.java
@@ -20,8 +20,6 @@ package org.apache.paimon.compression;
 
 import io.airlift.compress.lzo.LzoCompressor;
 import io.airlift.compress.lzo.LzoDecompressor;
-import io.airlift.compress.zstd.ZstdCompressor;
-import io.airlift.compress.zstd.ZstdDecompressor;
 
 import javax.annotation.Nullable;
 
@@ -46,7 +44,7 @@ public interface BlockCompressionFactory {
             case "LZO":
                 return new AirCompressorFactory(new LzoCompressor(), new LzoDecompressor());
             case "ZSTD":
-                return new AirCompressorFactory(new ZstdCompressor(), new ZstdDecompressor());
+                return new ZstdBlockCompressionFactory();
             default:
                 throw new IllegalStateException("Unknown CompressionMethod " + compression);
         }

--- a/paimon-common/src/main/java/org/apache/paimon/compression/ZstdBlockCompressionFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/compression/ZstdBlockCompressionFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.compression;
+
+/** Implementation of {@link BlockCompressionFactory} for zstd codec. */
+public class ZstdBlockCompressionFactory implements BlockCompressionFactory {
+
+    @Override
+    public BlockCompressor getCompressor() {
+        return new ZstdBlockCompressor();
+    }
+
+    @Override
+    public BlockDecompressor getDecompressor() {
+        return new ZstdBlockDecompressor();
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/compression/ZstdBlockCompressor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/compression/ZstdBlockCompressor.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.compression;
+
+import com.github.luben.zstd.RecyclingBufferPool;
+import com.github.luben.zstd.ZstdOutputStream;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static org.apache.paimon.compression.CompressorUtils.HEADER_LENGTH;
+
+/** A {@link BlockCompressor} for zstd. */
+public class ZstdBlockCompressor implements BlockCompressor {
+
+    private static final int MAX_BLOCK_SIZE = 128 * 1024;
+
+    @Override
+    public int getMaxCompressedSize(int srcSize) {
+        return HEADER_LENGTH + zstdMaxCompressedLength(srcSize);
+    }
+
+    private int zstdMaxCompressedLength(int uncompressedSize) {
+        // refer to io.airlift.compress.zstd.ZstdCompressor
+        int result = uncompressedSize + (uncompressedSize >>> 8);
+        if (uncompressedSize < MAX_BLOCK_SIZE) {
+            result += (MAX_BLOCK_SIZE - uncompressedSize) >>> 11;
+        }
+        return result;
+    }
+
+    @Override
+    public int compress(byte[] src, int srcOff, int srcLen, byte[] dst, int dstOff)
+            throws BufferCompressionException {
+        ByteArrayOutputStream stream = new ByteArrayOutputStream(dst, dstOff);
+        try (ZstdOutputStream zstdStream =
+                new ZstdOutputStream(stream, RecyclingBufferPool.INSTANCE, 1)) {
+            zstdStream.setWorkers(0);
+            zstdStream.write(src, srcOff, srcLen);
+        } catch (IOException e) {
+            throw new BufferCompressionException(e);
+        }
+        return stream.position() - dstOff;
+    }
+
+    private static class ByteArrayOutputStream extends OutputStream {
+
+        private final byte[] buf;
+        private int position;
+
+        public ByteArrayOutputStream(byte[] buf, int position) {
+            this.buf = buf;
+            this.position = position;
+        }
+
+        @Override
+        public void write(int b) {
+            buf[position] = (byte) b;
+            position += 1;
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            if ((off < 0) || (off > b.length) || (len < 0) || ((off + len) - b.length > 0)) {
+                throw new IndexOutOfBoundsException();
+            }
+            try {
+                System.arraycopy(b, off, buf, position, len);
+            } catch (IndexOutOfBoundsException e) {
+                throw new IOException(e);
+            }
+            position += len;
+        }
+
+        int position() {
+            return position;
+        }
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/compression/ZstdBlockDecompressor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/compression/ZstdBlockDecompressor.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.compression;
+
+import com.github.luben.zstd.RecyclingBufferPool;
+import com.github.luben.zstd.ZstdInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+/** A {@link BlockDecompressor} for zstd. */
+public class ZstdBlockDecompressor implements BlockDecompressor {
+
+    @Override
+    public int decompress(byte[] src, int srcOff, int srcLen, byte[] dst, int dstOff)
+            throws BufferDecompressionException {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(src, srcOff, srcLen);
+        try (ZstdInputStream decompressorStream =
+                new ZstdInputStream(inputStream, RecyclingBufferPool.INSTANCE)) {
+            int decompressedLen = 0;
+            while (true) {
+                int offset = dstOff + decompressedLen;
+                int count = decompressorStream.read(dst, offset, dst.length - offset);
+                if (count <= 0) {
+                    if (decompressorStream.available() != 0) {
+                        throw new BufferDecompressionException(
+                                "Dst is too small and the decompression was not completed.");
+                    }
+                    break;
+                }
+                decompressedLen += count;
+            }
+            return decompressedLen;
+        } catch (IOException e) {
+            throw new BufferDecompressionException(e);
+        }
+    }
+}

--- a/paimon-format/pom.xml
+++ b/paimon-format/pom.xml
@@ -37,7 +37,6 @@ under the License.
         <joda-time.version>2.5</joda-time.version>
         <commons.pool.version>1.6</commons.pool.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
-        <zstd-jni.version>1.5.5-11</zstd-jni.version>
         <storage-api.version>2.8.1</storage-api.version>
         <protobuf-java.version>3.19.6</protobuf-java.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,7 @@ under the License.
         <!-- TODO upgrade after connector releases x-1.19 version -->
         <test.flink.connector.kafka.version>3.0.1-1.18</test.flink.connector.kafka.version>
 
+        <zstd-jni.version>1.5.5-11</zstd-jni.version>
         <janino.version>3.0.11</janino.version>
         <mockito.version>3.4.6</mockito.version>
         <jaxb.api.version>2.3.1</jaxb.api.version>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Unify compression to zstd. 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
