### PR TITLE
[flink] FlinkCatalog should assert different path for creating table

### DIFF
--- a/docs/content/flink/sql-ddl.md
+++ b/docs/content/flink/sql-ddl.md
@@ -280,10 +280,7 @@ CREATE TABLE my_table (
     PRIMARY KEY (dt, hh, user_id) NOT ENFORCED
 );
 
-CREATE TABLE my_table_like LIKE my_table;
-
--- Create Paimon Table like other connector table
-CREATE TABLE my_table_like WITH ('connector' = 'paimon') LIKE my_table;
+CREATE TABLE my_table_like LIKE my_table (EXCLUDING OPTIONS);
 ```
 
 ## Work with Flink Temporary Tables

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -179,7 +179,7 @@ public class CatalogTableITCase extends CatalogITCaseBase {
     }
 
     @Test
-    public void testManifestsTable() throws Exception {
+    public void testManifestsTable() {
         sql("CREATE TABLE T (a INT, b INT)");
         sql("INSERT INTO T VALUES (1, 2)");
 
@@ -205,7 +205,7 @@ public class CatalogTableITCase extends CatalogITCaseBase {
     }
 
     @Test
-    public void testSchemasTable() throws Exception {
+    public void testSchemasTable() {
         sql(
                 "CREATE TABLE T(a INT, b INT, c STRING, PRIMARY KEY (a) NOT ENFORCED) with ('a.aa.aaa'='val1', 'b.bb.bbb'='val2')");
         sql("ALTER TABLE T SET ('snapshot.time-retained' = '5 h')");
@@ -240,7 +240,7 @@ public class CatalogTableITCase extends CatalogITCaseBase {
     }
 
     @Test
-    public void testSnapshotsSchemasTable() throws Exception {
+    public void testSnapshotsSchemasTable() {
         sql("CREATE TABLE T (a INT, b INT)");
         sql("INSERT INTO T VALUES (1, 2)");
         sql("INSERT INTO T VALUES (3, 4)");
@@ -261,9 +261,9 @@ public class CatalogTableITCase extends CatalogITCaseBase {
     }
 
     @Test
-    public void testCreateTableLike() throws Exception {
+    public void testCreateTableLike() {
         sql("CREATE TABLE T (a INT)");
-        sql("CREATE TABLE T1 LIKE T");
+        sql("CREATE TABLE T1 LIKE T (EXCLUDING OPTIONS)");
         List<Row> result =
                 sql(
                         "SELECT schema_id, fields, partition_keys, "


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Otherwise, it would be strange to create a table with a different path while the data is in another path.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
