### PR TITLE
[core][rollback] Skip non-existent snapshots in rollback

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/RollbackHelper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/RollbackHelper.java
@@ -119,8 +119,11 @@ public class RollbackHelper {
         List<Snapshot> toBeCleaned = new ArrayList<>();
         long to = Math.max(earliest, retainedSnapshot.id() + 1);
         for (long i = latest; i >= to; i--) {
-            toBeCleaned.add(snapshotManager.snapshot(i));
-            fileIO.deleteQuietly(snapshotManager.snapshotPath(i));
+            // Ignore the non-existent snapshots
+            if (snapshotManager.snapshotExists(i)) {
+                toBeCleaned.add(snapshotManager.snapshot(i));
+                fileIO.deleteQuietly(snapshotManager.snapshotPath(i));
+            }
         }
 
         // delete data files of snapshots


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Linked issue: close #3732 

Skip non-existent snapshots in rollback operation

### Tests

Added FileStoreTableTestBase#testRollbackToSnapshotSkipNonExistentSnapshot

### API and Format

no

### Documentation

no
