### PR TITLE
[core] Support setting the time field type for record level expire

### DIFF
--- a/docs/content/primary-key-table/compaction.md
+++ b/docs/content/primary-key-table/compaction.md
@@ -76,7 +76,7 @@ In compaction, you can configure record-Level expire time to expire records, you
 
 1. `'record-level.expire-time'`: time retain for records.
 2. `'record-level.time-field'`: time field for record level expire.
-3. `'record-level.time-field.type'`: time field type for record level expire, it can be second or millisecond.
+3. `'record-level.time-field-type'`: time field type for record level expire, it can be seconds-int or millis-long.
 
 Expiration happens in compaction, and there is no strong guarantee to expire records in time.
 

--- a/docs/content/primary-key-table/compaction.md
+++ b/docs/content/primary-key-table/compaction.md
@@ -75,7 +75,8 @@ use [dedicated compaction job]({{< ref "maintenance/dedicated-compaction#dedicat
 In compaction, you can configure record-Level expire time to expire records, you should configure:
 
 1. `'record-level.expire-time'`: time retain for records.
-2. `'record-level.time-field'`: time field for record level expire, it should be a seconds INT.
+2. `'record-level.time-field'`: time field for record level expire.
+3. `'record-level.time-field.type'`: time field type for record level expire, it can be second or millisecond.
 
 Expiration happens in compaction, and there is no strong guarantee to expire records in time.
 

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -588,10 +588,10 @@ This config option does not affect the default filesystem metastore.</td>
             <td>Time field for record level expire.</td>
         </tr>
         <tr>
-            <td><h5>record-level.time-field.type</h5></td>
+            <td><h5>record-level.time-field-type</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Time field for record level expire, it can be second or millisecond.</td>
+            <td>Time field type for record level expire.<br /><br />Possible values:<ul><li>"seconds-int": Timestamps in seconds should be INT type.</li><li>"millis-long": Timestamps in milliseconds should be BIGINT type.</li></ul></td>
         </tr>
         <tr>
             <td><h5>rowkind.field</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -585,7 +585,13 @@ This config option does not affect the default filesystem metastore.</td>
             <td><h5>record-level.time-field</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Time field for record level expire, it should be a seconds INT.</td>
+            <td>Time field for record level expire.</td>
+        </tr>
+        <tr>
+            <td><h5>record-level.time-field.type</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Time field for record level expire, it can be second or millisecond.</td>
         </tr>
         <tr>
             <td><h5>rowkind.field</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -589,9 +589,9 @@ This config option does not affect the default filesystem metastore.</td>
         </tr>
         <tr>
             <td><h5>record-level.time-field-type</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
-            <td>Time field type for record level expire.<br /><br />Possible values:<ul><li>"seconds-int": Timestamps in seconds should be INT type.</li><li>"millis-long": Timestamps in milliseconds should be BIGINT type.</li></ul></td>
+            <td style="word-wrap: break-word;">seconds-int</td>
+            <td><p>Enum</p></td>
+            <td>Time field type for record level expire, it can be seconds-int or millis-long.<br /><br />Possible values:<ul><li>"seconds-int": Timestamps in seconds should be INT type.</li><li>"millis-long": Timestamps in milliseconds should be BIGINT type.</li></ul></td>
         </tr>
         <tr>
             <td><h5>rowkind.field</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1251,8 +1251,14 @@ public class CoreOptions implements Serializable {
             key("record-level.time-field")
                     .stringType()
                     .noDefaultValue()
+                    .withDescription("Time field for record level expire.");
+
+    public static final ConfigOption<TimeFieldType> RECORD_LEVEL_TIME_FIELD_TYPE =
+            key("record-level.time-field.type")
+                    .enumType(TimeFieldType.class)
+                    .defaultValue(TimeFieldType.SECOND)
                     .withDescription(
-                            "Time field for record level expire, it should be a seconds INT.");
+                            "Time field type for record level expire, it can be second or millisecond.");
 
     public static final ConfigOption<String> FIELDS_DEFAULT_AGG_FUNC =
             key(FIELDS_PREFIX + "." + DEFAULT_AGG_FUNCTION)
@@ -2058,6 +2064,11 @@ public class CoreOptions implements Serializable {
         return options.get(RECORD_LEVEL_TIME_FIELD);
     }
 
+    @Nullable
+    public TimeFieldType recordLevelTimeFieldType() {
+        return options.get(RECORD_LEVEL_TIME_FIELD_TYPE);
+    }
+
     public boolean prepareCommitWaitCompaction() {
         if (!needLookup()) {
             return false;
@@ -2668,6 +2679,35 @@ public class CoreOptions implements Serializable {
         private final String description;
 
         LookupLocalFileType(String value, String description) {
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return text(description);
+        }
+    }
+
+    /** Time field type for record level expire. */
+    public enum TimeFieldType implements DescribedEnum {
+        SECOND(
+                "second",
+                "10-bit timestamp which indicates the number of seconds from 00:00:00 UTC on January 1, 1970 to the present, excluding milliseconds."),
+
+        MILLISECOND(
+                "millisecond",
+                "13-bit timestamp which indicates the number of milliseconds from 00:00:00 UTC on January 1, 1970 to the present, including millisecond information.");
+
+        private final String value;
+        private final String description;
+
+        TimeFieldType(String value, String description) {
             this.value = value;
             this.description = description;
         }

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1254,11 +1254,11 @@ public class CoreOptions implements Serializable {
                     .withDescription("Time field for record level expire.");
 
     public static final ConfigOption<TimeFieldType> RECORD_LEVEL_TIME_FIELD_TYPE =
-            key("record-level.time-field.type")
+            key("record-level.time-field-type")
                     .enumType(TimeFieldType.class)
-                    .defaultValue(TimeFieldType.SECOND)
+                    .defaultValue(TimeFieldType.SECONDS_INT)
                     .withDescription(
-                            "Time field type for record level expire, it can be second or millisecond.");
+                            "Time field type for record level expire, it can be seconds-int or millis-long.");
 
     public static final ConfigOption<String> FIELDS_DEFAULT_AGG_FUNC =
             key(FIELDS_PREFIX + "." + DEFAULT_AGG_FUNCTION)
@@ -2696,13 +2696,9 @@ public class CoreOptions implements Serializable {
 
     /** Time field type for record level expire. */
     public enum TimeFieldType implements DescribedEnum {
-        SECOND(
-                "second",
-                "10-bit timestamp which indicates the number of seconds from 00:00:00 UTC on January 1, 1970 to the present, excluding milliseconds."),
+        SECONDS_INT("seconds-int", "Timestamps in seconds should be INT type."),
 
-        MILLISECOND(
-                "millisecond",
-                "13-bit timestamp which indicates the number of milliseconds from 00:00:00 UTC on January 1, 1970 to the present, including millisecond information.");
+        MILLIS_LONG("millis-long", "Timestamps in milliseconds should be BIGINT type.");
 
         private final String value;
         private final String description;

--- a/paimon-core/src/main/java/org/apache/paimon/io/RecordLevelExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/RecordLevelExpire.java
@@ -21,6 +21,7 @@ package org.apache.paimon.io;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowType;
@@ -36,6 +37,7 @@ public class RecordLevelExpire {
 
     private final int timeField;
     private final int expireTime;
+    private final CoreOptions.TimeFieldType timeFieldType;
 
     @Nullable
     public static RecordLevelExpire create(CoreOptions options, RowType rowType) {
@@ -58,20 +60,25 @@ public class RecordLevelExpire {
                             "Can not find time field %s for record level expire.", timeField));
         }
 
+        CoreOptions.TimeFieldType timeFieldType = options.recordLevelTimeFieldType();
         DataField field = rowType.getField(timeField);
-        if (!(field.type() instanceof IntType)) {
+        if (!((timeFieldType == CoreOptions.TimeFieldType.SECOND && field.type() instanceof IntType)
+                || (timeFieldType == CoreOptions.TimeFieldType.MILLISECOND
+                        && field.type() instanceof BigIntType))) {
             throw new IllegalArgumentException(
                     String.format(
                             "Record level time field should be INT type, but is %s.",
                             field.type()));
         }
 
-        return new RecordLevelExpire(fieldIndex, (int) expireTime.getSeconds());
+        return new RecordLevelExpire(fieldIndex, (int) expireTime.getSeconds(), timeFieldType);
     }
 
-    private RecordLevelExpire(int timeField, int expireTime) {
+    private RecordLevelExpire(
+            int timeField, int expireTime, CoreOptions.TimeFieldType timeFieldType) {
         this.timeField = timeField;
         this.expireTime = expireTime;
+        this.timeFieldType = timeFieldType;
     }
 
     public FileReaderFactory<KeyValue> wrap(FileReaderFactory<KeyValue> readerFactory) {
@@ -85,7 +92,10 @@ public class RecordLevelExpire {
                     checkArgument(
                             !kv.value().isNullAt(timeField),
                             "Time field for record-level expire should not be null.");
-                    int recordTime = kv.value().getInt(timeField);
+                    int recordTime =
+                            timeFieldType == CoreOptions.TimeFieldType.SECOND
+                                    ? kv.value().getInt(timeField)
+                                    : (int) (kv.value().getLong(timeField) / 1000);
                     return currentTime <= recordTime + expireTime;
                 });
     }

--- a/paimon-core/src/test/java/org/apache/paimon/table/RecordLevelExpireWithMillisecondTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/RecordLevelExpireWithMillisecondTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.PrimaryKeyTableTestBase;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.utils.TraceableFileIO;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RecordLevelExpireWithMillisecondTest extends PrimaryKeyTableTestBase {
+    @Override
+    @BeforeEach
+    public void beforeEachBase() throws Exception {
+        super.beforeEachBase();
+        CatalogContext context =
+                CatalogContext.create(
+                        new Path(TraceableFileIO.SCHEME + "://" + tempPath.toString()));
+        Catalog catalog = CatalogFactory.createCatalog(context);
+        Identifier identifier = new Identifier("default", "T");
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        Schema schema =
+                Schema.newBuilder()
+                        .column("pt", DataTypes.INT())
+                        .column("pk", DataTypes.INT())
+                        .column("col1", DataTypes.BIGINT())
+                        .partitionKeys("pt")
+                        .primaryKey("pk", "pt")
+                        .options(tableOptions().toMap())
+                        .build();
+        catalog.createTable(identifier, schema, true);
+        table = (FileStoreTable) catalog.getTable(identifier);
+        commitUser = UUID.randomUUID().toString();
+    }
+
+    @Override
+    protected Options tableOptions() {
+        Options options = new Options();
+        options.set(CoreOptions.BUCKET, 1);
+        options.set(CoreOptions.RECORD_LEVEL_EXPIRE_TIME, Duration.ofSeconds(1));
+        options.set(CoreOptions.RECORD_LEVEL_TIME_FIELD, "col1");
+        options.set(
+                CoreOptions.RECORD_LEVEL_TIME_FIELD_TYPE, CoreOptions.TimeFieldType.MILLISECOND);
+        return options;
+    }
+
+    @Test
+    public void test() throws Exception {
+        writeCommit(GenericRow.of(1, 1, 1L), GenericRow.of(1, 2, 2L));
+
+        // can be queried
+        assertThat(query())
+                .containsExactlyInAnyOrder(GenericRow.of(1, 1, 1), GenericRow.of(1, 2, 2));
+
+        long currentSecs = System.currentTimeMillis();
+        writeCommit(GenericRow.of(1, 3, currentSecs));
+        writeCommit(GenericRow.of(1, 4, currentSecs + 60 * 60 * 1000));
+        Thread.sleep(2000);
+
+        // no compaction, can be queried
+        assertThat(query(new int[] {0, 1}))
+                .containsExactlyInAnyOrder(
+                        GenericRow.of(1, 1),
+                        GenericRow.of(1, 2),
+                        GenericRow.of(1, 3),
+                        GenericRow.of(1, 4));
+
+        // compact, expired
+        compact(1);
+        assertThat(query(new int[] {0, 1})).containsExactlyInAnyOrder(GenericRow.of(1, 4));
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/RecordLevelExpireWithMillisecondTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/RecordLevelExpireWithMillisecondTest.java
@@ -43,7 +43,6 @@ class RecordLevelExpireWithMillisecondTest extends PrimaryKeyTableTestBase {
     @Override
     @BeforeEach
     public void beforeEachBase() throws Exception {
-        super.beforeEachBase();
         CatalogContext context =
                 CatalogContext.create(
                         new Path(TraceableFileIO.SCHEME + "://" + tempPath.toString()));
@@ -80,8 +79,8 @@ class RecordLevelExpireWithMillisecondTest extends PrimaryKeyTableTestBase {
         writeCommit(GenericRow.of(1, 1, 1L), GenericRow.of(1, 2, 2L));
 
         // can be queried
-        assertThat(query())
-                .containsExactlyInAnyOrder(GenericRow.of(1, 1, 1), GenericRow.of(1, 2, 2));
+        assertThat(query(new int[] {0, 1}))
+                .containsExactlyInAnyOrder(GenericRow.of(1, 1), GenericRow.of(1, 2));
 
         long currentSecs = System.currentTimeMillis();
         writeCommit(GenericRow.of(1, 3, currentSecs));

--- a/paimon-core/src/test/java/org/apache/paimon/table/RecordLevelExpireWithMillisecondTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/RecordLevelExpireWithMillisecondTest.java
@@ -70,7 +70,7 @@ class RecordLevelExpireWithMillisecondTest extends PrimaryKeyTableTestBase {
         options.set(CoreOptions.RECORD_LEVEL_EXPIRE_TIME, Duration.ofSeconds(1));
         options.set(CoreOptions.RECORD_LEVEL_TIME_FIELD, "col1");
         options.set(
-                CoreOptions.RECORD_LEVEL_TIME_FIELD_TYPE, CoreOptions.TimeFieldType.MILLISECOND);
+                CoreOptions.RECORD_LEVEL_TIME_FIELD_TYPE, CoreOptions.TimeFieldType.MILLIS_LONG);
         return options;
     }
 


### PR DESCRIPTION
Change-Id: Iced3e7a7e6facb3cd37c87a2ee87723c9ba6d5ab

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3989 

<!-- What is the purpose of the change -->
Support setting the time field type for record level expire, it can be second or millisecond.

### Tests
Add a UT int RecordLevelExpireWithMillisecondTest.java

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
