### PR TITLE
[core] Support TimestampToNumericPrimitiveCastRule in casting

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/casting/CastExecutors.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/CastExecutors.java
@@ -70,6 +70,7 @@ public class CastExecutors {
                 .addRule(TimestampToTimeCastRule.INSTANCE)
                 .addRule(DateToTimestampCastRule.INSTANCE)
                 .addRule(TimeToTimestampCastRule.INSTANCE)
+                .addRule(TimestampToNumericPrimitiveCastRule.INSTANCE)
                 // To binary rules
                 .addRule(BinaryToBinaryCastRule.INSTANCE);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToNumericPrimitiveCastRule.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToNumericPrimitiveCastRule.java
@@ -44,12 +44,15 @@ public class TimestampToNumericPrimitiveCastRule extends AbstractCastRule<Timest
 
     @Override
     public CastExecutor<Timestamp, Number> create(DataType inputType, DataType targetType) {
-        if (inputType.is(DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
-            return value -> DateTimeUtils.unixTimestamp(value.getMillisecond());
-        } else if (inputType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
-            return value ->
-                    DateTimeUtils.unixTimestamp(
-                            Timestamp.fromLocalDateTime(value.toLocalDateTime()).getMillisecond());
+        if (targetType.is(DataTypeRoot.BIGINT)) {
+            if (inputType.is(DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
+                return value -> DateTimeUtils.unixTimestamp(value.getMillisecond());
+            } else if (inputType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
+                return value ->
+                        DateTimeUtils.unixTimestamp(
+                                Timestamp.fromLocalDateTime(value.toLocalDateTime())
+                                        .getMillisecond());
+            }
         }
         return null;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToNumericPrimitiveCastRule.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToNumericPrimitiveCastRule.java
@@ -43,6 +43,7 @@ public class TimestampToNumericPrimitiveCastRule extends AbstractCastRule<Timest
     }
 
     @Override
+    @SuppressWarnings("fallthrough")
     public CastExecutor<Timestamp, Number> create(DataType inputType, DataType targetType) {
         switch (targetType.getTypeRoot()) {
             case INTEGER:

--- a/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToNumericPrimitiveCastRule.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToNumericPrimitiveCastRule.java
@@ -25,8 +25,8 @@ import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.utils.DateTimeUtils;
 
 /**
- * @link DataTypeRoot#TIMESTAMP_WITHOUT_TIME_ZONE}/{@link
- *     DataTypeRoot#TIMESTAMP_WITH_LOCAL_TIME_ZONE} to {@link DataTypeFamily#NUMERIC} cast rule.
+ * {@link DataTypeRoot#TIMESTAMP_WITHOUT_TIME_ZONE}/{@link
+ * DataTypeRoot#TIMESTAMP_WITH_LOCAL_TIME_ZONE} to {@link DataTypeFamily#NUMERIC} cast rule.
  */
 public class TimestampToNumericPrimitiveCastRule extends AbstractCastRule<Timestamp, Number> {
 
@@ -43,21 +43,14 @@ public class TimestampToNumericPrimitiveCastRule extends AbstractCastRule<Timest
     }
 
     @Override
-    @SuppressWarnings("fallthrough")
     public CastExecutor<Timestamp, Number> create(DataType inputType, DataType targetType) {
-        switch (targetType.getTypeRoot()) {
-            case INTEGER:
-            case BIGINT:
-                if (inputType.is(DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
-                    return value -> DateTimeUtils.unixTimestamp(value.getMillisecond());
-                } else if (inputType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
-                    return value ->
-                            DateTimeUtils.unixTimestamp(
-                                    Timestamp.fromLocalDateTime(value.toLocalDateTime())
-                                            .getMillisecond());
-                }
-            default:
-                return null;
+        if (inputType.is(DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
+            return value -> DateTimeUtils.unixTimestamp(value.getMillisecond());
+        } else if (inputType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
+            return value ->
+                    DateTimeUtils.unixTimestamp(
+                            Timestamp.fromLocalDateTime(value.toLocalDateTime()).getMillisecond());
         }
+        return null;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToNumericPrimitiveCastRule.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToNumericPrimitiveCastRule.java
@@ -44,13 +44,19 @@ public class TimestampToNumericPrimitiveCastRule extends AbstractCastRule<Timest
 
     @Override
     public CastExecutor<Timestamp, Number> create(DataType inputType, DataType targetType) {
-        if (inputType.is(DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
-            return value -> DateTimeUtils.unixTimestamp(value.getMillisecond());
-        } else if (inputType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
-            return value ->
-                    DateTimeUtils.unixTimestamp(
-                            Timestamp.fromLocalDateTime(value.toLocalDateTime()).getMillisecond());
+        switch (targetType.getTypeRoot()) {
+            case INTEGER:
+            case BIGINT:
+                if (inputType.is(DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
+                    return value -> DateTimeUtils.unixTimestamp(value.getMillisecond());
+                } else if (inputType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
+                    return value ->
+                            DateTimeUtils.unixTimestamp(
+                                    Timestamp.fromLocalDateTime(value.toLocalDateTime())
+                                            .getMillisecond());
+                }
+            default:
+                return null;
         }
-        return null;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToNumericPrimitiveCastRule.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToNumericPrimitiveCastRule.java
@@ -38,22 +38,34 @@ public class TimestampToNumericPrimitiveCastRule extends AbstractCastRule<Timest
                 CastRulePredicate.builder()
                         .input(DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)
                         .input(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
-                        .target(DataTypeFamily.NUMERIC)
+                        .target(DataTypeRoot.BIGINT)
+                        .target(DataTypeRoot.INTEGER)
                         .build());
     }
 
     @Override
     public CastExecutor<Timestamp, Number> create(DataType inputType, DataType targetType) {
-        if (targetType.is(DataTypeRoot.BIGINT)) {
-            if (inputType.is(DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
+        if (inputType.is(DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
+            if (targetType.is(DataTypeRoot.BIGINT)) {
                 return value -> DateTimeUtils.unixTimestamp(value.getMillisecond());
-            } else if (inputType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
+            } else if (targetType.is(DataTypeRoot.INTEGER)) {
+                return value -> (int) DateTimeUtils.unixTimestamp(value.getMillisecond());
+            }
+        } else if (inputType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
+            if (targetType.is(DataTypeRoot.BIGINT)) {
                 return value ->
                         DateTimeUtils.unixTimestamp(
                                 Timestamp.fromLocalDateTime(value.toLocalDateTime())
                                         .getMillisecond());
+            } else if (targetType.is(DataTypeRoot.INTEGER)) {
+                return value ->
+                        (int)
+                                DateTimeUtils.unixTimestamp(
+                                        Timestamp.fromLocalDateTime(value.toLocalDateTime())
+                                                .getMillisecond());
             }
         }
+
         return null;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToNumericPrimitiveCastRule.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToNumericPrimitiveCastRule.java
@@ -24,7 +24,10 @@ import org.apache.paimon.types.DataTypeFamily;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.utils.DateTimeUtils;
 
-/** {@link DataTypeFamily#TIMESTAMP} to {@link DataTypeFamily#NUMERIC} cast rule. */
+/**
+ * @link DataTypeRoot#TIMESTAMP_WITHOUT_TIME_ZONE}/{@link
+ *     DataTypeRoot#TIMESTAMP_WITH_LOCAL_TIME_ZONE} to {@link DataTypeFamily#NUMERIC} cast rule.
+ */
 public class TimestampToNumericPrimitiveCastRule extends AbstractCastRule<Timestamp, Number> {
 
     static final TimestampToNumericPrimitiveCastRule INSTANCE =

--- a/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToNumericPrimitiveCastRule.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToNumericPrimitiveCastRule.java
@@ -24,8 +24,6 @@ import org.apache.paimon.types.DataTypeFamily;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.utils.DateTimeUtils;
 
-import java.time.ZoneId;
-
 /** {@link DataTypeFamily#TIMESTAMP} to {@link DataTypeFamily#NUMERIC} cast rule. */
 public class TimestampToNumericPrimitiveCastRule extends AbstractCastRule<Timestamp, Number> {
 
@@ -43,19 +41,13 @@ public class TimestampToNumericPrimitiveCastRule extends AbstractCastRule<Timest
 
     @Override
     public CastExecutor<Timestamp, Number> create(DataType inputType, DataType targetType) {
-        ZoneId zoneId =
-                inputType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
-                        ? ZoneId.systemDefault()
-                        : DateTimeUtils.UTC_ZONE.toZoneId();
-
-        switch (targetType.getTypeRoot()) {
-            case INTEGER:
-            case BIGINT:
-                return value ->
-                        DateTimeUtils.unixTimestamp(
-                                value.toLocalDateTime().atZone(zoneId).toInstant().toEpochMilli());
-            default:
-                return null;
+        if (inputType.is(DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
+            return value -> DateTimeUtils.unixTimestamp(value.getMillisecond());
+        } else if (inputType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
+            return value ->
+                    DateTimeUtils.unixTimestamp(
+                            Timestamp.fromLocalDateTime(value.toLocalDateTime()).getMillisecond());
         }
+        return null;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToNumericPrimitiveCastRule.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/TimestampToNumericPrimitiveCastRule.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.casting;
+
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeFamily;
+import org.apache.paimon.types.DataTypeRoot;
+import org.apache.paimon.utils.DateTimeUtils;
+
+import java.time.ZoneId;
+
+/** {@link DataTypeFamily#TIMESTAMP} to {@link DataTypeFamily#NUMERIC} cast rule. */
+public class TimestampToNumericPrimitiveCastRule extends AbstractCastRule<Timestamp, Number> {
+
+    static final TimestampToNumericPrimitiveCastRule INSTANCE =
+            new TimestampToNumericPrimitiveCastRule();
+
+    private TimestampToNumericPrimitiveCastRule() {
+        super(
+                CastRulePredicate.builder()
+                        .input(DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)
+                        .input(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+                        .target(DataTypeFamily.NUMERIC)
+                        .build());
+    }
+
+    @Override
+    public CastExecutor<Timestamp, Number> create(DataType inputType, DataType targetType) {
+        ZoneId zoneId =
+                inputType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+                        ? ZoneId.systemDefault()
+                        : DateTimeUtils.UTC_ZONE.toZoneId();
+
+        switch (targetType.getTypeRoot()) {
+            case INTEGER:
+            case BIGINT:
+                return value ->
+                        DateTimeUtils.unixTimestamp(
+                                value.toLocalDateTime().atZone(zoneId).toInstant().toEpochMilli());
+            default:
+                return null;
+        }
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -296,13 +296,19 @@ public class CastExecutorTest {
                 DateTimeUtils.timestampWithLocalZoneToTimestamp(timestamp, TimeZone.getDefault());
 
         long millisecond1 =
-                timestamp
+                timestamp1
                                 .toLocalDateTime()
                                 .atZone(DateTimeUtils.UTC_ZONE.toZoneId())
                                 .toInstant()
                                 .toEpochMilli()
                         / 1000L;
-        long millisecond2 = timestamp.getMillisecond() / 1000L;
+        long millisecond2 =
+                timestamp2
+                                .toLocalDateTime()
+                                .atZone(TimeZone.getDefault().toZoneId())
+                                .toInstant()
+                                .toEpochMilli()
+                        / 1000L;
 
         compareCastResult(
                 CastExecutors.resolve(new TimestampType(3), new BigIntType(false)),

--- a/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -287,6 +287,35 @@ public class CastExecutorTest {
     }
 
     @Test
+    public void testTimestampToNumeric() {
+        long mills = 1722308674000L;
+        Timestamp timestamp = Timestamp.fromEpochMillis(mills);
+        Timestamp timestamp1 =
+                DateTimeUtils.timestampToTimestampWithLocalZone(timestamp, DateTimeUtils.UTC_ZONE);
+        Timestamp timestamp2 =
+                DateTimeUtils.timestampWithLocalZoneToTimestamp(timestamp, TimeZone.getDefault());
+
+        long millisecond1 =
+                timestamp
+                                .toLocalDateTime()
+                                .atZone(DateTimeUtils.UTC_ZONE.toZoneId())
+                                .toInstant()
+                                .toEpochMilli()
+                        / 1000L;
+        long millisecond2 = timestamp.getMillisecond() / 1000L;
+
+        compareCastResult(
+                CastExecutors.resolve(new TimestampType(3), new BigIntType(false)),
+                timestamp1,
+                millisecond1);
+
+        compareCastResult(
+                CastExecutors.resolve(new LocalZonedTimestampType(3), new BigIntType(false)),
+                timestamp2,
+                millisecond2);
+    }
+
+    @Test
     public void testTimeToString() {
         compareCastResult(
                 CastExecutors.resolve(new TimeType(2), VarCharType.STRING_TYPE),

--- a/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -288,24 +288,35 @@ public class CastExecutorTest {
 
     @Test
     public void testTimestampToNumeric() {
-        long mills = System.currentTimeMillis();
+        long mills = System.currentTimeMillis() / 1000 * 1000;
         Timestamp timestamp1 = Timestamp.fromEpochMillis(mills);
-        long millisecond1 = timestamp1.getMillisecond();
-
+        long millisecond = timestamp1.getMillisecond();
         Timestamp timestamp2 =
                 Timestamp.fromLocalDateTime(
                         DateTimeUtils.toLocalDateTime(mills, TimeZone.getDefault().toZoneId()));
-        long millisecond2 = timestamp2.getMillisecond();
+        long millisecond1 = timestamp2.getMillisecond();
 
+        // cast from TimestampType to BigIntType
         compareCastResult(
                 CastExecutors.resolve(new TimestampType(3), new BigIntType(false)),
                 timestamp1,
-                DateTimeUtils.unixTimestamp(millisecond1));
+                DateTimeUtils.unixTimestamp(millisecond));
 
         compareCastResult(
                 CastExecutors.resolve(new LocalZonedTimestampType(3), new BigIntType(false)),
                 timestamp2,
-                DateTimeUtils.unixTimestamp(millisecond2));
+                DateTimeUtils.unixTimestamp(millisecond1));
+
+        // cast from BigIntType to TimestampType
+        compareCastResult(
+                CastExecutors.resolve(new BigIntType(false), new TimestampType(3)),
+                DateTimeUtils.unixTimestamp(millisecond),
+                timestamp1);
+
+        compareCastResult(
+                CastExecutors.resolve(new BigIntType(false), new LocalZonedTimestampType(3)),
+                DateTimeUtils.unixTimestamp(millisecond),
+                timestamp2);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -288,37 +288,24 @@ public class CastExecutorTest {
 
     @Test
     public void testTimestampToNumeric() {
-        long mills = 1722308674000L;
-        Timestamp timestamp = Timestamp.fromEpochMillis(mills);
-        Timestamp timestamp1 =
-                DateTimeUtils.timestampToTimestampWithLocalZone(timestamp, DateTimeUtils.UTC_ZONE);
-        Timestamp timestamp2 =
-                DateTimeUtils.timestampWithLocalZoneToTimestamp(timestamp, TimeZone.getDefault());
+        long mills = System.currentTimeMillis();
+        Timestamp timestamp1 = Timestamp.fromEpochMillis(mills);
+        long millisecond1 = timestamp1.getMillisecond();
 
-        long millisecond1 =
-                timestamp1
-                                .toLocalDateTime()
-                                .atZone(DateTimeUtils.UTC_ZONE.toZoneId())
-                                .toInstant()
-                                .toEpochMilli()
-                        / 1000L;
-        long millisecond2 =
-                timestamp2
-                                .toLocalDateTime()
-                                .atZone(TimeZone.getDefault().toZoneId())
-                                .toInstant()
-                                .toEpochMilli()
-                        / 1000L;
+        Timestamp timestamp2 =
+                Timestamp.fromLocalDateTime(
+                        DateTimeUtils.toLocalDateTime(mills, TimeZone.getDefault().toZoneId()));
+        long millisecond2 = timestamp2.getMillisecond();
 
         compareCastResult(
                 CastExecutors.resolve(new TimestampType(3), new BigIntType(false)),
                 timestamp1,
-                millisecond1);
+                DateTimeUtils.unixTimestamp(millisecond1));
 
         compareCastResult(
                 CastExecutors.resolve(new LocalZonedTimestampType(3), new BigIntType(false)),
                 timestamp2,
-                millisecond2);
+                DateTimeUtils.unixTimestamp(millisecond2));
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -296,7 +296,7 @@ public class CastExecutorTest {
                         DateTimeUtils.toLocalDateTime(mills, TimeZone.getDefault().toZoneId()));
         long millisecond1 = timestamp2.getMillisecond();
 
-        // cast from TimestampType to BigIntType
+        // cast from TimestampType to BigIntType or IntType
         compareCastResult(
                 CastExecutors.resolve(new TimestampType(3), new BigIntType(false)),
                 timestamp1,
@@ -307,7 +307,17 @@ public class CastExecutorTest {
                 timestamp2,
                 DateTimeUtils.unixTimestamp(millisecond1));
 
-        // cast from BigIntType to TimestampType
+        compareCastResult(
+                CastExecutors.resolve(new TimestampType(3), new IntType(false)),
+                timestamp1,
+                (int) DateTimeUtils.unixTimestamp(millisecond));
+
+        compareCastResult(
+                CastExecutors.resolve(new LocalZonedTimestampType(3), new IntType(false)),
+                timestamp2,
+                (int) DateTimeUtils.unixTimestamp(millisecond1));
+
+        // cast from BigIntType or IntType to TimestampType
         compareCastResult(
                 CastExecutors.resolve(new BigIntType(false), new TimestampType(3)),
                 DateTimeUtils.unixTimestamp(millisecond),
@@ -316,6 +326,16 @@ public class CastExecutorTest {
         compareCastResult(
                 CastExecutors.resolve(new BigIntType(false), new LocalZonedTimestampType(3)),
                 DateTimeUtils.unixTimestamp(millisecond),
+                timestamp2);
+
+        compareCastResult(
+                CastExecutors.resolve(new IntType(false), new TimestampType(3)),
+                (int) DateTimeUtils.unixTimestamp(millisecond),
+                timestamp1);
+
+        compareCastResult(
+                CastExecutors.resolve(new IntType(false), new LocalZonedTimestampType(3)),
+                (int) DateTimeUtils.unixTimestamp(millisecond),
                 timestamp2);
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Follow up https://github.com/apache/paimon/pull/3832 had support NumericPrimitive  to Timestamp  casting，this pr support Timestamp to NumericPrimitive  casting.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
CastExecutorTest##testTimestampToNumeric

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
