### PR TITLE
[core] Refactor exception handling of PartitionTimeExtractor

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionValuesTimeExpireStrategy.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionValuesTimeExpireStrategy.java
@@ -64,7 +64,8 @@ public class PartitionValuesTimeExpireStrategy extends PartitionExpireStrategy {
         @Override
         public boolean test(BinaryRow partition) {
             Object[] array = convertPartition(partition);
-            LocalDateTime partTime = timeExtractor.extract(partitionKeys, Arrays.asList(array));
+            LocalDateTime partTime =
+                    timeExtractor.extract(partitionKeys, Arrays.asList(array), true);
             return partTime != null && expireDateTime.isAfter(partTime);
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionValuesTimeExpireStrategy.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionValuesTimeExpireStrategy.java
@@ -26,15 +26,24 @@ import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.types.RowType;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * A partition expiration policy that compare the time extracted from the partition with the current
  * time.
  */
 public class PartitionValuesTimeExpireStrategy extends PartitionExpireStrategy {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(PartitionValuesTimeExpireStrategy.class);
 
     private final PartitionTimeExtractor timeExtractor;
 
@@ -64,9 +73,25 @@ public class PartitionValuesTimeExpireStrategy extends PartitionExpireStrategy {
         @Override
         public boolean test(BinaryRow partition) {
             Object[] array = convertPartition(partition);
-            LocalDateTime partTime =
-                    timeExtractor.extract(partitionKeys, Arrays.asList(array), true);
-            return partTime != null && expireDateTime.isAfter(partTime);
+            try {
+                LocalDateTime partTime = timeExtractor.extract(partitionKeys, Arrays.asList(array));
+                return expireDateTime.isAfter(partTime);
+            } catch (DateTimeParseException e) {
+                String partitionInfo =
+                        IntStream.range(0, partitionKeys.size())
+                                .mapToObj(i -> partitionKeys.get(i) + ":" + array[i])
+                                .collect(Collectors.joining(","));
+                LOG.warn(
+                        "Can't extract datetime from partition {}. If you want to configure partition expiration, please:\n"
+                                + "  1. Check the expiration configuration.\n"
+                                + "  2. Manually delete the partition using the drop-partition command if the partition"
+                                + " value is non-date formatted.\n"
+                                + "  3. Use '{}' expiration strategy by set '{}', which supports non-date formatted partition.",
+                        partitionInfo,
+                        CoreOptions.PartitionExpireStrategy.UPDATE_TIME,
+                        CoreOptions.PARTITION_EXPIRATION_STRATEGY.key());
+                return false;
+            }
         }
 
         @Override

--- a/paimon-core/src/test/java/org/apache/paimon/partition/PartitionTimeExtractorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/partition/PartitionTimeExtractorTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.testutils.assertj.PaimonAssertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -38,29 +39,23 @@ public class PartitionTimeExtractorTest {
         assertThat(
                         extractor.extract(
                                 Collections.emptyList(),
-                                Collections.singletonList("2023-01-01 20:08:08"),
-                                true))
+                                Collections.singletonList("2023-01-01 20:08:08")))
                 .isEqualTo(LocalDateTime.parse("2023-01-01T20:08:08"));
 
         assertThat(
                         extractor.extract(
                                 Collections.emptyList(),
-                                Collections.singletonList("2023-1-1 20:08:08"),
-                                true))
+                                Collections.singletonList("2023-1-1 20:08:08")))
                 .isEqualTo(LocalDateTime.parse("2023-01-01T20:08:08"));
 
         assertThat(
                         extractor.extract(
-                                Collections.emptyList(),
-                                Collections.singletonList("2023-01-01"),
-                                true))
+                                Collections.emptyList(), Collections.singletonList("2023-01-01")))
                 .isEqualTo(LocalDateTime.parse("2023-01-01T00:00:00"));
 
         assertThat(
                         extractor.extract(
-                                Collections.emptyList(),
-                                Collections.singletonList("2023-1-1"),
-                                true))
+                                Collections.emptyList(), Collections.singletonList("2023-1-1")))
                 .isEqualTo(LocalDateTime.parse("2023-01-01T00:00:00"));
     }
 
@@ -71,24 +66,20 @@ public class PartitionTimeExtractorTest {
         assertThat(
                         extractor.extract(
                                 Arrays.asList("year", "month", "day"),
-                                Arrays.asList("2023", "01", "01"),
-                                true))
+                                Arrays.asList("2023", "01", "01")))
                 .isEqualTo(LocalDateTime.parse("2023-01-01T00:00:00"));
 
         extractor = new PartitionTimeExtractor("$year-$month-$day $hour:00:00", null);
         assertThat(
                         extractor.extract(
                                 Arrays.asList("year", "month", "day", "hour"),
-                                Arrays.asList("2023", "01", "01", "01"),
-                                true))
+                                Arrays.asList("2023", "01", "01", "01")))
                 .isEqualTo(LocalDateTime.parse("2023-01-01T01:00:00"));
 
         extractor = new PartitionTimeExtractor("$dt", null);
         assertThat(
                         extractor.extract(
-                                Arrays.asList("other", "dt"),
-                                Arrays.asList("dummy", "2023-01-01"),
-                                true))
+                                Arrays.asList("other", "dt"), Arrays.asList("dummy", "2023-01-01")))
                 .isEqualTo(LocalDateTime.parse("2023-01-01T00:00:00"));
     }
 
@@ -97,30 +88,21 @@ public class PartitionTimeExtractorTest {
         PartitionTimeExtractor extractor = new PartitionTimeExtractor(null, "yyyyMMdd");
         assertThat(
                         extractor.extract(
-                                Collections.emptyList(),
-                                Collections.singletonList("20230101"),
-                                true))
+                                Collections.emptyList(), Collections.singletonList("20230101")))
                 .isEqualTo(LocalDateTime.parse("2023-01-01T00:00:00"));
     }
 
     @Test
     public void testExtractNonDateFormattedPartition() {
         PartitionTimeExtractor extractor = new PartitionTimeExtractor("$ds", "yyyyMMdd");
-        assertThat(
-                        extractor.extract(
-                                Collections.singletonList("ds"),
-                                Collections.singletonList("unknown"),
-                                true))
-                .isNull();
         assertThatThrownBy(
                         () ->
                                 extractor.extract(
                                         Collections.singletonList("ds"),
-                                        Collections.singletonList("unknown"),
-                                        false))
+                                        Collections.singletonList("unknown")))
                 .satisfies(
                         PaimonAssertions.anyCauseMatches(
-                                RuntimeException.class,
-                                "Can't extract datetime from partition 'ds:unknown' with formatter 'yyyyMMdd' and pattern '$ds'."));
+                                DateTimeParseException.class,
+                                "Text 'unknown' could not be parsed at index 0"));
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionMarkDoneTrigger.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionMarkDoneTrigger.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink.sink.partition;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionTimeExtractor;
@@ -31,12 +32,13 @@ import org.apache.flink.api.common.typeutils.base.ListSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -123,14 +125,8 @@ public class PartitionMarkDoneTrigger {
             String partition = entry.getKey();
 
             long lastUpdateTime = entry.getValue();
-            LinkedHashMap<String, String> partitionSpec =
-                    extractPartitionSpecFromPath(new Path(partition));
             long partitionStartTime =
-                    timeExtractor
-                            .extract(
-                                    new ArrayList<>(partitionSpec.keySet()),
-                                    new ArrayList<>(partitionSpec.values()),
-                                    false)
+                    extractDateTime(partition)
                             .atZone(ZoneId.systemDefault())
                             .toInstant()
                             .toEpochMilli();
@@ -143,6 +139,15 @@ public class PartitionMarkDoneTrigger {
             }
         }
         return needDone;
+    }
+
+    @VisibleForTesting
+    LocalDateTime extractDateTime(String partition) {
+        try {
+            return timeExtractor.extract(extractPartitionSpecFromPath(new Path(partition)));
+        } catch (DateTimeParseException e) {
+            throw new RuntimeException("Can't extract datetime from partition " + partition, e);
+        }
     }
 
     public void snapshotState() throws Exception {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionMarkDoneTrigger.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionMarkDoneTrigger.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -122,9 +123,14 @@ public class PartitionMarkDoneTrigger {
             String partition = entry.getKey();
 
             long lastUpdateTime = entry.getValue();
+            LinkedHashMap<String, String> partitionSpec =
+                    extractPartitionSpecFromPath(new Path(partition));
             long partitionStartTime =
                     timeExtractor
-                            .extract(extractPartitionSpecFromPath(new Path(partition)))
+                            .extract(
+                                    new ArrayList<>(partitionSpec.keySet()),
+                                    new ArrayList<>(partitionSpec.values()),
+                                    false)
                             .atZone(ZoneId.systemDefault())
                             .toInstant()
                             .toEpochMilli();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
When using `partition markdone`, if some partitions are non-date formatted, currently `PartitionTimeExtractor` will returns `null` and omits the exception. This PR refactor it for better trouble shooting.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
