### PR TITLE
[flink] When reading DataSplit, calculate fetch event time lag with earliest file creation time instead of latest

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java
@@ -112,6 +112,10 @@ public class DataSplit implements Split {
         return this.dataFiles.stream().mapToLong(DataFileMeta::creationTimeEpochMillis).max();
     }
 
+    public OptionalLong earliestFileCreationEpochMillis() {
+        return this.dataFiles.stream().mapToLong(DataFileMeta::creationTimeEpochMillis).min();
+    }
+
     @Override
     public long rowCount() {
         long rowCount = 0;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceSplitReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceSplitReader.java
@@ -181,7 +181,7 @@ public class FileStoreSourceSplitReader
         if (nextSplit.split() instanceof DataSplit) {
             long eventTime =
                     ((DataSplit) nextSplit.split())
-                            .latestFileCreationEpochMillis()
+                            .earliestFileCreationEpochMillis()
                             .orElse(FileStoreSourceReaderMetrics.UNDEFINED);
             metrics.recordSnapshotUpdate(eventTime);
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/ReadOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/ReadOperator.java
@@ -100,7 +100,7 @@ public class ReadOperator extends AbstractStreamOperator<RowData>
         // update metric when reading a new split
         long eventTime =
                 ((DataSplit) split)
-                        .latestFileCreationEpochMillis()
+                        .earliestFileCreationEpochMillis()
                         .orElse(FileStoreSourceReaderMetrics.UNDEFINED);
         sourceReaderMetrics.recordSnapshotUpdate(eventTime);
 


### PR DESCRIPTION
### Purpose

Currently when reading `DataSplit`, we calculate `currentFetchEventTimeLag` with the latest file creation time in this split. This is incorrect because fetch event time lag should be defined by the oldest data in this split.

This PR changes this behavior by using the earliest file creation time to calculate fetch event time lag.

### Tests

Tested by hand.

### API and Format

No format changes.

### Documentation

No new feature.
