### PR TITLE
[core] Introduce cache.manifest-max-memory to CachingCatalog

### DIFF
--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -45,10 +45,22 @@ under the License.
             <td>Controls the duration for which databases and tables in the catalog are cached.</td>
         </tr>
         <tr>
-            <td><h5>cache.manifest-max-memory</h5></td>
-            <td style="word-wrap: break-word;">0 bytes</td>
+            <td><h5>cache.manifest.max-memory</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>MemorySize</td>
             <td>Controls the maximum memory to cache manifest content.</td>
+        </tr>
+        <tr>
+            <td><h5>cache.manifest.small-file-memory</h5></td>
+            <td style="word-wrap: break-word;">128 mb</td>
+            <td>MemorySize</td>
+            <td>Controls the cache memory to cache small manifest files.</td>
+        </tr>
+        <tr>
+            <td><h5>cache.manifest.small-file-threshold</h5></td>
+            <td style="word-wrap: break-word;">512 kb</td>
+            <td>MemorySize</td>
+            <td>Controls the threshold of small manifest file.</td>
         </tr>
         <tr>
             <td><h5>client-pool-size</h5></td>

--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -58,7 +58,7 @@ under the License.
         </tr>
         <tr>
             <td><h5>cache.manifest.small-file-threshold</h5></td>
-            <td style="word-wrap: break-word;">512 kb</td>
+            <td style="word-wrap: break-word;">1 mb</td>
             <td>MemorySize</td>
             <td>Controls the threshold of small manifest file.</td>
         </tr>

--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -45,6 +45,12 @@ under the License.
             <td>Controls the duration for which databases and tables in the catalog are cached.</td>
         </tr>
         <tr>
+            <td><h5>cache.manifest-max-memory</h5></td>
+            <td style="word-wrap: break-word;">0 bytes</td>
+            <td>MemorySize</td>
+            <td>Controls the maximum memory to cache manifest content.</td>
+        </tr>
+        <tr>
             <td><h5>client-pool-size</h5></td>
             <td style="word-wrap: break-word;">2</td>
             <td>Integer</td>

--- a/paimon-common/src/main/java/org/apache/paimon/codegen/CompileUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/codegen/CompileUtils.java
@@ -20,7 +20,6 @@ package org.apache.paimon.codegen;
 
 import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
 import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Caffeine;
-import org.apache.paimon.shade.guava30.com.google.common.util.concurrent.MoreExecutors;
 
 import org.codehaus.janino.SimpleCompiler;
 import org.slf4j.Logger;
@@ -46,12 +45,12 @@ public final class CompileUtils {
      */
     static final Cache<ClassKey, Class<?>> COMPILED_CLASS_CACHE =
             Caffeine.newBuilder()
+                    .softValues()
                     // estimated maximum planning/startup time
                     .expireAfterAccess(Duration.ofMinutes(5))
                     // estimated cache size
                     .maximumSize(300)
-                    .softValues()
-                    .executor(MoreExecutors.directExecutor())
+                    .executor(Runnable::run)
                     .build();
 
     /**

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -105,10 +105,22 @@ public class CatalogOptions {
                     .withDescription(
                             "Controls the duration for which databases and tables in the catalog are cached.");
 
-    public static final ConfigOption<MemorySize> CACHE_MANIFEST_MAX_MEMORY =
-            key("cache.manifest-max-memory")
+    public static final ConfigOption<MemorySize> CACHE_MANIFEST_SMALL_FILE_MEMORY =
+            key("cache.manifest.small-file-memory")
                     .memoryType()
-                    .defaultValue(MemorySize.ofMebiBytes(0))
+                    .defaultValue(MemorySize.ofMebiBytes(128))
+                    .withDescription("Controls the cache memory to cache small manifest files.");
+
+    public static final ConfigOption<MemorySize> CACHE_MANIFEST_SMALL_FILE_THRESHOLD =
+            key("cache.manifest.small-file-threshold")
+                    .memoryType()
+                    .defaultValue(MemorySize.ofKibiBytes(512))
+                    .withDescription("Controls the threshold of small manifest file.");
+
+    public static final ConfigOption<MemorySize> CACHE_MANIFEST_MAX_MEMORY =
+            key("cache.manifest.max-memory")
+                    .memoryType()
+                    .noDefaultValue()
                     .withDescription("Controls the maximum memory to cache manifest content.");
 
     public static final ConfigOption<String> LINEAGE_META =

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -114,7 +114,7 @@ public class CatalogOptions {
     public static final ConfigOption<MemorySize> CACHE_MANIFEST_SMALL_FILE_THRESHOLD =
             key("cache.manifest.small-file-threshold")
                     .memoryType()
-                    .defaultValue(MemorySize.ofKibiBytes(512))
+                    .defaultValue(MemorySize.ofMebiBytes(1))
                     .withDescription("Controls the threshold of small manifest file.");
 
     public static final ConfigOption<MemorySize> CACHE_MANIFEST_MAX_MEMORY =

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -105,6 +105,12 @@ public class CatalogOptions {
                     .withDescription(
                             "Controls the duration for which databases and tables in the catalog are cached.");
 
+    public static final ConfigOption<MemorySize> CACHE_MANIFEST_MAX_MEMORY =
+            key("cache.manifest-max-memory")
+                    .memoryType()
+                    .defaultValue(MemorySize.ofMebiBytes(0))
+                    .withDescription("Controls the maximum memory to cache manifest content.");
+
     public static final ConfigOption<String> LINEAGE_META =
             key("lineage-meta")
                     .stringType()

--- a/paimon-common/src/main/java/org/apache/paimon/reader/RecordReaderIterator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/reader/RecordReaderIterator.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.reader;
 
 import org.apache.paimon.utils.CloseableIterator;
+import org.apache.paimon.utils.IOUtils;
 
 import java.io.IOException;
 
@@ -34,7 +35,8 @@ public class RecordReaderIterator<T> implements CloseableIterator<T> {
         this.reader = reader;
         try {
             this.currentIterator = reader.readBatch();
-        } catch (IOException e) {
+        } catch (Exception e) {
+            IOUtils.closeQuietly(reader);
             throw new RuntimeException(e);
         }
         this.advanced = false;

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -92,7 +92,8 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
         this.partitionType = partitionType;
         this.catalogEnvironment = catalogEnvironment;
         this.writeManifestCache =
-                SegmentsCache.create(options.pageSize(), options.writeManifestCache());
+                SegmentsCache.create(
+                        options.pageSize(), options.writeManifestCache(), Long.MAX_VALUE);
     }
 
     @Override
@@ -142,7 +143,11 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
 
     protected IndexManifestFile.Factory indexManifestFileFactory() {
         return new IndexManifestFile.Factory(
-                fileIO, options.manifestFormat(), options.manifestCompression(), pathFactory());
+                fileIO,
+                options.manifestFormat(),
+                options.manifestCompression(),
+                pathFactory(),
+                readManifestCache);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/FileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/FileStore.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon;
 
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.manifest.ManifestFile;
@@ -38,6 +39,7 @@ import org.apache.paimon.table.sink.TagCallback;
 import org.apache.paimon.tag.TagAutoManager;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.SegmentsCache;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
@@ -100,4 +102,6 @@ public interface FileStore<T> {
     boolean mergeSchema(RowType rowType, boolean allowExplicitCast);
 
     List<TagCallback> createTagCallbacks();
+
+    void setManifestCache(SegmentsCache<Path> manifestCache);
 }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
@@ -62,7 +62,6 @@ public class CachingCatalog extends DelegateCatalog {
     protected final Cache<String, Map<String, String>> databaseCache;
     protected final Cache<Identifier, Table> tableCache;
     @Nullable protected final SegmentsCache<Path> manifestCache;
-    protected final long manifestCacheThreshold;
 
     public CachingCatalog(Catalog wrapped) {
         this(
@@ -92,7 +91,6 @@ public class CachingCatalog extends DelegateCatalog {
             long manifestCacheThreshold,
             Ticker ticker) {
         super(wrapped);
-        this.manifestCacheThreshold = manifestCacheThreshold;
         if (expirationInterval.isZero() || expirationInterval.isNegative()) {
             throw new IllegalArgumentException(
                     "When cache.expiration-interval is set to negative or 0, the catalog cache should be disabled.");

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
@@ -18,11 +18,14 @@
 
 package org.apache.paimon.catalog;
 
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.utils.Preconditions;
+import org.apache.paimon.utils.SegmentsCache;
 
 import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
 import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Caffeine;
@@ -34,6 +37,8 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +46,7 @@ import java.util.Map;
 
 import static org.apache.paimon.catalog.AbstractCatalog.isSpecifiedSystemTable;
 import static org.apache.paimon.options.CatalogOptions.CACHE_EXPIRATION_INTERVAL_MS;
+import static org.apache.paimon.options.CatalogOptions.CACHE_MANIFEST_MAX_MEMORY;
 import static org.apache.paimon.table.system.SystemTableLoader.SYSTEM_TABLES;
 
 /** A {@link Catalog} to cache databases and tables and manifests. */
@@ -50,16 +56,25 @@ public class CachingCatalog extends DelegateCatalog {
 
     protected final Cache<String, Map<String, String>> databaseCache;
     protected final Cache<Identifier, Table> tableCache;
+    @Nullable protected final SegmentsCache<Path> manifestCache;
 
     public CachingCatalog(Catalog wrapped) {
-        this(wrapped, CACHE_EXPIRATION_INTERVAL_MS.defaultValue());
+        this(
+                wrapped,
+                CACHE_EXPIRATION_INTERVAL_MS.defaultValue(),
+                CACHE_MANIFEST_MAX_MEMORY.defaultValue());
     }
 
-    public CachingCatalog(Catalog wrapped, Duration expirationInterval) {
-        this(wrapped, expirationInterval, Ticker.systemTicker());
+    public CachingCatalog(
+            Catalog wrapped, Duration expirationInterval, MemorySize manifestMaxMemory) {
+        this(wrapped, expirationInterval, manifestMaxMemory, Ticker.systemTicker());
     }
 
-    public CachingCatalog(Catalog wrapped, Duration expirationInterval, Ticker ticker) {
+    public CachingCatalog(
+            Catalog wrapped,
+            Duration expirationInterval,
+            MemorySize manifestMaxMemory,
+            Ticker ticker) {
         super(wrapped);
         if (expirationInterval.isZero() || expirationInterval.isNegative()) {
             throw new IllegalArgumentException(
@@ -81,6 +96,7 @@ public class CachingCatalog extends DelegateCatalog {
                         .expireAfterAccess(expirationInterval)
                         .ticker(ticker)
                         .build();
+        this.manifestCache = SegmentsCache.create(manifestMaxMemory);
     }
 
     @Override
@@ -151,7 +167,7 @@ public class CachingCatalog extends DelegateCatalog {
             Table originTable = tableCache.getIfPresent(originIdentifier);
             if (originTable == null) {
                 originTable = wrapped.getTable(originIdentifier);
-                tableCache.put(originIdentifier, originTable);
+                putTableCache(originIdentifier, originTable);
             }
             table =
                     SystemTableLoader.load(
@@ -160,13 +176,20 @@ public class CachingCatalog extends DelegateCatalog {
             if (table == null) {
                 throw new TableNotExistException(identifier);
             }
-            tableCache.put(identifier, table);
+            putTableCache(identifier, table);
             return table;
         }
 
         table = wrapped.getTable(identifier);
-        tableCache.put(identifier, table);
+        putTableCache(identifier, table);
         return table;
+    }
+
+    private void putTableCache(Identifier identifier, Table table) {
+        if (manifestCache != null && table instanceof FileStoreTable) {
+            ((FileStoreTable) table).setManifestCache(manifestCache);
+        }
+        tableCache.put(identifier, table);
     }
 
     private class TableInvalidatingRemovalListener implements RemovalListener<Identifier, Table> {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogFactory.java
@@ -34,6 +34,7 @@ import java.io.UncheckedIOException;
 
 import static org.apache.paimon.options.CatalogOptions.CACHE_ENABLED;
 import static org.apache.paimon.options.CatalogOptions.CACHE_EXPIRATION_INTERVAL_MS;
+import static org.apache.paimon.options.CatalogOptions.CACHE_MANIFEST_MAX_MEMORY;
 import static org.apache.paimon.options.CatalogOptions.METASTORE;
 import static org.apache.paimon.options.CatalogOptions.WAREHOUSE;
 
@@ -76,7 +77,11 @@ public interface CatalogFactory extends Factory {
 
         Options options = context.options();
         if (options.get(CACHE_ENABLED)) {
-            catalog = new CachingCatalog(catalog, options.get(CACHE_EXPIRATION_INTERVAL_MS));
+            catalog =
+                    new CachingCatalog(
+                            catalog,
+                            options.get(CACHE_EXPIRATION_INTERVAL_MS),
+                            options.get(CACHE_MANIFEST_MAX_MEMORY));
         }
 
         PrivilegeManager privilegeManager =

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogFactory.java
@@ -24,17 +24,12 @@ import org.apache.paimon.factories.FactoryUtil;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.options.Options;
-import org.apache.paimon.privilege.FileBasedPrivilegeManager;
-import org.apache.paimon.privilege.PrivilegeManager;
 import org.apache.paimon.privilege.PrivilegedCatalog;
 import org.apache.paimon.utils.Preconditions;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-import static org.apache.paimon.options.CatalogOptions.CACHE_ENABLED;
-import static org.apache.paimon.options.CatalogOptions.CACHE_EXPIRATION_INTERVAL_MS;
-import static org.apache.paimon.options.CatalogOptions.CACHE_MANIFEST_MAX_MEMORY;
 import static org.apache.paimon.options.CatalogOptions.METASTORE;
 import static org.apache.paimon.options.CatalogOptions.WAREHOUSE;
 
@@ -74,27 +69,9 @@ public interface CatalogFactory extends Factory {
 
     static Catalog createCatalog(CatalogContext context, ClassLoader classLoader) {
         Catalog catalog = createUnwrappedCatalog(context, classLoader);
-
         Options options = context.options();
-        if (options.get(CACHE_ENABLED)) {
-            catalog =
-                    new CachingCatalog(
-                            catalog,
-                            options.get(CACHE_EXPIRATION_INTERVAL_MS),
-                            options.get(CACHE_MANIFEST_MAX_MEMORY));
-        }
-
-        PrivilegeManager privilegeManager =
-                new FileBasedPrivilegeManager(
-                        catalog.warehouse(),
-                        catalog.fileIO(),
-                        context.options().get(PrivilegedCatalog.USER),
-                        context.options().get(PrivilegedCatalog.PASSWORD));
-        if (privilegeManager.privilegeEnabled()) {
-            catalog = new PrivilegedCatalog(catalog, privilegeManager);
-        }
-
-        return catalog;
+        catalog = CachingCatalog.tryToCreate(catalog, options);
+        return PrivilegedCatalog.tryToCreate(catalog, options);
     }
 
     static Catalog createUnwrappedCatalog(CatalogContext context, ClassLoader classLoader) {

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestFile.java
@@ -67,6 +67,7 @@ public class IcebergManifestFile extends ObjectsFile<IcebergManifestEntry> {
         super(
                 fileIO,
                 new IcebergManifestEntrySerializer(partitionType),
+                IcebergManifestEntry.schema(partitionType),
                 readerFactory,
                 writerFactory,
                 compression,

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestList.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestList.java
@@ -39,6 +39,7 @@ public class IcebergManifestList extends ObjectsFile<IcebergManifestFileMeta> {
         super(
                 fileIO,
                 new IcebergManifestFileMetaSerializer(),
+                IcebergManifestFileMeta.schema(),
                 readerFactory,
                 writerFactory,
                 compression,

--- a/paimon-core/src/main/java/org/apache/paimon/index/IndexFileHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/IndexFileHandler.java
@@ -197,26 +197,6 @@ public class IndexFileHandler {
         return result;
     }
 
-    public List<IndexManifestEntry> scanEntries(String indexType, BinaryRow partition, int bucket) {
-        Snapshot snapshot = snapshotManager.latestSnapshot();
-        if (snapshot == null) {
-            return Collections.emptyList();
-        }
-        String indexManifest = snapshot.indexManifest();
-        if (indexManifest == null) {
-            return Collections.emptyList();
-        }
-        List<IndexManifestEntry> result = new ArrayList<>();
-        for (IndexManifestEntry file : indexManifestFile.read(indexManifest)) {
-            if (file.indexFile().indexType().equals(indexType)
-                    && file.partition().equals(partition)
-                    && file.bucket() == bucket) {
-                result.add(file);
-            }
-        }
-        return result;
-    }
-
     public Path filePath(IndexFileMeta file) {
         return pathFactory.toPath(file.fileName());
     }

--- a/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBState.java
+++ b/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBState.java
@@ -29,7 +29,6 @@ import org.apache.paimon.types.RowType;
 
 import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
 import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Caffeine;
-import org.apache.paimon.shade.guava30.com.google.common.util.concurrent.MoreExecutors;
 
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDB;
@@ -80,8 +79,9 @@ public abstract class RocksDBState<K, V, CacheV> {
         this.writeOptions = new WriteOptions().setDisableWAL(true);
         this.cache =
                 Caffeine.newBuilder()
+                        .softValues()
                         .maximumSize(lruCacheSize)
-                        .executor(MoreExecutors.directExecutor())
+                        .executor(Runnable::run)
                         .build();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestFile.java
@@ -22,11 +22,13 @@ import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.format.FormatReaderFactory;
 import org.apache.paimon.format.FormatWriterFactory;
 import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.ObjectsFile;
 import org.apache.paimon.utils.PathFactory;
+import org.apache.paimon.utils.SegmentsCache;
 import org.apache.paimon.utils.VersionedObjectSerializer;
 
 import javax.annotation.Nullable;
@@ -41,7 +43,8 @@ public class IndexManifestFile extends ObjectsFile<IndexManifestEntry> {
             FormatReaderFactory readerFactory,
             FormatWriterFactory writerFactory,
             String compression,
-            PathFactory pathFactory) {
+            PathFactory pathFactory,
+            @Nullable SegmentsCache<Path> cache) {
         super(
                 fileIO,
                 new IndexManifestEntrySerializer(),
@@ -49,7 +52,7 @@ public class IndexManifestFile extends ObjectsFile<IndexManifestEntry> {
                 writerFactory,
                 compression,
                 pathFactory,
-                null);
+                cache);
     }
 
     /** Write new index files to index manifest. */
@@ -72,16 +75,19 @@ public class IndexManifestFile extends ObjectsFile<IndexManifestEntry> {
         private final FileFormat fileFormat;
         private final String compression;
         private final FileStorePathFactory pathFactory;
+        @Nullable private final SegmentsCache<Path> cache;
 
         public Factory(
                 FileIO fileIO,
                 FileFormat fileFormat,
                 String compression,
-                FileStorePathFactory pathFactory) {
+                FileStorePathFactory pathFactory,
+                @Nullable SegmentsCache<Path> cache) {
             this.fileIO = fileIO;
             this.fileFormat = fileFormat;
             this.compression = compression;
             this.pathFactory = pathFactory;
+            this.cache = cache;
         }
 
         public IndexManifestFile create() {
@@ -91,7 +97,8 @@ public class IndexManifestFile extends ObjectsFile<IndexManifestEntry> {
                     fileFormat.createReaderFactory(schema),
                     fileFormat.createWriterFactory(schema),
                     compression,
-                    pathFactory.indexManifestFileFactory());
+                    pathFactory.indexManifestFileFactory(),
+                    cache);
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestFile.java
@@ -40,6 +40,7 @@ public class IndexManifestFile extends ObjectsFile<IndexManifestEntry> {
 
     private IndexManifestFile(
             FileIO fileIO,
+            RowType schema,
             FormatReaderFactory readerFactory,
             FormatWriterFactory writerFactory,
             String compression,
@@ -48,6 +49,7 @@ public class IndexManifestFile extends ObjectsFile<IndexManifestEntry> {
         super(
                 fileIO,
                 new IndexManifestEntrySerializer(),
+                schema,
                 readerFactory,
                 writerFactory,
                 compression,
@@ -94,6 +96,7 @@ public class IndexManifestFile extends ObjectsFile<IndexManifestEntry> {
             RowType schema = VersionedObjectSerializer.versionType(IndexManifestEntry.schema());
             return new IndexManifestFile(
                     fileIO,
+                    schema,
                     fileFormat.createReaderFactory(schema),
                     fileFormat.createWriterFactory(schema),
                     compression,

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java
@@ -62,7 +62,7 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
             String compression,
             PathFactory pathFactory,
             long suggestedFileSize,
-            @Nullable SegmentsCache<String> cache) {
+            @Nullable SegmentsCache<Path> cache) {
         super(fileIO, serializer, readerFactory, writerFactory, compression, pathFactory, cache);
         this.schemaManager = schemaManager;
         this.partitionType = partitionType;
@@ -156,7 +156,7 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
         private final String compression;
         private final FileStorePathFactory pathFactory;
         private final long suggestedFileSize;
-        @Nullable private final SegmentsCache<String> cache;
+        @Nullable private final SegmentsCache<Path> cache;
 
         public Factory(
                 FileIO fileIO,
@@ -166,7 +166,7 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
                 String compression,
                 FileStorePathFactory pathFactory,
                 long suggestedFileSize,
-                @Nullable SegmentsCache<String> cache) {
+                @Nullable SegmentsCache<Path> cache) {
             this.fileIO = fileIO;
             this.schemaManager = schemaManager;
             this.partitionType = partitionType;

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java
@@ -57,13 +57,22 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
             SchemaManager schemaManager,
             RowType partitionType,
             ManifestEntrySerializer serializer,
+            RowType schema,
             FormatReaderFactory readerFactory,
             FormatWriterFactory writerFactory,
             String compression,
             PathFactory pathFactory,
             long suggestedFileSize,
             @Nullable SegmentsCache<Path> cache) {
-        super(fileIO, serializer, readerFactory, writerFactory, compression, pathFactory, cache);
+        super(
+                fileIO,
+                serializer,
+                schema,
+                readerFactory,
+                writerFactory,
+                compression,
+                pathFactory,
+                cache);
         this.schemaManager = schemaManager;
         this.partitionType = partitionType;
         this.writerFactory = writerFactory;
@@ -184,6 +193,7 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
                     schemaManager,
                     partitionType,
                     new ManifestEntrySerializer(),
+                    entryType,
                     fileFormat.createReaderFactory(entryType),
                     fileFormat.createWriterFactory(entryType),
                     compression,
@@ -197,6 +207,7 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
             return new ObjectsFile<>(
                     fileIO,
                     new SimpleFileEntrySerializer(),
+                    entryType,
                     fileFormat.createReaderFactory(entryType),
                     fileFormat.createWriterFactory(entryType),
                     compression,

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestList.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestList.java
@@ -22,6 +22,7 @@ import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.format.FormatReaderFactory;
 import org.apache.paimon.format.FormatWriterFactory;
 import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.ObjectsFile;
@@ -46,7 +47,7 @@ public class ManifestList extends ObjectsFile<ManifestFileMeta> {
             FormatWriterFactory writerFactory,
             String compression,
             PathFactory pathFactory,
-            @Nullable SegmentsCache<String> cache) {
+            @Nullable SegmentsCache<Path> cache) {
         super(fileIO, serializer, readerFactory, writerFactory, compression, pathFactory, cache);
     }
 
@@ -66,14 +67,14 @@ public class ManifestList extends ObjectsFile<ManifestFileMeta> {
         private final FileFormat fileFormat;
         private final String compression;
         private final FileStorePathFactory pathFactory;
-        @Nullable private final SegmentsCache<String> cache;
+        @Nullable private final SegmentsCache<Path> cache;
 
         public Factory(
                 FileIO fileIO,
                 FileFormat fileFormat,
                 String compression,
                 FileStorePathFactory pathFactory,
-                @Nullable SegmentsCache<String> cache) {
+                @Nullable SegmentsCache<Path> cache) {
             this.fileIO = fileIO;
             this.fileFormat = fileFormat;
             this.compression = compression;

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestList.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestList.java
@@ -43,12 +43,21 @@ public class ManifestList extends ObjectsFile<ManifestFileMeta> {
     private ManifestList(
             FileIO fileIO,
             ManifestFileMetaSerializer serializer,
+            RowType schema,
             FormatReaderFactory readerFactory,
             FormatWriterFactory writerFactory,
             String compression,
             PathFactory pathFactory,
             @Nullable SegmentsCache<Path> cache) {
-        super(fileIO, serializer, readerFactory, writerFactory, compression, pathFactory, cache);
+        super(
+                fileIO,
+                serializer,
+                schema,
+                readerFactory,
+                writerFactory,
+                compression,
+                pathFactory,
+                cache);
     }
 
     /**
@@ -87,6 +96,7 @@ public class ManifestList extends ObjectsFile<ManifestFileMeta> {
             return new ManifestList(
                     fileIO,
                     new ManifestFileMetaSerializer(),
+                    metaType,
                     fileFormat.createReaderFactory(metaType),
                     fileFormat.createWriterFactory(metaType),
                     compression,

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/SimpleFileEntrySerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/SimpleFileEntrySerializer.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.manifest;
 
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.utils.VersionedObjectSerializer;
 
 import static org.apache.paimon.utils.SerializationUtils.deserializeBinaryRow;
@@ -51,7 +52,7 @@ public class SimpleFileEntrySerializer extends VersionedObjectSerializer<SimpleF
             throw new IllegalArgumentException("Unsupported version: " + version);
         }
 
-        InternalRow file = row.getRow(4, 3);
+        InternalRow file = row.getRow(4, DataFileMeta.SCHEMA.getFieldCount());
         return new SimpleFileEntry(
                 FileKind.fromByteValue(row.getByte(0)),
                 deserializeBinaryRow(row.getBinary(1)),

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/LookupFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/LookupFile.java
@@ -28,7 +28,6 @@ import org.apache.paimon.utils.FileIOUtils;
 import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
 import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.RemovalCause;
-import org.apache.paimon.shade.guava30.com.google.common.util.concurrent.MoreExecutors;
 
 import javax.annotation.Nullable;
 
@@ -91,7 +90,7 @@ public class LookupFile implements Closeable {
                 .maximumWeight(maxDiskSize.getKibiBytes())
                 .weigher(LookupFile::fileWeigh)
                 .removalListener(LookupFile::removalCallback)
-                .executor(MoreExecutors.directExecutor())
+                .executor(Runnable::run)
                 .build();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStore.java
@@ -21,6 +21,7 @@ package org.apache.paimon.privilege;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.FileStore;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.manifest.ManifestFile;
@@ -41,6 +42,7 @@ import org.apache.paimon.table.sink.TagCallback;
 import org.apache.paimon.tag.TagAutoManager;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.SegmentsCache;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
@@ -50,8 +52,6 @@ import java.util.List;
 
 /** {@link FileStore} with privilege checks. */
 public class PrivilegedFileStore<T> implements FileStore<T> {
-
-    private static final long serialVersionUID = 1L;
 
     private final FileStore<T> wrapped;
     private final PrivilegeChecker privilegeChecker;
@@ -198,5 +198,10 @@ public class PrivilegedFileStore<T> implements FileStore<T> {
     @Override
     public List<TagCallback> createTagCallbacks() {
         return wrapped.createTagCallbacks();
+    }
+
+    @Override
+    public void setManifestCache(SegmentsCache<Path> manifestCache) {
+        wrapped.setManifestCache(manifestCache);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -58,6 +58,7 @@ import org.apache.paimon.table.source.snapshot.StaticFromTimestampStartingScanne
 import org.apache.paimon.table.source.snapshot.StaticFromWatermarkStartingScanner;
 import org.apache.paimon.tag.TagPreview;
 import org.apache.paimon.utils.BranchManager;
+import org.apache.paimon.utils.SegmentsCache;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
@@ -106,6 +107,11 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
         }
         this.tableSchema = tableSchema;
         this.catalogEnvironment = catalogEnvironment;
+    }
+
+    @Override
+    public void setManifestCache(SegmentsCache<Path> manifestCache) {
+        store().setManifestCache(manifestCache);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/DelegatedFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/DelegatedFileStoreTable.java
@@ -35,6 +35,7 @@ import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.StreamDataTableScan;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.utils.BranchManager;
+import org.apache.paimon.utils.SegmentsCache;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
@@ -95,6 +96,11 @@ public abstract class DelegatedFileStoreTable implements FileStoreTable {
     @Override
     public FileIO fileIO() {
         return wrapped.fileIO();
+    }
+
+    @Override
+    public void setManifestCache(SegmentsCache<Path> manifestCache) {
+        wrapped.setManifestCache(manifestCache);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTable.java
@@ -20,6 +20,7 @@ package org.apache.paimon.table;
 
 import org.apache.paimon.FileStore;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.schema.TableSchema;
@@ -29,6 +30,7 @@ import org.apache.paimon.table.sink.RowKeyExtractor;
 import org.apache.paimon.table.sink.TableCommitImpl;
 import org.apache.paimon.table.sink.TableWriteImpl;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.SegmentsCache;
 
 import java.util.List;
 import java.util.Map;
@@ -39,6 +41,8 @@ import java.util.Optional;
  * InternalRow}.
  */
 public interface FileStoreTable extends DataTable {
+
+    void setManifestCache(SegmentsCache<Path> manifestCache);
 
     @Override
     default RowType rowType() {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsCache.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsCache.java
@@ -35,7 +35,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BiFunction;
 
 import static org.apache.paimon.utils.ObjectsFile.readFromIterator;
 
@@ -47,14 +46,14 @@ public class ObjectsCache<K, V> {
     private final ObjectSerializer<V> projectedSerializer;
     private final ThreadLocal<InternalRowSerializer> formatSerializer;
     private final FunctionWithIOException<K, Long> fileSizeFunction;
-    private final BiFunction<K, Long, CloseableIterator<InternalRow>> reader;
+    private final BiFunctionWithIOE<K, Long, CloseableIterator<InternalRow>> reader;
 
     public ObjectsCache(
             SegmentsCache<K> cache,
             ObjectSerializer<V> projectedSerializer,
             RowType formatSchema,
             FunctionWithIOException<K, Long> fileSizeFunction,
-            BiFunction<K, Long, CloseableIterator<InternalRow>> reader) {
+            BiFunctionWithIOE<K, Long, CloseableIterator<InternalRow>> reader) {
         this.cache = cache;
         this.projectedSerializer = projectedSerializer;
         this.formatSerializer =

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
@@ -165,13 +165,10 @@ public class ObjectsFile<T> {
         }
     }
 
-    private CloseableIterator<InternalRow> createIterator(Path file, @Nullable Long fileSize) {
-        try {
-            return FileUtils.createFormatReader(fileIO, readerFactory, file, fileSize)
-                    .toCloseableIterator();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+    private CloseableIterator<InternalRow> createIterator(Path file, @Nullable Long fileSize)
+            throws IOException {
+        return FileUtils.createFormatReader(fileIO, readerFactory, file, fileSize)
+                .toCloseableIterator();
     }
 
     private long fileSize(Path file) throws IOException {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
@@ -25,6 +25,7 @@ import org.apache.paimon.format.FormatWriterFactory;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.types.RowType;
 
 import javax.annotation.Nullable;
 
@@ -52,6 +53,7 @@ public class ObjectsFile<T> {
     public ObjectsFile(
             FileIO fileIO,
             ObjectSerializer<T> serializer,
+            RowType formatType,
             FormatReaderFactory readerFactory,
             FormatWriterFactory writerFactory,
             String compression,
@@ -67,7 +69,11 @@ public class ObjectsFile<T> {
                 cache == null
                         ? null
                         : new ObjectsCache<>(
-                                cache, serializer, this::fileSize, this::createIterator);
+                                cache,
+                                serializer,
+                                formatType,
+                                this::fileSize,
+                                this::createIterator);
     }
 
     public FileIO fileIO() {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SegmentsCache.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SegmentsCache.java
@@ -35,6 +35,7 @@ public class SegmentsCache<T> {
 
     private final int pageSize;
     private final Cache<T, Segments> cache;
+    private final MemorySize maxMemorySize;
     private final long maxElementSize;
 
     public SegmentsCache(int pageSize, MemorySize maxMemorySize, long maxElementSize) {
@@ -46,11 +47,16 @@ public class SegmentsCache<T> {
                         .maximumWeight(maxMemorySize.getBytes())
                         .executor(Runnable::run)
                         .build();
+        this.maxMemorySize = maxMemorySize;
         this.maxElementSize = maxElementSize;
     }
 
     public int pageSize() {
         return pageSize;
+    }
+
+    public MemorySize maxMemorySize() {
+        return maxMemorySize;
     }
 
     public long maxElementSize() {

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
@@ -39,6 +39,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.FileNotFoundException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -297,10 +298,21 @@ class CachingCatalogTest extends CatalogTestBase {
 
     @Test
     public void testManifestCache() throws Exception {
+        innerTestManifestCache(Long.MAX_VALUE);
+        assertThatThrownBy(() -> innerTestManifestCache(10))
+                .hasRootCauseInstanceOf(FileNotFoundException.class);
+    }
+
+    private void innerTestManifestCache(long manifestCacheThreshold) throws Exception {
         Catalog catalog =
-                new CachingCatalog(this.catalog, Duration.ofSeconds(10), MemorySize.ofMebiBytes(1));
+                new CachingCatalog(
+                        this.catalog,
+                        Duration.ofSeconds(10),
+                        MemorySize.ofMebiBytes(1),
+                        manifestCacheThreshold);
         Identifier tableIdent = new Identifier("db", "tbl");
-        catalog.createTable(new Identifier("db", "tbl"), DEFAULT_TABLE_SCHEMA, false);
+        catalog.dropTable(tableIdent, true);
+        catalog.createTable(tableIdent, DEFAULT_TABLE_SCHEMA, false);
 
         // write
         Table table = catalog.getTable(tableIdent);

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/TestableCachingCatalog.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/TestableCachingCatalog.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.catalog;
 
+import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.table.Table;
 
 import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
@@ -35,7 +36,7 @@ public class TestableCachingCatalog extends CachingCatalog {
     private final Duration cacheExpirationInterval;
 
     public TestableCachingCatalog(Catalog catalog, Duration expirationInterval, Ticker ticker) {
-        super(catalog, expirationInterval, ticker);
+        super(catalog, expirationInterval, MemorySize.ZERO, ticker);
         this.cacheExpirationInterval = expirationInterval;
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/TestableCachingCatalog.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/TestableCachingCatalog.java
@@ -36,7 +36,7 @@ public class TestableCachingCatalog extends CachingCatalog {
     private final Duration cacheExpirationInterval;
 
     public TestableCachingCatalog(Catalog catalog, Duration expirationInterval, Ticker ticker) {
-        super(catalog, expirationInterval, MemorySize.ZERO, ticker);
+        super(catalog, expirationInterval, MemorySize.ZERO, Long.MAX_VALUE, ticker);
         this.cacheExpirationInterval = expirationInterval;
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/IndexManifestFileHandlerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/IndexManifestFileHandlerTest.java
@@ -47,7 +47,8 @@ public class IndexManifestFileHandlerTest {
                                 fileStore.fileIO(),
                                 fileStore.options().manifestFormat(),
                                 "zstd",
-                                fileStore.pathFactory())
+                                fileStore.pathFactory(),
+                                null)
                         .create();
         IndexManifestFileHandler indexManifestFileHandler =
                 new IndexManifestFileHandler(indexManifestFile, BucketMode.BUCKET_UNAWARE);
@@ -81,7 +82,8 @@ public class IndexManifestFileHandlerTest {
                                 fileStore.fileIO(),
                                 fileStore.options().manifestFormat(),
                                 "zstd",
-                                fileStore.pathFactory())
+                                fileStore.pathFactory(),
+                                null)
                         .create();
         IndexManifestFileHandler indexManifestFileHandler =
                 new IndexManifestFileHandler(indexManifestFile, BucketMode.HASH_FIXED);

--- a/paimon-core/src/test/java/org/apache/paimon/utils/ObjectsCacheTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/ObjectsCacheTest.java
@@ -47,7 +47,7 @@ public class ObjectsCacheTest {
                         new SegmentsCache<>(1024, MemorySize.ofKibiBytes(5), Long.MAX_VALUE),
                         new StringSerializer(),
                         RowType.of(DataTypes.STRING()),
-                        k -> null,
+                        k -> 1L,
                         (k, size) ->
                                 CloseableIterator.adapterForIterator(
                                         map.get(k).stream()

--- a/paimon-core/src/test/java/org/apache/paimon/utils/ObjectsCacheTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/ObjectsCacheTest.java
@@ -46,6 +46,7 @@ public class ObjectsCacheTest {
                 new ObjectsCache<>(
                         new SegmentsCache<>(1024, MemorySize.ofKibiBytes(5), Long.MAX_VALUE),
                         new StringSerializer(),
+                        RowType.of(DataTypes.STRING()),
                         k -> null,
                         (k, size) ->
                                 CloseableIterator.adapterForIterator(

--- a/paimon-core/src/test/java/org/apache/paimon/utils/ObjectsCacheTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/ObjectsCacheTest.java
@@ -44,8 +44,9 @@ public class ObjectsCacheTest {
         Map<String, List<String>> map = new HashMap<>();
         ObjectsCache<String, String> cache =
                 new ObjectsCache<>(
-                        new SegmentsCache<>(1024, MemorySize.ofKibiBytes(5)),
+                        new SegmentsCache<>(1024, MemorySize.ofKibiBytes(5), Long.MAX_VALUE),
                         new StringSerializer(),
+                        k -> null,
                         (k, size) ->
                                 CloseableIterator.adapterForIterator(
                                         map.get(k).stream()


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

Next part for https://github.com/apache/paimon/pull/3829

Avoid costly manifest reading for table in CachingCatalog. Reusing `writeManifestCache` mechanism in `AbstractFileStore`.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
