### PR TITLE
[feature][flink] introduce RecordAttributesProcessor for write operators

### DIFF
--- a/paimon-flink/paimon-flink-1.15/src/main/java/org/apache/flink/streaming/runtime/streamrecord/RecordAttributes.java
+++ b/paimon-flink/paimon-flink-1.15/src/main/java/org/apache/flink/streaming/runtime/streamrecord/RecordAttributes.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.streamrecord;
+
+/** Placeholder class for new feature introduced since flink 1.19. Should never be used. */
+public class RecordAttributes extends StreamElement {}

--- a/paimon-flink/paimon-flink-1.15/src/main/java/org/apache/paimon/flink/ProcessRecordAttributesUtil.java
+++ b/paimon-flink/paimon-flink-1.15/src/main/java/org/apache/paimon/flink/ProcessRecordAttributesUtil.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.paimon.flink.sink.StoreSinkWrite;
+
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.runtime.streamrecord.RecordAttributes;
+
+/** Placeholder class for new feature introduced since flink 1.19. Should never be used. */
+public class ProcessRecordAttributesUtil {
+    public static void processWithWrite(RecordAttributes recordAttributes, StoreSinkWrite write) {}
+
+    public static void processWithOutput(RecordAttributes recordAttributes, Output output) {}
+}

--- a/paimon-flink/paimon-flink-1.16/src/main/java/org/apache/flink/streaming/runtime/streamrecord/RecordAttributes.java
+++ b/paimon-flink/paimon-flink-1.16/src/main/java/org/apache/flink/streaming/runtime/streamrecord/RecordAttributes.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.streamrecord;
+
+/** Placeholder class for new feature introduced since flink 1.19. Should never be used. */
+public class RecordAttributes extends StreamElement {}

--- a/paimon-flink/paimon-flink-1.16/src/main/java/org/apache/paimon/flink/ProcessRecordAttributesUtil.java
+++ b/paimon-flink/paimon-flink-1.16/src/main/java/org/apache/paimon/flink/ProcessRecordAttributesUtil.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.paimon.flink.sink.StoreSinkWrite;
+
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.runtime.streamrecord.RecordAttributes;
+
+/** Placeholder class for new feature introduced since flink 1.19. Should never be used. */
+public class ProcessRecordAttributesUtil {
+    public static void processWithWrite(RecordAttributes recordAttributes, StoreSinkWrite write) {}
+
+    public static void processWithOutput(RecordAttributes recordAttributes, Output output) {}
+}

--- a/paimon-flink/paimon-flink-1.17/src/main/java/org/apache/flink/streaming/runtime/streamrecord/RecordAttributes.java
+++ b/paimon-flink/paimon-flink-1.17/src/main/java/org/apache/flink/streaming/runtime/streamrecord/RecordAttributes.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.streamrecord;
+
+/** Placeholder class for new feature introduced since flink 1.19. Should never be used. */
+public class RecordAttributes extends StreamElement {}

--- a/paimon-flink/paimon-flink-1.17/src/main/java/org/apache/paimon/flink/ProcessRecordAttributesUtil.java
+++ b/paimon-flink/paimon-flink-1.17/src/main/java/org/apache/paimon/flink/ProcessRecordAttributesUtil.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.paimon.flink.sink.StoreSinkWrite;
+
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.runtime.streamrecord.RecordAttributes;
+
+/** Placeholder class for new feature introduced since flink 1.19. Should never be used. */
+public class ProcessRecordAttributesUtil {
+    public static void processWithWrite(RecordAttributes recordAttributes, StoreSinkWrite write) {}
+
+    public static void processWithOutput(RecordAttributes recordAttributes, Output output) {}
+}

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/flink/streaming/runtime/streamrecord/RecordAttributes.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/flink/streaming/runtime/streamrecord/RecordAttributes.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.streamrecord;
+
+/** Placeholder class for new feature introduced since flink 1.19. Should never be used. */
+public class RecordAttributes extends StreamElement {}

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/ProcessRecordAttributesUtil.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/ProcessRecordAttributesUtil.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.paimon.flink.sink.StoreSinkWrite;
+
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.runtime.streamrecord.RecordAttributes;
+
+/** Placeholder class for new feature introduced since flink 1.19. Should never be used. */
+public class ProcessRecordAttributesUtil {
+    public static void processWithWrite(RecordAttributes recordAttributes, StoreSinkWrite write) {}
+
+    public static void processWithOutput(RecordAttributes recordAttributes, Output output) {}
+}

--- a/paimon-flink/paimon-flink-1.19/pom.xml
+++ b/paimon-flink/paimon-flink-1.19/pom.xml
@@ -69,6 +69,13 @@ under the License.
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- test dependencies -->
 
         <dependency>

--- a/paimon-flink/paimon-flink-cdc/pom.xml
+++ b/paimon-flink/paimon-flink-cdc/pom.xml
@@ -301,6 +301,11 @@ under the License.
                         </goals>
                         <configuration>
                             <relocations>
+                                <!-- Avoid overriding the equivalent class introduced in flink and paimon-flink -->
+                                <relocation>
+                                    <pattern>org.apache.flink.streaming.runtime.streamrecord.RecordAttributes</pattern>
+                                    <shadedPattern>org.apache.flink.shaded.org.apache.flink.streaming.runtime.streamrecord.RecordAttributes</shadedPattern>
+                                </relocation>
                                 <!-- Same as flink-sql-connector-kafka. -->
                                 <relocation>
                                     <pattern>org.apache.kafka.connect</pattern>

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/flink/streaming/runtime/streamrecord/RecordAttributes.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/flink/streaming/runtime/streamrecord/RecordAttributes.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.streamrecord;
+
+/** Placeholder class for new feature introduced since flink 1.19. Should never be used. */
+public class RecordAttributes extends StreamElement {}

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/ProcessRecordAttributesUtil.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/ProcessRecordAttributesUtil.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.paimon.flink.sink.StoreSinkWrite;
+
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.runtime.streamrecord.RecordAttributes;
+
+/** Placeholder class for new feature introduced since flink 1.19. Should never be used. */
+public class ProcessRecordAttributesUtil {
+    public static void processWithWrite(RecordAttributes recordAttributes, StoreSinkWrite write) {}
+
+    public static void processWithOutput(RecordAttributes recordAttributes, Output output) {}
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/ProcessRecordAttributesUtil.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/ProcessRecordAttributesUtil.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.paimon.flink.sink.StoreSinkWrite;
+
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.runtime.streamrecord.RecordAttributes;
+
+/** Utils for {@link RecordAttributes}. */
+public class ProcessRecordAttributesUtil {
+    public static void processWithWrite(RecordAttributes recordAttributes, StoreSinkWrite write) {}
+
+    public static void processWithOutput(RecordAttributes recordAttributes, Output output) {
+        output.emitRecordAttributes(recordAttributes);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/HashBucketAssignerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/HashBucketAssignerOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.paimon.flink.ProcessRecordAttributesUtil;
 import org.apache.paimon.index.BucketAssigner;
 import org.apache.paimon.index.HashBucketAssigner;
 import org.apache.paimon.index.SimpleHashBucketAssigner;
@@ -32,6 +33,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.RecordAttributes;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 /** Assign bucket for the input record, output record with bucket. */
@@ -98,6 +100,11 @@ public class HashBucketAssignerOperator<T> extends AbstractStreamOperator<Tuple2
                 assigner.assign(
                         extractor.partition(value), extractor.trimmedPrimaryKey(value).hashCode());
         output.collect(new StreamRecord<>(new Tuple2<>(value, bucket)));
+    }
+
+    @Override
+    public void processRecordAttributes(RecordAttributes recordAttributes) {
+        ProcessRecordAttributesUtil.processWithOutput(recordAttributes, output);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StreamMapWithForwardingRecordAttributes.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StreamMapWithForwardingRecordAttributes.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.flink.ProcessRecordAttributesUtil;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.streaming.api.operators.StreamMap;
+import org.apache.flink.streaming.runtime.streamrecord.RecordAttributes;
+
+/** A {@link StreamMap} that forwards received {@link RecordAttributes} to downstream operators. */
+public class StreamMapWithForwardingRecordAttributes<IN, OUT> extends StreamMap<IN, OUT> {
+    public StreamMapWithForwardingRecordAttributes(MapFunction<IN, OUT> mapper) {
+        super(mapper);
+    }
+
+    @Override
+    public void processRecordAttributes(RecordAttributes recordAttributes) {
+        ProcessRecordAttributesUtil.processWithOutput(recordAttributes, output);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/TableWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/TableWriteOperator.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.flink.ProcessRecordAttributesUtil;
 import org.apache.paimon.flink.sink.StoreSinkWriteState.StateValueFilter;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
@@ -27,6 +28,7 @@ import org.apache.paimon.table.sink.ChannelComputer;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.runtime.streamrecord.RecordAttributes;
 
 import java.io.IOException;
 import java.util.List;
@@ -95,6 +97,12 @@ public abstract class TableWriteOperator<IN> extends PrepareCommitOperator<IN, C
         write =
                 storeSinkWriteProvider.provide(
                         table, commitUser, state, ioManager, memoryPool, getMetricGroup());
+    }
+
+    @Override
+    public void processRecordAttributes(RecordAttributes recordAttributes) throws Exception {
+        ProcessRecordAttributesUtil.processWithWrite(recordAttributes, write);
+        super.processRecordAttributes(recordAttributes);
     }
 
     protected abstract boolean containLogSystem();


### PR DESCRIPTION
### Purpose

This PR introduces RecordAttributesProcessor for write operators, providing the ability to handle record attributes during constructing sink operators.

### Tests

WriteOperatorTest.testProcessRecordAttributes is introduced to verify the correctness of this PR.

### API and Format

This change does not affect API or storage format.

### Documentation

This change does not introduce changes that require a document.
