### PR TITLE
[core] fix the collect of overlapped snapshots

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -682,8 +682,7 @@ public class SnapshotManager implements Serializable {
         return -1;
     }
 
-    private static int findNextOrEqualTag(
-            List<Snapshot> sortedSnapshots, long targetSnapshotId) {
+    private static int findNextOrEqualTag(List<Snapshot> sortedSnapshots, long targetSnapshotId) {
         for (int i = 0; i < sortedSnapshots.size(); i++) {
             if (sortedSnapshots.get(i).id() >= targetSnapshotId) {
                 return i;

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -665,7 +665,7 @@ public class SnapshotManager implements Serializable {
         List<Snapshot> overlappedSnapshots = new ArrayList<>();
         int right = findPreviousSnapshot(sortedSnapshots, endExclusive);
         if (right >= 0) {
-            int left = Math.max(findPreviousOrEqualSnapshot(sortedSnapshots, beginInclusive), 0);
+            int left = Math.max(findNextOrEqualTag(sortedSnapshots, beginInclusive), 0);
             for (int i = left; i <= right; i++) {
                 overlappedSnapshots.add(sortedSnapshots.get(i));
             }
@@ -682,10 +682,10 @@ public class SnapshotManager implements Serializable {
         return -1;
     }
 
-    private static int findPreviousOrEqualSnapshot(
-            List<Snapshot> sortedSnapshots, long targetSnapshotId) {
-        for (int i = sortedSnapshots.size() - 1; i >= 0; i--) {
-            if (sortedSnapshots.get(i).id() <= targetSnapshotId) {
+    private static int findNextOrEqualTag(
+            List<Snapshot> taggedSnapshots, long targetSnapshotId) {
+        for (int i = 0; i < taggedSnapshots.size(); i++) {
+            if (taggedSnapshots.get(i).id() >= targetSnapshotId) {
                 return i;
             }
         }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -683,9 +683,9 @@ public class SnapshotManager implements Serializable {
     }
 
     private static int findNextOrEqualTag(
-            List<Snapshot> taggedSnapshots, long targetSnapshotId) {
-        for (int i = 0; i < taggedSnapshots.size(); i++) {
-            if (taggedSnapshots.get(i).id() >= targetSnapshotId) {
+            List<Snapshot> sortedSnapshots, long targetSnapshotId) {
+        for (int i = 0; i < sortedSnapshots.size(); i++) {
+            if (sortedSnapshots.get(i).id() >= targetSnapshotId) {
                 return i;
             }
         }

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -138,7 +138,7 @@ public class SnapshotManagerTest {
         assertThat(snapshotManager.laterOrEqualWatermark(millis + 999)).isNull();
     }
 
-    private Snapshot createSnapshotWithMillis(long id, long millis) {
+    public Snapshot createSnapshotWithMillis(long id, long millis) {
         return new Snapshot(
                 id,
                 0L,

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -138,7 +138,7 @@ public class SnapshotManagerTest {
         assertThat(snapshotManager.laterOrEqualWatermark(millis + 999)).isNull();
     }
 
-    public Snapshot createSnapshotWithMillis(long id, long millis) {
+    private Snapshot createSnapshotWithMillis(long id, long millis) {
         return new Snapshot(
                 id,
                 0L,
@@ -365,5 +365,24 @@ public class SnapshotManagerTest {
         Assertions.assertThat(snapshotManager.earliestSnapshotId()).isEqualTo(6);
         Assertions.assertThat(snapshotManager.latestSnapshotId()).isEqualTo(10);
         Assertions.assertThat(snapshotManager.changelog(1)).isNotNull();
+    }
+
+    @Test
+    public void testOverlappedSnapshots() {
+        SnapshotManagerTest snapshotManagerTest = new SnapshotManagerTest();
+        List<Snapshot> taggedSnapshot = new ArrayList<>();
+        long millis = System.currentTimeMillis();
+        long[] snapshotId = new long[] {8, 9, 11, 12, 15};
+        for (long id : snapshotId) {
+            taggedSnapshot.add(snapshotManagerTest.createSnapshotWithMillis(id, millis));
+        }
+
+        int beginInclusive = 10, endExclusive = 15;
+        // overlapped snapshot is [11,12]
+        List<Snapshot> overlappedSnapshots =
+                SnapshotManager.findOverlappedSnapshots(taggedSnapshot, beginInclusive, endExclusive);
+        List<Long> overlappedIds =
+                overlappedSnapshots.stream().map(Snapshot::id).collect(Collectors.toList());
+        assertThat(overlappedIds).containsExactly(11L, 12L);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -380,7 +380,8 @@ public class SnapshotManagerTest {
         int beginInclusive = 10, endExclusive = 15;
         // overlapped snapshot is [11,12]
         List<Snapshot> overlappedSnapshots =
-                SnapshotManager.findOverlappedSnapshots(taggedSnapshot, beginInclusive, endExclusive);
+                SnapshotManager.findOverlappedSnapshots(
+                        taggedSnapshot, beginInclusive, endExclusive);
         List<Long> overlappedIds =
                 overlappedSnapshots.stream().map(Snapshot::id).collect(Collectors.toList());
         assertThat(overlappedIds).containsExactly(11L, 12L);

--- a/paimon-core/src/test/java/org/apache/paimon/utils/TagManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/TagManagerTest.java
@@ -41,14 +41,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Collectors;
 
 import static org.apache.paimon.operation.FileStoreTestUtils.commitData;
 import static org.apache.paimon.operation.FileStoreTestUtils.partitionedData;

--- a/paimon-core/src/test/java/org/apache/paimon/utils/TagManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/TagManagerTest.java
@@ -133,25 +133,6 @@ public class TagManagerTest {
         assertThat(tags.get(0).getValue()).contains("tag");
     }
 
-    @Test
-    public void testOverlappedSnapshots() {
-        SnapshotManagerTest snapshotManagerTest = new SnapshotManagerTest();
-        List<Snapshot> taggedSnapshot = new ArrayList<>();
-        long millis = System.currentTimeMillis();
-        long[] snapshotId = new long[] {7, 9, 11, 12};
-        for (long id : snapshotId) {
-            taggedSnapshot.add(snapshotManagerTest.createSnapshotWithMillis(id, millis));
-        }
-
-        int beginInclusive = 10, endExclusive = 15;
-        // overlapped snapshot is [11,12]
-        List<Snapshot> overlappedSnapshots =
-                TagManager.findOverlappedSnapshots(taggedSnapshot, beginInclusive, endExclusive);
-        List<Long> overlappedIds =
-                overlappedSnapshots.stream().map(Snapshot::id).collect(Collectors.toList());
-        assertThat(overlappedIds).containsExactly(11L, 12L);
-    }
-
     private TestFileStore createStore(TestKeyValueGenerator.GeneratorMode mode, int buckets)
             throws Exception {
         ThreadLocalRandom random = ThreadLocalRandom.current();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

When call `findOverlappedSnapshots(List<Snapshot> taggedSnapshots, long beginInclusive, long endExclusive)`.
If beginInclusive is 10, endExclusive is 15, the range is [10, 15), and the taggedSnapshots is [8, 9, 11, 12, 15].
In previous way, the overlapped snapshots is [9, 11, 12]. Actually is only [11, 12].



<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
