### PR TITLE
[core] Dynamic bucket mode cannot work with AQE

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -24,6 +24,7 @@ import org.apache.paimon.CoreOptions.TagCreationMode;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.SerializableRunnable;
@@ -47,8 +48,10 @@ import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 
@@ -222,8 +225,11 @@ public abstract class FlinkSink<T> implements Serializable {
                                         commitUser))
                         .setParallelism(parallelism == null ? input.getParallelism() : parallelism);
 
-        if (!isStreaming && table.coreOptions().writeManifestCache().getBytes() > 0) {
-            assertBatchAdaptiveParallelism(env, written.getParallelism());
+        boolean writeMCacheEnabled = table.coreOptions().writeManifestCache().getBytes() > 0;
+        boolean hashDynamicMode = table.bucketMode() == BucketMode.HASH_DYNAMIC;
+        if (!isStreaming && (writeMCacheEnabled || hashDynamicMode)) {
+            assertBatchAdaptiveParallelism(
+                    env, written.getParallelism(), writeMCacheEnabled, hashDynamicMode);
         }
 
         Options options = Options.fromMap(table.options());
@@ -316,11 +322,37 @@ public abstract class FlinkSink<T> implements Serializable {
 
     public static void assertBatchAdaptiveParallelism(
             StreamExecutionEnvironment env, int sinkParallelism) {
+        String msg =
+                "Paimon Sink does not support Flink's Adaptive Parallelism mode. "
+                        + "Please manually turn it off or set Paimon `sink.parallelism` manually.";
+        assertBatchAdaptiveParallelism(env, sinkParallelism, msg);
+    }
+
+    public static void assertBatchAdaptiveParallelism(
+            StreamExecutionEnvironment env,
+            int sinkParallelism,
+            boolean writeMCacheEnabled,
+            boolean hashDynamicMode) {
+        List<String> messages = new ArrayList<>();
+        if (writeMCacheEnabled) {
+            messages.add("Write Manifest Cache");
+        }
+        if (hashDynamicMode) {
+            messages.add("Dynamic Bucket Mode");
+        }
+        String msg =
+                String.format(
+                        "Paimon Sink with %s does not support Flink's Adaptive Parallelism mode. "
+                                + "Please manually turn it off or set Paimon `sink.parallelism` manually.",
+                        messages);
+        assertBatchAdaptiveParallelism(env, sinkParallelism, msg);
+    }
+
+    public static void assertBatchAdaptiveParallelism(
+            StreamExecutionEnvironment env, int sinkParallelism, String exceptionMsg) {
         try {
             checkArgument(
-                    sinkParallelism != -1 || !AdaptiveParallelism.isEnabled(env),
-                    "Paimon Sink does not support Flink's Adaptive Parallelism mode. "
-                            + "Please manually turn it off or set Paimon `sink.parallelism` manually.");
+                    sinkParallelism != -1 || !AdaptiveParallelism.isEnabled(env), exceptionMsg);
         } catch (NoClassDefFoundError ignored) {
             // before 1.17, there is no adaptive parallelism
         }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Dynamic bucket mode should know the distribution strategy to filter own data of a task.

If AQE enabled, there is no fixed distribution strategy, task cannot know the its own bucket index.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
