### PR TITLE
[cdc] Adjust-CdcJsonDeserializationSchema

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/CdcSourceRecord.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/CdcSourceRecord.java
@@ -18,9 +18,15 @@
 
 package org.apache.paimon.flink.action.cdc;
 
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.DeserializationFeature;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
 import javax.annotation.Nullable;
 
+import java.io.IOException;
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Objects;
 
 /** A data change record from the CDC source. */
@@ -32,16 +38,20 @@ public class CdcSourceRecord implements Serializable {
 
     @Nullable private final Object key;
 
-    // TODO Use generics to support more scenarios.
-    private final Object value;
+    private final byte[] value;
 
-    public CdcSourceRecord(@Nullable String topic, @Nullable Object key, Object value) {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public CdcSourceRecord(@Nullable String topic, @Nullable Object key, byte[] value) {
         this.topic = topic;
         this.key = key;
         this.value = value;
+        this.objectMapper
+                .configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
-    public CdcSourceRecord(Object value) {
+    public CdcSourceRecord(byte[] value) {
         this(null, null, value);
     }
 
@@ -55,29 +65,46 @@ public class CdcSourceRecord implements Serializable {
         return key;
     }
 
-    public Object getValue() {
+    public byte[] getBytes() {
         return value;
+    }
+
+    public String getString() {
+        return new String(value);
+    }
+
+    public JsonNode getJsonNode() {
+        try {
+            return objectMapper.readValue(value, JsonNode.class);
+        } catch (IOException e) {
+            throw new RuntimeException("Invalid Json:\n" + getString());
+        }
     }
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof CdcSourceRecord)) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
 
         CdcSourceRecord that = (CdcSourceRecord) o;
         return Objects.equals(topic, that.topic)
                 && Objects.equals(key, that.key)
-                && Objects.equals(value, that.value);
+                && Arrays.equals(value, that.value);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(topic, key, value);
+        int result = Objects.hash(topic, key);
+        result = 31 * result + Arrays.hashCode(value);
+        return result;
     }
 
     @Override
     public String toString() {
-        return topic + ": " + key + " " + value;
+        return topic + ": " + key + " " + getString();
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/RecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/RecordParser.java
@@ -205,7 +205,7 @@ public abstract class RecordParser
     }
 
     protected void setRoot(CdcSourceRecord record) {
-        root = (JsonNode) record.getValue();
+        root = record.getJsonNode();
     }
 
     protected JsonNode mergeOldRecord(JsonNode data, JsonNode oldNode) {

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumRecordParser.java
@@ -120,7 +120,7 @@ public class DebeziumRecordParser extends RecordParser {
 
     @Override
     protected void setRoot(CdcSourceRecord record) {
-        JsonNode node = (JsonNode) record.getValue();
+        JsonNode node = record.getJsonNode();
 
         hasSchema = false;
         if (node.has(FIELD_SCHEMA)) {

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBRecordParser.java
@@ -71,7 +71,7 @@ public class MongoDBRecordParser
     @Override
     public void flatMap(CdcSourceRecord value, Collector<RichCdcMultiplexRecord> out)
             throws Exception {
-        root = OBJECT_MAPPER.readValue((String) value.getValue(), JsonNode.class);
+        root = value.getJsonNode();
         String databaseName = extractString(FIELD_DATABASE);
         String collection = extractString(FIELD_TABLE);
         MongoVersionStrategy versionStrategy =

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlRecordParser.java
@@ -105,7 +105,7 @@ public class MySqlRecordParser implements FlatMapFunction<CdcSourceRecord, RichC
     @Override
     public void flatMap(CdcSourceRecord rawEvent, Collector<RichCdcMultiplexRecord> out)
             throws Exception {
-        root = objectMapper.readValue((String) rawEvent.getValue(), DebeziumEvent.class);
+        root = objectMapper.readValue(rawEvent.getBytes(), DebeziumEvent.class);
         currentTable = root.payload().source().get(AbstractSourceInfo.TABLE_NAME_KEY).asText();
         databaseName = root.payload().source().get(AbstractSourceInfo.DATABASE_NAME_KEY).asText();
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresRecordParser.java
@@ -115,7 +115,7 @@ public class PostgresRecordParser
     @Override
     public void flatMap(CdcSourceRecord rawEvent, Collector<RichCdcMultiplexRecord> out)
             throws Exception {
-        root = objectMapper.readValue((String) rawEvent.getValue(), DebeziumEvent.class);
+        root = objectMapper.readValue(rawEvent.getBytes(), DebeziumEvent.class);
 
         currentTable = root.payload().source().get(AbstractSourceInfo.TABLE_NAME_KEY).asText();
         databaseName = root.payload().source().get(AbstractSourceInfo.DATABASE_NAME_KEY).asText();

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/serialization/CdcDebeziumDeserializationSchema.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/serialization/CdcDebeziumDeserializationSchema.java
@@ -75,7 +75,7 @@ public class CdcDebeziumDeserializationSchema
         }
         byte[] bytes =
                 jsonConverter.fromConnectData(record.topic(), record.valueSchema(), record.value());
-        out.collect(new CdcSourceRecord(record.topic(), null, new String(bytes)));
+        out.collect(new CdcSourceRecord(record.topic(), null, bytes));
     }
 
     /** Initialize {@link JsonConverter} with given configs. */

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/serialization/CdcJsonDeserializationSchema.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/serialization/CdcJsonDeserializationSchema.java
@@ -21,7 +21,6 @@ package org.apache.paimon.flink.action.cdc.serialization;
 import org.apache.paimon.flink.action.cdc.CdcSourceRecord;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.DeserializationFeature;
-import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
@@ -53,13 +52,7 @@ public class CdcJsonDeserializationSchema implements DeserializationSchema<CdcSo
         if (message == null) {
             return null;
         }
-
-        try {
-            return new CdcSourceRecord(objectMapper.readValue(message, JsonNode.class));
-        } catch (Exception e) {
-            LOG.error("Invalid Json:\n{}", new String(message));
-            throw e;
-        }
+        return new CdcSourceRecord(message);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/watermark/CdcTimestampExtractorFactory.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/watermark/CdcTimestampExtractorFactory.java
@@ -70,9 +70,9 @@ public class CdcTimestampExtractorFactory implements Serializable {
 
         @Override
         public long extractTimestamp(CdcSourceRecord record) throws JsonProcessingException {
-            JsonNode json = JsonSerdeUtil.fromJson((String) record.getValue(), JsonNode.class);
             // If the record is a schema-change event return Long.MIN_VALUE as result.
-            return JsonSerdeUtil.extractValueOrDefault(json, Long.class, Long.MIN_VALUE, "ts_ms");
+            return JsonSerdeUtil.extractValueOrDefault(
+                    record.getJsonNode(), Long.class, Long.MIN_VALUE, "ts_ms");
         }
     }
 
@@ -84,7 +84,7 @@ public class CdcTimestampExtractorFactory implements Serializable {
         @Override
         public long extractTimestamp(CdcSourceRecord cdcSourceRecord)
                 throws JsonProcessingException {
-            JsonNode record = (JsonNode) cdcSourceRecord.getValue();
+            JsonNode record = cdcSourceRecord.getJsonNode();
             if (JsonSerdeUtil.isNodeExists(record, "mysqlType")) {
                 // Canal json
                 return JsonSerdeUtil.extractValue(record, Long.class, "ts");
@@ -117,10 +117,8 @@ public class CdcTimestampExtractorFactory implements Serializable {
 
         @Override
         public long extractTimestamp(CdcSourceRecord record) throws JsonProcessingException {
-            JsonNode json = JsonSerdeUtil.fromJson((String) record.getValue(), JsonNode.class);
-
             return JsonSerdeUtil.extractValueOrDefault(
-                    json, Long.class, Long.MIN_VALUE, "payload", "ts_ms");
+                    record.getJsonNode(), Long.class, Long.MIN_VALUE, "payload", "ts_ms");
         }
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/CdcDebeziumTimestampExtractorITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/CdcDebeziumTimestampExtractorITCase.java
@@ -53,7 +53,7 @@ public class CdcDebeziumTimestampExtractorITCase {
                 new CdcTimestampExtractorFactory.MysqlCdcTimestampExtractor();
 
         JsonNode data = objectMapper.readValue("{\"payload\" : {\"ts_ms\": 1}}", JsonNode.class);
-        CdcSourceRecord record = new CdcSourceRecord(data.toString());
+        CdcSourceRecord record = new CdcSourceRecord(data.toString().getBytes());
         assertThat(extractor.extractTimestamp(record)).isEqualTo(1L);
 
         // If the record is a schema-change event `ts_ms` would be null, just ignore the record.
@@ -63,7 +63,7 @@ public class CdcDebeziumTimestampExtractorITCase {
                         .getResource("mysql/debezium-event-change.json");
         assertThat(url).isNotNull();
         JsonNode schemaChangeEvent = objectMapper.readValue(url, JsonNode.class);
-        record = new CdcSourceRecord(schemaChangeEvent.toString());
+        record = new CdcSourceRecord(schemaChangeEvent.toString().getBytes());
         assertThat(extractor.extractTimestamp(record)).isEqualTo(Long.MIN_VALUE);
     }
 
@@ -73,7 +73,7 @@ public class CdcDebeziumTimestampExtractorITCase {
                 new CdcTimestampExtractorFactory.MongoDBCdcTimestampExtractor();
 
         JsonNode data = objectMapper.readValue("{\"ts_ms\": 1}", JsonNode.class);
-        CdcSourceRecord record = new CdcSourceRecord(data.toString());
+        CdcSourceRecord record = new CdcSourceRecord(data.toString().getBytes());
         assertThat(extractor.extractTimestamp(record)).isEqualTo(1L);
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

The serialization entry of cdc kafka_table/database_sync is CdcJsonDeserializationSchema, but CdcJsonDeserializationSchema#deserialize returns CdcSourceRecord(JsonNode). When users extend other format, there will be limitations. Most data serialization is based on byte[], not JsonNode. 
For example: 
Users need to use other serialization protocols to serialize data based on byte[], such as binlog of other databases.

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
