### PR TITLE
[flink] Consumer ID must be specified when using expiration-time

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
@@ -256,6 +256,12 @@ public class FlinkSourceBuilder {
                     "consumer.expiration-time should be specified when using consumer-id.");
         }
 
+        if (!conf.contains(CoreOptions.CONSUMER_ID)
+                && conf.contains(CoreOptions.CONSUMER_EXPIRATION_TIME)) {
+            throw new IllegalArgumentException(
+                    "consumer-id should be specified when using consumer.expiration-time.");
+        }
+
         if (sourceBounded) {
             return buildStaticFileSource();
         }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -771,6 +771,34 @@ public class CatalogTableITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testConsumerExpirationTimeInBatchMode() {
+        batchSql("CREATE TABLE T (a INT, b INT)");
+        batchSql("INSERT INTO T VALUES (1, 2)");
+        batchSql("INSERT INTO T VALUES (3, 4)");
+        batchSql("INSERT INTO T VALUES (5, 6), (7, 8)");
+        assertThatThrownBy(
+                        () ->
+                                sql(
+                                        "SELECT * FROM T /*+ OPTIONS('consumer.expiration-time' = '3h') */ WHERE a = 1"))
+                .rootCause()
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("consumer-id should be specified when using consumer.expiration-time.");
+    }
+
+    @Test
+    public void testConsumerExpirationTimeInStreamingMode() {
+        batchSql("CREATE TABLE T (a INT, b INT)");
+        batchSql("INSERT INTO T VALUES (1, 2)");
+        batchSql("INSERT INTO T VALUES (3, 4)");
+        assertThatThrownBy(
+                        () ->
+                                streamSqlIter(
+                                        "SELECT * FROM T /*+ OPTIONS('consumer.expiration-time' = '3h') */"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("consumer-id should be specified when using consumer.expiration-time.");
+    }
+
+    @Test
     public void testConsumerIdExpInStreamingMode() {
         batchSql("CREATE TABLE T (a INT, b INT)");
         batchSql("INSERT INTO T VALUES (1, 2)");


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Consumer ID must be specified when using expiration-time

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
