### PR TITLE
[core] MergeTreeWriter clear writer buffer at finally

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeWriter.java
@@ -227,6 +227,7 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
                         changelogWriter == null ? null : changelogWriter::write,
                         dataWriter::write);
             } finally {
+                writeBuffer.clear();
                 if (changelogWriter != null) {
                     changelogWriter.close();
                 }
@@ -251,8 +252,6 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
                 newFiles.add(dataMeta);
                 compactManager.addNewFile(dataMeta);
             }
-
-            writeBuffer.clear();
         }
 
         trySyncLatestCompaction(waitForLatestCompaction);

--- a/paimon-core/src/main/java/org/apache/paimon/sort/BinaryExternalSortBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/BinaryExternalSortBuffer.java
@@ -148,8 +148,8 @@ public class BinaryExternalSortBuffer implements SortBuffer {
         // release memory
         inMemorySortBuffer.clear();
         spillChannelIDs.clear();
-        channelManager.close();
         // delete files
+        channelManager.close();
         channelManager = new SpillChannelManager();
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
`writeBuffer.clear()` should be put at finally block in case failure.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
Pass CI

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
