### PR TITLE
[hive] alter table option support sync all properties to hms

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -802,7 +802,12 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     private void updateHmsTablePars(Table table, TableSchema schema) {
-        table.getParameters().putAll(convertToPropertiesPrefixKey(schema.options(), HIVE_PREFIX));
+        if (syncAllProperties()) {
+            table.getParameters().putAll(schema.options());
+        } else {
+            table.getParameters()
+                    .putAll(convertToPropertiesPrefixKey(schema.options(), HIVE_PREFIX));
+        }
     }
 
     @VisibleForTesting

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -389,6 +389,20 @@ public abstract class HiveCatalogITCaseBase {
                                 .contains("\tfile.format         \tavro                "))
                 .isTrue();
 
+        tEnv.executeSql("ALTER TABLE t01 SET ( 'file.format' = 'parquet' )").await();
+        assertThat(
+                        hiveShell
+                                .executeQuery("DESC FORMATTED t01")
+                                .contains("\tfile.format         \tparquet             "))
+                .isTrue();
+
+        tEnv.executeSql("ALTER TABLE t01 SET ('owner' = 'hive')").await();
+        assertThat(
+                        hiveShell
+                                .executeQuery("DESC FORMATTED t01")
+                                .contains("\towner               \thive                "))
+                .isTrue();
+
         tEnv.executeSql(
                         String.join(
                                 "\n",
@@ -412,6 +426,20 @@ public abstract class HiveCatalogITCaseBase {
                         hiveShell
                                 .executeQuery("DESC FORMATTED t02")
                                 .contains("\tfile.format         \tavro                "))
+                .isFalse();
+
+        tEnv.executeSql("ALTER TABLE t02 SET ( 'file.format' = 'parquet' )").await();
+        assertThat(
+                        hiveShell
+                                .executeQuery("DESC FORMATTED t02")
+                                .contains("\tfile.format         \tparquet             "))
+                .isFalse();
+
+        tEnv.executeSql("ALTER TABLE t02 SET ('owner' = 'hive')").await();
+        assertThat(
+                        hiveShell
+                                .executeQuery("DESC FORMATTED t02")
+                                .contains("\towner               \thive                "))
                 .isFalse();
     }
 


### PR DESCRIPTION

### Purpose
alter table option support sync all properties to hms

<!-- What is the purpose of the change -->

### Tests
testCreateCatalogWithSyncTblProperties

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
