### PR TITLE
[migrate] Support migrate table with specific separator 

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/ParameterUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ParameterUtils.java
@@ -35,9 +35,13 @@ public class ParameterUtils {
     }
 
     public static Map<String, String> parseCommaSeparatedKeyValues(String keyValues) {
+        return parseSeparatedKeyValues(keyValues, ",");
+    }
+
+    public static Map<String, String> parseSeparatedKeyValues(String keyValues, String separator) {
         Map<String, String> kvs = new HashMap<>();
         if (!StringUtils.isBlank(keyValues)) {
-            for (String kvString : keyValues.split(",")) {
+            for (String kvString : keyValues.split(separator)) {
                 parseKeyValueString(kvs, kvString);
             }
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateTableAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateTableAction.java
@@ -31,16 +31,20 @@ public class MigrateTableAction extends ActionBase {
     private final String hiveTableFullName;
     private final String tableProperties;
 
+    private final String separator;
+
     public MigrateTableAction(
             String connector,
             String warehouse,
             String hiveTableFullName,
             Map<String, String> catalogConfig,
-            String tableProperties) {
+            String tableProperties,
+            String separator) {
         super(warehouse, catalogConfig);
         this.connector = connector;
         this.hiveTableFullName = hiveTableFullName;
         this.tableProperties = tableProperties;
+        this.separator = separator;
     }
 
     @Override
@@ -48,6 +52,10 @@ public class MigrateTableAction extends ActionBase {
         MigrateTableProcedure migrateTableProcedure = new MigrateTableProcedure();
         migrateTableProcedure.withCatalog(catalog);
         migrateTableProcedure.call(
-                new DefaultProcedureContext(env), connector, hiveTableFullName, tableProperties);
+                new DefaultProcedureContext(env),
+                connector,
+                hiveTableFullName,
+                tableProperties,
+                separator);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateTableActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateTableActionFactory.java
@@ -28,6 +28,7 @@ public class MigrateTableActionFactory implements ActionFactory {
 
     private static final String SOURCE_TYPE = "source_type";
     private static final String OPTIONS = "options";
+    private static final String SEPARATOR = "separator";
 
     @Override
     public String identifier() {
@@ -41,10 +42,11 @@ public class MigrateTableActionFactory implements ActionFactory {
         String sourceHiveTable = params.get(TABLE);
         Map<String, String> catalogConfig = optionalConfigMap(params, CATALOG_CONF);
         String tableConf = params.get(OPTIONS);
+        String separator = params.get(SEPARATOR) == null ? "," : params.get(SEPARATOR);
 
         MigrateTableAction migrateTableAction =
                 new MigrateTableAction(
-                        connector, warehouse, sourceHiveTable, catalogConfig, tableConf);
+                        connector, warehouse, sourceHiveTable, catalogConfig, tableConf, separator);
         return Optional.of(migrateTableAction);
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateTableProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateTableProcedure.java
@@ -50,6 +50,16 @@ public class MigrateTableProcedure extends ProcedureBase {
             String sourceTablePath,
             String properties)
             throws Exception {
+        return call(procedureContext, connector, sourceTablePath, properties, ",");
+    }
+
+    public String[] call(
+            ProcedureContext procedureContext,
+            String connector,
+            String sourceTablePath,
+            String properties,
+            String separator)
+            throws Exception {
         String targetPaimonTablePath = sourceTablePath + PAIMON_SUFFIX;
 
         Identifier sourceTableId = Identifier.fromString(sourceTablePath);
@@ -62,7 +72,7 @@ public class MigrateTableProcedure extends ProcedureBase {
                         sourceTableId.getObjectName(),
                         targetTableId.getDatabaseName(),
                         targetTableId.getObjectName(),
-                        ParameterUtils.parseCommaSeparatedKeyValues(properties))
+                        ParameterUtils.parseSeparatedKeyValues(properties, separator))
                 .executeMigrate();
 
         LOG.info("Last step: rename " + targetTableId + " to " + sourceTableId);

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateTableProcedureITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateTableProcedureITCase.java
@@ -70,6 +70,8 @@ public class MigrateTableProcedureITCase extends ActionITCaseBase {
         testUpgradeNonPartitionTable("avro");
         resetMetastore();
         testUpgradePartitionTable("avro");
+        resetMetastore();
+        testUpgradePartitionTableWithSeparator("avro", ";");
     }
 
     @Test
@@ -77,7 +79,6 @@ public class MigrateTableProcedureITCase extends ActionITCaseBase {
         testUpgradeNonPartitionTable("parquet");
         resetMetastore();
         testUpgradePartitionTable("parquet");
-        testUpgradePartitionTableWithSeparator("parquet", ";");
     }
 
     private void resetMetastore() throws Exception {
@@ -151,8 +152,11 @@ public class MigrateTableProcedureITCase extends ActionITCaseBase {
                                 + "')")
                 .await();
         List<Row> r2 = ImmutableList.copyOf(tEnv.executeSql("SELECT * FROM hivetable").collect());
-
         Assertions.assertThatList(r1).containsExactlyInAnyOrderElementsOf(r2);
+
+        List<Row> r3 =
+                ImmutableList.copyOf(tEnv.executeSql("SHOW CREATE TABLE hivetable").collect());
+        assert (r3.get(0).toString().contains("'orc.encrypt' = 'pii:id,name',"));
     }
 
     public void testUpgradeNonPartitionTable(String format) throws Exception {

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateTableProcedureITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateTableProcedureITCase.java
@@ -77,6 +77,7 @@ public class MigrateTableProcedureITCase extends ActionITCaseBase {
         testUpgradeNonPartitionTable("parquet");
         resetMetastore();
         testUpgradePartitionTable("parquet");
+        testUpgradePartitionTableWithSeparator("parquet", ";");
     }
 
     private void resetMetastore() throws Exception {
@@ -111,6 +112,42 @@ public class MigrateTableProcedureITCase extends ActionITCaseBase {
         tEnv.executeSql(
                         "CALL sys.migrate_table('hive', 'default.hivetable', 'file.format="
                                 + format
+                                + "')")
+                .await();
+        List<Row> r2 = ImmutableList.copyOf(tEnv.executeSql("SELECT * FROM hivetable").collect());
+
+        Assertions.assertThatList(r1).containsExactlyInAnyOrderElementsOf(r2);
+    }
+
+    public void testUpgradePartitionTableWithSeparator(String format, String separator)
+            throws Exception {
+        TableEnvironment tEnv = tableEnvironmentBuilder().batchMode().build();
+        tEnv.executeSql("CREATE CATALOG HIVE WITH ('type'='hive')");
+        tEnv.useCatalog("HIVE");
+        tEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
+        tEnv.executeSql(
+                "CREATE TABLE hivetable (id string, name string) PARTITIONED BY (id2 int, id3 int) STORED AS "
+                        + format);
+        tEnv.executeSql("INSERT INTO hivetable VALUES ('a', 'bb', 2, 3)").await();
+        tEnv.executeSql("SHOW CREATE TABLE hivetable");
+
+        tEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
+        tEnv.executeSql("CREATE CATALOG PAIMON_GE WITH ('type'='paimon-generic')");
+        tEnv.useCatalog("PAIMON_GE");
+        List<Row> r1 = ImmutableList.copyOf(tEnv.executeSql("SELECT * FROM hivetable").collect());
+
+        tEnv.executeSql(
+                "CREATE CATALOG PAIMON WITH ('type'='paimon', 'metastore' = 'hive', 'uri' = 'thrift://localhost:"
+                        + PORT
+                        + "' , 'warehouse' = '"
+                        + System.getProperty(HiveConf.ConfVars.METASTOREWAREHOUSE.varname)
+                        + "')");
+        tEnv.useCatalog("PAIMON");
+        tEnv.executeSql(
+                        "CALL sys.migrate_table('hive', 'default.hivetable', 'file.format="
+                                + format
+                                + ";orc.encrypt=pii:id,name', '"
+                                + separator
                                 + "')")
                 .await();
         List<Row> r2 = ImmutableList.copyOf(tEnv.executeSql("SELECT * FROM hivetable").collect());
@@ -175,7 +212,8 @@ public class MigrateTableProcedureITCase extends ActionITCaseBase {
                         System.getProperty(HiveConf.ConfVars.METASTOREWAREHOUSE.varname),
                         "default.hivetable",
                         catalogConf,
-                        "");
+                        "",
+                        ",");
         migrateTableAction.run();
 
         tEnv.executeSql(

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateTableProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateTableProcedure.java
@@ -84,7 +84,7 @@ public class MigrateTableProcedure extends BaseProcedure {
         String properties = args.isNullAt(2) ? null : args.getString(2);
         boolean deleteNeed = args.isNullAt(3) || args.getBoolean(3);
         String targetTable = args.isNullAt(4) ? null : args.getString(4);
-        String separator = args.isNullAt(5) ? "," : args.getString(4);
+        String separator = args.isNullAt(5) ? "," : args.getString(5);
 
         Identifier sourceTableId = Identifier.fromString(sourceTable);
         Identifier tmpTableId =

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateTableProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateTableProcedure.java
@@ -53,7 +53,8 @@ public class MigrateTableProcedure extends BaseProcedure {
                 ProcedureParameter.required("table", StringType),
                 ProcedureParameter.optional("options", StringType),
                 ProcedureParameter.optional("delete_origin", BooleanType),
-                ProcedureParameter.optional("target_table", StringType)
+                ProcedureParameter.optional("target_table", StringType),
+                ProcedureParameter.optional("separator", StringType)
             };
 
     private static final StructType OUTPUT_TYPE =
@@ -83,6 +84,7 @@ public class MigrateTableProcedure extends BaseProcedure {
         String properties = args.isNullAt(2) ? null : args.getString(2);
         boolean deleteNeed = args.isNullAt(3) || args.getBoolean(3);
         String targetTable = args.isNullAt(4) ? null : args.getString(4);
+        String separator = args.isNullAt(5) ? "," : args.getString(4);
 
         Identifier sourceTableId = Identifier.fromString(sourceTable);
         Identifier tmpTableId =
@@ -101,7 +103,7 @@ public class MigrateTableProcedure extends BaseProcedure {
                             sourceTableId.getObjectName(),
                             tmpTableId.getDatabaseName(),
                             tmpTableId.getObjectName(),
-                            ParameterUtils.parseCommaSeparatedKeyValues(properties));
+                            ParameterUtils.parseSeparatedKeyValues(properties, separator));
 
             migrator.deleteOriginTable(deleteNeed);
             migrator.executeMigrate();

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -64,6 +64,14 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
           checkAnswer(
             spark.sql(s"SELECT * FROM hive_tbl ORDER BY id"),
             Row("1", "a", "p1") :: Row("2", "b", "p2") :: Nil)
+
+          assert(
+            spark
+              .sql("SHOW CREATE TABLE hive_tbl")
+              .collect()
+              .apply(0)
+              .toString()
+              .contains("'orc.encrypt' = 'pii:id,name',"))
         }
       }
     })

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -59,7 +59,7 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
           spark.sql(s"INSERT INTO hive_tbl VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
 
           spark.sql(
-            s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl', options => 'file.format=$format;orc.encrypt=pii:id,name')")
+            s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl', options => 'file.format=$format;orc.encrypt=pii:id,name', separator => ';')")
 
           checkAnswer(
             spark.sql(s"SELECT * FROM hive_tbl ORDER BY id"),


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

Support migrate table with specific separator

<!-- What is the purpose of the change -->

Currently options in migrate table only support separate by "," which cannot hold all conditions，such as if user want to set option like  **'orc.encrypt' = 'pii:id,name'** to do orc encrypt condition，this pr is aim to support with specific separator in options separate when call migrate_table.

ParameterUtils##parseCommaSeparatedKeyValues only separate keyValues with comma.

![1724069469632.png](https://github.com/user-attachments/assets/8ed377cf-850c-4ad6-ab78-ac006d4fd4ba)


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
