### PR TITLE
[core] Avoid 'trying to delete file' commit exception for expired partitions

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/InternalRowPartitionComputer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/InternalRowPartitionComputer.java
@@ -79,7 +79,7 @@ public class InternalRowPartitionComputer {
         return partValues;
     }
 
-    public static String toSimpleString(
+    public static String partToSimpleString(
             RowType partitionType, BinaryRow partition, String delimiter, int maxLength) {
         InternalRow.FieldGetter[] getters = partitionType.fieldGetters();
         StringBuilder builder = new StringBuilder();

--- a/paimon-common/src/test/java/org/apache/paimon/utils/InternalRowPartitionComputerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/InternalRowPartitionComputerTest.java
@@ -35,7 +35,7 @@ public class InternalRowPartitionComputerTest {
     public void testPartitionToString() {
         RowType rowType = RowType.of();
         BinaryRow binaryRow = new BinaryRow(0);
-        assertThat(InternalRowPartitionComputer.toSimpleString(rowType, binaryRow, "-", 30))
+        assertThat(InternalRowPartitionComputer.partToSimpleString(rowType, binaryRow, "-", 30))
                 .isEqualTo("");
 
         rowType = RowType.of(DataTypes.STRING(), DataTypes.INT());
@@ -43,7 +43,7 @@ public class InternalRowPartitionComputerTest {
         BinaryRowWriter writer = new BinaryRowWriter(binaryRow);
         writer.writeString(0, BinaryString.fromString("20240731"));
         writer.writeInt(1, 10);
-        assertThat(InternalRowPartitionComputer.toSimpleString(rowType, binaryRow, "-", 30))
+        assertThat(InternalRowPartitionComputer.partToSimpleString(rowType, binaryRow, "-", 30))
                 .isEqualTo("20240731-10");
 
         rowType = RowType.of(DataTypes.STRING(), DataTypes.INT());
@@ -51,7 +51,7 @@ public class InternalRowPartitionComputerTest {
         writer = new BinaryRowWriter(binaryRow);
         writer.setNullAt(0);
         writer.writeInt(1, 10);
-        assertThat(InternalRowPartitionComputer.toSimpleString(rowType, binaryRow, "-", 30))
+        assertThat(InternalRowPartitionComputer.partToSimpleString(rowType, binaryRow, "-", 30))
                 .isEqualTo("null-10");
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/FileEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/FileEntry.java
@@ -161,13 +161,4 @@ public interface FileEntry {
                 manifestFiles,
                 manifestReadParallelism);
     }
-
-    static <T extends FileEntry> void assertNoDelete(Collection<T> entries) {
-        for (T entry : entries) {
-            Preconditions.checkState(
-                    entry.kind() != FileKind.DELETE,
-                    "Trying to delete file %s which is not previously added.",
-                    entry.fileName());
-        }
-    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/LookupFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/LookupFile.java
@@ -40,7 +40,7 @@ import java.io.UncheckedIOException;
 import java.time.Duration;
 
 import static org.apache.paimon.mergetree.LookupUtils.fileKibiBytes;
-import static org.apache.paimon.utils.InternalRowPartitionComputer.toSimpleString;
+import static org.apache.paimon.utils.InternalRowPartitionComputer.partToSimpleString;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Lookup file for cache remote file to local. */
@@ -130,7 +130,7 @@ public class LookupFile {
         if (partition.getFieldCount() == 0) {
             return String.format("%s-%s", bucket, remoteFileName);
         } else {
-            String partitionString = toSimpleString(partitionType, partition, "-", 20);
+            String partitionString = partToSimpleString(partitionType, partition, "-", 20);
             return String.format("%s-%s-%s", partitionString, bucket, remoteFileName);
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
@@ -37,6 +37,8 @@ public interface FileStoreCommit extends AutoCloseable {
 
     FileStoreCommit ignoreEmptyCommit(boolean ignoreEmptyCommit);
 
+    FileStoreCommit withPartitionExpire(PartitionExpire partitionExpire);
+
     /** Find out which committables need to be retried when recovering from the failure. */
     List<ManifestCommittable> filterCommitted(List<ManifestCommittable> committables);
 

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionUpdateTimeExpireStrategy.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionUpdateTimeExpireStrategy.java
@@ -33,11 +33,8 @@ import java.util.stream.Collectors;
  */
 public class PartitionUpdateTimeExpireStrategy extends PartitionExpireStrategy {
 
-    private final RowType partitionType;
-
     public PartitionUpdateTimeExpireStrategy(RowType partitionType) {
         super(partitionType);
-        this.partitionType = partitionType;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionUpdateTimeExpireStrategy.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionUpdateTimeExpireStrategy.java
@@ -33,8 +33,11 @@ import java.util.stream.Collectors;
  */
 public class PartitionUpdateTimeExpireStrategy extends PartitionExpireStrategy {
 
+    private final RowType partitionType;
+
     public PartitionUpdateTimeExpireStrategy(RowType partitionType) {
         super(partitionType);
+        this.partitionType = partitionType;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionValuesTimeExpireStrategy.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionValuesTimeExpireStrategy.java
@@ -61,6 +61,10 @@ public class PartitionValuesTimeExpireStrategy extends PartitionExpireStrategy {
                 .readPartitionEntries();
     }
 
+    public boolean isExpired(LocalDateTime expireDateTime, BinaryRow partition) {
+        return new PartitionValuesTimePredicate(expireDateTime).test(partition);
+    }
+
     /** The expired partition predicate uses the date-format value of the partition. */
     private class PartitionValuesTimePredicate implements PartitionPredicate {
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
@@ -106,6 +106,7 @@ public class TableCommitImpl implements InnerTableCommit {
         commit.withLock(lock);
         if (partitionExpire != null) {
             partitionExpire.withLock(lock);
+            commit.withPartitionExpire(partitionExpire);
         }
 
         this.commit = commit;

--- a/paimon-core/src/test/java/org/apache/paimon/operation/PartitionExpireTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/PartitionExpireTest.java
@@ -264,11 +264,11 @@ public class PartitionExpireTest {
                         new DataIncrement(emptyList(), emptyList(), emptyList()),
                         new CompactIncrement(singletonList(file), emptyList(), emptyList()));
 
-        // should no exception
-        commit.commit(0L, singletonList(newMessage));
-
-        // read is ok
-        assertThat(read()).containsExactlyInAnyOrder("20230105:51");
+        assertThatThrownBy(() -> commit.commit(0L, singletonList(newMessage)))
+                .hasMessage(
+                        "You are writing data to expired partitions, and you can filter "
+                                + "this data to avoid job failover. Otherwise, continuous expired records will cause the"
+                                + " job to failover restart continuously. Expired partitions are: [20230101]");
     }
 
     private List<String> read() throws IOException {

--- a/paimon-core/src/test/java/org/apache/paimon/operation/PartitionExpireTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/PartitionExpireTest.java
@@ -247,11 +247,12 @@ public class PartitionExpireTest {
         table = newExpireTable();
 
         List<CommitMessage> commitMessages = write("20230101", "11");
+        write("20230105", "51");
 
         PartitionExpire expire = newExpire();
         expire.setLastCheck(date(1));
         expire.expire(date(5), Long.MAX_VALUE);
-        assertThat(read()).isEmpty();
+        assertThat(read()).containsExactlyInAnyOrder("20230105:51");
 
         TableCommitImpl commit = table.newCommit("");
         CommitMessageImpl message = (CommitMessageImpl) commitMessages.get(0);
@@ -265,6 +266,9 @@ public class PartitionExpireTest {
 
         // should no exception
         commit.commit(0L, singletonList(newMessage));
+
+        // read is ok
+        assertThat(read()).containsExactlyInAnyOrder("20230105:51");
     }
 
     private List<String> read() throws IOException {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
We recently found that, if data is written into expired partitions, commit conflicts may occur.

This PR avoid 'trying to delete file' commit exception for expired partitions in `FileStoreCommit`, just ignore expired deleted files.

Close #3340

Cover #3518

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

`PartitionExpireTest.testDeleteExpiredPartition`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
