### PR TITLE
[hotfix] Fix unstable Hive connector ut

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/RepairActionITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/RepairActionITCase.java
@@ -42,7 +42,7 @@ public class RepairActionITCase extends ActionITCaseBase {
 
     private static final TestHiveMetastore TEST_HIVE_METASTORE = new TestHiveMetastore();
 
-    private static final int PORT = 9083;
+    private static final int PORT = 9082;
 
     @BeforeEach
     public void beforeEach() {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Fix unstable Hive connector ut

hms port is 9083 in RepairActionITCase not stable because other test also use it，so change it to 9082.

![1721142223037.png](https://github.com/user-attachments/assets/ea8e58a0-16cc-41d0-948c-7e2c49ecd148)

![1721142221583.png](https://github.com/user-attachments/assets/0584be03-e80e-4335-925d-3b57d1ee1619)



<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
