### PR TITLE
[hive] exclude parquet-hadoop-bundle from paimon-hive-catalog.

### DIFF
--- a/paimon-hive/paimon-hive-catalog/pom.xml
+++ b/paimon-hive/paimon-hive-catalog/pom.xml
@@ -84,6 +84,10 @@ under the License.
                     <groupId>com.google.protobuf</groupId>
                     <artifactId>protobuf-java</artifactId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>parquet-hadoop-bundle</artifactId>
+                    <groupId>org.apache.parquet</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
[hive] exclude parquet-hadoop-bundle from paimon-hive-catalog.

<!-- Linking this pull request to the issue -->
Linked issue: close #3881 

<!-- What is the purpose of the change -->

### Tests


<!-- List UT and IT cases to verify this change -->
No.
### API and Format

<!-- Does this change affect API or storage format -->
No.
### Documentation

<!-- Does this change introduce a new feature -->
No.