### PR TITLE
[hive] migrate_file support save source table

### DIFF
--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -127,6 +127,17 @@ This section introduce all available spark procedures about paimon.
       <td>CALL sys.migrate_table(source_type => 'hive', table => 'default.T', options => 'file.format=parquet')</td>
     </tr>
     <tr>
+      <td>migrate_file</td>
+      <td>
+         Migrate from hive table to a paimon table. Arguments:
+            <li>source_type: the origin table's type to be migrated, such as hive. Cannot be empty.</li>
+            <li>source_table: name of the origin table to migrate. Cannot be empty.</li>
+            <li>target_table: name of the target table to be migrated. Cannot be empty.</li>
+            <li>delete_origin: If had set target_table, can set delete_origin to decide whether delete the origin table metadata from hms after migrate. Default is true</li>
+      </td>
+      <td>CALL sys.migrate_file(source_type => 'hive', table => 'default.T', delete_origin => true)</td>
+    </tr>
+    <tr>
       <td>remove_orphan_files</td>
       <td>
          To remove the orphan data files and metadata files. Arguments:

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateFileProcedureITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateFileProcedureITCase.java
@@ -109,10 +109,10 @@ public class MigrateFileProcedureITCase extends ActionITCaseBase {
         tEnv.useCatalog("HIVE");
         tEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
         tEnv.executeSql(
-                "CREATE TABLE hivetable (id string) PARTITIONED BY (id2 int, id3 int) STORED AS "
+                "CREATE TABLE hivetable01 (id string) PARTITIONED BY (id2 int, id3 int) STORED AS "
                         + format);
-        tEnv.executeSql("INSERT INTO hivetable VALUES" + data(100)).await();
-        tEnv.executeSql("SHOW CREATE TABLE hivetable");
+        tEnv.executeSql("INSERT INTO hivetable01 VALUES" + data(100)).await();
+        tEnv.executeSql("SHOW CREATE TABLE hivetable01");
 
         tEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
         tEnv.executeSql("CREATE CATALOG PAIMON_GE WITH ('type'='paimon-generic')");
@@ -126,11 +126,11 @@ public class MigrateFileProcedureITCase extends ActionITCaseBase {
                         + "')");
         tEnv.useCatalog("PAIMON");
         tEnv.executeSql(
-                "CREATE TABLE paimontable (id STRING, id2 INT, id3 INT) PARTITIONED BY (id2, id3) with ('bucket' = '-1');");
+                "CREATE TABLE paimontable01 (id STRING, id2 INT, id3 INT) PARTITIONED BY (id2, id3) with ('bucket' = '-1');");
         tEnv.executeSql(
-                        "CALL sys.migrate_file('hive', 'default.hivetable', 'default.paimontable'， false)")
+                        "CALL sys.migrate_file('hive', 'default.hivetable01', 'default.paimontable01'， false)")
                 .await();
-        List<Row> r1 = ImmutableList.copyOf(tEnv.executeSql("SELECT * FROM hivetable").collect());
+        List<Row> r1 = ImmutableList.copyOf(tEnv.executeSql("SELECT * FROM hivetable01").collect());
         Assertions.assertThat(r1.size() == 0);
     }
 

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateFileProcedureITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateFileProcedureITCase.java
@@ -128,7 +128,7 @@ public class MigrateFileProcedureITCase extends ActionITCaseBase {
         tEnv.executeSql(
                 "CREATE TABLE paimontable01 (id STRING, id2 INT, id3 INT) PARTITIONED BY (id2, id3) with ('bucket' = '-1');");
         tEnv.executeSql(
-                        "CALL sys.migrate_file('hive', 'default.hivetable01', 'default.paimontable01'， false)")
+                        "CALL sys.migrate_file('hive', 'default.hivetable01', 'default.paimontable01', false)")
                 .await();
         List<Row> r1 = ImmutableList.copyOf(tEnv.executeSql("SELECT * FROM hivetable01").collect());
         Assertions.assertThat(r1.size() == 0);

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateFileProcedureITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateFileProcedureITCase.java
@@ -130,6 +130,7 @@ public class MigrateFileProcedureITCase extends ActionITCaseBase {
         tEnv.executeSql(
                         "CALL sys.migrate_file('hive', 'default.hivetable01', 'default.paimontable01', false)")
                 .await();
+        tEnv.useCatalog("HIVE");
         List<Row> r1 = ImmutableList.copyOf(tEnv.executeSql("SELECT * FROM hivetable01").collect());
         Assertions.assertThat(r1.size() == 0);
     }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateFileProcedureITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateFileProcedureITCase.java
@@ -56,16 +56,19 @@ public class MigrateFileProcedureITCase extends ActionITCaseBase {
     @Test
     public void testOrc() throws Exception {
         test("orc");
+        testWithDeleteOrigin("orc");
     }
 
     @Test
     public void testAvro() throws Exception {
         test("avro");
+        testWithDeleteOrigin("avro");
     }
 
     @Test
     public void testParquet() throws Exception {
         test("parquet");
+        testWithDeleteOrigin("parquet");
     }
 
     public void test(String format) throws Exception {
@@ -98,6 +101,37 @@ public class MigrateFileProcedureITCase extends ActionITCaseBase {
         List<Row> r2 = ImmutableList.copyOf(tEnv.executeSql("SELECT * FROM paimontable").collect());
 
         Assertions.assertThatList(r1).containsExactlyInAnyOrderElementsOf(r2);
+    }
+
+    public void testWithDeleteOrigin(String format) throws Exception {
+        TableEnvironment tEnv = tableEnvironmentBuilder().batchMode().build();
+        tEnv.executeSql("CREATE CATALOG HIVE WITH ('type'='hive')");
+        tEnv.useCatalog("HIVE");
+        tEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
+        tEnv.executeSql(
+                "CREATE TABLE hivetable (id string) PARTITIONED BY (id2 int, id3 int) STORED AS "
+                        + format);
+        tEnv.executeSql("INSERT INTO hivetable VALUES" + data(100)).await();
+        tEnv.executeSql("SHOW CREATE TABLE hivetable");
+
+        tEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
+        tEnv.executeSql("CREATE CATALOG PAIMON_GE WITH ('type'='paimon-generic')");
+        tEnv.useCatalog("PAIMON_GE");
+
+        tEnv.executeSql(
+                "CREATE CATALOG PAIMON WITH ('type'='paimon', 'metastore' = 'hive', 'uri' = 'thrift://localhost:"
+                        + PORT
+                        + "' , 'warehouse' = '"
+                        + System.getProperty(HiveConf.ConfVars.METASTOREWAREHOUSE.varname)
+                        + "')");
+        tEnv.useCatalog("PAIMON");
+        tEnv.executeSql(
+                "CREATE TABLE paimontable (id STRING, id2 INT, id3 INT) PARTITIONED BY (id2, id3) with ('bucket' = '-1');");
+        tEnv.executeSql(
+                        "CALL sys.migrate_file('hive', 'default.hivetable', 'default.paimontable'， false)")
+                .await();
+        List<Row> r1 = ImmutableList.copyOf(tEnv.executeSql("SELECT * FROM hivetable").collect());
+        Assertions.assertThat(r1.size() == 0);
     }
 
     private String data(int i) {

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/RepairActionITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/RepairActionITCase.java
@@ -42,7 +42,7 @@ public class RepairActionITCase extends ActionITCaseBase {
 
     private static final TestHiveMetastore TEST_HIVE_METASTORE = new TestHiveMetastore();
 
-    private static final int PORT = 9083;
+    private static final int PORT = 9082;
 
     @BeforeEach
     public void beforeEach() {

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/RepairActionITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/RepairActionITCase.java
@@ -42,7 +42,7 @@ public class RepairActionITCase extends ActionITCaseBase {
 
     private static final TestHiveMetastore TEST_HIVE_METASTORE = new TestHiveMetastore();
 
-    private static final int PORT = 9082;
+    private static final int PORT = 9083;
 
     @BeforeEach
     public void beforeEach() {

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateFileProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateFileProcedureTest.scala
@@ -59,6 +59,43 @@ class MigrateFileProcedureTest extends PaimonHiveTestBase {
 
   Seq("parquet", "orc", "avro").foreach(
     format => {
+      test(
+        s"Paimon migrate file procedure: migrate $format non-partitioned table with delete source table") {
+        withTable("hive_tbl", "paimon_tbl") {
+          // create hive table
+          spark.sql(s"""
+                       |CREATE TABLE hive_tbl (id STRING, name STRING, pt STRING)
+                       |USING $format
+                       |""".stripMargin)
+
+          spark.sql(s"INSERT INTO hive_tbl VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
+
+          // create paimon table
+          spark.sql(s"""
+                       |CREATE TABLE paimon_tbl (id STRING, name STRING, pt STRING)
+                       |USING PAIMON
+                       |TBLPROPERTIES ('file.format'='$format', 'bucket'='-1')
+                       |""".stripMargin)
+
+          spark.sql(s"INSERT INTO paimon_tbl VALUES ('3', 'c', 'p1'), ('4', 'd', 'p2')")
+
+          spark.sql(
+            s"CALL sys.migrate_file(source_type => 'hive', source_table => '$hiveDbName.hive_tbl', target_table => '$hiveDbName.paimon_tbl', delete_origin => false)")
+
+          checkAnswer(spark.sql("SELECT * FROM hive_tbl ORDER BY id"), Nil)
+
+          checkAnswer(
+            spark.sql("SELECT * FROM paimon_tbl ORDER BY id"),
+            Row("1", "a", "p1") :: Row("2", "b", "p2") :: Row("3", "c", "p1") :: Row(
+              "4",
+              "d",
+              "p2") :: Nil)
+        }
+      }
+    })
+
+  Seq("parquet", "orc", "avro").foreach(
+    format => {
       test(s"Paimon migrate file procedure: migrate $format partitioned table") {
         withTable("hive_tbl", "paimon_tbl") {
           // create hive table
@@ -89,6 +126,45 @@ class MigrateFileProcedureTest extends PaimonHiveTestBase {
               "4",
               "d",
               "p2") :: Nil)
+        }
+      }
+    })
+
+  Seq("parquet", "orc", "avro").foreach(
+    format => {
+      test(
+        s"Paimon migrate file procedure: migrate $format partitioned table with delete source table") {
+        withTable("hive_tbl", "paimon_tbl") {
+          // create hive table
+          spark.sql(s"""
+                       |CREATE TABLE hive_tbl (id STRING, name STRING, pt STRING)
+                       |USING $format
+                       |PARTITIONED BY (pt)
+                       |""".stripMargin)
+
+          spark.sql(s"INSERT INTO hive_tbl VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
+
+          // create paimon table
+          spark.sql(s"""
+                       |CREATE TABLE paimon_tbl (id STRING, name STRING, pt STRING)
+                       |USING PAIMON
+                       |TBLPROPERTIES ('file.format'='$format', 'bucket'='-1')
+                       |PARTITIONED BY (pt)
+                       |""".stripMargin)
+
+          spark.sql(s"INSERT INTO paimon_tbl VALUES ('3', 'c', 'p1'), ('4', 'd', 'p2')")
+
+          spark.sql(
+            s"CALL sys.migrate_file(source_type => 'hive', source_table => '$hiveDbName.hive_tbl', target_table => '$hiveDbName.paimon_tbl', delete_origin => false)")
+
+          checkAnswer(
+            spark.sql("SELECT * FROM paimon_tbl ORDER BY id"),
+            Row("1", "a", "p1") :: Row("2", "b", "p2") :: Row("3", "c", "p1") :: Row(
+              "4",
+              "d",
+              "p2") :: Nil)
+
+          checkAnswer(spark.sql("SELECT * FROM paimon_tbl ORDER BY id"), Nil)
         }
       }
     })

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateFileProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateFileProcedureTest.scala
@@ -164,7 +164,7 @@ class MigrateFileProcedureTest extends PaimonHiveTestBase {
               "d",
               "p2") :: Nil)
 
-          checkAnswer(spark.sql("SELECT * FROM paimon_tbl ORDER BY id"), Nil)
+          checkAnswer(spark.sql("SELECT * FROM hive_tbl ORDER BY id"), Nil)
         }
       }
     })


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Currently migrate_file would delete source table after migrate，but some condition user hope save origin table.The pr is aim to support it.

<!-- Linking this pull request to the issue -->
Linked issue: close https://github.com/apache/paimon/issues/3781

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
