### PR TITLE
[core] Introduce AsyncPositionOutputStream

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -28,7 +28,7 @@ under the License.
     <tbody>
         <tr>
             <td><h5>async-file-write</h5></td>
-            <td style="word-wrap: break-word;">false</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Whether to enable asynchronous IO writing when writing files.</td>
         </tr>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -27,6 +27,12 @@ under the License.
     </thead>
     <tbody>
         <tr>
+            <td><h5>async-file-write</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to enable asynchronous IO writing when writing files.</td>
+        </tr>
+        <tr>
             <td><h5>auto-create</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1283,6 +1283,13 @@ public class CoreOptions implements Serializable {
                             "When a batch job queries from a table, if a partition does not exist in the current branch, "
                                     + "the reader will try to get this partition from this fallback branch.");
 
+    public static final ConfigOption<Boolean> ASYNC_FILE_WRITE =
+            key("async-file-write")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to enable asynchronous IO writing when writing files.");
+
     private final Options options;
 
     public CoreOptions(Map<String, String> options) {
@@ -2018,6 +2025,10 @@ public class CoreOptions implements Serializable {
         }
 
         return options.get(LOOKUP_WAIT);
+    }
+
+    public boolean asyncFileWrite() {
+        return options.get(ASYNC_FILE_WRITE);
     }
 
     public boolean metadataIcebergCompatible() {

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1286,7 +1286,7 @@ public class CoreOptions implements Serializable {
     public static final ConfigOption<Boolean> ASYNC_FILE_WRITE =
             key("async-file-write")
                     .booleanType()
-                    .defaultValue(false)
+                    .defaultValue(true)
                     .withDescription(
                             "Whether to enable asynchronous IO writing when writing files.");
 

--- a/paimon-common/src/main/java/org/apache/paimon/fs/AsyncPositionOutputStream.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/AsyncPositionOutputStream.java
@@ -42,14 +42,12 @@ public class AsyncPositionOutputStream extends PositionOutputStream {
     private final AtomicReference<Throwable> exception;
     private final Future<?> future;
 
-    private volatile boolean isClosed;
     private long position;
 
     public AsyncPositionOutputStream(PositionOutputStream out) {
         this.out = out;
         this.eventQueue = new LinkedBlockingQueue<>();
         this.exception = new AtomicReference<>();
-        this.isClosed = false;
         this.position = 0;
         this.future = EXECUTOR_SERVICE.submit(this::execute);
     }
@@ -65,7 +63,7 @@ public class AsyncPositionOutputStream extends PositionOutputStream {
 
     private void doWork() throws InterruptedException, IOException {
         try {
-            while (!isClosed) {
+            while (true) {
                 AsyncEvent event = eventQueue.poll(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
                 if (event == null) {
                     continue;
@@ -144,8 +142,6 @@ public class AsyncPositionOutputStream extends PositionOutputStream {
             throw new RuntimeException(e);
         } catch (ExecutionException e) {
             throw new RuntimeException(e);
-        } finally {
-            isClosed = true;
         }
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/fs/AsyncPositionOutputStream.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/AsyncPositionOutputStream.java
@@ -145,6 +145,9 @@ public class AsyncPositionOutputStream extends PositionOutputStream {
     private void checkException() throws IOException {
         Throwable throwable = exception.get();
         if (throwable != null) {
+            if (throwable instanceof IOException) {
+                throw (IOException) throwable;
+            }
             throw new IOException(throwable);
         }
     }

--- a/paimon-common/src/main/java/org/apache/paimon/fs/AsyncPositionOutputStream.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/AsyncPositionOutputStream.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fs;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.paimon.utils.ThreadUtils.newDaemonThreadFactory;
+
+/** A {@link PositionOutputStream} which uses a async thread to write data. */
+public class AsyncPositionOutputStream extends PositionOutputStream {
+
+    public static final ExecutorService EXECUTOR_SERVICE =
+            Executors.newCachedThreadPool(newDaemonThreadFactory("AsyncOutputStream"));
+
+    private final PositionOutputStream out;
+    private final LinkedBlockingQueue<AsyncEvent> eventQueue;
+    private final AtomicReference<Throwable> exception;
+    private final Future<?> future;
+
+    private volatile boolean isClosed;
+    private long position;
+
+    public AsyncPositionOutputStream(PositionOutputStream out) {
+        this.out = out;
+        this.eventQueue = new LinkedBlockingQueue<>();
+        this.exception = new AtomicReference<>();
+        this.isClosed = false;
+        this.position = 0;
+        this.future = EXECUTOR_SERVICE.submit(this::execute);
+    }
+
+    private void execute() {
+        try {
+            doWork();
+        } catch (Throwable e) {
+            exception.set(e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void doWork() throws InterruptedException, IOException {
+        try {
+            while (!isClosed) {
+                AsyncEvent event = eventQueue.poll(1, TimeUnit.SECONDS);
+                if (event == null) {
+                    continue;
+                }
+                if (event instanceof EndEvent) {
+                    return;
+                }
+                if (event instanceof DataEvent) {
+                    DataEvent dataEvent = (DataEvent) event;
+                    out.write(dataEvent.data);
+                }
+                if (event instanceof FlushEvent) {
+                    out.flush();
+                }
+            }
+        } finally {
+            out.close();
+        }
+    }
+
+    @Override
+    public long getPos() throws IOException {
+        checkException();
+        return position;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        checkException();
+        position++;
+        putEvent(new DataEvent(new byte[] {(byte) b}, 0, 1));
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        checkException();
+        position += b.length;
+        putEvent(new DataEvent(b, 0, b.length));
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        checkException();
+        position += len;
+        putEvent(new DataEvent(b, off, len));
+    }
+
+    @Override
+    public void flush() throws IOException {
+        checkException();
+        putEvent(new FlushEvent());
+    }
+
+    @Override
+    public void close() throws IOException {
+        checkException();
+        putEvent(new EndEvent());
+        try {
+            this.future.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        } finally {
+            isClosed = true;
+        }
+    }
+
+    private void putEvent(AsyncEvent event) {
+        try {
+            eventQueue.put(event);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void checkException() throws IOException {
+        Throwable throwable = exception.get();
+        if (throwable != null) {
+            throw new IOException(throwable);
+        }
+    }
+
+    private interface AsyncEvent {}
+
+    private static class DataEvent implements AsyncEvent {
+
+        private final byte[] data;
+
+        public DataEvent(byte[] input, int offset, int length) {
+            byte[] data = new byte[length];
+            System.arraycopy(input, offset, data, 0, length);
+            this.data = data;
+        }
+    }
+
+    private static class FlushEvent implements AsyncEvent {}
+
+    private static class EndEvent implements AsyncEvent {}
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fs/AsyncPositionOutputStream.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/AsyncPositionOutputStream.java
@@ -88,7 +88,7 @@ public class AsyncPositionOutputStream extends PositionOutputStream {
                 }
                 if (event instanceof DataEvent) {
                     DataEvent dataEvent = (DataEvent) event;
-                    out.write(dataEvent.data, dataEvent.offset, dataEvent.length);
+                    out.write(dataEvent.data, 0, dataEvent.length);
                     bufferQueue.add(dataEvent.data);
                 }
                 if (event instanceof FlushEvent) {
@@ -111,7 +111,7 @@ public class AsyncPositionOutputStream extends PositionOutputStream {
         if (buffer.getCount() == 0) {
             return;
         }
-        putEvent(new DataEvent(buffer.getBuffer(), 0, buffer.getCount()));
+        putEvent(new DataEvent(buffer.getBuffer(), buffer.getCount()));
         byte[] byteArray = bufferQueue.poll();
         if (byteArray == null) {
             byteArray = new byte[BUFFER_SIZE];
@@ -211,12 +211,10 @@ public class AsyncPositionOutputStream extends PositionOutputStream {
     private static class DataEvent implements AsyncEvent {
 
         private final byte[] data;
-        private final int offset;
         private final int length;
 
-        public DataEvent(byte[] data, int offset, int length) {
+        public DataEvent(byte[] data, int length) {
             this.data = data;
-            this.offset = offset;
             this.length = length;
         }
     }

--- a/paimon-common/src/main/java/org/apache/paimon/fs/AsyncPositionOutputStream.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/AsyncPositionOutputStream.java
@@ -125,6 +125,7 @@ public class AsyncPositionOutputStream extends PositionOutputStream {
                 if (await) {
                     return;
                 }
+                checkException();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new RuntimeException(e);

--- a/paimon-common/src/main/java/org/apache/paimon/utils/FixLenByteArrayOutputStream.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/FixLenByteArrayOutputStream.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import java.io.ByteArrayOutputStream;
+
+/** A {@link ByteArrayOutputStream} which can reuse byte array. */
+public class FixLenByteArrayOutputStream {
+
+    private byte[] buf;
+    private int count;
+
+    public void setBuffer(byte[] buffer) {
+        this.buf = buffer;
+    }
+
+    public byte[] getBuffer() {
+        return buf;
+    }
+
+    public int write(byte b[], int off, int len) {
+        if ((off < 0) || (off > b.length) || (len < 0) || ((off + len) - b.length > 0)) {
+            throw new IndexOutOfBoundsException();
+        }
+        int writeLen = Math.min(len, buf.length - count);
+        System.arraycopy(b, off, buf, count, writeLen);
+        count += writeLen;
+        return writeLen;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public int write(byte b) {
+        if (count < buf.length) {
+            buf[count] = b;
+            count += 1;
+            return 1;
+        }
+        return 0;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/FixLenByteArrayOutputStream.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/FixLenByteArrayOutputStream.java
@@ -34,7 +34,7 @@ public class FixLenByteArrayOutputStream {
         return buf;
     }
 
-    public int write(byte b[], int off, int len) {
+    public int write(byte[] b, int off, int len) {
         if ((off < 0) || (off > b.length) || (len < 0) || ((off + len) - b.length > 0)) {
             throw new IndexOutOfBoundsException();
         }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ReuseByteArrayOutputStream.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ReuseByteArrayOutputStream.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import java.io.ByteArrayOutputStream;
+
+/** A {@link ByteArrayOutputStream} which can reuse byte array. */
+public class ReuseByteArrayOutputStream extends ByteArrayOutputStream {
+
+    public ReuseByteArrayOutputStream(int size) {
+        super(size);
+    }
+
+    public void setBuffer(byte[] buffer) {
+        this.buf = buffer;
+    }
+
+    public byte[] getBuffer() {
+        return buf;
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/fs/AsyncPositionOutputStreamTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/AsyncPositionOutputStreamTest.java
@@ -71,6 +71,26 @@ class AsyncPositionOutputStreamTest {
     }
 
     @Test
+    public void testFlushWithException() throws IOException {
+        String msg = "your exception!";
+        ByteArrayPositionOutputStream byteOut =
+                new ByteArrayPositionOutputStream() {
+                    @Override
+                    public void write(byte[] b) throws IOException {
+                        try {
+                            Thread.sleep(100);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                        throw new IOException(msg);
+                    }
+                };
+        AsyncPositionOutputStream out = new AsyncPositionOutputStream(byteOut);
+        out.write(new byte[] {5, 6, 7});
+        assertThatThrownBy(out::flush).hasMessage(msg);
+    }
+
+    @Test
     public void testClose() throws IOException {
         ByteArrayPositionOutputStream byteOut =
                 new ByteArrayPositionOutputStream() {

--- a/paimon-common/src/test/java/org/apache/paimon/fs/AsyncPositionOutputStreamTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/AsyncPositionOutputStreamTest.java
@@ -68,6 +68,15 @@ class AsyncPositionOutputStreamTest {
         out.write(new byte[] {5, 6, 7});
         out.flush();
         assertThat(byteOut.getPos()).isEqualTo(6);
+
+        out.write(new byte[] {8, 9});
+
+        // test repeat flush
+        out.flush();
+        out.flush();
+        assertThat(byteOut.getPos()).isEqualTo(8);
+
+        assertThat(out.getBufferQueue().size()).isEqualTo(1);
     }
 
     @Test
@@ -76,13 +85,13 @@ class AsyncPositionOutputStreamTest {
         ByteArrayPositionOutputStream byteOut =
                 new ByteArrayPositionOutputStream() {
                     @Override
-                    public void write(byte[] b) throws IOException {
+                    public void write(byte[] b, int off, int len) {
                         try {
                             Thread.sleep(100);
                         } catch (InterruptedException e) {
                             throw new RuntimeException(e);
                         }
-                        throw new IOException(msg);
+                        throw new RuntimeException(msg);
                     }
                 };
         AsyncPositionOutputStream out = new AsyncPositionOutputStream(byteOut);
@@ -117,14 +126,14 @@ class AsyncPositionOutputStreamTest {
         ByteArrayPositionOutputStream out =
                 new ByteArrayPositionOutputStream() {
                     @Override
-                    public void write(byte[] b) throws IOException {
-                        throw new IOException(msg);
+                    public void write(byte[] b, int off, int len) {
+                        throw new RuntimeException(msg);
                     }
                 };
 
         AsyncPositionOutputStream asyncOut = new AsyncPositionOutputStream(out);
         asyncOut.write(new byte[] {1, 2, 3});
-        assertThatThrownBy(asyncOut::close).hasMessage(msg);
+        assertThatThrownBy(asyncOut::close).hasMessageContaining(msg);
         assertThat(out.closed).isTrue();
     }
 

--- a/paimon-common/src/test/java/org/apache/paimon/fs/AsyncPositionOutputStreamTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/AsyncPositionOutputStreamTest.java
@@ -22,11 +22,47 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AsyncPositionOutputStreamTest {
+
+    @Test
+    public void testHugeWriteByteArray() throws IOException {
+        ByteArrayPositionOutputStream result = new ByteArrayPositionOutputStream();
+        AsyncPositionOutputStream out = new AsyncPositionOutputStream(result);
+        int len = 10 * 1024;
+        ByteArrayOutputStream expected = new ByteArrayOutputStream(len);
+        ThreadLocalRandom rnd = ThreadLocalRandom.current();
+        for (int i = 0; i < len; i++) {
+            byte[] bytes = new byte[rnd.nextInt(20)];
+            rnd.nextBytes(bytes);
+            expected.write(bytes);
+            out.write(bytes);
+        }
+        out.close();
+
+        assertThat(result.out.toByteArray()).isEqualTo(expected.toByteArray());
+    }
+
+    @Test
+    public void testHugeWriteByte() throws IOException {
+        ByteArrayPositionOutputStream result = new ByteArrayPositionOutputStream();
+        AsyncPositionOutputStream out = new AsyncPositionOutputStream(result);
+        int len = 32 * 1024 + 20;
+        ByteArrayOutputStream expected = new ByteArrayOutputStream(len);
+        ThreadLocalRandom rnd = ThreadLocalRandom.current();
+        for (int i = 0; i < len; i++) {
+            int b = rnd.nextInt();
+            expected.write(b);
+            out.write(b);
+        }
+        out.close();
+
+        assertThat(result.out.toByteArray()).isEqualTo(expected.toByteArray());
+    }
 
     @Test
     public void testNormal() throws IOException {

--- a/paimon-common/src/test/java/org/apache/paimon/fs/AsyncPositionOutputStreamTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/AsyncPositionOutputStreamTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fs;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AsyncPositionOutputStreamTest {
+
+    @Test
+    public void testNormal() throws IOException {
+        ByteArrayPositionOutputStream byteOut = new ByteArrayPositionOutputStream();
+        AsyncPositionOutputStream out = new AsyncPositionOutputStream(byteOut);
+        out.write(1);
+        out.write(new byte[] {2, 3});
+        out.write(new byte[] {3, 4, 5}, 1, 1);
+        out.close();
+        assertThat(byteOut.out.toByteArray()).isEqualTo(new byte[] {1, 2, 3, 4});
+    }
+
+    @Test
+    public void testGetPos() throws IOException {
+        AsyncPositionOutputStream out =
+                new AsyncPositionOutputStream(new ByteArrayPositionOutputStream());
+        out.write(new byte[] {1, 2, 3});
+        assertThat(out.getPos()).isEqualTo(3);
+        out.write(new byte[] {5, 6, 7});
+        assertThat(out.getPos()).isEqualTo(6);
+    }
+
+    @Test
+    public void testFlush() throws IOException {
+        ByteArrayPositionOutputStream byteOut =
+                new ByteArrayPositionOutputStream() {
+                    @Override
+                    public void write(byte[] b) throws IOException {
+                        try {
+                            Thread.sleep(100);
+                            super.write(b);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                };
+        AsyncPositionOutputStream out = new AsyncPositionOutputStream(byteOut);
+        out.write(new byte[] {1, 2, 3});
+        out.write(new byte[] {5, 6, 7});
+        out.flush();
+        assertThat(byteOut.getPos()).isEqualTo(6);
+    }
+
+    @Test
+    public void testClose() throws IOException {
+        ByteArrayPositionOutputStream byteOut =
+                new ByteArrayPositionOutputStream() {
+                    @Override
+                    public void write(byte[] b) throws IOException {
+                        try {
+                            Thread.sleep(100);
+                            super.write(b);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                };
+        AsyncPositionOutputStream out = new AsyncPositionOutputStream(byteOut);
+        out.write(new byte[] {1, 2, 3});
+        out.write(new byte[] {5, 6, 7});
+        out.close();
+        assertThat(byteOut.getPos()).isEqualTo(6);
+    }
+
+    @Test
+    public void testThrowException() throws IOException {
+        String msg = "your exception!";
+        ByteArrayPositionOutputStream out =
+                new ByteArrayPositionOutputStream() {
+                    @Override
+                    public void write(byte[] b) throws IOException {
+                        throw new IOException(msg);
+                    }
+                };
+
+        AsyncPositionOutputStream asyncOut = new AsyncPositionOutputStream(out);
+        asyncOut.write(new byte[] {1, 2, 3});
+        assertThatThrownBy(asyncOut::close).hasMessage(msg);
+        assertThat(out.closed).isTrue();
+    }
+
+    private static class ByteArrayPositionOutputStream extends PositionOutputStream {
+
+        private final ByteArrayOutputStream out;
+
+        private boolean closed;
+
+        private ByteArrayPositionOutputStream() {
+            this.out = new ByteArrayOutputStream();
+        }
+
+        @Override
+        public long getPos() {
+            return out.size();
+        }
+
+        @Override
+        public void write(int b) {
+            out.write(b);
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            out.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) {
+            out.write(b, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            out.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            out.close();
+            closed = true;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestFile.java
@@ -125,7 +125,8 @@ public class IcebergManifestFile extends ObjectsFile<IcebergManifestEntry> {
                     factory,
                     path,
                     serializer::toRow,
-                    fileCompression);
+                    fileCompression,
+                    false);
             this.partitionStatsCollector = new SimpleStatsCollector(partitionType);
             this.sequenceNumber = sequenceNumber;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileWriter.java
@@ -93,7 +93,8 @@ public class KeyValueDataFileWriter
                 simpleStatsExtractor,
                 compression,
                 StatsCollectorFactories.createStatsFactories(
-                        options, KeyValue.schema(keyType, valueType).getFieldNames()));
+                        options, KeyValue.schema(keyType, valueType).getFieldNames()),
+                options.asyncFileWrite());
 
         this.keyType = keyType;
         this.valueType = valueType;

--- a/paimon-core/src/main/java/org/apache/paimon/io/RowDataFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/RowDataFileWriter.java
@@ -62,7 +62,8 @@ public class RowDataFileWriter extends StatsCollectingSingleFileWriter<InternalR
             String fileCompression,
             SimpleColStatsCollector.Factory[] statsCollectors,
             FileIndexOptions fileIndexOptions,
-            FileSource fileSource) {
+            FileSource fileSource,
+            boolean asyncFileWrite) {
         super(
                 fileIO,
                 factory,
@@ -71,7 +72,8 @@ public class RowDataFileWriter extends StatsCollectingSingleFileWriter<InternalR
                 writeSchema,
                 simpleStatsExtractor,
                 fileCompression,
-                statsCollectors);
+                statsCollectors,
+                asyncFileWrite);
         this.schemaId = schemaId;
         this.seqNumCounter = seqNumCounter;
         this.statsArraySerializer = new SimpleStatsConverter(writeSchema);

--- a/paimon-core/src/main/java/org/apache/paimon/io/RowDataRollingFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/RowDataRollingFileWriter.java
@@ -42,7 +42,8 @@ public class RowDataRollingFileWriter extends RollingFileWriter<InternalRow, Dat
             String fileCompression,
             SimpleColStatsCollector.Factory[] statsCollectors,
             FileIndexOptions fileIndexOptions,
-            FileSource fileSource) {
+            FileSource fileSource,
+            boolean asyncFileWrite) {
         super(
                 () ->
                         new RowDataFileWriter(
@@ -60,7 +61,8 @@ public class RowDataRollingFileWriter extends RollingFileWriter<InternalRow, Dat
                                 fileCompression,
                                 statsCollectors,
                                 fileIndexOptions,
-                                fileSource),
+                                fileSource,
+                                asyncFileWrite),
                 targetFileSize);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/io/SingleFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/SingleFileWriter.java
@@ -21,6 +21,7 @@ package org.apache.paimon.io;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FormatWriter;
 import org.apache.paimon.format.FormatWriterFactory;
+import org.apache.paimon.fs.AsyncPositionOutputStream;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
@@ -64,7 +65,7 @@ public abstract class SingleFileWriter<T, R> implements FileWriter<T, R> {
         this.converter = converter;
 
         try {
-            out = fileIO.newOutputStream(path, false);
+            out = new AsyncPositionOutputStream(fileIO.newOutputStream(path, false));
             writer = factory.create(out, compression);
         } catch (IOException e) {
             LOG.warn(

--- a/paimon-core/src/main/java/org/apache/paimon/io/SingleFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/SingleFileWriter.java
@@ -59,13 +59,17 @@ public abstract class SingleFileWriter<T, R> implements FileWriter<T, R> {
             FormatWriterFactory factory,
             Path path,
             Function<T, InternalRow> converter,
-            String compression) {
+            String compression,
+            boolean asyncWrite) {
         this.fileIO = fileIO;
         this.path = path;
         this.converter = converter;
 
         try {
-            out = new AsyncPositionOutputStream(fileIO.newOutputStream(path, false));
+            out = fileIO.newOutputStream(path, false);
+            if (asyncWrite) {
+                out = new AsyncPositionOutputStream(out);
+            }
             writer = factory.create(out, compression);
         } catch (IOException e) {
             LOG.warn(

--- a/paimon-core/src/main/java/org/apache/paimon/io/StatsCollectingSingleFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/StatsCollectingSingleFileWriter.java
@@ -53,8 +53,9 @@ public abstract class StatsCollectingSingleFileWriter<T, R> extends SingleFileWr
             RowType writeSchema,
             @Nullable SimpleStatsExtractor simpleStatsExtractor,
             String compression,
-            SimpleColStatsCollector.Factory[] statsCollectors) {
-        super(fileIO, factory, path, converter, compression);
+            SimpleColStatsCollector.Factory[] statsCollectors,
+            boolean asyncWrite) {
+        super(fileIO, factory, path, converter, compression, asyncWrite);
         this.simpleStatsExtractor = simpleStatsExtractor;
         if (this.simpleStatsExtractor == null) {
             this.simpleStatsCollector = new SimpleStatsCollector(writeSchema, statsCollectors);

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java
@@ -116,7 +116,13 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
         private long schemaId = Long.MIN_VALUE;
 
         ManifestEntryWriter(FormatWriterFactory factory, Path path, String fileCompression) {
-            super(ManifestFile.this.fileIO, factory, path, serializer::toRow, fileCompression);
+            super(
+                    ManifestFile.this.fileIO,
+                    factory,
+                    path,
+                    serializer::toRow,
+                    fileCompression,
+                    false);
 
             this.partitionStatsCollector = new SimpleStatsCollector(partitionType);
             this.partitionStatsSerializer = new SimpleStatsConverter(partitionType);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
@@ -163,7 +163,8 @@ public class AppendOnlyFileStoreWrite extends MemoryFileStoreWrite<InternalRow> 
                 spillCompression,
                 statsCollectors,
                 maxDiskSize,
-                fileIndexOptions);
+                fileIndexOptions,
+                options.asyncFileWrite());
     }
 
     public AppendOnlyCompactManager.CompactRewriter compactRewriter(
@@ -184,7 +185,8 @@ public class AppendOnlyFileStoreWrite extends MemoryFileStoreWrite<InternalRow> 
                             fileCompression,
                             statsCollectors,
                             fileIndexOptions,
-                            FileSource.COMPACT);
+                            FileSource.COMPACT,
+                            options.asyncFileWrite());
             try {
                 rewriter.write(bucketReader(partition, bucket).read(toCompact));
             } finally {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/MemoryFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/MemoryFileStoreWrite.java
@@ -49,7 +49,7 @@ import java.util.Map;
 public abstract class MemoryFileStoreWrite<T> extends AbstractFileStoreWrite<T> {
     private static final Logger LOG = LoggerFactory.getLogger(MemoryFileStoreWrite.class);
 
-    private final CoreOptions options;
+    protected final CoreOptions options;
     protected final CacheManager cacheManager;
     private MemoryPoolFactory writeBufferPool;
 

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -628,7 +628,8 @@ public class AppendOnlyWriterTest {
                         StatsCollectorFactories.createStatsFactories(
                                 options, AppendOnlyWriterTest.SCHEMA.getFieldNames()),
                         MemorySize.MAX_VALUE,
-                        new FileIndexOptions());
+                        new FileIndexOptions(),
+                        true);
         writer.setMemoryPool(
                 new HeapMemorySegmentPool(options.writeBufferSize(), options.pageSize()));
         return Pair.of(writer, compactManager.allFiles());

--- a/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
@@ -91,7 +91,8 @@ public class FileFormatSuffixTest extends KeyValueFileReadWriteTest {
                         StatsCollectorFactories.createStatsFactories(
                                 options, SCHEMA.getFieldNames()),
                         MemorySize.MAX_VALUE,
-                        new FileIndexOptions());
+                        new FileIndexOptions(),
+                        true);
         appendOnlyWriter.setMemoryPool(
                 new HeapMemorySegmentPool(options.writeBufferSize(), options.pageSize()));
         appendOnlyWriter.write(

--- a/paimon-core/src/test/java/org/apache/paimon/io/RollingFileWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/RollingFileWriterTest.java
@@ -90,7 +90,8 @@ public class RollingFileWriterTest {
                                                 new CoreOptions(new HashMap<>()),
                                                 SCHEMA.getFieldNames()),
                                         new FileIndexOptions(),
-                                        FileSource.APPEND),
+                                        FileSource.APPEND,
+                                        true),
                         TARGET_FILE_SIZE);
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This PR introduces asynchronous file writing to increase data throughput.

In order to avoid the problem of byte array reuse, all written arrays are copied once, which is the overhead brought by this PR. However, compared to writing files, copying a byte array seems to be less expensive.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

`AsyncPositionOutputStreamTest`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
