### PR TITLE
[core] OrphanFilesClean now support branches

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStoreTable.java
@@ -236,6 +236,12 @@ public class PrivilegedFileStoreTable extends DelegatedFileStoreTable {
     }
 
     @Override
+    public FileStoreTable switchToBranch(String branchName) {
+        return new PrivilegedFileStoreTable(
+                wrapped.switchToBranch(branchName), privilegeChecker, identifier);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/paimon-core/src/main/java/org/apache/paimon/table/DataTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/DataTable.java
@@ -43,6 +43,12 @@ public interface DataTable extends InnerTable {
 
     BranchManager branchManager();
 
+    /**
+     * Get {@link DataTable} with branch identified by {@code branchName}. Note that this method
+     * does not keep dynamic options in current table.
+     */
+    DataTable switchToBranch(String branchName);
+
     Path location();
 
     FileIO fileIO();

--- a/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
@@ -147,8 +147,19 @@ public class FallbackReadFileStoreTable extends DelegatedFileStoreTable {
                 wrapped.copyWithLatestSchema(), fallback.copyWithLatestSchema());
     }
 
+    @Override
+    public FileStoreTable switchToBranch(String branchName) {
+        return new FallbackReadFileStoreTable(wrapped.switchToBranch(branchName), fallback);
+    }
+
     private Map<String, String> rewriteFallbackOptions(Map<String, String> options) {
         Map<String, String> result = new HashMap<>(options);
+
+        // branch of fallback table should never change
+        String branchKey = CoreOptions.BRANCH.key();
+        if (options.containsKey(branchKey)) {
+            result.put(branchKey, fallback.options().get(branchKey));
+        }
 
         // snapshot ids may be different between the main branch and the fallback branch,
         // so we need to convert main branch snapshot id to millisecond,

--- a/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTable.java
@@ -111,4 +111,11 @@ public interface FileStoreTable extends DataTable {
     boolean supportStreamingReadOverwrite();
 
     RowKeyExtractor createRowKeyExtractor();
+
+    /**
+     * Get {@link DataTable} with branch identified by {@code branchName}. Note that this method
+     * does not keep dynamic options in current table.
+     */
+    @Override
+    FileStoreTable switchToBranch(String branchName);
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTableFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTableFactory.java
@@ -91,7 +91,7 @@ public class FileStoreTableFactory {
         Options options = new Options(table.options());
         String fallbackBranch = options.get(CoreOptions.SCAN_FALLBACK_BRANCH);
         if (!StringUtils.isNullOrWhitespaceOnly(fallbackBranch)) {
-            Options branchOptions = new Options();
+            Options branchOptions = new Options(dynamicOptions.toMap());
             branchOptions.set(CoreOptions.BRANCH, fallbackBranch);
             FileStoreTable fallbackTable =
                     createWithoutFallbackBranch(

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
@@ -175,6 +175,11 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
     }
 
     @Override
+    public DataTable switchToBranch(String branchName) {
+        return new AuditLogTable(wrapped.switchToBranch(branchName));
+    }
+
+    @Override
     public InnerTableRead newRead() {
         return new AuditLogRead(wrapped.newRead());
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/BucketsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/BucketsTable.java
@@ -130,6 +130,11 @@ public class BucketsTable implements DataTable, ReadonlyTable {
     }
 
     @Override
+    public DataTable switchToBranch(String branchName) {
+        return new BucketsTable(wrapped.switchToBranch(branchName), isContinuous, databaseName);
+    }
+
+    @Override
     public String name() {
         return "__internal_buckets_" + wrapped.location().getName();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/FileMonitorTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/FileMonitorTable.java
@@ -117,6 +117,11 @@ public class FileMonitorTable implements DataTable, ReadonlyTable {
     }
 
     @Override
+    public DataTable switchToBranch(String branchName) {
+        return new FileMonitorTable(wrapped.switchToBranch(branchName));
+    }
+
+    @Override
     public String name() {
         return "__internal_file_monitor_" + wrapped.location().getName();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ReadOptimizedTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ReadOptimizedTable.java
@@ -146,6 +146,11 @@ public class ReadOptimizedTable implements DataTable, ReadonlyTable {
     }
 
     @Override
+    public DataTable switchToBranch(String branchName) {
+        return new ReadOptimizedTable(wrapped.switchToBranch(branchName));
+    }
+
+    @Override
     public InnerTableRead newRead() {
         return wrapped.newRead();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/BranchManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/BranchManager.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.paimon.utils.FileUtils.listOriginalVersionedFiles;
 import static org.apache.paimon.utils.FileUtils.listVersionedDirectories;
 import static org.apache.paimon.utils.FileUtils.listVersionedFileStatus;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -68,16 +67,6 @@ public class BranchManager {
     /** Return the root Directory of branch. */
     public Path branchDirectory() {
         return new Path(tablePath + "/branch");
-    }
-
-    /** Return the root Directory of branch by given tablePath. */
-    public static Path branchDirectory(Path tablePath) {
-        return new Path(tablePath + "/branch");
-    }
-
-    public static List<String> branchNames(FileIO fileIO, Path tablePath) throws IOException {
-        return listOriginalVersionedFiles(fileIO, branchDirectory(tablePath), BRANCH_PREFIX)
-                .collect(Collectors.toList());
     }
 
     public static boolean isMainBranch(String branch) {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -50,7 +50,6 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
 import static org.apache.paimon.utils.BranchManager.DEFAULT_MAIN_BRANCH;
-import static org.apache.paimon.utils.BranchManager.branchNames;
 import static org.apache.paimon.utils.BranchManager.branchPath;
 import static org.apache.paimon.utils.FileUtils.listVersionedFiles;
 
@@ -114,10 +113,6 @@ public class SnapshotManager implements Serializable {
     }
 
     public Path snapshotDirectory() {
-        return new Path(branchPath(tablePath, branch) + "/snapshot");
-    }
-
-    public static Path snapshotDirectory(Path tablePath, String branch) {
         return new Path(branchPath(tablePath, branch) + "/snapshot");
     }
 
@@ -405,24 +400,10 @@ public class SnapshotManager implements Serializable {
      * be deleted by other processes, so just skip this snapshot.
      */
     public List<Snapshot> safelyGetAllSnapshots() throws IOException {
-        // For main branch
         List<Path> paths =
                 listVersionedFiles(fileIO, snapshotDirectory(), SNAPSHOT_PREFIX)
                         .map(id -> snapshotPath(id))
                         .collect(Collectors.toList());
-
-        // For other branch
-        List<String> allBranchNames = branchNames(fileIO, tablePath);
-        for (String branchName : allBranchNames) {
-            List<Path> branchPaths =
-                    listVersionedFiles(
-                                    fileIO,
-                                    snapshotDirectory(tablePath, branchName),
-                                    SNAPSHOT_PREFIX)
-                            .map(this::snapshotPath)
-                            .collect(Collectors.toList());
-            paths.addAll(branchPaths);
-        }
 
         List<Snapshot> snapshots = new ArrayList<>();
         for (Path path : paths) {
@@ -457,23 +438,8 @@ public class SnapshotManager implements Serializable {
      * Try to get non snapshot files. If any error occurred, just ignore it and return an empty
      * result.
      */
-    public List<Path> tryGetNonSnapshotFiles(Predicate<FileStatus> fileStatusFilter)
-            throws IOException {
-        // For main branch
-        List<Path> nonSnapshotFiles =
-                listPathWithFilter(snapshotDirectory(), fileStatusFilter, nonSnapshotFileFilter());
-
-        // For other branch
-        List<String> allBranchNames = branchNames(fileIO, tablePath);
-        allBranchNames.stream()
-                .map(
-                        branchName ->
-                                listPathWithFilter(
-                                        snapshotDirectory(tablePath, branchName),
-                                        fileStatusFilter,
-                                        nonSnapshotFileFilter()))
-                .forEach(nonSnapshotFiles::addAll);
-        return nonSnapshotFiles;
+    public List<Path> tryGetNonSnapshotFiles(Predicate<FileStatus> fileStatusFilter) {
+        return listPathWithFilter(snapshotDirectory(), fileStatusFilter, nonSnapshotFileFilter());
     }
 
     public List<Path> tryGetNonChangelogFiles(Predicate<FileStatus> fileStatusFilter) {

--- a/paimon-core/src/test/java/org/apache/paimon/operation/OrphanFilesCleanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/OrphanFilesCleanTest.java
@@ -361,6 +361,9 @@ public class OrphanFilesCleanTest {
         SnapshotManager snapshotManager = table.snapshotManager();
         writeData(snapshotManager, committedData, snapshotData, changelogData, commitTimes);
 
+        // create empty branch with same schema
+        table.createBranch("branch1");
+
         // generate non used files
         int shouldBeDeleted = generateUnUsedFile();
         assertThat(manuallyAddedFiles.size()).isEqualTo(shouldBeDeleted);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/RemoveOrphanFilesActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/RemoveOrphanFilesActionITCase.java
@@ -18,10 +18,19 @@
 
 package org.apache.paimon.flink.action;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.SchemaChange;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.sink.StreamTableCommit;
+import org.apache.paimon.table.sink.StreamTableWrite;
 import org.apache.paimon.table.sink.StreamWriteBuilder;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
@@ -37,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -190,5 +200,55 @@ public class RemoveOrphanFilesActionITCase extends ActionITCaseBase {
                         Row.of(orphanFile12.toUri().getPath()),
                         Row.of(orphanFile21.toUri().getPath()),
                         Row.of(orphanFile22.toUri().getPath()));
+    }
+
+    @Test
+    public void testCleanWithBranch() throws Exception {
+        // create main branch
+        FileStoreTable table = createTableAndWriteData(tableName);
+        Path orphanFile1 = getOrphanFilePath(table, ORPHAN_FILE_1);
+        Path orphanFile2 = getOrphanFilePath(table, ORPHAN_FILE_2);
+
+        // create first branch and write some data
+        table.createBranch("br");
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location(), "br");
+        TableSchema branchSchema =
+                schemaManager.commitChanges(SchemaChange.addColumn("v2", DataTypes.INT()));
+        Options branchOptions = new Options(branchSchema.options());
+        branchOptions.set(CoreOptions.BRANCH, "br");
+        branchSchema = branchSchema.copy(branchOptions.toMap());
+        FileStoreTable branchTable =
+                FileStoreTableFactory.create(table.fileIO(), table.location(), branchSchema);
+
+        String commitUser = UUID.randomUUID().toString();
+        StreamTableWrite write = branchTable.newWrite(commitUser);
+        StreamTableCommit commit = branchTable.newCommit(commitUser);
+        write.write(GenericRow.of(2L, BinaryString.fromString("Hello"), 20));
+        commit.commit(1, write.prepareCommit(false, 1));
+        write.close();
+        commit.close();
+
+        // create orphan file in snapshot directory of first branch
+        Path orphanFile3 = new Path(table.location(), "branch/branch-br/snapshot/orphan_file3");
+        branchTable.fileIO().writeFile(orphanFile3, "x", true);
+
+        // create second branch, which is empty
+        table.createBranch("br2");
+
+        // create orphan file in snapshot directory of second branch
+        Path orphanFile4 = new Path(table.location(), "branch/branch-br2/snapshot/orphan_file4");
+        branchTable.fileIO().writeFile(orphanFile4, "y", true);
+
+        String procedure =
+                String.format(
+                        "CALL sys.remove_orphan_files('%s.%s', '2999-12-31 23:59:59')",
+                        database, "*");
+        ImmutableList<Row> actualDeleteFile = ImmutableList.copyOf(callProcedure(procedure));
+        assertThat(actualDeleteFile)
+                .containsExactlyInAnyOrder(
+                        Row.of(orphanFile1.toUri().getPath()),
+                        Row.of(orphanFile2.toUri().getPath()),
+                        Row.of(orphanFile3.toUri().getPath()),
+                        Row.of(orphanFile4.toUri().getPath()));
     }
 }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -41,7 +41,6 @@ import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.TableType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
@@ -345,9 +344,7 @@ public class HiveCatalog extends AbstractCatalog {
                 continue;
             }
 
-            FileStoreTable table =
-                    FileStoreTableFactory.create(
-                            mainTable.fileIO(), mainTable.location(), branchSchema.get());
+            FileStoreTable table = mainTable.switchToBranch(branchName);
             if (!table.newScan().withPartitionFilter(partitionSpec).listPartitions().isEmpty()) {
                 return true;
             }


### PR DESCRIPTION
### Purpose

Currently `OrphanFilesClean` cannot handle data files created from branches and will mistakenly delete them. This PR modifies `OrphanFilesClean` so that it can support data from branches.

### Tests

IT cases.

### API and Format

No format changes.

### Documentation

No new feature.
