### PR TITLE
[core] fix CommitterOperator chain value when sink.committer-operator-chaining is false

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
@@ -121,7 +121,7 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
         this.committerFactory = checkNotNull(committerFactory);
         this.committableStateManager = committableStateManager;
         this.endInputWatermark = endInputWatermark;
-        setChainingStrategy(chaining ? ChainingStrategy.ALWAYS : ChainingStrategy.NEVER);
+        setChainingStrategy(chaining ? ChainingStrategy.ALWAYS : ChainingStrategy.HEAD);
     }
 
     @Override


### PR DESCRIPTION

when sink.committer-operator-chaining'='false',  an extra node appeared in our flink job.
This is a bug, fix it.

![image](https://github.com/user-attachments/assets/12cdf846-5f67-4923-a7ea-be66ac33c5fa)


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
