### PR TITLE
[spark] Support push down StringContains

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexReader.java
@@ -52,6 +52,11 @@ public abstract class FileIndexReader implements FunctionVisitor<FileIndexResult
     }
 
     @Override
+    public FileIndexResult visitContains(FieldRef fieldRef, Object literal) {
+        return REMAIN;
+    }
+
+    @Override
     public FileIndexResult visitLessThan(FieldRef fieldRef, Object literal) {
         return REMAIN;
     }

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/empty/EmptyFileIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/empty/EmptyFileIndexReader.java
@@ -53,6 +53,11 @@ public class EmptyFileIndexReader extends FileIndexReader {
     }
 
     @Override
+    public FileIndexResult visitContains(FieldRef fieldRef, Object literal) {
+        return SKIP;
+    }
+
+    @Override
     public FileIndexResult visitLessThan(FieldRef fieldRef, Object literal) {
         return SKIP;
     }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/Contains.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/Contains.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.predicate;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.types.DataType;
+
+import java.util.List;
+import java.util.Optional;
+
+/** A {@link NullFalseLeafBinaryFunction} to evaluate {@code filter like '%abc%'}. */
+public class Contains extends NullFalseLeafBinaryFunction {
+
+    public static final Contains INSTANCE = new Contains();
+
+    private Contains() {}
+
+    @Override
+    public boolean test(DataType type, Object field, Object patternLiteral) {
+        BinaryString fieldString = (BinaryString) field;
+        return fieldString.contains((BinaryString) patternLiteral);
+    }
+
+    @Override
+    public boolean test(
+            DataType type,
+            long rowCount,
+            Object min,
+            Object max,
+            Long nullCount,
+            Object patternLiteral) {
+        return true;
+    }
+
+    @Override
+    public Optional<LeafFunction> negate() {
+        return Optional.empty();
+    }
+
+    @Override
+    public <T> T visit(FunctionVisitor<T> visitor, FieldRef fieldRef, List<Object> literals) {
+        return visitor.visitContains(fieldRef, literals.get(0));
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/FunctionVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/FunctionVisitor.java
@@ -52,6 +52,8 @@ public interface FunctionVisitor<T> extends PredicateVisitor<T> {
 
     T visitEndsWith(FieldRef fieldRef, Object literal);
 
+    T visitContains(FieldRef fieldRef, Object literal);
+
     T visitLessThan(FieldRef fieldRef, Object literal);
 
     T visitGreaterOrEqual(FieldRef fieldRef, Object literal);

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/OnlyPartitionKeyEqualVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/OnlyPartitionKeyEqualVisitor.java
@@ -63,6 +63,11 @@ public class OnlyPartitionKeyEqualVisitor implements FunctionVisitor<Boolean> {
     }
 
     @Override
+    public Boolean visitContains(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
     public Boolean visitLessThan(FieldRef fieldRef, Object literal) {
         return false;
     }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
@@ -112,6 +112,10 @@ public class PredicateBuilder {
         return leaf(EndsWith.INSTANCE, idx, patternLiteral);
     }
 
+    public Predicate contains(int idx, Object patternLiteral) {
+        return leaf(Contains.INSTANCE, idx, patternLiteral);
+    }
+
     public Predicate leaf(NullFalseLeafBinaryFunction function, int idx, Object literal) {
         DataField field = rowType.getFields().get(idx);
         return new LeafPredicate(function, field.type(), idx, field.name(), singletonList(literal));

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/filter/OrcPredicateFunctionVisitor.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/filter/OrcPredicateFunctionVisitor.java
@@ -70,6 +70,11 @@ public class OrcPredicateFunctionVisitor
     }
 
     @Override
+    public Optional<OrcFilters.Predicate> visitContains(FieldRef fieldRef, Object literal) {
+        return Optional.empty();
+    }
+
+    @Override
     public Optional<OrcFilters.Predicate> visitLessThan(FieldRef fieldRef, Object literal) {
         return convertBinary(fieldRef, literal, OrcFilters.LessThan::new);
     }

--- a/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
+++ b/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
@@ -147,6 +147,11 @@ public class ParquetFilters {
         }
 
         @Override
+        public FilterPredicate visitContains(FieldRef fieldRef, Object literal) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public FilterPredicate visitIn(FieldRef fieldRef, List<Object> literals) {
             throw new UnsupportedOperationException();
         }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkFilterConverter.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkFilterConverter.java
@@ -36,6 +36,7 @@ import org.apache.spark.sql.sources.LessThan;
 import org.apache.spark.sql.sources.LessThanOrEqual;
 import org.apache.spark.sql.sources.Not;
 import org.apache.spark.sql.sources.Or;
+import org.apache.spark.sql.sources.StringContains;
 import org.apache.spark.sql.sources.StringEndsWith;
 import org.apache.spark.sql.sources.StringStartsWith;
 
@@ -63,7 +64,8 @@ public class SparkFilterConverter {
                     "Or",
                     "Not",
                     "StringStartsWith",
-                    "StringEndsWith");
+                    "StringEndsWith",
+                    "StringContains");
 
     private final RowType rowType;
     private final PredicateBuilder builder;
@@ -148,6 +150,11 @@ public class SparkFilterConverter {
             int index = fieldIndex(endsWith.attribute());
             Object literal = convertLiteral(index, endsWith.value());
             return builder.endsWith(index, literal);
+        } else if (filter instanceof StringContains) {
+            StringContains contains = (StringContains) filter;
+            int index = fieldIndex(contains.attribute());
+            Object literal = convertLiteral(index, contains.value());
+            return builder.contains(index, literal);
         }
 
         // TODO: AlwaysTrue, AlwaysFalse

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFilterConverterTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFilterConverterTest.java
@@ -40,6 +40,7 @@ import org.apache.spark.sql.sources.IsNull;
 import org.apache.spark.sql.sources.LessThan;
 import org.apache.spark.sql.sources.LessThanOrEqual;
 import org.apache.spark.sql.sources.Not;
+import org.apache.spark.sql.sources.StringContains;
 import org.apache.spark.sql.sources.StringEndsWith;
 import org.apache.spark.sql.sources.StringStartsWith;
 import org.junit.jupiter.api.Test;
@@ -167,6 +168,13 @@ public class SparkFilterConverterTest {
         boolean test1 = endsWithPre.test(10, min, max, new GenericArray(nullCount));
         assertThat(test).isEqualTo(true);
         assertThat(test1).isEqualTo(true);
+
+        // StringContains
+        StringContains stringContains = StringContains.apply("id", "aa");
+        Predicate contains = converter01.convert(stringContains);
+        assertThat(contains.test(row)).isEqualTo(true);
+        assertThat(contains.test(max)).isEqualTo(false);
+        assertThat(contains.test(min)).isEqualTo(true);
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This pr makes Spark engine supports push down `StringContains`, e.g., `col like '%xx%'`, and create a new predicate function `Contains` in Paimon to represent it.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
add test

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
