### PR TITLE
[core] Fix PredicateBuilder.convertJavaObject with timestamp with local zone

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
@@ -283,30 +283,32 @@ public class PredicateBuilder {
                 int scale = decimalType.getScale();
                 return Decimal.fromBigDecimal((BigDecimal) o, precision, scale);
             case TIMESTAMP_WITHOUT_TIME_ZONE:
-                Timestamp timestamp;
                 if (o instanceof java.sql.Timestamp) {
-                    timestamp = Timestamp.fromSQLTimestamp((java.sql.Timestamp) o);
+                    return Timestamp.fromSQLTimestamp((java.sql.Timestamp) o);
                 } else if (o instanceof Instant) {
                     Instant o1 = (Instant) o;
                     LocalDateTime dateTime = o1.atZone(ZoneId.systemDefault()).toLocalDateTime();
-                    timestamp = Timestamp.fromLocalDateTime(dateTime);
+                    return Timestamp.fromLocalDateTime(dateTime);
                 } else if (o instanceof LocalDateTime) {
-                    timestamp = Timestamp.fromLocalDateTime((LocalDateTime) o);
+                    return Timestamp.fromLocalDateTime((LocalDateTime) o);
                 } else {
-                    throw new UnsupportedOperationException("Unsupported object: " + o);
+                    throw new UnsupportedOperationException(
+                            String.format(
+                                    "Unsupported class %s for timestamp without timezone ",
+                                    o.getClass()));
                 }
-                return timestamp;
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
                 if (o instanceof java.sql.Timestamp) {
-                    timestamp = Timestamp.fromSQLTimestamp((java.sql.Timestamp) o);
+                    java.sql.Timestamp timestamp = (java.sql.Timestamp) o;
+                    return Timestamp.fromInstant(timestamp.toInstant());
                 } else if (o instanceof Instant) {
-                    timestamp = Timestamp.fromInstant((Instant) o);
-                } else if (o instanceof LocalDateTime) {
-                    timestamp = Timestamp.fromLocalDateTime((LocalDateTime) o);
+                    return Timestamp.fromInstant((Instant) o);
                 } else {
-                    throw new UnsupportedOperationException("Unsupported object: " + o);
+                    throw new UnsupportedOperationException(
+                            String.format(
+                                    "Unsupported class %s for timestamp with local time zone ",
+                                    o.getClass()));
                 }
-                return timestamp;
             default:
                 throw new UnsupportedOperationException(
                         "Unsupported predicate leaf type " + literalType.getTypeRoot().name());

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/SearchArgumentToPredicateConverterTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/SearchArgumentToPredicateConverterTest.java
@@ -75,6 +75,12 @@ public class SearchArgumentToPredicateConverterTest {
                 java.sql.Timestamp.valueOf("2022-05-17 16:25:53"),
                 DataTypes.TIMESTAMP(3),
                 Timestamp.fromSQLTimestamp(java.sql.Timestamp.valueOf("2022-05-17 16:25:53")));
+        testLiteral(
+                PredicateLeaf.Type.TIMESTAMP,
+                java.sql.Timestamp.valueOf("2022-05-17 16:25:53"),
+                DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3),
+                Timestamp.fromInstant(
+                        java.sql.Timestamp.valueOf("2022-05-17 16:25:53").toInstant()));
     }
 
     private void testLiteral(


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Timestamp with local zone should only use Timestamp.fromInstant.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
