### PR TITLE
chore: Update snappy version to 1.1.8.4 for aarch64 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@ under the License.
         <hadoop.version>2.8.5</hadoop.version>
         <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <snappy.version>1.1.8.3</snappy.version>
+        <snappy.version>1.1.8.4</snappy.version>
         <airlift.version>0.27</airlift.version>
         <lz4.version>1.8.0</lz4.version>
         <slf4j.version>1.7.32</slf4j.version>


### PR DESCRIPTION
### Purpose

We have used paimon embedded in our spark/flink jobs, and we want to make these jobs run on the aarch64 machines, this PR is to make this  feasible

### Tests

aarch64 cpu arch compatibility: the compiled jar has been passed the alibaba's yoda tool check

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
