### PR TITLE
[core] Support NumericPrimitiveToTimestamp in casting

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/casting/CastExecutors.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/CastExecutors.java
@@ -45,6 +45,7 @@ public class CastExecutors {
                 .addRule(NumericPrimitiveToDecimalCastRule.INSTANCE)
                 .addRule(DecimalToNumericPrimitiveCastRule.INSTANCE)
                 .addRule(NumericPrimitiveCastRule.INSTANCE)
+                .addRule(NumericPrimitiveToTimestamp.INSTANCE)
                 // Boolean <-> numeric rules
                 .addRule(BooleanToNumericCastRule.INSTANCE)
                 .addRule(NumericToBooleanCastRule.INSTANCE)

--- a/paimon-core/src/main/java/org/apache/paimon/casting/NumericPrimitiveToTimestamp.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/NumericPrimitiveToTimestamp.java
@@ -45,28 +45,18 @@ public class NumericPrimitiveToTimestamp extends AbstractCastRule<Number, Timest
 
     @Override
     public CastExecutor<Number, Timestamp> create(DataType inputType, DataType targetType) {
-        if (targetType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
-            switch (inputType.getTypeRoot()) {
-                case INTEGER:
-                case BIGINT:
-                    return value ->
-                            Timestamp.fromLocalDateTime(
-                                    DateTimeUtils.toLocalDateTime(
-                                            value.longValue(), ZoneId.systemDefault()));
-                default:
-                    return null;
-            }
-        } else {
-            switch (inputType.getTypeRoot()) {
-                case INTEGER:
-                case BIGINT:
-                    return value ->
-                            Timestamp.fromLocalDateTime(
-                                    DateTimeUtils.toLocalDateTime(
-                                            value.longValue(), DateTimeUtils.UTC_ZONE.toZoneId()));
-                default:
-                    return null;
-            }
+        ZoneId zoneId =
+                targetType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+                        ? ZoneId.systemDefault()
+                        : DateTimeUtils.UTC_ZONE.toZoneId();
+        switch (inputType.getTypeRoot()) {
+            case INTEGER:
+            case BIGINT:
+                return value ->
+                        Timestamp.fromLocalDateTime(
+                                DateTimeUtils.toLocalDateTime(value.longValue(), zoneId));
+            default:
+                return null;
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/casting/NumericPrimitiveToTimestamp.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/NumericPrimitiveToTimestamp.java
@@ -1,0 +1,44 @@
+package org.apache.paimon.casting;
+
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeFamily;
+import org.apache.paimon.types.DataTypeRoot;
+import org.apache.paimon.utils.DateTimeUtils;
+
+import java.time.ZoneId;
+
+public class NumericPrimitiveToTimestamp extends AbstractCastRule<Number, Timestamp> {
+
+    static final NumericPrimitiveToTimestamp INSTANCE = new NumericPrimitiveToTimestamp();
+
+    private NumericPrimitiveToTimestamp() {
+        super(
+                CastRulePredicate.builder()
+                        .input(DataTypeFamily.NUMERIC)
+                        .target(DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)
+                        .target(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+                        .build());
+    }
+
+    @Override
+    public CastExecutor<Number, Timestamp> create(DataType inputType, DataType targetType) {
+        if (targetType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
+            switch (inputType.getTypeRoot()) {
+                case INTEGER:
+                case BIGINT:
+                    return value -> Timestamp.fromLocalDateTime(DateTimeUtils.toLocalDateTime(value.longValue(), ZoneId.systemDefault()));
+                default:
+                    return null;
+            }
+        } else {
+            switch (inputType.getTypeRoot()) {
+                case INTEGER:
+                case BIGINT:
+                    return value -> Timestamp.fromLocalDateTime(DateTimeUtils.toLocalDateTime(value.longValue(), DateTimeUtils.UTC_ZONE.toZoneId()));
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/casting/NumericPrimitiveToTimestamp.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/NumericPrimitiveToTimestamp.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.paimon.casting;
 
 import org.apache.paimon.data.Timestamp;
@@ -8,6 +26,10 @@ import org.apache.paimon.utils.DateTimeUtils;
 
 import java.time.ZoneId;
 
+/**
+ * {{@link DataTypeFamily#INTEGER_NUMERIC} to @link DataTypeRoot#TIMESTAMP_WITHOUT_TIME_ZONE}/{@link
+ * DataTypeRoot#TIMESTAMP_WITH_LOCAL_TIME_ZONE}.
+ */
 public class NumericPrimitiveToTimestamp extends AbstractCastRule<Number, Timestamp> {
 
     static final NumericPrimitiveToTimestamp INSTANCE = new NumericPrimitiveToTimestamp();
@@ -27,7 +49,10 @@ public class NumericPrimitiveToTimestamp extends AbstractCastRule<Number, Timest
             switch (inputType.getTypeRoot()) {
                 case INTEGER:
                 case BIGINT:
-                    return value -> Timestamp.fromLocalDateTime(DateTimeUtils.toLocalDateTime(value.longValue(), ZoneId.systemDefault()));
+                    return value ->
+                            Timestamp.fromLocalDateTime(
+                                    DateTimeUtils.toLocalDateTime(
+                                            value.longValue(), ZoneId.systemDefault()));
                 default:
                     return null;
             }
@@ -35,7 +60,10 @@ public class NumericPrimitiveToTimestamp extends AbstractCastRule<Number, Timest
             switch (inputType.getTypeRoot()) {
                 case INTEGER:
                 case BIGINT:
-                    return value -> Timestamp.fromLocalDateTime(DateTimeUtils.toLocalDateTime(value.longValue(), DateTimeUtils.UTC_ZONE.toZoneId()));
+                    return value ->
+                            Timestamp.fromLocalDateTime(
+                                    DateTimeUtils.toLocalDateTime(
+                                            value.longValue(), DateTimeUtils.UTC_ZONE.toZoneId()));
                 default:
                     return null;
             }

--- a/paimon-core/src/main/java/org/apache/paimon/casting/NumericPrimitiveToTimestamp.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/NumericPrimitiveToTimestamp.java
@@ -54,7 +54,7 @@ public class NumericPrimitiveToTimestamp extends AbstractCastRule<Number, Timest
             case BIGINT:
                 return value ->
                         Timestamp.fromLocalDateTime(
-                                DateTimeUtils.toLocalDateTime(value.longValue(), zoneId));
+                                DateTimeUtils.toLocalDateTime(value.longValue() * 1000, zoneId));
             default:
                 return null;
         }

--- a/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -106,7 +106,8 @@ public class CastExecutorTest {
         compareCastResult(
                 CastExecutors.resolve(new BigIntType(false), new LocalZonedTimestampType(3)),
                 1721898748000L,
-                DateTimeUtils.parseTimestampData("2024-07-25 09:12:28.000", 3, TimeZone.getTimeZone("Asia/Shanghai")));
+                DateTimeUtils.parseTimestampData(
+                        "2024-07-25 09:12:28.000", 3, TimeZone.getTimeZone("Asia/Shanghai")));
 
         compareCastResult(
                 CastExecutors.resolve(new BigIntType(false), new TimestampType(3)),

--- a/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -104,6 +104,11 @@ public class CastExecutorTest {
     @Test
     public void testNumericToTimestamp() {
         compareCastResult(
+                CastExecutors.resolve(new BigIntType(false), new LocalZonedTimestampType(3)),
+                1721898748000L,
+                DateTimeUtils.parseTimestampData("2024-07-25 09:12:28.000", 3, TimeZone.getTimeZone("Asia/Shanghai")));
+
+        compareCastResult(
                 CastExecutors.resolve(new BigIntType(false), new TimestampType(3)),
                 1721898748000L,
                 DateTimeUtils.parseTimestampData("2024-07-25 09:12:28.000", 3));

--- a/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -107,7 +107,7 @@ public class CastExecutorTest {
                 CastExecutors.resolve(new BigIntType(false), new LocalZonedTimestampType(3)),
                 1721898748000L,
                 DateTimeUtils.parseTimestampData(
-                        "2024-07-25 09:12:28.000", 3, TimeZone.getTimeZone("Asia/Shanghai")));
+                        "2024-07-25 17:12:28.000", 3, TimeZone.getTimeZone("Asia/Shanghai")));
 
         compareCastResult(
                 CastExecutors.resolve(new BigIntType(false), new TimestampType(3)),

--- a/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -104,12 +104,6 @@ public class CastExecutorTest {
     @Test
     public void testNumericToTimestamp() {
         compareCastResult(
-                CastExecutors.resolve(new BigIntType(false), new LocalZonedTimestampType(3)),
-                1721898748000L,
-                DateTimeUtils.parseTimestampData(
-                        "2024-07-25 17:12:28.000", 3, TimeZone.getTimeZone("Asia/Shanghai")));
-
-        compareCastResult(
                 CastExecutors.resolve(new BigIntType(false), new TimestampType(3)),
                 1721898748000L,
                 DateTimeUtils.parseTimestampData("2024-07-25 09:12:28.000", 3));

--- a/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -105,8 +105,17 @@ public class CastExecutorTest {
     public void testNumericToTimestamp() {
         compareCastResult(
                 CastExecutors.resolve(new BigIntType(false), new TimestampType(3)),
-                1721898748000L,
+                1721898748,
                 DateTimeUtils.parseTimestampData("2024-07-25 09:12:28.000", 3));
+
+        Timestamp timestamp = Timestamp.fromEpochMillis(1721898748000L);
+        String tsString = DateTimeUtils.formatTimestamp(timestamp, TimeZone.getDefault(), 3);
+        Timestamp timestamp1 = DateTimeUtils.parseTimestampData(tsString, 3);
+
+        compareCastResult(
+                CastExecutors.resolve(new BigIntType(false), new LocalZonedTimestampType(3)),
+                1721898748L,
+                timestamp1);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -100,6 +100,18 @@ public class CastExecutorTest {
         compareCastResult(
                 CastExecutors.resolve(new FloatType(false), new DoubleType(false)), 1F, 1D);
     }
+    @Test
+    public void testNumericToTimestamp() {
+        compareCastResult(
+                CastExecutors.resolve(new BigIntType(false), new LocalZonedTimestampType(3)),
+                1721898748000l,
+                DateTimeUtils.parseTimestampData("2024-07-25 17:12:28.000", 3));
+
+        compareCastResult(
+                CastExecutors.resolve(new BigIntType(false), new TimestampType(3)),
+                1721898748000l,
+                DateTimeUtils.parseTimestampData("2024-07-25 09:12:28.000", 3));
+    }
 
     @Test
     public void testNumericToDecimal() {

--- a/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -105,12 +105,12 @@ public class CastExecutorTest {
     public void testNumericToTimestamp() {
         compareCastResult(
                 CastExecutors.resolve(new BigIntType(false), new LocalZonedTimestampType(3)),
-                1721898748000l,
+                1721898748000L,
                 DateTimeUtils.parseTimestampData("2024-07-25 17:12:28.000", 3));
 
         compareCastResult(
                 CastExecutors.resolve(new BigIntType(false), new TimestampType(3)),
-                1721898748000l,
+                1721898748000L,
                 DateTimeUtils.parseTimestampData("2024-07-25 09:12:28.000", 3));
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -100,6 +100,7 @@ public class CastExecutorTest {
         compareCastResult(
                 CastExecutors.resolve(new FloatType(false), new DoubleType(false)), 1F, 1D);
     }
+
     @Test
     public void testNumericToTimestamp() {
         compareCastResult(

--- a/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -104,11 +104,6 @@ public class CastExecutorTest {
     @Test
     public void testNumericToTimestamp() {
         compareCastResult(
-                CastExecutors.resolve(new BigIntType(false), new LocalZonedTimestampType(3)),
-                1721898748000L,
-                DateTimeUtils.parseTimestampData("2024-07-25 17:12:28.000", 3));
-
-        compareCastResult(
                 CastExecutors.resolve(new BigIntType(false), new TimestampType(3)),
                 1721898748000L,
                 DateTimeUtils.parseTimestampData("2024-07-25 09:12:28.000", 3));


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Currently paimon casting not support numeric to timestamp cast，the pr is aimed to support it.

<!-- Linking this pull request to the issue -->
Linked issue: https://github.com/apache/paimon/issues/3833

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
