### PR TITLE
[core] Support creating Iceberg metadata based on old ones

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/AbstractIcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/AbstractIcebergCommitCallback.java
@@ -454,8 +454,10 @@ public abstract class AbstractIcebergCommitCallback implements CommitCallback {
             for (int i = 0; i < numFields; i++) {
                 IcebergPartitionSummary summary = fileMeta.partitions().get(i);
                 DataType fieldType = partitionType.getTypeAt(i);
-                minValues.setField(i, IcebergConversions.toObject(fieldType, summary.lowerBound()));
-                maxValues.setField(i, IcebergConversions.toObject(fieldType, summary.upperBound()));
+                minValues.setField(
+                        i, IcebergConversions.toPaimonObject(fieldType, summary.lowerBound()));
+                maxValues.setField(
+                        i, IcebergConversions.toPaimonObject(fieldType, summary.upperBound()));
                 // IcebergPartitionSummary only has `containsNull` field and does not have the
                 // exact number of nulls.
                 nullCounts[i] = summary.containsNull() ? 1 : 0;

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/AbstractIcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/AbstractIcebergCommitCallback.java
@@ -286,7 +286,6 @@ public abstract class AbstractIcebergCommitCallback implements CommitCallback {
         List<IcebergManifestFileMeta> baseManifestFileMetas =
                 manifestList.read(baseMetadata.currentSnapshot().manifestList());
 
-        Pair<List<IcebergManifestFileMeta>, Boolean> createManifestFileMetasResult;
         // Note that `isAddOnly(commitable)` and `removedFiles.isEmpty()` may be different,
         // because if a file's level is changed, it will first be removed and then added.
         // In this case, if `baseMetadata` already contains this file, we should not add a

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/AppendOnlyIcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/AppendOnlyIcebergCommitCallback.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg;
+
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.table.FileStoreTable;
+
+/** {@link AbstractIcebergCommitCallback} for append only tables. */
+public class AppendOnlyIcebergCommitCallback extends AbstractIcebergCommitCallback {
+
+    public AppendOnlyIcebergCommitCallback(FileStoreTable table, String commitUser) {
+        super(table, commitUser);
+    }
+
+    @Override
+    protected boolean shouldAddFileToIceberg(DataFileMeta meta) {
+        return true;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/PrimaryKeyIcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/PrimaryKeyIcebergCommitCallback.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg;
+
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.table.FileStoreTable;
+
+/** {@link AbstractIcebergCommitCallback} for primary key tables. */
+public class PrimaryKeyIcebergCommitCallback extends AbstractIcebergCommitCallback {
+
+    public PrimaryKeyIcebergCommitCallback(FileStoreTable table, String commitUser) {
+        super(table, commitUser);
+    }
+
+    @Override
+    protected boolean shouldAddFileToIceberg(DataFileMeta meta) {
+        int maxLevel = table.coreOptions().numLevels() - 1;
+        return meta.level() == maxLevel;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergConversions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergConversions.java
@@ -84,7 +84,7 @@ public class IcebergConversions {
         }
     }
 
-    public static Object toObject(DataType type, byte[] bytes) {
+    public static Object toPaimonObject(DataType type, byte[] bytes) {
         switch (type.getTypeRoot()) {
             case BOOLEAN:
                 return bytes[0] != 0;

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestEntry.java
@@ -90,6 +90,10 @@ public class IcebergManifestEntry {
         return status;
     }
 
+    public boolean isLive() {
+        return status == Status.ADDED || status == Status.EXISTING;
+    }
+
     public long snapshotId() {
         return snapshotId;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestFileMeta.java
@@ -157,6 +157,10 @@ public class IcebergManifestFileMeta {
         return deletedRowsCount;
     }
 
+    public long liveRowsCount() {
+        return addedRowsCount + existingRowsCount;
+    }
+
     public List<IcebergPartitionSummary> partitions() {
         return partitions;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergSnapshotSummary.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergSnapshotSummary.java
@@ -35,8 +35,8 @@ public class IcebergSnapshotSummary {
 
     private static final String FIELD_OPERATION = "operation";
 
-    public static final String OPERATION_APPEND = "append";
-    public static final String OPERATION_OVERWRITE = "overwrite";
+    public static final IcebergSnapshotSummary APPEND = new IcebergSnapshotSummary("append");
+    public static final IcebergSnapshotSummary OVERWRITE = new IcebergSnapshotSummary("overwrite");
 
     @JsonProperty(FIELD_OPERATION)
     private final String operation;

--- a/paimon-core/src/main/java/org/apache/paimon/metastore/AddPartitionCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/AddPartitionCommitCallback.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.metastore;
 
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.ManifestCommittable;
@@ -27,8 +28,6 @@ import org.apache.paimon.table.sink.CommitMessage;
 
 import org.apache.paimon.shade.guava30.com.google.common.cache.Cache;
 import org.apache.paimon.shade.guava30.com.google.common.cache.CacheBuilder;
-
-import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.List;
@@ -52,8 +51,7 @@ public class AddPartitionCommitCallback implements CommitCallback {
     }
 
     @Override
-    public void call(
-            List<ManifestEntry> committedEntries, long identifier, @Nullable Long watermark) {
+    public void call(List<ManifestEntry> committedEntries, Snapshot snapshot) {
         committedEntries.stream()
                 .filter(e -> FileKind.ADD.equals(e.kind()))
                 .map(ManifestEntry::partition)

--- a/paimon-core/src/main/java/org/apache/paimon/metastore/TagPreviewCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/TagPreviewCommitCallback.java
@@ -18,12 +18,11 @@
 
 package org.apache.paimon.metastore;
 
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.table.sink.CommitCallback;
 import org.apache.paimon.tag.TagPreview;
-
-import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Optional;
@@ -40,10 +39,9 @@ public class TagPreviewCommitCallback implements CommitCallback {
     }
 
     @Override
-    public void call(
-            List<ManifestEntry> committedEntries, long identifier, @Nullable Long watermark) {
+    public void call(List<ManifestEntry> committedEntries, Snapshot snapshot) {
         long currentMillis = System.currentTimeMillis();
-        Optional<String> tagOptional = tagPreview.extractTag(currentMillis, watermark);
+        Optional<String> tagOptional = tagPreview.extractTag(currentMillis, snapshot.watermark());
         tagOptional.ifPresent(tagCallback::notifyCreation);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -1007,7 +1007,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                                 identifier,
                                 commitKind.name()));
             }
-            commitCallbacks.forEach(callback -> callback.call(tableFiles, identifier, watermark));
+            commitCallbacks.forEach(callback -> callback.call(tableFiles, newSnapshot));
             return true;
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -24,7 +24,6 @@ import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
-import org.apache.paimon.iceberg.IcebergCommitCallback;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.metastore.AddPartitionCommitCallback;
@@ -397,7 +396,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
                 options.forceCreatingSnapshot());
     }
 
-    private List<CommitCallback> createCommitCallbacks(String commitUser) {
+    protected List<CommitCallback> createCommitCallbacks(String commitUser) {
         List<CommitCallback> callbacks =
                 new ArrayList<>(CallbackUtils.loadCommitCallbacks(coreOptions()));
         CoreOptions options = coreOptions();
@@ -421,10 +420,6 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
                                     metastoreClientFactory.create(), options.tagToPartitionField()),
                             tagPreview);
             callbacks.add(callback);
-        }
-
-        if (options.metadataIcebergCompatible()) {
-            callbacks.add(new IcebergCommitCallback(this, commitUser));
         }
 
         return callbacks;

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
@@ -23,6 +23,7 @@ import org.apache.paimon.KeyValue;
 import org.apache.paimon.KeyValueFileStore;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.iceberg.PrimaryKeyIcebergCommitCallback;
 import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.mergetree.compact.LookupMergeFunction;
 import org.apache.paimon.mergetree.compact.MergeFunctionFactory;
@@ -33,6 +34,7 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.schema.KeyValueFieldsExtractor;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.query.LocalTableQuery;
+import org.apache.paimon.table.sink.CommitCallback;
 import org.apache.paimon.table.sink.TableWriteImpl;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.KeyValueTableRead;
@@ -176,5 +178,17 @@ class PrimaryKeyFileStoreTable extends AbstractFileStoreTable {
     @Override
     public LocalTableQuery newLocalTableQuery() {
         return new LocalTableQuery(this);
+    }
+
+    @Override
+    protected List<CommitCallback> createCommitCallbacks(String commitUser) {
+        List<CommitCallback> callbacks = super.createCommitCallbacks(commitUser);
+        CoreOptions options = coreOptions();
+
+        if (options.metadataIcebergCompatible()) {
+            callbacks.add(new PrimaryKeyIcebergCommitCallback(this, commitUser));
+        }
+
+        return callbacks;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/CommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/CommitCallback.java
@@ -18,10 +18,9 @@
 
 package org.apache.paimon.table.sink;
 
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.manifest.ManifestEntry;
-
-import javax.annotation.Nullable;
 
 import java.util.List;
 
@@ -38,7 +37,7 @@ import java.util.List;
  */
 public interface CommitCallback extends AutoCloseable {
 
-    void call(List<ManifestEntry> committedEntries, long identifier, @Nullable Long watermark);
+    void call(List<ManifestEntry> committedEntries, Snapshot snapshot);
 
     void retry(ManifestCommittable committable);
 }

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
@@ -76,20 +76,25 @@ public class IcebergCompatibilityTest {
                         },
                         new String[] {"k1", "k2", "v1", "v2"});
 
-        int numRecords = 1000;
+        int numRounds = 5;
+        int numRecords = 500;
         ThreadLocalRandom random = ThreadLocalRandom.current();
-        List<TestRecord> testRecords = new ArrayList<>();
-        for (int i = 0; i < numRecords; i++) {
-            int k1 = random.nextInt(0, 100);
-            String k2 = String.valueOf(random.nextInt(1000, 1010));
-            int v1 = random.nextInt();
-            long v2 = random.nextLong();
-            testRecords.add(
-                    new TestRecord(
-                            BinaryRow.EMPTY_ROW,
-                            String.format("%d|%s", k1, k2),
-                            String.format("%d|%d", v1, v2),
-                            GenericRow.of(k1, BinaryString.fromString(k2), v1, v2)));
+        List<List<TestRecord>> testRecords = new ArrayList<>();
+        for (int r = 0; r < numRounds; r++) {
+            List<TestRecord> round = new ArrayList<>();
+            for (int i = 0; i < numRecords; i++) {
+                int k1 = random.nextInt(0, 100);
+                String k2 = String.valueOf(random.nextInt(1000, 1010));
+                int v1 = random.nextInt();
+                long v2 = random.nextLong();
+                round.add(
+                        new TestRecord(
+                                BinaryRow.EMPTY_ROW,
+                                String.format("%d|%s", k1, k2),
+                                String.format("%d|%d", v1, v2),
+                                GenericRow.of(k1, BinaryString.fromString(k2), v1, v2)));
+            }
+            testRecords.add(round);
         }
 
         runCompatibilityTest(
@@ -124,26 +129,31 @@ public class IcebergCompatibilityTest {
                     return b;
                 };
 
-        int numRecords = 1000;
+        int numRounds = 5;
+        int numRecords = 500;
         ThreadLocalRandom random = ThreadLocalRandom.current();
-        List<TestRecord> testRecords = new ArrayList<>();
-        for (int i = 0; i < numRecords; i++) {
-            int pt1 = random.nextInt(0, 2);
-            String pt2 = String.valueOf(random.nextInt(10, 12));
-            String k = String.valueOf(random.nextInt(0, 100));
-            int v1 = random.nextInt();
-            long v2 = random.nextLong();
-            testRecords.add(
-                    new TestRecord(
-                            binaryRow.apply(pt1, pt2),
-                            String.format("%d|%s|%s", pt1, pt2, k),
-                            String.format("%d|%d", v1, v2),
-                            GenericRow.of(
-                                    pt1,
-                                    BinaryString.fromString(pt2),
-                                    BinaryString.fromString(k),
-                                    v1,
-                                    v2)));
+        List<List<TestRecord>> testRecords = new ArrayList<>();
+        for (int r = 0; r < numRounds; r++) {
+            List<TestRecord> round = new ArrayList<>();
+            for (int i = 0; i < numRecords; i++) {
+                int pt1 = random.nextInt(0, 2);
+                String pt2 = String.valueOf(random.nextInt(10, 12));
+                String k = String.valueOf(random.nextInt(0, 100));
+                int v1 = random.nextInt();
+                long v2 = random.nextLong();
+                round.add(
+                        new TestRecord(
+                                binaryRow.apply(pt1, pt2),
+                                String.format("%d|%s|%s", pt1, pt2, k),
+                                String.format("%d|%d", v1, v2),
+                                GenericRow.of(
+                                        pt1,
+                                        BinaryString.fromString(pt2),
+                                        BinaryString.fromString(k),
+                                        v1,
+                                        v2)));
+            }
+            testRecords.add(round);
         }
 
         runCompatibilityTest(
@@ -200,53 +210,58 @@ public class IcebergCompatibilityTest {
                     return b;
                 };
 
-        int numRecords = 1000;
+        int numRounds = 5;
+        int numRecords = 500;
         ThreadLocalRandom random = ThreadLocalRandom.current();
-        List<TestRecord> testRecords = new ArrayList<>();
-        for (int i = 0; i < numRecords; i++) {
-            int pt = random.nextInt(0, 2);
-            boolean vBoolean = random.nextBoolean();
-            long vBigInt = random.nextLong();
-            float vFloat = random.nextFloat();
-            double vDouble = random.nextDouble();
-            Decimal vDecimal = Decimal.fromUnscaledLong(random.nextLong(0, 100000000), 8, 3);
-            String vChar = String.valueOf(random.nextInt());
-            String vVarChar = String.valueOf(random.nextInt());
-            byte[] vBinary = String.valueOf(random.nextInt()).getBytes();
-            byte[] vVarBinary = String.valueOf(random.nextInt()).getBytes();
-            int vDate = random.nextInt(0, 30000);
+        List<List<TestRecord>> testRecords = new ArrayList<>();
+        for (int r = 0; r < numRounds; r++) {
+            List<TestRecord> round = new ArrayList<>();
+            for (int i = 0; i < numRecords; i++) {
+                int pt = random.nextInt(0, 2);
+                boolean vBoolean = random.nextBoolean();
+                long vBigInt = random.nextLong();
+                float vFloat = random.nextFloat();
+                double vDouble = random.nextDouble();
+                Decimal vDecimal = Decimal.fromUnscaledLong(random.nextLong(0, 100000000), 8, 3);
+                String vChar = String.valueOf(random.nextInt());
+                String vVarChar = String.valueOf(random.nextInt());
+                byte[] vBinary = String.valueOf(random.nextInt()).getBytes();
+                byte[] vVarBinary = String.valueOf(random.nextInt()).getBytes();
+                int vDate = random.nextInt(0, 30000);
 
-            String k =
-                    String.format(
-                            "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s",
-                            pt,
-                            vBoolean,
-                            vBigInt,
-                            vFloat,
-                            vDouble,
-                            vDecimal,
-                            vChar,
-                            vVarChar,
-                            new String(vBinary),
-                            new String(vVarBinary),
-                            LocalDate.ofEpochDay(vDate));
-            testRecords.add(
-                    new TestRecord(
-                            binaryRow.apply(pt),
-                            k,
-                            "",
-                            GenericRow.of(
-                                    pt,
-                                    vBoolean,
-                                    vBigInt,
-                                    vFloat,
-                                    vDouble,
-                                    vDecimal,
-                                    BinaryString.fromString(vChar),
-                                    BinaryString.fromString(vVarChar),
-                                    vBinary,
-                                    vVarBinary,
-                                    vDate)));
+                String k =
+                        String.format(
+                                "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s",
+                                pt,
+                                vBoolean,
+                                vBigInt,
+                                vFloat,
+                                vDouble,
+                                vDecimal,
+                                vChar,
+                                vVarChar,
+                                new String(vBinary),
+                                new String(vVarBinary),
+                                LocalDate.ofEpochDay(vDate));
+                round.add(
+                        new TestRecord(
+                                binaryRow.apply(pt),
+                                k,
+                                "",
+                                GenericRow.of(
+                                        pt,
+                                        vBoolean,
+                                        vBigInt,
+                                        vFloat,
+                                        vDouble,
+                                        vDecimal,
+                                        BinaryString.fromString(vChar),
+                                        BinaryString.fromString(vVarChar),
+                                        vBinary,
+                                        vVarBinary,
+                                        vDate)));
+            }
+            testRecords.add(round);
         }
 
         runCompatibilityTest(
@@ -275,7 +290,7 @@ public class IcebergCompatibilityTest {
             RowType rowType,
             List<String> partitionKeys,
             List<String> primaryKeys,
-            List<TestRecord> testRecords,
+            List<List<TestRecord>> testRecords,
             Function<Record, String> icebergRecordToKey,
             Function<Record, String> icebergRecordToValue)
             throws Exception {
@@ -302,34 +317,38 @@ public class IcebergCompatibilityTest {
         TableCommitImpl commit = table.newCommit(commitUser);
 
         Map<String, String> expected = new HashMap<>();
-        for (TestRecord testRecord : testRecords) {
-            expected.put(testRecord.key, testRecord.value);
-            write.write(testRecord.record);
-        }
+        for (List<TestRecord> round : testRecords) {
+            for (TestRecord testRecord : round) {
+                expected.put(testRecord.key, testRecord.value);
+                write.write(testRecord.record);
+            }
 
-        if (!primaryKeys.isEmpty()) {
-            for (BinaryRow partition :
-                    testRecords.stream().map(t -> t.partition).collect(Collectors.toSet())) {
-                for (int b = 0; b < 2; b++) {
-                    write.compact(partition, b, true);
+            if (!primaryKeys.isEmpty()) {
+                for (BinaryRow partition :
+                        round.stream().map(t -> t.partition).collect(Collectors.toSet())) {
+                    for (int b = 0; b < 2; b++) {
+                        write.compact(partition, b, true);
+                    }
                 }
             }
+            commit.commit(1, write.prepareCommit(true, 1));
+
+            HadoopCatalog icebergCatalog =
+                    new HadoopCatalog(new Configuration(), tempDir.toString());
+            TableIdentifier icebergIdentifier = TableIdentifier.of("mydb.db", "t");
+            org.apache.iceberg.Table icebergTable = icebergCatalog.loadTable(icebergIdentifier);
+            CloseableIterable<Record> result = IcebergGenerics.read(icebergTable).build();
+            Map<String, String> actual = new HashMap<>();
+            for (Record record : result) {
+                actual.put(icebergRecordToKey.apply(record), icebergRecordToValue.apply(record));
+            }
+            result.close();
+
+            assertThat(actual).isEqualTo(expected);
         }
-        commit.commit(1, write.prepareCommit(true, 1));
+
         write.close();
         commit.close();
-
-        HadoopCatalog icebergCatalog = new HadoopCatalog(new Configuration(), tempDir.toString());
-        TableIdentifier icebergIdentifier = TableIdentifier.of("mydb.db", "t");
-        org.apache.iceberg.Table icebergTable = icebergCatalog.loadTable(icebergIdentifier);
-        CloseableIterable<Record> result = IcebergGenerics.read(icebergTable).build();
-        Map<String, String> actual = new HashMap<>();
-        for (Record record : result) {
-            actual.put(icebergRecordToKey.apply(record), icebergRecordToValue.apply(record));
-        }
-        result.close();
-
-        assertThat(actual).isEqualTo(expected);
     }
 
     private static class TestRecord {

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
@@ -218,16 +218,21 @@ public class IcebergCompatibilityTest {
             List<TestRecord> round = new ArrayList<>();
             for (int i = 0; i < numRecords; i++) {
                 int pt = random.nextInt(0, 2);
-                boolean vBoolean = random.nextBoolean();
-                long vBigInt = random.nextLong();
-                float vFloat = random.nextFloat();
-                double vDouble = random.nextDouble();
-                Decimal vDecimal = Decimal.fromUnscaledLong(random.nextLong(0, 100000000), 8, 3);
-                String vChar = String.valueOf(random.nextInt());
-                String vVarChar = String.valueOf(random.nextInt());
-                byte[] vBinary = String.valueOf(random.nextInt()).getBytes();
-                byte[] vVarBinary = String.valueOf(random.nextInt()).getBytes();
-                int vDate = random.nextInt(0, 30000);
+                Boolean vBoolean = random.nextBoolean() ? random.nextBoolean() : null;
+                Long vBigInt = random.nextBoolean() ? random.nextLong() : null;
+                Float vFloat = random.nextBoolean() ? random.nextFloat() : null;
+                Double vDouble = random.nextBoolean() ? random.nextDouble() : null;
+                Decimal vDecimal =
+                        random.nextBoolean()
+                                ? Decimal.fromUnscaledLong(random.nextLong(0, 100000000), 8, 3)
+                                : null;
+                String vChar = random.nextBoolean() ? String.valueOf(random.nextInt()) : null;
+                String vVarChar = random.nextBoolean() ? String.valueOf(random.nextInt()) : null;
+                byte[] vBinary =
+                        random.nextBoolean() ? String.valueOf(random.nextInt()).getBytes() : null;
+                byte[] vVarBinary =
+                        random.nextBoolean() ? String.valueOf(random.nextInt()).getBytes() : null;
+                Integer vDate = random.nextBoolean() ? random.nextInt(0, 30000) : null;
 
                 String k =
                         String.format(
@@ -240,9 +245,9 @@ public class IcebergCompatibilityTest {
                                 vDecimal,
                                 vChar,
                                 vVarChar,
-                                new String(vBinary),
-                                new String(vVarBinary),
-                                LocalDate.ofEpochDay(vDate));
+                                vBinary == null ? null : new String(vBinary),
+                                vVarBinary == null ? null : new String(vVarBinary),
+                                vDate == null ? null : LocalDate.ofEpochDay(vDate));
                 round.add(
                         new TestRecord(
                                 binaryRow.apply(pt),
@@ -269,20 +274,23 @@ public class IcebergCompatibilityTest {
                 Collections.emptyList(),
                 Collections.emptyList(),
                 testRecords,
-                r ->
-                        String.format(
-                                "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s",
-                                r.get(0),
-                                r.get(1),
-                                r.get(2),
-                                r.get(3),
-                                r.get(4),
-                                r.get(5),
-                                r.get(6),
-                                r.get(7),
-                                new String(r.get(8, ByteBuffer.class).array()),
-                                new String(r.get(9, ByteBuffer.class).array()),
-                                r.get(10)),
+                r -> {
+                    ByteBuffer vBinary = r.get(8, ByteBuffer.class);
+                    ByteBuffer vVarBinary = r.get(9, ByteBuffer.class);
+                    return String.format(
+                            "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s",
+                            r.get(0),
+                            r.get(1),
+                            r.get(2),
+                            r.get(3),
+                            r.get(4),
+                            r.get(5),
+                            r.get(6),
+                            r.get(7),
+                            vBinary == null ? null : new String(vBinary.array()),
+                            vVarBinary == null ? null : new String(vVarBinary.array()),
+                            r.get(10));
+                },
                 r -> "");
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/sink/TableCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/sink/TableCommitTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.sink;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
@@ -41,8 +42,6 @@ import org.apache.paimon.utils.FailingFileIO;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-
-import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -180,8 +179,8 @@ public class TableCommitTest {
         }
 
         @Override
-        public void call(List<ManifestEntry> entries, long identifier, @Nullable Long watermark) {
-            commitCallbackResult.get(testId).add(identifier);
+        public void call(List<ManifestEntry> entries, Snapshot snapshot) {
+            commitCallbackResult.get(testId).add(snapshot.commitIdentifier());
         }
 
         @Override

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonCommitTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonCommitTest.scala
@@ -18,7 +18,7 @@
 
 package org.apache.paimon.spark
 
-import org.apache.paimon.CoreOptions
+import org.apache.paimon.{CoreOptions, Snapshot}
 import org.apache.paimon.manifest.{ManifestCommittable, ManifestEntry}
 import org.apache.paimon.table.sink.CommitCallback
 
@@ -64,10 +64,7 @@ object PaimonCommitTest {
 
 case class CustomCommitCallback(testId: String) extends CommitCallback {
 
-  override def call(
-      committedEntries: List[ManifestEntry],
-      identifier: Long,
-      watermark: lang.Long): Unit = {
+  override def call(committedEntries: List[ManifestEntry], snapshot: Snapshot): Unit = {
     PaimonCommitTest.id = testId
   }
 


### PR DESCRIPTION
### Purpose

In #3731 we introduce `IcebergCommitCallback` to create Iceberg metadata. In this PR we improve this class so that it can reuse Iceberg manifest files created before to create new Iceberg metadata.

### Tests

Unit tests.

### API and Format

No changes in Paimon format.

### Documentation

Document will be added later.
