### PR TITLE
[core] Fix FieldCountAgg should return the same data type as fieldType.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldCountAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldCountAgg.java
@@ -36,63 +36,65 @@ public class FieldCountAgg extends FieldAggregator {
 
     @Override
     public Object agg(Object accumulator, Object inputField) {
-        Object count;
-        if (accumulator == null || inputField == null) {
-            count = (accumulator == null ? (inputField == null ? 0 : 1) : accumulator);
-        } else {
-            // ordered by type root definition
-            switch (fieldType.getTypeRoot()) {
-                case TINYINT:
-                    count = (byte) ((byte) accumulator + 1);
-                    break;
-                case SMALLINT:
-                    count = (short) ((short) accumulator + 1);
-                    break;
-                case INTEGER:
-                    count = (int) accumulator + 1;
-                    break;
-                case BIGINT:
-                    count = (long) accumulator + 1L;
-                    break;
-                default:
-                    String msg =
-                            String.format(
-                                    "type %s not support in %s",
-                                    fieldType.getTypeRoot().toString(), this.getClass().getName());
-                    throw new IllegalArgumentException(msg);
-            }
+
+        if (accumulator != null && inputField == null) {
+            return accumulator;
         }
-        return count;
+        // ordered by type root definition
+        switch (fieldType.getTypeRoot()) {
+            case TINYINT:
+                return accumulator == null
+                        ? (inputField == null ? (byte) 0 : (byte) 1)
+                        : (byte) ((byte) accumulator + 1);
+            case SMALLINT:
+                return accumulator == null
+                        ? (inputField == null ? (short) 0 : (short) 1)
+                        : (short) ((short) accumulator + 1);
+            case INTEGER:
+                return accumulator == null ? (inputField == null ? 0 : 1) : (int) accumulator + 1;
+            case BIGINT:
+                return accumulator == null
+                        ? (inputField == null ? 0L : 1L)
+                        : (long) accumulator + 1L;
+            default:
+                String msg =
+                        String.format(
+                                "type %s not support in %s",
+                                fieldType.getTypeRoot().toString(), this.getClass().getName());
+                throw new IllegalArgumentException(msg);
+        }
     }
 
     @Override
     public Object retract(Object accumulator, Object inputField) {
-        Object count;
-        if (accumulator == null || inputField == null) {
-            count = (accumulator == null ? (inputField == null ? 0 : -1) : accumulator);
-        } else {
-            // ordered by type root definition
-            switch (fieldType.getTypeRoot()) {
-                case TINYINT:
-                    count = (byte) ((byte) accumulator - 1);
-                    break;
-                case SMALLINT:
-                    count = (short) ((short) accumulator - 1);
-                    break;
-                case INTEGER:
-                    count = (int) accumulator - 1;
-                    break;
-                case BIGINT:
-                    count = (long) accumulator - 1L;
-                    break;
-                default:
-                    String msg =
-                            String.format(
-                                    "type %s not support in %s",
-                                    fieldType.getTypeRoot().toString(), this.getClass().getName());
-                    throw new IllegalArgumentException(msg);
-            }
+
+        if (accumulator != null && inputField == null) {
+            return accumulator;
         }
-        return count;
+
+        // ordered by type root definition
+        switch (fieldType.getTypeRoot()) {
+            case TINYINT:
+                return accumulator == null
+                        ? (inputField == null ? (byte) 0 : (byte) -1)
+                        : (byte) ((byte) accumulator - 1);
+            case SMALLINT:
+                return accumulator == null
+                        ? (inputField == null ? (short) 0 : (short) -1)
+                        : (short) ((short) accumulator - 1);
+            case INTEGER:
+                return accumulator == null ? (inputField == null ? 0 : -1) : (int) accumulator - 1;
+
+            case BIGINT:
+                return accumulator == null
+                        ? (inputField == null ? 0L : -1L)
+                        : (long) accumulator - 1L;
+            default:
+                String msg =
+                        String.format(
+                                "type %s not support in %s",
+                                fieldType.getTypeRoot().toString(), this.getClass().getName());
+                throw new IllegalArgumentException(msg);
+        }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -166,23 +166,23 @@ public class FieldAggregatorTest {
         assertThat(fieldCountAggInt.agg(3, 6)).isEqualTo(4);
 
         FieldCountAgg fieldCountAggLong = new FieldCountAgg(new BigIntType());
-        assertThat(fieldCountAggLong.agg(null, null)).isEqualTo(0);
+        assertThat(fieldCountAggLong.agg(null, null)).isEqualTo(0L);
         assertThat(fieldCountAggLong.agg((long) 1, null)).isEqualTo((long) 1);
-        assertThat(fieldCountAggLong.agg(null, (long) 15)).isEqualTo(1);
+        assertThat(fieldCountAggLong.agg(null, (long) 15)).isEqualTo(1L);
         assertThat(fieldCountAggLong.agg((long) 1, 0)).isEqualTo((long) 2);
         assertThat(fieldCountAggLong.agg((long) 3, (long) 6)).isEqualTo((long) 4);
 
         FieldCountAgg fieldCountAggByte = new FieldCountAgg(new TinyIntType());
-        assertThat(fieldCountAggByte.agg(null, null)).isEqualTo(0);
+        assertThat(fieldCountAggByte.agg(null, null)).isEqualTo((byte) 0);
         assertThat(fieldCountAggByte.agg((byte) 1, null)).isEqualTo((byte) 1);
-        assertThat(fieldCountAggByte.agg(null, (byte) 15)).isEqualTo(1);
+        assertThat(fieldCountAggByte.agg(null, (byte) 15)).isEqualTo((byte) 1);
         assertThat(fieldCountAggByte.agg((byte) 1, 0)).isEqualTo((byte) 2);
         assertThat(fieldCountAggByte.agg((byte) 3, (byte) 6)).isEqualTo((byte) 4);
 
         FieldCountAgg fieldCountAggShort = new FieldCountAgg(new SmallIntType());
-        assertThat(fieldCountAggShort.agg(null, null)).isEqualTo(0);
+        assertThat(fieldCountAggShort.agg(null, null)).isEqualTo((short) 0);
         assertThat(fieldCountAggShort.agg((short) 1, null)).isEqualTo((short) 1);
-        assertThat(fieldCountAggShort.agg(null, (short) 15)).isEqualTo(1);
+        assertThat(fieldCountAggShort.agg(null, (short) 15)).isEqualTo((short) 1);
         assertThat(fieldCountAggShort.agg((short) 1, 0)).isEqualTo((short) 2);
         assertThat(fieldCountAggShort.agg((short) 3, (short) 6)).isEqualTo((short) 4);
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
```
CREATE  TABLE testAggregation ( 
id STRING  
,name STRING 
,dt STRING 
,PRIMARY KEY(id, dt) NOT ENFORCED 
,agg_count bigint 
) PARTITIONED BY (dt) WITH ( 
'bucket' = '1' 
,'auto-create' = 'false' 
,'fields.agg_count.aggregate-function' = 'count' 
,'connector' = 'paimon' 
,'merge-engine' = 'aggregation' 
);

insert datas to trigger compaction.
```
throw ClassCastException ：

<img width="1404" alt="image" src="https://github.com/user-attachments/assets/e1703005-07ac-48d7-87eb-5d5dac05b32d">

FieldType is Bigint type, but return Integer type.

<img width="1165" alt="image" src="https://github.com/user-attachments/assets/2bcfcdb9-0a39-40d3-a1ea-eac3f9c7568c">

Eventually, an error occurs when executing method `getLong` :

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/cdb8e91a-9c3a-4968-802b-afba9220f101">


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
