### PR TITLE
[core] The manifest schema should not be nullable

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestEntry.java
@@ -91,7 +91,7 @@ public class IndexManifestEntry {
                                         newStringType(false),
                                         new IntType(false),
                                         new IntType(false)))));
-        return new RowType(fields);
+        return new RowType(false, fields);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntry.java
@@ -111,7 +111,7 @@ public class ManifestEntry implements FileEntry {
         fields.add(new DataField(2, "_BUCKET", new IntType(false)));
         fields.add(new DataField(3, "_TOTAL_BUCKETS", new IntType(false)));
         fields.add(new DataField(4, "_FILE", DataFileMeta.schema()));
-        return new RowType(fields);
+        return new RowType(false, fields);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFileMeta.java
@@ -105,7 +105,7 @@ public class ManifestFileMeta {
         fields.add(new DataField(3, "_NUM_DELETED_FILES", new BigIntType(false)));
         fields.add(new DataField(4, "_PARTITION_STATS", SimpleStatsConverter.schema()));
         fields.add(new DataField(5, "_SCHEMA_ID", new BigIntType(false)));
-        return new RowType(fields);
+        return new RowType(false, fields);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/utils/VersionedObjectSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/VersionedObjectSerializer.java
@@ -41,7 +41,7 @@ public abstract class VersionedObjectSerializer<T> extends ObjectSerializer<T> {
         List<DataField> fields = new ArrayList<>();
         fields.add(new DataField(-1, "_VERSION", new IntType(false)));
         fields.addAll(rowType.getFields());
-        return new RowType(fields);
+        return new RowType(false, fields);
     }
 
     /**


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The manifest schema should not be nullable, otherwise it will be wrapped with union null in avro which can not be read from Spark.

```sql
select * from
`avro`.`/Users/cathy/Desktop/tmp/spark-3.5.1-bin-hadoop3/warehouse/default.db/t/manifest/manifest-list-f1f00e99-398c-43e4-846f-6d88dad0aeb7-1`;
```

before
```
Caused by: org.apache.spark.sql.avro.IncompatibleSchemaException: Cannot convert Avro type ["null",{"type":"record","name":"record","namespace":"org.apache.paimon.avro.generated","fields":[{"name":"_VERSION","type":"int"},{"name":"_KIND","type":"int"},{"name":"_PARTITION","type":"bytes"},{"name":"_BUCKET","type":"int"},{"name":"_TOTAL_BUCKETS","type":"int"},{"name":"_FILE","type":["null",{"type":"record","name":"record__FILE","fields":[{"name":"_FILE_NAME","type":"string"},{"name":"_FILE_SIZE","type":"long"},{"name":"_ROW_COUNT","type":"long"},{"name":"_MIN_KEY","type":"bytes"},{"name":"_MAX_KEY","type":"bytes"},{"name":"_KEY_STATS","type":["null",{"type":"record","name":"record__FILE__KEY_STATS","fields":[{"name":"_MIN_VALUES","type":"bytes"},{"name":"_MAX_VALUES","type":"bytes"},{"name":"_NULL_COUNTS","type":["null",{"type":"array","items":["null","long"]}],"default":null}]}],"default":null},{"name":"_VALUE_STATS","type":["null",{"type":"record","name":"record__FILE__VALUE_STATS","fields":[{"name":"_MIN_VALUES","type":"bytes"},{"name":"_MAX_VALUES","type":"bytes"},{"name":"_NULL_COUNTS","type":["null",{"type":"array","items":["null","long"]}],"default":null}]}],"default":null},{"name":"_MIN_SEQUENCE_NUMBER","type":"long"},{"name":"_MAX_SEQUENCE_NUMBER","type":"long"},{"name":"_SCHEMA_ID","type":"long"},{"name":"_LEVEL","type":"int"},{"name":"_EXTRA_FILES","type":{"type":"array","items":"string"}},{"name":"_CREATION_TIME","type":["null",{"type":"long","logicalType":"timestamp-millis"}],"default":null},{"name":"_DELETE_ROW_COUNT","type":["null","long"],"default":null},{"name":"_EMBEDDED_FILE_INDEX","type":["null","bytes"],"default":null},{"name":"_FILE_SOURCE","type":["null","int"],"default":null}]}],"default":null}]}] to SQL type STRUCT<_VERSION: INT, _KIND: INT, _PARTITION: BINARY, _BUCKET: INT, _TOTAL_BUCKETS: INT, _FILE: STRUCT<_FILE_NAME: STRING, _FILE_SIZE: BIGINT, _ROW_COUNT: BIGINT, _MIN_KEY: BINARY, _MAX_KEY: BINARY, _KEY_STATS: STRUCT<_MIN_VALUES: BINARY, _MAX_VALUES: BINARY, _NULL_COUNTS: ARRAY<BIGINT>>, _VALUE_STATS: STRUCT<_MIN_VALUES: BINARY, _MAX_VALUES: BINARY, _NULL_COUNTS: ARRAY<BIGINT>>, _MIN_SEQUENCE_NUMBER: BIGINT, _MAX_SEQUENCE_NUMBER: BIGINT, _SCHEMA_ID: BIGINT, _LEVEL: INT, _EXTRA_FILES: ARRAY<STRING>, _CREATION_TIME: TIMESTAMP, _DELETE_ROW_COUNT: BIGINT, _EMBEDDED_FILE_INDEX: BINARY, _FILE_SOURCE: INT>>.

```

after
```
2   manifest-9f355fcf-f2e1-41f0-9cb0-0116dfbfcc5f-0 1856    1   0   {"_MIN_VALUES":,"_MAX_VALUES":,"_NULL_COUNTS":[]}   0
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

Pass CI

### API and Format

<!-- Does this change affect API or storage format -->

no

### Documentation

<!-- Does this change introduce a new feature -->
