### PR TITLE
[core] Catalog support list `sys` namespace for end user

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -27,6 +27,7 @@ import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.Table;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -85,6 +86,23 @@ public interface Catalog extends AutoCloseable {
      * Get the names of all databases in this catalog.
      *
      * @return a list of the names of all databases
+     */
+    default List<String> listDatabases(boolean includeSystem) {
+        List<String> userDatabases = listDatabases();
+        if (includeSystem) {
+            List<String> allDatabases = new ArrayList<>(userDatabases.size() + 1);
+            allDatabases.add(SYSTEM_DATABASE_NAME);
+            allDatabases.addAll(userDatabases);
+            return allDatabases;
+        } else {
+            return userDatabases;
+        }
+    }
+
+    /**
+     * Get the names of user databases in this catalog.
+     *
+     * @return a list of the names of user databases
      */
     List<String> listDatabases();
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -174,7 +174,7 @@ public class FlinkCatalog extends AbstractCatalog {
 
     @Override
     public List<String> listDatabases() throws CatalogException {
-        return catalog.listDatabases();
+        return catalog.listDatabases(true);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkCatalogTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkCatalogTest.java
@@ -409,12 +409,14 @@ public class FlinkCatalogTest {
     public void testCreateDb_Database() throws Exception {
         catalog.createDatabase(path1.getDatabaseName(), null, false);
         List<String> dbs = catalog.listDatabases();
-        assertThat(dbs).hasSize(2);
+        assertThat(dbs).hasSize(3);
         assertThat(new HashSet<>(dbs))
                 .isEqualTo(
                         new HashSet<>(
                                 Arrays.asList(
-                                        path1.getDatabaseName(), catalog.getDefaultDatabase())));
+                                        path1.getDatabaseName(),
+                                        catalog.getDefaultDatabase(),
+                                        "sys")));
     }
 
     @Test
@@ -585,12 +587,12 @@ public class FlinkCatalogTest {
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage(
                         "Creating table in default database is disabled, please specify a database name.");
-        assertThatCollection(catalog.listDatabases()).isEmpty();
+        assertThatCollection(catalog.listDatabases()).containsOnly("sys");
 
         catalog.createDatabase("db1", null, false);
         assertThatCode(() -> catalog.createTable(path1, this.createTable(new HashMap<>(0)), false))
                 .doesNotThrowAnyException();
-        assertThat(catalog.listDatabases()).containsExactlyInAnyOrder("db1");
+        assertThat(catalog.listDatabases()).containsExactlyInAnyOrder("sys", "db1");
 
         conf.set(FlinkCatalogOptions.DEFAULT_DATABASE, "default-db");
         Catalog catalog1 =

--- a/paimon-hive/paimon-hive-connector-2.3/src/test/java/org/apache/paimon/hive/Hive23CatalogITCase.java
+++ b/paimon-hive/paimon-hive-connector-2.3/src/test/java/org/apache/paimon/hive/Hive23CatalogITCase.java
@@ -80,6 +80,7 @@ public class Hive23CatalogITCase extends HiveCatalogITCaseBase {
                 .isEqualTo(
                         Arrays.asList(
                                 Row.of("default"),
+                                Row.of("sys"),
                                 Row.of("test_db"),
                                 Row.of(TestHiveMetaStoreClient.MOCK_DATABASE)));
     }

--- a/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/Hive31CatalogITCase.java
+++ b/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/Hive31CatalogITCase.java
@@ -78,6 +78,7 @@ public class Hive31CatalogITCase extends HiveCatalogITCaseBase {
         assertThat(collect("SHOW DATABASES"))
                 .isEqualTo(
                         Arrays.asList(
+                                Row.of("sys"),
                                 Row.of("default"),
                                 Row.of("test_db"),
                                 Row.of(TestHiveMetaStoreClient.MOCK_DATABASE)));

--- a/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/Hive31CatalogITCase.java
+++ b/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/Hive31CatalogITCase.java
@@ -78,8 +78,8 @@ public class Hive31CatalogITCase extends HiveCatalogITCaseBase {
         assertThat(collect("SHOW DATABASES"))
                 .isEqualTo(
                         Arrays.asList(
-                                Row.of("sys"),
                                 Row.of("default"),
+                                Row.of("sys"),
                                 Row.of("test_db"),
                                 Row.of(TestHiveMetaStoreClient.MOCK_DATABASE)));
     }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -229,11 +229,12 @@ public abstract class HiveCatalogITCaseBase {
     public void testDatabaseOperations() throws Exception {
         // create database
         tEnv.executeSql("CREATE DATABASE test_db2").await();
+        // Flink will sort by database name, so the `default` database is at the first..
         assertThat(collect("SHOW DATABASES"))
                 .isEqualTo(
                         Arrays.asList(
-                                Row.of("sys"),
                                 Row.of("default"),
+                                Row.of("sys"),
                                 Row.of("test_db"),
                                 Row.of("test_db2")));
         tEnv.executeSql("CREATE DATABASE IF NOT EXISTS test_db2").await();
@@ -245,7 +246,7 @@ public abstract class HiveCatalogITCaseBase {
         // drop database
         tEnv.executeSql("DROP DATABASE test_db2").await();
         assertThat(collect("SHOW DATABASES"))
-                .isEqualTo(Arrays.asList(Row.of("sys"), Row.of("default"), Row.of("test_db")));
+                .isEqualTo(Arrays.asList(Row.of("default"), Row.of("sys"), Row.of("test_db")));
         tEnv.executeSql("DROP DATABASE IF EXISTS test_db2").await();
 
         assertThatThrownBy(() -> tEnv.executeSql("DROP DATABASE test_db2").await())
@@ -270,7 +271,7 @@ public abstract class HiveCatalogITCaseBase {
 
         tEnv.executeSql("DROP DATABASE test_db2 CASCADE").await();
         assertThat(collect("SHOW DATABASES"))
-                .isEqualTo(Arrays.asList(Row.of("sys"), Row.of("default"), Row.of("test_db")));
+                .isEqualTo(Arrays.asList(Row.of("default"), Row.of("sys"), Row.of("test_db")));
         assertThat(tablePath.getFileSystem().exists(tablePath)).isFalse();
     }
 

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -230,7 +230,12 @@ public abstract class HiveCatalogITCaseBase {
         // create database
         tEnv.executeSql("CREATE DATABASE test_db2").await();
         assertThat(collect("SHOW DATABASES"))
-                .isEqualTo(Arrays.asList(Row.of("default"), Row.of("test_db"), Row.of("test_db2")));
+                .isEqualTo(
+                        Arrays.asList(
+                                Row.of("sys"),
+                                Row.of("default"),
+                                Row.of("test_db"),
+                                Row.of("test_db2")));
         tEnv.executeSql("CREATE DATABASE IF NOT EXISTS test_db2").await();
 
         assertThatThrownBy(() -> tEnv.executeSql("CREATE DATABASE test_db2").await())
@@ -240,7 +245,7 @@ public abstract class HiveCatalogITCaseBase {
         // drop database
         tEnv.executeSql("DROP DATABASE test_db2").await();
         assertThat(collect("SHOW DATABASES"))
-                .isEqualTo(Arrays.asList(Row.of("default"), Row.of("test_db")));
+                .isEqualTo(Arrays.asList(Row.of("sys"), Row.of("default"), Row.of("test_db")));
         tEnv.executeSql("DROP DATABASE IF EXISTS test_db2").await();
 
         assertThatThrownBy(() -> tEnv.executeSql("DROP DATABASE test_db2").await())
@@ -265,7 +270,7 @@ public abstract class HiveCatalogITCaseBase {
 
         tEnv.executeSql("DROP DATABASE test_db2 CASCADE").await();
         assertThat(collect("SHOW DATABASES"))
-                .isEqualTo(Arrays.asList(Row.of("default"), Row.of("test_db")));
+                .isEqualTo(Arrays.asList(Row.of("sys"), Row.of("default"), Row.of("test_db")));
         assertThat(tablePath.getFileSystem().exists(tablePath)).isFalse();
     }
 

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -125,7 +125,7 @@ public class SparkCatalog extends SparkBaseCatalog {
 
     @Override
     public String[][] listNamespaces() {
-        List<String> databases = catalog.listDatabases();
+        List<String> databases = catalog.listDatabases(true);
         String[][] namespaces = new String[databases.size()][];
         for (int i = 0; i < databases.size(); i++) {
             namespaces[i] = new String[] {databases.get(i)};

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkGenericCatalogWithHiveTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkGenericCatalogWithHiveTest.java
@@ -141,7 +141,7 @@ public class SparkGenericCatalogWithHiveTest {
         spark2.sql("USE paimon");
         spark2.sql("USE my_db");
         assertThat(spark2.sql("SHOW NAMESPACES").collectAsList().stream().map(Object::toString))
-                .containsExactlyInAnyOrder("[default]", "[my_db]");
+                .containsExactlyInAnyOrder("[sys]", "[default]", "[my_db]");
         assertThat(
                         spark2.sql("SHOW TABLES").collectAsList().stream()
                                 .map(s -> s.get(1))

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadITCase.java
@@ -586,7 +586,7 @@ public class SparkReadITCase extends SparkReadTestBase {
                         spark.sql("SHOW NAMESPACES").collectAsList().stream()
                                 .map(row -> row.getString(0))
                                 .collect(Collectors.toList()))
-                .containsExactlyInAnyOrder("bar", "default");
+                .containsExactlyInAnyOrder("bar", "default", "sys");
 
         Path nsPath = new Path(warehousePath, "bar.db");
         assertThat(new File(nsPath.toUri())).exists();
@@ -594,7 +594,7 @@ public class SparkReadITCase extends SparkReadTestBase {
         // drop namespace
         spark.sql("DROP NAMESPACE bar");
         assertThat(spark.sql("SHOW NAMESPACES").collectAsList().toString())
-                .isEqualTo("[[default]]");
+                .isEqualTo("[[sys], [default]]");
         assertThat(new File(nsPath.toUri())).doesNotExist();
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This pr adds `sys` database when calling `listDatabases(includeSystem)` in `Catalog`, so that user can be aware of the Paimon sys database featrue.

However, it seems `listDatabases` is used by Paimon internal, e.g., list all table path, so only support catalog `listNamespaces` to only affects end-user.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
add test

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
