### PR TITLE
[core] Identifier can now recognize branch and system tables

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/StringUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/StringUtils.java
@@ -373,7 +373,7 @@ public class StringUtils {
      * @return an array of parsed Strings, {@code null} if null String input
      */
     public static String[] split(final String str, final String separatorChars) {
-        return splitWorker(str, separatorChars, -1, false);
+        return split(str, separatorChars, -1, false);
     }
 
     /**
@@ -388,7 +388,7 @@ public class StringUtils {
      *     separators; if {@code false}, adjacent separators are treated as one separator.
      * @return an array of parsed Strings, {@code null} if null String input
      */
-    private static String[] splitWorker(
+    public static String[] split(
             final String str,
             final String separatorChars,
             final int max,

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -38,8 +38,7 @@ import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.system.SystemTableLoader;
-import org.apache.paimon.utils.Pair;
-import org.apache.paimon.utils.StringUtils;
+import org.apache.paimon.utils.Preconditions;
 
 import javax.annotation.Nullable;
 
@@ -156,6 +155,7 @@ public abstract class AbstractCatalog implements Catalog {
     @Override
     public void dropPartition(Identifier identifier, Map<String, String> partitionSpec)
             throws TableNotExistException {
+        checkNotSystemTable(identifier, "dropPartition");
         Table table = getTable(identifier);
         FileStoreTable fileStoreTable = (FileStoreTable) table;
         try (FileStoreCommit commit =
@@ -181,7 +181,7 @@ public abstract class AbstractCatalog implements Catalog {
             throw new DatabaseNotExistException(name);
         }
 
-        if (!cascade && listTables(name).size() > 0) {
+        if (!cascade && !listTables(name).isEmpty()) {
             throw new DatabaseNotEmptyException(name);
         }
 
@@ -282,14 +282,6 @@ public abstract class AbstractCatalog implements Catalog {
         validateIdentifierNameCaseInsensitive(identifier);
         validateFieldNameCaseInsensitiveInSchemaChange(changes);
 
-        Optional<Pair<Identifier, String>> optionalBranchName =
-                getOriginalIdentifierAndBranch(identifier);
-        String branchName = DEFAULT_MAIN_BRANCH;
-        if (optionalBranchName.isPresent()) {
-            identifier = optionalBranchName.get().getLeft();
-            branchName = optionalBranchName.get().getRight();
-        }
-
         if (!tableExists(identifier)) {
             if (ignoreIfNotExists) {
                 return;
@@ -297,11 +289,10 @@ public abstract class AbstractCatalog implements Catalog {
             throw new TableNotExistException(identifier);
         }
 
-        alterTableImpl(identifier, branchName, changes);
+        alterTableImpl(identifier, changes);
     }
 
-    protected abstract void alterTableImpl(
-            Identifier identifier, String branchName, List<SchemaChange> changes)
+    protected abstract void alterTableImpl(Identifier identifier, List<SchemaChange> changes)
             throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException;
 
     @Nullable
@@ -317,7 +308,7 @@ public abstract class AbstractCatalog implements Catalog {
     @Override
     public Table getTable(Identifier identifier) throws TableNotExistException {
         if (isSystemDatabase(identifier.getDatabaseName())) {
-            String tableName = identifier.getObjectName();
+            String tableName = identifier.getTableName();
             Table table =
                     SystemTableLoader.loadGlobal(
                             tableName,
@@ -330,12 +321,17 @@ public abstract class AbstractCatalog implements Catalog {
             }
             return table;
         } else if (isSpecifiedSystemTable(identifier)) {
-            String[] splits = tableAndSystemName(identifier);
-            String tableName = splits[0];
-            String type = splits[1];
             FileStoreTable originTable =
-                    getDataTable(new Identifier(identifier.getDatabaseName(), tableName));
-            Table table = SystemTableLoader.load(type, originTable);
+                    getDataTable(
+                            new Identifier(
+                                    identifier.getDatabaseName(),
+                                    identifier.getTableName(),
+                                    identifier.getBranchName(),
+                                    null));
+            Table table =
+                    SystemTableLoader.load(
+                            Preconditions.checkNotNull(identifier.getSystemTableName()),
+                            originTable);
             if (table == null) {
                 throw new TableNotExistException(identifier);
             }
@@ -346,15 +342,8 @@ public abstract class AbstractCatalog implements Catalog {
     }
 
     private FileStoreTable getDataTable(Identifier identifier) throws TableNotExistException {
-        Optional<Pair<Identifier, String>> optionalBranchName =
-                getOriginalIdentifierAndBranch(identifier);
-        String branch = DEFAULT_MAIN_BRANCH;
-        if (optionalBranchName.isPresent()) {
-            identifier = optionalBranchName.get().getLeft();
-            branch = optionalBranchName.get().getRight();
-        }
-
-        TableSchema tableSchema = getDataTableSchema(identifier, branch);
+        Preconditions.checkArgument(identifier.getSystemTableName() == null);
+        TableSchema tableSchema = getDataTableSchema(identifier);
         return FileStoreTableFactory.create(
                 fileIO,
                 getDataTableLocation(identifier),
@@ -394,35 +383,16 @@ public abstract class AbstractCatalog implements Catalog {
         }
     }
 
-    protected abstract TableSchema getDataTableSchema(Identifier identifier, String branchName)
+    protected abstract TableSchema getDataTableSchema(Identifier identifier)
             throws TableNotExistException;
 
     @VisibleForTesting
     public Path getDataTableLocation(Identifier identifier) {
-        return new Path(newDatabasePath(identifier.getDatabaseName()), identifier.getObjectName());
+        return new Path(newDatabasePath(identifier.getDatabaseName()), identifier.getTableName());
     }
 
-    private static Optional<Pair<Identifier, String>> getOriginalIdentifierAndBranch(
-            Identifier identifier) {
-        String tableName = identifier.getObjectName();
-        if (tableName.contains(BRANCH_PREFIX)) {
-            int idx = tableName.indexOf(BRANCH_PREFIX);
-            String branchName = tableName.substring(idx + BRANCH_PREFIX.length());
-            if (StringUtils.isNullOrWhitespaceOnly(branchName)) {
-                return Optional.empty();
-            } else {
-                return Optional.of(
-                        Pair.of(
-                                Identifier.create(
-                                        identifier.getDatabaseName(), tableName.substring(0, idx)),
-                                branchName));
-            }
-        }
-        return Optional.empty();
-    }
-
-    protected void checkNotBranch(Identifier identifier, String method) {
-        if (getOriginalIdentifierAndBranch(identifier).isPresent()) {
+    protected static void checkNotBranch(Identifier identifier, String method) {
+        if (identifier.getBranchName() != null) {
             throw new IllegalArgumentException(
                     String.format(
                             "Cannot '%s' for branch table '%s', "
@@ -431,23 +401,23 @@ public abstract class AbstractCatalog implements Catalog {
         }
     }
 
-    protected void assertMainBranch(String branchName) {
-        if (!DEFAULT_MAIN_BRANCH.equals(branchName)) {
+    protected void assertMainBranch(Identifier identifier) {
+        if (identifier.getBranchName() != null
+                && !DEFAULT_MAIN_BRANCH.equals(identifier.getBranchName())) {
             throw new UnsupportedOperationException(
                     this.getClass().getName() + " currently does not support table branches");
         }
     }
 
     public static boolean isSpecifiedSystemTable(Identifier identifier) {
-        return identifier.getObjectName().contains(SYSTEM_TABLE_SPLITTER)
-                && !getOriginalIdentifierAndBranch(identifier).isPresent();
+        return identifier.getSystemTableName() != null;
     }
 
     protected static boolean isSystemTable(Identifier identifier) {
         return isSystemDatabase(identifier.getDatabaseName()) || isSpecifiedSystemTable(identifier);
     }
 
-    protected void checkNotSystemTable(Identifier identifier, String method) {
+    protected static void checkNotSystemTable(Identifier identifier, String method) {
         if (isSystemTable(identifier)) {
             throw new IllegalArgumentException(
                     String.format(
@@ -460,26 +430,12 @@ public abstract class AbstractCatalog implements Catalog {
         tableDefaultOptions.forEach(options::putIfAbsent);
     }
 
-    public static String[] tableAndSystemName(Identifier identifier) {
-        String[] splits = StringUtils.split(identifier.getObjectName(), SYSTEM_TABLE_SPLITTER);
-        if (splits.length != 2) {
-            throw new IllegalArgumentException(
-                    "System table can only contain one '$' separator, but this is: "
-                            + identifier.getObjectName());
-        }
-        return splits;
-    }
-
     public static Path newTableLocation(String warehouse, Identifier identifier) {
-        if (isSpecifiedSystemTable(identifier)) {
-            throw new IllegalArgumentException(
-                    String.format(
-                            "Table name[%s] cannot contain '%s' separator",
-                            identifier.getObjectName(), SYSTEM_TABLE_SPLITTER));
-        }
+        checkNotBranch(identifier, "newTableLocation");
+        checkNotSystemTable(identifier, "newTableLocation");
         return new Path(
                 newDatabasePath(warehouse, identifier.getDatabaseName()),
-                identifier.getObjectName());
+                identifier.getTableName());
     }
 
     public static Path newDatabasePath(String warehouse, String database) {
@@ -548,18 +504,29 @@ public abstract class AbstractCatalog implements Catalog {
     protected List<String> listTablesInFileSystem(Path databasePath) throws IOException {
         List<String> tables = new ArrayList<>();
         for (FileStatus status : fileIO.listDirectories(databasePath)) {
-            if (status.isDir() && tableExistsInFileSystem(status.getPath())) {
+            if (status.isDir() && tableExistsInFileSystem(status.getPath(), DEFAULT_MAIN_BRANCH)) {
                 tables.add(status.getPath().getName());
             }
         }
         return tables;
     }
 
-    protected boolean tableExistsInFileSystem(Path tablePath) {
-        return !new SchemaManager(fileIO, tablePath).listAllIds().isEmpty();
+    protected boolean tableExistsInFileSystem(Path tablePath, String branchName) {
+        return !new SchemaManager(fileIO, tablePath, branchName).listAllIds().isEmpty();
     }
 
-    public Optional<TableSchema> tableSchemaInFileSystem(Path tablePath) {
-        return new SchemaManager(fileIO, tablePath).latest();
+    public Optional<TableSchema> tableSchemaInFileSystem(Path tablePath, String branchName) {
+        return new SchemaManager(fileIO, tablePath, branchName)
+                .latest()
+                .map(
+                        s -> {
+                            if (!DEFAULT_MAIN_BRANCH.equals(branchName)) {
+                                Options branchOptions = new Options(s.options());
+                                branchOptions.set(CoreOptions.BRANCH, branchName);
+                                return s.copy(branchOptions.toMap());
+                            } else {
+                                return s;
+                            }
+                        });
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -48,9 +48,9 @@ public interface Catalog extends AutoCloseable {
 
     String DEFAULT_DATABASE = "default";
 
-    String BRANCH_PREFIX = "$branch_";
     String SYSTEM_TABLE_SPLITTER = "$";
     String SYSTEM_DATABASE_NAME = "sys";
+    String SYSTEM_BRANCH_PREFIX = "branch_";
     String COMMENT_PROP = "comment";
     String TABLE_DEFAULT_OPTION_PREFIX = "table-default.";
     String DB_LOCATION_PROP = "location";

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
@@ -37,18 +37,18 @@ public class CatalogUtils {
     }
 
     public static String database(Path path) {
-        return SchemaManager.fromPath(path.toString(), false).getDatabaseName();
+        return SchemaManager.identifierFromPath(path.toString(), false).getDatabaseName();
     }
 
     public static String database(String path) {
-        return SchemaManager.fromPath(path, false).getDatabaseName();
+        return SchemaManager.identifierFromPath(path, false).getDatabaseName();
     }
 
     public static String table(Path path) {
-        return SchemaManager.fromPath(path.toString(), false).getObjectName();
+        return SchemaManager.identifierFromPath(path.toString(), false).getObjectName();
     }
 
     public static String table(String path) {
-        return SchemaManager.fromPath(path, false).getObjectName();
+        return SchemaManager.identifierFromPath(path, false).getObjectName();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Identifier.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Identifier.java
@@ -115,7 +115,7 @@ public class Identifier implements Serializable {
             return;
         }
 
-        String[] splits = StringUtils.split(object, Catalog.SYSTEM_TABLE_SPLITTER);
+        String[] splits = StringUtils.split(object, Catalog.SYSTEM_TABLE_SPLITTER, -1, true);
         if (splits.length == 1) {
             table = object;
             branch = null;
@@ -130,7 +130,9 @@ public class Identifier implements Serializable {
                 systemTable = splits[1];
             }
         } else if (splits.length == 3) {
-            Preconditions.checkArgument(splits[1].startsWith(Catalog.SYSTEM_BRANCH_PREFIX));
+            Preconditions.checkArgument(
+                    splits[1].startsWith(Catalog.SYSTEM_BRANCH_PREFIX),
+                    "System table can only contain one '$' separator, but this is: " + object);
             table = splits[0];
             branch = splits[1].substring(Catalog.SYSTEM_BRANCH_PREFIX.length());
             systemTable = splits[2];

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -193,7 +193,8 @@ public class SchemaManager implements Serializable {
                     latest().orElseThrow(
                                     () ->
                                             new Catalog.TableNotExistException(
-                                                    fromPath(branchPath(), true)));
+                                                    identifierFromPath(
+                                                            tableRoot.toString(), true, branch)));
             Map<String, String> newOptions = new HashMap<>(oldTableSchema.options());
             List<DataField> newFields = new ArrayList<>(oldTableSchema.fields());
             AtomicInteger highestFieldId = new AtomicInteger(oldTableSchema.highestFieldId());
@@ -219,13 +220,14 @@ public class SchemaManager implements Serializable {
                     SchemaChange.Move move = addColumn.move();
                     if (newFields.stream().anyMatch(f -> f.name().equals(addColumn.fieldName()))) {
                         throw new Catalog.ColumnAlreadyExistException(
-                                fromPath(branchPath(), true), addColumn.fieldName());
+                                identifierFromPath(tableRoot.toString(), true, branch),
+                                addColumn.fieldName());
                     }
                     Preconditions.checkArgument(
                             addColumn.dataType().isNullable(),
                             "Column %s cannot specify NOT NULL in the %s table.",
                             addColumn.fieldName(),
-                            fromPath(branchPath(), true).getFullName());
+                            identifierFromPath(tableRoot.toString(), true, branch).getFullName());
                     int id = highestFieldId.incrementAndGet();
                     DataType dataType =
                             ReassignFieldId.reassign(addColumn.dataType(), highestFieldId);
@@ -256,7 +258,8 @@ public class SchemaManager implements Serializable {
                     validateNotPrimaryAndPartitionKey(oldTableSchema, rename.fieldName());
                     if (newFields.stream().anyMatch(f -> f.name().equals(rename.newName()))) {
                         throw new Catalog.ColumnAlreadyExistException(
-                                fromPath(branchPath(), true), rename.fieldName());
+                                identifierFromPath(tableRoot.toString(), true, branch),
+                                rename.fieldName());
                     }
 
                     updateNestedColumn(
@@ -275,7 +278,8 @@ public class SchemaManager implements Serializable {
                     if (!newFields.removeIf(
                             f -> f.name().equals(((DropColumn) change).fieldName()))) {
                         throw new Catalog.ColumnNotExistException(
-                                fromPath(branchPath(), true), drop.fieldName());
+                                identifierFromPath(tableRoot.toString(), true, branch),
+                                drop.fieldName());
                     }
                     if (newFields.isEmpty()) {
                         throw new IllegalArgumentException("Cannot drop all fields in table");
@@ -511,7 +515,8 @@ public class SchemaManager implements Serializable {
         }
         if (!found) {
             throw new Catalog.ColumnNotExistException(
-                    fromPath(branchPath(), true), Arrays.toString(updateFieldNames));
+                    identifierFromPath(tableRoot.toString(), true, branch),
+                    Arrays.toString(updateFieldNames));
         }
     }
 
@@ -587,13 +592,18 @@ public class SchemaManager implements Serializable {
         }
     }
 
-    public static Identifier fromPath(String tablePath, boolean ignoreIfUnknownDatabase) {
+    public static Identifier identifierFromPath(String tablePath, boolean ignoreIfUnknownDatabase) {
+        return identifierFromPath(tablePath, ignoreIfUnknownDatabase, null);
+    }
+
+    public static Identifier identifierFromPath(
+            String tablePath, boolean ignoreIfUnknownDatabase, @Nullable String branchName) {
         String[] paths = tablePath.split("/");
         if (paths.length < 2) {
             if (!ignoreIfUnknownDatabase) {
                 throw new IllegalArgumentException(
                         String.format(
-                                "Path '%s' is not a legacy path, please use catalog table path instead: 'warehouse_path/your_database.db/your_table'.",
+                                "Path '%s' is not a valid path, please use catalog table path instead: 'warehouse_path/your_database.db/your_table'.",
                                 tablePath));
             }
             return new Identifier(UNKNOWN_DATABASE, paths[0]);
@@ -605,12 +615,12 @@ public class SchemaManager implements Serializable {
             if (!ignoreIfUnknownDatabase) {
                 throw new IllegalArgumentException(
                         String.format(
-                                "Path '%s' is not a legacy path, please use catalog table path instead: 'warehouse_path/your_database.db/your_table'.",
+                                "Path '%s' is not a valid path, please use catalog table path instead: 'warehouse_path/your_database.db/your_table'.",
                                 tablePath));
             }
-            return new Identifier(UNKNOWN_DATABASE, paths[paths.length - 1]);
+            return new Identifier(UNKNOWN_DATABASE, paths[paths.length - 1], branchName, null);
         }
         database = database.substring(0, index);
-        return new Identifier(database, paths[paths.length - 1]);
+        return new Identifier(database, paths[paths.length - 1], branchName, null);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -598,6 +598,10 @@ public class SchemaManager implements Serializable {
 
     public static Identifier identifierFromPath(
             String tablePath, boolean ignoreIfUnknownDatabase, @Nullable String branchName) {
+        if (DEFAULT_MAIN_BRANCH.equals(branchName)) {
+            branchName = null;
+        }
+
         String[] paths = tablePath.split("/");
         if (paths.length < 2) {
             if (!ignoreIfUnknownDatabase) {
@@ -621,6 +625,7 @@ public class SchemaManager implements Serializable {
             return new Identifier(UNKNOWN_DATABASE, paths[paths.length - 1], branchName, null);
         }
         database = database.substring(0, index);
+
         return new Identifier(database, paths[paths.length - 1], branchName, null);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -116,16 +116,24 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
 
     @Override
     public String name() {
-        Identifier identifier = catalogEnvironment.identifier();
-        return identifier == null ? location().getName() : identifier.getObjectName();
+        return identifier().getObjectName();
     }
 
     @Override
     public String fullName() {
+        return identifier().getFullName();
+    }
+
+    public Identifier identifier() {
         Identifier identifier = catalogEnvironment.identifier();
         return identifier == null
-                ? SchemaManager.fromPath(location().toUri().toString(), true).getFullName()
-                : identifier.getFullName();
+                ? SchemaManager.identifierFromPath(
+                        location().toUri().toString(),
+                        true,
+                        options().containsKey(CoreOptions.BRANCH.key())
+                                ? coreOptions().branch()
+                                : null)
+                : identifier;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -130,9 +130,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
                 ? SchemaManager.identifierFromPath(
                         location().toUri().toString(),
                         true,
-                        options().containsKey(CoreOptions.BRANCH.key())
-                                ? coreOptions().branch()
-                                : null)
+                        options().get(CoreOptions.BRANCH.key()))
                 : identifier;
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -239,7 +239,7 @@ public abstract class CatalogTestBase {
                                         DEFAULT_TABLE_SCHEMA,
                                         false))
                 .withMessage(
-                        "Cannot 'createTable' for system table 'Identifier{database='test_db', table='$system_table'}', please use data table.");
+                        "Cannot 'createTable' for system table 'Identifier{database='test_db', object='$system_table'}', please use data table.");
 
         // Create table throws DatabaseNotExistException when database does not exist
         assertThatExceptionOfType(Catalog.DatabaseNotExistException.class)
@@ -367,7 +367,7 @@ public abstract class CatalogTestBase {
                                 catalog.dropTable(
                                         Identifier.create("test_db", "$system_table"), false))
                 .withMessage(
-                        "Cannot 'dropTable' for system table 'Identifier{database='test_db', table='$system_table'}', please use data table.");
+                        "Cannot 'dropTable' for system table 'Identifier{database='test_db', object='$system_table'}', please use data table.");
 
         // Drop table throws TableNotExistException when table does not exist and ignoreIfNotExists
         // is false
@@ -402,7 +402,7 @@ public abstract class CatalogTestBase {
                                         toTable,
                                         false))
                 .withMessage(
-                        "Cannot 'renameTable' for system table 'Identifier{database='test_db', table='$system_table'}', please use data table.");
+                        "Cannot 'renameTable' for system table 'Identifier{database='test_db', object='$system_table'}', please use data table.");
 
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(
@@ -412,7 +412,7 @@ public abstract class CatalogTestBase {
                                         Identifier.create("test_db", "$system_table"),
                                         false))
                 .withMessage(
-                        "Cannot 'renameTable' for system table 'Identifier{database='test_db', table='$system_table'}', please use data table.");
+                        "Cannot 'renameTable' for system table 'Identifier{database='test_db', object='$system_table'}', please use data table.");
 
         // Rename table throws TableNotExistException when table does not exist
         assertThatExceptionOfType(Catalog.TableNotExistException.class)
@@ -466,7 +466,7 @@ public abstract class CatalogTestBase {
                                                 SchemaChange.addColumn("col2", DataTypes.DATE())),
                                         false))
                 .withMessage(
-                        "Cannot 'alterTable' for system table 'Identifier{database='test_db', table='$system_table'}', please use data table.");
+                        "Cannot 'alterTable' for system table 'Identifier{database='test_db', object='$system_table'}', please use data table.");
 
         // Alter table throws TableNotExistException when table does not exist
         assertThatExceptionOfType(Catalog.TableNotExistException.class)

--- a/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
@@ -76,7 +76,7 @@ public class SchemaEvolutionTest {
     @BeforeEach
     public void beforeEach() {
         tablePath = new Path(tempDir.toUri());
-        identifier = SchemaManager.fromPath(tablePath.toString(), true);
+        identifier = SchemaManager.identifierFromPath(tablePath.toString(), true);
         schemaManager = new SchemaManager(LocalFileIO.create(), tablePath);
         commitUser = UUID.randomUUID().toString();
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BranchSqlITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BranchSqlITCase.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** IT cases for table with branches using SQL. */
 public class BranchSqlITCase extends CatalogITCaseBase {
@@ -378,13 +378,8 @@ public class BranchSqlITCase extends CatalogITCaseBase {
         sql("ALTER TABLE `t$branch_pk` ADD (v2 INT)");
         sql("ALTER TABLE t SET ( 'scan.fallback-branch' = 'pk' )");
 
-        try {
-            sql("INSERT INTO t VALUES (1, 10, 'apple')");
-            fail("Expecting exceptions");
-        } catch (Exception e) {
-            assertThat(e)
-                    .hasMessageContaining("Branch main and pk does not have the same row type");
-        }
+        assertThatThrownBy(() -> sql("INSERT INTO t VALUES (1, 10, 'apple')"))
+                .hasMessageContaining("Branch main and pk does not have the same row type");
     }
 
     private List<String> collectResult(String sql) throws Exception {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -172,11 +172,10 @@ public class CatalogTableITCase extends CatalogITCaseBase {
         assertThatThrownBy(() -> sql("CREATE TABLE T$snapshots (a INT, b INT)"))
                 .hasRootCauseMessage(
                         "Cannot 'createTable' for system table "
-                                + "'Identifier{database='default', table='T$snapshots'}', please use data table.");
+                                + "'Identifier{database='default', object='T$snapshots'}', please use data table.");
         assertThatThrownBy(() -> sql("CREATE TABLE T$aa$bb (a INT, b INT)"))
                 .hasRootCauseMessage(
-                        "Cannot 'createTable' for system table "
-                                + "'Identifier{database='default', table='T$aa$bb'}', please use data table.");
+                        "System table can only contain one '$' separator, but this is: T$aa$bb");
     }
 
     @Test


### PR DESCRIPTION
### Purpose

In # we allow visit table branches by `$branch_`. Now an identifier may represent a data table, or a system table, or a table branch.

In this PR, we add some methods in `Identifier` so that it can recognize branches and system tables. Catalogs will need these methods to get schemas, communicate with metastores, etc.

### Tests

This is a refactor. Existing tests should cover the changes.

### API and Format

`Identifier` is a public API. This PR adds some methods to the class.

### Documentation

No new feature.
