### PR TITLE
[core] Get size should after close output in emptyIndexFile

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorIndexFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorIndexFileWriter.java
@@ -72,9 +72,8 @@ public class DeletionVectorIndexFileWriter {
         try {
             while (iterator.hasNext()) {
                 Map.Entry<String, DeletionVector> entry = iterator.next();
-                long currentSize = writer.write(entry.getKey(), entry.getValue());
-
-                if (writer.writtenSizeInBytes() + currentSize > targetSizeInBytes) {
+                writer.write(entry.getKey(), entry.getValue());
+                if (writer.writtenSizeInBytes() > targetSizeInBytes) {
                     break;
                 }
             }
@@ -92,50 +91,43 @@ public class DeletionVectorIndexFileWriter {
      * <p>TODO: We can consider sending a message to delete the deletion file in the future.
      */
     private List<IndexFileMeta> emptyIndexFile() throws IOException {
-        try (SingleIndexFileWriter writer = new SingleIndexFileWriter()) {
-            return Collections.singletonList(writer.writtenIndexFile());
-        }
+        SingleIndexFileWriter writer = new SingleIndexFileWriter();
+        writer.close();
+        return Collections.singletonList(writer.writtenIndexFile());
     }
 
     private class SingleIndexFileWriter implements Closeable {
 
         private final Path path;
-
         private final DataOutputStream dataOutputStream;
-
         private final LinkedHashMap<String, Pair<Integer, Integer>> dvRanges;
 
-        private long writtenSizeInBytes = 0L;
-
-        public SingleIndexFileWriter() throws IOException {
+        private SingleIndexFileWriter() throws IOException {
             this.path = indexPathFactory.newPath();
             this.dataOutputStream = new DataOutputStream(fileIO.newOutputStream(path, true));
             dataOutputStream.writeByte(VERSION_ID_V1);
             this.dvRanges = new LinkedHashMap<>();
         }
 
-        public long writtenSizeInBytes() {
-            return this.writtenSizeInBytes;
+        private long writtenSizeInBytes() {
+            return dataOutputStream.size();
         }
 
-        public long write(String key, DeletionVector deletionVector) throws IOException {
+        private void write(String key, DeletionVector deletionVector) throws IOException {
             Preconditions.checkNotNull(dataOutputStream);
             byte[] data = deletionVector.serializeToBytes();
             int size = data.length;
-
             dvRanges.put(key, Pair.of(dataOutputStream.size(), size));
             dataOutputStream.writeInt(size);
             dataOutputStream.write(data);
             dataOutputStream.writeInt(calculateChecksum(data));
-            writtenSizeInBytes += size;
-            return size;
         }
 
-        public IndexFileMeta writtenIndexFile() throws IOException {
+        public IndexFileMeta writtenIndexFile() {
             return new IndexFileMeta(
                     DELETION_VECTORS_INDEX,
                     path.getName(),
-                    fileIO.getFileSize(path),
+                    writtenSizeInBytes(),
                     dvRanges.size(),
                     dvRanges);
         }

--- a/paimon-core/src/test/java/org/apache/paimon/deletionvectors/DeletionVectorsIndexFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/deletionvectors/DeletionVectorsIndexFileTest.java
@@ -160,7 +160,7 @@ public class DeletionVectorsIndexFileTest {
         List<IndexFileMeta> indexFiles = deletionVectorsIndexFile.write(fileToDV);
 
         // assert 1
-        assertThat(indexFiles.size()).isEqualTo(5);
+        assertThat(indexFiles.size()).isEqualTo(3);
         Map<String, DeletionVector> dvs =
                 deletionVectorsIndexFile.readAllDeletionVectors(indexFiles);
         for (String file : dvs.keySet()) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3891

See issue, there will be FileNotFound when using s3

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

The bug is only in S3, cannot re-produce in unit tests.

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
