### PR TITLE
[core] add interface in Catalog for CloneAction adapter CachingCatalog

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -20,6 +20,7 @@ package org.apache.paimon.catalog;
 
 import org.apache.paimon.annotation.Public;
 import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.metastore.MetastoreClient;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
@@ -168,6 +169,13 @@ public interface Catalog extends AutoCloseable {
      * @throws DatabaseNotExistException if the database does not exist
      */
     List<String> listTables(String databaseName) throws DatabaseNotExistException;
+
+    /**
+     * Get the table location in this catalog.
+     *
+     * @return the table location
+     */
+    Path getDataTableLocation(Identifier identifier);
 
     /**
      * Check if a table exists in this catalog.

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.catalog;
 
 import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.metastore.MetastoreClient;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
@@ -132,6 +133,11 @@ public class DelegateCatalog implements Catalog {
     @Override
     public Table getTable(Identifier identifier) throws TableNotExistException {
         return wrapped.getTable(identifier);
+    }
+
+    @Override
+    public Path getDataTableLocation(Identifier identifier) {
+        return wrapped.getDataTableLocation(identifier);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/CopyFileOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/CopyFileOperator.java
@@ -34,8 +34,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
-import static org.apache.paimon.CoreOptions.PATH;
-
 /** A Operator to copy files. */
 public class CopyFileOperator extends AbstractStreamOperator<CloneFileInfo>
         implements OneInputStreamOperator<CloneFileInfo, CloneFileInfo> {
@@ -69,19 +67,11 @@ public class CopyFileOperator extends AbstractStreamOperator<CloneFileInfo>
         FileIO sourceTableFileIO = sourceCatalog.fileIO();
         FileIO targetTableFileIO = targetCatalog.fileIO();
         Path sourceTableRootPath =
-                new Path(
-                        sourceCatalog
-                                .getTable(
-                                        Identifier.fromString(cloneFileInfo.getSourceIdentifier()))
-                                .options()
-                                .get(PATH.key()));
+                sourceCatalog.getDataTableLocation(
+                        Identifier.fromString(cloneFileInfo.getSourceIdentifier()));
         Path targetTableRootPath =
-                new Path(
-                        targetCatalog
-                                .getTable(
-                                        Identifier.fromString(cloneFileInfo.getTargetIdentifier()))
-                                .options()
-                                .get(PATH.key()));
+                targetCatalog.getDataTableLocation(
+                        Identifier.fromString(cloneFileInfo.getTargetIdentifier()));
 
         String filePathExcludeTableRoot = cloneFileInfo.getFilePathExcludeTableRoot();
         Path sourcePath = new Path(sourceTableRootPath + filePathExcludeTableRoot);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

Now CloneActionITCase is unstabitily, because we use Catalog#getTable which means the schema file must be copied completely, but in a distributed environment, this cannot be guaranteed.
So we add interface in Catalog for CloneAction adapter CachingCatalog.

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
