### PR TITLE
[core] FileStore should not be serializable

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/FileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/FileStore.java
@@ -42,7 +42,6 @@ import org.apache.paimon.utils.TagManager;
 
 import javax.annotation.Nullable;
 
-import java.io.Serializable;
 import java.util.List;
 
 /**
@@ -50,7 +49,7 @@ import java.util.List;
  *
  * @param <T> type of record to read and write.
  */
-public interface FileStore<T> extends Serializable {
+public interface FileStore<T> {
 
     FileStorePathFactory pathFactory();
 

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -61,8 +61,6 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 /** {@link FileStore} for querying and updating {@link KeyValue}s. */
 public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
 
-    private static final long serialVersionUID = 1L;
-
     private final boolean crossPartitionUpdate;
     private final RowType bucketKeyType;
     private final RowType keyType;

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
@@ -159,7 +159,6 @@ trait PaimonCommand extends WithFileStoreTable with ExpressionHelper {
     val metadataCols = Seq(FILE_PATH, ROW_INDEX)
     val filteredRelation = createNewScanPlan(candidateDataSplits, condition, relation, metadataCols)
 
-    val store = table.store()
     val location = table.location
     createDataset(sparkSession, filteredRelation)
       .select(FILE_PATH_COLUMN, ROW_INDEX_COLUMN)
@@ -174,7 +173,7 @@ trait PaimonCommand extends WithFileStoreTable with ExpressionHelper {
 
           val relativeFilePath = location.toUri.relativize(new URI(filePath)).toString
           val (partition, bucket) = dataFileToPartitionAndBucket.toMap.apply(relativeFilePath)
-          val pathFactory = store.pathFactory()
+          val pathFactory = table.store().pathFactory()
           val partitionAndBucket = pathFactory
             .relativePartitionAndBucketPath(partition, bucket)
             .toString

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
@@ -18,7 +18,7 @@
 
 package org.apache.paimon.spark.commands
 
-import org.apache.paimon.deletionvectors.{BitmapDeletionVector, DeletionVector}
+import org.apache.paimon.deletionvectors.BitmapDeletionVector
 import org.apache.paimon.fs.Path
 import org.apache.paimon.index.IndexFileMeta
 import org.apache.paimon.io.{CompactIncrement, DataFileMeta, DataIncrement, IndexIncrement}
@@ -159,7 +159,8 @@ trait PaimonCommand extends WithFileStoreTable with ExpressionHelper {
     val metadataCols = Seq(FILE_PATH, ROW_INDEX)
     val filteredRelation = createNewScanPlan(candidateDataSplits, condition, relation, metadataCols)
 
-    val location = table.location
+    val my_table = table
+    val location = my_table.location
     createDataset(sparkSession, filteredRelation)
       .select(FILE_PATH_COLUMN, ROW_INDEX_COLUMN)
       .as[(String, Long)]
@@ -173,7 +174,7 @@ trait PaimonCommand extends WithFileStoreTable with ExpressionHelper {
 
           val relativeFilePath = location.toUri.relativize(new URI(filePath)).toString
           val (partition, bucket) = dataFileToPartitionAndBucket.toMap.apply(relativeFilePath)
-          val pathFactory = table.store().pathFactory()
+          val pathFactory = my_table.store().pathFactory()
           val partitionAndBucket = pathFactory
             .relativePartitionAndBucketPath(partition, bucket)
             .toString

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -19,7 +19,6 @@
 package org.apache.paimon.spark.commands
 
 import org.apache.paimon.CoreOptions.WRITE_ONLY
-import org.apache.paimon.data.BinaryRow
 import org.apache.paimon.deletionvectors.{DeletionVector, DeletionVectorIndexFileMaintainer}
 import org.apache.paimon.index.{BucketAssigner, SimpleHashBucketAssigner}
 import org.apache.paimon.io.{CompactIncrement, DataIncrement, IndexIncrement}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -207,12 +207,11 @@ case class PaimonSparkWriter(table: FileStoreTable) {
     val sparkSession = deletionVectors.sparkSession
     import sparkSession.implicits._
     val snapshotId = table.snapshotManager().latestSnapshotId();
-    val fileStore = table.store()
     val serializedCommits = deletionVectors
       .groupByKey(_.partitionAndBucket)
       .mapGroups {
         case (_, iter: Iterator[SparkDeletionVectors]) =>
-          val indexHandler = fileStore.newIndexFileHandler()
+          val indexHandler = table.store().newIndexFileHandler()
           var dvIndexFileMaintainer: DeletionVectorIndexFileMaintainer = null
           while (iter.hasNext) {
             val sdv: SparkDeletionVectors = iter.next()


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
For example, `SegmentsCache` in `AbstractFileStore` is not serializable.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
