### PR TITLE
[core] Clarify the purpose of method findOverlappedSnapshots and move…

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -77,10 +77,10 @@ public abstract class FileDeletionBase<T extends Snapshot> {
 
     protected boolean changelogDecoupled;
 
-    /** Used to record which tag is cached. */
+    /** Used to record which snapshot is cached. */
     private long cachedSnapshotId = 0;
 
-    /** Used to cache data files used by current tag. */
+    /** Used to cache data files used by current snapshot. */
     private final Map<BinaryRow, Map<Integer, Set<String>>> cachedSnapshotDataFiles =
             new HashMap<>();
 
@@ -331,7 +331,7 @@ public abstract class FileDeletionBase<T extends Snapshot> {
     public Predicate<ManifestEntry> dataFileSkipper(
             List<Snapshot> skippingSnapshots, long expiringSnapshotId) throws Exception {
         int index = SnapshotManager.findPreviousSnapshot(skippingSnapshots, expiringSnapshotId);
-        // refresh tag data files
+        // refresh snapshot data files
         if (index >= 0) {
             Snapshot previousSnapshot = skippingSnapshots.get(index);
             if (previousSnapshot.id() != cachedSnapshotId) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireChangelogImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireChangelogImpl.java
@@ -134,10 +134,11 @@ public class ExpireChangelogImpl implements ExpireSnapshots {
             LOG.debug("Changelog expire range is [" + earliestId + ", " + endExclusiveId + ")");
         }
 
-        List<Snapshot> taggedSnapshots = tagManager.taggedSnapshots();
+        List<Snapshot> referencedSnapshots = tagManager.taggedSnapshots();
 
         List<Snapshot> skippingSnapshots =
-                TagManager.findOverlappedSnapshots(taggedSnapshots, earliestId, endExclusiveId);
+                SnapshotManager.findOverlappedSnapshots(
+                        referencedSnapshots, earliestId, endExclusiveId);
         skippingSnapshots.add(snapshotManager.changelog(endExclusiveId));
         Set<String> manifestSkippSet = changelogDeletion.manifestSkippingSet(skippingSnapshots);
         for (long id = earliestId; id < endExclusiveId; id++) {
@@ -147,7 +148,7 @@ public class ExpireChangelogImpl implements ExpireSnapshots {
             Changelog changelog = snapshotManager.longLivedChangelog(id);
             Predicate<ManifestEntry> skipper;
             try {
-                skipper = changelogDeletion.dataFileSkipper(taggedSnapshots, id);
+                skipper = changelogDeletion.dataFileSkipper(referencedSnapshots, id);
             } catch (Exception e) {
                 LOG.info(
                         String.format(

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
@@ -153,7 +153,7 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
                     "Snapshot expire range is [" + beginInclusiveId + ", " + endExclusiveId + ")");
         }
 
-        List<Snapshot> taggedSnapshots = tagManager.taggedSnapshots();
+        List<Snapshot> referencedSnapshots = tagManager.taggedSnapshots();
 
         // delete merge tree files
         // deleted merge tree files in a snapshot are not used by the next snapshot, so the range of
@@ -166,7 +166,7 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
             // expire merge tree files and collect changed buckets
             Predicate<ManifestEntry> skipper;
             try {
-                skipper = snapshotDeletion.dataFileSkipper(taggedSnapshots, id);
+                skipper = snapshotDeletion.dataFileSkipper(referencedSnapshots, id);
             } catch (Exception e) {
                 LOG.info(
                         String.format(
@@ -198,8 +198,8 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
 
         // delete manifests and indexFiles
         List<Snapshot> skippingSnapshots =
-                TagManager.findOverlappedSnapshots(
-                        taggedSnapshots, beginInclusiveId, endExclusiveId);
+                SnapshotManager.findOverlappedSnapshots(
+                        referencedSnapshots, beginInclusiveId, endExclusiveId);
         skippingSnapshots.add(snapshotManager.snapshot(endExclusiveId));
         Set<String> skippingSet = snapshotDeletion.manifestSkippingSet(skippingSnapshots);
         for (long id = beginInclusiveId; id < endExclusiveId; id++) {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -668,6 +668,42 @@ public class SnapshotManager implements Serializable {
         return listVersionedFiles(fileIO, dir, prefix).reduce(reducer).orElse(null);
     }
 
+    /**
+     * Find the overlapping snapshots between sortedSnapshots and range of [beginInclusive,
+     * endExclusive).
+     */
+    public static List<Snapshot> findOverlappedSnapshots(
+            List<Snapshot> sortedSnapshots, long beginInclusive, long endExclusive) {
+        List<Snapshot> overlappedSnapshots = new ArrayList<>();
+        int right = findPreviousSnapshot(sortedSnapshots, endExclusive);
+        if (right >= 0) {
+            int left = Math.max(findPreviousOrEqualSnapshot(sortedSnapshots, beginInclusive), 0);
+            for (int i = left; i <= right; i++) {
+                overlappedSnapshots.add(sortedSnapshots.get(i));
+            }
+        }
+        return overlappedSnapshots;
+    }
+
+    public static int findPreviousSnapshot(List<Snapshot> sortedSnapshots, long targetSnapshotId) {
+        for (int i = sortedSnapshots.size() - 1; i >= 0; i--) {
+            if (sortedSnapshots.get(i).id() < targetSnapshotId) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static int findPreviousOrEqualSnapshot(
+            List<Snapshot> sortedSnapshots, long targetSnapshotId) {
+        for (int i = sortedSnapshots.size() - 1; i >= 0; i--) {
+            if (sortedSnapshots.get(i).id() <= targetSnapshotId) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     public void deleteLatestHint() throws IOException {
         Path snapshotDir = snapshotDirectory();
         Path hintFile = new Path(snapshotDir, LATEST);

--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -366,36 +366,4 @@ public class TagManager {
                         "Didn't find tag with snapshot id '%s'.This is unexpected.",
                         taggedSnapshot.id()));
     }
-
-    public static List<Snapshot> findOverlappedSnapshots(
-            List<Snapshot> taggedSnapshots, long beginInclusive, long endExclusive) {
-        List<Snapshot> snapshots = new ArrayList<>();
-        int right = findPreviousTag(taggedSnapshots, endExclusive);
-        if (right >= 0) {
-            int left = Math.max(findPreviousOrEqualTag(taggedSnapshots, beginInclusive), 0);
-            for (int i = left; i <= right; i++) {
-                snapshots.add(taggedSnapshots.get(i));
-            }
-        }
-        return snapshots;
-    }
-
-    public static int findPreviousTag(List<Snapshot> taggedSnapshots, long targetSnapshotId) {
-        for (int i = taggedSnapshots.size() - 1; i >= 0; i--) {
-            if (taggedSnapshots.get(i).id() < targetSnapshotId) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
-    private static int findPreviousOrEqualTag(
-            List<Snapshot> taggedSnapshots, long targetSnapshotId) {
-        for (int i = taggedSnapshots.size() - 1; i >= 0; i--) {
-            if (taggedSnapshots.get(i).id() <= targetSnapshotId) {
-                return i;
-            }
-        }
-        return -1;
-    }
 }


### PR DESCRIPTION
… to snapshotManager.

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Clarify the purpose of method `findOverlappedSnapshots` is to find the overlapping snapshots between snapshots that still referenced by tags/branches and range of [beginInclusive, endExclusive), not only tagSnapshots.


<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
