### PR TITLE
[spark] Fix spark query with filter timestamp

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
@@ -279,7 +279,6 @@ public class PredicateBuilder {
                 int scale = decimalType.getScale();
                 return Decimal.fromBigDecimal((BigDecimal) o, precision, scale);
             case TIMESTAMP_WITHOUT_TIME_ZONE:
-            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
                 Timestamp timestamp;
                 if (o instanceof java.sql.Timestamp) {
                     timestamp = Timestamp.fromSQLTimestamp((java.sql.Timestamp) o);
@@ -287,6 +286,17 @@ public class PredicateBuilder {
                     timestamp =
                             Timestamp.fromInstant(
                                     ((Instant) o).plusMillis(TimeUnit.HOURS.toMillis(8)));
+                } else if (o instanceof LocalDateTime) {
+                    timestamp = Timestamp.fromLocalDateTime((LocalDateTime) o);
+                } else {
+                    throw new UnsupportedOperationException("Unsupported object: " + o);
+                }
+                return timestamp;
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                if (o instanceof java.sql.Timestamp) {
+                    timestamp = Timestamp.fromSQLTimestamp((java.sql.Timestamp) o);
+                } else if (o instanceof Instant) {
+                    timestamp = Timestamp.fromInstant((Instant) o);
                 } else if (o instanceof LocalDateTime) {
                     timestamp = Timestamp.fromLocalDateTime((LocalDateTime) o);
                 } else {

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
@@ -36,6 +36,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -46,7 +47,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
@@ -283,9 +283,9 @@ public class PredicateBuilder {
                 if (o instanceof java.sql.Timestamp) {
                     timestamp = Timestamp.fromSQLTimestamp((java.sql.Timestamp) o);
                 } else if (o instanceof Instant) {
-                    timestamp =
-                            Timestamp.fromInstant(
-                                    ((Instant) o).plusMillis(TimeUnit.HOURS.toMillis(8)));
+                    Instant o1 = (Instant) o;
+                    LocalDateTime dateTime = o1.atZone(ZoneId.systemDefault()).toLocalDateTime();
+                    timestamp = Timestamp.fromLocalDateTime(dateTime);
                 } else if (o instanceof LocalDateTime) {
                     timestamp = Timestamp.fromLocalDateTime((LocalDateTime) o);
                 } else {

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
@@ -283,7 +284,9 @@ public class PredicateBuilder {
                 if (o instanceof java.sql.Timestamp) {
                     timestamp = Timestamp.fromSQLTimestamp((java.sql.Timestamp) o);
                 } else if (o instanceof Instant) {
-                    timestamp = Timestamp.fromInstant((Instant) o);
+                    timestamp =
+                            Timestamp.fromInstant(
+                                    ((Instant) o).plusMillis(TimeUnit.HOURS.toMillis(8)));
                 } else if (o instanceof LocalDateTime) {
                     timestamp = Timestamp.fromLocalDateTime((LocalDateTime) o);
                 } else {

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFilterConverterTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFilterConverterTest.java
@@ -45,7 +45,7 @@ import java.sql.Date;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -160,7 +160,7 @@ public class SparkFilterConverterTest {
 
         java.sql.Timestamp timestamp = java.sql.Timestamp.valueOf("2018-10-18 00:00:57.907");
         LocalDateTime localDateTime = LocalDateTime.parse("2018-10-18T00:00:57.907");
-        Instant instant = localDateTime.toInstant(ZoneOffset.UTC);
+        Instant instant = localDateTime.atZone(ZoneId.systemDefault()).toInstant();
 
         Predicate instantExpression = converter.convert(GreaterThan.apply("x", instant));
         Predicate timestampExpression = converter.convert(GreaterThan.apply("x", timestamp));


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
 Fix spark query with filter timestamp

before fix:
spark-sql> select * from bdsp_prd.z_paimon_pk_table where dt='2024-04-11 11:01:00' limit 10;
OK
pk	v1	v2	dt
Time taken: 1.198 seconds
spark-sql> 24/07/11 16:44:13 WARN SparkContext: Successfully stopped SparkContext


after fix，user can query by filter timestamp type：
Spark master: yarn, Application Id: application_1719458929416_3440055
spark-sql> select * from bdsp_prd.z_paimon_pk_table where dt='2024-07-09 12:22:21' limit 10;
24/07/11 16:34:03 WARN TaskSetManager: Finished tasks (1/1) in stage 0.0
OK
pk	v1	v2	dt
2	12.3	21	2024-07-09 12:22:21
Time taken: 18.313 seconds, Fetched 1 row(s)


<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
