### PR TITLE
[orc] [arrow] Add precision for orc timestamp type

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/converter/Arrow2PaimonVectorConverter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/converter/Arrow2PaimonVectorConverter.java
@@ -78,7 +78,6 @@ import org.apache.arrow.vector.TinyIntVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.complex.ListVector;
-import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.StructVector;
 
 import java.time.LocalDateTime;
@@ -463,13 +462,13 @@ public interface Arrow2PaimonVectorConverter {
                     new MapColumnVector() {
 
                         private boolean inited = false;
-                        private MapVector mapVector;
+                        private ListVector mapVector;
                         private ColumnVector keyColumnVector;
                         private ColumnVector valueColumnVector;
 
                         private void init() {
                             if (!inited) {
-                                this.mapVector = (MapVector) vector;
+                                this.mapVector = (ListVector) vector;
                                 StructVector listVector = (StructVector) mapVector.getDataVector();
 
                                 FieldVector keyVector = listVector.getChildrenFromFields().get(0);

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/OrcSplitReaderUtil.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/OrcSplitReaderUtil.java
@@ -25,6 +25,7 @@ import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.VarCharType;
 
 import org.apache.orc.TypeDescription;
@@ -74,9 +75,11 @@ public class OrcSplitReaderUtil {
             case DATE:
                 return TypeDescription.createDate();
             case TIMESTAMP_WITHOUT_TIME_ZONE:
-                return TypeDescription.createTimestamp();
+                return TypeDescription.createTimestamp()
+                        .withPrecision(((TimestampType) type).getPrecision());
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-                return TypeDescription.createTimestampInstant();
+                return TypeDescription.createTimestampInstant()
+                        .withPrecision(((TimestampType) type).getPrecision());
             case ARRAY:
                 ArrayType arrayType = (ArrayType) type;
                 return TypeDescription.createList(toOrcType(arrayType.getElementType()));


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
1 Add precision for timestamp type while write orc file
2 Usr ListVector instead of MapVector

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
