### PR TITLE
[flink] support history partition compaction in dedicated compaction job.

### DIFF
--- a/docs/content/flink/procedures.md
+++ b/docs/content/flink/procedures.md
@@ -68,6 +68,7 @@ All available procedures are listed below.
             <li>order_by(optional): the columns need to be sort. Left empty if 'order_strategy' is 'none'.</li>
             <li>options(optional): additional dynamic options of the table.</li>
             <li>where(optional): partition predicate(Can't be used together with "partitions"). Note: as where is a keyword,a pair of backticks need to add around like `where`.</li>
+            <li>partition_idle_time(optional): this is used to do a full compaction for partition which had not received any new data for 'partition_idle_time'. And only these partitions will be compacted. This argument can not be used with order compact.</li>
       </td>
       <td>
          -- use partition filter <br/>
@@ -85,6 +86,7 @@ All available procedures are listed below.
          CALL [catalog.]sys.compact_database('includingDatabases', 'mode', 'includingTables') <br/><br/> 
          CALL [catalog.]sys.compact_database('includingDatabases', 'mode', 'includingTables', 'excludingTables') <br/><br/>
          CALL [catalog.]sys.compact_database('includingDatabases', 'mode', 'includingTables', 'excludingTables', 'tableOptions')
+         CALL [catalog.]sys.compact_database('includingDatabases', 'mode', 'includingTables', 'excludingTables', 'tableOptions', 'partitionIdleTime')
       </td>
       <td>
          To compact databases. Arguments:
@@ -95,6 +97,7 @@ All available procedures are listed below.
             <li>includingTables: to specify tables. You can use regular expression.</li>
             <li>excludingTables: to specify tables that are not compacted. You can use regular expression.</li>
             <li>tableOptions: additional dynamic options of the table.</li>
+            <li>partition_idle_time: this is used to do a full compaction for partition which had not received any new data for 'partition_idle_time'. And only these partitions will be compacted.</li>
       </td>
       <td>
          CALL sys.compact_database('db1|db2', 'combined', 'table_.*', 'ignore', 'sink.parallelism=4')

--- a/docs/content/maintenance/dedicated-compaction.md
+++ b/docs/content/maintenance/dedicated-compaction.md
@@ -128,7 +128,7 @@ For more usage of the compact action, see
 
 {{< /tab >}}
 
-{{< tab "Flink" >}}
+{{< tab "Flink SQL" >}}
 
 Run the following sql:
 
@@ -178,7 +178,7 @@ You can run the following command to submit a compaction job for multiple databa
 * `--including_databases` is used to specify which database is to be compacted. In compact mode, you need to specify a database name, in compact_database mode, you could specify multiple database, regular expression is supported.
 * `--including_tables` is used to specify which source tables are to be compacted, you must use '|' to separate multiple tables, the format is `databaseName.tableName`, regular expression is supported. For example, specifying "--including_tables db1.t1|db2.+" means to compact table 'db1.t1' and all tables in the db2 database.
 * `--excluding_tables`  is used to specify which source tables are not to be compacted. The usage is same as "--including_tables". "--excluding_tables" has higher priority than "--including_tables" if you specified both.
-* `mode` is used to specify compaction mode. Possible values:
+* `--mode` is used to specify compaction mode. Possible values:
   * "divided" (the default mode if you haven't specified one): start a sink for each table, the compaction of the new table requires restarting the job.
   * "combined": start a single combined sink for all tables, the new table will be automatically compacted.
 * `--catalog_conf` is the configuration for Paimon catalog. Each configuration should be specified in the format `key=value`. See [here]({{< ref "maintenance/configurations" >}}) for a complete list of catalog configurations.
@@ -243,7 +243,7 @@ For more usage of the compact_database action, see
 
 {{< /tab >}}
 
-{{< tab "Flink" >}}
+{{< tab "Flink SQL" >}}
 
 Run the following sql:
 
@@ -284,7 +284,7 @@ you can trigger a compact with specified column sort to speed up queries.
     --database <database-name> \ 
     --table <table-name> \
     --order_strategy <orderType> \
-    --order_by <col1,col2,...>
+    --order_by <col1,col2,...> \
     [--partition <partition-name>] \
     [--catalog_conf <paimon-catalog-conf> [--catalog_conf <paimon-catalog-conf> ...]] \
     [--table_conf <paimon-table-dynamic-conf> [--table_conf <paimon-table-dynamic-conf>] ...]
@@ -296,7 +296,7 @@ The sort parallelism is the same as the sink parallelism, you can dynamically sp
 
 {{< /tab >}}
 
-{{< tab "Flink" >}}
+{{< tab "Flink SQL" >}}
 
 Run the following sql:
 
@@ -308,3 +308,108 @@ CALL sys.compact(`table` => 'default.T', order_strategy => 'zorder', order_by =>
 
 {{< /tabs >}}
 
+## Historical Partition Compact
+
+You can run the following command to submit a compaction job for partition which has not received any new data for a period of time. Small files in those partitions will be full compacted.
+
+{{< hint info >}}
+
+This feature now is only used in batch mode.
+
+{{< /hint >}}
+
+### For Table
+
+This is for one table.
+{{< tabs "history-partition-compaction-job for table" >}}
+
+{{< tab "Flink Action Jar" >}}
+
+```bash  
+<FLINK_HOME>/bin/flink run \
+    -D execution.runtime-mode=batch \
+    /path/to/paimon-flink-action-{{< version >}}.jar \
+    compact \
+    --warehouse <warehouse-path> \
+    --database <database-name> \ 
+    --table <table-name> \
+    --partition_idle_time <partition-idle-time> \ 
+    [--partition <partition-name>] \
+    [--catalog_conf <paimon-catalog-conf> [--catalog_conf <paimon-catalog-conf> ...]] \
+    [--table_conf <paimon-table-dynamic-conf> [--table_conf <paimon-table-dynamic-conf>] ...]
+```
+There are one new configuration in `Historical Partition Compact`
+
+* `--partition_idle_time`: this is used to do a full compaction for partition which had not received any new data for 'partition_idle_time'. And only these partitions will be compacted.
+
+{{< /tab >}}
+
+{{< tab "Flink SQL" >}}
+
+Run the following sql:
+
+```sql
+-- history partition compact table
+CALL sys.compact(`table` => 'default.T', 'partition_idle_time' => '5s')
+```
+{{< /tab >}}
+
+{{< /tabs >}}
+
+### For Databases
+
+This is for multiple tables in different databases.
+{{< tabs "history-partition-compaction-job for databases" >}}
+
+{{< tab "Flink Action Jar" >}}
+
+```bash  
+<FLINK_HOME>/bin/flink run \
+    -D execution.runtime-mode=batch \
+    /path/to/paimon-flink-action-{{< version >}}.jar \
+    compact_database \
+    --warehouse <warehouse-path> \
+    --including_databases <database-name|name-regular-expr> \
+    --partition_idle_time <partition-idle-time> \ 
+    [--including_tables <paimon-table-name|name-regular-expr>] \
+    [--excluding_tables <paimon-table-name|name-regular-expr>] \
+    [--mode <compact-mode>] \
+    [--catalog_conf <paimon-catalog-conf> [--catalog_conf <paimon-catalog-conf> ...]] \
+    [--table_conf <paimon-table_conf> [--table_conf <paimon-table_conf> ...]]
+```
+
+Example: compact historical partitions for tables in database
+
+```bash
+<FLINK_HOME>/bin/flink run \
+    /path/to/paimon-flink-action-{{< version >}}.jar \
+    compact_database \
+    --warehouse s3:///path/to/warehouse \
+    --including_databases test_db \
+    --partition_idle_time 60s \
+    --catalog_conf s3.endpoint=https://****.com \
+    --catalog_conf s3.access-key=***** \
+    --catalog_conf s3.secret-key=*****
+```
+
+{{< /tab >}}
+
+{{< tab "Flink SQL" >}}
+
+Run the following sql:
+
+```sql
+-- history partition compact table
+CALL sys.compact_database('includingDatabases', 'mode', 'includingTables', 'excludingTables', 'tableOptions', 'partition_idle_time')
+```
+
+Example: compact historical partitions for tables in database
+
+```sql
+-- history partition compact table
+CALL sys.compact_database('test_db', 'combined', '', '', '', '60s')
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}

--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -47,11 +47,13 @@ This section introduce all available spark procedures about paimon.
             <li>order_strategy: 'order' or 'zorder' or 'hilbert' or 'none'. Left empty for 'none'.</li>
             <li>order_columns: the columns need to be sort. Left empty if 'order_strategy' is 'none'.</li>
             <li>max_concurrent_jobs: when sort compact is used, files in one partition are grouped and submitted as a single spark compact job. This parameter controls the maximum number of jobs that can be submitted simultaneously. The default value is 15.</li>
+            <li>partition_idle_time: this is used to do a full compaction for partition which had not received any new data for 'partition_idle_time'. And only these partitions will be compacted. This argument can not be used with order compact.</li>
       </td>
       <td>
          SET spark.sql.shuffle.partitions=10; --set the compact parallelism <br/><br/>
          CALL sys.compact(table => 'T', partitions => 'p=0;p=1',  order_strategy => 'zorder', order_by => 'a,b') <br/><br/>
-         CALL sys.compact(table => 'T', where => 'p>0 and p<3', order_strategy => 'zorder', order_by => 'a,b')
+         CALL sys.compact(table => 'T', where => 'p>0 and p<3', order_strategy => 'zorder', order_by => 'a,b') <br/><br/>
+         CALL sys.compact(table => 'T', partition_idle_time => '60s')
       </td>
     </tr>
     <tr>

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
@@ -22,7 +22,9 @@ import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.action.CompactAction;
 import org.apache.paimon.flink.action.SortCompactAction;
 import org.apache.paimon.utils.ParameterUtils;
+import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.StringUtils;
+import org.apache.paimon.utils.TimeUtils;
 
 import org.apache.flink.table.procedure.ProcedureContext;
 
@@ -96,6 +98,27 @@ public class CompactProcedure extends ProcedureBase {
             String tableOptions,
             String whereSql)
             throws Exception {
+        return call(
+                procedureContext,
+                tableId,
+                partitions,
+                orderStrategy,
+                orderByColumns,
+                tableOptions,
+                whereSql,
+                "");
+    }
+
+    public String[] call(
+            ProcedureContext procedureContext,
+            String tableId,
+            String partitions,
+            String orderStrategy,
+            String orderByColumns,
+            String tableOptions,
+            String whereSql,
+            String partitionIdleTime)
+            throws Exception {
 
         String warehouse = catalog.warehouse();
         Map<String, String> catalogOptions = catalog.options();
@@ -114,8 +137,14 @@ public class CompactProcedure extends ProcedureBase {
                             identifier.getObjectName(),
                             catalogOptions,
                             tableConf);
+            if (!(StringUtils.isBlank(partitionIdleTime))) {
+                action.withPartitionIdleTime(TimeUtils.parseDuration(partitionIdleTime));
+            }
             jobName = "Compact Job";
         } else if (!orderStrategy.isEmpty() && !orderByColumns.isEmpty()) {
+            Preconditions.checkArgument(
+                    StringUtils.isBlank(partitionIdleTime),
+                    "sort compact do not support 'partition_idle_time'.");
             action =
                     new SortCompactAction(
                                     warehouse,

--- a/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/procedure/ProcedurePositionalArgumentsITCase.java
+++ b/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/procedure/ProcedurePositionalArgumentsITCase.java
@@ -58,6 +58,9 @@ public class ProcedurePositionalArgumentsITCase extends CatalogITCaseBase {
                                 sql(
                                         "CALL sys.compact('default.T', '', '', '', 'sink.parallelism=1','pt=1')"))
                 .doesNotThrowAnyException();
+        assertThatCode(() -> sql("CALL sys.compact('default.T', '', 'zorder', 'k', '','','5s')"))
+                .message()
+                .contains("sort compact do not support 'partition_idle_time'.");
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactDatabaseAction.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,6 +68,8 @@ public class CompactDatabaseAction extends ActionBase {
     private final Map<String, FileStoreTable> tableMap = new HashMap<>();
 
     private Options tableOptions = new Options();
+
+    @Nullable private Duration partitionIdleTime = null;
 
     public CompactDatabaseAction(String warehouse, Map<String, String> catalogConfig) {
         super(warehouse, catalogConfig);
@@ -98,6 +101,11 @@ public class CompactDatabaseAction extends ActionBase {
 
     public CompactDatabaseAction withTableOptions(Map<String, String> tableOptions) {
         this.tableOptions = Options.fromMap(tableOptions);
+        return this;
+    }
+
+    public CompactDatabaseAction withPartitionIdleTime(@Nullable Duration partitionIdleTime) {
+        this.partitionIdleTime = partitionIdleTime;
         return this;
     }
 
@@ -191,11 +199,14 @@ public class CompactDatabaseAction extends ActionBase {
                 conf.get(ExecutionOptions.RUNTIME_MODE) == RuntimeExecutionMode.STREAMING;
         CombinedTableCompactorSourceBuilder sourceBuilder =
                 new CombinedTableCompactorSourceBuilder(
-                        catalogLoader(),
-                        databasePattern,
-                        includingPattern,
-                        excludingPattern,
-                        tableOptions.get(CoreOptions.CONTINUOUS_DISCOVERY_INTERVAL).toMillis());
+                                catalogLoader(),
+                                databasePattern,
+                                includingPattern,
+                                excludingPattern,
+                                tableOptions
+                                        .get(CoreOptions.CONTINUOUS_DISCOVERY_INTERVAL)
+                                        .toMillis())
+                        .withPartitionIdleTime(partitionIdleTime);
 
         // multi bucket table which has multi bucket in a partition like fix bucket and dynamic
         // bucket
@@ -225,7 +236,9 @@ public class CompactDatabaseAction extends ActionBase {
             FileStoreTable table,
             boolean isStreaming) {
 
-        CompactorSourceBuilder sourceBuilder = new CompactorSourceBuilder(fullName, table);
+        CompactorSourceBuilder sourceBuilder =
+                new CompactorSourceBuilder(fullName, table)
+                        .withPartitionIdleTime(partitionIdleTime);
         CompactorSinkBuilder sinkBuilder = new CompactorSinkBuilder(table);
 
         DataStreamSource<RowData> source =
@@ -242,6 +255,7 @@ public class CompactDatabaseAction extends ActionBase {
                 new UnawareBucketCompactionTopoBuilder(env, fullName, table);
 
         unawareBucketCompactionTopoBuilder.withContinuousMode(isStreaming);
+        unawareBucketCompactionTopoBuilder.withPartitionIdleTime(partitionIdleTime);
         unawareBucketCompactionTopoBuilder.build();
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactDatabaseProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactDatabaseProcedure.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.flink.action.CompactDatabaseAction;
 import org.apache.paimon.utils.StringUtils;
+import org.apache.paimon.utils.TimeUtils;
 
 import org.apache.flink.table.procedure.ProcedureContext;
 
@@ -98,6 +99,25 @@ public class CompactDatabaseProcedure extends ProcedureBase {
             String excludingTables,
             String tableOptions)
             throws Exception {
+        return call(
+                procedureContext,
+                includingDatabases,
+                mode,
+                includingTables,
+                excludingTables,
+                tableOptions,
+                "");
+    }
+
+    public String[] call(
+            ProcedureContext procedureContext,
+            String includingDatabases,
+            String mode,
+            String includingTables,
+            String excludingTables,
+            String tableOptions,
+            String partitionIdleTime)
+            throws Exception {
         String warehouse = catalog.warehouse();
         Map<String, String> catalogOptions = catalog.options();
         CompactDatabaseAction action =
@@ -108,6 +128,9 @@ public class CompactDatabaseProcedure extends ProcedureBase {
                         .withDatabaseCompactMode(nullable(mode));
         if (!StringUtils.isBlank(tableOptions)) {
             action.withTableOptions(parseCommaSeparatedKeyValues(tableOptions));
+        }
+        if (!StringUtils.isBlank(partitionIdleTime)) {
+            action.withPartitionIdleTime(TimeUtils.parseDuration(partitionIdleTime));
         }
 
         return execute(procedureContext, action, "Compact database job");

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CombinedTableCompactorSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CombinedTableCompactorSourceBuilder.java
@@ -34,6 +34,9 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 
+import javax.annotation.Nullable;
+
+import java.time.Duration;
 import java.util.regex.Pattern;
 
 /**
@@ -49,6 +52,7 @@ public class CombinedTableCompactorSourceBuilder {
 
     private boolean isContinuous = false;
     private StreamExecutionEnvironment env;
+    @Nullable private Duration partitionIdleTime = null;
 
     public CombinedTableCompactorSourceBuilder(
             Catalog.Loader catalogLoader,
@@ -73,6 +77,12 @@ public class CombinedTableCompactorSourceBuilder {
         return this;
     }
 
+    public CombinedTableCompactorSourceBuilder withPartitionIdleTime(
+            @Nullable Duration partitionIdleTime) {
+        this.partitionIdleTime = partitionIdleTime;
+        return this;
+    }
+
     public DataStream<RowData> buildAwareBucketTableSource() {
         Preconditions.checkArgument(env != null, "StreamExecutionEnvironment should not be null.");
         RowType produceType = BucketsTable.getRowType();
@@ -94,7 +104,8 @@ public class CombinedTableCompactorSourceBuilder {
                     catalogLoader,
                     includingPattern,
                     excludingPattern,
-                    databasePattern);
+                    databasePattern,
+                    partitionIdleTime);
         }
     }
 
@@ -116,7 +127,8 @@ public class CombinedTableCompactorSourceBuilder {
                     catalogLoader,
                     includingPattern,
                     excludingPattern,
-                    databasePattern);
+                    databasePattern,
+                    partitionIdleTime);
         }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedAwareBatchSourceFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedAwareBatchSourceFunction.java
@@ -39,6 +39,7 @@ import org.apache.flink.table.data.RowData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.regex.Pattern;
 
 import static org.apache.paimon.flink.compact.MultiTableScanBase.ScanResult.FINISHED;
@@ -98,7 +99,8 @@ public class CombinedAwareBatchSourceFunction
             Catalog.Loader catalogLoader,
             Pattern includingPattern,
             Pattern excludingPattern,
-            Pattern databasePattern) {
+            Pattern databasePattern,
+            Duration partitionIdleTime) {
         CombinedAwareBatchSourceFunction function =
                 new CombinedAwareBatchSourceFunction(
                         catalogLoader, includingPattern, excludingPattern, databasePattern);
@@ -112,7 +114,10 @@ public class CombinedAwareBatchSourceFunction
                 .partitionCustom(
                         (key, numPartitions) -> key % numPartitions,
                         split -> ((DataSplit) split.f0).bucket())
-                .transform(name, typeInfo, new MultiTablesReadOperator(catalogLoader, false));
+                .transform(
+                        name,
+                        typeInfo,
+                        new MultiTablesReadOperator(catalogLoader, false, partitionIdleTime));
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedUnawareBatchSourceFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedUnawareBatchSourceFunction.java
@@ -20,9 +20,14 @@ package org.apache.paimon.flink.source.operator;
 
 import org.apache.paimon.append.MultiTableUnawareAppendCompactionTask;
 import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.flink.compact.MultiTableScanBase;
 import org.apache.paimon.flink.compact.MultiUnawareBucketTableScan;
 import org.apache.paimon.flink.sink.MultiTableCompactionTaskTypeInfo;
+import org.apache.paimon.manifest.PartitionEntry;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.Table;
 
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.configuration.Configuration;
@@ -36,7 +41,13 @@ import org.apache.flink.streaming.runtime.partitioner.RebalancePartitioner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.apache.paimon.flink.compact.MultiTableScanBase.ScanResult.FINISHED;
 import static org.apache.paimon.flink.compact.MultiTableScanBase.ScanResult.IS_EMPTY;
@@ -96,7 +107,8 @@ public class CombinedUnawareBatchSourceFunction
             Catalog.Loader catalogLoader,
             Pattern includingPattern,
             Pattern excludingPattern,
-            Pattern databasePattern) {
+            Pattern databasePattern,
+            @Nullable Duration partitionIdleTime) {
         CombinedUnawareBatchSourceFunction function =
                 new CombinedUnawareBatchSourceFunction(
                         catalogLoader, includingPattern, excludingPattern, databasePattern);
@@ -115,11 +127,51 @@ public class CombinedUnawareBatchSourceFunction
                                 Boundedness.BOUNDED)
                         .forceNonParallel();
 
+        if (partitionIdleTime != null) {
+            source =
+                    source.transform(
+                            name,
+                            compactionTaskTypeInfo,
+                            new MultiUnawareTablesReadOperator(catalogLoader, partitionIdleTime));
+        }
+
         PartitionTransformation<MultiTableUnawareAppendCompactionTask> transformation =
                 new PartitionTransformation<>(
                         source.getTransformation(), new RebalancePartitioner<>());
 
         return new DataStream<>(env, transformation);
+    }
+
+    private static Long getPartitionInfo(
+            Identifier tableIdentifier,
+            BinaryRow partition,
+            Map<Identifier, Map<BinaryRow, Long>> multiTablesPartitionInfo,
+            Catalog catalog) {
+        Map<BinaryRow, Long> partitionInfo = multiTablesPartitionInfo.get(tableIdentifier);
+        if (partitionInfo == null) {
+            try {
+                Table table = catalog.getTable(tableIdentifier);
+                if (!(table instanceof FileStoreTable)) {
+                    LOGGER.error(
+                            String.format(
+                                    "Only FileStoreTable supports compact action. The table type is '%s'.",
+                                    table.getClass().getName()));
+                }
+                FileStoreTable fileStoreTable = (FileStoreTable) table;
+                List<PartitionEntry> partitions =
+                        fileStoreTable.newSnapshotReader().partitionEntries();
+                partitionInfo =
+                        partitions.stream()
+                                .collect(
+                                        Collectors.toMap(
+                                                PartitionEntry::partition,
+                                                PartitionEntry::lastFileCreationTime));
+                multiTablesPartitionInfo.put(tableIdentifier, partitionInfo);
+            } catch (Catalog.TableNotExistException e) {
+                LOGGER.error(String.format("table: %s not found.", tableIdentifier.getFullName()));
+            }
+        }
+        return partitionInfo.get(partition);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/MultiUnawareTablesReadOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/MultiUnawareTablesReadOperator.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.operator;
+
+import org.apache.paimon.append.MultiTableUnawareAppendCompactionTask;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.manifest.PartitionEntry;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.utils.Preconditions;
+
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * The operator is used for historical partition compaction. It reads {@link
+ * MultiTableUnawareAppendCompactionTask} received from the preceding {@link
+ * CombinedUnawareBatchSourceFunction} and filter partitions which is not historical.
+ */
+public class MultiUnawareTablesReadOperator
+        extends AbstractStreamOperator<MultiTableUnawareAppendCompactionTask>
+        implements OneInputStreamOperator<
+                MultiTableUnawareAppendCompactionTask, MultiTableUnawareAppendCompactionTask> {
+    private static final long serialVersionUID = 1L;
+
+    private final Catalog.Loader catalogLoader;
+
+    private final Duration partitionIdleTime;
+
+    public MultiUnawareTablesReadOperator(
+            Catalog.Loader catalogLoader, Duration partitionIdleTime) {
+        this.catalogLoader = catalogLoader;
+        this.partitionIdleTime = partitionIdleTime;
+    }
+
+    private transient Catalog catalog;
+    private transient Map<Identifier, FileStoreTable> tablesMap;
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        tablesMap = new HashMap<>();
+        catalog = catalogLoader.load();
+    }
+
+    @Override
+    public void processElement(StreamRecord<MultiTableUnawareAppendCompactionTask> record) {
+        Identifier identifier = record.getValue().tableIdentifier();
+        BinaryRow partition = record.getValue().partition();
+        FileStoreTable table = getTable(identifier);
+        Map<BinaryRow, Long> partitionInfo = getPartitionInfo(table);
+        if (checkIsHistoryPartition(partition, partitionInfo)) {
+            output.collect(record);
+        }
+    }
+
+    private FileStoreTable getTable(Identifier tableId) {
+        FileStoreTable table = tablesMap.get(tableId);
+        if (table == null) {
+            try {
+                Table newTable = catalog.getTable(tableId);
+                Preconditions.checkArgument(
+                        newTable instanceof FileStoreTable,
+                        "Only FileStoreTable supports compact action. The table type is '%s'.",
+                        newTable.getClass().getName());
+                table = (FileStoreTable) newTable;
+                tablesMap.put(tableId, table);
+            } catch (Catalog.TableNotExistException e) {
+                LOG.error(String.format("table: %s not found.", tableId.getFullName()));
+            }
+        }
+
+        return table;
+    }
+
+    private Map<BinaryRow, Long> getPartitionInfo(FileStoreTable table) {
+        List<PartitionEntry> partitions = table.newSnapshotReader().partitionEntries();
+        return partitions.stream()
+                .collect(
+                        Collectors.toMap(
+                                PartitionEntry::partition, PartitionEntry::lastFileCreationTime));
+    }
+
+    private boolean checkIsHistoryPartition(
+            BinaryRow partition, Map<BinaryRow, Long> partitionInfo) {
+        long historyMilli =
+                LocalDateTime.now()
+                        .minus(partitionIdleTime)
+                        .atZone(ZoneId.systemDefault())
+                        .toInstant()
+                        .toEpochMilli();
+        return partitionInfo.get(partition) <= historyMilli;
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        if (catalog != null) {
+            catalog.close();
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/MultiTablesCompactorUtil.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/MultiTablesCompactorUtil.java
@@ -62,6 +62,20 @@ public class MultiTablesCompactorUtil {
         }
     }
 
+    public static Map<String, String> partitionCompactOptions() {
+
+        return new HashMap<String, String>() {
+            {
+                put(CoreOptions.SCAN_TIMESTAMP_MILLIS.key(), null);
+                put(CoreOptions.SCAN_TIMESTAMP.key(), null);
+                put(CoreOptions.SCAN_FILE_CREATION_TIME_MILLIS.key(), null);
+                put(CoreOptions.SCAN_SNAPSHOT_ID.key(), null);
+                put(CoreOptions.SCAN_MODE.key(), CoreOptions.StartupMode.LATEST_FULL.toString());
+                put(CoreOptions.WRITE_ONLY.key(), "false");
+            }
+        };
+    }
+
     public static boolean shouldCompactTable(
             Identifier tableIdentifier, Pattern includingPattern, Pattern excludingPattern) {
         String paimonFullTableName = tableIdentifier.getFullName();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/MultiTablesCompactorSourceBuilderITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/MultiTablesCompactorSourceBuilderITCase.java
@@ -53,6 +53,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -488,6 +489,109 @@ public class MultiTablesCompactorSourceBuilderITCase extends AbstractTestBase
                 .hasSameElementsAs(
                         Arrays.asList(
                                 "+I 1|20221209|15|0|1|db3|t1", "+I 1|20221208|16|0|1|db3|t1"));
+        it.close();
+    }
+
+    @ParameterizedTest(name = "defaultOptions = {0}")
+    @ValueSource(booleans = {true, false})
+    public void testHistoryPatitionRead(boolean defaultOptions) throws Exception {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.WRITE_ONLY.key(), "true");
+        if (!defaultOptions) {
+            // change options to test whether CompactorSourceBuilder work normally
+            options.put(CoreOptions.SCAN_SNAPSHOT_ID.key(), "2");
+        }
+        options.put("bucket", "1");
+        long monitorInterval = 1000;
+        Duration partitionIdleTime = Duration.ofMillis(3000);
+        List<FileStoreTable> tables = new ArrayList<>();
+
+        for (String dbName : DATABASE_NAMES) {
+            for (String tableName : TABLE_NAMES) {
+                FileStoreTable table =
+                        createTable(
+                                dbName,
+                                tableName,
+                                ROW_TYPE_MAP.get(tableName),
+                                Arrays.asList("dt", "hh"),
+                                Arrays.asList("dt", "hh", "k"),
+                                options);
+                tables.add(table);
+                SnapshotManager snapshotManager = table.snapshotManager();
+                StreamWriteBuilder streamWriteBuilder =
+                        table.newStreamWriteBuilder().withCommitUser(commitUser);
+                StreamTableWrite write = streamWriteBuilder.newWrite();
+                StreamTableCommit commit = streamWriteBuilder.newCommit();
+
+                writeData(
+                        write,
+                        commit,
+                        0,
+                        rowData(1, 100, 15, BinaryString.fromString("20221208")),
+                        rowData(1, 100, 16, BinaryString.fromString("20221208")),
+                        rowData(1, 100, 15, BinaryString.fromString("20221209")));
+
+                writeData(
+                        write,
+                        commit,
+                        1,
+                        rowData(2, 100, 15, BinaryString.fromString("20221208")),
+                        rowData(2, 100, 16, BinaryString.fromString("20221208")),
+                        rowData(2, 100, 15, BinaryString.fromString("20221209")));
+
+                Snapshot snapshot = snapshotManager.snapshot(snapshotManager.latestSnapshotId());
+                assertThat(snapshot.id()).isEqualTo(2);
+                assertThat(snapshot.commitKind()).isEqualTo(Snapshot.CommitKind.APPEND);
+
+                write.close();
+                commit.close();
+            }
+        }
+
+        // sleep 3 seconds, and update partition 20221208-16
+        Thread.sleep(3000);
+
+        for (FileStoreTable table : tables) {
+            StreamWriteBuilder streamWriteBuilder =
+                    table.newStreamWriteBuilder().withCommitUser(commitUser);
+            StreamTableWrite write = streamWriteBuilder.newWrite();
+            StreamTableCommit commit = streamWriteBuilder.newCommit();
+            writeData(write, commit, 2, rowData(3, 100, 16, BinaryString.fromString("20221208")));
+        }
+
+        StreamExecutionEnvironment env =
+                streamExecutionEnvironmentBuilder()
+                        .batchMode()
+                        .parallelism(ThreadLocalRandom.current().nextInt(2) + 1)
+                        .build();
+
+        DataStream<RowData> source =
+                new CombinedTableCompactorSourceBuilder(
+                                catalogLoader(),
+                                Pattern.compile("db1|db2"),
+                                Pattern.compile(".*"),
+                                null,
+                                monitorInterval)
+                        .withPartitionIdleTime(partitionIdleTime)
+                        .withContinuousMode(false)
+                        .withEnv(env)
+                        .buildAwareBucketTableSource();
+        CloseableIterator<RowData> it = source.executeAndCollect();
+        List<String> actual = new ArrayList<>();
+        while (it.hasNext()) {
+            actual.add(toString(it.next()));
+        }
+        assertThat(actual)
+                .hasSameElementsAs(
+                        Arrays.asList(
+                                "+I 3|20221208|15|0|0|db1|t1",
+                                "+I 3|20221209|15|0|0|db1|t1",
+                                "+I 3|20221208|15|0|0|db1|t2",
+                                "+I 3|20221209|15|0|0|db1|t2",
+                                "+I 3|20221208|15|0|0|db2|t1",
+                                "+I 3|20221209|15|0|0|db2|t1",
+                                "+I 3|20221208|15|0|0|db2|t2",
+                                "+I 3|20221209|15|0|0|db2|t2"));
         it.close();
     }
 

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
@@ -22,6 +22,7 @@ import org.apache.paimon.Snapshot.CommitKind
 import org.apache.paimon.fs.Path
 import org.apache.paimon.spark.PaimonSparkTestBase
 import org.apache.paimon.table.FileStoreTable
+import org.apache.paimon.table.source.DataSplit
 
 import org.apache.spark.sql.{Dataset, Row}
 import org.apache.spark.sql.execution.streaming.MemoryStream
@@ -480,6 +481,11 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
     assert(intercept[IllegalArgumentException] {
       spark.sql("CALL sys.compact(table => 'T', order_strategy => 'sort', order_by => 'pt')")
     }.getMessage.contains("order_by should not contain partition cols"))
+
+    assert(intercept[IllegalArgumentException] {
+      spark.sql(
+        "CALL sys.compact(table => 'T', order_strategy => 'sort', order_by => 'id', partition_idle_time =>'5s')")
+    }.getMessage.contains("sort compact do not support 'partition_idle_time'"))
   }
 
   test("Paimon Procedure: compact with where") {
@@ -559,6 +565,87 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
       spark.sql(s"SELECT * FROM T ORDER BY id"),
       Row(1, "a", "p1") :: Row(2, "b", "p2") :: Row(3, "c", "p1") :: Row(4, "d", "p2") ::
         Row(5, "e", "p1") :: Row(6, "f", "p2") :: Nil)
+  }
+
+  test("Paimon Procedure: compact with partition_idle_time for pk table") {
+    Seq(1, -1).foreach(
+      bucket => {
+        withTable("T") {
+          val dynamicBucketArgs = if (bucket == -1) " ,'dynamic-bucket.initial-buckets'='1'" else ""
+          spark.sql(
+            s"""
+               |CREATE TABLE T (id INT, value STRING, dt STRING, hh INT)
+               |TBLPROPERTIES ('primary-key'='id, dt, hh', 'bucket'='$bucket', 'write-only'='true'$dynamicBucketArgs)
+               |PARTITIONED BY (dt, hh)
+               |""".stripMargin)
+
+          val table = loadTable("T")
+
+          spark.sql(s"INSERT INTO T VALUES (1, '1', '2024-01-01', 0), (2, '2', '2024-01-01', 1)")
+          spark.sql(s"INSERT INTO T VALUES (5, '5', '2024-01-02', 0), (6, '6', '2024-01-02', 1)")
+          spark.sql(s"INSERT INTO T VALUES (3, '3', '2024-01-01', 0), (4, '4', '2024-01-01', 1)")
+          spark.sql(s"INSERT INTO T VALUES (7, '7', '2024-01-02', 0), (8, '8', '2024-01-02', 1)")
+
+          Thread.sleep(10000);
+          spark.sql(s"INSERT INTO T VALUES (9, '9', '2024-01-01', 0), (10, '10', '2024-01-02', 0)")
+
+          spark.sql("CALL sys.compact(table => 'T', partition_idle_time => '10s')")
+          val dataSplits = table.newSnapshotReader.read.dataSplits.asScala.toList
+          Assertions
+            .assertThat(dataSplits.size)
+            .isEqualTo(4)
+          Assertions.assertThat(lastSnapshotCommand(table).equals(CommitKind.COMPACT)).isTrue
+          for (dataSplit: DataSplit <- dataSplits) {
+            if (dataSplit.partition().getInt(1) == 0) {
+              Assertions
+                .assertThat(dataSplit.dataFiles().size())
+                .isEqualTo(3)
+            } else {
+              Assertions
+                .assertThat(dataSplit.dataFiles().size())
+                .isEqualTo(1)
+            }
+          }
+        }
+      })
+
+  }
+
+  test("Paimon Procedure: compact with partition_idle_time for unaware bucket append table") {
+    spark.sql(
+      s"""
+         |CREATE TABLE T (id INT, value STRING, dt STRING, hh INT)
+         |TBLPROPERTIES ('bucket'='-1', 'write-only'='true', 'compaction.min.file-num'='2', 'compaction.max.file-num'='2')
+         |PARTITIONED BY (dt, hh)
+         |""".stripMargin)
+
+    val table = loadTable("T")
+
+    spark.sql(s"INSERT INTO T VALUES (1, '1', '2024-01-01', 0), (2, '2', '2024-01-01', 1)")
+    spark.sql(s"INSERT INTO T VALUES (5, '5', '2024-01-02', 0), (6, '6', '2024-01-02', 1)")
+    spark.sql(s"INSERT INTO T VALUES (3, '3', '2024-01-01', 0), (4, '4', '2024-01-01', 1)")
+    spark.sql(s"INSERT INTO T VALUES (7, '7', '2024-01-02', 0), (8, '8', '2024-01-02', 1)")
+
+    Thread.sleep(10000);
+    spark.sql(s"INSERT INTO T VALUES (9, '9', '2024-01-01', 0), (10, '10', '2024-01-02', 0)")
+
+    spark.sql("CALL sys.compact(table => 'T', partition_idle_time => '10s')")
+    val dataSplits = table.newSnapshotReader.read.dataSplits.asScala.toList
+    Assertions
+      .assertThat(dataSplits.size)
+      .isEqualTo(4)
+    Assertions.assertThat(lastSnapshotCommand(table).equals(CommitKind.COMPACT)).isTrue
+    for (dataSplit: DataSplit <- dataSplits) {
+      if (dataSplit.partition().getInt(1) == 0) {
+        Assertions
+          .assertThat(dataSplit.dataFiles().size())
+          .isEqualTo(3)
+      } else {
+        Assertions
+          .assertThat(dataSplit.dataFiles().size())
+          .isEqualTo(1)
+      }
+    }
   }
 
   def lastSnapshotCommand(table: FileStoreTable): CommitKind = {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
If a partition has not received any new data writes for an extended period, we consider it to be a history partition. To further reduce the number of small files, it is necessary to perform a full compaction on history partitions.

This pr is to support doing a full compaction for history partition with a dedicated compaction job. Compared to dedicated compaction before:
you can set `history_time`, if a partition don't receive any new data for `history_time`, it will be full compacted.

**note: this feature is only supported in batch mode.**

### Tests

<!-- List UT and IT cases to verify this change -->

`CompactDatabaseActionITCase#testHistoryPartitionCompact`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
