### PR TITLE
[core] Add manifestListReader and manifestFileReader to Table

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Identifier.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Identifier.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.catalog;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.BranchManager;
@@ -28,6 +29,7 @@ import org.apache.paimon.utils.StringUtils;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Objects;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -41,6 +43,13 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 public class Identifier implements Serializable {
 
     private static final long serialVersionUID = 1L;
+
+    public static final RowType SCHEMA =
+            new RowType(
+                    false,
+                    Arrays.asList(
+                            new DataField(0, "_DATABASE", DataTypes.STRING()),
+                            new DataField(0, "_OBJECT", DataTypes.STRING())));
 
     public static final String UNKNOWN_DATABASE = "unknown";
 
@@ -189,9 +198,5 @@ public class Identifier implements Serializable {
     @Override
     public String toString() {
         return String.format("Identifier{database='%s', object='%s'}", database, object);
-    }
-
-    public static RowType schema() {
-        return RowType.builder().fields(DataTypes.STRING(), DataTypes.STRING()).build();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Identifier.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Identifier.java
@@ -49,7 +49,7 @@ public class Identifier implements Serializable {
                     false,
                     Arrays.asList(
                             new DataField(0, "_DATABASE", DataTypes.STRING()),
-                            new DataField(0, "_OBJECT", DataTypes.STRING())));
+                            new DataField(1, "_OBJECT", DataTypes.STRING())));
 
     public static final String UNKNOWN_DATABASE = "unknown";
 

--- a/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMeta.java
@@ -28,15 +28,32 @@ import org.apache.paimon.utils.Pair;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Objects;
 
 import static org.apache.paimon.utils.SerializationUtils.newStringType;
 
 /** Metadata of index file. */
 public class IndexFileMeta {
+
+    public static final RowType SCHEMA =
+            new RowType(
+                    false,
+                    Arrays.asList(
+                            new DataField(0, "_INDEX_TYPE", newStringType(false)),
+                            new DataField(1, "_FILE_NAME", newStringType(false)),
+                            new DataField(2, "_FILE_SIZE", new BigIntType(false)),
+                            new DataField(3, "_ROW_COUNT", new BigIntType(false)),
+                            new DataField(
+                                    4,
+                                    "_DELETION_VECTORS_RANGES",
+                                    new ArrayType(
+                                            true,
+                                            RowType.of(
+                                                    newStringType(false),
+                                                    new IntType(false),
+                                                    new IntType(false))))));
 
     private final String indexType;
     private final String fileName;
@@ -122,24 +139,5 @@ public class IndexFileMeta {
                 + ", deletionVectorsRanges="
                 + deletionVectorsRanges
                 + '}';
-    }
-
-    public static RowType schema() {
-        List<DataField> fields = new ArrayList<>();
-        fields.add(new DataField(0, "_INDEX_TYPE", newStringType(false)));
-        fields.add(new DataField(1, "_FILE_NAME", newStringType(false)));
-        fields.add(new DataField(2, "_FILE_SIZE", new BigIntType(false)));
-        fields.add(new DataField(3, "_ROW_COUNT", new BigIntType(false)));
-        fields.add(
-                new DataField(
-                        4,
-                        "_DELETION_VECTORS_RANGES",
-                        new ArrayType(
-                                true,
-                                RowType.of(
-                                        newStringType(false),
-                                        new IntType(false),
-                                        new IntType(false)))));
-        return new RowType(fields);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMetaSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMetaSerializer.java
@@ -33,7 +33,7 @@ import java.util.LinkedHashMap;
 public class IndexFileMetaSerializer extends ObjectSerializer<IndexFileMeta> {
 
     public IndexFileMetaSerializer() {
-        super(IndexFileMeta.schema());
+        super(IndexFileMeta.SCHEMA);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta.java
@@ -19,12 +19,12 @@
 package org.apache.paimon.io;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.annotation.Public;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.stats.SimpleStats;
-import org.apache.paimon.stats.SimpleStatsConverter;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
@@ -50,19 +50,25 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.SerializationUtils.newBytesType;
 import static org.apache.paimon.utils.SerializationUtils.newStringType;
 
-/** Metadata of a data file. */
+/**
+ * Metadata of a data file.
+ *
+ * @since 0.9.0
+ */
+@Public
 public class DataFileMeta {
 
     public static final RowType SCHEMA =
             new RowType(
+                    false,
                     Arrays.asList(
                             new DataField(0, "_FILE_NAME", newStringType(false)),
                             new DataField(1, "_FILE_SIZE", new BigIntType(false)),
                             new DataField(2, "_ROW_COUNT", new BigIntType(false)),
                             new DataField(3, "_MIN_KEY", newBytesType(false)),
                             new DataField(4, "_MAX_KEY", newBytesType(false)),
-                            new DataField(5, "_KEY_STATS", SimpleStatsConverter.schema()),
-                            new DataField(6, "_VALUE_STATS", SimpleStatsConverter.schema()),
+                            new DataField(5, "_KEY_STATS", SimpleStats.SCHEMA),
+                            new DataField(6, "_VALUE_STATS", SimpleStats.SCHEMA),
                             new DataField(7, "_MIN_SEQUENCE_NUMBER", new BigIntType(false)),
                             new DataField(8, "_MAX_SEQUENCE_NUMBER", new BigIntType(false)),
                             new DataField(9, "_SCHEMA_ID", new BigIntType(false)),
@@ -488,10 +494,6 @@ public class DataFileMeta {
                 creationTime,
                 deleteRowCount,
                 fileSource);
-    }
-
-    public static RowType schema() {
-        return SCHEMA;
     }
 
     public static long getMaxSequenceNumber(List<DataFileMeta> fileMetas) {

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta08Serializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta08Serializer.java
@@ -24,7 +24,6 @@ import org.apache.paimon.data.safe.SafeBinaryRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.data.serializer.InternalSerializers;
 import org.apache.paimon.stats.SimpleStats;
-import org.apache.paimon.stats.SimpleStatsConverter;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
@@ -62,8 +61,8 @@ public class DataFileMeta08Serializer implements Serializable {
         fields.add(new DataField(2, "_ROW_COUNT", new BigIntType(false)));
         fields.add(new DataField(3, "_MIN_KEY", newBytesType(false)));
         fields.add(new DataField(4, "_MAX_KEY", newBytesType(false)));
-        fields.add(new DataField(5, "_KEY_STATS", SimpleStatsConverter.schema()));
-        fields.add(new DataField(6, "_VALUE_STATS", SimpleStatsConverter.schema()));
+        fields.add(new DataField(5, "_KEY_STATS", SimpleStats.SCHEMA));
+        fields.add(new DataField(6, "_VALUE_STATS", SimpleStats.SCHEMA));
         fields.add(new DataField(7, "_MIN_SEQUENCE_NUMBER", new BigIntType(false)));
         fields.add(new DataField(8, "_MAX_SEQUENCE_NUMBER", new BigIntType(false)));
         fields.add(new DataField(9, "_SCHEMA_ID", new BigIntType(false)));

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMetaSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMetaSerializer.java
@@ -36,7 +36,7 @@ public class DataFileMetaSerializer extends ObjectSerializer<DataFileMeta> {
     private static final long serialVersionUID = 1L;
 
     public DataFileMetaSerializer() {
-        super(DataFileMeta.schema());
+        super(DataFileMeta.SCHEMA);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/io/IdentifierSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/IdentifierSerializer.java
@@ -28,7 +28,7 @@ import org.apache.paimon.utils.ObjectSerializer;
 public class IdentifierSerializer extends ObjectSerializer<Identifier> {
 
     public IdentifierSerializer() {
-        super(Identifier.schema());
+        super(Identifier.SCHEMA);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestEntry.java
@@ -27,8 +27,7 @@ import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.TinyIntType;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 import java.util.Objects;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -37,6 +36,27 @@ import static org.apache.paimon.utils.SerializationUtils.newStringType;
 
 /** Manifest entry for index file. */
 public class IndexManifestEntry {
+
+    public static final RowType SCHEMA =
+            new RowType(
+                    false,
+                    Arrays.asList(
+                            new DataField(0, "_KIND", new TinyIntType(false)),
+                            new DataField(1, "_PARTITION", newBytesType(false)),
+                            new DataField(2, "_BUCKET", new IntType(false)),
+                            new DataField(3, "_INDEX_TYPE", newStringType(false)),
+                            new DataField(4, "_FILE_NAME", newStringType(false)),
+                            new DataField(5, "_FILE_SIZE", new BigIntType(false)),
+                            new DataField(6, "_ROW_COUNT", new BigIntType(false)),
+                            new DataField(
+                                    7,
+                                    "_DELETIONS_VECTORS_RANGES",
+                                    new ArrayType(
+                                            true,
+                                            RowType.of(
+                                                    newStringType(false),
+                                                    new IntType(false),
+                                                    new IntType(false))))));
 
     private final FileKind kind;
     private final BinaryRow partition;
@@ -70,28 +90,6 @@ public class IndexManifestEntry {
 
     public IndexFileMeta indexFile() {
         return indexFile;
-    }
-
-    public static RowType schema() {
-        List<DataField> fields = new ArrayList<>();
-        fields.add(new DataField(0, "_KIND", new TinyIntType(false)));
-        fields.add(new DataField(1, "_PARTITION", newBytesType(false)));
-        fields.add(new DataField(2, "_BUCKET", new IntType(false)));
-        fields.add(new DataField(3, "_INDEX_TYPE", newStringType(false)));
-        fields.add(new DataField(4, "_FILE_NAME", newStringType(false)));
-        fields.add(new DataField(5, "_FILE_SIZE", new BigIntType(false)));
-        fields.add(new DataField(6, "_ROW_COUNT", new BigIntType(false)));
-        fields.add(
-                new DataField(
-                        7,
-                        "_DELETIONS_VECTORS_RANGES",
-                        new ArrayType(
-                                true,
-                                RowType.of(
-                                        newStringType(false),
-                                        new IntType(false),
-                                        new IntType(false)))));
-        return new RowType(false, fields);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestEntrySerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestEntrySerializer.java
@@ -33,7 +33,7 @@ import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
 public class IndexManifestEntrySerializer extends VersionedObjectSerializer<IndexManifestEntry> {
 
     public IndexManifestEntrySerializer() {
-        super(IndexManifestEntry.schema());
+        super(IndexManifestEntry.SCHEMA);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestFile.java
@@ -93,7 +93,7 @@ public class IndexManifestFile extends ObjectsFile<IndexManifestEntry> {
         }
 
         public IndexManifestFile create() {
-            RowType schema = VersionedObjectSerializer.versionType(IndexManifestEntry.schema());
+            RowType schema = VersionedObjectSerializer.versionType(IndexManifestEntry.SCHEMA);
             return new IndexManifestFile(
                     fileIO,
                     schema,

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntry.java
@@ -18,27 +18,37 @@
 
 package org.apache.paimon.manifest;
 
+import org.apache.paimon.annotation.Public;
 import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileMeta;
-import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.TinyIntType;
-import org.apache.paimon.utils.Filter;
 
-import javax.annotation.Nullable;
-
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
 
 import static org.apache.paimon.utils.SerializationUtils.newBytesType;
 
-/** Entry of a manifest file, representing an addition / deletion of a data file. */
+/**
+ * Entry of a manifest file, representing an addition / deletion of a data file.
+ *
+ * @since 0.9.0
+ */
+@Public
 public class ManifestEntry implements FileEntry {
+
+    public static final RowType SCHEMA =
+            new RowType(
+                    false,
+                    Arrays.asList(
+                            new DataField(0, "_KIND", new TinyIntType(false)),
+                            new DataField(1, "_PARTITION", newBytesType(false)),
+                            new DataField(2, "_BUCKET", new IntType(false)),
+                            new DataField(3, "_TOTAL_BUCKETS", new IntType(false)),
+                            new DataField(4, "_FILE", DataFileMeta.SCHEMA)));
 
     private final FileKind kind;
     // for tables without partition this field should be a row with 0 columns (not null)
@@ -104,16 +114,6 @@ public class ManifestEntry implements FileEntry {
         return new Identifier(partition, bucket, file.level(), file.fileName());
     }
 
-    public static RowType schema() {
-        List<DataField> fields = new ArrayList<>();
-        fields.add(new DataField(0, "_KIND", new TinyIntType(false)));
-        fields.add(new DataField(1, "_PARTITION", newBytesType(false)));
-        fields.add(new DataField(2, "_BUCKET", new IntType(false)));
-        fields.add(new DataField(3, "_TOTAL_BUCKETS", new IntType(false)));
-        fields.add(new DataField(4, "_FILE", DataFileMeta.schema()));
-        return new RowType(false, fields);
-    }
-
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof ManifestEntry)) {
@@ -135,67 +135,6 @@ public class ManifestEntry implements FileEntry {
     @Override
     public String toString() {
         return String.format("{%s, %s, %d, %d, %s}", kind, partition, bucket, totalBuckets, file);
-    }
-
-    /**
-     * According to the {@link ManifestCacheFilter}, entry that needs to be cached will be retained,
-     * so the entry that will not be accessed in the future will not be cached.
-     *
-     * <p>Implemented to {@link InternalRow} is for performance (No deserialization).
-     */
-    public static Filter<InternalRow> createCacheRowFilter(
-            @Nullable ManifestCacheFilter manifestCacheFilter, int numOfBuckets) {
-        if (manifestCacheFilter == null) {
-            return Filter.alwaysTrue();
-        }
-
-        Function<InternalRow, BinaryRow> partitionGetter =
-                ManifestEntrySerializer.partitionGetter();
-        Function<InternalRow, Integer> bucketGetter = ManifestEntrySerializer.bucketGetter();
-        Function<InternalRow, Integer> totalBucketGetter =
-                ManifestEntrySerializer.totalBucketGetter();
-        return row -> {
-            if (numOfBuckets != totalBucketGetter.apply(row)) {
-                return true;
-            }
-
-            return manifestCacheFilter.test(partitionGetter.apply(row), bucketGetter.apply(row));
-        };
-    }
-
-    /**
-     * Read the corresponding entries based on the current required partition and bucket.
-     *
-     * <p>Implemented to {@link InternalRow} is for performance (No deserialization).
-     */
-    public static Filter<InternalRow> createEntryRowFilter(
-            @Nullable PartitionPredicate partitionFilter,
-            @Nullable Filter<Integer> bucketFilter,
-            @Nullable Filter<String> fileNameFilter,
-            int numOfBuckets) {
-        Function<InternalRow, BinaryRow> partitionGetter =
-                ManifestEntrySerializer.partitionGetter();
-        Function<InternalRow, Integer> bucketGetter = ManifestEntrySerializer.bucketGetter();
-        Function<InternalRow, Integer> totalBucketGetter =
-                ManifestEntrySerializer.totalBucketGetter();
-        Function<InternalRow, String> fileNameGetter = ManifestEntrySerializer.fileNameGetter();
-        return row -> {
-            if ((partitionFilter != null && !partitionFilter.test(partitionGetter.apply(row)))) {
-                return false;
-            }
-
-            if (bucketFilter != null
-                    && numOfBuckets == totalBucketGetter.apply(row)
-                    && !bucketFilter.test(bucketGetter.apply(row))) {
-                return false;
-            }
-
-            if (fileNameFilter != null && !fileNameFilter.test((fileNameGetter.apply(row)))) {
-                return false;
-            }
-
-            return true;
-        };
     }
 
     public static long recordCount(List<ManifestEntry> manifestEntries) {

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntrySerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntrySerializer.java
@@ -38,7 +38,7 @@ public class ManifestEntrySerializer extends VersionedObjectSerializer<ManifestE
     private final DataFileMetaSerializer dataFileMetaSerializer;
 
     public ManifestEntrySerializer() {
-        super(ManifestEntry.schema());
+        super(ManifestEntry.SCHEMA);
         this.dataFileMetaSerializer = new DataFileMetaSerializer();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java
@@ -197,7 +197,7 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
         }
 
         public ManifestFile create() {
-            RowType entryType = VersionedObjectSerializer.versionType(ManifestEntry.schema());
+            RowType entryType = VersionedObjectSerializer.versionType(ManifestEntry.SCHEMA);
             return new ManifestFile(
                     fileIO,
                     schemaManager,
@@ -213,7 +213,7 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
         }
 
         public ObjectsFile<SimpleFileEntry> createSimpleFileEntryReader() {
-            RowType entryType = VersionedObjectSerializer.versionType(ManifestEntry.schema());
+            RowType entryType = VersionedObjectSerializer.versionType(ManifestEntry.SCHEMA);
             return new ObjectsFile<>(
                     fileIO,
                     new SimpleFileEntrySerializer(),

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFileMeta.java
@@ -18,38 +18,35 @@
 
 package org.apache.paimon.manifest;
 
-import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.io.RollingFileWriter;
-import org.apache.paimon.manifest.FileEntry.Identifier;
-import org.apache.paimon.partition.PartitionPredicate;
+import org.apache.paimon.annotation.Public;
 import org.apache.paimon.stats.SimpleStats;
-import org.apache.paimon.stats.SimpleStatsConverter;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.VarCharType;
-import org.apache.paimon.utils.IOUtils;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nullable;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.Arrays;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
 
-import static org.apache.paimon.utils.Preconditions.checkArgument;
-
-/** Metadata of a manifest file. */
+/**
+ * Metadata of a manifest file.
+ *
+ * @since 0.9.0
+ */
+@Public
 public class ManifestFileMeta {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ManifestFileMeta.class);
+    public static final RowType SCHEMA =
+            new RowType(
+                    false,
+                    Arrays.asList(
+                            new DataField(
+                                    0, "_FILE_NAME", new VarCharType(false, Integer.MAX_VALUE)),
+                            new DataField(1, "_FILE_SIZE", new BigIntType(false)),
+                            new DataField(2, "_NUM_ADDED_FILES", new BigIntType(false)),
+                            new DataField(3, "_NUM_DELETED_FILES", new BigIntType(false)),
+                            new DataField(4, "_PARTITION_STATS", SimpleStats.SCHEMA),
+                            new DataField(5, "_SCHEMA_ID", new BigIntType(false))));
 
     private final String fileName;
     private final long fileSize;
@@ -97,17 +94,6 @@ public class ManifestFileMeta {
         return schemaId;
     }
 
-    public static RowType schema() {
-        List<DataField> fields = new ArrayList<>();
-        fields.add(new DataField(0, "_FILE_NAME", new VarCharType(false, Integer.MAX_VALUE)));
-        fields.add(new DataField(1, "_FILE_SIZE", new BigIntType(false)));
-        fields.add(new DataField(2, "_NUM_ADDED_FILES", new BigIntType(false)));
-        fields.add(new DataField(3, "_NUM_DELETED_FILES", new BigIntType(false)));
-        fields.add(new DataField(4, "_PARTITION_STATS", SimpleStatsConverter.schema()));
-        fields.add(new DataField(5, "_SCHEMA_ID", new BigIntType(false)));
-        return new RowType(false, fields);
-    }
-
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof ManifestFileMeta)) {
@@ -133,269 +119,5 @@ public class ManifestFileMeta {
         return String.format(
                 "{%s, %d, %d, %d, %s, %d}",
                 fileName, fileSize, numAddedFiles, numDeletedFiles, partitionStats, schemaId);
-    }
-
-    /**
-     * Merge several {@link ManifestFileMeta}s. {@link ManifestEntry}s representing first adding and
-     * then deleting the same data file will cancel each other.
-     *
-     * <p>NOTE: This method is atomic.
-     */
-    public static List<ManifestFileMeta> merge(
-            List<ManifestFileMeta> input,
-            ManifestFile manifestFile,
-            long suggestedMetaSize,
-            int suggestedMinMetaCount,
-            long manifestFullCompactionSize,
-            RowType partitionType,
-            @Nullable Integer manifestReadParallelism) {
-        // these are the newly created manifest files, clean them up if exception occurs
-        List<ManifestFileMeta> newMetas = new ArrayList<>();
-
-        try {
-            Optional<List<ManifestFileMeta>> fullCompacted =
-                    tryFullCompaction(
-                            input,
-                            newMetas,
-                            manifestFile,
-                            suggestedMetaSize,
-                            manifestFullCompactionSize,
-                            partitionType,
-                            manifestReadParallelism);
-            return fullCompacted.orElseGet(
-                    () ->
-                            tryMinorCompaction(
-                                    input,
-                                    newMetas,
-                                    manifestFile,
-                                    suggestedMetaSize,
-                                    suggestedMinMetaCount,
-                                    manifestReadParallelism));
-        } catch (Throwable e) {
-            // exception occurs, clean up and rethrow
-            for (ManifestFileMeta manifest : newMetas) {
-                manifestFile.delete(manifest.fileName);
-            }
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static List<ManifestFileMeta> tryMinorCompaction(
-            List<ManifestFileMeta> input,
-            List<ManifestFileMeta> newMetas,
-            ManifestFile manifestFile,
-            long suggestedMetaSize,
-            int suggestedMinMetaCount,
-            @Nullable Integer manifestReadParallelism) {
-        List<ManifestFileMeta> result = new ArrayList<>();
-        List<ManifestFileMeta> candidates = new ArrayList<>();
-        long totalSize = 0;
-        // merge existing small manifest files
-        for (ManifestFileMeta manifest : input) {
-            totalSize += manifest.fileSize;
-            candidates.add(manifest);
-            if (totalSize >= suggestedMetaSize) {
-                // reach suggested file size, perform merging and produce new file
-                mergeCandidates(
-                        candidates, manifestFile, result, newMetas, manifestReadParallelism);
-                candidates.clear();
-                totalSize = 0;
-            }
-        }
-
-        // merge the last bit of manifests if there are too many
-        if (candidates.size() >= suggestedMinMetaCount) {
-            mergeCandidates(candidates, manifestFile, result, newMetas, manifestReadParallelism);
-        } else {
-            result.addAll(candidates);
-        }
-        return result;
-    }
-
-    private static void mergeCandidates(
-            List<ManifestFileMeta> candidates,
-            ManifestFile manifestFile,
-            List<ManifestFileMeta> result,
-            List<ManifestFileMeta> newMetas,
-            @Nullable Integer manifestReadParallelism) {
-        if (candidates.size() == 1) {
-            result.add(candidates.get(0));
-            return;
-        }
-
-        Map<Identifier, ManifestEntry> map = new LinkedHashMap<>();
-        FileEntry.mergeEntries(manifestFile, candidates, map, manifestReadParallelism);
-        if (!map.isEmpty()) {
-            List<ManifestFileMeta> merged = manifestFile.write(new ArrayList<>(map.values()));
-            result.addAll(merged);
-            newMetas.addAll(merged);
-        }
-    }
-
-    public static Optional<List<ManifestFileMeta>> tryFullCompaction(
-            List<ManifestFileMeta> inputs,
-            List<ManifestFileMeta> newMetas,
-            ManifestFile manifestFile,
-            long suggestedMetaSize,
-            long sizeTrigger,
-            RowType partitionType,
-            @Nullable Integer manifestReadParallelism)
-            throws Exception {
-        // 1. should trigger full compaction
-
-        List<ManifestFileMeta> base = new ArrayList<>();
-        long totalManifestSize = 0;
-        int i = 0;
-        for (; i < inputs.size(); i++) {
-            ManifestFileMeta file = inputs.get(i);
-            if (file.numDeletedFiles == 0 && file.fileSize >= suggestedMetaSize) {
-                base.add(file);
-                totalManifestSize += file.fileSize;
-            } else {
-                break;
-            }
-        }
-
-        List<ManifestFileMeta> delta = new ArrayList<>();
-        long deltaDeleteFileNum = 0;
-        long totalDeltaFileSize = 0;
-        for (; i < inputs.size(); i++) {
-            ManifestFileMeta file = inputs.get(i);
-            delta.add(file);
-            totalManifestSize += file.fileSize;
-            deltaDeleteFileNum += file.numDeletedFiles();
-            totalDeltaFileSize += file.fileSize();
-        }
-
-        if (totalDeltaFileSize < sizeTrigger) {
-            return Optional.empty();
-        }
-
-        // 2. do full compaction
-
-        LOG.info(
-                "Start Manifest File Full Compaction, pick the number of delete file: {}, total manifest file size: {}",
-                deltaDeleteFileNum,
-                totalManifestSize);
-
-        // 2.1. try to skip base files by partition filter
-
-        Map<Identifier, ManifestEntry> deltaMerged = new LinkedHashMap<>();
-        FileEntry.mergeEntries(manifestFile, delta, deltaMerged, manifestReadParallelism);
-
-        List<ManifestFileMeta> result = new ArrayList<>();
-        int j = 0;
-        if (partitionType.getFieldCount() > 0) {
-            Set<BinaryRow> deletePartitions = computeDeletePartitions(deltaMerged);
-            PartitionPredicate predicate =
-                    PartitionPredicate.fromMultiple(partitionType, deletePartitions);
-            if (predicate != null) {
-                for (; j < base.size(); j++) {
-                    // TODO: optimize this to binary search.
-                    ManifestFileMeta file = base.get(j);
-                    if (predicate.test(
-                            file.numAddedFiles + file.numDeletedFiles,
-                            file.partitionStats.minValues(),
-                            file.partitionStats.maxValues(),
-                            file.partitionStats.nullCounts())) {
-                        break;
-                    } else {
-                        result.add(file);
-                    }
-                }
-            } else {
-                // There is no DELETE Entry in Delta, Base don't need compaction
-                j = base.size();
-                result.addAll(base);
-            }
-        }
-
-        // 2.2. try to skip base files by reading entries
-
-        Set<Identifier> deleteEntries = new HashSet<>();
-        deltaMerged.forEach(
-                (k, v) -> {
-                    if (v.kind() == FileKind.DELETE) {
-                        deleteEntries.add(k);
-                    }
-                });
-
-        List<ManifestEntry> mergedEntries = new ArrayList<>();
-        for (; j < base.size(); j++) {
-            ManifestFileMeta file = base.get(j);
-            boolean contains = false;
-            for (ManifestEntry entry : manifestFile.read(file.fileName, file.fileSize)) {
-                checkArgument(entry.kind() == FileKind.ADD);
-                if (deleteEntries.contains(entry.identifier())) {
-                    contains = true;
-                } else {
-                    mergedEntries.add(entry);
-                }
-            }
-            if (contains) {
-                // already read this file into fullMerged
-                j++;
-                break;
-            } else {
-                mergedEntries.clear();
-                result.add(file);
-            }
-        }
-
-        // 2.3. merge
-
-        RollingFileWriter<ManifestEntry, ManifestFileMeta> writer =
-                manifestFile.createRollingWriter();
-        Exception exception = null;
-        try {
-
-            // 2.3.1 merge mergedEntries
-            for (ManifestEntry entry : mergedEntries) {
-                writer.write(entry);
-            }
-            mergedEntries.clear();
-
-            // 2.3.2 merge base files
-            for (ManifestEntry entry :
-                    FileEntry.readManifestEntries(
-                            manifestFile, base.subList(j, base.size()), manifestReadParallelism)) {
-                checkArgument(entry.kind() == FileKind.ADD);
-                if (!deleteEntries.contains(entry.identifier())) {
-                    writer.write(entry);
-                }
-            }
-
-            // 2.3.3 merge deltaMerged
-            for (ManifestEntry entry : deltaMerged.values()) {
-                if (entry.kind() == FileKind.ADD) {
-                    writer.write(entry);
-                }
-            }
-        } catch (Exception e) {
-            exception = e;
-        } finally {
-            if (exception != null) {
-                IOUtils.closeQuietly(writer);
-                throw exception;
-            }
-            writer.close();
-        }
-
-        List<ManifestFileMeta> merged = writer.result();
-        result.addAll(merged);
-        newMetas.addAll(merged);
-        return Optional.of(result);
-    }
-
-    private static Set<BinaryRow> computeDeletePartitions(
-            Map<Identifier, ManifestEntry> deltaMerged) {
-        Set<BinaryRow> partitions = new HashSet<>();
-        for (ManifestEntry manifestEntry : deltaMerged.values()) {
-            if (manifestEntry.kind() == FileKind.DELETE) {
-                BinaryRow partition = manifestEntry.partition();
-                partitions.add(partition);
-            }
-        }
-        return partitions;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFileMetaSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFileMetaSerializer.java
@@ -30,7 +30,7 @@ public class ManifestFileMetaSerializer extends VersionedObjectSerializer<Manife
     private static final long serialVersionUID = 1L;
 
     public ManifestFileMetaSerializer() {
-        super(ManifestFileMeta.schema());
+        super(ManifestFileMeta.SCHEMA);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestList.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestList.java
@@ -140,7 +140,7 @@ public class ManifestList extends ObjectsFile<ManifestFileMeta> {
         }
 
         public ManifestList create() {
-            RowType metaType = VersionedObjectSerializer.versionType(ManifestFileMeta.schema());
+            RowType metaType = VersionedObjectSerializer.versionType(ManifestFileMeta.SCHEMA);
             return new ManifestList(
                     fileIO,
                     new ManifestFileMetaSerializer(),

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/SimpleFileEntrySerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/SimpleFileEntrySerializer.java
@@ -32,7 +32,7 @@ public class SimpleFileEntrySerializer extends VersionedObjectSerializer<SimpleF
     private final int version;
 
     public SimpleFileEntrySerializer() {
-        super(ManifestEntry.schema());
+        super(ManifestEntry.SCHEMA);
         this.version = new ManifestEntrySerializer().getVersion();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -864,7 +864,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             }
             // merge manifest files with changes
             newMetas.addAll(
-                    ManifestFileMeta.merge(
+                    ManifestFileMerger.merge(
                             oldMetas,
                             manifestFile,
                             manifestTargetSize.getBytes(),

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileMerger.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileMerger.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.operation;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.io.RollingFileWriter;
+import org.apache.paimon.manifest.FileEntry;
+import org.apache.paimon.manifest.FileKind;
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.ManifestFile;
+import org.apache.paimon.manifest.ManifestFileMeta;
+import org.apache.paimon.partition.PartitionPredicate;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.IOUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Util for merging manifest files. */
+public class ManifestFileMerger {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ManifestFileMerger.class);
+
+    /**
+     * Merge several {@link ManifestFileMeta}s. {@link ManifestEntry}s representing first adding and
+     * then deleting the same data file will cancel each other.
+     *
+     * <p>NOTE: This method is atomic.
+     */
+    public static List<ManifestFileMeta> merge(
+            List<ManifestFileMeta> input,
+            ManifestFile manifestFile,
+            long suggestedMetaSize,
+            int suggestedMinMetaCount,
+            long manifestFullCompactionSize,
+            RowType partitionType,
+            @Nullable Integer manifestReadParallelism) {
+        // these are the newly created manifest files, clean them up if exception occurs
+        List<ManifestFileMeta> newMetas = new ArrayList<>();
+
+        try {
+            Optional<List<ManifestFileMeta>> fullCompacted =
+                    tryFullCompaction(
+                            input,
+                            newMetas,
+                            manifestFile,
+                            suggestedMetaSize,
+                            manifestFullCompactionSize,
+                            partitionType,
+                            manifestReadParallelism);
+            return fullCompacted.orElseGet(
+                    () ->
+                            tryMinorCompaction(
+                                    input,
+                                    newMetas,
+                                    manifestFile,
+                                    suggestedMetaSize,
+                                    suggestedMinMetaCount,
+                                    manifestReadParallelism));
+        } catch (Throwable e) {
+            // exception occurs, clean up and rethrow
+            for (ManifestFileMeta manifest : newMetas) {
+                manifestFile.delete(manifest.fileName());
+            }
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static List<ManifestFileMeta> tryMinorCompaction(
+            List<ManifestFileMeta> input,
+            List<ManifestFileMeta> newMetas,
+            ManifestFile manifestFile,
+            long suggestedMetaSize,
+            int suggestedMinMetaCount,
+            @Nullable Integer manifestReadParallelism) {
+        List<ManifestFileMeta> result = new ArrayList<>();
+        List<ManifestFileMeta> candidates = new ArrayList<>();
+        long totalSize = 0;
+        // merge existing small manifest files
+        for (ManifestFileMeta manifest : input) {
+            totalSize += manifest.fileSize();
+            candidates.add(manifest);
+            if (totalSize >= suggestedMetaSize) {
+                // reach suggested file size, perform merging and produce new file
+                mergeCandidates(
+                        candidates, manifestFile, result, newMetas, manifestReadParallelism);
+                candidates.clear();
+                totalSize = 0;
+            }
+        }
+
+        // merge the last bit of manifests if there are too many
+        if (candidates.size() >= suggestedMinMetaCount) {
+            mergeCandidates(candidates, manifestFile, result, newMetas, manifestReadParallelism);
+        } else {
+            result.addAll(candidates);
+        }
+        return result;
+    }
+
+    private static void mergeCandidates(
+            List<ManifestFileMeta> candidates,
+            ManifestFile manifestFile,
+            List<ManifestFileMeta> result,
+            List<ManifestFileMeta> newMetas,
+            @Nullable Integer manifestReadParallelism) {
+        if (candidates.size() == 1) {
+            result.add(candidates.get(0));
+            return;
+        }
+
+        Map<FileEntry.Identifier, ManifestEntry> map = new LinkedHashMap<>();
+        FileEntry.mergeEntries(manifestFile, candidates, map, manifestReadParallelism);
+        if (!map.isEmpty()) {
+            List<ManifestFileMeta> merged = manifestFile.write(new ArrayList<>(map.values()));
+            result.addAll(merged);
+            newMetas.addAll(merged);
+        }
+    }
+
+    public static Optional<List<ManifestFileMeta>> tryFullCompaction(
+            List<ManifestFileMeta> inputs,
+            List<ManifestFileMeta> newMetas,
+            ManifestFile manifestFile,
+            long suggestedMetaSize,
+            long sizeTrigger,
+            RowType partitionType,
+            @Nullable Integer manifestReadParallelism)
+            throws Exception {
+        // 1. should trigger full compaction
+
+        List<ManifestFileMeta> base = new ArrayList<>();
+        long totalManifestSize = 0;
+        int i = 0;
+        for (; i < inputs.size(); i++) {
+            ManifestFileMeta file = inputs.get(i);
+            if (file.numDeletedFiles() == 0 && file.fileSize() >= suggestedMetaSize) {
+                base.add(file);
+                totalManifestSize += file.fileSize();
+            } else {
+                break;
+            }
+        }
+
+        List<ManifestFileMeta> delta = new ArrayList<>();
+        long deltaDeleteFileNum = 0;
+        long totalDeltaFileSize = 0;
+        for (; i < inputs.size(); i++) {
+            ManifestFileMeta file = inputs.get(i);
+            delta.add(file);
+            totalManifestSize += file.fileSize();
+            deltaDeleteFileNum += file.numDeletedFiles();
+            totalDeltaFileSize += file.fileSize();
+        }
+
+        if (totalDeltaFileSize < sizeTrigger) {
+            return Optional.empty();
+        }
+
+        // 2. do full compaction
+
+        LOG.info(
+                "Start Manifest File Full Compaction, pick the number of delete file: {}, total manifest file size: {}",
+                deltaDeleteFileNum,
+                totalManifestSize);
+
+        // 2.1. try to skip base files by partition filter
+
+        Map<FileEntry.Identifier, ManifestEntry> deltaMerged = new LinkedHashMap<>();
+        FileEntry.mergeEntries(manifestFile, delta, deltaMerged, manifestReadParallelism);
+
+        List<ManifestFileMeta> result = new ArrayList<>();
+        int j = 0;
+        if (partitionType.getFieldCount() > 0) {
+            Set<BinaryRow> deletePartitions = computeDeletePartitions(deltaMerged);
+            PartitionPredicate predicate =
+                    PartitionPredicate.fromMultiple(partitionType, deletePartitions);
+            if (predicate != null) {
+                for (; j < base.size(); j++) {
+                    // TODO: optimize this to binary search.
+                    ManifestFileMeta file = base.get(j);
+                    if (predicate.test(
+                            file.numAddedFiles() + file.numDeletedFiles(),
+                            file.partitionStats().minValues(),
+                            file.partitionStats().maxValues(),
+                            file.partitionStats().nullCounts())) {
+                        break;
+                    } else {
+                        result.add(file);
+                    }
+                }
+            } else {
+                // There is no DELETE Entry in Delta, Base don't need compaction
+                j = base.size();
+                result.addAll(base);
+            }
+        }
+
+        // 2.2. try to skip base files by reading entries
+
+        Set<FileEntry.Identifier> deleteEntries = new HashSet<>();
+        deltaMerged.forEach(
+                (k, v) -> {
+                    if (v.kind() == FileKind.DELETE) {
+                        deleteEntries.add(k);
+                    }
+                });
+
+        List<ManifestEntry> mergedEntries = new ArrayList<>();
+        for (; j < base.size(); j++) {
+            ManifestFileMeta file = base.get(j);
+            boolean contains = false;
+            for (ManifestEntry entry : manifestFile.read(file.fileName(), file.fileSize())) {
+                checkArgument(entry.kind() == FileKind.ADD);
+                if (deleteEntries.contains(entry.identifier())) {
+                    contains = true;
+                } else {
+                    mergedEntries.add(entry);
+                }
+            }
+            if (contains) {
+                // already read this file into fullMerged
+                j++;
+                break;
+            } else {
+                mergedEntries.clear();
+                result.add(file);
+            }
+        }
+
+        // 2.3. merge
+
+        RollingFileWriter<ManifestEntry, ManifestFileMeta> writer =
+                manifestFile.createRollingWriter();
+        Exception exception = null;
+        try {
+
+            // 2.3.1 merge mergedEntries
+            for (ManifestEntry entry : mergedEntries) {
+                writer.write(entry);
+            }
+            mergedEntries.clear();
+
+            // 2.3.2 merge base files
+            for (ManifestEntry entry :
+                    FileEntry.readManifestEntries(
+                            manifestFile, base.subList(j, base.size()), manifestReadParallelism)) {
+                checkArgument(entry.kind() == FileKind.ADD);
+                if (!deleteEntries.contains(entry.identifier())) {
+                    writer.write(entry);
+                }
+            }
+
+            // 2.3.3 merge deltaMerged
+            for (ManifestEntry entry : deltaMerged.values()) {
+                if (entry.kind() == FileKind.ADD) {
+                    writer.write(entry);
+                }
+            }
+        } catch (Exception e) {
+            exception = e;
+        } finally {
+            if (exception != null) {
+                IOUtils.closeQuietly(writer);
+                throw exception;
+            }
+            writer.close();
+        }
+
+        List<ManifestFileMeta> merged = writer.result();
+        result.addAll(merged);
+        newMetas.addAll(merged);
+        return Optional.of(result);
+    }
+
+    private static Set<BinaryRow> computeDeletePartitions(
+            Map<FileEntry.Identifier, ManifestEntry> deltaMerged) {
+        Set<BinaryRow> partitions = new HashSet<>();
+        for (ManifestEntry manifestEntry : deltaMerged.values()) {
+            if (manifestEntry.kind() == FileKind.DELETE) {
+                BinaryRow partition = manifestEntry.partition();
+                partitions.add(partition);
+            }
+        }
+        return partitions;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStoreTable.java
@@ -21,6 +21,8 @@ package org.apache.paimon.privilege;
 import org.apache.paimon.FileStore;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.manifest.ManifestCacheFilter;
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.stats.Statistics;
 import org.apache.paimon.table.DelegatedFileStoreTable;
@@ -35,6 +37,7 @@ import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.StreamDataTableScan;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.utils.BranchManager;
+import org.apache.paimon.utils.SimpleFileReader;
 import org.apache.paimon.utils.TagManager;
 
 import java.time.Duration;
@@ -89,6 +92,16 @@ public class PrivilegedFileStoreTable extends DelegatedFileStoreTable {
     public FileStoreTable copy(Map<String, String> dynamicOptions) {
         return new PrivilegedFileStoreTable(
                 wrapped.copy(dynamicOptions), privilegeChecker, identifier);
+    }
+
+    @Override
+    public SimpleFileReader<ManifestFileMeta> manifestListReader() {
+        return wrapped.manifestListReader();
+    }
+
+    @Override
+    public SimpleFileReader<ManifestEntry> manifestFileReader() {
+        return wrapped.manifestFileReader();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/stats/SimpleStats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/SimpleStats.java
@@ -18,15 +18,22 @@
 
 package org.apache.paimon.stats;
 
+import org.apache.paimon.annotation.Public;
 import org.apache.paimon.data.BinaryArray;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.BigIntType;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 import static org.apache.paimon.data.BinaryRow.EMPTY_ROW;
 import static org.apache.paimon.utils.SerializationUtils.deserializeBinaryRow;
+import static org.apache.paimon.utils.SerializationUtils.newBytesType;
 import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
 
 /**
@@ -40,8 +47,19 @@ import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
  *
  * <p>All statistics are stored in the form of a Binary, which can significantly reduce its memory
  * consumption, but the cost is that the column type needs to be known when getting.
+ *
+ * @since 0.9.0
  */
+@Public
 public class SimpleStats {
+
+    public static final RowType SCHEMA =
+            new RowType(
+                    false,
+                    Arrays.asList(
+                            new DataField(0, "_MIN_VALUES", newBytesType(false)),
+                            new DataField(1, "_MAX_VALUES", newBytesType(false)),
+                            new DataField(2, "_NULL_COUNTS", new ArrayType(new BigIntType(true)))));
 
     /** Empty stats for 0 column number. */
     public static final SimpleStats EMPTY_STATS =

--- a/paimon-core/src/main/java/org/apache/paimon/stats/SimpleStatsConverter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/SimpleStatsConverter.java
@@ -31,19 +31,11 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.format.SimpleColStats;
-import org.apache.paimon.types.ArrayType;
-import org.apache.paimon.types.BigIntType;
-import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.ProjectedRow;
 
 import javax.annotation.Nullable;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.apache.paimon.utils.SerializationUtils.newBytesType;
 
 /** Converter for array of {@link SimpleColStats}. */
 public class SimpleStatsConverter {
@@ -106,14 +98,6 @@ public class SimpleStatsConverter {
         }
 
         return new NullCountsEvoArray(indexMapping, nullCounts, rowCount);
-    }
-
-    public static RowType schema() {
-        List<DataField> fields = new ArrayList<>();
-        fields.add(new DataField(0, "_MIN_VALUES", newBytesType(false)));
-        fields.add(new DataField(1, "_MAX_VALUES", newBytesType(false)));
-        fields.add(new DataField(2, "_NULL_COUNTS", new ArrayType(new BigIntType(true))));
-        return new RowType(fields);
     }
 
     private static RowType toAllFieldsNullableRowType(RowType rowType) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -25,6 +25,8 @@ import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.iceberg.IcebergCommitCallback;
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.metastore.AddPartitionCommitCallback;
 import org.apache.paimon.metastore.AddPartitionTagCallback;
 import org.apache.paimon.metastore.MetastoreClient;
@@ -60,6 +62,7 @@ import org.apache.paimon.tag.TagPreview;
 import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.SegmentsCache;
+import org.apache.paimon.utils.SimpleFileReader;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.SnapshotNotExistException;
 import org.apache.paimon.utils.TagManager;
@@ -124,6 +127,16 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
     @Override
     public Snapshot snapshot(long snapshotId) {
         return store().snapshotManager().snapshot(snapshotId);
+    }
+
+    @Override
+    public SimpleFileReader<ManifestFileMeta> manifestListReader() {
+        return store().manifestListFactory().create();
+    }
+
+    @Override
+    public SimpleFileReader<ManifestEntry> manifestFileReader() {
+        return store().manifestFileFactory().create();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
@@ -23,6 +23,8 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
@@ -38,6 +40,7 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.Preconditions;
+import org.apache.paimon.utils.SimpleFileReader;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -70,6 +73,16 @@ public class FallbackReadFileStoreTable extends DelegatedFileStoreTable {
         return new FallbackReadFileStoreTable(
                 wrapped.copy(dynamicOptions),
                 fallback.copy(rewriteFallbackOptions(dynamicOptions)));
+    }
+
+    @Override
+    public SimpleFileReader<ManifestFileMeta> manifestListReader() {
+        return wrapped.manifestListReader();
+    }
+
+    @Override
+    public SimpleFileReader<ManifestEntry> manifestFileReader() {
+        return wrapped.manifestFileReader();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/ReadonlyTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ReadonlyTable.java
@@ -19,6 +19,8 @@
 package org.apache.paimon.table;
 
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.stats.Statistics;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.sink.InnerTableCommit;
@@ -26,6 +28,7 @@ import org.apache.paimon.table.sink.InnerTableWrite;
 import org.apache.paimon.table.sink.StreamWriteBuilder;
 import org.apache.paimon.table.sink.WriteSelector;
 import org.apache.paimon.table.source.StreamDataTableScan;
+import org.apache.paimon.utils.SimpleFileReader;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -118,6 +121,22 @@ public interface ReadonlyTable extends InnerTable {
         throw new UnsupportedOperationException(
                 String.format(
                         "Readonly Table %s does not support snapshot.",
+                        this.getClass().getSimpleName()));
+    }
+
+    @Override
+    default SimpleFileReader<ManifestFileMeta> manifestListReader() {
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Readonly Table %s does not support manifestListReader.",
+                        this.getClass().getSimpleName()));
+    }
+
+    @Override
+    default SimpleFileReader<ManifestEntry> manifestFileReader() {
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Readonly Table %s does not support manifestFileReader.",
                         this.getClass().getSimpleName()));
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/Table.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/Table.java
@@ -21,11 +21,14 @@ package org.apache.paimon.table;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.annotation.Experimental;
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.stats.Statistics;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.sink.StreamWriteBuilder;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.SimpleFileReader;
 
 import java.io.Serializable;
 import java.time.Duration;
@@ -82,6 +85,14 @@ public interface Table extends Serializable {
     /** Get the {@link Snapshot} from snapshot id. */
     @Experimental
     Snapshot snapshot(long snapshotId);
+
+    /** Reader to read manifest file meta from manifest list file. */
+    @Experimental
+    SimpleFileReader<ManifestFileMeta> manifestListReader();
+
+    /** Reader to read manifest entry from manifest file. */
+    @Experimental
+    SimpleFileReader<ManifestEntry> manifestFileReader();
 
     /** Rollback table's state to a specific snapshot. */
     @Experimental

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/CommitMessageLegacyV2Serializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/CommitMessageLegacyV2Serializer.java
@@ -28,7 +28,6 @@ import org.apache.paimon.io.DataIncrement;
 import org.apache.paimon.io.DataInputView;
 import org.apache.paimon.io.IndexIncrement;
 import org.apache.paimon.stats.SimpleStats;
-import org.apache.paimon.stats.SimpleStatsConverter;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
@@ -90,8 +89,8 @@ public class CommitMessageLegacyV2Serializer {
         fields.add(new DataField(2, "_ROW_COUNT", new BigIntType(false)));
         fields.add(new DataField(3, "_MIN_KEY", newBytesType(false)));
         fields.add(new DataField(4, "_MAX_KEY", newBytesType(false)));
-        fields.add(new DataField(5, "_KEY_STATS", SimpleStatsConverter.schema()));
-        fields.add(new DataField(6, "_VALUE_STATS", SimpleStatsConverter.schema()));
+        fields.add(new DataField(5, "_KEY_STATS", SimpleStats.SCHEMA));
+        fields.add(new DataField(6, "_VALUE_STATS", SimpleStats.SCHEMA));
         fields.add(new DataField(7, "_MIN_SEQUENCE_NUMBER", new BigIntType(false)));
         fields.add(new DataField(8, "_MAX_SEQUENCE_NUMBER", new BigIntType(false)));
         fields.add(new DataField(9, "_SCHEMA_ID", new BigIntType(false)));

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
@@ -27,6 +27,8 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.predicate.LeafPredicate;
@@ -55,6 +57,7 @@ import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.ProjectedRow;
+import org.apache.paimon.utils.SimpleFileReader;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
@@ -109,6 +112,16 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
     @Override
     public Snapshot snapshot(long snapshotId) {
         return wrapped.snapshot(snapshotId);
+    }
+
+    @Override
+    public SimpleFileReader<ManifestFileMeta> manifestListReader() {
+        return wrapped.manifestListReader();
+    }
+
+    @Override
+    public SimpleFileReader<ManifestEntry> manifestFileReader() {
+        return wrapped.manifestFileReader();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/BucketsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/BucketsTable.java
@@ -28,6 +28,8 @@ import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFileMetaSerializer;
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.table.DataTable;
@@ -47,6 +49,7 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.IteratorRecordReader;
+import org.apache.paimon.utils.SimpleFileReader;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
@@ -113,6 +116,16 @@ public class BucketsTable implements DataTable, ReadonlyTable {
     @Override
     public Snapshot snapshot(long snapshotId) {
         return wrapped.snapshot(snapshotId);
+    }
+
+    @Override
+    public SimpleFileReader<ManifestFileMeta> manifestListReader() {
+        return wrapped.manifestListReader();
+    }
+
+    @Override
+    public SimpleFileReader<ManifestEntry> manifestFileReader() {
+        return wrapped.manifestFileReader();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/FileMonitorTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/FileMonitorTable.java
@@ -29,6 +29,8 @@ import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFileMetaSerializer;
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.table.DataTable;
@@ -47,6 +49,7 @@ import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.IteratorRecordReader;
+import org.apache.paimon.utils.SimpleFileReader;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
@@ -100,6 +103,16 @@ public class FileMonitorTable implements DataTable, ReadonlyTable {
     @Override
     public Snapshot snapshot(long snapshotId) {
         return wrapped.snapshot(snapshotId);
+    }
+
+    @Override
+    public SimpleFileReader<ManifestFileMeta> manifestListReader() {
+        return wrapped.manifestListReader();
+    }
+
+    @Override
+    public SimpleFileReader<ManifestEntry> manifestFileReader() {
+        return wrapped.manifestFileReader();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ReadOptimizedTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ReadOptimizedTable.java
@@ -22,6 +22,8 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.operation.DefaultValueAssigner;
 import org.apache.paimon.table.DataTable;
 import org.apache.paimon.table.FileStoreTable;
@@ -34,6 +36,7 @@ import org.apache.paimon.table.source.StreamDataTableScan;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.BranchManager;
+import org.apache.paimon.utils.SimpleFileReader;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
@@ -70,6 +73,16 @@ public class ReadOptimizedTable implements DataTable, ReadonlyTable {
     @Override
     public Snapshot snapshot(long snapshotId) {
         return wrapped.snapshot(snapshotId);
+    }
+
+    @Override
+    public SimpleFileReader<ManifestFileMeta> manifestListReader() {
+        return wrapped.manifestListReader();
+    }
+
+    @Override
+    public SimpleFileReader<ManifestEntry> manifestFileReader() {
+        return wrapped.manifestFileReader();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
@@ -39,7 +39,7 @@ import java.util.List;
 import static org.apache.paimon.utils.FileUtils.checkExists;
 
 /** A file which contains several {@link T}s, provides read and write. */
-public class ObjectsFile<T> {
+public class ObjectsFile<T> implements SimpleFileReader<T> {
 
     protected final FileIO fileIO;
     protected final ObjectSerializer<T> serializer;
@@ -88,6 +88,7 @@ public class ObjectsFile<T> {
         }
     }
 
+    @Override
     public List<T> read(String fileName) {
         return read(fileName, null);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SimpleFileReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SimpleFileReader.java
@@ -16,40 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.manifest;
+package org.apache.paimon.utils;
 
 import org.apache.paimon.annotation.Public;
 
+import java.util.List;
+
 /**
- * Kind of a file.
+ * A reader for reading file to entries.
  *
  * @since 0.9.0
  */
 @Public
-public enum FileKind {
-    ADD((byte) 0),
+public interface SimpleFileReader<T> {
 
-    DELETE((byte) 1);
-
-    private final byte value;
-
-    FileKind(byte value) {
-        this.value = value;
-    }
-
-    public byte toByteValue() {
-        return value;
-    }
-
-    public static FileKind fromByteValue(byte value) {
-        switch (value) {
-            case 0:
-                return ADD;
-            case 1:
-                return DELETE;
-            default:
-                throw new UnsupportedOperationException(
-                        "Unsupported byte value '" + value + "' for value kind.");
-        }
-    }
+    List<T> read(String fileName);
 }

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.manifest;
 
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.operation.ManifestFileMerger;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.FailingFileIO;
@@ -71,7 +72,7 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
 
         // no trigger Full Compaction
         List<ManifestFileMeta> actual =
-                ManifestFileMeta.merge(
+                ManifestFileMerger.merge(
                         input, manifestFile, 500, 3, Long.MAX_VALUE, getPartitionType(), null);
         assertThat(actual).hasSameSizeAs(expected);
 
@@ -104,7 +105,7 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         ManifestFile failingManifestFile =
                 createManifestFile(FailingFileIO.getFailingPath(failingName, tempDir.toString()));
         try {
-            ManifestFileMeta.merge(
+            ManifestFileMerger.merge(
                     input,
                     failingManifestFile,
                     500,
@@ -143,7 +144,8 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         addDeltaManifests(input, true);
         // trigger full compaction
         List<ManifestFileMeta> merged =
-                ManifestFileMeta.merge(input, manifestFile, 500, 3, 200, getPartitionType(), null);
+                ManifestFileMerger.merge(
+                        input, manifestFile, 500, 3, 200, getPartitionType(), null);
 
         // 1st Manifest don't need to Merge
         assertSameContent(input.get(0), merged.get(0), manifestFile);
@@ -159,7 +161,8 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         List<ManifestFileMeta> input = createBaseManifestFileMetas(true);
 
         List<ManifestFileMeta> merged =
-                ManifestFileMeta.merge(input, manifestFile, 500, 3, 200, getPartitionType(), null);
+                ManifestFileMerger.merge(
+                        input, manifestFile, 500, 3, 200, getPartitionType(), null);
 
         assertEquivalentEntries(input, merged);
         assertThat(merged).hasSameElementsAs(input);
@@ -171,7 +174,8 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         input1.add(delta);
 
         List<ManifestFileMeta> merged1 =
-                ManifestFileMeta.merge(input1, manifestFile, 500, 3, 200, getPartitionType(), null);
+                ManifestFileMerger.merge(
+                        input1, manifestFile, 500, 3, 200, getPartitionType(), null);
 
         assertThat(base).hasSameElementsAs(merged1);
         assertEquivalentEntries(input1, merged1);
@@ -182,7 +186,8 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         List<ManifestFileMeta> input = new ArrayList<>();
         addDeltaManifests(input, true);
         List<ManifestFileMeta> merged =
-                ManifestFileMeta.merge(input, manifestFile, 500, 3, 200, getPartitionType(), null);
+                ManifestFileMerger.merge(
+                        input, manifestFile, 500, 3, 200, getPartitionType(), null);
         assertEquivalentEntries(input, merged);
     }
 
@@ -208,7 +213,8 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         input.add(makeManifest(makeEntry(true, "G")));
 
         List<ManifestFileMeta> merged =
-                ManifestFileMeta.merge(input, manifestFile, 500, 3, 200, getPartitionType(), null);
+                ManifestFileMerger.merge(
+                        input, manifestFile, 500, 3, 200, getPartitionType(), null);
         assertEquivalentEntries(input, merged);
     }
 
@@ -239,7 +245,7 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         // no trigger for delta size
         List<ManifestFileMeta> newMetas2 = new ArrayList<>();
         Optional<List<ManifestFileMeta>> fullCompacted =
-                ManifestFileMeta.tryFullCompaction(
+                ManifestFileMerger.tryFullCompaction(
                         input,
                         newMetas2,
                         manifestFile,
@@ -253,7 +259,7 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         // trigger full compaction
         List<ManifestFileMeta> newMetas3 = new ArrayList<>();
         List<ManifestFileMeta> merged =
-                ManifestFileMeta.tryFullCompaction(
+                ManifestFileMerger.tryFullCompaction(
                                 input, newMetas3, manifestFile, 500, 100, getPartitionType(), null)
                         .get();
 
@@ -278,7 +284,7 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
 
         List<ManifestFileMeta> newMetas = new ArrayList<>();
         List<ManifestFileMeta> mergedManifest =
-                ManifestFileMeta.tryFullCompaction(
+                ManifestFileMerger.tryFullCompaction(
                                 input, newMetas, manifestFile, 500, 100, getPartitionType(), null)
                         .get();
 

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/NoPartitionManifestFileMetaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/NoPartitionManifestFileMetaTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.manifest;
 
+import org.apache.paimon.operation.ManifestFileMerger;
 import org.apache.paimon.types.RowType;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -46,7 +47,8 @@ public class NoPartitionManifestFileMetaTest extends ManifestFileMetaTestBase {
         addDeltaManifests(input, false);
 
         List<ManifestFileMeta> merged =
-                ManifestFileMeta.merge(input, manifestFile, 500, 3, 200, getPartitionType(), null);
+                ManifestFileMerger.merge(
+                        input, manifestFile, 500, 3, 200, getPartitionType(), null);
         assertEquivalentEntries(input, merged);
 
         // the first one is not deleted, it should not be merged


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Next PR of #3982

We should expose more interfaces to compute engines, there may be various needs, and these data structures inherently need to consider compatibility; We can make them public.

- Add manifestListReader and manifestFileReader to Table
- Make ManifestFileMeta ManifestEntry DataFileMeta public. 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
