### PR TITLE
[hive][spark] Support create table with specified location using hive catalog

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -133,6 +133,10 @@ public abstract class AbstractCatalog implements Catalog {
         return catalogOptions.getOptional(ALLOW_UPPER_CASE).orElse(true);
     }
 
+    protected boolean externalTableEnabled() {
+        return false;
+    }
+
     @Override
     public void createDatabase(String name, boolean ignoreIfExists, Map<String, String> properties)
             throws DatabaseAlreadyExistException {
@@ -272,6 +276,7 @@ public abstract class AbstractCatalog implements Catalog {
         validateIdentifierNameCaseInsensitive(identifier);
         validateFieldNameCaseInsensitive(schema.rowType().getFieldNames());
         validateAutoCreateClose(schema.options());
+        validateExternalTableSupport(schema.options());
 
         // check db exists
         getDatabase(identifier.getDatabaseName());
@@ -588,6 +593,15 @@ public abstract class AbstractCatalog implements Catalog {
                 String.format(
                         "The value of %s property should be %s.",
                         CoreOptions.AUTO_CREATE.key(), Boolean.FALSE));
+    }
+
+    private void validateExternalTableSupport(Map<String, String> options) {
+        if (!externalTableEnabled() && options.containsKey(CoreOptions.PATH.key())) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "The current catalog %s does not support external tables, so specifying the path is not allowed when creating a table.",
+                            this.getClass().getSimpleName()));
+        }
     }
 
     // =============================== Meta in File System =====================================

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -133,7 +133,7 @@ public abstract class AbstractCatalog implements Catalog {
         return catalogOptions.getOptional(ALLOW_UPPER_CASE).orElse(true);
     }
 
-    protected boolean externalTableEnabled() {
+    protected boolean allowCustomTablePath() {
         return false;
     }
 
@@ -276,7 +276,7 @@ public abstract class AbstractCatalog implements Catalog {
         validateIdentifierNameCaseInsensitive(identifier);
         validateFieldNameCaseInsensitive(schema.rowType().getFieldNames());
         validateAutoCreateClose(schema.options());
-        validateExternalTableSupport(schema.options());
+        validateCustomTablePath(schema.options());
 
         // check db exists
         getDatabase(identifier.getDatabaseName());
@@ -595,11 +595,11 @@ public abstract class AbstractCatalog implements Catalog {
                         CoreOptions.AUTO_CREATE.key(), Boolean.FALSE));
     }
 
-    private void validateExternalTableSupport(Map<String, String> options) {
-        if (!externalTableEnabled() && options.containsKey(CoreOptions.PATH.key())) {
+    private void validateCustomTablePath(Map<String, String> options) {
+        if (!allowCustomTablePath() && options.containsKey(CoreOptions.PATH.key())) {
             throw new UnsupportedOperationException(
                     String.format(
-                            "The current catalog %s does not support external tables, so specifying the path is not allowed when creating a table.",
+                            "The current catalog %s does not support specifying the table path when creating a table.",
                             this.getClass().getSimpleName()));
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/schema/Schema.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/Schema.java
@@ -341,13 +341,4 @@ public class Schema {
             return new Schema(columns, partitionKeys, primaryKeys, options, comment);
         }
     }
-
-    public static Schema fromTableSchema(TableSchema tableSchema) {
-        return new Schema(
-                tableSchema.fields(),
-                tableSchema.partitionKeys(),
-                tableSchema.primaryKeys(),
-                tableSchema.options(),
-                tableSchema.comment());
-    }
 }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -963,11 +963,12 @@ public class HiveCatalog extends AbstractCatalog {
                 }
             } catch (TableNotExistException e) {
                 // hive table does not exist.
-                Table finalNewTable =
-                        newTable == null
-                                ? createHiveTable(
-                                        identifier, tableSchema, location, usingExternalTable())
-                                : newTable;
+                if (newTable == null) {
+                    newTable =
+                            createHiveTable(
+                                    identifier, tableSchema, location, usingExternalTable());
+                }
+                Table finalNewTable = newTable;
                 clients.execute(client -> client.createTable(finalNewTable));
             }
 

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -83,7 +83,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -208,6 +207,12 @@ public class HiveCatalog extends AbstractCatalog {
         } catch (TableNotExistException ignored) {
         }
         return getTableLocation(identifier, table);
+    }
+
+    private Path initialTableLocation(Map<String, String> tableOptions, Identifier identifier) {
+        return tableOptions.containsKey(CoreOptions.PATH.key())
+                ? new Path(tableOptions.get(CoreOptions.PATH.key()))
+                : getTableLocation(identifier, null);
     }
 
     private Path getTableLocation(Identifier identifier, @Nullable Table table) {
@@ -634,8 +639,11 @@ public class HiveCatalog extends AbstractCatalog {
                         options,
                         schema.comment());
         try {
-            Path location = getTableLocation(identifier, null);
-            Table hiveTable = createHiveFormatTable(identifier, newSchema, location);
+            Map<String, String> tableOptions = schema.options();
+            boolean externalTable =
+                    options.containsKey(CoreOptions.PATH.key()) || usingExternalTable();
+            Path location = initialTableLocation(tableOptions, identifier);
+            Table hiveTable = createHiveFormatTable(identifier, newSchema, location, externalTable);
             clients.execute(client -> client.createTable(hiveTable));
         } catch (Exception e) {
             // we don't need to delete directories since HMS will roll back db and fs if failed.
@@ -654,18 +662,19 @@ public class HiveCatalog extends AbstractCatalog {
     @Override
     protected void dropTableImpl(Identifier identifier) {
         try {
+            boolean externalTable = isExternalTable(getHmsTable(identifier));
             clients.execute(
                     client ->
                             client.dropTable(
                                     identifier.getDatabaseName(),
                                     identifier.getTableName(),
-                                    true,
+                                    !externalTable,
                                     false,
                                     true));
 
             // When drop a Hive external table, only the hive metadata is deleted and the data files
             // are not deleted.
-            if (usingExternalTable()) {
+            if (externalTable) {
                 return;
             }
 
@@ -680,7 +689,7 @@ public class HiveCatalog extends AbstractCatalog {
             } catch (Exception ee) {
                 LOG.error("Delete directory[{}] fail for table {}", path, identifier, ee);
             }
-        } catch (TException e) {
+        } catch (TException | TableNotExistException e) {
             throw new RuntimeException("Failed to drop table " + identifier.getFullName(), e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -691,13 +700,12 @@ public class HiveCatalog extends AbstractCatalog {
 
     @Override
     protected void createTableImpl(Identifier identifier, Schema schema) {
-        // first commit changes to underlying files
-        // if changes on Hive fails there is no harm to perform the same changes to files again
-        Path location = getTableLocation(identifier, null);
+        Map<String, String> tableOptions = schema.options();
+        boolean externalTable = options.containsKey(CoreOptions.PATH.key()) || usingExternalTable();
+        Path location = initialTableLocation(tableOptions, identifier);
         TableSchema tableSchema;
         try {
-            tableSchema =
-                    schemaManager(identifier, location).createTable(schema, usingExternalTable());
+            tableSchema = schemaManager(identifier, location).createTable(schema, externalTable);
         } catch (Exception e) {
             throw new RuntimeException(
                     "Failed to commit changes of table "
@@ -709,7 +717,9 @@ public class HiveCatalog extends AbstractCatalog {
         try {
             clients.execute(
                     client ->
-                            client.createTable(createHiveTable(identifier, tableSchema, location)));
+                            client.createTable(
+                                    createHiveTable(
+                                            identifier, tableSchema, location, externalTable)));
         } catch (Exception e) {
             try {
                 fileIO.deleteDirectoryQuietly(location);
@@ -720,7 +730,8 @@ public class HiveCatalog extends AbstractCatalog {
         }
     }
 
-    private Table createHiveTable(Identifier identifier, TableSchema tableSchema, Path location) {
+    private Table createHiveTable(
+            Identifier identifier, TableSchema tableSchema, Path location, boolean externalTable) {
         checkArgument(Options.fromMap(tableSchema.options()).get(TYPE) != FORMAT_TABLE);
 
         Map<String, String> tblProperties;
@@ -740,13 +751,14 @@ public class HiveCatalog extends AbstractCatalog {
             }
         }
 
-        Table table = newHmsTable(identifier, tblProperties, PAIMON_TABLE_TYPE_VALUE);
+        Table table =
+                newHmsTable(identifier, tblProperties, PAIMON_TABLE_TYPE_VALUE, externalTable);
         updateHmsTable(table, identifier, tableSchema, PAIMON_TABLE_TYPE_VALUE, location);
         return table;
     }
 
     private Table createHiveFormatTable(
-            Identifier identifier, TableSchema tableSchema, Path location) {
+            Identifier identifier, TableSchema tableSchema, Path location, boolean externalTable) {
         Options options = Options.fromMap(tableSchema.options());
         checkArgument(options.get(TYPE) == FORMAT_TABLE);
 
@@ -757,7 +769,7 @@ public class HiveCatalog extends AbstractCatalog {
 
         Map<String, String> tblProperties = new HashMap<>();
 
-        Table table = newHmsTable(identifier, tblProperties, provider);
+        Table table = newHmsTable(identifier, tblProperties, provider, externalTable);
         updateHmsTable(table, identifier, tableSchema, provider, location);
 
         if (FormatTable.Format.CSV.toString().equalsIgnoreCase(provider)) {
@@ -865,6 +877,11 @@ public class HiveCatalog extends AbstractCatalog {
         return catalogOptions.getOptional(ALLOW_UPPER_CASE).orElse(false);
     }
 
+    @Override
+    protected boolean externalTableEnabled() {
+        return true;
+    }
+
     public boolean syncAllProperties() {
         return catalogOptions.get(SYNC_ALL_PROPERTIES);
     }
@@ -921,10 +938,13 @@ public class HiveCatalog extends AbstractCatalog {
         TableSchema tableSchema =
                 tableSchemaInFileSystem(location, identifier.getBranchNameOrDefault())
                         .orElseThrow(() -> new TableNotExistException(identifier));
-        Table newTable = createHiveTable(identifier, tableSchema, location);
+
         try {
+            Table newTable = null;
             try {
                 Table table = getHmsTable(identifier);
+                newTable =
+                        createHiveTable(identifier, tableSchema, location, isExternalTable(table));
                 checkArgument(
                         isPaimonTable(table),
                         "Table %s is not a paimon table in hive metastore.",
@@ -935,7 +955,8 @@ public class HiveCatalog extends AbstractCatalog {
                 }
             } catch (TableNotExistException e) {
                 // hive table does not exist.
-                clients.execute(client -> client.createTable(newTable));
+                Table finalNewTable = newTable;
+                clients.execute(client -> client.createTable(finalNewTable));
             }
 
             // repair partitions
@@ -1012,13 +1033,17 @@ public class HiveCatalog extends AbstractCatalog {
         return table != null && TableType.VIRTUAL_VIEW.name().equals(table.getTableType());
     }
 
+    private boolean isExternalTable(Table table) {
+        return (table != null && TableType.EXTERNAL_TABLE.name().equals(table.getTableType()))
+                || usingExternalTable();
+    }
+
     private Table newHmsTable(
-            Identifier identifier, Map<String, String> tableParameters, String provider) {
+            Identifier identifier,
+            Map<String, String> tableParameters,
+            String provider,
+            boolean externalTable) {
         long currentTimeMillis = System.currentTimeMillis();
-        CatalogTableType tableType =
-                OptionsUtils.convertToEnum(
-                        hiveConf.get(TABLE_TYPE.key(), CatalogTableType.MANAGED.toString()),
-                        CatalogTableType.class);
         if (provider == null) {
             provider = PAIMON_TABLE_TYPE_VALUE;
         }
@@ -1036,7 +1061,9 @@ public class HiveCatalog extends AbstractCatalog {
                         tableParameters,
                         null,
                         null,
-                        tableType.toString().toUpperCase(Locale.ROOT) + "_TABLE");
+                        externalTable
+                                ? TableType.EXTERNAL_TABLE.name()
+                                : TableType.MANAGED_TABLE.name());
         table.getParameters().put(TABLE_TYPE_PROP, provider.toUpperCase());
         if (PAIMON_TABLE_TYPE_VALUE.equalsIgnoreCase(provider)) {
             table.getParameters()
@@ -1045,7 +1072,7 @@ public class HiveCatalog extends AbstractCatalog {
             table.getParameters().put(FILE_FORMAT.key(), provider.toLowerCase());
             table.getParameters().put(TYPE.key(), FORMAT_TABLE.toString());
         }
-        if (CatalogTableType.EXTERNAL.equals(tableType)) {
+        if (externalTable) {
             table.getParameters().put("EXTERNAL", "TRUE");
         }
         return table;

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -640,8 +640,7 @@ public class HiveCatalog extends AbstractCatalog {
                         schema.comment());
         try {
             Map<String, String> tableOptions = schema.options();
-            boolean externalTable =
-                    options.containsKey(CoreOptions.PATH.key()) || usingExternalTable();
+            boolean externalTable = createExternalTable(tableOptions);
             Path location = initialTableLocation(tableOptions, identifier);
             Table hiveTable = createHiveFormatTable(identifier, newSchema, location, externalTable);
             clients.execute(client -> client.createTable(hiveTable));
@@ -651,7 +650,10 @@ public class HiveCatalog extends AbstractCatalog {
         }
     }
 
-    private boolean usingExternalTable() {
+    private boolean createExternalTable(Map<String, String> tableOptions) {
+        if (tableOptions.containsKey(CoreOptions.PATH.key())) {
+            return true;
+        }
         CatalogTableType tableType =
                 OptionsUtils.convertToEnum(
                         hiveConf.get(TABLE_TYPE.key(), CatalogTableType.MANAGED.toString()),
@@ -701,7 +703,7 @@ public class HiveCatalog extends AbstractCatalog {
     @Override
     protected void createTableImpl(Identifier identifier, Schema schema) {
         Map<String, String> tableOptions = schema.options();
-        boolean externalTable = options.containsKey(CoreOptions.PATH.key()) || usingExternalTable();
+        boolean externalTable = createExternalTable(tableOptions);
         Path location = initialTableLocation(tableOptions, identifier);
         TableSchema tableSchema;
         try {
@@ -1034,8 +1036,7 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     private boolean isExternalTable(Table table) {
-        return (table != null && TableType.EXTERNAL_TABLE.name().equals(table.getTableType()))
-                || usingExternalTable();
+        return table != null && TableType.EXTERNAL_TABLE.name().equals(table.getTableType());
     }
 
     private Table newHmsTable(

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -878,7 +878,7 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     @Override
-    protected boolean externalTableEnabled() {
+    protected boolean allowCustomTablePath() {
         return true;
     }
 

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -18,8 +18,8 @@
 
 package org.apache.paimon.hive;
 
-import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogTestBase;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.client.ClientPool;

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -415,7 +415,6 @@ public class SparkCatalog extends SparkBaseCatalog implements SupportFunction, S
             String path = normalizedProperties.remove(TableCatalog.PROP_LOCATION);
             normalizedProperties.put(CoreOptions.PATH.key(), path);
         }
-
         String pkAsString = properties.get(PRIMARY_KEY_IDENTIFIER);
         List<String> primaryKeys =
                 pkAsString == null

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -411,6 +411,11 @@ public class SparkCatalog extends SparkBaseCatalog implements SupportFunction, S
         }
         normalizedProperties.remove(PRIMARY_KEY_IDENTIFIER);
         normalizedProperties.remove(TableCatalog.PROP_COMMENT);
+        if (normalizedProperties.containsKey(TableCatalog.PROP_LOCATION)) {
+            String path = normalizedProperties.remove(TableCatalog.PROP_LOCATION);
+            normalizedProperties.put(CoreOptions.PATH.key(), path);
+        }
+
         String pkAsString = properties.get(PRIMARY_KEY_IDENTIFIER);
         List<String> primaryKeys =
                 pkAsString == null

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkTable.scala
@@ -64,6 +64,9 @@ case class SparkTable(table: Table)
         if (table.comment.isPresent) {
           properties.put(TableCatalog.PROP_COMMENT, table.comment.get)
         }
+        if (properties.containsKey(CoreOptions.PATH.key())) {
+          properties.put(TableCatalog.PROP_LOCATION, properties.get(CoreOptions.PATH.key()))
+        }
         properties
       case _ => Collections.emptyMap()
     }

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadITCase.java
@@ -190,17 +190,21 @@ public class SparkReadITCase extends SparkReadTestBase {
         spark.sql("INSERT INTO partitionedTable VALUES(1,'aaa','bbb')");
         spark.sql(
                 "CREATE TABLE partitionedTableAs PARTITIONED BY (a) AS SELECT * FROM partitionedTable");
+
+        String tablePath = new Path(warehousePath, "default.db/partitionedTableAs").toString();
         assertThat(spark.sql("SHOW CREATE TABLE partitionedTableAs").collectAsList().toString())
                 .isEqualTo(
                         String.format(
                                 "[[%s"
                                         + "PARTITIONED BY (a)\n"
+                                        + "LOCATION '%s'\n"
                                         + "TBLPROPERTIES (\n"
                                         + "  'path' = '%s')\n"
                                         + "]]",
                                 showCreateString(
                                         "partitionedTableAs", "a BIGINT", "b STRING", "c STRING"),
-                                new Path(warehousePath, "default.db/partitionedTableAs")));
+                                tablePath,
+                                tablePath));
         List<Row> resultPartition = spark.sql("SELECT * FROM partitionedTableAs").collectAsList();
         assertThat(resultPartition.stream().map(Row::toString))
                 .containsExactlyInAnyOrder("[1,aaa,bbb]");
@@ -217,17 +221,21 @@ public class SparkReadITCase extends SparkReadTestBase {
         spark.sql("INSERT INTO testTable VALUES(1,'a','b')");
         spark.sql(
                 "CREATE TABLE testTableAs TBLPROPERTIES ('file.format' = 'parquet') AS SELECT * FROM testTable");
+
+        String testTableAsPath = new Path(warehousePath, "default.db/testTableAs").toString();
         assertThat(spark.sql("SHOW CREATE TABLE testTableAs").collectAsList().toString())
                 .isEqualTo(
                         String.format(
                                 "[[%s"
+                                        + "LOCATION '%s'\n"
                                         + "TBLPROPERTIES (\n"
                                         + "  'file.format' = 'parquet',\n"
                                         + "  'path' = '%s')\n"
                                         + "]]",
                                 showCreateString(
                                         "testTableAs", "a BIGINT", "b VARCHAR(10)", "c CHAR(10)"),
-                                new Path(warehousePath, "default.db/testTableAs")));
+                                testTableAsPath,
+                                testTableAsPath));
         List<Row> resultProp = spark.sql("SELECT * FROM testTableAs").collectAsList();
 
         assertThat(resultProp.stream().map(Row::toString))
@@ -245,13 +253,18 @@ public class SparkReadITCase extends SparkReadTestBase {
                         + "COMMENT 'table comment'");
         spark.sql("INSERT INTO t_pk VALUES(1,'aaa','bbb')");
         spark.sql("CREATE TABLE t_pk_as TBLPROPERTIES ('primary-key' = 'a') AS SELECT * FROM t_pk");
+
+        String tPkAsPath = new Path(warehousePath, "default.db/t_pk_as").toString();
         assertThat(spark.sql("SHOW CREATE TABLE t_pk_as").collectAsList().toString())
                 .isEqualTo(
                         String.format(
-                                "[[%sTBLPROPERTIES (\n  'path' = '%s',\n  'primary-key' = 'a')\n]]",
+                                "[[%s"
+                                        + "LOCATION '%s'\n"
+                                        + "TBLPROPERTIES (\n  'path' = '%s',\n  'primary-key' = 'a')\n]]",
                                 showCreateString(
                                         "t_pk_as", "a BIGINT NOT NULL", "b STRING", "c STRING"),
-                                new Path(warehousePath, "default.db/t_pk_as")));
+                                tPkAsPath,
+                                tPkAsPath));
         List<Row> resultPk = spark.sql("SELECT * FROM t_pk_as").collectAsList();
 
         assertThat(resultPk.stream().map(Row::toString)).containsExactlyInAnyOrder("[1,aaa,bbb]");
@@ -270,11 +283,14 @@ public class SparkReadITCase extends SparkReadTestBase {
         spark.sql("INSERT INTO t_all VALUES(1,2,'bbb','2020-01-01','12')");
         spark.sql(
                 "CREATE TABLE t_all_as PARTITIONED BY (dt) TBLPROPERTIES ('primary-key' = 'dt,hh') AS SELECT * FROM t_all");
+
+        String tAllAsPath = new Path(warehousePath, "default.db/t_all_as").toString();
         assertThat(spark.sql("SHOW CREATE TABLE t_all_as").collectAsList().toString())
                 .isEqualTo(
                         String.format(
                                 "[[%s"
                                         + "PARTITIONED BY (dt)\n"
+                                        + "LOCATION '%s'\n"
                                         + "TBLPROPERTIES (\n"
                                         + "  'path' = '%s',\n"
                                         + "  'primary-key' = 'dt,hh')\n"
@@ -286,7 +302,8 @@ public class SparkReadITCase extends SparkReadTestBase {
                                         "behavior STRING",
                                         "dt STRING NOT NULL",
                                         "hh STRING NOT NULL"),
-                                new Path(warehousePath, "default.db/t_all_as")));
+                                tAllAsPath,
+                                tAllAsPath));
         List<Row> resultAll = spark.sql("SELECT * FROM t_all_as").collectAsList();
         assertThat(resultAll.stream().map(Row::toString))
                 .containsExactlyInAnyOrder("[1,2,bbb,2020-01-01,12]");
@@ -363,12 +380,15 @@ public class SparkReadITCase extends SparkReadTestBase {
                         + "  'k1' = 'v1'\n"
                         + ")");
 
+        String tablePath = new Path(warehousePath, "default.db/tbl").toString();
+
         assertThat(spark.sql("SHOW CREATE TABLE tbl").collectAsList().toString())
                 .isEqualTo(
                         String.format(
                                 "[[%s"
                                         + "PARTITIONED BY (b)\n"
                                         + "COMMENT 'tbl comment'\n"
+                                        + "LOCATION '%s'\n"
                                         + "TBLPROPERTIES (\n"
                                         + "  'k1' = 'v1',\n"
                                         + "  'path' = '%s',\n"
@@ -377,7 +397,8 @@ public class SparkReadITCase extends SparkReadTestBase {
                                         "tbl",
                                         "a INT NOT NULL COMMENT 'a comment'",
                                         "b STRING NOT NULL"),
-                                new Path(warehousePath, "default.db/tbl")));
+                                tablePath,
+                                tablePath));
     }
 
     @Test

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadITCase.java
@@ -190,8 +190,7 @@ public class SparkReadITCase extends SparkReadTestBase {
         spark.sql("INSERT INTO partitionedTable VALUES(1,'aaa','bbb')");
         spark.sql(
                 "CREATE TABLE partitionedTableAs PARTITIONED BY (a) AS SELECT * FROM partitionedTable");
-
-        String tablePath = new Path(warehousePath, "default.db/partitionedTableAs").toString();
+        Path tablePath = new Path(warehousePath, "default.db/partitionedTableAs");
         assertThat(spark.sql("SHOW CREATE TABLE partitionedTableAs").collectAsList().toString())
                 .isEqualTo(
                         String.format(
@@ -221,8 +220,7 @@ public class SparkReadITCase extends SparkReadTestBase {
         spark.sql("INSERT INTO testTable VALUES(1,'a','b')");
         spark.sql(
                 "CREATE TABLE testTableAs TBLPROPERTIES ('file.format' = 'parquet') AS SELECT * FROM testTable");
-
-        String testTableAsPath = new Path(warehousePath, "default.db/testTableAs").toString();
+        tablePath = new Path(warehousePath, "default.db/testTableAs");
         assertThat(spark.sql("SHOW CREATE TABLE testTableAs").collectAsList().toString())
                 .isEqualTo(
                         String.format(
@@ -234,8 +232,8 @@ public class SparkReadITCase extends SparkReadTestBase {
                                         + "]]",
                                 showCreateString(
                                         "testTableAs", "a BIGINT", "b VARCHAR(10)", "c CHAR(10)"),
-                                testTableAsPath,
-                                testTableAsPath));
+                                tablePath,
+                                tablePath));
         List<Row> resultProp = spark.sql("SELECT * FROM testTableAs").collectAsList();
 
         assertThat(resultProp.stream().map(Row::toString))
@@ -253,8 +251,7 @@ public class SparkReadITCase extends SparkReadTestBase {
                         + "COMMENT 'table comment'");
         spark.sql("INSERT INTO t_pk VALUES(1,'aaa','bbb')");
         spark.sql("CREATE TABLE t_pk_as TBLPROPERTIES ('primary-key' = 'a') AS SELECT * FROM t_pk");
-
-        String tPkAsPath = new Path(warehousePath, "default.db/t_pk_as").toString();
+        tablePath = new Path(warehousePath, "default.db/t_pk_as");
         assertThat(spark.sql("SHOW CREATE TABLE t_pk_as").collectAsList().toString())
                 .isEqualTo(
                         String.format(
@@ -263,8 +260,8 @@ public class SparkReadITCase extends SparkReadTestBase {
                                         + "TBLPROPERTIES (\n  'path' = '%s',\n  'primary-key' = 'a')\n]]",
                                 showCreateString(
                                         "t_pk_as", "a BIGINT NOT NULL", "b STRING", "c STRING"),
-                                tPkAsPath,
-                                tPkAsPath));
+                                tablePath,
+                                tablePath));
         List<Row> resultPk = spark.sql("SELECT * FROM t_pk_as").collectAsList();
 
         assertThat(resultPk.stream().map(Row::toString)).containsExactlyInAnyOrder("[1,aaa,bbb]");
@@ -283,8 +280,7 @@ public class SparkReadITCase extends SparkReadTestBase {
         spark.sql("INSERT INTO t_all VALUES(1,2,'bbb','2020-01-01','12')");
         spark.sql(
                 "CREATE TABLE t_all_as PARTITIONED BY (dt) TBLPROPERTIES ('primary-key' = 'dt,hh') AS SELECT * FROM t_all");
-
-        String tAllAsPath = new Path(warehousePath, "default.db/t_all_as").toString();
+        tablePath = new Path(warehousePath, "default.db/t_all_as");
         assertThat(spark.sql("SHOW CREATE TABLE t_all_as").collectAsList().toString())
                 .isEqualTo(
                         String.format(
@@ -302,8 +298,8 @@ public class SparkReadITCase extends SparkReadTestBase {
                                         "behavior STRING",
                                         "dt STRING NOT NULL",
                                         "hh STRING NOT NULL"),
-                                tAllAsPath,
-                                tAllAsPath));
+                                tablePath,
+                                tablePath));
         List<Row> resultAll = spark.sql("SELECT * FROM t_all_as").collectAsList();
         assertThat(resultAll.stream().map(Row::toString))
                 .containsExactlyInAnyOrder("[1,2,bbb,2020-01-01,12]");
@@ -380,8 +376,7 @@ public class SparkReadITCase extends SparkReadTestBase {
                         + "  'k1' = 'v1'\n"
                         + ")");
 
-        String tablePath = new Path(warehousePath, "default.db/tbl").toString();
-
+        Path tablePath = new Path(warehousePath, "default.db/tbl");
         assertThat(spark.sql("SHOW CREATE TABLE tbl").collectAsList().toString())
                 .isEqualTo(
                         String.format(

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonHiveTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/PaimonHiveTestBase.scala
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.spark
 
-import org.apache.paimon.Snapshot
 import org.apache.paimon.hive.TestHiveMetastore
 
 import org.apache.hadoop.conf.Configuration

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
@@ -556,7 +556,7 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
             sql(
               s"CREATE TABLE external_tbl (id INT) USING paimon LOCATION '${tbLocation.getCanonicalPath}'")
           }.getMessage
-          assert(error.contains("does not support external tables"))
+          assert(error.contains("not support"))
 
           // create managed table
           sql("CREATE TABLE managed_tbl (id INT) USING paimon")

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
@@ -546,4 +546,28 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
         }
     }
   }
+
+  test("Paimon DDL: create and drop external / managed table") {
+    withTempDir {
+      tbLocation =>
+        withTable("external_tbl", "managed_tbl") {
+          // create external table
+          val error = intercept[UnsupportedOperationException] {
+            sql(
+              s"CREATE TABLE external_tbl (id INT) USING paimon LOCATION '${tbLocation.getCanonicalPath}'")
+          }.getMessage
+          assert(error.contains("does not support external tables"))
+
+          // create managed table
+          sql("CREATE TABLE managed_tbl (id INT) USING paimon")
+          val table = loadTable("managed_tbl")
+          val fileIO = table.fileIO()
+          val tableLocation = table.location()
+
+          // drop managed table
+          sql("DROP TABLE managed_tbl")
+          assert(!fileIO.exists(tableLocation))
+        }
+    }
+  }
 }

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTestBase.scala
@@ -297,6 +297,56 @@ abstract class DDLWithHiveCatalogTestBase extends PaimonHiveTestBase {
     }
   }
 
+  test("Paimon DDL with hive catalog: create and drop external / managed table") {
+    Seq(sparkCatalogName, paimonHiveCatalogName).foreach {
+      catalogName =>
+        spark.sql(s"USE $catalogName")
+        withTempDir {
+          tbLocation =>
+            withDatabase("paimon_db") {
+              spark.sql(s"CREATE DATABASE paimon_db")
+              spark.sql(s"USE paimon_db")
+              withTable("external_tbl", "managed_tbl") {
+                val expertTbLocation = tbLocation.getCanonicalPath
+                // create external table
+                spark.sql(
+                  s"CREATE TABLE external_tbl (id INT) USING paimon LOCATION '$expertTbLocation'")
+                spark.sql("INSERT INTO external_tbl VALUES (1)")
+                checkAnswer(spark.sql("SELECT * FROM external_tbl"), Row(1))
+                val table = loadTable("paimon_db", "external_tbl")
+                val fileIO = table.fileIO()
+                val actualTbLocation = table.location()
+                assert(actualTbLocation.toString.split(':').apply(1).equals(expertTbLocation))
+
+                // drop external table
+                spark.sql("DROP TABLE external_tbl")
+                assert(fileIO.exists(actualTbLocation))
+
+                // create external table again using the same location
+                spark.sql(
+                  s"CREATE TABLE external_tbl (id INT) USING paimon LOCATION '$expertTbLocation'")
+                checkAnswer(spark.sql("SELECT * FROM external_tbl"), Row(1))
+                assert(
+                  loadTable("paimon_db", "external_tbl")
+                    .location()
+                    .toString
+                    .split(':')
+                    .apply(1)
+                    .equals(expertTbLocation))
+
+                // create managed table
+                spark.sql(s"CREATE TABLE managed_tbl (id INT) USING paimon")
+                val managedTbLocation = loadTable("paimon_db", "managed_tbl").location()
+
+                // drop managed table
+                spark.sql("DROP TABLE managed_tbl")
+                assert(!fileIO.exists(managedTbLocation))
+              }
+            }
+        }
+    }
+  }
+
   def getDatabaseProp(dbName: String, propertyName: String): String = {
     spark
       .sql(s"DESC DATABASE EXTENDED $dbName")


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
~~This relocates the 'path' property in the table options to 'location' for better presentation.~~

- Adapt 'path' to Spark's 'location' in table props ( the 'path' is still preserved in table props)
- Support the customization of the table location when creating a table(only allowed for creating external table using hive catalog)

Spark uses the reserved property `location` to indicate the location of the table, and in the output of `DESC EXTENDED`, the location information will be displayed under the "# Detailed Table Information" section for better visibility.

```text
+----------------------------+-----------------------------------------------------------------------------------------------------+-------+
|col_name                    |data_type                                                                                            |comment|
+----------------------------+-----------------------------------------------------------------------------------------------------+-------+
|a                           |bigint                                                                                               |NULL   |
|b                           |varchar(10)                                                                                          |NULL   |
|c                           |char(10)                                                                                             |NULL   |
|                            |                                                                                                     |       |
|# Metadata Columns          |                                                                                                     |       |
|__paimon_file_path          |string                                                                                               |       |
|__paimon_row_index          |bigint                                                                                               |       |
|                            |                                                                                                     |       |
|# Detailed Table Information|                                                                                                     |       |
|Name                        |default.testTableAs                                                                                  |       |
|Type                        |MANAGED                                                                                              |       |
|Location                    |file:/var/folders/2r/v_2n6mbj41v7q14m8f3j9q4w0000gn/T/junit3802231298897594813/default.db/testTableAs|       |
|Provider                    |paimon                                                                                               |       |
|Owner                       |zhongyujiang                                                                                         |       |
|Table Properties            |[file.format=parquet]                                                                                |       |
+----------------------------+-----------------------------------------------------------------------------------------------------+-------+
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
