### PR TITLE
[flink] Introduce bypass append compact coordinator and worker

### DIFF
--- a/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.paimon.Snapshot;
+
+import org.apache.flink.types.Row;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test case for append-only managed unaware-bucket table. */
+public class UnawareBucketAppendOnlyTableITCase extends CatalogITCaseBase {
+
+    @Override
+    protected List<String> ddl() {
+        return Collections.singletonList(
+                "CREATE TABLE IF NOT EXISTS append_table (id INT, data STRING) WITH ('bucket' = '-1')");
+    }
+
+    @Test
+    public void testCompactionInStreamingMode() throws Exception {
+        batchSql("ALTER TABLE append_table SET ('compaction.min.file-num' = '2')");
+        batchSql("ALTER TABLE append_table SET ('compaction.early-max.file-num' = '4')");
+        batchSql("ALTER TABLE append_table SET ('continuous.discovery-interval' = '1 s')");
+
+        sEnv.getConfig().getConfiguration().set(CHECKPOINTING_INTERVAL, Duration.ofMillis(500));
+        sEnv.executeSql(
+                "CREATE TEMPORARY TABLE Orders_in (\n"
+                        + "    f0        INT,\n"
+                        + "    f1        STRING\n"
+                        + ") WITH (\n"
+                        + "    'connector' = 'datagen',\n"
+                        + "    'rows-per-second' = '1',\n"
+                        + "    'number-of-rows' = '10'\n"
+                        + ")");
+
+        assertStreamingHasCompact("INSERT INTO append_table SELECT * FROM Orders_in", 60000);
+        // ensure data gen finished
+        Thread.sleep(5000);
+
+        List<Row> rows = batchSql("SELECT * FROM append_table");
+        assertThat(rows.size()).isEqualTo(10);
+    }
+
+    private void assertStreamingHasCompact(String sql, long timeout) throws Exception {
+        long start = System.currentTimeMillis();
+        long currentId = 1;
+        sEnv.executeSql(sql);
+        Snapshot snapshot;
+        while (true) {
+            snapshot = findSnapshot("append_table", currentId);
+            if (snapshot != null) {
+                if (snapshot.commitKind() == Snapshot.CommitKind.COMPACT) {
+                    break;
+                }
+                currentId++;
+            }
+            long now = System.currentTimeMillis();
+            if (now - start > timeout) {
+                throw new RuntimeException(
+                        "Time up for streaming execute, don't get expected result.");
+            }
+            Thread.sleep(1000);
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-1.18/src/test/resources/log4j2-test.properties
+++ b/paimon-flink/paimon-flink-1.18/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%tid %t] %-5p %c %x - %m%n

--- a/paimon-flink/paimon-flink-1.19/pom.xml
+++ b/paimon-flink/paimon-flink-1.19/pom.xml
@@ -42,6 +42,12 @@ under the License.
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-flink-common</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -54,6 +60,51 @@ under the License.
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java-bridge</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- test dependencies -->
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-flink-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-files</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.21</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/paimon-flink/paimon-flink-1.19/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-1.19/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.paimon.Snapshot;
+
+import org.apache.flink.types.Row;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test case for append-only managed unaware-bucket table. */
+public class UnawareBucketAppendOnlyTableITCase extends CatalogITCaseBase {
+
+    @Override
+    protected List<String> ddl() {
+        return Collections.singletonList(
+                "CREATE TABLE IF NOT EXISTS append_table (id INT, data STRING) WITH ('bucket' = '-1')");
+    }
+
+    @Test
+    public void testCompactionInStreamingMode() throws Exception {
+        batchSql("ALTER TABLE append_table SET ('compaction.min.file-num' = '2')");
+        batchSql("ALTER TABLE append_table SET ('compaction.early-max.file-num' = '4')");
+        batchSql("ALTER TABLE append_table SET ('continuous.discovery-interval' = '1 s')");
+
+        sEnv.getConfig().getConfiguration().set(CHECKPOINTING_INTERVAL, Duration.ofMillis(500));
+        sEnv.executeSql(
+                "CREATE TEMPORARY TABLE Orders_in (\n"
+                        + "    f0        INT,\n"
+                        + "    f1        STRING\n"
+                        + ") WITH (\n"
+                        + "    'connector' = 'datagen',\n"
+                        + "    'rows-per-second' = '1',\n"
+                        + "    'number-of-rows' = '10'\n"
+                        + ")");
+
+        assertStreamingHasCompact("INSERT INTO append_table SELECT * FROM Orders_in", 60000);
+        // ensure data gen finished
+        Thread.sleep(5000);
+
+        List<Row> rows = batchSql("SELECT * FROM append_table");
+        assertThat(rows.size()).isEqualTo(10);
+    }
+
+    private void assertStreamingHasCompact(String sql, long timeout) throws Exception {
+        long start = System.currentTimeMillis();
+        long currentId = 1;
+        sEnv.executeSql(sql);
+        Snapshot snapshot;
+        while (true) {
+            snapshot = findSnapshot("append_table", currentId);
+            if (snapshot != null) {
+                if (snapshot.commitKind() == Snapshot.CommitKind.COMPACT) {
+                    break;
+                }
+                currentId++;
+            }
+            long now = System.currentTimeMillis();
+            if (now - start > timeout) {
+                throw new RuntimeException(
+                        "Time up for streaming execute, don't get expected result.");
+            }
+            Thread.sleep(1000);
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-1.19/src/test/resources/log4j2-test.properties
+++ b/paimon-flink/paimon-flink-1.19/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%tid %t] %-5p %c %x - %m%n

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/UnawareBucketCompactionTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/UnawareBucketCompactionTopoBuilder.java
@@ -20,7 +20,6 @@ package org.apache.paimon.flink.compact;
 
 import org.apache.paimon.append.AppendOnlyCompactionTask;
 import org.apache.paimon.flink.FlinkConnectorOptions;
-import org.apache.paimon.flink.sink.Committable;
 import org.apache.paimon.flink.sink.UnawareBucketCompactionSink;
 import org.apache.paimon.flink.source.BucketUnawareCompactSource;
 import org.apache.paimon.options.Options;
@@ -71,27 +70,17 @@ public class UnawareBucketCompactionTopoBuilder {
 
     public void build() {
         // build source from UnawareSourceFunction
-        DataStreamSource<AppendOnlyCompactionTask> source = buildSource(false);
+        DataStreamSource<AppendOnlyCompactionTask> source = buildSource();
 
         // from source, construct the full flink job
         sinkFromSource(source);
     }
 
-    public DataStream<Committable> fetchUncommitted(String commitUser) {
-        DataStreamSource<AppendOnlyCompactionTask> source = buildSource(true);
-
-        // rebalance input to default or assigned parallelism
-        DataStream<AppendOnlyCompactionTask> rebalanced = rebalanceInput(source);
-
-        return new UnawareBucketCompactionSink(table)
-                .doWrite(rebalanced, commitUser, rebalanced.getParallelism());
-    }
-
-    private DataStreamSource<AppendOnlyCompactionTask> buildSource(boolean emitMaxWatermark) {
+    private DataStreamSource<AppendOnlyCompactionTask> buildSource() {
         long scanInterval = table.coreOptions().continuousDiscoveryInterval().toMillis();
         BucketUnawareCompactSource source =
                 new BucketUnawareCompactSource(
-                        table, isContinuous, scanInterval, partitionPredicate, emitMaxWatermark);
+                        table, isContinuous, scanInterval, partitionPredicate);
 
         return BucketUnawareCompactSource.buildSource(env, source, isContinuous, tableIdentifier);
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendBypassCompactWorkerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendBypassCompactWorkerOperator.java
@@ -24,9 +24,9 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.types.Either;
 
-/** A {@link CompactWorkerOperator} to bypass Committable inputs. */
+/** A {@link AppendCompactWorkerOperator} to bypass Committable inputs. */
 public class AppendBypassCompactWorkerOperator
-        extends CompactWorkerOperator<Either<Committable, AppendOnlyCompactionTask>> {
+        extends AppendCompactWorkerOperator<Either<Committable, AppendOnlyCompactionTask>> {
 
     public AppendBypassCompactWorkerOperator(FileStoreTable table, String commitUser) {
         super(table, commitUser);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendBypassCompactWorkerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendBypassCompactWorkerOperator.java
@@ -19,24 +19,31 @@
 package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.append.AppendOnlyCompactionTask;
-import org.apache.paimon.flink.source.BucketUnawareCompactSource;
 import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.types.Either;
 
-/**
- * Operator to execute {@link AppendOnlyCompactionTask} passed from {@link
- * BucketUnawareCompactSource} for compacting single unaware bucket tables in divided mode.
- */
-public class AppendOnlySingleTableCompactionWorkerOperator
-        extends CompactWorkerOperator<AppendOnlyCompactionTask> {
+/** A {@link CompactWorkerOperator} to bypass Committable inputs. */
+public class AppendBypassCompactWorkerOperator
+        extends CompactWorkerOperator<Either<Committable, AppendOnlyCompactionTask>> {
 
-    public AppendOnlySingleTableCompactionWorkerOperator(FileStoreTable table, String commitUser) {
+    public AppendBypassCompactWorkerOperator(FileStoreTable table, String commitUser) {
         super(table, commitUser);
     }
 
     @Override
-    public void processElement(StreamRecord<AppendOnlyCompactionTask> element) throws Exception {
-        this.unawareBucketCompactor.processElement(element.getValue());
+    public void open() throws Exception {
+        super.open();
+    }
+
+    @Override
+    public void processElement(StreamRecord<Either<Committable, AppendOnlyCompactionTask>> element)
+            throws Exception {
+        if (element.getValue().isLeft()) {
+            output.collect(new StreamRecord<>(element.getValue().left()));
+        } else {
+            unawareBucketCompactor.processElement(element.getValue().right());
+        }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendCompactWorkerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendCompactWorkerOperator.java
@@ -41,9 +41,10 @@ import java.util.concurrent.TimeUnit;
  * An abstract Operator to execute {@link AppendOnlyCompactionTask} passed from {@link
  * BucketUnawareCompactSource} for compacting table. This operator is always in async mode.
  */
-public abstract class CompactWorkerOperator<IN> extends PrepareCommitOperator<IN, Committable> {
+public abstract class AppendCompactWorkerOperator<IN>
+        extends PrepareCommitOperator<IN, Committable> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(CompactWorkerOperator.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AppendCompactWorkerOperator.class);
 
     private final FileStoreTable table;
     private final String commitUser;
@@ -52,7 +53,7 @@ public abstract class CompactWorkerOperator<IN> extends PrepareCommitOperator<IN
 
     private transient ExecutorService lazyCompactExecutor;
 
-    public CompactWorkerOperator(FileStoreTable table, String commitUser) {
+    public AppendCompactWorkerOperator(FileStoreTable table, String commitUser) {
         super(Options.fromMap(table.options()));
         this.table = table;
         this.commitUser = commitUser;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendOnlySingleTableCompactionWorkerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendOnlySingleTableCompactionWorkerOperator.java
@@ -29,7 +29,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
  * BucketUnawareCompactSource} for compacting single unaware bucket tables in divided mode.
  */
 public class AppendOnlySingleTableCompactionWorkerOperator
-        extends CompactWorkerOperator<AppendOnlyCompactionTask> {
+        extends AppendCompactWorkerOperator<AppendOnlyCompactionTask> {
 
     public AppendOnlySingleTableCompactionWorkerOperator(FileStoreTable table, String commitUser) {
         super(table, commitUser);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactWorkerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactWorkerOperator.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.append.AppendOnlyCompactionTask;
+import org.apache.paimon.flink.compact.UnawareBucketCompactor;
+import org.apache.paimon.flink.source.BucketUnawareCompactSource;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.utils.ExecutorThreadFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An abstract Operator to execute {@link AppendOnlyCompactionTask} passed from {@link
+ * BucketUnawareCompactSource} for compacting table. This operator is always in async mode.
+ */
+public abstract class CompactWorkerOperator<IN> extends PrepareCommitOperator<IN, Committable> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CompactWorkerOperator.class);
+
+    private final FileStoreTable table;
+    private final String commitUser;
+
+    protected transient UnawareBucketCompactor unawareBucketCompactor;
+
+    private transient ExecutorService lazyCompactExecutor;
+
+    public CompactWorkerOperator(FileStoreTable table, String commitUser) {
+        super(Options.fromMap(table.options()));
+        this.table = table;
+        this.commitUser = commitUser;
+    }
+
+    @VisibleForTesting
+    Iterable<Future<CommitMessage>> result() {
+        return unawareBucketCompactor.result();
+    }
+
+    @Override
+    public void open() throws Exception {
+        LOG.debug("Opened a append-only table compaction worker.");
+        this.unawareBucketCompactor =
+                new UnawareBucketCompactor(table, commitUser, this::workerExecutor);
+    }
+
+    @Override
+    protected List<Committable> prepareCommit(boolean waitCompaction, long checkpointId)
+            throws IOException {
+        return this.unawareBucketCompactor.prepareCommit(waitCompaction, checkpointId);
+    }
+
+    private ExecutorService workerExecutor() {
+        if (lazyCompactExecutor == null) {
+            lazyCompactExecutor =
+                    Executors.newSingleThreadScheduledExecutor(
+                            new ExecutorThreadFactory(
+                                    Thread.currentThread().getName()
+                                            + "-append-only-compact-worker"));
+        }
+        return lazyCompactExecutor;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (lazyCompactExecutor != null) {
+            // ignore runnable tasks in queue
+            lazyCompactExecutor.shutdownNow();
+            if (!lazyCompactExecutor.awaitTermination(120, TimeUnit.SECONDS)) {
+                LOG.warn(
+                        "Executors shutdown timeout, there may be some files aren't deleted correctly");
+            }
+            this.unawareBucketCompactor.close();
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketSink.java
@@ -72,14 +72,14 @@ public abstract class UnawareBucketSink<T> extends FlinkWriteSink<T> {
         if (enableCompaction && isStreamingMode && !boundedInput) {
             written =
                     written.transform(
-                                    "Compact Bypass Coordinator",
+                                    "Compact Coordinator: " + table.name(),
                                     new EitherTypeInfo<>(
                                             new CommittableTypeInfo(),
                                             new CompactionTaskTypeInfo()),
                                     new AppendBypassCoordinateOperator<>(table))
                             .forceNonParallel()
                             .transform(
-                                    "Compact Worker",
+                                    "Compact Worker: " + table.name(),
                                     new CommittableTypeInfo(),
                                     new AppendBypassCompactWorkerOperator(table, initialCommitUser))
                             .setParallelism(written.getParallelism());

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/AppendBypassCoordinateOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/AppendBypassCoordinateOperator.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source;
+
+import org.apache.paimon.append.AppendOnlyCompactionTask;
+import org.apache.paimon.append.AppendOnlyTableCompactionCoordinator;
+import org.apache.paimon.table.FileStoreTable;
+
+import org.apache.flink.api.common.operators.ProcessingTimeService;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.types.Either;
+
+import java.util.List;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/**
+ * A {@link OneInputStreamOperator} to accept commit messages and send append compact coordinate
+ * compact task to downstream operators.
+ */
+public class AppendBypassCoordinateOperator<CommitT>
+        extends AbstractStreamOperator<Either<CommitT, AppendOnlyCompactionTask>>
+        implements OneInputStreamOperator<CommitT, Either<CommitT, AppendOnlyCompactionTask>>,
+                ProcessingTimeService.ProcessingTimeCallback {
+
+    private final FileStoreTable table;
+
+    private transient long intervalMs;
+    private transient AppendOnlyTableCompactionCoordinator coordinator;
+
+    public AppendBypassCoordinateOperator(FileStoreTable table) {
+        this.table = table;
+        this.chainingStrategy = ChainingStrategy.NEVER;
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        checkArgument(
+                getRuntimeContext().getTaskInfo().getNumberOfParallelSubtasks() == 1,
+                "Compaction Coordinator parallelism in paimon MUST be one.");
+        this.coordinator = new AppendOnlyTableCompactionCoordinator(table, true, null);
+        this.intervalMs = table.coreOptions().continuousDiscoveryInterval().toMillis();
+
+        long now = getProcessingTimeService().getCurrentProcessingTime();
+        getProcessingTimeService().registerTimer(now, this);
+    }
+
+    @Override
+    public void onProcessingTime(long time) {
+        while (true) {
+            List<AppendOnlyCompactionTask> tasks = coordinator.run();
+            for (AppendOnlyCompactionTask task : tasks) {
+                output.collect(new StreamRecord<>(Either.Right(task)));
+            }
+
+            if (tasks.isEmpty()) {
+                break;
+            }
+        }
+
+        getProcessingTimeService().registerTimer(time + this.intervalMs, this);
+    }
+
+    @Override
+    public void processElement(StreamRecord<CommitT> record) throws Exception {
+        output.collect(new StreamRecord<>(Either.Left(record.getValue())));
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/AppendBypassCoordinateOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/AppendBypassCoordinateOperator.java
@@ -56,7 +56,7 @@ public class AppendBypassCoordinateOperator<CommitT>
     public void open() throws Exception {
         super.open();
         checkArgument(
-                getRuntimeContext().getTaskInfo().getNumberOfParallelSubtasks() == 1,
+                getRuntimeContext().getNumberOfParallelSubtasks() == 1,
                 "Compaction Coordinator parallelism in paimon MUST be one.");
         this.coordinator = new AppendOnlyTableCompactionCoordinator(table, true, null);
         this.intervalMs = table.coreOptions().continuousDiscoveryInterval().toMillis();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/AppendBypassCoordinateOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/AppendBypassCoordinateOperator.java
@@ -85,9 +85,4 @@ public class AppendBypassCoordinateOperator<CommitT>
     public void processElement(StreamRecord<CommitT> record) throws Exception {
         output.collect(new StreamRecord<>(Either.Left(record.getValue())));
     }
-
-    @Override
-    public void close() throws Exception {
-        super.close();
-    }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
@@ -189,6 +189,7 @@ public class UnawareBucketAppendOnlyTableITCase extends CatalogITCaseBase {
     public void testCompactionInStreamingMode() throws Exception {
         batchSql("ALTER TABLE append_table SET ('compaction.min.file-num' = '2')");
         batchSql("ALTER TABLE append_table SET ('compaction.early-max.file-num' = '4')");
+        batchSql("ALTER TABLE append_table SET ('continuous.discovery-interval' = '1 s')");
 
         sEnv.getConfig().getConfiguration().set(CHECKPOINTING_INTERVAL, Duration.ofMillis(500));
         sEnv.executeSql(
@@ -213,6 +214,7 @@ public class UnawareBucketAppendOnlyTableITCase extends CatalogITCaseBase {
     public void testCompactionInStreamingModeWithMaxWatermark() throws Exception {
         batchSql("ALTER TABLE append_table SET ('compaction.min.file-num' = '2')");
         batchSql("ALTER TABLE append_table SET ('compaction.early-max.file-num' = '4')");
+        batchSql("ALTER TABLE append_table SET ('continuous.discovery-interval' = '1 s')");
 
         sEnv.getConfig().getConfiguration().set(CHECKPOINTING_INTERVAL, Duration.ofMillis(500));
         sEnv.executeSql(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Inline compaction of append table (bucket = -1) has a special independent topology. It has caused many problems:

1. Causing the bounded streaming to not end.
2. There is an issue with sending the watermark (which has been fixed by send max watermark).
3. Causing great confusion to users

Overall, it is quite risky, and we can actually hang the compact after the writer, making its lifecycle very easy to control.
 
<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
