### PR TITLE
[spark] Fix stats estimation with char and varchar

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -127,7 +127,9 @@ abstract class PaimonBaseScan(
 
   override def estimateStatistics(): Statistics = {
     val stats = PaimonStatistics(this)
-    if (reservedFilters.nonEmpty) {
+    // When statistics doesn't exist, we don't need to perform FilterEstimation on stats,
+    // because in this scenario stats is calculated through splits and partition pruning has been done.
+    if (statistics.isPresent && reservedFilters.nonEmpty) {
       filterStatistics(stats, reservedFilters)
     } else {
       stats

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -127,9 +127,8 @@ abstract class PaimonBaseScan(
 
   override def estimateStatistics(): Statistics = {
     val stats = PaimonStatistics(this)
-    // When statistics doesn't exist, we don't need to perform FilterEstimation on stats,
-    // because in this scenario stats is calculated through splits and partition pruning has been done.
-    if (statistics.isPresent && reservedFilters.nonEmpty) {
+    // When using paimon stats, we need to perform additional FilterEstimation with reservedFilters on stats.
+    if (stats.paimonStatsEnabled && reservedFilters.nonEmpty) {
       filterStatistics(stats, reservedFilters)
     } else {
       stats

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonStatistics.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonStatistics.scala
@@ -38,7 +38,7 @@ case class PaimonStatistics[T <: PaimonBaseScan](scan: T) extends Statistics {
 
   private lazy val scannedTotalSize: Long = rowCount * scan.readSchema().defaultSize
 
-  private lazy val paimonStats = scan.statistics.orElseGet(null)
+  private lazy val paimonStats = if (scan.statistics.isPresent) scan.statistics.get() else null
 
   lazy val paimonStatsEnabled: Boolean = paimonStats != null
 

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
@@ -95,19 +95,19 @@ abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
       s"""
          |CREATE TABLE T (id STRING, name STRING, byte_col BYTE, short_col SHORT, int_col INT, long_col LONG,
          |float_col FLOAT, double_col DOUBLE, decimal_col DECIMAL(10, 5), boolean_col BOOLEAN, date_col DATE,
-         |timestamp_col TIMESTAMP, binary BINARY)
+         |timestamp_col TIMESTAMP, binary BINARY, char_col CHAR(20), varchar_col VARCHAR(20))
          |USING PAIMON
          |TBLPROPERTIES ('primary-key'='id')
          |""".stripMargin)
 
     spark.sql(
-      s"INSERT INTO T VALUES ('1', 'a', 1, 1, 1, 1, 1.0, 1.0, 12.12345, true, cast('2020-01-01' as date), cast('2020-01-01 00:00:00' as timestamp), binary('example binary1'))")
+      s"INSERT INTO T VALUES ('1', 'a', 1, 1, 1, 1, 1.0, 1.0, 12.12345, true, cast('2020-01-01' as date), cast('2020-01-01 00:00:00' as timestamp), binary('example binary1'), 'a', 'a')")
     spark.sql(
-      s"INSERT INTO T VALUES ('2', 'aaa', 1, null, 1, 1, 1.0, 1.0, 12.12345, true, cast('2020-01-02' as date), cast('2020-01-02 00:00:00' as timestamp), binary('example binary1'))")
+      s"INSERT INTO T VALUES ('2', 'aaa', 1, null, 1, 1, 1.0, 1.0, 12.12345, true, cast('2020-01-02' as date), cast('2020-01-02 00:00:00' as timestamp), binary('example binary1'), 'aaa', 'aaa')")
     spark.sql(
-      s"INSERT INTO T VALUES ('3', 'bbbb', 2, 1, 1, 1, 1.0, 1.0, 22.12345, true, cast('2020-01-02' as date), cast('2020-01-02 00:00:00' as timestamp), null)")
+      s"INSERT INTO T VALUES ('3', 'bbbb', 2, 1, 1, 1, 1.0, 1.0, 22.12345, true, cast('2020-01-02' as date), cast('2020-01-02 00:00:00' as timestamp), null, 'bbbb', 'bbbb')")
     spark.sql(
-      s"INSERT INTO T VALUES ('4', 'bbbbbbbb', 2, 2, 2, 2, 2.0, 2.0, 22.12345, false, cast('2020-01-01' as date), cast('2020-01-01 00:00:00' as timestamp), binary('example binary2'))")
+      s"INSERT INTO T VALUES ('4', 'bbbbbbbb', 2, 2, 2, 2, 2.0, 2.0, 22.12345, false, cast('2020-01-01' as date), cast('2020-01-01 00:00:00' as timestamp), binary('example binary2'), 'bbbbbbbb', 'bbbbbbbb')")
 
     spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR ALL COLUMNS")
 
@@ -163,9 +163,22 @@ abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
     Assertions.assertEquals(
       ColStats.newColStats(12, 2, null, null, 1, 15, 15),
       colStats.get("binary"))
+    // From Spark 3.4, the written char col is padded
+    if (gteqSpark3_4) {
+      Assertions.assertEquals(
+        ColStats.newColStats(13, 4, null, null, 0, 20, 20),
+        colStats.get("char_col"))
+    } else {
+      Assertions.assertEquals(
+        ColStats.newColStats(13, 4, null, null, 0, 4, 8),
+        colStats.get("char_col"))
+    }
+    Assertions.assertEquals(
+      ColStats.newColStats(14, 4, null, null, 0, 4, 8),
+      colStats.get("varchar_col"))
 
     spark.sql(
-      s"INSERT INTO T VALUES ('5', 'bbbbbbbbbbbbbbbb', 3, 3, 3, 3, 3.0, 3.0, 32.12345, false, cast('2020-01-03' as date), cast('2020-01-03 00:00:00' as timestamp), binary('binary3'))")
+      s"INSERT INTO T VALUES ('5', 'bbbbbbbbbbbbbbbb', 3, 3, 3, 3, 3.0, 3.0, 32.12345, false, cast('2020-01-03' as date), cast('2020-01-03 00:00:00' as timestamp), binary('binary3'), 'bbbbbbbbbbbbbbbb', 'bbbbbbbbbbbbbbbb')")
 
     spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR ALL COLUMNS")
 
@@ -221,6 +234,18 @@ abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
     Assertions.assertEquals(
       ColStats.newColStats(12, 3, null, null, 1, 13, 15),
       colStats.get("binary"))
+    if (gteqSpark3_4) {
+      Assertions.assertEquals(
+        ColStats.newColStats(13, 5, null, null, 0, 20, 20),
+        colStats.get("char_col"))
+    } else {
+      Assertions.assertEquals(
+        ColStats.newColStats(13, 5, null, null, 0, 7, 16),
+        colStats.get("char_col"))
+    }
+    Assertions.assertEquals(
+      ColStats.newColStats(14, 5, null, null, 0, 7, 16),
+      colStats.get("varchar_col"))
   }
 
   test("Paimon analyze: analyze unsupported cols") {
@@ -372,6 +397,29 @@ abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
     sql = "SELECT * FROM T WHERE id < 1"
     Assertions.assertEquals(4L, getScanStatistic(sql).rowCount.get.longValue())
     checkAnswer(spark.sql(sql), Nil)
+  }
+
+  test("Paimon analyze: partition filter push down hit with char/varchar") {
+    Seq("char(10)", "varchar(10)").foreach(
+      partitionType => {
+        withTable("T") {
+          sql(s"""
+                 |CREATE TABLE T (id INT, name STRING, pt $partitionType)
+                 |TBLPROPERTIES ('primary-key'='id, pt')
+                 |PARTITIONED BY (pt)
+                 |""".stripMargin)
+
+          sql("INSERT INTO T VALUES (1, 'a', '1'), (2, 'b', '1'), (3, 'c', '2'), (4, 'd', '3')")
+          sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR ALL COLUMNS")
+
+          // For col type such as char, varchar that don't have min and max, filter estimation on stats has no effect.
+          var sqlText = "SELECT * FROM T WHERE pt < '1'"
+          Assertions.assertEquals(4L, getScanStatistic(sqlText).rowCount.get.longValue())
+
+          sqlText = "SELECT id FROM T WHERE pt < '1'"
+          Assertions.assertEquals(4L, getScanStatistic(sqlText).rowCount.get.longValue())
+        }
+      })
   }
 
   protected def statsFileCount(tableLocation: Path, fileIO: FileIO): Int = {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Fix query with char&varchar after analyze when partition filter push down hit
```
VarcharType(10) (of class org.apache.spark.sql.types.VarcharType)
scala.MatchError: VarcharType(10) (of class org.apache.spark.sql.types.VarcharType)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.FilterEstimation.evaluateBinary(FilterEstimation.scala:281)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.FilterEstimation.calculateSingleCondition(FilterEstimation.scala:148)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.FilterEstimation.calculateFilterSelectivity(FilterEstimation.scala:118)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.FilterEstimation.estimate(FilterEstimation.scala:50)
	at org.apache.paimon.spark.statistics.StatisticsHelperBase.filterStatistics(StatisticsHelperBase.scala:51)
	at org.apache.paimon.spark.statistics.StatisticsHelperBase.filterStatistics$(StatisticsHelperBase.scala:44)
	at org.apache.paimon.spark.PaimonBaseScan.filterStatistics(PaimonBaseScan.scala:42)
```


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
