### PR TITLE
[core] support user define delimiter with list agg

### DIFF
--- a/docs/content/primary-key-table/merge-engine/aggregation.md
+++ b/docs/content/primary-key-table/merge-engine/aggregation.md
@@ -93,6 +93,7 @@ Current supported aggregate functions and data types are:
 ### listagg
   The listagg function concatenates multiple string values into a single string.
   It supports STRING data type.
+  Each field not part of the primary keys can be given a list agg delimiter, specified by the fields.<field-name>.list-agg-delimiter table property, otherwise it will use "," as default.
 
 ### bool_and
   The bool_and function evaluates whether all values in a boolean set are true.

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -81,6 +81,8 @@ public class CoreOptions implements Serializable {
 
     public static final String DISTINCT = "distinct";
 
+    public static final String LIST_AGG_DELIMITER = "list-agg-delimiter";
+
     public static final String FILE_INDEX = "file-index";
 
     public static final String COLUMNS = "columns";
@@ -1472,6 +1474,13 @@ public class CoreOptions implements Serializable {
                 key(FIELDS_PREFIX + "." + fieldName + "." + DISTINCT)
                         .booleanType()
                         .defaultValue(false));
+    }
+
+    public String fieldListAggDelimiter(String fieldName) {
+        return options.get(
+                key(FIELDS_PREFIX + "." + fieldName + "." + LIST_AGG_DELIMITER)
+                        .stringType()
+                        .defaultValue(","));
     }
 
     @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregator.java
@@ -74,7 +74,7 @@ public abstract class FieldAggregator implements Serializable {
                         fieldAggregator = new FieldLastValueAgg(fieldType);
                         break;
                     case FieldListaggAgg.NAME:
-                        fieldAggregator = new FieldListaggAgg(fieldType);
+                        fieldAggregator = new FieldListaggAgg(fieldType, options, field);
                         break;
                     case FieldBoolOrAgg.NAME:
                         fieldAggregator = new FieldBoolOrAgg(fieldType);

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldListaggAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldListaggAgg.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.mergetree.compact.aggregate;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.utils.StringUtils;
@@ -27,11 +28,11 @@ public class FieldListaggAgg extends FieldAggregator {
 
     public static final String NAME = "listagg";
 
-    // TODO: make it configurable by with clause
-    public static final String DELIMITER = ",";
+    private final String delimiter;
 
-    public FieldListaggAgg(DataType dataType) {
+    public FieldListaggAgg(DataType dataType, CoreOptions options, String field) {
         super(dataType);
+        this.delimiter = options.fieldListAggDelimiter(field);
     }
 
     @Override
@@ -54,7 +55,7 @@ public class FieldListaggAgg extends FieldAggregator {
                     BinaryString inFieldSD = (BinaryString) inputField;
                     concatenate =
                             StringUtils.concat(
-                                    mergeFieldSD, BinaryString.fromString(DELIMITER), inFieldSD);
+                                    mergeFieldSD, BinaryString.fromString(delimiter), inFieldSD);
                     break;
                 default:
                     String msg =

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/IntervalPartitionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/IntervalPartitionTest.java
@@ -48,8 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** Tests for {@link IntervalPartition}. */
 public class IntervalPartitionTest {
 
-    private static final RecordComparator COMPARATOR =
-            (RecordComparator) (o1, o2) -> o1.getInt(0) - o2.getInt(0);
+    private static final RecordComparator COMPARATOR = (o1, o2) -> o1.getInt(0) - o2.getInt(0);
 
     @Test
     public void testSameMinKey() {

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.mergetree.compact.aggregate;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.GenericArray;
@@ -42,6 +43,8 @@ import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.utils.RoaringBitmap32;
 import org.apache.paimon.utils.RoaringBitmap64;
+
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 
 import org.junit.jupiter.api.Test;
 
@@ -123,12 +126,28 @@ public class FieldAggregatorTest {
     }
 
     @Test
-    public void testFieldListaggAgg() {
-        FieldListaggAgg fieldListaggAgg = new FieldListaggAgg(new VarCharType());
+    public void testFieldListAggWithDefaultDelimiter() {
+        FieldListaggAgg fieldListaggAgg =
+                new FieldListaggAgg(
+                        new VarCharType(), new CoreOptions(new HashMap<>()), "fieldName");
         BinaryString accumulator = BinaryString.fromString("user1");
         BinaryString inputField = BinaryString.fromString("user2");
         assertThat(fieldListaggAgg.agg(accumulator, inputField).toString())
                 .isEqualTo("user1,user2");
+    }
+
+    @Test
+    public void testFieldListAggWithCustomDelimiter() {
+        FieldListaggAgg fieldListaggAgg =
+                new FieldListaggAgg(
+                        new VarCharType(),
+                        CoreOptions.fromMap(
+                                ImmutableMap.of("fields.fieldName.list-agg-delimiter", "-")),
+                        "fieldName");
+        BinaryString accumulator = BinaryString.fromString("user1");
+        BinaryString inputField = BinaryString.fromString("user2");
+        assertThat(fieldListaggAgg.agg(accumulator, inputField).toString())
+                .isEqualTo("user1-user2");
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

1、In my company, user want set field delimiter when use list agg.
2、Eliminate todo left over from two years ago.

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
