### PR TITLE
[core] Throw SnapshotNotExistException when the snapshot for creating tag does not exist.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotNotExistException.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotNotExistException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.Snapshot;
+
+/** Thrown by TagManager or SnapshotManager when the specified snapshotId does not exist. */
+public class SnapshotNotExistException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public SnapshotNotExistException(long snapshotId) {
+        super("Snapshot " + snapshotId + " does not exist");
+    }
+
+    public SnapshotNotExistException(String errMsg) {
+        super(errMsg);
+    }
+
+    public static void checkNotNull(Snapshot snapshotId, String errMsg) {
+        if (snapshotId == null) {
+            throw new SnapshotNotExistException(errMsg);
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CreateTagsProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CreateTagsProcedureITCase.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.procedure;
+
+import org.apache.paimon.flink.CatalogITCaseBase;
+import org.apache.paimon.utils.SnapshotNotExistException;
+
+import org.apache.flink.types.Row;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+
+/** IT Case for {@link CreateTagProcedure}. */
+public class CreateTagsProcedureITCase extends CatalogITCaseBase {
+
+    @Test
+    public void testCreateTags() {
+        sql(
+                "CREATE TABLE T ("
+                        + " k STRING,"
+                        + " dt STRING,"
+                        + " PRIMARY KEY (k, dt) NOT ENFORCED"
+                        + ") PARTITIONED BY (dt) WITH ("
+                        + " 'bucket' = '1'"
+                        + ")");
+        sql("insert into T values('k', '2024-01-01')");
+        sql("insert into T values('k2', '2024-01-02')");
+
+        sql("CALL sys.create_tag('default.T', 'tag1')");
+
+        assertThat(
+                        sql("select * from T /*+ OPTIONS('scan.tag-name'='tag1') */").stream()
+                                .map(Row::toString))
+                .containsExactlyInAnyOrder("+I[k2, 2024-01-02]", "+I[k, 2024-01-01]");
+
+        sql("CALL sys.create_tag('default.T', 'tag2', 1)");
+
+        assertThat(
+                        sql("select * from T /*+ OPTIONS('scan.tag-name'='tag2') */").stream()
+                                .map(Row::toString))
+                .containsExactlyInAnyOrder("+I[k, 2024-01-01]");
+    }
+
+    @Test
+    public void testThrowSnapshotNotExistException() {
+        sql(
+                "CREATE TABLE T ("
+                        + " k STRING,"
+                        + " dt STRING,"
+                        + " PRIMARY KEY (k, dt) NOT ENFORCED"
+                        + ") PARTITIONED BY (dt) WITH ("
+                        + " 'bucket' = '1'"
+                        + ")");
+
+        assertThatException()
+                .isThrownBy(() -> sql("CALL sys.create_tag('default.T', 'tag1')"))
+                .withRootCauseInstanceOf(SnapshotNotExistException.class)
+                .withMessageContaining("Cannot create tag because latest snapshot doesn't exist.");
+
+        assertThatException()
+                .isThrownBy(() -> sql("CALL sys.create_tag('default.T', 'tag1', 1)"))
+                .withRootCauseInstanceOf(SnapshotNotExistException.class)
+                .withMessageContaining(
+                        "Cannot create tag because given snapshot #1 doesn't exist.");
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Creating failed : 
<img width="590" alt="image" src="https://github.com/user-attachments/assets/977a649c-d5f1-4cca-809b-9474d8767ff1">

Creating successful : 
<img width="1170" alt="image" src="https://github.com/user-attachments/assets/3728109d-351c-4fbd-a2f5-10a36f3dc6f0">

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
