### PR TITLE
[spark] fix bug that use the wrong version of commit message serializer

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -384,7 +384,7 @@ public class CompactProcedure extends BaseProcedure {
             for (byte[] serializedMessage : serializedMessages) {
                 messages.add(
                         messageSerializerser.deserialize(
-                                serializer.getVersion(), serializedMessage));
+                                messageSerializerser.getVersion(), serializedMessage));
             }
             commit.commit(messages);
         } catch (Exception e) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
