### PR TITLE
[arrow] Remove field vector set row count to avoid performance issue

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/writer/ArrowFieldWriter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/writer/ArrowFieldWriter.java
@@ -71,7 +71,6 @@ public abstract class ArrowFieldWriter {
         } else {
             doWrite(rowIndex, getters, pos);
         }
-        fieldVector.setValueCount(fieldVector.getValueCount() + 1);
     }
 
     protected abstract void doWrite(int rowIndex, DataGetters getters, int pos);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
FieldVecotor.setValueCount() takes much time

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
