### PR TITLE
[spark] Fix Comaptibility in getting NamedReference from spark32 to spark35

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/PaimonUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/PaimonUtils.scala
@@ -65,7 +65,7 @@ object PaimonUtils {
   }
 
   def fieldReference(name: String): NamedReference = {
-    FieldReference.column(name)
+    FieldReference(name)
   }
 
   def bytesToString(size: Long): String = {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Fix Comaptibility in getting NamedReference from spark32 to spark35 with a common api to get NamedReference

spark3.3+ ：

![1723710126919.png](https://github.com/user-attachments/assets/9c150cfd-1bfb-43d9-aff9-f1445302dacb)

spark3.2：

![1723710125390.png](https://github.com/user-attachments/assets/3e25ffef-3025-4238-9f7d-a8df6055902e)

then sql would error out as ：

![1723710128213.png](https://github.com/user-attachments/assets/4b29704c-d39f-41e7-abdc-df3a3914afb0)



<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
