### PR TITLE
[pom] Replaces the maven property with project property.

### DIFF
--- a/.mvn/readme.txt
+++ b/.mvn/readme.txt
@@ -1,4 +1,0 @@
-The .mvn directory is needed to be able to use the ${maven.multiModuleProjectDirectory} property, since git cannot
-commit an empty directory, add this file.
-
-Once we do not use ${maven.multiModuleProjectDirectory}, we can remove this file and .mvn directory.

--- a/pom.xml
+++ b/pom.xml
@@ -828,19 +828,18 @@ under the License.
                             </importOrder>
 
                             <licenseHeader>
-                                <!-- replace it with ${project.rootDirectory} after maven 4.0.0, see MNG-7038 -->
-                                <file>${maven.multiModuleProjectDirectory}/copyright.txt</file>
+                                <file>copyright.txt</file>
                                 <delimiter>${spotless.delimiter}</delimiter>
                             </licenseHeader>
                         </java>
                         <scala>
                             <scalafmt>
                                 <version>3.4.3</version>
-                                <file>${maven.multiModuleProjectDirectory}/.scalafmt.conf</file>
+                                <file>.scalafmt.conf</file>
                             </scalafmt>
 
                             <licenseHeader>
-                                <file>${maven.multiModuleProjectDirectory}/copyright.txt</file>
+                                <file>copyright.txt</file>
                                 <delimiter>${spotless.delimiter}</delimiter>
                             </licenseHeader>
                         </scala>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

In my production environment I get compilation errors : 
```
[ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:2.13.0:check (spotless-check) on project paimon-parent: Execution spotless-check of goal com.diffplug.spotless:spotless-maven-plugin:2.13.0:check failed: Unable to locate file with path: ${maven.multiModuleProjectDirectory}/.scalafmt.conf: Could not find resource '${maven.multiModuleProjectDirectory}/.scalafmt.conf'. -> [Help 1]
```

Parameter ${maven.multiModuleProjectDirectory}  is not a recommended parameter. Use ${project.basedir} instead of it. 

References ：
https://stackoverflow.com/questions/29778262/what-is-maven-multimoduleprojectdirectory-used-for

https://github.com/apache/iotdb/pull/12982

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
