### PR TITLE
[core] Support commit isolation level

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1303,6 +1303,14 @@ public class CoreOptions implements Serializable {
                             "The maximum number of concurrent deleting files. "
                                     + "By default is the number of processors available to the Java virtual machine.");
 
+    public static final ConfigOption<CommitIsolationLevel> COMMIT_ISOLATION_LEVEL =
+            key("commit.isolation-level")
+                    .enumType(CommitIsolationLevel.class)
+                    .defaultValue(CommitIsolationLevel.READ_COMMITTED)
+                    .withDescription(
+                            "Controls the isolation level of the commit operation, "
+                                    + "with a relaxed isolation level being used by default.");
+
     private final Options options;
 
     public CoreOptions(Map<String, String> options) {
@@ -2566,6 +2574,12 @@ public class CoreOptions implements Serializable {
     public enum RangeStrategy {
         SIZE,
         QUANTITY
+    }
+
+    /** Commit isolation level. */
+    public enum CommitIsolationLevel {
+        READ_COMMITTED,
+        SERIALIZABLE
     }
 
     /** Specifies the log consistency mode for table. */

--- a/paimon-common/src/main/java/org/apache/paimon/exception/CommitFailedException.java
+++ b/paimon-common/src/main/java/org/apache/paimon/exception/CommitFailedException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.exception;
+
+/** When this exception is thrown, the commit fails and some data cleanup can be performed. */
+public class CommitFailedException extends RuntimeException {
+    public CommitFailedException(String msg) {
+        super(msg);
+    }
+
+    public CommitFailedException(Throwable e) {
+        super(e);
+    }
+
+    public CommitFailedException(String msg, Throwable e) {
+        super(msg, e);
+    }
+
+    public CommitFailedException(Throwable e, String msg, Object... args) {
+        super(String.format(msg, args), e);
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/exception/CommitStateUnknownException.java
+++ b/paimon-common/src/main/java/org/apache/paimon/exception/CommitStateUnknownException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.exception;
+
+/**
+ * When this exception is thrown, you should stop whatever you are doing. Don't clean/delete
+ * anything.This is because we can't be sure that the commit was successful.
+ */
+public class CommitStateUnknownException extends RuntimeException {
+    public CommitStateUnknownException(String msg) {
+        super(msg);
+    }
+
+    public CommitStateUnknownException(Throwable e) {
+        super(e);
+    }
+
+    public CommitStateUnknownException(String msg, Throwable e) {
+        super(msg, e);
+    }
+
+    public CommitStateUnknownException(Throwable e, String msg, Object... args) {
+        super(String.format(msg, args), e);
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/exception/DirtyCommitException.java
+++ b/paimon-common/src/main/java/org/apache/paimon/exception/DirtyCommitException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.exception;
+
+/**
+ * This means that in the case of concurrent operations, a client has a dirty commit. In this case,
+ * we should clean up the commit and stop it.
+ */
+public class DirtyCommitException extends RuntimeException {
+    public DirtyCommitException(String msg) {
+        super(msg);
+    }
+
+    public DirtyCommitException(Throwable e) {
+        super(e);
+    }
+
+    public DirtyCommitException(String msg, Throwable e) {
+        super(msg, e);
+    }
+
+    public DirtyCommitException(Throwable e, String msg, Object... args) {
+        super(String.format(msg, args), e);
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
@@ -238,6 +238,9 @@ public interface FileIO extends Serializable {
         try {
             writeFile(tmp, content, false);
             success = rename(tmp, path);
+        } catch (IOException e) {
+            // try check once
+            success = exists(path) && !exists(tmp);
         } finally {
             if (!success) {
                 deleteQuietly(tmp);

--- a/paimon-core/pom.xml
+++ b/paimon-core/pom.xml
@@ -204,6 +204,30 @@ under the License.
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
+            <type>jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <type>jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
+            <type>jar</type>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -46,6 +46,7 @@ import org.apache.paimon.table.sink.CallbackUtils;
 import org.apache.paimon.table.sink.TagCallback;
 import org.apache.paimon.tag.TagAutoManager;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.SegmentsCache;
 import org.apache.paimon.utils.SnapshotManager;
@@ -206,7 +207,9 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 newStatsFileHandler(),
                 bucketMode(),
                 options.scanManifestParallelism(),
-                schema.options());
+                schema.options(),
+                newBranchManager(),
+                newTagManager());
     }
 
     @Override
@@ -239,6 +242,12 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
     @Override
     public TagManager newTagManager() {
         return new TagManager(fileIO, options.path());
+    }
+
+    @Override
+    public BranchManager newBranchManager() {
+        return new BranchManager(
+                fileIO, options.path(), snapshotManager(), newTagManager(), schemaManager);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -205,7 +205,8 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 options.branch(),
                 newStatsFileHandler(),
                 bucketMode(),
-                options.scanManifestParallelism());
+                options.scanManifestParallelism(),
+                schema.options());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/FileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/FileStore.java
@@ -36,6 +36,7 @@ import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.sink.TagCallback;
 import org.apache.paimon.tag.TagAutoManager;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
@@ -85,6 +86,8 @@ public interface FileStore<T> extends Serializable {
     ChangelogDeletion newChangelogDeletion();
 
     TagManager newTagManager();
+
+    BranchManager newBranchManager();
 
     TagDeletion newTagDeletion();
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -1021,6 +1021,14 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             // If the commit succeeds, we ignore all exceptions thrown by the successful commit;
             // otherwise, we throw an exception.
             if (!success && useSerializableIsolation) {
+                cleanUpTmpManifests(
+                        previousChangesListName,
+                        newChangesListName,
+                        changelogListName,
+                        newIndexManifest,
+                        oldMetas,
+                        newMetas,
+                        changelogMetas);
                 throw new CommitFailedException(e.getMessage(), e);
             }
         }

--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStore.java
@@ -39,6 +39,7 @@ import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.sink.TagCallback;
 import org.apache.paimon.tag.TagAutoManager;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
@@ -155,6 +156,12 @@ public class PrivilegedFileStore<T> implements FileStore<T> {
     public TagManager newTagManager() {
         privilegeChecker.assertCanInsert(identifier);
         return wrapped.newTagManager();
+    }
+
+    @Override
+    public BranchManager newBranchManager() {
+        privilegeChecker.assertCanInsert(identifier);
+        return wrapped.newBranchManager();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/utils/BranchManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/BranchManager.java
@@ -284,7 +284,7 @@ public class BranchManager {
                             .collect(Collectors.toList());
 
             // Delete latest snapshot hint
-            snapshotManager.deleteLatestHint();
+            snapshotManager.removeSnapshotLatestHint();
 
             fileIO.deleteFilesQuietly(deletePaths);
             fileIO.copyFiles(

--- a/paimon-core/src/main/java/org/apache/paimon/utils/BranchManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/BranchManager.java
@@ -364,4 +364,18 @@ public class BranchManager {
             throw new RuntimeException(e);
         }
     }
+
+    /** Get all branch createdFromSnapshots. */
+    public List<Snapshot> branchSnapshots() {
+        ArrayList<Snapshot> snapshotList = new ArrayList<>();
+        branches()
+                .forEach(
+                        b -> {
+                            long createdFromSnapshot = b.getCreatedFromSnapshot();
+                            if (snapshotManager.snapshotExists(createdFromSnapshot)) {
+                                snapshotList.add(snapshotManager.snapshot(createdFromSnapshot));
+                            }
+                        });
+        return snapshotList;
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -664,12 +664,6 @@ public class SnapshotManager implements Serializable {
         return listVersionedFiles(fileIO, dir, prefix).reduce(reducer).orElse(null);
     }
 
-    public void deleteLatestHint() throws IOException {
-        Path snapshotDir = snapshotDirectory();
-        Path hintFile = new Path(snapshotDir, LATEST);
-        fileIO.delete(hintFile, false);
-    }
-
     public void commitLatestHint(long snapshotId) throws IOException {
         commitHint(snapshotId, LATEST, snapshotDirectory());
     }
@@ -689,5 +683,33 @@ public class SnapshotManager implements Serializable {
     private void commitHint(long snapshotId, String fileName, Path dir) throws IOException {
         Path hintFile = new Path(dir, fileName);
         fileIO.overwriteFileUtf8(hintFile, String.valueOf(snapshotId));
+    }
+
+    public @Nullable Long latestSnapshotIdWithOutHint() throws IOException {
+        return findByListFiles(Math::max, snapshotDirectory(), SNAPSHOT_PREFIX);
+    }
+
+    public boolean removeSnapshot(long snapshotId) throws IOException {
+        return fileIO.delete(snapshotPath(snapshotId), false);
+    }
+
+    public boolean removeChangeLog(long snapshotId) throws IOException {
+        return fileIO.delete(longLivedChangelogPath(snapshotId), false);
+    }
+
+    public boolean removeSnapshotLatestHint() throws IOException {
+        return fileIO.delete(new Path(snapshotDirectory(), LATEST), false);
+    }
+
+    public boolean removeSnapshotEarliestHint() throws IOException {
+        return fileIO.delete(new Path(snapshotDirectory(), EARLIEST), false);
+    }
+
+    public boolean removeChangeLogLatestHint() throws IOException {
+        return fileIO.delete(new Path(changelogDirectory(), LATEST), false);
+    }
+
+    public boolean removeChangeLogEarliestHint() throws IOException {
+        return fileIO.delete(new Path(changelogDirectory(), EARLIEST), false);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -363,7 +363,9 @@ public class TestFileStore extends KeyValueFileStore {
 
         List<Snapshot> snapshots = new ArrayList<>();
         for (long id = snapshotIdBeforeCommit + 1; id <= snapshotIdAfterCommit; id++) {
-            snapshots.add(snapshotManager.snapshot(id));
+            if (snapshotManager.snapshotExists(id)) {
+                snapshots.add(snapshotManager.snapshot(id));
+            }
         }
         return snapshots;
     }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -1067,7 +1067,7 @@ public class FileStoreCommitTest {
                                                 return p.callRealMethod();
                                             })
                                     .when(spyCommit)
-                                    .doCommit(anyLong(), any(), any(), anyBoolean(), anyBoolean());
+                                    .doCommit(anyLong(), any(), any(), anyBoolean());
                             return spyCommit;
                         })
                 .when(spyStore)
@@ -1236,7 +1236,7 @@ public class FileStoreCommitTest {
                                                 return p.callRealMethod();
                                             })
                                     .when(spyCommit)
-                                    .doCommit(anyLong(), any(), any(), anyBoolean(), anyBoolean());
+                                    .doCommit(anyLong(), any(), any(), anyBoolean());
                             return spyCommit;
                         })
                 .when(spyStore)
@@ -1322,7 +1322,7 @@ public class FileStoreCommitTest {
                                                 return p.callRealMethod();
                                             })
                                     .when(spyCommit)
-                                    .doCommit(anyLong(), any(), any(), anyBoolean(), anyBoolean());
+                                    .doCommit(anyLong(), any(), any(), anyBoolean());
                             return spyCommit;
                         })
                 .when(spyStore)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
For the file system catalog, there are many situations where we need to support stricter commit policies.This is especially true for third-party databases that use paimon as their underlying storage.

We define the commit isolation level option to control the behavior.


<!-- Linking this pull request to the issue -->
Linked issue: none

<!-- What is the purpose of the change -->
1. Disable retry after failed commits in strict mode
2. In strict mode, reject and clean up potentially dirty commits.
3. Categorized possible exceptions and adjusted the exception handling logic.
4. Supports concurrency control.
5. In strict mode, do not use any hint file.

### Tests

<!-- List UT and IT cases to verify this change -->
See FileStoreCommitTest.java.

### API and Format

<!-- Does this change affect API or storage format -->
None

### Documentation

<!-- Does this change introduce a new feature -->

#### Glossary:
- Dirty-commit: commitSnapshotId < CurrentLatestSnapshotId  - snapshot.num-retained.max && commit-success=True && snapshotManager.exists(commitSnapshotId)=True && (commitSnapshotId not belong any tag/branch)

#### Flow chat (use strict mode):
```mermaid
    graph TD
START[startCommit] -->USE-LOCK{USE-LOCK?}
USE-LOCK -->|YES| COMMIT_WITH_LOCK{COMMIT_WITH_LOCK_SUCCESS}
USE-LOCK -->|NO| CHECK-BEFORE{CHECK-BEFORE-SUCCESS?}
CHECK-BEFORE -->|NO| COMMIT_FAILED
CHECK-BEFORE -->|YES| COMMIT{COMMIT_SUCCESS?}
COMMIT --> |commit state unknown| COMMIT_FAILED
COMMIT --> |not success| COMMIT_FAILED
COMMIT --> |YES| IS_DIRTY_COMMIT{IS_DIRTY_COMMIT?}
IS_DIRTY_COMMIT --> |YES| COMMIT_FAILED
IS_DIRTY_COMMIT --> |NO| COMMIT_SUCCESS
COMMIT_WITH_LOCK --> |failed-normal| RETRY
COMMIT_WITH_LOCK --> |failed - strict mode| COMMIT_FAILED
COMMIT_WITH_LOCK --> |success| COMMIT_SUCCESS
RETRY --> END
COMMIT_SUCCESS --> END
COMMIT_FAILED --> END
```

