### PR TITLE
[flink] create table validate options

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
@@ -1032,4 +1032,26 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
         // change name from non-physical column to physical column is not allowed
         assertThatThrownBy(() -> sql("ALTER TABLE T MODIFY name VARCHAR COMMENT 'header3'"));
     }
+
+    @Test
+    public void testCreateTableWithInvalidOption() {
+        assertThatThrownBy(
+                        () ->
+                                sql(
+                                        "CREATE TABLE MyTable (\n"
+                                                + "  user_id BIGINT,\n"
+                                                + "  item_id BIGINT,\n"
+                                                + "  behavior STRING,\n"
+                                                + "  dt STRING,\n"
+                                                + "  hh STRING,\n"
+                                                + "  PRIMARY KEY (dt, hh, user_id) NOT ENFORCED\n"
+                                                + "  ) PARTITIONED BY (dt) WITH (\n"
+                                                + "    'partition.expiration-time' = '1 d',\n"
+                                                + "    'partition.timestamp-formattedsdsr' = 'yyyyMMdd'   -- this is required in `values-time` strategy.\n"
+                                                + ");\n"),
+                        "")
+                .rootCause()
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid option: partition.timestamp-formattedsdsr");
+    }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
A wrong table parameter can also be successfully built. I think it need validate options.
![wecom-temp-79456-8b30745bfde073a039835c4e0678b158](https://github.com/user-attachments/assets/859c0679-a041-4391-be22-42f7939871ae)


### Tests
SchemaChangeITCase#testCreateTableWithInvalidOption

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
