### PR TITLE
[hotfix] Fix port occupied in KvQueryTableTest

### DIFF
--- a/paimon-service/paimon-service-runtime/src/test/java/org/apache/paimon/service/KvQueryTableTest.java
+++ b/paimon-service/paimon-service-runtime/src/test/java/org/apache/paimon/service/KvQueryTableTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -71,8 +72,8 @@ public class KvQueryTableTest extends PrimaryKeyTableTestBase {
         this.query0 = table.newLocalTableQuery().withIOManager(ioManager);
         this.query1 = table.newLocalTableQuery().withIOManager(ioManager);
 
-        this.server0 = createServer(0, query0, 7777);
-        this.server1 = createServer(1, query1, 7900);
+        this.server0 = createServer(0, query0, 7700, 7799);
+        this.server1 = createServer(1, query1, 7900, 7999);
         registryServers();
 
         this.client =
@@ -86,14 +87,18 @@ public class KvQueryTableTest extends PrimaryKeyTableTestBase {
         serviceManager.resetService(PRIMARY_KEY_LOOKUP, addresses);
     }
 
-    private KvQueryServer createServer(int serverId, TableQuery query, int port) {
+    private KvQueryServer createServer(int serverId, TableQuery query, int minPort, int maxPort) {
         try {
+            List<Integer> portList = new ArrayList<>();
+            for (int p = minPort; p <= maxPort; p++) {
+                portList.add(p);
+            }
             KvQueryServer server =
                     new KvQueryServer(
                             serverId,
                             2,
                             InetAddress.getLocalHost().getHostName(),
-                            Collections.singletonList(port).iterator(),
+                            portList.iterator(),
                             1,
                             1,
                             query,
@@ -159,8 +164,8 @@ public class KvQueryTableTest extends PrimaryKeyTableTestBase {
         innerTestServerRestart(
                 () -> {
                     shutdownServers();
-                    KvQueryTableTest.this.server0 = createServer(0, query0, 7777);
-                    KvQueryTableTest.this.server1 = createServer(1, query1, 7900);
+                    KvQueryTableTest.this.server0 = createServer(0, query0, 7700, 7799);
+                    KvQueryTableTest.this.server1 = createServer(1, query1, 7900, 7999);
                     registryServers();
                 });
     }
@@ -170,8 +175,8 @@ public class KvQueryTableTest extends PrimaryKeyTableTestBase {
         innerTestServerRestart(
                 () -> {
                     shutdownServers();
-                    KvQueryTableTest.this.server0 = createServer(0, query0, 7900);
-                    KvQueryTableTest.this.server1 = createServer(1, query1, 7777);
+                    KvQueryTableTest.this.server0 = createServer(0, query0, 7900, 7999);
+                    KvQueryTableTest.this.server1 = createServer(1, query1, 7700, 7799);
                     registryServers();
                 });
     }
@@ -181,8 +186,8 @@ public class KvQueryTableTest extends PrimaryKeyTableTestBase {
         innerTestServerRestart(
                 () -> {
                     shutdownServers();
-                    KvQueryTableTest.this.server0 = createServer(0, query0, 7778);
-                    KvQueryTableTest.this.server1 = createServer(1, query1, 7901);
+                    KvQueryTableTest.this.server0 = createServer(0, query0, 7700, 7799);
+                    KvQueryTableTest.this.server1 = createServer(1, query1, 7900, 7999);
                     registryServers();
                 });
     }


### PR DESCRIPTION
### Purpose

Fix port occupied in KvQueryTableTest

### Tests

Fix port occupied in KvQueryTableTest

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
