### PR TITLE
[WIP][core] Introduce buckets table

### DIFF
--- a/docs/content/maintenance/system-tables.md
+++ b/docs/content/maintenance/system-tables.md
@@ -292,6 +292,24 @@ SELECT * FROM my_table$aggregation_fields;
 3 rows in set
 */
 ```
+### Buckets Table
+
+You can query the bucket files of the table.
+
+```sql
+SELECT * FROM my_table$buckets;
+
+/*
++---------+--------------+--------------------+------------+-------------------+---------------------------+-------------------------+
+|  bucket | record_count | file_size_in_bytes | file_count | level0_file_count | level0_file_backlog_ratio |        last_update_time |
++---------+--------------+--------------------+------------+-------------------+---------------------------+-------------------------+
+|    1    |            1 |                645 |          6 |                 6 |                      1.2  | 2024-06-24 10:25:57.400 |
++---------+--------------+--------------------+------------+-------------------+---------------------------+-------------------------+
+*/
+
+```
+The Level 0 file backlog ratio reflects whether compaction is being performed in a timely manner.
+Formula: level0_file_backlog_ratio = level0_file_count / num-sorted-run.compaction-trigger.
 
 ### Partitions Table
 

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/BucketEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/BucketEntry.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.manifest;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.paimon.manifest.FileKind.DELETE;
+
+/** Entry representing a bucket. */
+public class BucketEntry {
+
+    private final int bucket;
+    private final long recordCount;
+    private final long fileSizeInBytes;
+    private final long fileCount;
+    private final long level0FileCount;
+    private final int triggerNum;
+    private final long lastFileCreationTime;
+
+    public BucketEntry(
+            int bucket,
+            long recordCount,
+            long fileSizeInBytes,
+            long fileCount,
+            long level0FileCount,
+            int triggerNum,
+            long lastFileCreationTime) {
+        this.bucket = bucket;
+        this.recordCount = recordCount;
+        this.fileSizeInBytes = fileSizeInBytes;
+        this.fileCount = fileCount;
+        this.level0FileCount = level0FileCount;
+        this.triggerNum = triggerNum;
+        this.lastFileCreationTime = lastFileCreationTime;
+    }
+
+    public int bucket() {
+        return bucket;
+    }
+
+    public long recordCount() {
+        return recordCount;
+    }
+
+    public long fileSizeInBytes() {
+        return fileSizeInBytes;
+    }
+
+    public long fileCount() {
+        return fileCount;
+    }
+
+    public long triggerNum() {
+        return triggerNum;
+    }
+
+    public long level0FileCount() {
+        return level0FileCount;
+    }
+
+    public long lastFileCreationTime() {
+        return lastFileCreationTime;
+    }
+
+    public BucketEntry merge(BucketEntry entry) {
+        return new BucketEntry(
+                bucket,
+                recordCount + entry.recordCount,
+                fileSizeInBytes + entry.fileSizeInBytes,
+                fileCount + entry.fileCount,
+                level0FileCount + entry.level0FileCount,
+                triggerNum,
+                Math.max(lastFileCreationTime, entry.lastFileCreationTime));
+    }
+
+    public static BucketEntry fromManifestEntry(ManifestEntry entry, int triggerNum) {
+        long recordCount = entry.file().rowCount();
+        long fileSizeInBytes = entry.file().fileSize();
+        long fileCount = 1;
+        long level0FileCount = 0;
+        if (entry.level() == 0) {
+            level0FileCount = 1;
+        }
+        if (entry.kind() == DELETE) {
+            recordCount = -recordCount;
+            fileSizeInBytes = -fileSizeInBytes;
+            fileCount = -fileCount;
+            level0FileCount = -level0FileCount;
+        }
+        return new BucketEntry(
+                entry.bucket(),
+                recordCount,
+                fileSizeInBytes,
+                fileCount,
+                level0FileCount,
+                triggerNum,
+                entry.file().creationTimeEpochMillis());
+    }
+
+    public static Collection<BucketEntry> merge(
+            Collection<ManifestEntry> fileEntries, int triggerNum) {
+        Map<Integer, BucketEntry> bucktes = new HashMap<>();
+        for (ManifestEntry entry : fileEntries) {
+            BucketEntry bucketEntry = fromManifestEntry(entry, triggerNum);
+            bucktes.compute(
+                    entry.bucket(),
+                    (part, old) -> old == null ? bucketEntry : old.merge(bucketEntry));
+        }
+        return bucktes.values();
+    }
+
+    public static void merge(Collection<BucketEntry> from, Map<Integer, BucketEntry> to) {
+        for (BucketEntry entry : from) {
+            to.compute(entry.bucket(), (part, old) -> old == null ? entry : old.merge(entry));
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BucketEntry that = (BucketEntry) o;
+        return recordCount == that.recordCount
+                && fileSizeInBytes == that.fileSizeInBytes
+                && fileCount == that.fileCount
+                && level0FileCount == that.level0FileCount
+                && triggerNum == that.triggerNum
+                && lastFileCreationTime == that.lastFileCreationTime
+                && Objects.equals(bucket, that.bucket);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                bucket,
+                recordCount,
+                fileSizeInBytes,
+                fileCount,
+                level0FileCount,
+                triggerNum,
+                lastFileCreationTime);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
@@ -21,6 +21,7 @@ package org.apache.paimon.operation;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.BucketEntry;
 import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.manifest.ManifestEntry;
@@ -84,6 +85,8 @@ public interface FileStoreScan {
     List<SimpleFileEntry> readSimpleEntries();
 
     List<PartitionEntry> readPartitionEntries();
+
+    List<BucketEntry> readBucketEntries();
 
     default List<BinaryRow> listPartitions() {
         return readPartitionEntries().stream()

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
@@ -21,6 +21,7 @@ package org.apache.paimon.table.source.snapshot;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.manifest.BucketEntry;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.predicate.Predicate;
@@ -86,6 +87,8 @@ public interface SnapshotReader {
     List<BinaryRow> partitions();
 
     List<PartitionEntry> partitionEntries();
+
+    List<BucketEntry> bucketEntries();
 
     /** Result plan of this scan. */
     interface Plan extends TableScan.Plan {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
@@ -27,6 +27,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.BucketEntry;
 import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.metrics.MetricRegistry;
@@ -331,6 +332,11 @@ public class SnapshotReaderImpl implements SnapshotReader {
     @Override
     public List<PartitionEntry> partitionEntries() {
         return scan.readPartitionEntries();
+    }
+
+    @Override
+    public List<BucketEntry> bucketEntries() {
+        return scan.readBucketEntries();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
@@ -27,6 +27,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.manifest.BucketEntry;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.predicate.LeafPredicate;
@@ -329,6 +330,11 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
         @Override
         public List<PartitionEntry> partitionEntries() {
             return snapshotReader.partitionEntries();
+        }
+
+        @Override
+        public List<BucketEntry> bucketEntries() {
+            return snapshotReader.bucketEntries();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/BucketsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/BucketsTable.java
@@ -18,189 +18,151 @@
 
 package org.apache.paimon.table.system;
 
-import org.apache.paimon.CoreOptions;
-import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.disk.IOManager;
-import org.apache.paimon.fs.FileIO;
-import org.apache.paimon.fs.Path;
-import org.apache.paimon.io.DataFileMeta;
-import org.apache.paimon.io.DataFileMetaSerializer;
+import org.apache.paimon.manifest.BucketEntry;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
-import org.apache.paimon.table.DataTable;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.ReadonlyTable;
-import org.apache.paimon.table.source.DataSplit;
-import org.apache.paimon.table.source.DataTableScan;
+import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.InnerTableRead;
+import org.apache.paimon.table.source.InnerTableScan;
+import org.apache.paimon.table.source.ReadOnceTableScan;
+import org.apache.paimon.table.source.SingletonSplit;
 import org.apache.paimon.table.source.Split;
-import org.apache.paimon.table.source.StreamDataTableScan;
 import org.apache.paimon.table.source.TableRead;
-import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.types.BigIntType;
-import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.DoubleType;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowType;
-import org.apache.paimon.types.VarCharType;
-import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.IteratorRecordReader;
-import org.apache.paimon.utils.SnapshotManager;
-import org.apache.paimon.utils.TagManager;
+import org.apache.paimon.utils.ProjectedRow;
 
-import javax.annotation.Nullable;
+import org.apache.paimon.shade.guava30.com.google.common.collect.Iterators;
 
-import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalLong;
 
-import static org.apache.paimon.utils.SerializationUtils.newBytesType;
-import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
+import static org.apache.paimon.catalog.Catalog.SYSTEM_TABLE_SPLITTER;
 
-/**
- * A table to produce modified partitions and buckets for each snapshot.
- *
- * <p>Only used internally by dedicated compact job sources.
- */
-public class BucketsTable implements DataTable, ReadonlyTable {
+/** A {@link Table} for showing partitions info. */
+public class BucketsTable implements ReadonlyTable {
 
     private static final long serialVersionUID = 1L;
 
-    private final FileStoreTable wrapped;
-    private final boolean isContinuous;
+    public static final String BUCKETS = "buckets";
 
-    @Nullable private final String databaseName;
+    public static final RowType TABLE_TYPE =
+            new RowType(
+                    Arrays.asList(
+                            new DataField(0, "bucket", new IntType(true)),
+                            new DataField(1, "record_count", new BigIntType(false)),
+                            new DataField(2, "file_size_in_bytes", new BigIntType(false)),
+                            new DataField(3, "file_count", new BigIntType(false)),
+                            new DataField(4, "level0_file_count", new BigIntType(false)),
+                            new DataField(5, "level0_file_backlog_ratio", new DoubleType(false)),
+                            new DataField(6, "last_update_time", DataTypes.TIMESTAMP_MILLIS())));
 
-    private static final RowType ROW_TYPE =
-            RowType.of(
-                    new DataType[] {
-                        new BigIntType(false),
-                        newBytesType(false),
-                        new IntType(false),
-                        newBytesType(false),
-                        new VarCharType(true, Integer.MAX_VALUE),
-                        new VarCharType(false, Integer.MAX_VALUE)
-                    },
-                    new String[] {
-                        "_SNAPSHOT_ID",
-                        "_PARTITION",
-                        "_BUCKET",
-                        "_FILES",
-                        "_DATABASE_NAME",
-                        "_TABLE_NAME"
-                    });
+    private final FileStoreTable storeTable;
 
-    public BucketsTable(FileStoreTable wrapped, boolean isContinuous) {
-        this(wrapped, isContinuous, null);
-    }
-
-    // if need to specify the database of a table, use this method
-    public BucketsTable(FileStoreTable wrapped, boolean isContinuous, String databaseName) {
-        this.wrapped = wrapped;
-        this.isContinuous = isContinuous;
-        this.databaseName = databaseName;
-    }
-
-    @Override
-    public OptionalLong latestSnapshotId() {
-        return wrapped.latestSnapshotId();
-    }
-
-    @Override
-    public Path location() {
-        return wrapped.location();
-    }
-
-    @Override
-    public SnapshotManager snapshotManager() {
-        return wrapped.snapshotManager();
-    }
-
-    @Override
-    public TagManager tagManager() {
-        return wrapped.tagManager();
-    }
-
-    @Override
-    public BranchManager branchManager() {
-        return wrapped.branchManager();
+    public BucketsTable(FileStoreTable storeTable) {
+        this.storeTable = storeTable;
     }
 
     @Override
     public String name() {
-        return "__internal_buckets_" + wrapped.location().getName();
+        return storeTable.name() + SYSTEM_TABLE_SPLITTER + BUCKETS;
     }
 
     @Override
     public RowType rowType() {
-        return ROW_TYPE;
-    }
-
-    @Override
-    public Map<String, String> options() {
-        return wrapped.options();
+        return TABLE_TYPE;
     }
 
     @Override
     public List<String> primaryKeys() {
-        return Collections.emptyList();
+        return Collections.singletonList("buckets");
     }
 
     @Override
-    public SnapshotReader newSnapshotReader() {
-        return wrapped.newSnapshotReader();
-    }
-
-    @Override
-    public DataTableScan newScan() {
-        return wrapped.newScan();
-    }
-
-    @Override
-    public StreamDataTableScan newStreamScan() {
-        return wrapped.newStreamScan();
-    }
-
-    @Override
-    public CoreOptions coreOptions() {
-        return wrapped.coreOptions();
+    public InnerTableScan newScan() {
+        return new BucketsScan();
     }
 
     @Override
     public InnerTableRead newRead() {
-        return new BucketsRead();
+        return new BucketsRead(storeTable);
     }
 
     @Override
-    public BucketsTable copy(Map<String, String> dynamicOptions) {
-        return new BucketsTable(wrapped.copy(dynamicOptions), isContinuous, databaseName);
+    public Table copy(Map<String, String> dynamicOptions) {
+        return new BucketsTable(storeTable.copy(dynamicOptions));
     }
 
-    @Override
-    public FileIO fileIO() {
-        return wrapped.fileIO();
+    private static class BucketsScan extends ReadOnceTableScan {
+
+        @Override
+        public InnerTableScan withFilter(Predicate predicate) {
+            // TODO
+            return this;
+        }
+
+        @Override
+        public Plan innerPlan() {
+            return () -> Collections.singletonList(new BucketsSplit());
+        }
     }
 
-    public static RowType getRowType() {
-        return ROW_TYPE;
+    private static class BucketsSplit extends SingletonSplit {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            return o != null && getClass() == o.getClass();
+        }
+
+        @Override
+        public int hashCode() {
+            return 1;
+        }
     }
 
-    private class BucketsRead implements InnerTableRead {
+    private static class BucketsRead implements InnerTableRead {
 
-        private final DataFileMetaSerializer dataFileMetaSerializer = new DataFileMetaSerializer();
+        private final FileStoreTable fileStoreTable;
+
+        private int[][] projection;
+
+        public BucketsRead(FileStoreTable table) {
+            this.fileStoreTable = table;
+        }
 
         @Override
         public InnerTableRead withFilter(Predicate predicate) {
-            // filter is done by scan
+            // TODO
             return this;
         }
 
         @Override
         public InnerTableRead withProjection(int[][] projection) {
-            throw new UnsupportedOperationException("BucketsRead does not support projection");
+            this.projection = projection;
+            return this;
         }
 
         @Override
@@ -209,30 +171,39 @@ public class BucketsTable implements DataTable, ReadonlyTable {
         }
 
         @Override
-        public RecordReader<InternalRow> createReader(Split split) throws IOException {
-            if (!(split instanceof DataSplit)) {
+        public RecordReader<InternalRow> createReader(Split split) {
+            if (!(split instanceof BucketsSplit)) {
                 throw new IllegalArgumentException("Unsupported split: " + split.getClass());
             }
 
-            DataSplit dataSplit = (DataSplit) split;
+            List<BucketEntry> partitions = fileStoreTable.newSnapshotReader().bucketEntries();
 
-            List<DataFileMeta> files = Collections.emptyList();
-            if (isContinuous) {
-                // Serialized files are only useful in streaming jobs.
-                // Batch compact jobs only run once, so they only need to know what buckets should
-                // be compacted and don't need to concern incremental new files.
-                files = dataSplit.dataFiles();
+            List<InternalRow> results = new ArrayList<>(partitions.size());
+            for (BucketEntry entry : partitions) {
+                results.add(toRow(entry));
             }
-            InternalRow row =
-                    GenericRow.of(
-                            dataSplit.snapshotId(),
-                            serializeBinaryRow(dataSplit.partition()),
-                            dataSplit.bucket(),
-                            dataFileMetaSerializer.serializeList(files),
-                            BinaryString.fromString(databaseName),
-                            BinaryString.fromString(wrapped.name()));
 
-            return new IteratorRecordReader<>(Collections.singletonList(row).iterator());
+            Iterator<InternalRow> iterator = results.iterator();
+            if (projection != null) {
+                iterator =
+                        Iterators.transform(
+                                iterator, row -> ProjectedRow.from(projection).replaceRow(row));
+            }
+            return new IteratorRecordReader<>(iterator);
+        }
+
+        private GenericRow toRow(BucketEntry entry) {
+            return GenericRow.of(
+                    entry.bucket(),
+                    entry.recordCount(),
+                    entry.fileSizeInBytes(),
+                    entry.fileCount(),
+                    entry.level0FileCount(),
+                    (double) entry.level0FileCount() / entry.triggerNum(),
+                    Timestamp.fromLocalDateTime(
+                            LocalDateTime.ofInstant(
+                                    Instant.ofEpochMilli(entry.lastFileCreationTime()),
+                                    ZoneId.systemDefault())));
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ModifiedPartitionBucketTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ModifiedPartitionBucketTable.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.system;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.DataFileMetaSerializer;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.table.DataTable;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.ReadonlyTable;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.DataTableScan;
+import org.apache.paimon.table.source.InnerTableRead;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.StreamDataTableScan;
+import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.table.source.snapshot.SnapshotReader;
+import org.apache.paimon.types.BigIntType;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.utils.BranchManager;
+import org.apache.paimon.utils.IteratorRecordReader;
+import org.apache.paimon.utils.SnapshotManager;
+import org.apache.paimon.utils.TagManager;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalLong;
+
+import static org.apache.paimon.utils.SerializationUtils.newBytesType;
+import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
+
+/**
+ * A table to produce modified partitions and buckets for each snapshot.
+ *
+ * <p>Only used internally by dedicated compact job sources.
+ */
+public class ModifiedPartitionBucketTable implements DataTable, ReadonlyTable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final FileStoreTable wrapped;
+    private final boolean isContinuous;
+
+    @Nullable private final String databaseName;
+
+    private static final RowType ROW_TYPE =
+            RowType.of(
+                    new DataType[] {
+                        new BigIntType(false),
+                        newBytesType(false),
+                        new IntType(false),
+                        newBytesType(false),
+                        new VarCharType(true, Integer.MAX_VALUE),
+                        new VarCharType(false, Integer.MAX_VALUE)
+                    },
+                    new String[] {
+                        "_SNAPSHOT_ID",
+                        "_PARTITION",
+                        "_BUCKET",
+                        "_FILES",
+                        "_DATABASE_NAME",
+                        "_TABLE_NAME"
+                    });
+
+    public ModifiedPartitionBucketTable(FileStoreTable wrapped, boolean isContinuous) {
+        this(wrapped, isContinuous, null);
+    }
+
+    // if need to specify the database of a table, use this method
+    public ModifiedPartitionBucketTable(
+            FileStoreTable wrapped, boolean isContinuous, String databaseName) {
+        this.wrapped = wrapped;
+        this.isContinuous = isContinuous;
+        this.databaseName = databaseName;
+    }
+
+    @Override
+    public OptionalLong latestSnapshotId() {
+        return wrapped.latestSnapshotId();
+    }
+
+    @Override
+    public Path location() {
+        return wrapped.location();
+    }
+
+    @Override
+    public SnapshotManager snapshotManager() {
+        return wrapped.snapshotManager();
+    }
+
+    @Override
+    public TagManager tagManager() {
+        return wrapped.tagManager();
+    }
+
+    @Override
+    public BranchManager branchManager() {
+        return wrapped.branchManager();
+    }
+
+    @Override
+    public String name() {
+        return "__internal_buckets_" + wrapped.location().getName();
+    }
+
+    @Override
+    public RowType rowType() {
+        return ROW_TYPE;
+    }
+
+    @Override
+    public Map<String, String> options() {
+        return wrapped.options();
+    }
+
+    @Override
+    public List<String> primaryKeys() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public SnapshotReader newSnapshotReader() {
+        return wrapped.newSnapshotReader();
+    }
+
+    @Override
+    public DataTableScan newScan() {
+        return wrapped.newScan();
+    }
+
+    @Override
+    public StreamDataTableScan newStreamScan() {
+        return wrapped.newStreamScan();
+    }
+
+    @Override
+    public CoreOptions coreOptions() {
+        return wrapped.coreOptions();
+    }
+
+    @Override
+    public InnerTableRead newRead() {
+        return new BucketsRead();
+    }
+
+    @Override
+    public ModifiedPartitionBucketTable copy(Map<String, String> dynamicOptions) {
+        return new ModifiedPartitionBucketTable(
+                wrapped.copy(dynamicOptions), isContinuous, databaseName);
+    }
+
+    @Override
+    public FileIO fileIO() {
+        return wrapped.fileIO();
+    }
+
+    public static RowType getRowType() {
+        return ROW_TYPE;
+    }
+
+    private class BucketsRead implements InnerTableRead {
+
+        private final DataFileMetaSerializer dataFileMetaSerializer = new DataFileMetaSerializer();
+
+        @Override
+        public InnerTableRead withFilter(Predicate predicate) {
+            // filter is done by scan
+            return this;
+        }
+
+        @Override
+        public InnerTableRead withProjection(int[][] projection) {
+            throw new UnsupportedOperationException("BucketsRead does not support projection");
+        }
+
+        @Override
+        public TableRead withIOManager(IOManager ioManager) {
+            return this;
+        }
+
+        @Override
+        public RecordReader<InternalRow> createReader(Split split) throws IOException {
+            if (!(split instanceof DataSplit)) {
+                throw new IllegalArgumentException("Unsupported split: " + split.getClass());
+            }
+
+            DataSplit dataSplit = (DataSplit) split;
+
+            List<DataFileMeta> files = Collections.emptyList();
+            if (isContinuous) {
+                // Serialized files are only useful in streaming jobs.
+                // Batch compact jobs only run once, so they only need to know what buckets should
+                // be compacted and don't need to concern incremental new files.
+                files = dataSplit.dataFiles();
+            }
+            InternalRow row =
+                    GenericRow.of(
+                            dataSplit.snapshotId(),
+                            serializeBinaryRow(dataSplit.partition()),
+                            dataSplit.bucket(),
+                            dataFileMetaSerializer.serializeList(files),
+                            BinaryString.fromString(databaseName),
+                            BinaryString.fromString(wrapped.name()));
+
+            return new IteratorRecordReader<>(Collections.singletonList(row).iterator());
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
@@ -42,6 +42,7 @@ import static org.apache.paimon.table.system.AggregationFieldsTable.AGGREGATION_
 import static org.apache.paimon.table.system.AllTableOptionsTable.ALL_TABLE_OPTIONS;
 import static org.apache.paimon.table.system.AuditLogTable.AUDIT_LOG;
 import static org.apache.paimon.table.system.BranchesTable.BRANCHES;
+import static org.apache.paimon.table.system.BucketsTable.BUCKETS;
 import static org.apache.paimon.table.system.CatalogOptionsTable.CATALOG_OPTIONS;
 import static org.apache.paimon.table.system.ConsumersTable.CONSUMERS;
 import static org.apache.paimon.table.system.FilesTable.FILES;
@@ -67,6 +68,7 @@ public class SystemTableLoader {
                     .put(OPTIONS, OptionsTable::new)
                     .put(SCHEMAS, SchemasTable::new)
                     .put(PARTITIONS, PartitionsTable::new)
+                    .put(BUCKETS, BucketsTable::new)
                     .put(AUDIT_LOG, AuditLogTable::new)
                     .put(FILES, FilesTable::new)
                     .put(TAGS, TagsTable::new)

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/ContinuousAppendAndCompactFollowUpScannerTest.java
@@ -33,7 +33,7 @@ import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.table.source.TableScan;
-import org.apache.paimon.table.system.BucketsTable;
+import org.apache.paimon.table.system.ModifiedPartitionBucketTable;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
@@ -88,7 +88,7 @@ public class ContinuousAppendAndCompactFollowUpScannerTest extends ScannerTestBa
         write.close();
         commit.close();
 
-        BucketsTable bucketsTable = new BucketsTable(table, true);
+        ModifiedPartitionBucketTable bucketsTable = new ModifiedPartitionBucketTable(table, true);
         TableRead read = bucketsTable.newRead();
         ContinuousAppendAndCompactFollowUpScanner scanner =
                 new ContinuousAppendAndCompactFollowUpScanner();

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/BucketsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/BucketsTableTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.system;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.SchemaUtils;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.types.DataTypes;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link BucketsTable}. */
+public class BucketsTableTest extends TableTestBase {
+
+    private static final String tableName = "MyTable";
+
+    private FileStoreTable table;
+
+    private BucketsTable bucketsTable;
+
+    @BeforeEach
+    public void before() throws Exception {
+        FileIO fileIO = LocalFileIO.create();
+        Path tablePath = new Path(String.format("%s/%s.db/%s", warehouse, database, tableName));
+        Schema schema =
+                Schema.newBuilder()
+                        .column("pk", DataTypes.INT())
+                        .column("pt", DataTypes.INT())
+                        .column("col1", DataTypes.INT())
+                        .primaryKey("pk")
+                        .option("bucket", "2")
+                        .build();
+        TableSchema tableSchema =
+                SchemaUtils.forceCommit(new SchemaManager(fileIO, tablePath), schema);
+        table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath, tableSchema);
+
+        Identifier filesTableId =
+                identifier(tableName + Catalog.SYSTEM_TABLE_SPLITTER + BucketsTable.BUCKETS);
+        bucketsTable = (BucketsTable) catalog.getTable(filesTableId);
+
+        // snapshot 1: append
+        write(table, GenericRow.of(1, 1, 1), GenericRow.of(2, 2, 1));
+
+        write(table, GenericRow.of(3, 1, 1), GenericRow.of(4, 2, 2));
+    }
+
+    @Test
+    public void testBucketRecordCount() throws Exception {
+        List<InternalRow> expectedRow = new ArrayList<>();
+        expectedRow.add(GenericRow.of(0));
+        expectedRow.add(GenericRow.of(1));
+
+        // Only read partition and record count, record size may not stable.
+        List<InternalRow> result = read(bucketsTable, new int[][] {{0}});
+        assertThat(result).containsExactlyInAnyOrderElementsOf(expectedRow);
+    }
+
+    @Test
+    public void testBucketFileBacklogRatio() throws Exception {
+        write(table, GenericRow.of(5, 1, 3));
+        write(table, GenericRow.of(7, 1, 3));
+        write(table, GenericRow.of(8, 1, 3));
+        write(table, GenericRow.of(9, 1, 3));
+        write(table, GenericRow.of(10, 1, 3));
+        List<InternalRow> expectedRow = new ArrayList<>();
+        expectedRow.add(GenericRow.of(0, 0L, 0.0));
+        expectedRow.add(GenericRow.of(1, 3L, 0.6));
+
+        List<InternalRow> result = read(bucketsTable, new int[][] {{0}, {4}, {5}});
+        assertThat(result).containsExactlyInAnyOrderElementsOf(expectedRow);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/MultiAwareBucketTableScan.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/MultiAwareBucketTableScan.java
@@ -24,7 +24,7 @@ import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.StreamTableScan;
-import org.apache.paimon.table.system.BucketsTable;
+import org.apache.paimon.table.system.ModifiedPartitionBucketTable;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 
@@ -44,7 +44,7 @@ import static org.apache.paimon.flink.utils.MultiTablesCompactorUtil.compactOpti
  */
 public class MultiAwareBucketTableScan extends MultiTableScanBase<Tuple2<Split, String>> {
 
-    protected transient Map<Identifier, BucketsTable> tablesMap;
+    protected transient Map<Identifier, ModifiedPartitionBucketTable> tablesMap;
     protected transient Map<Identifier, StreamTableScan> scansMap;
 
     public MultiAwareBucketTableScan(
@@ -87,8 +87,9 @@ public class MultiAwareBucketTableScan extends MultiTableScanBase<Tuple2<Split, 
     @Override
     public void addScanTable(FileStoreTable fileStoreTable, Identifier identifier) {
         if (fileStoreTable.bucketMode() != BucketMode.BUCKET_UNAWARE) {
-            BucketsTable bucketsTable =
-                    new BucketsTable(fileStoreTable, isStreaming, identifier.getDatabaseName())
+            ModifiedPartitionBucketTable bucketsTable =
+                    new ModifiedPartitionBucketTable(
+                                    fileStoreTable, isStreaming, identifier.getDatabaseName())
                             .copy(compactOptions(isStreaming));
             tablesMap.put(identifier, bucketsTable);
             scansMap.put(identifier, bucketsTable.newReadBuilder().newStreamScan());

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/BucketsRowChannelComputer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/BucketsRowChannelComputer.java
@@ -20,13 +20,15 @@ package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.table.sink.ChannelComputer;
-import org.apache.paimon.table.system.BucketsTable;
+import org.apache.paimon.table.system.ModifiedPartitionBucketTable;
 
 import org.apache.flink.table.data.RowData;
 
 import static org.apache.paimon.utils.SerializationUtils.deserializeBinaryRow;
 
-/** {@link ChannelComputer} to partition {@link RowData} from {@link BucketsTable}. */
+/**
+ * {@link ChannelComputer} to partition {@link RowData} from {@link ModifiedPartitionBucketTable}.
+ */
 public class BucketsRowChannelComputer implements ChannelComputer<RowData> {
 
     private transient int numberOfChannels;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CombinedTableCompactorSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CombinedTableCompactorSourceBuilder.java
@@ -25,7 +25,7 @@ import org.apache.paimon.flink.source.operator.CombinedAwareBatchSourceFunction;
 import org.apache.paimon.flink.source.operator.CombinedAwareStreamingSourceFunction;
 import org.apache.paimon.flink.source.operator.CombinedUnawareBatchSourceFunction;
 import org.apache.paimon.flink.source.operator.CombinedUnawareStreamingSourceFunction;
-import org.apache.paimon.table.system.BucketsTable;
+import org.apache.paimon.table.system.ModifiedPartitionBucketTable;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Preconditions;
 
@@ -75,7 +75,7 @@ public class CombinedTableCompactorSourceBuilder {
 
     public DataStream<RowData> buildAwareBucketTableSource() {
         Preconditions.checkArgument(env != null, "StreamExecutionEnvironment should not be null.");
-        RowType produceType = BucketsTable.getRowType();
+        RowType produceType = ModifiedPartitionBucketTable.getRowType();
         if (isContinuous) {
             return CombinedAwareStreamingSourceFunction.buildSource(
                     env,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
@@ -25,7 +25,7 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.ReadBuilder;
-import org.apache.paimon.table.system.BucketsTable;
+import org.apache.paimon.table.system.ModifiedPartitionBucketTable;
 import org.apache.paimon.types.RowType;
 
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
@@ -68,7 +68,7 @@ public class CompactorSourceBuilder {
         return this;
     }
 
-    private Source<RowData, ?, ?> buildSource(BucketsTable bucketsTable) {
+    private Source<RowData, ?, ?> buildSource(ModifiedPartitionBucketTable bucketsTable) {
 
         if (isContinuous) {
             bucketsTable = bucketsTable.copy(streamingCompactOptions());
@@ -93,7 +93,8 @@ public class CompactorSourceBuilder {
             throw new IllegalArgumentException("StreamExecutionEnvironment should not be null.");
         }
 
-        BucketsTable bucketsTable = new BucketsTable(table, isContinuous);
+        ModifiedPartitionBucketTable bucketsTable =
+                new ModifiedPartitionBucketTable(table, isContinuous);
         RowType produceType = bucketsTable.rowType();
         DataStreamSource<RowData> dataStream =
                 env.fromSource(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/MultiTablesReadOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/MultiTablesReadOperator.java
@@ -27,7 +27,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
-import org.apache.paimon.table.system.BucketsTable;
+import org.apache.paimon.table.system.ModifiedPartitionBucketTable;
 import org.apache.paimon.utils.CloseableIterator;
 import org.apache.paimon.utils.Preconditions;
 
@@ -63,7 +63,7 @@ public class MultiTablesReadOperator extends AbstractStreamOperator<RowData>
 
     private transient Catalog catalog;
     private transient IOManager ioManager;
-    private transient Map<Identifier, BucketsTable> tablesMap;
+    private transient Map<Identifier, ModifiedPartitionBucketTable> tablesMap;
     private transient Map<Identifier, TableRead> readsMap;
     private transient StreamRecord<RowData> reuseRecord;
     private transient FlinkRowData reuseRow;
@@ -99,7 +99,7 @@ public class MultiTablesReadOperator extends AbstractStreamOperator<RowData>
     }
 
     private TableRead getTableRead(Identifier tableId) {
-        BucketsTable table = tablesMap.get(tableId);
+        ModifiedPartitionBucketTable table = tablesMap.get(tableId);
         if (table == null) {
             try {
                 Table newTable = catalog.getTable(tableId);
@@ -108,7 +108,7 @@ public class MultiTablesReadOperator extends AbstractStreamOperator<RowData>
                         "Only FileStoreTable supports compact action. The table type is '%s'.",
                         newTable.getClass().getName());
                 table =
-                        new BucketsTable(
+                        new ModifiedPartitionBucketTable(
                                         (FileStoreTable) newTable,
                                         isStreaming,
                                         tableId.getDatabaseName())


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The Level 0 file backlog ratio reflects whether compaction is being performed in a timely manner.
Formula: level0_file_backlog_ratio = level0_file_count / num-sorted-run.compaction-trigger.


| bucket | record_count | file_size_in_bytes | file_count | level0_file_count | level0_file_backlog_ratio | last_update_time       |
|--------|--------------|--------------------|------------|-------------------|------------------|------------------------|
| 1      | 1            | 645                | 1          | 0                 | 0              | 2024-06-24 10:25:57.400|



<!-- What is the purpose of the change -->

### Tests
<img width="1140" alt="image" src="https://github.com/user-attachments/assets/8ad559f2-75d7-4ad2-b278-6cae870d3b4b">

org.apache.paimon.table.system.BucketsTableTest
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation
System Tables
<!-- Does this change introduce a new feature -->
