### PR TITLE
[spark] Fix the generation of PaimonInputPartition 

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/ScanHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/ScanHelper.scala
@@ -85,7 +85,7 @@ trait ScanHelper extends Logging {
 
     def closeInputPartition(): Unit = {
       closeDataSplit()
-      if (currentSplit.nonEmpty) {
+      if (currentSplits.nonEmpty) {
         partitions += PaimonInputPartition(currentSplits.toArray)
       }
       currentSplits.clear()


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
