### PR TITLE
[core] Remove duplicate ConfigOption.withDeprecatedKeys

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1148,6 +1148,12 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "In watermarking, if a source remains idle beyond the specified timeout duration, it triggers snapshot advancement and facilitates tag creation.");
 
+    public static final ConfigOption<Integer> PARQUET_ENABLE_DICTIONARY =
+            key("parquet.enable.dictionary")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription("Turn off the dictionary encoding for all fields in parquet.");
+
     public static final ConfigOption<String> SINK_WATERMARK_TIME_ZONE =
             key("sink.watermark-time-zone")
                     .stringType()

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -286,7 +286,7 @@ public class CoreOptions implements Serializable {
             key("snapshot.clean-empty-directories")
                     .booleanType()
                     .defaultValue(false)
-                    .withDeprecatedKeys("snapshot.expire.clean-empty-directories")
+                    .withFallbackKeys("snapshot.expire.clean-empty-directories")
                     .withDescription(
                             Description.builder()
                                     .text(
@@ -322,7 +322,7 @@ public class CoreOptions implements Serializable {
             key("ignore-delete")
                     .booleanType()
                     .defaultValue(false)
-                    .withDeprecatedKeys(
+                    .withFallbackKeys(
                             "first-row.ignore-delete",
                             "deduplicate.ignore-delete",
                             "partial-update.ignore-delete")
@@ -359,7 +359,7 @@ public class CoreOptions implements Serializable {
             key("write-only")
                     .booleanType()
                     .defaultValue(false)
-                    .withDeprecatedKeys("write.compaction-skip")
+                    .withFallbackKeys("write.compaction-skip")
                     .withDescription(
                             "If set to true, compactions and snapshot expiration will be skipped. "
                                     + "This option is used along with dedicated compact jobs.");
@@ -522,7 +522,7 @@ public class CoreOptions implements Serializable {
             key("compaction.max.file-num")
                     .intType()
                     .defaultValue(50)
-                    .withDeprecatedKeys("compaction.early-max.file-num")
+                    .withFallbackKeys("compaction.early-max.file-num")
                     .withDescription(
                             "For file set [f_0,...,f_N], the maximum file number to trigger a compaction "
                                     + "for append-only table, even if sum(size(f_i)) < targetFileSize. This value "
@@ -574,7 +574,7 @@ public class CoreOptions implements Serializable {
             key("scan.mode")
                     .enumType(StartupMode.class)
                     .defaultValue(StartupMode.DEFAULT)
-                    .withDeprecatedKeys("log.scan")
+                    .withFallbackKeys("log.scan")
                     .withDescription("Specify the scanning behavior of the source.");
 
     public static final ConfigOption<String> SCAN_TIMESTAMP =
@@ -588,7 +588,7 @@ public class CoreOptions implements Serializable {
             key("scan.timestamp-millis")
                     .longType()
                     .noDefaultValue()
-                    .withDeprecatedKeys("log.scan.timestamp-millis")
+                    .withFallbackKeys("log.scan.timestamp-millis")
                     .withDescription(
                             "Optional timestamp used in case of \"from-timestamp\" scan mode. "
                                     + "If there is no snapshot earlier than this time, the earliest snapshot will be chosen.");
@@ -1147,12 +1147,6 @@ public class CoreOptions implements Serializable {
                     .noDefaultValue()
                     .withDescription(
                             "In watermarking, if a source remains idle beyond the specified timeout duration, it triggers snapshot advancement and facilitates tag creation.");
-
-    public static final ConfigOption<Integer> PARQUET_ENABLE_DICTIONARY =
-            key("parquet.enable.dictionary")
-                    .intType()
-                    .noDefaultValue()
-                    .withDescription("Turn off the dictionary encoding for all fields in parquet.");
 
     public static final ConfigOption<String> SINK_WATERMARK_TIME_ZONE =
             key("sink.watermark-time-zone")

--- a/paimon-common/src/main/java/org/apache/paimon/options/ConfigOption.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/ConfigOption.java
@@ -128,29 +128,6 @@ public class ConfigOption<T> {
 
     /**
      * Creates a new config option, using this option's key and default value, and adding the given
-     * deprecated keys.
-     *
-     * <p>When obtaining a value from the configuration via {@link Options#get(ConfigOption)}, the
-     * deprecated keys will be checked in the order provided to this method. The first key for which
-     * a value is found will be used - that value will be returned.
-     *
-     * @param deprecatedKeys The deprecated keys, in the order in which they should be checked.
-     * @return A new config options, with the given deprecated keys.
-     */
-    public ConfigOption<T> withDeprecatedKeys(String... deprecatedKeys) {
-        final Stream<FallbackKey> newDeprecatedKeys =
-                Arrays.stream(deprecatedKeys).map(FallbackKey::createDeprecatedKey);
-        final Stream<FallbackKey> currentAlternativeKeys = Arrays.stream(this.fallbackKeys);
-
-        // put deprecated keys last so that they are de-prioritized
-        final FallbackKey[] mergedAlternativeKeys =
-                Stream.concat(currentAlternativeKeys, newDeprecatedKeys)
-                        .toArray(FallbackKey[]::new);
-        return new ConfigOption<>(key, clazz, description, defaultValue, mergedAlternativeKeys);
-    }
-
-    /**
-     * Creates a new config option, using this option's key and default value, and adding the given
      * description. The given description is used when generation the configuration documentation.
      *
      * @param description The description for this option.

--- a/paimon-common/src/main/java/org/apache/paimon/security/SecurityConfiguration.java
+++ b/paimon-common/src/main/java/org/apache/paimon/security/SecurityConfiguration.java
@@ -34,7 +34,7 @@ public class SecurityConfiguration {
             key("security.kerberos.login.keytab")
                     .stringType()
                     .noDefaultValue()
-                    .withDeprecatedKeys("security.keytab")
+                    .withFallbackKeys("security.keytab")
                     .withDescription(
                             "Absolute path to a Kerberos keytab file that contains the user credentials.");
 
@@ -42,7 +42,7 @@ public class SecurityConfiguration {
             key("security.kerberos.login.principal")
                     .stringType()
                     .noDefaultValue()
-                    .withDeprecatedKeys("security.principal")
+                    .withFallbackKeys("security.principal")
                     .withDescription("Kerberos principal name associated with the keytab.");
 
     public static final ConfigOption<Boolean> KERBEROS_LOGIN_USETICKETCACHE =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -211,7 +211,7 @@ public class FlinkConnectorOptions {
             key("scan.remove-normalize")
                     .booleanType()
                     .defaultValue(false)
-                    .withDeprecatedKeys("log.scan.remove-normalize")
+                    .withFallbackKeys("log.scan.remove-normalize")
                     .withDescription(
                             "Whether to force the removal of the normalize node when streaming read."
                                     + " Note: This is dangerous and is likely to cause data errors if downstream"


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In ConfigOption, withDeprecatedKeys is very similar with withFallbackKeys. We can just keep only one.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
