### PR TITLE
[spark] CompactUnAwareBucketTable uses union to replace submit job by self

### DIFF
--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -46,7 +46,6 @@ This section introduce all available spark procedures about paimon.
             <li>where: partition predicate. Left empty for all partitions. (Can't be used together with "partitions")</li>          
             <li>order_strategy: 'order' or 'zorder' or 'hilbert' or 'none'. Left empty for 'none'.</li>
             <li>order_columns: the columns need to be sort. Left empty if 'order_strategy' is 'none'.</li>
-            <li>max_concurrent_jobs: when sort compact is used, files in one partition are grouped and submitted as a single spark compact job. This parameter controls the maximum number of jobs that can be submitted simultaneously. The default value is 15.</li>
             <li>partition_idle_time: this is used to do a full compaction for partition which had not received any new data for 'partition_idle_time'. And only these partitions will be compacted. This argument can not be used with order compact.</li>
       </td>
       <td>

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
@@ -250,7 +250,7 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
     }
   }
 
-  test("Paimon Procedure: sort compact with max_concurrent_jobs") {
+  test("Paimon Procedure: sort compact with multi-partitions") {
     Seq("order", "zorder").foreach {
       orderStrategy =>
         {
@@ -276,7 +276,7 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
 
             checkAnswer(
               spark.sql(
-                s"CALL sys.compact(table => 'T', order_strategy => '$orderStrategy', order_by => 'id', max_concurrent_jobs => 2)"),
+                s"CALL sys.compact(table => 'T', order_strategy => '$orderStrategy', order_by => 'id')"),
               Seq(true).toDF())
 
             val result = List(Row(1), Row(2), Row(3), Row(4)).asJava


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

This pr uses Union(datasets) to replace submit each dataset by self to reudce driver limiation and overhead, and also remove the option `max_concurrent_jobs`, it is unncessary since we do not have such config for hash_fixed or hash_dynamic.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
Pass CI

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
