### PR TITLE
[core] Introduce CachingCatalog

### DIFF
--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -40,7 +40,7 @@ under the License.
         </tr>
         <tr>
             <td><h5>cache.expiration-interval</h5></td>
-            <td style="word-wrap: break-word;">30 s</td>
+            <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>
             <td>Controls the duration for which entries in the catalog are cached.</td>
         </tr>

--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -33,6 +33,18 @@ under the License.
             <td>Indicates whether this catalog allow upper case, its default value depends on the implementation of the specific catalog.</td>
         </tr>
         <tr>
+            <td><h5>cache-enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Controls whether the catalog will cache table entries upon load.</td>
+        </tr>
+        <tr>
+            <td><h5>cache.expiration-interval</h5></td>
+            <td style="word-wrap: break-word;">30 s</td>
+            <td>Duration</td>
+            <td>Controls the duration for which entries in the catalog are cached.</td>
+        </tr>
+        <tr>
             <td><h5>client-pool-size</h5></td>
             <td style="word-wrap: break-word;">2</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -36,13 +36,13 @@ under the License.
             <td><h5>cache-enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
-            <td>Controls whether the catalog will cache table entries upon load.</td>
+            <td>Controls whether the catalog will cache databases, tables and manifests.</td>
         </tr>
         <tr>
             <td><h5>cache.expiration-interval</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>
-            <td>Controls the duration for which entries in the catalog are cached.</td>
+            <td>Controls the duration for which databases and tables in the catalog are cached.</td>
         </tr>
         <tr>
             <td><h5>client-pool-size</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -91,6 +91,20 @@ public class CatalogOptions {
                     .defaultValue(2)
                     .withDescription("Configure the size of the connection pool.");
 
+    public static final ConfigOption<Boolean> CACHE_ENABLED =
+            key("cache-enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Controls whether the catalog will cache table entries upon load.");
+
+    public static final ConfigOption<Duration> CACHE_EXPIRATION_INTERVAL_MS =
+            key("cache.expiration-interval")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(30))
+                    .withDescription(
+                            "Controls the duration for which entries in the catalog are cached.");
+
     public static final ConfigOption<String> LINEAGE_META =
             key("lineage-meta")
                     .stringType()

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -96,14 +96,14 @@ public class CatalogOptions {
                     .booleanType()
                     .defaultValue(true)
                     .withDescription(
-                            "Controls whether the catalog will cache table entries upon load.");
+                            "Controls whether the catalog will cache databases, tables and manifests.");
 
     public static final ConfigOption<Duration> CACHE_EXPIRATION_INTERVAL_MS =
             key("cache.expiration-interval")
                     .durationType()
                     .defaultValue(Duration.ofSeconds(60))
                     .withDescription(
-                            "Controls the duration for which entries in the catalog are cached.");
+                            "Controls the duration for which databases and tables in the catalog are cached.");
 
     public static final ConfigOption<String> LINEAGE_META =
             key("lineage-meta")

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -101,7 +101,7 @@ public class CatalogOptions {
     public static final ConfigOption<Duration> CACHE_EXPIRATION_INTERVAL_MS =
             key("cache.expiration-interval")
                     .durationType()
-                    .defaultValue(Duration.ofSeconds(30))
+                    .defaultValue(Duration.ofSeconds(60))
                     .withDescription(
                             "Controls the duration for which entries in the catalog are cached.");
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.catalog;
+
+import org.apache.paimon.schema.SchemaChange;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.system.SystemTableLoader;
+
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Caffeine;
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.RemovalCause;
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.RemovalListener;
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Ticker;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.paimon.catalog.AbstractCatalog.isSpecifiedSystemTable;
+import static org.apache.paimon.catalog.AbstractCatalog.tableAndSystemName;
+import static org.apache.paimon.options.CatalogOptions.CACHE_EXPIRATION_INTERVAL_MS;
+import static org.apache.paimon.table.system.SystemTableLoader.SYSTEM_TABLES;
+
+/** A {@link Catalog} to cache databases and tables and manifests. */
+public class CachingCatalog extends DelegateCatalog {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CachingCatalog.class);
+
+    protected final Cache<String, Map<String, String>> databaseCache;
+    protected final Cache<Identifier, Table> tableCache;
+
+    public CachingCatalog(Catalog wrapped) {
+        this(wrapped, CACHE_EXPIRATION_INTERVAL_MS.defaultValue());
+    }
+
+    public CachingCatalog(Catalog wrapped, Duration expirationInterval) {
+        this(wrapped, expirationInterval, Ticker.systemTicker());
+    }
+
+    public CachingCatalog(Catalog wrapped, Duration expirationInterval, Ticker ticker) {
+        super(wrapped);
+        if (expirationInterval.isZero() || expirationInterval.isNegative()) {
+            throw new IllegalArgumentException(
+                    "When cache.expiration-interval is set to negative or 0, the catalog cache should be disabled.");
+        }
+
+        this.databaseCache =
+                Caffeine.newBuilder()
+                        .softValues()
+                        .executor(Runnable::run)
+                        .expireAfterAccess(expirationInterval)
+                        .ticker(ticker)
+                        .build();
+        this.tableCache =
+                Caffeine.newBuilder()
+                        .softValues()
+                        .removalListener(new TableInvalidatingRemovalListener())
+                        .executor(Runnable::run)
+                        .expireAfterAccess(expirationInterval)
+                        .ticker(ticker)
+                        .build();
+    }
+
+    @Override
+    public Map<String, String> loadDatabaseProperties(String databaseName)
+            throws DatabaseNotExistException {
+        Map<String, String> properties = databaseCache.getIfPresent(databaseName);
+        if (properties != null) {
+            return properties;
+        }
+
+        properties = super.loadDatabaseProperties(databaseName);
+        databaseCache.put(databaseName, properties);
+        return properties;
+    }
+
+    @Override
+    public void dropDatabase(String name, boolean ignoreIfNotExists, boolean cascade)
+            throws DatabaseNotExistException, DatabaseNotEmptyException {
+        super.dropDatabase(name, ignoreIfNotExists, cascade);
+        databaseCache.invalidate(name);
+        if (cascade) {
+            List<Identifier> tables = new ArrayList<>();
+            for (Identifier identifier : tableCache.asMap().keySet()) {
+                if (identifier.getDatabaseName().equals(name)) {
+                    tables.add(identifier);
+                }
+            }
+            tables.forEach(tableCache::invalidate);
+        }
+    }
+
+    @Override
+    public void dropTable(Identifier identifier, boolean ignoreIfNotExists)
+            throws TableNotExistException {
+        super.dropTable(identifier, ignoreIfNotExists);
+        invalidateTable(identifier);
+    }
+
+    @Override
+    public void renameTable(Identifier fromTable, Identifier toTable, boolean ignoreIfNotExists)
+            throws TableNotExistException, TableAlreadyExistException {
+        super.renameTable(fromTable, toTable, ignoreIfNotExists);
+        invalidateTable(fromTable);
+    }
+
+    @Override
+    public void alterTable(
+            Identifier identifier, List<SchemaChange> changes, boolean ignoreIfNotExists)
+            throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException {
+        super.alterTable(identifier, changes, ignoreIfNotExists);
+        invalidateTable(identifier);
+    }
+
+    @Override
+    public Table getTable(Identifier identifier) throws TableNotExistException {
+        Table table = tableCache.getIfPresent(identifier);
+        if (table != null) {
+            return table;
+        }
+
+        if (isSpecifiedSystemTable(identifier)) {
+            String[] splits = tableAndSystemName(identifier);
+            String tableName = splits[0];
+            String type = splits[1];
+
+            Identifier originIdentifier =
+                    Identifier.create(identifier.getDatabaseName(), tableName);
+            Table originTable = tableCache.getIfPresent(originIdentifier);
+            if (originTable == null) {
+                originTable = wrapped.getTable(originIdentifier);
+                tableCache.put(originIdentifier, originTable);
+            }
+            table = SystemTableLoader.load(type, (FileStoreTable) originTable);
+            if (table == null) {
+                throw new TableNotExistException(identifier);
+            }
+            tableCache.put(identifier, table);
+            return table;
+        }
+
+        table = wrapped.getTable(identifier);
+        tableCache.put(identifier, table);
+        return table;
+    }
+
+    private class TableInvalidatingRemovalListener implements RemovalListener<Identifier, Table> {
+        @Override
+        public void onRemoval(
+                Identifier tableIdentifier, Table table, @NonNull RemovalCause cause) {
+            LOG.debug("Evicted {} from the table cache ({})", tableIdentifier, cause);
+            if (RemovalCause.EXPIRED.equals(cause)) {
+                if (!isSpecifiedSystemTable(tableIdentifier)) {
+                    tableCache.invalidateAll(allSystemTables(tableIdentifier));
+                }
+            }
+        }
+    }
+
+    private void invalidateTable(Identifier identifier) {
+        tableCache.invalidate(identifier);
+        tableCache.invalidateAll(allSystemTables(identifier));
+    }
+
+    private static Iterable<Identifier> allSystemTables(Identifier ident) {
+        List<Identifier> tables = new ArrayList<>();
+        for (String type : SYSTEM_TABLES) {
+            tables.add(Identifier.fromString(ident.getFullName() + SYSTEM_TABLE_SPLITTER + type));
+        }
+        return tables;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
@@ -168,20 +168,24 @@ public class CachingCatalog extends DelegateCatalog {
 
     private class TableInvalidatingRemovalListener implements RemovalListener<Identifier, Table> {
         @Override
-        public void onRemoval(
-                Identifier tableIdentifier, Table table, @NonNull RemovalCause cause) {
-            LOG.debug("Evicted {} from the table cache ({})", tableIdentifier, cause);
+        public void onRemoval(Identifier identifier, Table table, @NonNull RemovalCause cause) {
+            LOG.debug("Evicted {} from the table cache ({})", identifier, cause);
             if (RemovalCause.EXPIRED.equals(cause)) {
-                if (!isSpecifiedSystemTable(tableIdentifier)) {
-                    tableCache.invalidateAll(allSystemTables(tableIdentifier));
-                }
+                tryInvalidateSysTables(identifier);
             }
         }
     }
 
-    private void invalidateTable(Identifier identifier) {
+    @Override
+    public void invalidateTable(Identifier identifier) {
         tableCache.invalidate(identifier);
-        tableCache.invalidateAll(allSystemTables(identifier));
+        tryInvalidateSysTables(identifier);
+    }
+
+    private void tryInvalidateSysTables(Identifier identifier) {
+        if (!isSpecifiedSystemTable(identifier)) {
+            tableCache.invalidateAll(allSystemTables(identifier));
+        }
     }
 
     private static Iterable<Identifier> allSystemTables(Identifier ident) {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -244,6 +244,16 @@ public interface Catalog extends AutoCloseable {
             throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException;
 
     /**
+     * Invalidate cached table metadata for an {@link Identifier identifier}.
+     *
+     * <p>If the table is already loaded or cached, drop cached data. If the table does not exist or
+     * is not cached, do nothing. Calling this method should not query remote services.
+     *
+     * @param identifier a table identifier
+     */
+    default void invalidateTable(Identifier identifier) {}
+
+    /**
      * Drop the partition of the specify table.
      *
      * @param identifier path of the table to drop partition

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
@@ -63,7 +63,7 @@ public class FileSystemCatalog extends AbstractCatalog {
 
     @Override
     protected void createDatabaseImpl(String name, Map<String, String> properties) {
-        if (properties.containsKey(AbstractCatalog.DB_LOCATION_PROP)) {
+        if (properties.containsKey(Catalog.DB_LOCATION_PROP)) {
             throw new IllegalArgumentException(
                     "Cannot specify location for a database when using fileSystem catalog.");
         }

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -65,7 +65,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.apache.paimon.catalog.AbstractCatalog.DB_SUFFIX;
+import static org.apache.paimon.catalog.Catalog.DB_SUFFIX;
 import static org.apache.paimon.catalog.Identifier.UNKNOWN_DATABASE;
 import static org.apache.paimon.utils.BranchManager.DEFAULT_MAIN_BRANCH;
 import static org.apache.paimon.utils.FileUtils.listVersionedFiles;

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.catalog;
+
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.schema.SchemaChange;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.system.SystemTableLoader;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.utils.FakeTicker;
+
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CachingCatalogTest extends CatalogTestBase {
+
+    private static final Duration EXPIRATION_TTL = Duration.ofMinutes(5);
+    private static final Duration HALF_OF_EXPIRATION = EXPIRATION_TTL.dividedBy(2);
+
+    private FakeTicker ticker;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        catalog = new FileSystemCatalog(fileIO, new Path(warehouse));
+        ticker = new FakeTicker();
+        catalog.createDatabase("db", false);
+    }
+
+    @Override
+    @Test
+    public void testListDatabasesWhenNoDatabases() {
+        List<String> databases = catalog.listDatabases();
+        assertThat(databases).contains("db");
+    }
+
+    @Test
+    public void testInvalidateSystemTablesIfBaseTableIsModified() throws Exception {
+        Catalog catalog = new CachingCatalog(this.catalog);
+        Identifier tableIdent = new Identifier("db", "tbl");
+        catalog.createTable(new Identifier("db", "tbl"), DEFAULT_TABLE_SCHEMA, false);
+        Identifier sysIdent = new Identifier("db", "tbl$files");
+        Table sysTable = catalog.getTable(sysIdent);
+        catalog.alterTable(tableIdent, SchemaChange.addColumn("col3", DataTypes.INT()), false);
+        assertThat(catalog.getTable(sysIdent)).isNotSameAs(sysTable);
+    }
+
+    @Test
+    public void testInvalidateSysTablesIfBaseTableIsDropped() throws Exception {
+        Catalog catalog = new CachingCatalog(this.catalog);
+        Identifier tableIdent = new Identifier("db", "tbl");
+        catalog.createTable(new Identifier("db", "tbl"), DEFAULT_TABLE_SCHEMA, false);
+        Identifier sysIdent = new Identifier("db", "tbl$files");
+        catalog.getTable(sysIdent);
+        catalog.dropTable(tableIdent, false);
+        assertThatThrownBy(() -> catalog.getTable(sysIdent))
+                .hasMessage("Table db.tbl does not exist.");
+    }
+
+    @Test
+    public void testTableExpiresAfterInterval() throws Exception {
+        TestableCachingCatalog catalog =
+                new TestableCachingCatalog(this.catalog, EXPIRATION_TTL, ticker);
+
+        Identifier tableIdent = new Identifier("db", "tbl");
+        catalog.createTable(tableIdent, DEFAULT_TABLE_SCHEMA, false);
+        Table table = catalog.getTable(tableIdent);
+
+        // Ensure table is cached with full ttl remaining upon creation
+        assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+        assertThat(catalog.remainingAgeFor(tableIdent)).isPresent().get().isEqualTo(EXPIRATION_TTL);
+
+        ticker.advance(HALF_OF_EXPIRATION);
+        assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+        assertThat(catalog.ageOf(tableIdent)).isPresent().get().isEqualTo(HALF_OF_EXPIRATION);
+
+        ticker.advance(HALF_OF_EXPIRATION.plus(Duration.ofSeconds(10)));
+        assertThat(catalog.cache().asMap()).doesNotContainKey(tableIdent);
+        assertThat(catalog.getTable(tableIdent))
+                .as("CachingCatalog should return a new instance after expiration")
+                .isNotSameAs(table);
+    }
+
+    @Test
+    public void testCatalogExpirationTtlRefreshesAfterAccessViaCatalog() throws Exception {
+        TestableCachingCatalog catalog =
+                new TestableCachingCatalog(this.catalog, EXPIRATION_TTL, ticker);
+
+        Identifier tableIdent = new Identifier("db", "tbl");
+        catalog.createTable(tableIdent, DEFAULT_TABLE_SCHEMA, false);
+        catalog.getTable(tableIdent);
+        assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+        assertThat(catalog.ageOf(tableIdent)).isPresent().get().isEqualTo(Duration.ZERO);
+
+        ticker.advance(HALF_OF_EXPIRATION);
+        assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+        assertThat(catalog.ageOf(tableIdent)).isPresent().get().isEqualTo(HALF_OF_EXPIRATION);
+        assertThat(catalog.remainingAgeFor(tableIdent))
+                .isPresent()
+                .get()
+                .isEqualTo(HALF_OF_EXPIRATION);
+
+        Duration oneMinute = Duration.ofMinutes(1L);
+        ticker.advance(oneMinute);
+        assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+        assertThat(catalog.ageOf(tableIdent))
+                .isPresent()
+                .get()
+                .isEqualTo(HALF_OF_EXPIRATION.plus(oneMinute));
+        assertThat(catalog.remainingAgeFor(tableIdent))
+                .get()
+                .isEqualTo(HALF_OF_EXPIRATION.minus(oneMinute));
+
+        // Access the table via the catalog, which should refresh the TTL
+        Table table = catalog.getTable(tableIdent);
+        assertThat(catalog.ageOf(tableIdent)).get().isEqualTo(Duration.ZERO);
+        assertThat(catalog.remainingAgeFor(tableIdent)).get().isEqualTo(EXPIRATION_TTL);
+
+        ticker.advance(HALF_OF_EXPIRATION);
+        assertThat(catalog.ageOf(tableIdent)).get().isEqualTo(HALF_OF_EXPIRATION);
+        assertThat(catalog.remainingAgeFor(tableIdent)).get().isEqualTo(HALF_OF_EXPIRATION);
+    }
+
+    @Test
+    public void testCacheExpirationEagerlyRemovesSysTables() throws Exception {
+        TestableCachingCatalog catalog =
+                new TestableCachingCatalog(this.catalog, EXPIRATION_TTL, ticker);
+
+        Identifier tableIdent = new Identifier("db", "tbl");
+        catalog.createTable(tableIdent, DEFAULT_TABLE_SCHEMA, false);
+        Table table = catalog.getTable(tableIdent);
+        assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+        assertThat(catalog.ageOf(tableIdent)).get().isEqualTo(Duration.ZERO);
+
+        ticker.advance(HALF_OF_EXPIRATION);
+        assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+        assertThat(catalog.ageOf(tableIdent)).get().isEqualTo(HALF_OF_EXPIRATION);
+
+        for (Identifier sysTable : sysTables(tableIdent)) {
+            catalog.getTable(sysTable);
+        }
+        assertThat(catalog.cache().asMap()).containsKeys(sysTables(tableIdent));
+        assertThat(Arrays.stream(sysTables(tableIdent)).map(catalog::ageOf))
+                .isNotEmpty()
+                .allMatch(age -> age.isPresent() && age.get().equals(Duration.ZERO));
+
+        assertThat(catalog.remainingAgeFor(tableIdent))
+                .as("Loading a non-cached sys table should refresh the main table's age")
+                .isEqualTo(Optional.of(EXPIRATION_TTL));
+
+        // Move time forward and access already cached sys tables.
+        ticker.advance(HALF_OF_EXPIRATION);
+        for (Identifier sysTable : sysTables(tableIdent)) {
+            catalog.getTable(sysTable);
+        }
+        assertThat(Arrays.stream(sysTables(tableIdent)).map(catalog::ageOf))
+                .isNotEmpty()
+                .allMatch(age -> age.isPresent() && age.get().equals(Duration.ZERO));
+
+        assertThat(catalog.remainingAgeFor(tableIdent))
+                .as("Accessing a cached sys table should not affect the main table's age")
+                .isEqualTo(Optional.of(HALF_OF_EXPIRATION));
+
+        // Move time forward so the data table drops.
+        ticker.advance(HALF_OF_EXPIRATION);
+        assertThat(catalog.cache().asMap()).doesNotContainKey(tableIdent);
+
+        Arrays.stream(sysTables(tableIdent))
+                .forEach(
+                        sysTable ->
+                                assertThat(catalog.cache().asMap())
+                                        .as(
+                                                "When a data table expires, its sys tables should expire regardless of age")
+                                        .doesNotContainKeys(sysTable));
+    }
+
+    @Test
+    public void testDeadlock() throws Exception {
+        Catalog underlyCatalog = this.catalog;
+        TestableCachingCatalog catalog =
+                new TestableCachingCatalog(this.catalog, Duration.ofSeconds(1), ticker);
+        int numThreads = 20;
+        List<Identifier> createdTables = new ArrayList<>();
+        for (int i = 0; i < numThreads; i++) {
+            Identifier tableIdent = new Identifier("db", "tbl" + i);
+            catalog.createTable(tableIdent, DEFAULT_TABLE_SCHEMA, false);
+            createdTables.add(tableIdent);
+        }
+
+        Cache<Identifier, Table> cache = catalog.cache();
+        AtomicInteger cacheGetCount = new AtomicInteger(0);
+        AtomicInteger cacheCleanupCount = new AtomicInteger(0);
+        ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        for (int i = 0; i < numThreads; i++) {
+            if (i % 2 == 0) {
+                String table = "tbl" + i;
+                executor.submit(
+                        () -> {
+                            ticker.advance(Duration.ofSeconds(2));
+                            cache.get(
+                                    new Identifier("db", table),
+                                    identifier -> {
+                                        try {
+                                            return underlyCatalog.getTable(identifier);
+                                        } catch (Catalog.TableNotExistException e) {
+                                            throw new RuntimeException(e);
+                                        }
+                                    });
+                            cacheGetCount.incrementAndGet();
+                        });
+            } else {
+                executor.submit(
+                        () -> {
+                            ticker.advance(Duration.ofSeconds(2));
+                            cache.cleanUp();
+                            cacheCleanupCount.incrementAndGet();
+                        });
+            }
+        }
+        executor.awaitTermination(2, TimeUnit.SECONDS);
+        assertThat(cacheGetCount).hasValue(numThreads / 2);
+        assertThat(cacheCleanupCount).hasValue(numThreads / 2);
+
+        executor.shutdown();
+    }
+
+    @Test
+    public void testCachingCatalogRejectsExpirationIntervalOfZero() {
+        Assertions.assertThatThrownBy(
+                        () -> new TestableCachingCatalog(this.catalog, Duration.ZERO, ticker))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "When cache.expiration-interval is set to negative or 0, the catalog cache should be disabled.");
+    }
+
+    @Test
+    public void testInvalidateTableForChainedCachingCatalogs() throws Exception {
+        TestableCachingCatalog wrappedCatalog =
+                new TestableCachingCatalog(this.catalog, EXPIRATION_TTL, ticker);
+        TestableCachingCatalog catalog =
+                new TestableCachingCatalog(wrappedCatalog, EXPIRATION_TTL, ticker);
+        Identifier tableIdent = new Identifier("db", "tbl");
+        catalog.createTable(tableIdent, DEFAULT_TABLE_SCHEMA, false);
+        catalog.getTable(tableIdent);
+        assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+        catalog.dropTable(tableIdent, false);
+        assertThat(catalog.cache().asMap()).doesNotContainKey(tableIdent);
+        assertThat(wrappedCatalog.cache().asMap()).doesNotContainKey(tableIdent);
+    }
+
+    public static Identifier[] sysTables(Identifier tableIdent) {
+        return SystemTableLoader.SYSTEM_TABLES.stream()
+                .map(type -> Identifier.fromString(tableIdent.getFullName() + "$" + type))
+                .toArray(Identifier[]::new);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -55,6 +55,7 @@ public abstract class CatalogTestBase {
     protected String warehouse;
     protected FileIO fileIO;
     protected Catalog catalog;
+
     protected static final Schema DEFAULT_TABLE_SCHEMA =
             new Schema(
                     Lists.newArrayList(
@@ -63,18 +64,6 @@ public abstract class CatalogTestBase {
                             new DataField(2, "col2", DataTypes.STRING())),
                     Collections.emptyList(),
                     Collections.emptyList(),
-                    Maps.newHashMap(),
-                    "");
-
-    protected static final Schema PARTITION_SCHEMA =
-            new Schema(
-                    Lists.newArrayList(
-                            new DataField(0, "pk1", DataTypes.INT()),
-                            new DataField(1, "pk2", DataTypes.STRING()),
-                            new DataField(3, "pk3", DataTypes.STRING()),
-                            new DataField(4, "col", DataTypes.STRING())),
-                    Arrays.asList("pk1", "pk2"),
-                    Arrays.asList("pk1", "pk2", "pk3"),
                     Maps.newHashMap(),
                     "");
 
@@ -95,7 +84,10 @@ public abstract class CatalogTestBase {
     }
 
     @Test
-    public abstract void testListDatabasesWhenNoDatabases();
+    public void testListDatabasesWhenNoDatabases() {
+        List<String> databases = catalog.listDatabases();
+        assertThat(databases).isEqualTo(new ArrayList<>());
+    }
 
     @Test
     public void testListDatabases() throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/FileSystemCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/FileSystemCatalogTest.java
@@ -18,29 +18,15 @@
 
 package org.apache.paimon.catalog;
 
-import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
-import org.apache.paimon.table.TableType;
 
-import static org.apache.paimon.options.CatalogOptions.TABLE_TYPE;
+import org.junit.jupiter.api.BeforeEach;
 
-/** Factory to create {@link FileSystemCatalog}. */
-public class FileSystemCatalogFactory implements CatalogFactory {
+class FileSystemCatalogTest extends CatalogTestBase {
 
-    public static final String IDENTIFIER = "filesystem";
-
-    @Override
-    public String identifier() {
-        return IDENTIFIER;
-    }
-
-    @Override
-    public Catalog create(FileIO fileIO, Path warehouse, CatalogContext context) {
-        if (!TableType.MANAGED.equals(context.options().get(TABLE_TYPE))) {
-            throw new IllegalArgumentException(
-                    "Only managed table is supported in File system catalog.");
-        }
-
-        return new FileSystemCatalog(fileIO, warehouse, context.options());
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        catalog = new FileSystemCatalog(fileIO, new Path(warehouse));
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/TestableCachingCatalog.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/TestableCachingCatalog.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.catalog;
+
+import org.apache.paimon.table.Table;
+
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Ticker;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * A wrapper around CachingCatalog that provides accessor methods to test the underlying cache,
+ * without making those fields public in the CachingCatalog itself.
+ */
+public class TestableCachingCatalog extends CachingCatalog {
+
+    private final Duration cacheExpirationInterval;
+
+    public TestableCachingCatalog(Catalog catalog, Duration expirationInterval, Ticker ticker) {
+        super(catalog, expirationInterval, ticker);
+        this.cacheExpirationInterval = expirationInterval;
+    }
+
+    public Cache<Identifier, Table> cache() {
+        // cleanUp must be called as tests apply assertions directly on the underlying map, but
+        // metadata
+        // table map entries are cleaned up asynchronously.
+        tableCache.cleanUp();
+        return tableCache;
+    }
+
+    public Optional<Duration> ageOf(Identifier identifier) {
+        return tableCache.policy().expireAfterAccess().get().ageOf(identifier);
+    }
+
+    public Optional<Duration> remainingAgeFor(Identifier identifier) {
+        return ageOf(identifier).map(cacheExpirationInterval::minus);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcCatalogTest.java
@@ -32,8 +32,6 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectOutputStream;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -86,13 +84,6 @@ public class JdbcCatalogTest extends CatalogTestBase {
         Thread.sleep(2000);
         assertThat(JdbcUtils.acquire(((JdbcCatalog) catalog).getConnections(), lockId, 1000))
                 .isTrue();
-    }
-
-    @Test
-    @Override
-    public void testListDatabasesWhenNoDatabases() {
-        List<String> databases = catalog.listDatabases();
-        assertThat(databases).isEqualTo(new ArrayList<>());
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/AllTableOptionsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/AllTableOptionsTableTest.java
@@ -18,10 +18,7 @@
 
 package org.apache.paimon.table.system;
 
-import org.apache.paimon.catalog.AbstractCatalog;
 import org.apache.paimon.catalog.Identifier;
-import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.fs.Path;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.TableTestBase;
 import org.apache.paimon.types.DataTypes;
@@ -29,18 +26,12 @@ import org.apache.paimon.types.DataTypes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Spliterator;
-import java.util.Spliterators;
+import java.util.Objects;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import static org.apache.paimon.catalog.Catalog.SYSTEM_DATABASE_NAME;
 import static org.apache.paimon.table.system.AllTableOptionsTable.ALL_TABLE_OPTIONS;
-import static org.apache.paimon.table.system.AllTableOptionsTable.options;
-import static org.apache.paimon.table.system.AllTableOptionsTable.toRow;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for {@link AllTableOptionsTable}. */
@@ -69,18 +60,14 @@ public class AllTableOptionsTableTest extends TableTestBase {
 
     @Test
     public void testSchemasTable() throws Exception {
-        List<InternalRow> expectRow = getExceptedResult();
-        List<InternalRow> result = read(allTableOptionsTable);
-        assertThat(result).containsExactlyElementsOf(expectRow);
-    }
-
-    private List<InternalRow> getExceptedResult() {
-        AbstractCatalog abstractCatalog = (AbstractCatalog) catalog;
-        Map<String, Map<String, Path>> stringMapMap = abstractCatalog.allTablePaths();
-        Iterator<InternalRow> rows =
-                toRow(options(((AbstractCatalog) catalog).fileIO(), stringMapMap));
-        return StreamSupport.stream(
-                        Spliterators.spliteratorUnknownSize(rows, Spliterator.ORDERED), false)
-                .collect(Collectors.toList());
+        List<String> result =
+                read(allTableOptionsTable).stream()
+                        .map(Objects::toString)
+                        .collect(Collectors.toList());
+        assertThat(result)
+                .containsExactlyInAnyOrder(
+                        "+I(default,T,fields.sales.aggregate-function,sum)",
+                        "+I(default,T,merge-engine,aggregation)",
+                        "+I(default,T,fields.price.aggregate-function,max)");
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/utils/FakeTicker.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/FakeTicker.java
@@ -16,31 +16,27 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.catalog;
+package org.apache.paimon.utils;
 
-import org.apache.paimon.fs.FileIO;
-import org.apache.paimon.fs.Path;
-import org.apache.paimon.table.TableType;
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Ticker;
 
-import static org.apache.paimon.options.CatalogOptions.TABLE_TYPE;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
 
-/** Factory to create {@link FileSystemCatalog}. */
-public class FileSystemCatalogFactory implements CatalogFactory {
+/** A {@code Ticker} whose value can be advanced programmatically in tests. */
+public class FakeTicker implements Ticker {
 
-    public static final String IDENTIFIER = "filesystem";
+    private final AtomicLong nanos = new AtomicLong();
 
-    @Override
-    public String identifier() {
-        return IDENTIFIER;
+    public FakeTicker() {}
+
+    public FakeTicker advance(Duration duration) {
+        nanos.addAndGet(duration.toNanos());
+        return this;
     }
 
     @Override
-    public Catalog create(FileIO fileIO, Path warehouse, CatalogContext context) {
-        if (!TableType.MANAGED.equals(context.options().get(TABLE_TYPE))) {
-            throw new IllegalArgumentException(
-                    "Only managed table is supported in File system catalog.");
-        }
-
-        return new FileSystemCatalog(fileIO, warehouse, context.options());
+    public long read() {
+        return nanos.get();
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.flink.action.cdc;
 
-import org.apache.paimon.catalog.AbstractCatalog;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.flink.action.Action;
 import org.apache.paimon.flink.action.MultiTablesSinkMode;
@@ -120,9 +119,9 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
 
     @Override
     protected void validateCaseSensitivity() {
-        AbstractCatalog.validateCaseInsensitive(allowUpperCase, "Database", database);
-        AbstractCatalog.validateCaseInsensitive(allowUpperCase, "Table prefix", tablePrefix);
-        AbstractCatalog.validateCaseInsensitive(allowUpperCase, "Table suffix", tableSuffix);
+        Catalog.validateCaseInsensitive(allowUpperCase, "Database", database);
+        Catalog.validateCaseInsensitive(allowUpperCase, "Table prefix", tablePrefix);
+        Catalog.validateCaseInsensitive(allowUpperCase, "Table suffix", tableSuffix);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionBase.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.flink.action.cdc;
 
 import org.apache.paimon.annotation.VisibleForTesting;
-import org.apache.paimon.catalog.AbstractCatalog;
+import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.action.Action;
@@ -114,8 +114,8 @@ public abstract class SyncTableActionBase extends SynchronizationActionBase {
 
     @Override
     protected void validateCaseSensitivity() {
-        AbstractCatalog.validateCaseInsensitive(allowUpperCase, "Database", database);
-        AbstractCatalog.validateCaseInsensitive(allowUpperCase, "Table", table);
+        Catalog.validateCaseInsensitive(allowUpperCase, "Database", database);
+        Catalog.validateCaseInsensitive(allowUpperCase, "Table", table);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseTableListITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseTableListITCase.java
@@ -45,7 +45,7 @@ public class MySqlSyncDatabaseTableListITCase extends MySqlActionITCaseBase {
     }
 
     @Test
-    @Timeout(120)
+    @Timeout(180)
     public void testActionRunResult() throws Exception {
         Map<String, String> mySqlConfig = getBasicMySqlConfig();
         mySqlConfig.put(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -347,10 +347,7 @@ public class FlinkCatalog extends AbstractCatalog {
             // Although catalog.createTable will copy the default options, but we need this info
             // here before create table, such as table-default.kafka.bootstrap.servers defined in
             // catalog options. Temporarily, we copy the default options here.
-            if (catalog instanceof org.apache.paimon.catalog.AbstractCatalog) {
-                ((org.apache.paimon.catalog.AbstractCatalog) catalog)
-                        .copyTableDefaultOptions(options);
-            }
+            Catalog.tableDefaultOptions(catalog.options()).forEach(options::putIfAbsent);
             options.put(REGISTER_TIMEOUT.key(), logStoreAutoRegisterTimeout.toString());
             registerLogSystem(catalog, identifier, options, classLoader);
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ActionBase.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ActionBase.java
@@ -40,6 +40,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.options.CatalogOptions.CACHE_ENABLED;
+
 /** Abstract base of {@link Action} for table. */
 public abstract class ActionBase implements Action {
 
@@ -54,6 +56,11 @@ public abstract class ActionBase implements Action {
     public ActionBase(String warehouse, Map<String, String> catalogConfig) {
         catalogOptions = Options.fromMap(catalogConfig);
         catalogOptions.set(CatalogOptions.WAREHOUSE, warehouse);
+
+        // disable cache to avoid concurrent modification exception
+        if (!catalogOptions.contains(CACHE_ENABLED)) {
+            catalogOptions.set(CACHE_ENABLED, false);
+        }
 
         catalog = initPaimonCatalog();
         flinkCatalog = initFlinkCatalog();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.flink.utils.TableMigrationUtils;
-import org.apache.paimon.hive.HiveCatalog;
 import org.apache.paimon.migrate.Migrator;
 import org.apache.paimon.utils.ParameterUtils;
 
@@ -47,14 +46,10 @@ public class MigrateDatabaseProcedure extends ProcedureBase {
             String sourceDatabasePath,
             String properties)
             throws Exception {
-        if (!(catalog instanceof HiveCatalog)) {
-            throw new IllegalArgumentException("Only support Hive Catalog");
-        }
-        HiveCatalog hiveCatalog = (HiveCatalog) this.catalog;
         List<Migrator> migrators =
                 TableMigrationUtils.getImporters(
                         connector,
-                        hiveCatalog,
+                        catalog,
                         sourceDatabasePath,
                         ParameterUtils.parseCommaSeparatedKeyValues(properties));
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateFileProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateFileProcedure.java
@@ -20,7 +20,6 @@ package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.utils.TableMigrationUtils;
-import org.apache.paimon.hive.HiveCatalog;
 import org.apache.paimon.migrate.Migrator;
 
 import org.apache.flink.table.procedure.ProcedureContext;
@@ -62,9 +61,6 @@ public class MigrateFileProcedure extends ProcedureBase {
             String targetPaimonTablePath,
             boolean deleteOrigin)
             throws Exception {
-        if (!(catalog instanceof HiveCatalog)) {
-            throw new IllegalArgumentException("Only support Hive Catalog");
-        }
         Identifier sourceTableId = Identifier.fromString(sourceTablePath);
         Identifier targetTableId = Identifier.fromString(targetPaimonTablePath);
 
@@ -76,7 +72,7 @@ public class MigrateFileProcedure extends ProcedureBase {
         Migrator importer =
                 TableMigrationUtils.getImporter(
                         connector,
-                        (HiveCatalog) catalog,
+                        catalog,
                         sourceTableId.getDatabaseName(),
                         sourceTableId.getObjectName(),
                         targetTableId.getDatabaseName(),

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateTableProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateTableProcedure.java
@@ -20,7 +20,6 @@ package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.utils.TableMigrationUtils;
-import org.apache.paimon.hive.HiveCatalog;
 import org.apache.paimon.utils.ParameterUtils;
 
 import org.apache.flink.table.procedure.ProcedureContext;
@@ -51,10 +50,6 @@ public class MigrateTableProcedure extends ProcedureBase {
             String sourceTablePath,
             String properties)
             throws Exception {
-        if (!(catalog instanceof HiveCatalog)) {
-            throw new IllegalArgumentException("Only support Hive Catalog");
-        }
-
         String targetPaimonTablePath = sourceTablePath + PAIMON_SUFFIX;
 
         Identifier sourceTableId = Identifier.fromString(sourceTablePath);
@@ -62,7 +57,7 @@ public class MigrateTableProcedure extends ProcedureBase {
 
         TableMigrationUtils.getImporter(
                         connector,
-                        (HiveCatalog) catalog,
+                        catalog,
                         sourceTableId.getDatabaseName(),
                         sourceTableId.getObjectName(),
                         targetTableId.getDatabaseName(),

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RepairProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RepairProcedure.java
@@ -20,7 +20,6 @@ package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
-import org.apache.paimon.hive.HiveCatalog;
 import org.apache.paimon.utils.StringUtils;
 
 import org.apache.flink.table.procedure.ProcedureContext;
@@ -55,10 +54,6 @@ public class RepairProcedure extends ProcedureBase {
 
     public String[] call(ProcedureContext procedureContext, String identifier)
             throws Catalog.DatabaseNotExistException, Catalog.TableNotExistException {
-        if (!(catalog instanceof HiveCatalog)) {
-            throw new IllegalArgumentException("Only support Hive Catalog");
-        }
-
         if (StringUtils.isBlank(identifier)) {
             catalog.repairCatalog();
             return new String[] {"Success"};

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -19,14 +19,7 @@
 package org.apache.paimon.flink;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.fs.Path;
-import org.apache.paimon.fs.local.LocalFileIO;
-import org.apache.paimon.schema.Schema;
-import org.apache.paimon.schema.SchemaManager;
-import org.apache.paimon.schema.SchemaUtils;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.types.DataField;
-import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.utils.BlockingIterator;
 import org.apache.paimon.utils.DateTimeUtils;
 
@@ -38,7 +31,6 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -438,33 +430,6 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
 
         sql("INSERT INTO ignore_delete VALUES (1, 'B')");
         assertThat(sql("SELECT * FROM ignore_delete")).containsExactly(Row.of(1, "B"));
-    }
-
-    @Test
-    public void testIgnoreDeleteCompatible() throws Exception {
-        sql(
-                "CREATE TABLE ignore_delete (pk INT PRIMARY KEY NOT ENFORCED, v STRING) "
-                        + "WITH ('merge-engine' = 'deduplicate', 'write-only' = 'true')");
-
-        sql("INSERT INTO ignore_delete VALUES (1, 'A')");
-        // write delete records
-        sql("DELETE FROM ignore_delete WHERE pk = 1");
-        assertThat(sql("SELECT * FROM ignore_delete")).isEmpty();
-
-        // set ignore-delete and read
-        Map<String, String> newOptions = new HashMap<>();
-        newOptions.put(CoreOptions.IGNORE_DELETE.key(), "true");
-        SchemaUtils.forceCommit(
-                new SchemaManager(LocalFileIO.create(), new Path(path, "default.db/ignore_delete")),
-                new Schema(
-                        Arrays.asList(
-                                new DataField(0, "pk", DataTypes.INT().notNull()),
-                                new DataField(1, "v", DataTypes.STRING())),
-                        Collections.emptyList(),
-                        Collections.singletonList("pk"),
-                        newOptions,
-                        null));
-        assertThat(sql("SELECT * FROM ignore_delete")).containsExactlyInAnyOrder(Row.of(1, "A"));
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FileSystemCatalogITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FileSystemCatalogITCase.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.flink;
 
-import org.apache.paimon.catalog.AbstractCatalog;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogLock;
 import org.apache.paimon.catalog.CatalogLockContext;
@@ -98,7 +97,7 @@ public class FileSystemCatalogITCase extends AbstractTestBase {
         Identifier identifier = new Identifier(DB_NAME, "t3");
         Catalog catalog =
                 ((FlinkCatalog) tEnv.getCatalog(tEnv.getCurrentCatalog()).get()).catalog();
-        Path tablePath = ((AbstractCatalog) catalog).getDataTableLocation(identifier);
+        Path tablePath = new Path(catalog.getTable(identifier).options().get("path"));
         assertThat(tablePath.toString())
                 .isEqualTo(new File(path, DB_NAME + ".db" + File.separator + "t3").toString());
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkCatalogTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkCatalogTest.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.flink;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.catalog.AbstractCatalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.log.LogSinkProvider;
@@ -647,9 +646,18 @@ public class FlinkCatalogTest {
             CatalogTable t2,
             Map<String, String> optionsToAdd,
             Set<String> optionsToRemove) {
-        Path tablePath =
-                ((AbstractCatalog) ((FlinkCatalog) catalog).catalog())
-                        .getDataTableLocation(FlinkCatalog.toIdentifier(path));
+        Path tablePath;
+        try {
+            tablePath =
+                    new Path(
+                            ((FlinkCatalog) catalog)
+                                    .catalog()
+                                    .getTable(FlinkCatalog.toIdentifier(path))
+                                    .options()
+                                    .get(CoreOptions.PATH.key()));
+        } catch (org.apache.paimon.catalog.Catalog.TableNotExistException e) {
+            throw new RuntimeException(e);
+        }
         Map<String, String> options = new HashMap<>(t1.getOptions());
         options.put("path", tablePath.toString());
         options.putAll(optionsToAdd);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PartialUpdateITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PartialUpdateITCase.java
@@ -18,14 +18,6 @@
 
 package org.apache.paimon.flink;
 
-import org.apache.paimon.CoreOptions;
-import org.apache.paimon.fs.Path;
-import org.apache.paimon.fs.local.LocalFileIO;
-import org.apache.paimon.schema.Schema;
-import org.apache.paimon.schema.SchemaManager;
-import org.apache.paimon.schema.SchemaUtils;
-import org.apache.paimon.types.DataField;
-import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.utils.BlockingIterator;
 import org.apache.paimon.utils.CommonTestUtils;
 
@@ -44,9 +36,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
@@ -626,38 +616,5 @@ public class PartialUpdateITCase extends CatalogITCaseBase {
                         Row.ofKind(RowKind.UPDATE_BEFORE, 1, null, "apple"),
                         Row.ofKind(RowKind.UPDATE_AFTER, 1, "A", "apple"));
         iterator.close();
-    }
-
-    @Test
-    public void testIgnoreDeleteCompatible() throws Exception {
-        sql(
-                "CREATE TABLE ignore_delete (pk INT PRIMARY KEY NOT ENFORCED, a STRING, b STRING) WITH ("
-                        + " 'merge-engine' = 'deduplicate',"
-                        + " 'write-only' = 'true')");
-        sql("INSERT INTO ignore_delete VALUES (1, CAST (NULL AS STRING), 'apple')");
-        // write delete records
-        sql("DELETE FROM ignore_delete WHERE pk = 1");
-        sql("INSERT INTO ignore_delete VALUES (1, 'A', CAST (NULL AS STRING))");
-        assertThat(sql("SELECT * FROM ignore_delete"))
-                .containsExactlyInAnyOrder(Row.of(1, "A", null));
-
-        // force altering merge engine and read
-        Map<String, String> newOptions = new HashMap<>();
-        newOptions.put(
-                CoreOptions.MERGE_ENGINE.key(), CoreOptions.MergeEngine.PARTIAL_UPDATE.toString());
-        newOptions.put(CoreOptions.IGNORE_DELETE.key(), "true");
-        SchemaUtils.forceCommit(
-                new SchemaManager(LocalFileIO.create(), new Path(path, "default.db/ignore_delete")),
-                new Schema(
-                        Arrays.asList(
-                                new DataField(0, "pk", DataTypes.INT().notNull()),
-                                new DataField(1, "a", DataTypes.STRING()),
-                                new DataField(2, "b", DataTypes.STRING())),
-                        Collections.emptyList(),
-                        Collections.singletonList("pk"),
-                        newOptions,
-                        null));
-        assertThat(sql("SELECT * FROM ignore_delete"))
-                .containsExactlyInAnyOrder(Row.of(1, "A", "apple"));
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ActionITCaseBase.java
@@ -51,6 +51,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static org.apache.paimon.options.CatalogOptions.CACHE_ENABLED;
+
 /** {@link Action} test base. */
 public abstract class ActionITCaseBase extends AbstractTestBase {
 
@@ -70,7 +72,9 @@ public abstract class ActionITCaseBase extends AbstractTestBase {
         tableName = "test_table_" + UUID.randomUUID();
         commitUser = UUID.randomUUID().toString();
         incrementalIdentifier = 0;
-        catalog = CatalogFactory.createCatalog(CatalogContext.create(new Path(warehouse)));
+        CatalogContext context = CatalogContext.create(new Path(warehouse));
+        context.options().set(CACHE_ENABLED, false);
+        catalog = CatalogFactory.createCatalog(context);
     }
 
     @AfterEach

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/privilege/PrivilegeProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/privilege/PrivilegeProcedureITCase.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.flink.procedure.privilege;
 
 import org.apache.paimon.catalog.Catalog;
-import org.apache.paimon.catalog.FileSystemCatalog;
 import org.apache.paimon.flink.FlinkCatalog;
 import org.apache.paimon.flink.util.AbstractTestBase;
 import org.apache.paimon.privilege.FileBasedPrivilegeManager;
@@ -85,7 +84,6 @@ public class PrivilegeProcedureITCase extends AbstractTestBase {
         Catalog paimonCatalog = ((FlinkCatalog) catalog).catalog();
         assertThat(paimonCatalog).isInstanceOf(PrivilegedCatalog.class);
         PrivilegedCatalog privilegedCatalog = (PrivilegedCatalog) paimonCatalog;
-        assertThat(privilegedCatalog.wrapped()).isInstanceOf(FileSystemCatalog.class);
         assertThat(privilegedCatalog.privilegeManager())
                 .isInstanceOf(FileBasedPrivilegeManager.class);
         assertThat(privilegedCatalog.privilegeManager().privilegeEnabled()).isTrue();

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -36,9 +36,6 @@ import org.apache.paimon.operation.Lock;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.options.OptionsUtils;
-import org.apache.paimon.privilege.FileBasedPrivilegeManager;
-import org.apache.paimon.privilege.PrivilegeManager;
-import org.apache.paimon.privilege.PrivilegedCatalog;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.schema.SchemaManager;
@@ -875,25 +872,12 @@ public class HiveCatalog extends AbstractCatalog {
             throw new UncheckedIOException(e);
         }
 
-        Catalog catalog =
-                new HiveCatalog(
-                        fileIO,
-                        hiveConf,
-                        options.get(HiveCatalogFactory.METASTORE_CLIENT_CLASS),
-                        options,
-                        warehouse.toUri().toString());
-
-        PrivilegeManager privilegeManager =
-                new FileBasedPrivilegeManager(
-                        warehouse.toString(),
-                        fileIO,
-                        context.options().get(PrivilegedCatalog.USER),
-                        context.options().get(PrivilegedCatalog.PASSWORD));
-        if (privilegeManager.privilegeEnabled()) {
-            catalog = new PrivilegedCatalog(catalog, privilegeManager);
-        }
-
-        return catalog;
+        return new HiveCatalog(
+                fileIO,
+                hiveConf,
+                options.get(HiveCatalogFactory.METASTORE_CLIENT_CLASS),
+                options,
+                warehouse.toUri().toString());
     }
 
     public static HiveConf createHiveConf(CatalogContext context) {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -220,6 +220,14 @@ public class SparkCatalog extends SparkBaseCatalog {
     }
 
     @Override
+    public void invalidateTable(Identifier ident) {
+        try {
+            catalog.invalidateTable(toIdentifier(ident));
+        } catch (NoSuchTableException ignored) {
+        }
+    }
+
+    @Override
     public SparkTable loadTable(Identifier ident) throws NoSuchTableException {
         return loadSparkTable(ident, Collections.emptyMap());
     }

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFileIndexITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFileIndexITCase.java
@@ -59,6 +59,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.options.CatalogOptions.CACHE_ENABLED;
 import static org.apache.paimon.options.CatalogOptions.WAREHOUSE;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -88,6 +89,7 @@ public class SparkFileIndexITCase extends SparkWriteITCase {
 
         Options options = new Options();
         options.set(WAREHOUSE, spark.conf().get("spark.sql.catalog.paimon.warehouse"));
+        options.set(CACHE_ENABLED, false);
         fileSystemCatalog =
                 (FileSystemCatalog) CatalogFactory.createCatalog(CatalogContext.create(options));
     }

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
@@ -19,7 +19,7 @@
 package org.apache.paimon.spark
 
 import org.apache.paimon.catalog.{Catalog, CatalogContext, CatalogFactory, Identifier}
-import org.apache.paimon.options.Options
+import org.apache.paimon.options.{CatalogOptions, Options}
 import org.apache.paimon.spark.catalog.Catalogs
 import org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions
 import org.apache.paimon.spark.sql.{SparkVersionSupport, WithTableOptions}
@@ -36,6 +36,8 @@ import org.scalactic.source.Position
 import org.scalatest.Tag
 
 import java.io.File
+import java.util
+import java.util.{HashMap => JHashMap}
 import java.util.TimeZone
 
 import scala.util.Random
@@ -64,6 +66,7 @@ class PaimonSparkTestBase
     super.sparkConf
       .set("spark.sql.catalog.paimon", classOf[SparkCatalog].getName)
       .set("spark.sql.catalog.paimon.warehouse", tempDBDir.getCanonicalPath)
+      .set("spark.sql.catalog.paimon.cache-enabled", "false")
       .set("spark.sql.extensions", classOf[PaimonSparkSessionExtensions].getName)
       .set("spark.serializer", serializer)
   }
@@ -122,7 +125,9 @@ class PaimonSparkTestBase
 
   private def initCatalog(): Catalog = {
     val currentCatalog = spark.sessionState.catalogManager.currentCatalog.name()
-    val options = Catalogs.catalogOptions(currentCatalog, spark.sessionState.conf)
+    val options =
+      new JHashMap[String, String](Catalogs.catalogOptions(currentCatalog, spark.sessionState.conf))
+    options.put(CatalogOptions.CACHE_ENABLED.key(), "false")
     val catalogContext =
       CatalogContext.create(Options.fromMap(options), spark.sessionState.newHadoopConf())
     CatalogFactory.createCatalog(catalogContext)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Introduce a caching catalog, it is enabled by default, and its expiration interval is 30 s.

This can effectively reduce interaction with the metastore and lower the pressure on the metastore.

This is based on https://github.com/apache/paimon/pull/3824

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
