### PR TITLE
 [core] fix the issue that BinaryExternalMerger spill files may be leaked.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/sort/AbstractBinaryExternalMerger.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/AbstractBinaryExternalMerger.java
@@ -173,7 +173,6 @@ public abstract class AbstractBinaryExternalMerger<Entry> implements Closeable {
         channelManager.addChannel(mergedChannelID);
         ChannelWriterOutputView output = null;
 
-        int numBytesInLastBlock;
         int numBlocksWritten;
         try {
             output =
@@ -191,14 +190,14 @@ public abstract class AbstractBinaryExternalMerger<Entry> implements Closeable {
                 output.getChannel().deleteChannel();
             }
             throw e;
-        }
-
-        // remove, close and delete channels
-        for (FileIOChannel channel : openChannels) {
-            channelManager.removeChannel(channel.getChannelID());
-            try {
-                channel.closeAndDelete();
-            } catch (Throwable ignored) {
+        } finally {
+            // remove, close and delete channels
+            for (FileIOChannel channel : openChannels) {
+                channelManager.removeChannel(channel.getChannelID());
+                try {
+                    channel.closeAndDelete();
+                } catch (Throwable ignored) {
+                }
             }
         }
 


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3974 

<!-- What is the purpose of the change -->
 [core] fix the issue that BinaryExternalMerger spill files may be leaked.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
