### PR TITLE
[core] Remove bounded check for append compact topology

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcUnawareBucketSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcUnawareBucketSink.java
@@ -29,7 +29,7 @@ import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 public class CdcUnawareBucketSink extends UnawareBucketSink<CdcRecord> {
 
     public CdcUnawareBucketSink(FileStoreTable table, Integer parallelism) {
-        super(table, null, null, parallelism, false);
+        super(table, null, null, parallelism);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkTableSinkBase.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkTableSinkBase.java
@@ -135,7 +135,6 @@ public abstract class FlinkTableSinkBase
                                     new DataStream<>(
                                             dataStream.getExecutionEnvironment(),
                                             dataStream.getTransformation()))
-                            .inputBounded(context.isBounded())
                             .clusteringIfPossible(
                                     conf.get(CLUSTERING_COLUMNS),
                                     conf.get(CLUSTERING_STRATEGY),

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowUnawareBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowUnawareBucketSink.java
@@ -32,9 +32,8 @@ public class RowUnawareBucketSink extends UnawareBucketSink<InternalRow> {
             FileStoreTable table,
             Map<String, String> overwritePartitions,
             LogSinkFunction logSinkFunction,
-            Integer parallelism,
-            boolean boundedInput) {
-        super(table, overwritePartitions, logSinkFunction, parallelism, boundedInput);
+            Integer parallelism) {
+        super(table, overwritePartitions, logSinkFunction, parallelism);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketSink.java
@@ -42,19 +42,16 @@ public abstract class UnawareBucketSink<T> extends FlinkWriteSink<T> {
     protected final LogSinkFunction logSinkFunction;
 
     @Nullable protected final Integer parallelism;
-    protected final boolean boundedInput;
 
     public UnawareBucketSink(
             FileStoreTable table,
             @Nullable Map<String, String> overwritePartitions,
             LogSinkFunction logSinkFunction,
-            @Nullable Integer parallelism,
-            boolean boundedInput) {
+            @Nullable Integer parallelism) {
         super(table, overwritePartitions);
         this.table = table;
         this.logSinkFunction = logSinkFunction;
         this.parallelism = parallelism;
-        this.boundedInput = boundedInput;
     }
 
     @Override
@@ -69,7 +66,7 @@ public abstract class UnawareBucketSink<T> extends FlinkWriteSink<T> {
                                 .get(ExecutionOptions.RUNTIME_MODE)
                         == RuntimeExecutionMode.STREAMING;
         // if enable compaction, we need to add compaction topology to this job
-        if (enableCompaction && isStreamingMode && !boundedInput) {
+        if (enableCompaction && isStreamingMode) {
             written =
                     written.transform(
                                     "Compact Coordinator: " + table.name(),


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
#3936 hang the compact after the writer, making its lifecycle very easy to control.

So in the bounded streaming mode, we can have a compact topology.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
