### PR TITLE
[Feature][Flink] Make FlinkCatalogFactory pluggable

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSinkTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSinkTest.java
@@ -57,7 +57,7 @@ public class FlinkCdcMultiTableSinkTest {
 
         FlinkCdcMultiTableSink sink =
                 new FlinkCdcMultiTableSink(
-                        () -> FlinkCatalogFactory.createPaimonCatalog(new Options()),
+                        () -> FlinkCatalogFactory.INSTANCE.createPaimonCatalog(new Options()),
                         FlinkConnectorOptions.SINK_COMMITTER_CPU.defaultValue(),
                         null,
                         true,

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkITCase.java
@@ -161,7 +161,7 @@ public class FlinkCdcSyncDatabaseSinkITCase extends AbstractTestBase {
         Options catalogOptions = new Options();
         catalogOptions.set("warehouse", tempDir.toString());
         Catalog.Loader catalogLoader =
-                () -> FlinkCatalogFactory.createPaimonCatalog(catalogOptions);
+                () -> FlinkCatalogFactory.INSTANCE.createPaimonCatalog(catalogOptions);
 
         new FlinkCdcSyncDatabaseSinkBuilder<TestCdcEvent>()
                 .withInput(source)

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncTableSinkITCase.java
@@ -158,7 +158,7 @@ public class FlinkCdcSyncTableSinkITCase extends AbstractTestBase {
         Options catalogOptions = new Options();
         catalogOptions.set("warehouse", tempDir.toString());
         Catalog.Loader catalogLoader =
-                () -> FlinkCatalogFactory.createPaimonCatalog(catalogOptions);
+                () -> FlinkCatalogFactory.INSTANCE.createPaimonCatalog(catalogOptions);
 
         new CdcSinkBuilder<TestCdcEvent>()
                 .withInput(source)

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalogFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalogFactory.java
@@ -33,6 +33,8 @@ public class FlinkCatalogFactory implements org.apache.flink.table.factories.Cat
 
     public static final String IDENTIFIER = "paimon";
 
+    public static final FlinkCatalogFactory INSTANCE = new FlinkCatalogFactory();
+
     @Override
     public String factoryIdentifier() {
         return IDENTIFIER;
@@ -57,7 +59,7 @@ public class FlinkCatalogFactory implements org.apache.flink.table.factories.Cat
                 context.getClassLoader());
     }
 
-    public static FlinkCatalog createCatalog(
+    public FlinkCatalog createCatalog(
             String catalogName, CatalogContext context, ClassLoader classLoader) {
         return new FlinkCatalog(
                 CatalogFactory.createCatalog(context, classLoader),
@@ -67,7 +69,7 @@ public class FlinkCatalogFactory implements org.apache.flink.table.factories.Cat
                 context.options());
     }
 
-    public static FlinkCatalog createCatalog(String catalogName, Catalog catalog, Options options) {
+    public FlinkCatalog createCatalog(String catalogName, Catalog catalog, Options options) {
         return new FlinkCatalog(
                 catalog,
                 catalogName,
@@ -76,7 +78,7 @@ public class FlinkCatalogFactory implements org.apache.flink.table.factories.Cat
                 options);
     }
 
-    public static Catalog createPaimonCatalog(Options catalogOptions) {
+    public Catalog createPaimonCatalog(Options catalogOptions) {
         return CatalogFactory.createCatalog(
                 CatalogContext.create(catalogOptions, new FlinkFileIOLoader()));
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalogOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalogOptions.java
@@ -27,6 +27,11 @@ import java.time.Duration;
 
 /** Options for flink catalog. */
 public class FlinkCatalogOptions {
+    @ExcludeFromDocumentation("Only for internal use")
+    public static final ConfigOption<String> CATALOG_TYPE =
+            ConfigOptions.key("catalog-type")
+                    .stringType()
+                    .defaultValue(FlinkCatalogFactory.IDENTIFIER);
 
     public static final ConfigOption<String> DEFAULT_DATABASE =
             ConfigOptions.key("default-database")

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/CloneSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/CloneSourceBuilder.java
@@ -68,7 +68,8 @@ public class CloneSourceBuilder {
 
     public DataStream<Tuple2<String, String>> build() throws Exception {
         try (Catalog sourceCatalog =
-                FlinkCatalogFactory.createPaimonCatalog(Options.fromMap(sourceCatalogConfig))) {
+                FlinkCatalogFactory.INSTANCE.createPaimonCatalog(
+                        Options.fromMap(sourceCatalogConfig))) {
             return build(sourceCatalog);
         }
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/CopyFileOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/CopyFileOperator.java
@@ -56,11 +56,11 @@ public class CopyFileOperator extends AbstractStreamOperator<CloneFileInfo>
     public void open() throws Exception {
         sourceCatalog =
                 (AbstractCatalog)
-                        FlinkCatalogFactory.createPaimonCatalog(
+                        FlinkCatalogFactory.INSTANCE.createPaimonCatalog(
                                 Options.fromMap(sourceCatalogConfig));
         targetCatalog =
                 (AbstractCatalog)
-                        FlinkCatalogFactory.createPaimonCatalog(
+                        FlinkCatalogFactory.INSTANCE.createPaimonCatalog(
                                 Options.fromMap(targetCatalogConfig));
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/PickFilesForCloneOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/PickFilesForCloneOperator.java
@@ -62,9 +62,11 @@ public class PickFilesForCloneOperator extends AbstractStreamOperator<CloneFileI
     @Override
     public void open() throws Exception {
         sourceCatalog =
-                FlinkCatalogFactory.createPaimonCatalog(Options.fromMap(sourceCatalogConfig));
+                FlinkCatalogFactory.INSTANCE.createPaimonCatalog(
+                        Options.fromMap(sourceCatalogConfig));
         targetCatalog =
-                FlinkCatalogFactory.createPaimonCatalog(Options.fromMap(targetCatalogConfig));
+                FlinkCatalogFactory.INSTANCE.createPaimonCatalog(
+                        Options.fromMap(targetCatalogConfig));
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/SnapshotHintOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/SnapshotHintOperator.java
@@ -53,7 +53,8 @@ public class SnapshotHintOperator extends AbstractStreamOperator<CloneFileInfo>
     @Override
     public void open() throws Exception {
         targetCatalog =
-                FlinkCatalogFactory.createPaimonCatalog(Options.fromMap(targetCatalogConfig));
+                FlinkCatalogFactory.INSTANCE.createPaimonCatalog(
+                        Options.fromMap(targetCatalogConfig));
         identifiers = new HashSet<>();
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkCatalogTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkCatalogTest.java
@@ -109,7 +109,7 @@ public class FlinkCatalogTest {
         conf.setString("warehouse", path);
         conf.set(LOG_SYSTEM_AUTO_REGISTER, true);
         catalog =
-                FlinkCatalogFactory.createCatalog(
+                FlinkCatalogFactory.INSTANCE.createCatalog(
                         "test-catalog",
                         CatalogContext.create(conf),
                         FlinkCatalogTest.class.getClassLoader());
@@ -572,7 +572,7 @@ public class FlinkCatalogTest {
         conf.set(LOG_SYSTEM_AUTO_REGISTER, true);
         conf.set(DISABLE_CREATE_TABLE_IN_DEFAULT_DB, true);
         Catalog catalog =
-                FlinkCatalogFactory.createCatalog(
+                FlinkCatalogFactory.INSTANCE.createCatalog(
                         "test-ddl-catalog",
                         CatalogContext.create(conf),
                         FlinkCatalogTest.class.getClassLoader());
@@ -595,7 +595,7 @@ public class FlinkCatalogTest {
 
         conf.set(FlinkCatalogOptions.DEFAULT_DATABASE, "default-db");
         Catalog catalog1 =
-                FlinkCatalogFactory.createCatalog(
+                FlinkCatalogFactory.INSTANCE.createCatalog(
                         "test-ddl-catalog1",
                         CatalogContext.create(conf),
                         FlinkCatalogTest.class.getClassLoader());

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/MultiTablesCompactorSourceBuilderITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/MultiTablesCompactorSourceBuilderITCase.java
@@ -561,6 +561,6 @@ public class MultiTablesCompactorSourceBuilderITCase extends AbstractTestBase
     private Catalog.Loader catalogLoader() {
         // to make the action workflow serializable
         catalogOptions.set(CatalogOptions.WAREHOUSE, warehouse);
-        return () -> FlinkCatalogFactory.createPaimonCatalog(catalogOptions);
+        return () -> FlinkCatalogFactory.INSTANCE.createPaimonCatalog(catalogOptions);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/paimon-flink/paimon-flink-common/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.paimon.flink.action.CompactActionITCase$TestFlinkCatalogFactory


### PR DESCRIPTION
### Purpose

This PR makes FlinkCatalogFactory pluggable.

### Tests

Unit tests are added in CompactionITCase to cover the introduced code.

### API and Format

This change does not affect format, and the introduced APIs are not for public usage for now.

### Documentation

This change introduces changes that does not need document.
