### PR TITLE
[core] Cleaning snapshots or deleting tags should skip those referenced by branches.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/FileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/FileStore.java
@@ -23,6 +23,7 @@ import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.manifest.ManifestFile;
 import org.apache.paimon.manifest.ManifestList;
+import org.apache.paimon.operation.BranchDeletion;
 import org.apache.paimon.operation.ChangelogDeletion;
 import org.apache.paimon.operation.FileStoreCommit;
 import org.apache.paimon.operation.FileStoreScan;
@@ -38,6 +39,7 @@ import org.apache.paimon.table.sink.CommitCallback;
 import org.apache.paimon.table.sink.TagCallback;
 import org.apache.paimon.tag.TagAutoManager;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.SegmentsCache;
 import org.apache.paimon.utils.SnapshotManager;
@@ -90,7 +92,11 @@ public interface FileStore<T> {
 
     TagManager newTagManager();
 
+    BranchManager newBranchManager();
+
     TagDeletion newTagDeletion();
+
+    BranchDeletion newBranchDeletion();
 
     @Nullable
     PartitionExpire newPartitionExpire(String commitUser);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/BranchDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/BranchDeletion.java
@@ -37,12 +37,12 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
 
-/** Delete tag files. */
-public class TagDeletion extends FileDeletionBase<Snapshot> {
+/** Delete branch files. */
+public class BranchDeletion extends FileDeletionBase<Snapshot> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(TagDeletion.class);
+    private static final Logger LOG = LoggerFactory.getLogger(BranchDeletion.class);
 
-    public TagDeletion(
+    public BranchDeletion(
             FileIO fileIO,
             FileStorePathFactory pathFactory,
             ManifestFile manifestFile,
@@ -63,12 +63,12 @@ public class TagDeletion extends FileDeletionBase<Snapshot> {
     }
 
     @Override
-    public void cleanUnusedDataFiles(Snapshot taggedSnapshot, Predicate<ManifestEntry> skipper) {
+    public void cleanUnusedDataFiles(Snapshot snapshotToClean, Predicate<ManifestEntry> skipper) {
         Collection<ManifestEntry> manifestEntries;
         try {
-            manifestEntries = readMergedDataFiles(taggedSnapshot);
+            manifestEntries = readMergedDataFiles(snapshotToClean);
         } catch (IOException e) {
-            LOG.info("Skip data file clean for the tag of id {}.", taggedSnapshot.id(), e);
+            LOG.info("Skip data file clean for the snapshot {}.", snapshotToClean.id(), e);
             return;
         }
 
@@ -88,8 +88,8 @@ public class TagDeletion extends FileDeletionBase<Snapshot> {
     }
 
     @Override
-    public void cleanUnusedManifests(Snapshot taggedSnapshot, Set<String> skippingSet) {
+    public void cleanUnusedManifests(Snapshot snapshotToClean, Set<String> skippingSet) {
         // doesn't clean changelog files because they are handled by SnapshotDeletion
-        cleanUnusedManifests(taggedSnapshot, skippingSet, true, false);
+        cleanUnusedManifests(snapshotToClean, skippingSet, true, false);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -344,6 +344,19 @@ public abstract class FileDeletionBase<T extends Snapshot> {
         return entry -> false;
     }
 
+    public Predicate<ManifestEntry> dataFileSkipper(Snapshot skippingSnapshot) throws Exception {
+        return dataFileSkipper(Collections.singletonList(skippingSnapshot));
+    }
+
+    public Predicate<ManifestEntry> dataFileSkipper(List<Snapshot> skippingSnapshots)
+            throws Exception {
+        Map<BinaryRow, Map<Integer, Set<String>>> skipped = new HashMap<>();
+        for (Snapshot snapshot : skippingSnapshots) {
+            addMergedDataFiles(skipped, snapshot);
+        }
+        return entry -> containsDataFile(skipped, entry);
+    }
+
     /**
      * It is possible that a job was killed during expiration and some manifest files have been
      * deleted, so if the clean methods need to get manifests of a snapshot to be cleaned, we should

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -488,4 +488,21 @@ public abstract class FileDeletionBase<T extends Snapshot> {
             throw new RuntimeException(e);
         }
     }
+
+    public Set<Path> extractDataFilePaths(
+            Collection<ManifestEntry> manifestEntries, Predicate<ManifestEntry> skipper) {
+        Set<Path> dataFileToDelete = new HashSet<>();
+        for (ManifestEntry entry : manifestEntries) {
+            if (!skipper.test(entry)) {
+                Path bucketPath = pathFactory.bucketPath(entry.partition(), entry.bucket());
+                dataFileToDelete.add(new Path(bucketPath, entry.file().fileName()));
+                for (String file : entry.file().extraFiles()) {
+                    dataFileToDelete.add(new Path(bucketPath, file));
+                }
+
+                recordDeletionBuckets(entry);
+            }
+        }
+        return dataFileToDelete;
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/TagDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/TagDeletion.java
@@ -21,7 +21,6 @@ package org.apache.paimon.operation;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.fs.FileIO;
-import org.apache.paimon.fs.Path;
 import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFile;
@@ -34,7 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -73,19 +71,7 @@ public class TagDeletion extends FileDeletionBase<Snapshot> {
             return;
         }
 
-        Set<Path> dataFileToDelete = new HashSet<>();
-        for (ManifestEntry entry : manifestEntries) {
-            if (!skipper.test(entry)) {
-                Path bucketPath = pathFactory.bucketPath(entry.partition(), entry.bucket());
-                dataFileToDelete.add(new Path(bucketPath, entry.file().fileName()));
-                for (String file : entry.file().extraFiles()) {
-                    dataFileToDelete.add(new Path(bucketPath, file));
-                }
-
-                recordDeletionBuckets(entry);
-            }
-        }
-        deleteFiles(dataFileToDelete, fileIO::deleteQuietly);
+        deleteFiles(extractDataFilePaths(manifestEntries, skipper), fileIO::deleteQuietly);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/operation/TagDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/TagDeletion.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.operation;
 
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.index.IndexFileHandler;
@@ -91,5 +92,11 @@ public class TagDeletion extends FileDeletionBase<Snapshot> {
     public void cleanUnusedManifests(Snapshot taggedSnapshot, Set<String> skippingSet) {
         // doesn't clean changelog files because they are handled by SnapshotDeletion
         cleanUnusedManifests(taggedSnapshot, skippingSet, true, false);
+    }
+
+    @VisibleForTesting
+    public Collection<ManifestEntry> getDataFilesFromSnapshot(Snapshot snapshot)
+            throws IOException {
+        return readMergedDataFiles(snapshot);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStore.java
@@ -26,6 +26,7 @@ import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.manifest.ManifestFile;
 import org.apache.paimon.manifest.ManifestList;
+import org.apache.paimon.operation.BranchDeletion;
 import org.apache.paimon.operation.ChangelogDeletion;
 import org.apache.paimon.operation.FileStoreCommit;
 import org.apache.paimon.operation.FileStoreScan;
@@ -41,6 +42,7 @@ import org.apache.paimon.table.sink.CommitCallback;
 import org.apache.paimon.table.sink.TagCallback;
 import org.apache.paimon.tag.TagAutoManager;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.SegmentsCache;
 import org.apache.paimon.utils.SnapshotManager;
@@ -162,6 +164,17 @@ public class PrivilegedFileStore<T> implements FileStore<T> {
     public TagManager newTagManager() {
         privilegeChecker.assertCanInsert(identifier);
         return wrapped.newTagManager();
+    }
+
+    @Override
+    public BranchManager newBranchManager() {
+        privilegeChecker.assertCanInsert(identifier);
+        return wrapped.newBranchManager();
+    }
+
+    @Override
+    public BranchDeletion newBranchDeletion() {
+        return wrapped.newBranchDeletion();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -351,13 +351,16 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
     @Override
     public ExpireSnapshots newExpireSnapshots() {
         return new ExpireSnapshotsImpl(
-                snapshotManager(), store().newSnapshotDeletion(), store().newTagManager());
+                snapshotManager(),
+                store().newSnapshotDeletion(),
+                store().newTagManager(),
+                branchManager());
     }
 
     @Override
     public ExpireSnapshots newExpireChangelog() {
         return new ExpireChangelogImpl(
-                snapshotManager(), tagManager(), store().newChangelogDeletion());
+                snapshotManager(), tagManager(), store().newChangelogDeletion(), branchManager());
     }
 
     @Override
@@ -566,6 +569,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
                         tagName,
                         store().newTagDeletion(),
                         snapshotManager(),
+                        branchManager(),
                         store().createTagCallbacks());
     }
 
@@ -627,7 +631,13 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
 
     @Override
     public BranchManager branchManager() {
-        return new BranchManager(fileIO, path, snapshotManager(), tagManager(), schemaManager());
+        return new BranchManager(
+                fileIO,
+                path,
+                snapshotManager(),
+                tagManager(),
+                schemaManager(),
+                store().newBranchDeletion());
     }
 
     private RollbackHelper rollbackHelper() {

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoCreation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoCreation.java
@@ -24,6 +24,7 @@ import org.apache.paimon.operation.TagDeletion;
 import org.apache.paimon.table.sink.TagCallback;
 import org.apache.paimon.tag.TagTimeExtractor.ProcessTimeExtractor;
 import org.apache.paimon.tag.TagTimeExtractor.WatermarkExtractor;
+import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
@@ -51,6 +52,8 @@ public class TagAutoCreation {
 
     private final SnapshotManager snapshotManager;
     private final TagManager tagManager;
+    private final BranchManager branchManager;
+
     private final TagDeletion tagDeletion;
     private final TagTimeExtractor timeExtractor;
     private final TagPeriodHandler periodHandler;
@@ -67,6 +70,7 @@ public class TagAutoCreation {
     private TagAutoCreation(
             SnapshotManager snapshotManager,
             TagManager tagManager,
+            BranchManager branchManager,
             TagDeletion tagDeletion,
             TagTimeExtractor timeExtractor,
             TagPeriodHandler periodHandler,
@@ -78,6 +82,7 @@ public class TagAutoCreation {
             List<TagCallback> callbacks) {
         this.snapshotManager = snapshotManager;
         this.tagManager = tagManager;
+        this.branchManager = branchManager;
         this.tagDeletion = tagDeletion;
         this.timeExtractor = timeExtractor;
         this.periodHandler = periodHandler;
@@ -182,6 +187,7 @@ public class TagAutoCreation {
                                 checkAndGetOneAutoTag(tag),
                                 tagDeletion,
                                 snapshotManager,
+                                branchManager,
                                 callbacks);
                         i++;
                         if (i == toDelete) {
@@ -211,6 +217,7 @@ public class TagAutoCreation {
             CoreOptions options,
             SnapshotManager snapshotManager,
             TagManager tagManager,
+            BranchManager branchManager,
             TagDeletion tagDeletion,
             List<TagCallback> callbacks) {
         TagTimeExtractor extractor = TagTimeExtractor.createForAutoTag(options);
@@ -220,6 +227,7 @@ public class TagAutoCreation {
         return new TagAutoCreation(
                 snapshotManager,
                 tagManager,
+                branchManager,
                 tagDeletion,
                 extractor,
                 TagPeriodHandler.create(options),

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoManager.java
@@ -21,6 +21,7 @@ package org.apache.paimon.tag;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.operation.TagDeletion;
 import org.apache.paimon.table.sink.TagCallback;
+import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
@@ -50,6 +51,7 @@ public class TagAutoManager {
             CoreOptions options,
             SnapshotManager snapshotManager,
             TagManager tagManager,
+            BranchManager branchManager,
             TagDeletion tagDeletion,
             List<TagCallback> callbacks) {
         TagTimeExtractor extractor = TagTimeExtractor.createForAutoTag(options);
@@ -58,8 +60,14 @@ public class TagAutoManager {
                 extractor == null
                         ? null
                         : TagAutoCreation.create(
-                                options, snapshotManager, tagManager, tagDeletion, callbacks),
-                TagTimeExpire.create(snapshotManager, tagManager, tagDeletion, callbacks));
+                                options,
+                                snapshotManager,
+                                tagManager,
+                                branchManager,
+                                tagDeletion,
+                                callbacks),
+                TagTimeExpire.create(
+                        snapshotManager, tagManager, branchManager, tagDeletion, callbacks));
     }
 
     public TagAutoCreation getTagAutoCreation() {

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagTimeExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagTimeExpire.java
@@ -20,6 +20,7 @@ package org.apache.paimon.tag;
 
 import org.apache.paimon.operation.TagDeletion;
 import org.apache.paimon.table.sink.TagCallback;
+import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
@@ -38,16 +39,19 @@ public class TagTimeExpire {
 
     private final SnapshotManager snapshotManager;
     private final TagManager tagManager;
+    private final BranchManager branchManager;
     private final TagDeletion tagDeletion;
     private final List<TagCallback> callbacks;
 
     private TagTimeExpire(
             SnapshotManager snapshotManager,
             TagManager tagManager,
+            BranchManager branchManager,
             TagDeletion tagDeletion,
             List<TagCallback> callbacks) {
         this.snapshotManager = snapshotManager;
         this.tagManager = tagManager;
+        this.branchManager = branchManager;
         this.tagDeletion = tagDeletion;
         this.callbacks = callbacks;
     }
@@ -67,7 +71,8 @@ public class TagTimeExpire {
                         "Delete tag {}, because its existence time has reached its timeRetained of {}.",
                         tagName,
                         timeRetained);
-                tagManager.deleteTag(tagName, tagDeletion, snapshotManager, callbacks);
+                tagManager.deleteTag(
+                        tagName, tagDeletion, snapshotManager, branchManager, callbacks);
             }
         }
     }
@@ -75,8 +80,10 @@ public class TagTimeExpire {
     public static TagTimeExpire create(
             SnapshotManager snapshotManager,
             TagManager tagManager,
+            BranchManager branchManager,
             TagDeletion tagDeletion,
             List<TagCallback> callbacks) {
-        return new TagTimeExpire(snapshotManager, tagManager, tagDeletion, callbacks);
+        return new TagTimeExpire(
+                snapshotManager, tagManager, branchManager, tagDeletion, callbacks);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -706,7 +706,7 @@ public class SnapshotManager implements Serializable {
         }
         throw new RuntimeException(
                 String.format(
-                        "Didn't find tag with snapshot id '%s'.This is unexpected.",
+                        "Didn't find snapshot id '%s' in the list, this is unexpected.",
                         targetSnapshot.id()));
     }
 
@@ -715,17 +715,17 @@ public class SnapshotManager implements Serializable {
         List<Snapshot> skippedSnapshots = new ArrayList<>();
 
         int index = SnapshotManager.findIndex(targetSnapshot, snapshotList);
-        // the left neighbor tag
+        // the nearest left neighbor snapshot.
         if (index - 1 >= 0) {
             skippedSnapshots.add(snapshotList.get(index - 1));
         }
-        // the nearest right neighbor
-        Snapshot right = snapshotManager.earliestSnapshot();
+        // the nearest right neighbor snapshot.
+        Snapshot nearestRight = snapshotManager.earliestSnapshot();
         if (index + 1 < snapshotList.size()) {
-            Snapshot rightTag = snapshotList.get(index + 1);
-            right = right.id() < rightTag.id() ? right : rightTag;
+            Snapshot rightSnapshot = snapshotList.get(index + 1);
+            nearestRight = nearestRight.id() < rightSnapshot.id() ? nearestRight : rightSnapshot;
         }
-        skippedSnapshots.add(right);
+        skippedSnapshots.add(nearestRight);
         return skippedSnapshots;
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -158,7 +158,8 @@ public class TestFileStore extends KeyValueFileStore {
         return new ExpireSnapshotsImpl(
                         snapshotManager(),
                         newSnapshotDeletion(),
-                        new TagManager(fileIO, options.path()))
+                        new TagManager(fileIO, options.path()),
+                        newBranchManager())
                 .config(
                         ExpireConfig.builder()
                                 .snapshotRetainMax(numRetainedMax)
@@ -171,7 +172,8 @@ public class TestFileStore extends KeyValueFileStore {
         return new ExpireSnapshotsImpl(
                         snapshotManager(),
                         newSnapshotDeletion(),
-                        new TagManager(fileIO, options.path()))
+                        new TagManager(fileIO, options.path()),
+                        newBranchManager())
                 .config(expireConfig);
     }
 
@@ -180,7 +182,8 @@ public class TestFileStore extends KeyValueFileStore {
                 new ExpireChangelogImpl(
                         snapshotManager(),
                         new TagManager(fileIO, options.path()),
-                        newChangelogDeletion());
+                        newChangelogDeletion(),
+                        newBranchManager());
         impl.config(config);
         return impl;
     }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -162,6 +162,7 @@ public class ExpireSnapshotsTest {
                         "tag" + id,
                         store.newTagDeletion(),
                         snapshotManager,
+                        store.newBranchManager(),
                         Collections.emptyList());
             }
         }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
@@ -388,6 +388,7 @@ public class FileDeletionTest {
         TestFileStore store = createStore(TestKeyValueGenerator.GeneratorMode.NON_PARTITIONED, 3);
         tagManager = new TagManager(fileIO, store.options().path());
         SnapshotManager snapshotManager = store.snapshotManager();
+        BranchManager branchManager = store.newBranchManager();
         TestKeyValueGenerator gen =
                 new TestKeyValueGenerator(TestKeyValueGenerator.GeneratorMode.NON_PARTITIONED);
         BinaryRow partition = gen.getPartition(gen.next());
@@ -439,7 +440,7 @@ public class FileDeletionTest {
                 "tag1",
                 store.newTagDeletion(),
                 snapshotManager,
-                store.newBranchManager(),
+                branchManager,
                 Collections.emptyList());
 
         // check data files
@@ -466,6 +467,7 @@ public class FileDeletionTest {
         TestFileStore store = createStore(TestKeyValueGenerator.GeneratorMode.NON_PARTITIONED, 3);
         tagManager = new TagManager(fileIO, store.options().path());
         SnapshotManager snapshotManager = store.snapshotManager();
+        BranchManager branchManager = store.newBranchManager();
         TestKeyValueGenerator gen =
                 new TestKeyValueGenerator(TestKeyValueGenerator.GeneratorMode.NON_PARTITIONED);
         BinaryRow partition = gen.getPartition(gen.next());
@@ -520,7 +522,7 @@ public class FileDeletionTest {
                 "tag2",
                 store.newTagDeletion(),
                 snapshotManager,
-                store.newBranchManager(),
+                branchManager,
                 Collections.emptyList());
 
         // check data files

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/BatchWriteGeneratorTagOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/BatchWriteGeneratorTagOperator.java
@@ -115,7 +115,11 @@ public class BatchWriteGeneratorTagOperator<CommitT, GlobalCommitT>
             // If the tag already exists, delete the tag
             if (tagManager.tagExists(tagName)) {
                 tagManager.deleteTag(
-                        tagName, tagDeletion, snapshotManager, table.store().createTagCallbacks());
+                        tagName,
+                        tagDeletion,
+                        snapshotManager,
+                        table.branchManager(),
+                        table.store().createTagCallbacks());
             }
             // Create a new tag
             tagManager.createTag(
@@ -128,7 +132,11 @@ public class BatchWriteGeneratorTagOperator<CommitT, GlobalCommitT>
         } catch (Exception e) {
             if (tagManager.tagExists(tagName)) {
                 tagManager.deleteTag(
-                        tagName, tagDeletion, snapshotManager, table.store().createTagCallbacks());
+                        tagName,
+                        tagDeletion,
+                        snapshotManager,
+                        table.branchManager(),
+                        table.store().createTagCallbacks());
             }
         }
     }
@@ -148,7 +156,7 @@ public class BatchWriteGeneratorTagOperator<CommitT, GlobalCommitT>
                 for (List<String> tagNames : tagManager.tags().values()) {
                     if (tagCount - tagNames.size() >= tagNumRetainedMax) {
                         tagManager.deleteAllTagsOfOneSnapshot(
-                                tagNames, tagDeletion, snapshotManager);
+                                tagNames, tagDeletion, snapshotManager, table.branchManager());
                         tagCount = tagCount - tagNames.size();
                     } else {
                         List<String> sortedTagNames = tagManager.sortTagsOfOneSnapshot(tagNames);
@@ -157,6 +165,7 @@ public class BatchWriteGeneratorTagOperator<CommitT, GlobalCommitT>
                                     toBeDeleted,
                                     tagDeletion,
                                     snapshotManager,
+                                    table.branchManager(),
                                     table.store().createTagCallbacks());
                             tagCount--;
                             if (tagCount == tagNumRetainedMax) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -260,6 +260,7 @@ public abstract class FlinkSink<T> implements Serializable {
                             (CommitterOperator<Committable, ManifestCommittable>) committerOperator,
                             table::snapshotManager,
                             table::tagManager,
+                            table::branchManager,
                             () -> table.store().newTagDeletion(),
                             () -> table.store().createTagCallbacks(),
                             table.coreOptions().tagDefaultTimeRetained());

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AutoTagForSavepointCommitterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AutoTagForSavepointCommitterOperatorTest.java
@@ -207,6 +207,7 @@ public class AutoTagForSavepointCommitterOperatorTest extends CommitterOperatorT
                         super.createCommitterOperator(table, commitUser, committableStateManager),
                 table::snapshotManager,
                 table::tagManager,
+                table::branchManager,
                 () -> table.store().newTagDeletion(),
                 () -> table.store().createTagCallbacks(),
                 table.store().options().tagDefaultTimeRetained());
@@ -224,6 +225,7 @@ public class AutoTagForSavepointCommitterOperatorTest extends CommitterOperatorT
                                 table, commitUser, committableStateManager, initializeFunction),
                 table::snapshotManager,
                 table::tagManager,
+                table::branchManager,
                 () -> table.store().newTagDeletion(),
                 () -> table.store().createTagCallbacks(),
                 table.store().options().tagDefaultTimeRetained());


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Next part for #3808

The purpose of this pr : 

The purpose of the branch is to asynchronously recover data and overwrite the main branch 
[paimon branch](https://cwiki.apache.org/confluence/display/PAIMON/PIP-9%3A+Support+Branch ) . If the recovery operation takes too long, the snapshot referenced by the branch may be expired and deleted, which will make the branch unavailable.
Let's say we created tag1 and branch1 based on snapshot-1, when snapshot-1 expires then the related `manifest file` will be deleted. However ,if the `manifest file` is referenced by the some tag, it will not be cleaned up.
But if the `manifest file` is still referenced by branch-1, it will still be cleaned, this led to query branch1 will throw `manifets file` not found exception.

Solution :

1: Skip cleanup :   Merge snapshots referenced by branch or tag in the code of `ExpireSnapshotsImpl#expireUntil` then skip the files associated with these snapshots.
2: When to clean : Referring to the logic of `delete tag`, when we delete the branch, we also clean up the expired snapshot files (manifest files and data files).
3: delete tag/branch :  Now, when deleting a tag or branch, we need to consider whether the snapshot involved is still referenced by other tags/branches.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

`TagManager#deleteTag` :  Add logical , whether the snapshot is referenced by other branch, if so, the `doClean` of the snapshot should be skipped.

`BranchManager#deleteBranch` :  Add logical , If the snapshot has expired and is not referenced by another branch or tag, trigger `doClean` to delete manifest&data file.


<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
