### PR TITLE
[avro] Do not flush on every block for DataFileWriter

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/avro/AvroFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/avro/AvroFileFormat.java
@@ -124,6 +124,7 @@ public class AvroFileFormat extends FileFormat {
                                         new DataFileWriter<>(datumWriter);
                                 dataFileWriter.setCodec(createCodecFactory(compression));
                                 dataFileWriter.create(schema, out);
+                                dataFileWriter.setFlushOnEveryBlock(false);
                                 return dataFileWriter;
                             });
         }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Improve performance:
No need to flush every block for avro writer.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
