### PR TITLE
[benchmark] Fix the problem that parquet-related benchmark test cases call the wrong method in `TableReadBenchmark` class

### DIFF
--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/TableReadBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/TableReadBenchmark.java
@@ -124,7 +124,8 @@ public class TableReadBenchmark extends TableBenchmark {
     @Test
     public void testParquetReadProjection1() throws Exception {
         innerTestProjection(
-                Collections.singletonMap("parquet", prepareData(parquet(), "parquet")), new int[] {10});
+                Collections.singletonMap("parquet", prepareData(parquet(), "parquet")),
+                new int[] {10});
         /*
          * OpenJDK 64-Bit Server VM 1.8.0_292-b10 on Mac OS X 10.16
          * Apple M1 Pro

--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/TableReadBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/TableReadBenchmark.java
@@ -110,27 +110,27 @@ public class TableReadBenchmark extends TableBenchmark {
     @Test
     public void testParquetReadProjection() throws Exception {
         innerTestProjection(
-                Collections.singletonMap("parquet", prepareData(orc(), "parquet")),
+                Collections.singletonMap("parquet", prepareData(parquet(), "parquet")),
                 new int[] {0, 5, 10, 14});
         /*
          * OpenJDK 64-Bit Server VM 1.8.0_292-b10 on Mac OS X 10.16
          * Apple M1 Pro
          * read:                            Best/Avg Time(ms)    Row Rate(K/s)      Per Row(ns)   Relative
          * ------------------------------------------------------------------------------------------------
-         * OPERATORTEST_read_read-orc            716 /  728           4187.4            238.8       1.0X
+         * OPERATORTEST_read_read-parquet            716 /  728           4187.4            238.8       1.0X
          */
     }
 
     @Test
     public void testParquetReadProjection1() throws Exception {
         innerTestProjection(
-                Collections.singletonMap("parquet", prepareData(orc(), "parquet")), new int[] {10});
+                Collections.singletonMap("parquet", prepareData(parquet(), "parquet")), new int[] {10});
         /*
          * OpenJDK 64-Bit Server VM 1.8.0_292-b10 on Mac OS X 10.16
          * Apple M1 Pro
          * read:                            Best/Avg Time(ms)    Row Rate(K/s)      Per Row(ns)   Relative
          * ------------------------------------------------------------------------------------------------
-         * OPERATORTEST_read_read-orc            716 /  728           4187.4            238.8       1.0X
+         * OPERATORTEST_read_read-parquet            716 /  728           4187.4            238.8       1.0X
          */
     }
 
@@ -142,7 +142,7 @@ public class TableReadBenchmark extends TableBenchmark {
 
     private Options parquet() {
         Options options = new Options();
-        options.set(CoreOptions.FILE_FORMAT, CoreOptions.FILE_FORMAT_ORC);
+        options.set(CoreOptions.FILE_FORMAT, CoreOptions.FILE_FORMAT_PARQUET);
         return options;
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Fix the problem that parquet-related benchmark test cases call the wrong method in `TableReadBenchmark` class.
<!-- Linking this pull request to the issue -->
Linked issue: close #3727

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
