### PR TITLE
[core] Change expire parition log

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
@@ -98,7 +98,7 @@ public class PartitionExpire {
             Object[] array = strategy.convertPartition(partition.partition());
             Map<String, String> partString = strategy.toPartitionString(array);
             expired.add(partString);
-            LOG.info("Expire Partition: {}", partition);
+            LOG.info("Expire Partition: {}", partString);
         }
         if (!expired.isEmpty()) {
             if (metastoreClient != null) {


### PR DESCRIPTION
### Purpose
Make expire partition log more readable

LOG changed before: ```Expire Partition: org.apache.paimon.data.BinaryRow@b2d8cadd``` 
LOG changed after: ```Expire Partition: {dt=20240710, hour=4}```

<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
