### PR TITLE
[core] Move commit callbacks from TableCommit into FileStoreCommit

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -43,6 +43,7 @@ import org.apache.paimon.stats.StatsFileHandler;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.CatalogEnvironment;
 import org.apache.paimon.table.sink.CallbackUtils;
+import org.apache.paimon.table.sink.CommitCallback;
 import org.apache.paimon.table.sink.TagCallback;
 import org.apache.paimon.tag.TagAutoManager;
 import org.apache.paimon.types.RowType;
@@ -55,6 +56,7 @@ import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
@@ -184,6 +186,11 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
 
     @Override
     public FileStoreCommitImpl newCommit(String commitUser) {
+        return newCommit(commitUser, Collections.emptyList());
+    }
+
+    @Override
+    public FileStoreCommitImpl newCommit(String commitUser, List<CommitCallback> callbacks) {
         return new FileStoreCommitImpl(
                 fileIO,
                 schemaManager,
@@ -205,7 +212,8 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 options.branch(),
                 newStatsFileHandler(),
                 bucketMode(),
-                options.scanManifestParallelism());
+                options.scanManifestParallelism(),
+                callbacks);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/FileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/FileStore.java
@@ -33,6 +33,7 @@ import org.apache.paimon.operation.TagDeletion;
 import org.apache.paimon.service.ServiceManager;
 import org.apache.paimon.stats.StatsFileHandler;
 import org.apache.paimon.table.BucketMode;
+import org.apache.paimon.table.sink.CommitCallback;
 import org.apache.paimon.table.sink.TagCallback;
 import org.apache.paimon.tag.TagAutoManager;
 import org.apache.paimon.types.RowType;
@@ -79,6 +80,8 @@ public interface FileStore<T> extends Serializable {
     FileStoreWrite<T> newWrite(String commitUser, ManifestCacheFilter manifestFilter);
 
     FileStoreCommit newCommit(String commitUser);
+
+    FileStoreCommit newCommit(String commitUser, List<CommitCallback> callbacks);
 
     SnapshotDeletion newSnapshotDeletion();
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -172,13 +172,14 @@ public abstract class AbstractCatalog implements Catalog {
             throws TableNotExistException {
         Table table = getTable(identifier);
         FileStoreTable fileStoreTable = (FileStoreTable) table;
-        FileStoreCommit commit =
+        try (FileStoreCommit commit =
                 fileStoreTable
                         .store()
                         .newCommit(
-                                createCommitUser(fileStoreTable.coreOptions().toConfiguration()));
-        commit.dropPartitions(
-                Collections.singletonList(partitionSpec), BatchWriteBuilder.COMMIT_IDENTIFIER);
+                                createCommitUser(fileStoreTable.coreOptions().toConfiguration()))) {
+            commit.dropPartitions(
+                    Collections.singletonList(partitionSpec), BatchWriteBuilder.COMMIT_IDENTIFIER);
+        }
     }
 
     protected abstract void createDatabaseImpl(String name, Map<String, String> properties);
@@ -354,8 +355,7 @@ public abstract class AbstractCatalog implements Catalog {
             }
             return table;
         } else {
-            Table table = getDataTable(identifier);
-            return table;
+            return getDataTable(identifier);
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/metastore/TagPreviewCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/TagPreviewCommitCallback.java
@@ -19,8 +19,11 @@
 package org.apache.paimon.metastore;
 
 import org.apache.paimon.manifest.ManifestCommittable;
+import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.table.sink.CommitCallback;
 import org.apache.paimon.tag.TagPreview;
+
+import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Optional;
@@ -37,12 +40,19 @@ public class TagPreviewCommitCallback implements CommitCallback {
     }
 
     @Override
-    public void call(List<ManifestCommittable> committables) {
+    public void call(
+            List<ManifestEntry> committedEntries, long identifier, @Nullable Long watermark) {
         long currentMillis = System.currentTimeMillis();
-        for (ManifestCommittable c : committables) {
-            Optional<String> tagOptional = tagPreview.extractTag(currentMillis, c.watermark());
-            tagOptional.ifPresent(tagCallback::notifyCreation);
-        }
+        Optional<String> tagOptional = tagPreview.extractTag(currentMillis, watermark);
+        tagOptional.ifPresent(tagCallback::notifyCreation);
+    }
+
+    @Override
+    public void retry(ManifestCommittable committable) {
+        long currentMillis = System.currentTimeMillis();
+        Optional<String> tagOptional =
+                tagPreview.extractTag(currentMillis, committable.watermark());
+        tagOptional.ifPresent(tagCallback::notifyCreation);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
@@ -28,18 +28,17 @@ import org.apache.paimon.utils.FileStorePathFactory;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /** Commit operation which provides commit and overwrite. */
-public interface FileStoreCommit {
+public interface FileStoreCommit extends AutoCloseable {
 
     /** With global lock. */
     FileStoreCommit withLock(Lock lock);
 
     FileStoreCommit ignoreEmptyCommit(boolean ignoreEmptyCommit);
 
-    /** Find out which commit identifier need to be retried when recovering from the failure. */
-    Set<Long> filterCommitted(Set<Long> commitIdentifiers);
+    /** Find out which committables need to be retried when recovering from the failure. */
+    List<ManifestCommittable> filterCommitted(List<ManifestCommittable> committables);
 
     /** Commit from manifest committable. */
     void commit(ManifestCommittable committable, Map<String, String> properties);
@@ -88,4 +87,7 @@ public interface FileStoreCommit {
     FileStorePathFactory pathFactory();
 
     FileIO fileIO();
+
+    @Override
+    void close();
 }

--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStore.java
@@ -36,6 +36,7 @@ import org.apache.paimon.operation.TagDeletion;
 import org.apache.paimon.service.ServiceManager;
 import org.apache.paimon.stats.StatsFileHandler;
 import org.apache.paimon.table.BucketMode;
+import org.apache.paimon.table.sink.CommitCallback;
 import org.apache.paimon.table.sink.TagCallback;
 import org.apache.paimon.tag.TagAutoManager;
 import org.apache.paimon.types.RowType;
@@ -137,6 +138,12 @@ public class PrivilegedFileStore<T> implements FileStore<T> {
     public FileStoreCommit newCommit(String commitUser) {
         privilegeChecker.assertCanInsert(identifier);
         return wrapped.newCommit(commitUser);
+    }
+
+    @Override
+    public FileStoreCommit newCommit(String commitUser, List<CommitCallback> callbacks) {
+        privilegeChecker.assertCanInsert(identifier);
+        return wrapped.newCommit(commitUser, callbacks);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -367,8 +367,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
         }
 
         return new TableCommitImpl(
-                store().newCommit(commitUser),
-                createCommitCallbacks(commitUser),
+                store().newCommit(commitUser, createCommitCallbacks(commitUser)),
                 snapshotExpire,
                 options.writeOnly() ? null : store().newPartitionExpire(commitUser),
                 options.writeOnly() ? null : store().newTagCreationManager(),
@@ -389,7 +388,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
 
         if (options.partitionedTableInMetastore()
                 && metastoreClientFactory != null
-                && tableSchema.partitionKeys().size() > 0) {
+                && !tableSchema.partitionKeys().isEmpty()) {
             callbacks.add(new AddPartitionCommitCallback(metastoreClientFactory.create()));
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/CommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/CommitCallback.java
@@ -19,6 +19,9 @@
 package org.apache.paimon.table.sink;
 
 import org.apache.paimon.manifest.ManifestCommittable;
+import org.apache.paimon.manifest.ManifestEntry;
+
+import javax.annotation.Nullable;
 
 import java.util.List;
 
@@ -35,5 +38,7 @@ import java.util.List;
  */
 public interface CommitCallback extends AutoCloseable {
 
-    void call(List<ManifestCommittable> committables);
+    void call(List<ManifestEntry> committedEntries, long identifier, @Nullable Long watermark);
+
+    void retry(ManifestCommittable committable);
 }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
@@ -155,6 +155,7 @@ public class FileDeletionTest {
         partitionSpec.put("hr", "8");
         commit.overwrite(
                 partitionSpec, new ManifestCommittable(commitIdentifier++), Collections.emptyMap());
+        commit.close();
 
         // step 4: generate snapshot 4 by cleaning dt=0402/hr=12/bucket-0
         BinaryRow partition = partitions.get(7);

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreTestUtils.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreTestUtils.java
@@ -90,7 +90,6 @@ public class FileStoreTestUtils {
             long commitIdentifier,
             Map<BinaryRow, Map<Integer, RecordWriter<KeyValue>>> writers)
             throws Exception {
-        FileStoreCommit commit = store.newCommit();
         ManifestCommittable committable = new ManifestCommittable(commitIdentifier, null);
         for (Map.Entry<BinaryRow, Map<Integer, RecordWriter<KeyValue>>> entryWithPartition :
                 writers.entrySet()) {
@@ -106,7 +105,9 @@ public class FileStoreTestUtils {
             }
         }
 
-        commit.commit(committable, Collections.emptyMap());
+        try (FileStoreCommit commit = store.newCommit()) {
+            commit.commit(committable, Collections.emptyMap());
+        }
 
         writers.values().stream()
                 .flatMap(m -> m.values().stream())

--- a/paimon-core/src/test/java/org/apache/paimon/operation/TestCommitThread.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/TestCommitThread.java
@@ -193,8 +193,7 @@ public class TestCommitThread extends Thread {
         while (true) {
             try {
                 if (shouldCheckFilter) {
-                    if (commit.filterCommitted(Collections.singleton(committable.identifier()))
-                            .isEmpty()) {
+                    if (commit.filterCommitted(Collections.singletonList(committable)).isEmpty()) {
                         break;
                     }
                 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/sink/TableCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/sink/TableCommitTest.java
@@ -24,6 +24,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.io.DataFilePathFactory;
 import org.apache.paimon.manifest.ManifestCommittable;
+import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
@@ -40,6 +41,8 @@ import org.apache.paimon.utils.FailingFileIO;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -177,8 +180,13 @@ public class TableCommitTest {
         }
 
         @Override
-        public void call(List<ManifestCommittable> committables) {
-            committables.forEach(c -> commitCallbackResult.get(testId).add(c.identifier()));
+        public void call(List<ManifestEntry> entries, long identifier, @Nullable Long watermark) {
+            commitCallbackResult.get(testId).add(identifier);
+        }
+
+        @Override
+        public void retry(ManifestCommittable committable) {
+            commitCallbackResult.get(testId).add(committable.identifier());
         }
 
         @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/DropPartitionProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/DropPartitionProcedure.java
@@ -52,14 +52,15 @@ public class DropPartitionProcedure extends ProcedureBase {
 
         FileStoreTable fileStoreTable =
                 (FileStoreTable) catalog.getTable(Identifier.fromString(tableId));
-        FileStoreCommit commit =
+        try (FileStoreCommit commit =
                 fileStoreTable
                         .store()
                         .newCommit(
-                                createCommitUser(fileStoreTable.coreOptions().toConfiguration()));
-        commit.dropPartitions(
-                ParameterUtils.getPartitions(partitionStrings),
-                BatchWriteBuilder.COMMIT_IDENTIFIER);
+                                createCommitUser(fileStoreTable.coreOptions().toConfiguration()))) {
+            commit.dropPartitions(
+                    ParameterUtils.getPartitions(partitionStrings),
+                    BatchWriteBuilder.COMMIT_IDENTIFIER);
+        }
 
         return new String[] {"Success"};
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/SupportsRowLevelOperationFlinkTableSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/SupportsRowLevelOperationFlinkTableSink.java
@@ -161,18 +161,18 @@ public abstract class SupportsRowLevelOperationFlinkTableSink extends FlinkTable
     @Override
     public Optional<Long> executeDeletion() {
         FileStoreTable fileStoreTable = (FileStoreTable) table;
-        FileStoreCommit commit =
+        try (FileStoreCommit commit =
                 fileStoreTable
                         .store()
                         .newCommit(
-                                createCommitUser(fileStoreTable.coreOptions().toConfiguration()));
-        long identifier = BatchWriteBuilder.COMMIT_IDENTIFIER;
-        if (deletePredicate == null) {
-            commit.truncateTable(identifier);
-            return Optional.empty();
-        } else {
-            checkArgument(deleteIsDropPartition());
-            commit.dropPartitions(Collections.singletonList(deletePartitions()), identifier);
+                                createCommitUser(fileStoreTable.coreOptions().toConfiguration()))) {
+            long identifier = BatchWriteBuilder.COMMIT_IDENTIFIER;
+            if (deletePredicate == null) {
+                commit.truncateTable(identifier);
+            } else {
+                checkArgument(deleteIsDropPartition());
+                commit.dropPartitions(Collections.singletonList(deletePartitions()), identifier);
+            }
             return Optional.empty();
         }
     }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonPartitionManagement.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonPartitionManagement.scala
@@ -59,6 +59,7 @@ trait PaimonPartitionManagement extends SupportsPartitionManagement {
         commit.dropPartitions(
           Collections.singletonList(partitionMap),
           BatchWriteBuilder.COMMIT_IDENTIFIER)
+        commit.close()
         true
       case _ =>
         throw new UnsupportedOperationException("Only FileStoreTable supports drop partitions.")


### PR DESCRIPTION
### Purpose

Currently `CommitCallback`s are called in `TableCommitImpl`. However as many places directly use `FileStoreCommitImpl` instead of `TableCommitImpl`, commit callbacks won't be called for these usages.

In this PR we move commit callbacks from `TableCommit` into `FileStoreCommit`, so in all scenarios commit callbacks can be called.

### Tests

This is a code refactor. Existing tests should cover this change.

### API and Format

No API / format changes.

### Documentation

No new feature.
