### PR TITLE
[spark] Fix alter table column type change nullability

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaChange.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaChange.java
@@ -68,7 +68,12 @@ public interface SchemaChange extends Serializable {
     }
 
     static SchemaChange updateColumnType(String fieldName, DataType newDataType) {
-        return new UpdateColumnType(fieldName, newDataType);
+        return new UpdateColumnType(fieldName, newDataType, false);
+    }
+
+    static SchemaChange updateColumnType(
+            String fieldName, DataType newDataType, boolean keepNullability) {
+        return new UpdateColumnType(fieldName, newDataType, keepNullability);
     }
 
     static SchemaChange updateColumnNullability(String fieldName, boolean newNullability) {
@@ -338,10 +343,13 @@ public interface SchemaChange extends Serializable {
 
         private final String fieldName;
         private final DataType newDataType;
+        // If true, do not change the target field nullability
+        private final boolean keepNullability;
 
-        private UpdateColumnType(String fieldName, DataType newDataType) {
+        private UpdateColumnType(String fieldName, DataType newDataType, boolean keepNullability) {
             this.fieldName = fieldName;
             this.newDataType = newDataType;
+            this.keepNullability = keepNullability;
         }
 
         public String fieldName() {
@@ -350,6 +358,10 @@ public interface SchemaChange extends Serializable {
 
         public DataType newDataType() {
             return newDataType;
+        }
+
+        public boolean keepNullability() {
+            return keepNullability;
         }
 
         @Override

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -356,7 +356,7 @@ public class SparkCatalog extends SparkBaseCatalog {
             TableChange.UpdateColumnType update = (TableChange.UpdateColumnType) change;
             validateAlterNestedField(update.fieldNames());
             return SchemaChange.updateColumnType(
-                    update.fieldNames()[0], toPaimonType(update.newDataType()));
+                    update.fieldNames()[0], toPaimonType(update.newDataType()), true);
         } else if (change instanceof TableChange.UpdateColumnNullability) {
             TableChange.UpdateColumnNullability update =
                     (TableChange.UpdateColumnNullability) change;

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadTestBase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadTestBase.java
@@ -178,6 +178,13 @@ public abstract class SparkReadTestBase {
                         tableName));
     }
 
+    protected static void createTableWithNonNullColumn(String tableName) {
+        spark.sql(
+                String.format(
+                        "CREATE TABLE paimon.default.%s (a INT NOT NULL, b BIGINT NOT NULL, c STRING) TBLPROPERTIES ('bucket' = '1', 'primary-key'='a', 'file.format'='avro')",
+                        tableName));
+    }
+
     protected static FileStoreTable getTable(String tableName) {
         return FileStoreTableFactory.create(
                 LocalFileIO.create(),
@@ -238,5 +245,9 @@ public abstract class SparkReadTestBase {
     // default schema
     protected String defaultShowCreateString(String table) {
         return showCreateString(table, "a INT NOT NULL", "b BIGINT", "c STRING");
+    }
+
+    protected String defaultShowCreateStringWithNonNullColumn(String table) {
+        return showCreateString(table, "a INT NOT NULL", "b BIGINT NOT NULL", "c STRING");
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

Spark catalog `TableChange.UpdateColumnType` should only change the data type, but paimon always changes the nullable to true. This pr keeps the original field nullability.

To fix the issue:

```sql
CREATE TABLE t (a INT, b BIGINT NOT NULL) USING paimon;
ALTER TABLE t CHANGE COLUMN b TYPE string;

SHOW CREATE TABLE t; => b STRING NOT NULL
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
add test

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
