### PR TITLE
[core] AsyncPositionOutputStream should not flush after close.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/AsyncPositionOutputStream.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/AsyncPositionOutputStream.java
@@ -52,6 +52,7 @@ public class AsyncPositionOutputStream extends PositionOutputStream {
 
     private int totalBuffers;
     private long position;
+    private boolean closed = false;
 
     public AsyncPositionOutputStream(PositionOutputStream out) {
         this.out = out;
@@ -172,6 +173,9 @@ public class AsyncPositionOutputStream extends PositionOutputStream {
 
     @Override
     public void flush() throws IOException {
+        if (closed) {
+            throw new RuntimeException("Already closed");
+        }
         checkException();
         flushBuffer();
         FlushEvent event = new FlushEvent();
@@ -204,6 +208,7 @@ public class AsyncPositionOutputStream extends PositionOutputStream {
         } catch (ExecutionException e) {
             throw new RuntimeException(e);
         }
+        this.closed = true;
     }
 
     private void sendEndEvent() {

--- a/paimon-common/src/test/java/org/apache/paimon/fs/AsyncPositionOutputStreamTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/AsyncPositionOutputStreamTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AsyncPositionOutputStreamTest {
@@ -171,6 +172,14 @@ class AsyncPositionOutputStreamTest {
         asyncOut.write(new byte[] {1, 2, 3});
         assertThatThrownBy(asyncOut::close).hasMessageContaining(msg);
         assertThat(out.closed).isTrue();
+    }
+
+    @Test
+    public void testCloseFlushThrowsException() throws Exception {
+        AsyncPositionOutputStream asyncPositionOutputStream =
+                new AsyncPositionOutputStream(new ByteArrayPositionOutputStream());
+        asyncPositionOutputStream.close();
+        assertThatCode(asyncPositionOutputStream::flush).hasMessage("Already closed");
     }
 
     private static class ByteArrayPositionOutputStream extends PositionOutputStream {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Add check for AsyncPositionOutputStream, it should not call flush after close is called.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
