### PR TITLE
[core] Immutable table options can now be changed on an empty table

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/Schema.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/Schema.java
@@ -161,7 +161,11 @@ public class Schema {
                         "Cannot define primary key on DDL and table options at the same time.");
             }
             String pk = options.get(CoreOptions.PRIMARY_KEY.key());
-            primaryKeys = Arrays.asList(pk.split(","));
+            primaryKeys =
+                    Arrays.stream(pk.split(","))
+                            .map(String::trim)
+                            .filter(s -> !s.isEmpty())
+                            .collect(Collectors.toList());
             options.remove(CoreOptions.PRIMARY_KEY.key());
         }
         return primaryKeys;
@@ -174,7 +178,11 @@ public class Schema {
                         "Cannot define partition on DDL and table options at the same time.");
             }
             String partitions = options.get(CoreOptions.PARTITION.key());
-            partitionKeys = Arrays.asList(partitions.split(","));
+            partitionKeys =
+                    Arrays.stream(partitions.split(","))
+                            .map(String::trim)
+                            .filter(s -> !s.isEmpty())
+                            .collect(Collectors.toList());
             options.remove(CoreOptions.PARTITION.key());
         }
         return partitionKeys;

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -467,7 +467,7 @@ public class SchemaManagerTest {
 
         // set immutable options and set primary keys
         manager.commitChanges(
-                SchemaChange.setOption("primary-key", "f0,f1"),
+                SchemaChange.setOption("primary-key", "f0, f1"),
                 SchemaChange.setOption("partition", "f0"),
                 SchemaChange.setOption("bucket", "2"),
                 SchemaChange.setOption("merge-engine", "first-row"));

--- a/paimon-flink/paimon-flink-1.16/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-1.16/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink;
 
+import org.apache.flink.types.Row;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -44,9 +45,29 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
     }
 
     @Test
-    public void testSetAndResetImmutableOptions() {
+    public void testSetAndResetImmutableOptionsOnEmptyTables() {
+        sql("CREATE TABLE T1 (a INT, b INT)");
+        sql(
+                "ALTER TABLE T1 SET ('primary-key' = 'a', 'bucket' = '1', 'merge-engine' = 'first-row')");
+        sql("INSERT INTO T1 VALUES (1, 10), (2, 20), (1, 11), (2, 21)");
+        assertThat(queryAndSort("SELECT * FROM T1")).containsExactly(Row.of(1, 10), Row.of(2, 20));
+        assertThatThrownBy(() -> sql("ALTER TABLE T1 SET ('merge-engine' = 'deduplicate')"))
+                .rootCause()
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Change 'merge-engine' is not supported yet.");
+
+        sql(
+                "CREATE TABLE T2 (a INT, b INT, PRIMARY KEY (a) NOT ENFORCED) WITH ('bucket' = '1', 'merge-engine' = 'first-row')");
+        sql("ALTER TABLE T2 RESET ('merge-engine')");
+        sql("INSERT INTO T2 VALUES (1, 10), (2, 20), (1, 11), (2, 21)");
+        assertThat(queryAndSort("SELECT * FROM T2")).containsExactly(Row.of(1, 11), Row.of(2, 21));
+    }
+
+    @Test
+    public void testSetAndResetImmutableOptionsOnNonEmptyTables() {
         // bucket-key is immutable
         sql("CREATE TABLE T1 (a STRING, b STRING, c STRING)");
+        sql("INSERT INTO T1 VALUES ('a', 'b', 'c')");
 
         assertThatThrownBy(() -> sql("ALTER TABLE T1 SET ('bucket-key' = 'c')"))
                 .rootCause()
@@ -55,6 +76,7 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
 
         sql(
                 "CREATE TABLE T2 (a STRING, b STRING, c STRING) WITH ('bucket' = '1', 'bucket-key' = 'c')");
+        sql("INSERT INTO T2 VALUES ('a', 'b', 'c')");
         assertThatThrownBy(() -> sql("ALTER TABLE T2 RESET ('bucket-key')"))
                 .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
@@ -63,6 +85,7 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
         // merge-engine is immutable
         sql(
                 "CREATE TABLE T4 (a STRING, b STRING, c STRING) WITH ('merge-engine' = 'partial-update')");
+        sql("INSERT INTO T4 VALUES ('a', 'b', 'c')");
         assertThatThrownBy(() -> sql("ALTER TABLE T4 RESET ('merge-engine')"))
                 .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
@@ -70,6 +93,7 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
 
         // sequence.field is immutable
         sql("CREATE TABLE T5 (a STRING, b STRING, c STRING) WITH ('sequence.field' = 'b')");
+        sql("INSERT INTO T5 VALUES ('a', 'b', 'c')");
         assertThatThrownBy(() -> sql("ALTER TABLE T5 SET ('sequence.field' = 'c')"))
                 .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
@@ -846,10 +846,30 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
     }
 
     @Test
-    public void testSetAndResetImmutableOptions() throws Exception {
+    public void testSetAndResetImmutableOptionsOnEmptyTables() {
+        sql("CREATE TABLE T1 (a INT, b INT)");
+        sql(
+                "ALTER TABLE T1 SET ('primary-key' = 'a', 'bucket' = '1', 'merge-engine' = 'first-row')");
+        sql("INSERT INTO T1 VALUES (1, 10), (2, 20), (1, 11), (2, 21)");
+        assertThat(queryAndSort("SELECT * FROM T1")).containsExactly(Row.of(1, 10), Row.of(2, 20));
+        assertThatThrownBy(() -> sql("ALTER TABLE T1 SET ('merge-engine' = 'deduplicate')"))
+                .rootCause()
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Change 'merge-engine' is not supported yet.");
+
+        sql(
+                "CREATE TABLE T2 (a INT, b INT, PRIMARY KEY (a) NOT ENFORCED) WITH ('bucket' = '1', 'merge-engine' = 'first-row')");
+        sql("ALTER TABLE T2 RESET ('merge-engine')");
+        sql("INSERT INTO T2 VALUES (1, 10), (2, 20), (1, 11), (2, 21)");
+        assertThat(queryAndSort("SELECT * FROM T2")).containsExactly(Row.of(1, 11), Row.of(2, 21));
+    }
+
+    @Test
+    public void testSetAndResetImmutableOptionsOnNonEmptyTables() {
         // bucket-key is immutable
         sql(
                 "CREATE TABLE T1 (a STRING, b STRING, c STRING) WITH ('bucket' = '1', 'bucket-key' = 'a')");
+        sql("INSERT INTO T1 VALUES ('a', 'b', 'c')");
 
         assertThatThrownBy(() -> sql("ALTER TABLE T1 SET ('bucket-key' = 'c')"))
                 .rootCause()
@@ -858,6 +878,7 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
 
         sql(
                 "CREATE TABLE T2 (a STRING, b STRING, c STRING) WITH ('bucket' = '1', 'bucket-key' = 'c')");
+        sql("INSERT INTO T2 VALUES ('a', 'b', 'c')");
         assertThatThrownBy(() -> sql("ALTER TABLE T2 RESET ('bucket-key')"))
                 .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
@@ -866,6 +887,7 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
         // merge-engine is immutable
         sql(
                 "CREATE TABLE T4 (a STRING, b STRING, c STRING) WITH ('merge-engine' = 'partial-update')");
+        sql("INSERT INTO T4 VALUES ('a', 'b', 'c')");
         assertThatThrownBy(() -> sql("ALTER TABLE T4 RESET ('merge-engine')"))
                 .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
@@ -873,6 +895,7 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
 
         // sequence.field is immutable
         sql("CREATE TABLE T5 (a STRING, b STRING, c STRING) WITH ('sequence.field' = 'b')");
+        sql("INSERT INTO T5 VALUES ('a', 'b', 'c')");
         assertThatThrownBy(() -> sql("ALTER TABLE T5 SET ('sequence.field' = 'c')"))
                 .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)


### PR DESCRIPTION
### Purpose

Currently we have some immutable table options (for example, merge-engine and primary-key). Once the table is created, they cannot be changed.

However for an empty table, changing these options does not affect any data. Also ,we've supported different schemas for different branches in #3757. Users can set primary keys to a newly created branch with this feature.

### Tests

* Unit tests.

### API and Format

No API / format changes.

### Documentation

No new feature.
