### PR TITLE
[core] Support BinaryToStringCastRule in casting

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/casting/BinaryToStringCastRule.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/BinaryToStringCastRule.java
@@ -39,5 +39,4 @@ public class BinaryToStringCastRule extends AbstractCastRule<byte[], BinaryStrin
     public CastExecutor<byte[], BinaryString> create(DataType inputType, DataType targetType) {
         return value -> BinaryString.fromBytes(value);
     }
-
 }

--- a/paimon-core/src/main/java/org/apache/paimon/casting/BinaryToStringCastRule.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/BinaryToStringCastRule.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.casting;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeFamily;
+
+/** {@link DataTypeFamily#BINARY_STRING} to {@link DataTypeFamily#CHARACTER_STRING} cast rule. */
+public class BinaryToStringCastRule extends AbstractCastRule<byte[], BinaryString> {
+
+    static final BinaryToStringCastRule INSTANCE = new BinaryToStringCastRule();
+
+    private BinaryToStringCastRule() {
+        super(
+                CastRulePredicate.builder()
+                        .input(DataTypeFamily.BINARY_STRING)
+                        .target(DataTypeFamily.CHARACTER_STRING)
+                        .build());
+    }
+
+    @Override
+    public CastExecutor<byte[], BinaryString> create(DataType inputType, DataType targetType) {
+        return value -> BinaryString.fromBytes(value);
+    }
+
+}

--- a/paimon-core/src/main/java/org/apache/paimon/casting/CastExecutors.java
+++ b/paimon-core/src/main/java/org/apache/paimon/casting/CastExecutors.java
@@ -72,7 +72,8 @@ public class CastExecutors {
                 .addRule(TimeToTimestampCastRule.INSTANCE)
                 .addRule(TimestampToNumericPrimitiveCastRule.INSTANCE)
                 // To binary rules
-                .addRule(BinaryToBinaryCastRule.INSTANCE);
+                .addRule(BinaryToBinaryCastRule.INSTANCE)
+                .addRule(BinaryToStringCastRule.INSTANCE);
     }
 
     /* ------- Entrypoint ------- */

--- a/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -560,6 +560,21 @@ public class CastExecutorTest {
                 "12345678".getBytes());
     }
 
+    @Test
+    public void testBinaryToString() {
+        // binary(5) to string(10)
+        compareCastResult(
+                CastExecutors.resolve(new VarBinaryType(5), new VarCharType(10)),
+                "12345".getBytes(),
+                BinaryString.fromString("12345"));
+
+        // binary(20) to string(10)
+        compareCastResult(
+                CastExecutors.resolve(new VarBinaryType(20), new VarCharType(10)),
+                "12345678".getBytes(),
+                BinaryString.fromString("12345678"));
+    }
+
     // To binary rules
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Currently only support string to binary casting，this pr is aimed to support BinaryToStringCastRule in casting
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
CastExecutorTest##testBinaryToString

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
