### PR TITLE
[core] Enable catalog lock when the file io is object store

### DIFF
--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -94,7 +94,7 @@ under the License.
         </tr>
         <tr>
             <td><h5>lock.enabled</h5></td>
-            <td style="word-wrap: break-word;">false</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Boolean</td>
             <td>Enable Catalog Lock.</td>
         </tr>

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -57,7 +57,7 @@ public class CatalogOptions {
     public static final ConfigOption<Boolean> LOCK_ENABLED =
             ConfigOptions.key("lock.enabled")
                     .booleanType()
-                    .defaultValue(false)
+                    .noDefaultValue()
                     .withDescription("Enable Catalog Lock.");
 
     public static final ConfigOption<String> LOCK_TYPE =

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -118,7 +118,7 @@ public abstract class AbstractCatalog implements Catalog {
     }
 
     protected boolean lockEnabled() {
-        return catalogOptions.get(LOCK_ENABLED);
+        return catalogOptions.getOptional(LOCK_ENABLED).orElse(fileIO.isObjectStore());
     }
 
     @Override

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveLocationTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveLocationTest.java
@@ -77,7 +77,7 @@ public class HiveLocationTest {
 
     private IMetaStoreClient hmsClient;
 
-    private String objectStorepath;
+    private String objectStorePath;
 
     private FileIO fileIO;
 
@@ -85,26 +85,27 @@ public class HiveLocationTest {
 
     @Before
     public void before() throws IOException {
-        objectStorepath = minioTestContainer.getS3UriForDefaultBucket() + "/" + UUID.randomUUID();
+        objectStorePath = minioTestContainer.getS3UriForDefaultBucket() + "/" + UUID.randomUUID();
 
-        Options conf = new Options();
-        conf.set(CatalogOptions.WAREHOUSE, objectStorepath);
-        conf.set(CatalogOptions.METASTORE, "hive");
-        conf.set(CatalogOptions.URI, "");
-        conf.set(
+        Options options = new Options();
+        options.set(CatalogOptions.WAREHOUSE, objectStorePath);
+        options.set(CatalogOptions.METASTORE, "hive");
+        options.set(CatalogOptions.URI, "");
+        options.set(CatalogOptions.LOCK_ENABLED, false);
+        options.set(
                 HiveCatalogOptions.HIVE_CONF_DIR,
                 hiveShell.getBaseDir().getRoot().getPath() + HIVE_CONF);
-        conf.set(HiveCatalogOptions.LOCATION_IN_PROPERTIES, true);
+        options.set(HiveCatalogOptions.LOCATION_IN_PROPERTIES, true);
 
         for (Map.Entry<String, String> stringStringEntry :
                 minioTestContainer.getS3ConfigOptions().entrySet()) {
-            conf.set(stringStringEntry.getKey(), stringStringEntry.getValue());
+            options.set(stringStringEntry.getKey(), stringStringEntry.getValue());
         }
 
         // create CatalogContext using the options
-        catalogContext = CatalogContext.create(conf);
+        catalogContext = CatalogContext.create(options);
 
-        Path warehouse = new Path(objectStorepath);
+        Path warehouse = new Path(objectStorePath);
         fileIO = getFileIO(catalogContext, warehouse);
         fileIO.mkdirs(warehouse);
 
@@ -148,7 +149,7 @@ public class HiveLocationTest {
             assertThat(hmsClient.getDatabase(db)).isNotNull();
 
             Path actual = catalog.newDatabasePath(db);
-            Path expected = new Path(this.objectStorepath + "/" + db + ".db");
+            Path expected = new Path(this.objectStorePath + "/" + db + ".db");
             assertThat(fileIO.exists(expected)).isTrue();
             assertThat(actual).isEqualTo(expected);
 
@@ -196,7 +197,7 @@ public class HiveLocationTest {
                         tableIdentifier.getDatabaseName(), tableIdentifier.getObjectName());
         String location =
                 hmsClientTablea.getParameters().get(LocationKeyExtractor.TBPROPERTIES_LOCATION_KEY);
-        String expected = this.objectStorepath + "/" + db + ".db" + "/" + table;
+        String expected = this.objectStorePath + "/" + db + ".db" + "/" + table;
         assertThat(fileIO.exists(new Path(expected))).isTrue();
         assertThat(location).isEqualTo(expected);
     }
@@ -246,7 +247,7 @@ public class HiveLocationTest {
 
         String[][] params =
                 new String[][] {
-                    {"table1", objectStorepath},
+                    {"table1", objectStorePath},
                     {"table2", hiveShell.getBaseDir().getRoot().getAbsolutePath()},
                 };
         for (String[] param : params) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
object store commit has no guarantee.
For safety, enable catalog lock when the file io is object store.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
