### PR TITLE
[hive] bugfix jdbc paimon hive client pool (#3004)

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -79,6 +79,13 @@ public abstract class CatalogTestBase {
     @AfterEach
     void tearDown() throws Exception {
         if (catalog != null) {
+            List<String> dbs = catalog.listDatabases();
+            for (String db : dbs) {
+                try {
+                    catalog.dropDatabase(db, true, true);
+                } catch (Exception ignored) {
+                }
+            }
             catalog.close();
         }
     }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/CachedClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/CachedClientPool.java
@@ -48,6 +48,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -64,6 +65,7 @@ import static org.apache.paimon.options.CatalogOptions.CLIENT_POOL_SIZE;
 public class CachedClientPool implements ClientPool<IMetaStoreClient, TException> {
 
     private static final String CONF_ELEMENT_PREFIX = "conf:";
+    private static final String CONF_OPTIONS_ALL = "*";
 
     private static Cache<Key, HiveClientPool> clientPoolCache;
 
@@ -77,7 +79,7 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
         this.conf = conf;
         this.clientPoolSize = options.get(CLIENT_POOL_SIZE);
         this.evictionInterval = options.get(CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS);
-        this.key = extractKey(options.get(CLIENT_POOL_CACHE_KEYS), conf);
+        this.key = extractKey(options.get(CLIENT_POOL_CACHE_KEYS), conf, options);
         this.clientClassName = clientClassName;
         init();
     }
@@ -85,7 +87,27 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
     @VisibleForTesting
     HiveClientPool clientPool() {
         return clientPoolCache.get(
-                key, k -> new HiveClientPool(clientPoolSize, conf, clientClassName));
+                key,
+                k ->
+                        new HiveClientPool(
+                                clientPoolSize, conf, clientClassName, this.getCurrentUser(k)));
+    }
+
+    private UserGroupInformation getCurrentUser(Key key) {
+        try {
+            for (Object elem : key.elements) {
+                if (elem instanceof UserGroupInformationConf) {
+                    return ((UserGroupInformationConf) elem).ugi;
+                }
+                if (elem instanceof UserNameConf) {
+                    return UserGroupInformation.createProxyUser(
+                            ((UserNameConf) elem).userName, UserGroupInformation.getCurrentUser());
+                }
+            }
+            return UserGroupInformation.getCurrentUser();
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     private synchronized void init() {
@@ -142,7 +164,7 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
     }
 
     @VisibleForTesting
-    static Key extractKey(String cacheKeys, Configuration conf) {
+    static Key extractKey(String cacheKeys, Configuration conf, Options options) {
         // generate key elements in a certain order, so that the Key instances are comparable
         List<Object> elements = Lists.newArrayList();
         elements.add(conf.get(HiveConf.ConfVars.METASTOREURIS.varname, ""));
@@ -157,12 +179,15 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
             String trimmed = element.trim();
             if (trimmed.toLowerCase(Locale.ROOT).startsWith(CONF_ELEMENT_PREFIX)) {
                 String key = trimmed.substring(CONF_ELEMENT_PREFIX.length());
-
-                Preconditions.checkArgument(
-                        !confElements.containsKey(key),
-                        "Conf key element %s already specified",
-                        key);
-                confElements.put(key, conf.get(key));
+                String value = CONF_OPTIONS_ALL;
+                if (!CONF_OPTIONS_ALL.equals(key)) {
+                    Preconditions.checkArgument(
+                            !confElements.containsKey(key),
+                            "Conf key element %s already specified",
+                            key);
+                    value = confElements.get(key);
+                }
+                confElements.put(key, value);
             } else {
                 KeyElementType type = KeyElementType.valueOf(trimmed.toUpperCase());
                 switch (type) {
@@ -183,7 +208,8 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
             switch (type) {
                 case UGI:
                     try {
-                        elements.add(UserGroupInformation.getCurrentUser());
+                        elements.add(
+                                UserGroupInformationConf.of(UserGroupInformation.getCurrentUser()));
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);
                     }
@@ -200,7 +226,11 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
             }
         }
         for (String key : confElements.keySet()) {
-            elements.add(ConfElement.of(key, confElements.get(key)));
+            if (CONF_OPTIONS_ALL.equals(confElements.get(key))) {
+                elements.add(options);
+            } else {
+                elements.add(ConfElement.of(key, confElements.get(key)));
+            }
         }
         return Key.of(elements);
     }
@@ -218,6 +248,38 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
 
         public static Key of(List<Object> elements) {
             return new Key(elements);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            final Key that = (Key) o;
+            if (this.elements.size() != that.elements.size()) {
+                return false;
+            }
+            for (int i = 0; i < elements.size(); i++) {
+                if (!Objects.equals(this.elements.get(i), that.elements.get(i))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int hashCode = 0;
+            synchronized (elements) {
+                for (Object p : elements) {
+                    hashCode ^= p.hashCode();
+                }
+            }
+            return hashCode;
         }
     }
 
@@ -239,8 +301,84 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
             return value;
         }
 
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            ConfElement other = (ConfElement) obj;
+            return Objects.equals(key, other.key) && Objects.equals(value, other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(key, value);
+        }
+
         public static ConfElement of(String key, String value) {
             return new ConfElement(key, value);
+        }
+    }
+
+    static class UserGroupInformationConf {
+
+        private final UserGroupInformation ugi;
+
+        private UserGroupInformationConf(UserGroupInformation ugi) {
+            this.ugi = ugi;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            UserGroupInformationConf other = (UserGroupInformationConf) obj;
+            return Objects.equals(other.ugi.getUserName(), ugi.getUserName());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(ugi.getUserName());
+        }
+
+        public static UserGroupInformationConf of(UserGroupInformation ugi) {
+            return new UserGroupInformationConf(ugi);
+        }
+    }
+
+    static class UserNameConf {
+        private final String userName;
+
+        private UserNameConf(String userName) {
+            this.userName = userName;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            UserNameConf other = (UserNameConf) obj;
+            return Objects.equals(other.userName, userName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(userName);
+        }
+
+        public static UserNameConf of(String userName) {
+            return new UserNameConf(userName);
         }
     }
 

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/CachedClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/CachedClientPool.java
@@ -78,7 +78,7 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
         this.conf = conf;
         this.clientPoolSize = options.get(CLIENT_POOL_SIZE);
         this.evictionInterval = options.get(CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS);
-        this.key = extractKey(options.get(CLIENT_POOL_CACHE_KEYS), conf);
+        this.key = extractKey(clientClassName, options.get(CLIENT_POOL_CACHE_KEYS), conf);
         this.clientClassName = clientClassName;
         init();
         // set ugi information to hms client
@@ -152,9 +152,10 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
     }
 
     @VisibleForTesting
-    static Key extractKey(String cacheKeys, Configuration conf) {
+    static Key extractKey(String clientClassName, String cacheKeys, Configuration conf) {
         // generate key elements in a certain order, so that the Key instances are comparable
         List<Object> elements = Lists.newArrayList();
+        elements.add(clientClassName);
         elements.add(conf.get(HiveConf.ConfVars.METASTOREURIS.varname, ""));
         elements.add(HiveCatalogOptions.IDENTIFIER);
         if (cacheKeys == null || cacheKeys.isEmpty()) {

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/CachedClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/CachedClientPool.java
@@ -52,7 +52,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static org.apache.paimon.hive.HiveCatalogOptions.CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS;
 import static org.apache.paimon.hive.HiveCatalogOptions.CLIENT_POOL_CACHE_KEYS;
@@ -269,11 +268,6 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
                 }
             }
             return hashCode;
-        }
-
-        @Override
-        public String toString() {
-            return elements.stream().map(Object::toString).collect(Collectors.joining(","));
         }
     }
 

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/HiveClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/HiveClientPool.java
@@ -45,12 +45,6 @@ public class HiveClientPool extends ClientPool.ClientPoolImpl<IMetaStoreClient, 
         this.hiveConf = new HiveConf(conf, HiveClientPool.class);
         this.hiveConf.addResource(conf);
         this.clientClassName = clientClassName;
-        // set ugi information to hms client
-        try {
-            this.run(client -> null);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to connect to Hive Metastore", e);
-        }
     }
 
     @Override

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/pool/TestCachedClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/pool/TestCachedClientPool.java
@@ -1,0 +1,392 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.hive.pool;
+
+import org.apache.paimon.options.Options;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.ql.security.authorization.plugin.AuthorizationMetaStoreFilterHook;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.thrift.TException;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.security.PrivilegedAction;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link CachedClientPool}. */
+public class TestCachedClientPool {
+
+    @Test
+    public void testCacheKeyNotSame() {
+        // client1 use cache key type:paimon
+        Options options1 = new Options();
+        options1.set("type", "paimon");
+        options1.set("paimon.catalog.type", "hive");
+        options1.set("hive.metastore.uris", "thrift://localhost:9083");
+        options1.set("client-pool-cache.keys", "conf:type");
+        CachedClientPool cache1 =
+                new CachedClientPool(
+                        new Configuration(), options1, HiveMetaStoreClient.class.getName());
+
+        // client2 use cache key type:paimon
+        Options options2 = new Options();
+        options2.set("type", "paimon");
+        options2.set("paimon.catalog.type", "hive");
+        options2.set("hive.metastore.uris", "thrift://localhost:9083");
+        options2.set("client-pool-cache.keys", "conf:paimon.catalog.type");
+        CachedClientPool cache2 =
+                new CachedClientPool(
+                        new Configuration(), options2, HiveMetaStoreClient.class.getName());
+
+        // assert return the different object instance
+        assertThat(cache1.clientPool()).isNotEqualTo(cache2.clientPool());
+    }
+
+    @Test
+    public void testCacheKeySame() {
+        Options options = new Options();
+        options.set("type", "paimon");
+        options.set("paimon.catalog.type", "hive");
+        options.set("hive.metastore.uris", "thrift://localhost:9083");
+        options.set("client-pool-cache.keys", "conf:type");
+
+        // client1 & client2 use the same cache key paimon.catalog.type:hive
+        CachedClientPool cache1 =
+                new CachedClientPool(
+                        new Configuration(), options, HiveMetaStoreClient.class.getName());
+        CachedClientPool cache2 =
+                new CachedClientPool(
+                        new Configuration(), options, HiveMetaStoreClient.class.getName());
+
+        // assert return the same object instance
+        assertThat(cache1.clientPool()).isEqualTo(cache2.clientPool());
+    }
+
+    @Test
+    public void testCacheKeyUGINotSame() {
+        // user paimon1 login
+        Options options1 = new Options();
+        options1.set("type", "paimon");
+        options1.set("paimon.catalog.type", "hive");
+        options1.set("hive.metastore.uris", "thrift://localhost:9083");
+        options1.set("client-pool-cache.keys", "ugi,conf:type");
+
+        CachedClientPool cache1 =
+                UserGroupInformation.createRemoteUser("paimon1")
+                        .doAs(
+                                (PrivilegedAction<CachedClientPool>)
+                                        () ->
+                                                new CachedClientPool(
+                                                        new Configuration(),
+                                                        options1,
+                                                        HiveMetaStoreClient.class.getName()));
+
+        // user paimon2 login
+        Options options2 = new Options();
+        options2.set("type", "paimon");
+        options2.set("paimon.catalog.type", "hive");
+        options2.set("hive.metastore.uris", "thrift://localhost:9083");
+        options2.set("client-pool-cache.keys", "ugi,conf:type");
+
+        CachedClientPool cache2 =
+                UserGroupInformation.createRemoteUser("paimon2")
+                        .doAs(
+                                (PrivilegedAction<CachedClientPool>)
+                                        () ->
+                                                new CachedClientPool(
+                                                        new Configuration(),
+                                                        options2,
+                                                        HiveMetaStoreClient.class.getName()));
+
+        assertThat(cache1.clientPool()).isNotEqualTo(cache2.clientPool());
+    }
+
+    @Test
+    public void testCacheKeyUGISame() {
+        Options options = new Options();
+        options.set("type", "paimon");
+        options.set("paimon.catalog.type", "hive");
+        options.set("hive.metastore.uris", "thrift://localhost:9083");
+        options.set("client-pool-cache.keys", "ugi,conf:type");
+
+        // user paimon login
+        CachedClientPool cache1 =
+                UserGroupInformation.createRemoteUser("paimon")
+                        .doAs(
+                                (PrivilegedAction<CachedClientPool>)
+                                        () ->
+                                                new CachedClientPool(
+                                                        new Configuration(),
+                                                        options,
+                                                        HiveMetaStoreClient.class.getName()));
+
+        // user paimon login again
+        CachedClientPool cache2 =
+                UserGroupInformation.createRemoteUser("paimon")
+                        .doAs(
+                                (PrivilegedAction<CachedClientPool>)
+                                        () ->
+                                                new CachedClientPool(
+                                                        new Configuration(),
+                                                        options,
+                                                        HiveMetaStoreClient.class.getName()));
+
+        assertThat(cache1.clientPool()).isEqualTo(cache2.clientPool());
+    }
+
+    @Test
+    public void testCacheKeyOptionNotSame() {
+        // client1 use option1 instance
+        Options options1 = new Options();
+        options1.set("type", "paimon");
+        options1.set("paimon.catalog.type", "hive");
+        options1.set("hive.metastore.uris", "thrift://localhost:9083");
+        options1.set("client-pool-cache.keys", "conf:*");
+        CachedClientPool cache1 =
+                new CachedClientPool(
+                        new Configuration(), options1, HiveMetaStoreClient.class.getName());
+
+        // client1 use option2 instance
+        Options options2 = new Options();
+        options2.set("type", "hive");
+        options2.set("paimon.catalog.type", "hive");
+        options2.set("hive.metastore.uris", "thrift://localhost:9083");
+        options1.set("client-pool-cache.keys", "conf:*");
+        CachedClientPool cache2 =
+                new CachedClientPool(
+                        new Configuration(), options2, HiveMetaStoreClient.class.getName());
+
+        // assert return the different object instance
+        assertThat(cache1.clientPool()).isNotEqualTo(cache2.clientPool());
+    }
+
+    @Test
+    public void testCacheKeyOptionSame1() {
+        // need use the same option instance
+        Options options = new Options();
+        options.set("type", "paimon");
+        options.set("paimon.catalog.type", "hive");
+        options.set("hive.metastore.uris", "thrift://localhost:9083");
+        options.set("client-pool-cache.keys", "conf:*");
+
+        // client1 & client2 use the same option instance
+        CachedClientPool cache1 =
+                new CachedClientPool(
+                        new Configuration(), options, HiveMetaStoreClient.class.getName());
+        CachedClientPool cache2 =
+                new CachedClientPool(
+                        new Configuration(), options, HiveMetaStoreClient.class.getName());
+
+        // assert return the same object instance
+        assertThat(cache1.clientPool()).isEqualTo(cache2.clientPool());
+    }
+
+    @Test
+    public void testCacheKeyOptionSame2() {
+        // client1 use option1 instance
+        Options options1 = new Options();
+        options1.set("type", "paimon");
+        options1.set("paimon.catalog.type", "hive");
+        options1.set("hive.metastore.uris", "thrift://localhost:9083");
+        options1.set("client-pool-cache.keys", "conf:*");
+        CachedClientPool cache1 =
+                new CachedClientPool(
+                        new Configuration(), options1, HiveMetaStoreClient.class.getName());
+
+        // client1 use option2 instance
+        Options options2 = new Options();
+        options2.set("type", "paimon");
+        options2.set("paimon.catalog.type", "hive");
+        options2.set("hive.metastore.uris", "thrift://localhost:9083");
+        options2.set("client-pool-cache.keys", "conf:*");
+        CachedClientPool cache2 =
+                new CachedClientPool(
+                        new Configuration(), options2, HiveMetaStoreClient.class.getName());
+
+        // assert return the same object instance
+        assertThat(cache1.clientPool()).isEqualTo(cache2.clientPool());
+    }
+
+    @Test
+    public void testCacheKeyOptionAllNotSame() {
+        // user paimon1 login
+        Options options1 = new Options();
+        options1.set("type", "paimon");
+        options1.set("paimon.catalog.type", "hive");
+        options1.set("hive.metastore.uris", "thrift://localhost:9083");
+        options1.set("client-pool-cache.keys", "ugi,conf:*");
+
+        CachedClientPool cache1 =
+                UserGroupInformation.createRemoteUser("paimon1")
+                        .doAs(
+                                (PrivilegedAction<CachedClientPool>)
+                                        () ->
+                                                new CachedClientPool(
+                                                        new Configuration(),
+                                                        options1,
+                                                        HiveMetaStoreClient.class.getName()));
+
+        // user paimon2 login
+        Options options2 = new Options();
+        options2.set("type", "hive");
+        options2.set("paimon.catalog.type", "hive");
+        options2.set("hive.metastore.uris", "thrift://localhost:9083");
+        options2.set("client-pool-cache.keys", "ugi,conf:*");
+
+        CachedClientPool cache2 =
+                UserGroupInformation.createRemoteUser("paimon2")
+                        .doAs(
+                                (PrivilegedAction<CachedClientPool>)
+                                        () ->
+                                                new CachedClientPool(
+                                                        new Configuration(),
+                                                        options2,
+                                                        HiveMetaStoreClient.class.getName()));
+
+        // assert return the different object instance
+        assertThat(cache1.clientPool()).isNotEqualTo(cache2.clientPool());
+    }
+
+    @Test
+    public void testCacheKeyOptionAllSame() {
+        Options options = new Options();
+        options.set("type", "paimon");
+        options.set("paimon.catalog.type", "hive");
+        options.set("hive.metastore.uris", "thrift://localhost:9083");
+        options.set("client-pool-cache.keys", "ugi,conf:type");
+
+        // user paimon login
+        CachedClientPool cache1 =
+                UserGroupInformation.createRemoteUser("paimon")
+                        .doAs(
+                                (PrivilegedAction<CachedClientPool>)
+                                        () ->
+                                                new CachedClientPool(
+                                                        new Configuration(),
+                                                        options,
+                                                        HiveMetaStoreClient.class.getName()));
+
+        // user paimon login again
+        CachedClientPool cache2 =
+                UserGroupInformation.createRemoteUser("paimon")
+                        .doAs(
+                                (PrivilegedAction<CachedClientPool>)
+                                        () ->
+                                                new CachedClientPool(
+                                                        new Configuration(),
+                                                        options,
+                                                        HiveMetaStoreClient.class.getName()));
+
+        assertThat(cache1.clientPool()).isEqualTo(cache2.clientPool());
+    }
+
+    @Test
+    public void testLoginPaimon() throws TException {
+        // user paimon login
+        Options options = new Options();
+        options.set("type", "paimon");
+        options.set("paimon.catalog.type", "hive");
+        options.set("hive.metastore.uris", "thrift://30.150.24.155:9083");
+        options.set("client-pool-cache.keys", "ugi,conf:*");
+        options.set(
+                "hive.metastore.filter.hook", MockAuthorizationMetaStoreFilterHook.class.getName());
+
+        Configuration config = new Configuration();
+        config.set("current.user", "paimon");
+        config.set(
+                "hive.metastore.filter.hook", MockAuthorizationMetaStoreFilterHook.class.getName());
+        CachedClientPool cache =
+                UserGroupInformation.createRemoteUser("paimon")
+                        .doAs(
+                                (PrivilegedAction<CachedClientPool>)
+                                        () ->
+                                                new CachedClientPool(
+                                                        config,
+                                                        options,
+                                                        HiveMetaStoreClient.class.getName()));
+
+        // contain default database
+        assertThat(cache.clientPool().newClient().getAllDatabases()).contains("default");
+    }
+
+    @Test
+    public void testLoginRoot() throws TException {
+        // user paimon login
+        Options options = new Options();
+        options.set("type", "paimon");
+        options.set("paimon.catalog.type", "hive");
+        options.set("hive.metastore.uris", "thrift://30.150.24.155:9083");
+        options.set("client-pool-cache.keys", "ugi,conf:*");
+
+        Configuration config = new Configuration();
+        config.set("current.user", "root");
+        config.set(
+                "hive.metastore.filter.hook", MockAuthorizationMetaStoreFilterHook.class.getName());
+        CachedClientPool cache =
+                UserGroupInformation.createRemoteUser("root")
+                        .doAs(
+                                (PrivilegedAction<CachedClientPool>)
+                                        () ->
+                                                new CachedClientPool(
+                                                        config,
+                                                        options,
+                                                        HiveMetaStoreClient.class.getName()));
+
+        // contain default database
+        assertThat(cache.clientPool().newClient().getAllDatabases()).contains("default");
+    }
+
+    /** Tests for {@link CachedClientPool}. */
+    public static class MockAuthorizationMetaStoreFilterHook
+            extends AuthorizationMetaStoreFilterHook {
+        HiveConf conf;
+        UserGroupInformation ugi;
+
+        public MockAuthorizationMetaStoreFilterHook(HiveConf conf) throws IOException {
+            super(conf);
+            this.conf = conf;
+            this.ugi = UserGroupInformation.getCurrentUser();
+            this.checkCurrentUser(this.conf);
+        }
+
+        public List<String> filterDatabases(List<String> dbList) throws MetaException {
+            return this.ugi.doAs(
+                    (PrivilegedAction<List<String>>)
+                            () -> {
+                                this.checkCurrentUser(this.conf);
+                                return dbList;
+                            });
+        }
+
+        private void checkCurrentUser(HiveConf conf) {
+            try {
+                assertThat(UserGroupInformation.getCurrentUser().getUserName())
+                        .isEqualTo(conf.get("current.user"));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/pool/TestCachedClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/pool/TestCachedClientPool.java
@@ -99,7 +99,7 @@ public class TestCachedClientPool {
         options1.set("type", "paimon");
         options1.set("paimon.catalog.type", "hive");
         options1.set("hive.metastore.uris", "thrift://localhost:9083");
-        options1.set("client-pool-cache.keys", "ugi,conf:type");
+        options1.set("client-pool-cache.keys", "user_name,conf:type");
 
         CachedClientPool cache1 =
                 UserGroupInformation.createRemoteUser("paimon1")
@@ -116,7 +116,7 @@ public class TestCachedClientPool {
         options2.set("type", "paimon");
         options2.set("paimon.catalog.type", "hive");
         options2.set("hive.metastore.uris", "thrift://localhost:9083");
-        options2.set("client-pool-cache.keys", "ugi,conf:type");
+        options2.set("client-pool-cache.keys", "user_name,conf:type");
 
         CachedClientPool cache2 =
                 UserGroupInformation.createRemoteUser("paimon2")
@@ -137,7 +137,7 @@ public class TestCachedClientPool {
         options.set("type", "paimon");
         options.set("paimon.catalog.type", "hive");
         options.set("hive.metastore.uris", "thrift://localhost:9083");
-        options.set("client-pool-cache.keys", "ugi,conf:type");
+        options.set("client-pool-cache.keys", "user_name,conf:type");
 
         // user paimon login
         CachedClientPool cache1 =
@@ -244,7 +244,7 @@ public class TestCachedClientPool {
         options1.set("type", "paimon");
         options1.set("paimon.catalog.type", "hive");
         options1.set("hive.metastore.uris", "thrift://localhost:9083");
-        options1.set("client-pool-cache.keys", "ugi,conf:*");
+        options1.set("client-pool-cache.keys", "user_name,conf:*");
 
         CachedClientPool cache1 =
                 UserGroupInformation.createRemoteUser("paimon1")
@@ -261,7 +261,7 @@ public class TestCachedClientPool {
         options2.set("type", "hive");
         options2.set("paimon.catalog.type", "hive");
         options2.set("hive.metastore.uris", "thrift://localhost:9083");
-        options2.set("client-pool-cache.keys", "ugi,conf:*");
+        options2.set("client-pool-cache.keys", "user_name,conf:*");
 
         CachedClientPool cache2 =
                 UserGroupInformation.createRemoteUser("paimon2")
@@ -283,7 +283,7 @@ public class TestCachedClientPool {
         options.set("type", "paimon");
         options.set("paimon.catalog.type", "hive");
         options.set("hive.metastore.uris", "thrift://localhost:9083");
-        options.set("client-pool-cache.keys", "ugi,conf:type");
+        options.set("client-pool-cache.keys", "user_name,conf:type");
 
         // user paimon login
         CachedClientPool cache1 =
@@ -317,7 +317,7 @@ public class TestCachedClientPool {
         options.set("type", "paimon");
         options.set("paimon.catalog.type", "hive");
         options.set("hive.metastore.uris", "thrift://30.150.24.155:9083");
-        options.set("client-pool-cache.keys", "ugi,conf:*");
+        options.set("client-pool-cache.keys", "user_name,conf:*");
         options.set(
                 "hive.metastore.filter.hook", MockAuthorizationMetaStoreFilterHook.class.getName());
 
@@ -346,7 +346,7 @@ public class TestCachedClientPool {
         options.set("type", "paimon");
         options.set("paimon.catalog.type", "hive");
         options.set("hive.metastore.uris", "thrift://30.150.24.155:9083");
-        options.set("client-pool-cache.keys", "ugi,conf:*");
+        options.set("client-pool-cache.keys", "user_name,conf:*");
 
         Configuration config = new Configuration();
         config.set("current.user", "root");
@@ -381,7 +381,7 @@ public class TestCachedClientPool {
                                                 options.set(
                                                         "hive.metastore.uris",
                                                         "thrift://30.150.24.155:9083");
-                                                options.set("client-pool-cache.keys", "ugi,conf:*");
+                                                options.set("client-pool-cache.keys", "user_name,conf:*");
 
                                                 // hive config
                                                 HiveConf hiveConf = new HiveConf();
@@ -461,5 +461,13 @@ public class TestCachedClientPool {
                 throw new RuntimeException(e);
             }
         }
+    }
+
+    @Test
+    public void testUgi() throws IOException {
+        UserGroupInformation user1 = UserGroupInformation.createProxyUser("hive", UserGroupInformation.getCurrentUser());
+        UserGroupInformation user2 = UserGroupInformation.createProxyUser("hive", UserGroupInformation.getCurrentUser());
+        System.out.println(user1.hashCode()==user2.hashCode());
+        System.out.println(user1.equals(user2));
     }
 }

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/pool/TestCachedClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/pool/TestCachedClientPool.java
@@ -381,7 +381,9 @@ public class TestCachedClientPool {
                                                 options.set(
                                                         "hive.metastore.uris",
                                                         "thrift://30.150.24.155:9083");
-                                                options.set("client-pool-cache.keys", "user_name,conf:*");
+                                                options.set(
+                                                        "client-pool-cache.keys",
+                                                        "user_name,conf:*");
 
                                                 // hive config
                                                 HiveConf hiveConf = new HiveConf();
@@ -465,9 +467,11 @@ public class TestCachedClientPool {
 
     @Test
     public void testUgi() throws IOException {
-        UserGroupInformation user1 = UserGroupInformation.createProxyUser("hive", UserGroupInformation.getCurrentUser());
-        UserGroupInformation user2 = UserGroupInformation.createProxyUser("hive", UserGroupInformation.getCurrentUser());
-        System.out.println(user1.hashCode()==user2.hashCode());
+        UserGroupInformation user1 =
+                UserGroupInformation.createProxyUser("hive", UserGroupInformation.getCurrentUser());
+        UserGroupInformation user2 =
+                UserGroupInformation.createProxyUser("hive", UserGroupInformation.getCurrentUser());
+        System.out.println(user1.hashCode() == user2.hashCode());
         System.out.println(user1.equals(user2));
     }
 }

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/pool/TestCachedClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/pool/TestCachedClientPool.java
@@ -427,7 +427,6 @@ public class TestCachedClientPool {
                                                 throw new RuntimeException(e);
                                             }
                                         });
-        ;
 
         // contain default database
         assertThat(catalog.listDatabases()).contains("default");


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
1. Fix the bug linking Paimon to Hive's Catalog:
- The key of the cached item has not overridden the HashCode and Equals methods.
- The value of the cached item, that is, when creating the Hive client, the UGI information was not passed.

2. Add Paimon's options as the cache key to simplify user usage。
```
DROP CATALOG paimon_thrift;
CREATE EXTERNAL CATALOG `paimon_thrift`
PROPERTIES (
  "type"  =  "paimon",
  "paimon.catalog.type"  =  "hive",
  "paimon.catalog.warehouse"  =  "hdfs://localhost:9000/user/hive/warehouse/"
  "hive.metastore.uris"  =  "thrift://localhost:9083",
  'paimon.option.client-pool-cache.keys'='ugi,conf:*'
);
set catalog paimon_thrift;
show databases;
```

### Tests
1. Fix before
![image](https://github.com/user-attachments/assets/270eef37-a825-4d93-ae6c-cacc1933b83c)

2. Fix after
![image](https://github.com/user-attachments/assets/56decece-7891-46fc-9823-97aca4818a2b)

