### PR TITLE
[spark] Support global options via SQL conf

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -52,10 +52,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.apache.paimon.spark.PaimonOptionHelper.mergeOptions;
-import static org.apache.paimon.spark.PaimonOptionHelper.withDynamicOptions;
 import static org.apache.paimon.spark.SparkCatalogOptions.DEFAULT_DATABASE;
 import static org.apache.paimon.spark.SparkTypeUtils.toPaimonType;
+import static org.apache.paimon.spark.util.OptionUtils.mergeOptions;
+import static org.apache.paimon.spark.util.OptionUtils.withDynamicOptions;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Spark {@link TableCatalog} for paimon. */

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -236,7 +236,7 @@ public class SparkCatalog extends SparkBaseCatalog {
         return loadSparkTable(
                 ident,
                 Collections.singletonMap(
-                        CoreOptions.SCAN_VERSION.key(), String.valueOf(timestamp)));
+                        CoreOptions.SCAN_TIMESTAMP_MILLIS.key(), String.valueOf(timestamp)));
     }
 
     @Override

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -54,8 +54,8 @@ import java.util.stream.Collectors;
 
 import static org.apache.paimon.spark.SparkCatalogOptions.DEFAULT_DATABASE;
 import static org.apache.paimon.spark.SparkTypeUtils.toPaimonType;
-import static org.apache.paimon.spark.util.OptionUtils.mergeOptions;
-import static org.apache.paimon.spark.util.OptionUtils.withDynamicOptions;
+import static org.apache.paimon.spark.util.OptionUtils.copyWithSQLConf;
+import static org.apache.paimon.spark.util.OptionUtils.mergeSQLConf;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Spark {@link TableCatalog} for paimon. */
@@ -377,7 +377,7 @@ public class SparkCatalog extends SparkBaseCatalog {
                                     return references.length == 1
                                             && references[0] instanceof FieldReference;
                                 }));
-        Map<String, String> normalizedProperties = mergeOptions(properties);
+        Map<String, String> normalizedProperties = mergeSQLConf(properties);
         normalizedProperties.remove(PRIMARY_KEY_IDENTIFIER);
         normalizedProperties.remove(TableCatalog.PROP_COMMENT);
         String pkAsString = properties.get(PRIMARY_KEY_IDENTIFIER);
@@ -450,7 +450,7 @@ public class SparkCatalog extends SparkBaseCatalog {
             throws NoSuchTableException {
         try {
             return new SparkTable(
-                    withDynamicOptions(catalog.getTable(toIdentifier(ident)), extraOptions));
+                    copyWithSQLConf(catalog.getTable(toIdentifier(ident)), extraOptions));
         } catch (Catalog.TableNotExistException e) {
             throw new NoSuchTableException(ident);
         }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonOptionHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonOptionHelper.scala
@@ -43,7 +43,7 @@ object PaimonOptionHelper extends SQLConfHelper {
     mergedOptions
   }
 
-  def withDynamicOptions[T <: Table](table: T, extraOptions: JMap[String, String] = null): T = {
+  def withDynamicOptions[T <: Table](table: T, extraOptions: JMap[String, String]): T = {
     val mergedOptions = mergeOptions(extraOptions)
     if (mergedOptions.isEmpty) {
       table

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonOptionHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonOptionHelper.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark
+
+import org.apache.paimon.table.Table
+
+import org.apache.spark.sql.catalyst.SQLConfHelper
+
+import java.util.{HashMap => JHashMap, Map => JMap}
+
+import scala.collection.JavaConverters._
+
+object PaimonOptionHelper extends SQLConfHelper {
+
+  private val PAIMON_OPTION_PREFIX = "spark.paimon."
+
+  def mergeOptions(extraOptions: JMap[String, String]): JMap[String, String] = {
+    val mergedOptions = new JHashMap[String, String](
+      conf.getAllConfs
+        .filterKeys(_.startsWith(PAIMON_OPTION_PREFIX))
+        .map {
+          case (key, value) =>
+            key.stripPrefix(PAIMON_OPTION_PREFIX) -> value
+        }
+        .asJava)
+    mergedOptions.putAll(extraOptions)
+    mergedOptions
+  }
+
+  def withDynamicOptions[T <: Table](table: T, extraOptions: JMap[String, String] = null): T = {
+    val mergedOptions = mergeOptions(extraOptions)
+    if (mergedOptions.isEmpty) {
+      table
+    } else {
+      table.copy(mergedOptions).asInstanceOf[T]
+    }
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkSource.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkSource.scala
@@ -22,6 +22,7 @@ import org.apache.paimon.catalog.CatalogContext
 import org.apache.paimon.options.Options
 import org.apache.paimon.spark.commands.WriteIntoPaimonTable
 import org.apache.paimon.spark.sources.PaimonSink
+import org.apache.paimon.spark.util.OptionUtils.mergeSQLConf
 import org.apache.paimon.table.{DataTable, FileStoreTable, FileStoreTableFactory}
 import org.apache.paimon.table.system.AuditLogTable
 
@@ -64,7 +65,7 @@ class SparkSource
       schema: StructType,
       partitioning: Array[Transform],
       properties: JMap[String, String]): Table = {
-    new SparkTable(loadTable(properties))
+    SparkTable(loadTable(properties))
   }
 
   override def createRelation(
@@ -80,7 +81,7 @@ class SparkSource
 
   private def loadTable(options: JMap[String, String]): DataTable = {
     val catalogContext = CatalogContext.create(
-      Options.fromMap(options),
+      Options.fromMap(mergeSQLConf(options)),
       SparkSession.active.sessionState.newHadoopConf())
     val table = FileStoreTableFactory.create(catalogContext)
     if (Options.fromMap(options).get(SparkConnectorOptions.READ_CHANGELOG)) {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/OptionUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/OptionUtils.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.spark
+package org.apache.paimon.spark.util
 
 import org.apache.paimon.table.Table
 
@@ -26,7 +26,7 @@ import java.util.{HashMap => JHashMap, Map => JMap}
 
 import scala.collection.JavaConverters._
 
-object PaimonOptionHelper extends SQLConfHelper {
+object OptionUtils extends SQLConfHelper {
 
   private val PAIMON_OPTION_PREFIX = "spark.paimon."
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/OptionUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/OptionUtils.scala
@@ -30,7 +30,7 @@ object OptionUtils extends SQLConfHelper {
 
   private val PAIMON_OPTION_PREFIX = "spark.paimon."
 
-  def mergeOptions(extraOptions: JMap[String, String]): JMap[String, String] = {
+  def mergeSQLConf(extraOptions: JMap[String, String]): JMap[String, String] = {
     val mergedOptions = new JHashMap[String, String](
       conf.getAllConfs
         .filterKeys(_.startsWith(PAIMON_OPTION_PREFIX))
@@ -43,8 +43,8 @@ object OptionUtils extends SQLConfHelper {
     mergedOptions
   }
 
-  def withDynamicOptions[T <: Table](table: T, extraOptions: JMap[String, String]): T = {
-    val mergedOptions = mergeOptions(extraOptions)
+  def copyWithSQLConf[T <: Table](table: T, extraOptions: JMap[String, String]): T = {
+    val mergedOptions = mergeSQLConf(extraOptions)
     if (mergedOptions.isEmpty) {
       table
     } else {

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/PaimonOptionTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/PaimonOptionTest.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+import org.apache.paimon.spark.PaimonSparkTestBase
+import org.apache.paimon.table.FileStoreTableFactory
+
+import org.apache.spark.sql.Row
+import org.junit.jupiter.api.Assertions
+
+class PaimonOptionTest extends PaimonSparkTestBase {
+
+  test("Paimon Option: create table with sql conf") {
+    withSQLConf("spark.paimon.file.block-size" -> "512M") {
+      sql("CREATE TABLE T (id INT)")
+      val table = loadTable("T")
+      // check options in schema file directly
+      val fileStoreTable = FileStoreTableFactory.create(table.fileIO(), table.location())
+      Assertions.assertEquals("512M", fileStoreTable.options().get("file.block-size"))
+    }
+  }
+
+  test("Paimon Option: query table with sql conf") {
+    sql("CREATE TABLE T (id INT)")
+    sql("INSERT INTO T VALUES 1")
+    sql("INSERT INTO T VALUES 2")
+    checkAnswer(sql("SELECT * FROM T ORDER BY id"), Row(1) :: Row(2) :: Nil)
+
+    // query with mutable option
+    withSQLConf("spark.paimon.scan.snapshot-id" -> "1") {
+      checkAnswer(sql("SELECT * FROM T ORDER BY id"), Row(1))
+    }
+
+    // query with immutable option
+    withSQLConf("spark.paimon.bucket" -> "1") {
+      assertThrows[UnsupportedOperationException] {
+        sql("SELECT * FROM T ORDER BY id")
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Users can configure paimon option globally via `spark.paimon.x`, e.g.

`set spark.paimon.file.block-size=512M` to control the file block size globally

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
