### PR TITLE
[core] fix skew bug of stream read unware bucket table

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -255,7 +255,7 @@ under the License.
             <td>If the new snapshot has not been generated when the checkpoint starts to trigger, the enumerator will block the checkpoint and wait for the new snapshot. Set the maximum waiting time to avoid infinite waiting, if timeout, the checkpoint will fail. Note that it should be set smaller than the checkpoint timeout.</td>
         </tr>
         <tr>
-            <td><h5>streaming-read.shuffle-by-partition</h5></td>
+            <td><h5>streaming-read.shuffle-bucket-with-partition</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Whether shuffle by partition and bucket when streaming read.</td>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -217,8 +217,8 @@ public class FlinkConnectorOptions {
                                     + " Note: This is dangerous and is likely to cause data errors if downstream"
                                     + " is used to calculate aggregation and the input is not complete changelog.");
 
-    public static final ConfigOption<Boolean> STREAMING_READ_SHUFFLE_BY_PARTITION =
-            key("streaming-read.shuffle-by-partition")
+    public static final ConfigOption<Boolean> STREAMING_READ_SHUFFLE_BUCKET_WITH_PARTITION =
+            key("streaming-read.shuffle-bucket-with-partition")
                     .booleanType()
                     .defaultValue(true)
                     .withDescription(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
@@ -76,7 +76,7 @@ public class ContinuousFileSplitEnumerator
 
     private final int splitMaxNum;
 
-    private final boolean shuffleByPartition;
+    private final boolean shuffleBucketWithPartition;
 
     @Nullable protected Long nextSnapshotId;
 
@@ -92,7 +92,7 @@ public class ContinuousFileSplitEnumerator
             StreamTableScan scan,
             BucketMode bucketMode,
             int splitMaxPerTask,
-            boolean shuffleByPartition) {
+            boolean shuffleBucketWithPartition) {
         checkArgument(discoveryInterval > 0L);
         this.context = checkNotNull(context);
         this.nextSnapshotId = nextSnapshotId;
@@ -102,7 +102,7 @@ public class ContinuousFileSplitEnumerator
         this.scan = scan;
         this.splitAssigner = createSplitAssigner(bucketMode);
         this.splitMaxNum = context.currentParallelism() * splitMaxPerTask;
-        this.shuffleByPartition = shuffleByPartition;
+        this.shuffleBucketWithPartition = shuffleBucketWithPartition;
         addSplits(remainSplits);
 
         this.consumerProgressCalculator =
@@ -281,7 +281,7 @@ public class ContinuousFileSplitEnumerator
 
     protected int assignSuggestedTask(FileStoreSourceSplit split) {
         DataSplit dataSplit = ((DataSplit) split.split());
-        if (shuffleByPartition) {
+        if (shuffleBucketWithPartition) {
             return ChannelComputer.select(
                     dataSplit.partition(), dataSplit.bucket(), context.currentParallelism());
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileStoreSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileStoreSource.java
@@ -110,6 +110,6 @@ public class ContinuousFileStoreSource extends FlinkSource {
                 scan,
                 bucketMode,
                 options.get(CoreOptions.SCAN_MAX_SPLITS_PER_TASK),
-                options.get(FlinkConnectorOptions.STREAMING_READ_SHUFFLE_BY_PARTITION));
+                options.get(FlinkConnectorOptions.STREAMING_READ_SHUFFLE_BUCKET_WITH_PARTITION));
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumerator.java
@@ -95,7 +95,7 @@ public class AlignedContinuousFileSplitEnumerator extends ContinuousFileSplitEnu
             BucketMode bucketMode,
             long alignTimeout,
             int splitPerTaskMax,
-            boolean shuffleByPartition) {
+            boolean shuffleBucketWithPartition) {
         super(
                 context,
                 remainSplits,
@@ -104,7 +104,7 @@ public class AlignedContinuousFileSplitEnumerator extends ContinuousFileSplitEnu
                 scan,
                 bucketMode,
                 splitPerTaskMax,
-                shuffleByPartition);
+                shuffleBucketWithPartition);
         this.pendingPlans = new ArrayBlockingQueue<>(MAX_PENDING_PLAN);
         this.alignedAssigner = (AlignedSplitAssigner) super.splitAssigner;
         this.nextSnapshotId = nextSnapshotId;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileStoreSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileStoreSource.java
@@ -92,6 +92,6 @@ public class AlignedContinuousFileStoreSource extends ContinuousFileStoreSource 
                 bucketMode,
                 options.get(FlinkConnectorOptions.SOURCE_CHECKPOINT_ALIGN_TIMEOUT).toMillis(),
                 options.get(CoreOptions.SCAN_MAX_SPLITS_PER_TASK),
-                options.get(FlinkConnectorOptions.STREAMING_READ_SHUFFLE_BY_PARTITION));
+                options.get(FlinkConnectorOptions.STREAMING_READ_SHUFFLE_BUCKET_WITH_PARTITION));
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/MonitorFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/MonitorFunction.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink.source.operator;
 
 import org.apache.paimon.flink.utils.JavaTypeInfo;
+import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.sink.ChannelComputer;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.EndOfScanException;
@@ -38,6 +39,7 @@ import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -51,6 +53,8 @@ import java.util.List;
 import java.util.NavigableMap;
 import java.util.OptionalLong;
 import java.util.TreeMap;
+
+import static org.apache.paimon.table.BucketMode.BUCKET_UNAWARE;
 
 /**
  * This is the single (non-parallel) monitoring task, it is responsible for:
@@ -230,23 +234,44 @@ public class MonitorFunction extends RichSourceFunction<Split>
             ReadBuilder readBuilder,
             long monitorInterval,
             boolean emitSnapshotWatermark,
-            boolean shuffleByPartition) {
-        return env.addSource(
-                        new MonitorFunction(readBuilder, monitorInterval, emitSnapshotWatermark),
-                        name + "-Monitor",
-                        new JavaTypeInfo<>(Split.class))
-                .forceNonParallel()
-                .partitionCustom(
-                        (key, numPartitions) -> {
-                            if (shuffleByPartition) {
-                                return ChannelComputer.select(key.f0, key.f1, numPartitions);
-                            }
-                            return ChannelComputer.select(key.f1, numPartitions);
-                        },
-                        split -> {
-                            DataSplit dataSplit = (DataSplit) split;
-                            return Tuple2.of(dataSplit.partition(), dataSplit.bucket());
-                        })
-                .transform(name + "-Reader", typeInfo, new ReadOperator(readBuilder));
+            boolean shuffleBucketWithPartition,
+            BucketMode bucketMode) {
+        SingleOutputStreamOperator<Split> singleOutputStreamOperator =
+                env.addSource(
+                                new MonitorFunction(
+                                        readBuilder, monitorInterval, emitSnapshotWatermark),
+                                name + "-Monitor",
+                                new JavaTypeInfo<>(Split.class))
+                        .forceNonParallel();
+
+        DataStream<Split> sourceDataStream =
+                bucketMode == BUCKET_UNAWARE
+                        ? shuffleUnwareBucket(singleOutputStreamOperator)
+                        : shuffleNonUnwareBucket(
+                                singleOutputStreamOperator, shuffleBucketWithPartition);
+
+        return sourceDataStream.transform(
+                name + "-Reader", typeInfo, new ReadOperator(readBuilder));
+    }
+
+    private static DataStream<Split> shuffleUnwareBucket(
+            SingleOutputStreamOperator<Split> singleOutputStreamOperator) {
+        return singleOutputStreamOperator.rebalance();
+    }
+
+    private static DataStream<Split> shuffleNonUnwareBucket(
+            SingleOutputStreamOperator<Split> singleOutputStreamOperator,
+            boolean shuffleBucketWithPartition) {
+        return singleOutputStreamOperator.partitionCustom(
+                (key, numPartitions) -> {
+                    if (shuffleBucketWithPartition) {
+                        return ChannelComputer.select(key.f0, key.f1, numPartitions);
+                    }
+                    return ChannelComputer.select(key.f1, numPartitions);
+                },
+                split -> {
+                    DataSplit dataSplit = (DataSplit) split;
+                    return Tuple2.of(dataSplit.partition(), dataSplit.bucket());
+                });
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
@@ -86,6 +86,22 @@ public class AppendOnlyTableITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testReadUnwareBucketTableWithRebalanceShuffle() throws Exception {
+        batchSql(
+                "CREATE TABLE append_scalable_table (id INT, data STRING) "
+                        + "WITH ('bucket' = '-1', 'consumer-id' = 'test', 'consumer.expiration-time' = '365 d', 'target-file-size' = '1 B', 'source.split.target-size' = '1 B', 'scan.parallelism' = '4')");
+        batchSql("INSERT INTO append_scalable_table VALUES (1, 'AAA'), (2, 'BBB')");
+        batchSql("INSERT INTO append_scalable_table VALUES (1, 'AAA'), (2, 'BBB')");
+        batchSql("INSERT INTO append_scalable_table VALUES (1, 'AAA'), (2, 'BBB')");
+        batchSql("INSERT INTO append_scalable_table VALUES (1, 'AAA'), (2, 'BBB')");
+
+        BlockingIterator<Row, Row> iterator =
+                BlockingIterator.of(streamSqlIter(("SELECT id FROM append_scalable_table")));
+        assertThat(iterator.collect(2)).containsExactlyInAnyOrder(Row.of(1), Row.of(2));
+        iterator.close();
+    }
+
+    @Test
     public void testReadPartitionOrder() {
         setParallelism(1);
         batchSql("INSERT INTO part_table VALUES (1, 'AAA', 'part-1')");


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

Now when stream read a unware bucket table with comsume_id and consumer.mode = exactly-once. SKEW will happy, this is a bug, now fix it.
![image](https://github.com/user-attachments/assets/a9e98a5c-6016-421b-baaf-e7d0f03010cd)


### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
