### PR TITLE
[spark] Apply MergePaimonScalarSubqueries only when paimon scan exists

### DIFF
--- a/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueries.scala
+++ b/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueries.scala
@@ -20,11 +20,11 @@ package org.apache.paimon.spark.catalyst.optimizer
 
 import org.apache.paimon.spark.PaimonScan
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, ExprId, ScalarSubquery, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeReference, ExprId, ScalarSubquery}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
 
-object MergePaimonScalarSubqueriers extends MergePaimonScalarSubqueriersBase {
+object MergePaimonScalarSubqueries extends MergePaimonScalarSubqueriesBase {
 
   override def tryMergeDataSourceV2ScanRelation(
       newV2ScanRelation: DataSourceV2ScanRelation,
@@ -32,26 +32,15 @@ object MergePaimonScalarSubqueriers extends MergePaimonScalarSubqueriersBase {
       : Option[(LogicalPlan, AttributeMap[Attribute])] = {
     (newV2ScanRelation, cachedV2ScanRelation) match {
       case (
-            DataSourceV2ScanRelation(
-              newRelation,
-              newScan: PaimonScan,
-              newOutput,
-              newPartitioning,
-              newOrdering),
+            DataSourceV2ScanRelation(newRelation, newScan: PaimonScan, newOutput, newPartitioning),
             DataSourceV2ScanRelation(
               cachedRelation,
               cachedScan: PaimonScan,
               _,
-              cachedPartitioning,
-              cacheOrdering)) =>
+              cachedPartitioning)) =>
         checkIdenticalPlans(newRelation, cachedRelation).flatMap {
           outputMap =>
-            if (
-              samePartitioning(newPartitioning, cachedPartitioning, outputMap) && sameOrdering(
-                newOrdering,
-                cacheOrdering,
-                outputMap)
-            ) {
+            if (samePartitioning(newPartitioning, cachedPartitioning, outputMap)) {
               mergePaimonScan(newScan, cachedScan).map {
                 mergedScan =>
                   val mergedAttributes = mergedScan
@@ -81,16 +70,7 @@ object MergePaimonScalarSubqueriers extends MergePaimonScalarSubqueriersBase {
     }
   }
 
-  private def sameOrdering(
-      newOrdering: Option[Seq[SortOrder]],
-      cachedOrdering: Option[Seq[SortOrder]],
-      outputAttrMap: AttributeMap[Attribute]): Boolean = {
-    val mappedNewOrdering = newOrdering.map(_.map(mapAttributes(_, outputAttrMap)))
-    mappedNewOrdering.map(_.map(_.canonicalized)) == cachedOrdering.map(_.map(_.canonicalized))
-  }
-
   override protected def createScalarSubquery(plan: LogicalPlan, exprId: ExprId): ScalarSubquery = {
     ScalarSubquery(plan, exprId = exprId)
   }
-
 }

--- a/paimon-spark/paimon-spark-3.5/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueries.scala
+++ b/paimon-spark/paimon-spark-3.5/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueries.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, Attri
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
 
-object MergePaimonScalarSubqueriers extends MergePaimonScalarSubqueriersBase {
+object MergePaimonScalarSubqueries extends MergePaimonScalarSubqueriesBase {
 
   override def tryMergeDataSourceV2ScanRelation(
       newV2ScanRelation: DataSourceV2ScanRelation,

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/EvalSubqueriesForDeleteTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/EvalSubqueriesForDeleteTable.scala
@@ -37,8 +37,8 @@ import scala.collection.JavaConverters._
  * in advance. So that when running [[DeleteFromPaimonTableCommand]], we can directly call
  * dropPartitions to achieve fast deletion.
  *
- * Note: this rule must be placed before [[MergePaimonScalarSubqueriers]], because
- * [[MergePaimonScalarSubqueriers]] will merge subqueries.
+ * Note: this rule must be placed before [[MergePaimonScalarSubqueries]], because
+ * [[MergePaimonScalarSubqueries]] will merge subqueries.
  */
 object EvalSubqueriesForDeleteTable extends Rule[LogicalPlan] with ExpressionHelper with Logging {
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueries.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueries.scala
@@ -21,7 +21,7 @@ package org.apache.paimon.spark.catalyst.optimizer
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 
-object MergePaimonScalarSubqueriers extends Rule[LogicalPlan] {
+object MergePaimonScalarSubqueries extends Rule[LogicalPlan] {
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
     plan

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueriesBase.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueriesBase.scala
@@ -40,7 +40,7 @@ import scala.collection.mutable.ArrayBuffer
  * reused. So we extend the [[tryMergePlans]] method to check and merge
  * [[DataSourceV2ScanRelation]]s, thus we can merge scalar subqueries for paimon.
  */
-trait MergePaimonScalarSubqueriersBase extends Rule[LogicalPlan] with PredicateHelper {
+trait MergePaimonScalarSubqueriesBase extends Rule[LogicalPlan] with PredicateHelper {
   def apply(plan: LogicalPlan): LogicalPlan = {
     plan match {
       // Subquery reuse needs to be enabled for this optimization.

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueriesBase.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueriesBase.scala
@@ -44,7 +44,7 @@ trait MergePaimonScalarSubqueriesBase extends Rule[LogicalPlan] with PredicateHe
   def apply(plan: LogicalPlan): LogicalPlan = {
     plan match {
       // Subquery reuse needs to be enabled for this optimization.
-      case _ if !conf.getConf(SQLConf.SUBQUERY_REUSE_ENABLED) && !containPaimonScan(plan) => plan
+      case _ if !conf.getConf(SQLConf.SUBQUERY_REUSE_ENABLED) && !existsPaimonScan(plan) => plan
 
       // This rule does a whole plan traversal, no need to run on subqueries.
       case _: Subquery => plan
@@ -56,7 +56,7 @@ trait MergePaimonScalarSubqueriesBase extends Rule[LogicalPlan] with PredicateHe
     }
   }
 
-  private def containPaimonScan(plan: LogicalPlan): Boolean = {
+  private def existsPaimonScan(plan: LogicalPlan): Boolean = {
     plan.find {
       case r: DataSourceV2ScanRelation => r.scan.isInstanceOf[PaimonScan]
       case _ => false

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/extensions/PaimonSparkSessionExtensions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/extensions/PaimonSparkSessionExtensions.scala
@@ -19,7 +19,7 @@
 package org.apache.paimon.spark.extensions
 
 import org.apache.paimon.spark.catalyst.analysis.{PaimonAnalysis, PaimonDeleteTable, PaimonIncompatiblePHRRules, PaimonIncompatibleResolutionRules, PaimonMergeInto, PaimonPostHocResolutionRules, PaimonProcedureResolver, PaimonUpdateTable}
-import org.apache.paimon.spark.catalyst.optimizer.{EvalSubqueriesForDeleteTable, MergePaimonScalarSubqueriers}
+import org.apache.paimon.spark.catalyst.optimizer.{EvalSubqueriesForDeleteTable, MergePaimonScalarSubqueries}
 import org.apache.paimon.spark.catalyst.plans.logical.PaimonTableValuedFunctions
 import org.apache.paimon.spark.execution.PaimonStrategy
 
@@ -54,7 +54,7 @@ class PaimonSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
 
     // optimization rules
     extensions.injectOptimizerRule(_ => EvalSubqueriesForDeleteTable)
-    extensions.injectOptimizerRule(_ => MergePaimonScalarSubqueriers)
+    extensions.injectOptimizerRule(_ => MergePaimonScalarSubqueries)
 
     // planner extensions
     extensions.injectPlannerStrategy(spark => PaimonStrategy(spark))

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/PaimonOptimizationTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/PaimonOptimizationTestBase.scala
@@ -20,7 +20,7 @@ package org.apache.paimon.spark.sql
 
 import org.apache.paimon.Snapshot.CommitKind
 import org.apache.paimon.spark.PaimonSparkTestBase
-import org.apache.paimon.spark.catalyst.optimizer.MergePaimonScalarSubqueriers
+import org.apache.paimon.spark.catalyst.optimizer.MergePaimonScalarSubqueries
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.{Attribute, CreateNamedStruct, Literal, NamedExpression}
@@ -39,7 +39,7 @@ abstract class PaimonOptimizationTestBase extends PaimonSparkTestBase {
 
   private object Optimize extends RuleExecutor[LogicalPlan] {
     val batches: immutable.Seq[Batch] =
-      Batch("MergePaimonScalarSubqueries", Once, MergePaimonScalarSubqueriers) :: Nil
+      Batch("MergePaimonScalarSubqueries", Once, MergePaimonScalarSubqueries) :: Nil
   }
 
   test("Paimon Optimization: merge scalar subqueries") {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

- Apply MergePaimonScalarSubqueries only when paimon scan exists
- fix typo

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
