### PR TITLE
[hive] Add a option for HiveCatalog to decide sync all properties to hms

### DIFF
--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -111,6 +111,12 @@ under the License.
             <td>Metastore of paimon catalog, supports filesystem, hive and jdbc.</td>
         </tr>
         <tr>
+            <td><h5>sync-all-properties</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Sync all table properties to hive metastore</td>
+        </tr>
+        <tr>
             <td><h5>table.type</h5></td>
             <td style="word-wrap: break-word;">managed</td>
             <td><p>Enum</p></td>

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -150,4 +150,10 @@ public class CatalogOptions {
                     .withDescription(
                             "Indicates whether this catalog allow upper case, "
                                     + "its default value depends on the implementation of the specific catalog.");
+
+    public static final ConfigOption<Boolean> SYNC_ALL_PROPERTIES =
+            ConfigOptions.key("sync-all-properties")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Sync all table properties to hive metastore");
 }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -91,6 +91,7 @@ import static org.apache.paimon.hive.HiveCatalogOptions.HIVE_CONF_DIR;
 import static org.apache.paimon.hive.HiveCatalogOptions.IDENTIFIER;
 import static org.apache.paimon.hive.HiveCatalogOptions.LOCATION_IN_PROPERTIES;
 import static org.apache.paimon.options.CatalogOptions.ALLOW_UPPER_CASE;
+import static org.apache.paimon.options.CatalogOptions.SYNC_ALL_PROPERTIES;
 import static org.apache.paimon.options.CatalogOptions.TABLE_TYPE;
 import static org.apache.paimon.options.OptionsUtils.convertToPropertiesPrefixKey;
 import static org.apache.paimon.utils.BranchManager.DEFAULT_MAIN_BRANCH;
@@ -516,10 +517,14 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     private Table createHiveTable(Identifier identifier, TableSchema tableSchema) {
-        Table table =
-                newHmsTable(
-                        identifier,
-                        convertToPropertiesPrefixKey(tableSchema.options(), HIVE_PREFIX));
+        Map<String, String> tblProperties;
+        if (syncAllProperties()) {
+            tblProperties = new HashMap<>(tableSchema.options());
+        } else {
+            tblProperties = convertToPropertiesPrefixKey(tableSchema.options(), HIVE_PREFIX);
+        }
+
+        Table table = newHmsTable(identifier, tblProperties);
         updateHmsTable(table, identifier, tableSchema);
         return table;
     }
@@ -605,6 +610,10 @@ public class HiveCatalog extends AbstractCatalog {
     @Override
     public boolean allowUpperCase() {
         return catalogOptions.getOptional(ALLOW_UPPER_CASE).orElse(false);
+    }
+
+    public boolean syncAllProperties() {
+        return catalogOptions.get(SYNC_ALL_PROPERTIES);
     }
 
     @Override


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx
Add a option for HiveCatalog to decide sync all properties to hms.
Currently HiveCatalog had not sync all tblproperties to hms，this not fitable for platform dev which need collect these metadata，so add option to control it default is false.

before fix:
```
CREATE TABLE paimon_q_02 (
  `user_id` STRING COMMENT '任务用到的库',
  `used_table` STRING COMMENT '任务用到的表',
  `day` STRING COMMENT '按天进行分区')
USING paimon
PARTITIONED BY (day)
TBLPROPERTIES(
  'file.format' = 'parquet',
  'file.compression' = 'ZSTD')
```
then TABLE_PARAMS not contains 'file.format' = 'parquet', 'file.compression' = 'ZSTD':
```
"tableParams":{"owner":"yuydws","totalSize":"623","numRows":"-1","rawDataSize":"-1","provider":"paimon","COLUMN_STATS_ACCURATE":"false","numFiles":"1","transient_lastDdlTime":"1723718372","storage_handler":"org.apache.paimon.hive.PaimonStorageHandler","table_type":"PAIMON"}
```
after fix:
then TABLE_PARAMS contains 'file.format' = 'parquet', 'file.compression' = 'ZSTD':
```
"tableParams":{"owner":"yuydws","totalSize":"623","numRows":"-1","rawDataSize":"-1","provider":"paimon","COLUMN_STATS_ACCURATE":"false","numFiles":"1","transient_lastDdlTime":"1723718372","file.format":"parquet","file.compression":"ZSTD","storage_handler":"org.apache.paimon.hive.PaimonStorageHandler","table_type":"PAIMON"}
```


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
