### PR TITLE
[core][bug]Fix partition table get index RowType error

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/crosspartition/IndexBootstrap.java
+++ b/paimon-core/src/main/java/org/apache/paimon/crosspartition/IndexBootstrap.java
@@ -142,6 +142,7 @@ public class IndexBootstrap implements Serializable {
                 new ArrayList<>(
                         schema.projectedLogicalRowType(
                                         Stream.concat(primaryKeys.stream(), partitionKeys.stream())
+                                                .distinct()
                                                 .collect(Collectors.toList()))
                                 .getFields());
         bootstrapFields.add(

--- a/paimon-core/src/test/java/org/apache/paimon/crosspartition/IndexBootstrapTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/crosspartition/IndexBootstrapTest.java
@@ -117,8 +117,9 @@ public class IndexBootstrapTest extends TableTestBase {
     public void testBootstrapType() throws Exception {
         FileStoreTable table = (FileStoreTable) createTable();
         RowType indexRowType = IndexBootstrap.bootstrapType(table.schema());
+        assertThat(indexRowType.getFieldNames()).contains(BUCKET_FIELD);
         assertThat(indexRowType.getFieldIndex(BUCKET_FIELD))
-                .isEqualTo(RowType.currentHighestFieldId(indexRowType.getFields()));
+                .isEqualTo(2); // the last field is bucket, which is not in table schema
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/GlobalDynamicBucketTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/GlobalDynamicBucketTableITCase.java
@@ -174,23 +174,23 @@ public class GlobalDynamicBucketTableITCase extends CatalogITCaseBase {
     @Test
     public void testBootstrapType() throws Exception {
         Catalog catalog = CatalogFactory.createCatalog(CatalogContext.create(new Path(path)));
-        FileStoreTable T = (FileStoreTable) catalog.getTable(Identifier.create("default", "T"));
-        FileStoreTable partial_update_t =
+        FileStoreTable t = (FileStoreTable) catalog.getTable(Identifier.create("default", "T"));
+        FileStoreTable partialUpdateT =
                 (FileStoreTable) catalog.getTable(Identifier.create("default", "partial_update_t"));
-        FileStoreTable first_row_t =
+        FileStoreTable firstRowT =
                 (FileStoreTable) catalog.getTable(Identifier.create("default", "first_row_t"));
-        assertThat(IndexBootstrap.bootstrapType(T.schema()).getFieldNames()).contains(BUCKET_FIELD);
-        assertThat(IndexBootstrap.bootstrapType(partial_update_t.schema()).getFieldNames())
+        assertThat(IndexBootstrap.bootstrapType(t.schema()).getFieldNames()).contains(BUCKET_FIELD);
+        assertThat(IndexBootstrap.bootstrapType(partialUpdateT.schema()).getFieldNames())
                 .contains(BUCKET_FIELD);
-        assertThat(IndexBootstrap.bootstrapType(first_row_t.schema()).getFieldNames())
+        assertThat(IndexBootstrap.bootstrapType(firstRowT.schema()).getFieldNames())
                 .contains(BUCKET_FIELD);
-        assertThat(IndexBootstrap.bootstrapType(T.schema()).getFieldIndex(BUCKET_FIELD))
+        assertThat(IndexBootstrap.bootstrapType(t.schema()).getFieldIndex(BUCKET_FIELD))
                 .isEqualTo(2);
         assertThat(
-                        IndexBootstrap.bootstrapType(partial_update_t.schema())
+                        IndexBootstrap.bootstrapType(partialUpdateT.schema())
                                 .getFieldIndex(BUCKET_FIELD))
                 .isEqualTo(2);
-        assertThat(IndexBootstrap.bootstrapType(first_row_t.schema()).getFieldIndex(BUCKET_FIELD))
+        assertThat(IndexBootstrap.bootstrapType(firstRowT.schema()).getFieldIndex(BUCKET_FIELD))
                 .isEqualTo(2);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/GlobalDynamicBucketTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/GlobalDynamicBucketTableITCase.java
@@ -18,12 +18,21 @@
 
 package org.apache.paimon.flink;
 
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.crosspartition.IndexBootstrap;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.table.FileStoreTable;
+
 import org.apache.flink.types.Row;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
+import static org.apache.paimon.crosspartition.IndexBootstrap.BUCKET_FIELD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** ITCase for batch file store. */
@@ -160,5 +169,28 @@ public class GlobalDynamicBucketTableITCase extends CatalogITCaseBase {
         sql("insert into large_t select * from src");
         sql("insert into large_t select * from src");
         assertThat(sql("select k, count(*) from large_t group by k having count(*) > 1")).isEmpty();
+    }
+
+    @Test
+    public void testBootstrapType() throws Exception {
+        Catalog catalog = CatalogFactory.createCatalog(CatalogContext.create(new Path(path)));
+        FileStoreTable T = (FileStoreTable) catalog.getTable(Identifier.create("default", "T"));
+        FileStoreTable partial_update_t =
+                (FileStoreTable) catalog.getTable(Identifier.create("default", "partial_update_t"));
+        FileStoreTable first_row_t =
+                (FileStoreTable) catalog.getTable(Identifier.create("default", "first_row_t"));
+        assertThat(IndexBootstrap.bootstrapType(T.schema()).getFieldNames()).contains(BUCKET_FIELD);
+        assertThat(IndexBootstrap.bootstrapType(partial_update_t.schema()).getFieldNames())
+                .contains(BUCKET_FIELD);
+        assertThat(IndexBootstrap.bootstrapType(first_row_t.schema()).getFieldNames())
+                .contains(BUCKET_FIELD);
+        assertThat(IndexBootstrap.bootstrapType(T.schema()).getFieldIndex(BUCKET_FIELD))
+                .isEqualTo(2);
+        assertThat(
+                        IndexBootstrap.bootstrapType(partial_update_t.schema())
+                                .getFieldIndex(BUCKET_FIELD))
+                .isEqualTo(2);
+        assertThat(IndexBootstrap.bootstrapType(first_row_t.schema()).getFieldIndex(BUCKET_FIELD))
+                .isEqualTo(2);
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->
In the case of partitioned tables,  call  IndexBootstrap.bootstrapType function  throw exception:  "Field names must be unique. Found duplicates: [dt]"    

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3886 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
