### PR TITLE
[core] Move schema validation of FallbackReadFileStoreTable from constructor to scanner

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BranchSqlITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BranchSqlITCase.java
@@ -342,7 +342,7 @@ public class BranchSqlITCase extends CatalogITCaseBase {
         sql("ALTER TABLE `t$branch_pk` ADD (v2 INT)");
         sql("ALTER TABLE t SET ( 'scan.fallback-branch' = 'pk' )");
 
-        assertThatThrownBy(() -> sql("INSERT INTO t VALUES (1, 10, 'apple')"))
+        assertThatThrownBy(() -> sql("SELECT * FROM t"))
                 .hasMessageContaining("Branch main and pk does not have the same row type");
     }
 


### PR DESCRIPTION
### Purpose

Currently schema of main branch and fallback branch are validated in the constructor of `FallbackReadFileStoreTable`. However if the user mistakenly changed the schema of one branch, he won't be able to drop or alter this table, because the object cannot be created.

This PR fixes this issue by moving the validation before creating `TableScan`.

### Tests

Existing tests should cover the change.

### API and Format

No format changes.

### Documentation

No new feature.
