### PR TITLE
[core] fix hll class not found

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/HllSketchUtil.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/HllSketchUtil.java
@@ -21,9 +21,19 @@ package org.apache.paimon.utils;
 import org.apache.paimon.annotation.VisibleForTesting;
 
 import org.apache.datasketches.hll.HllSketch;
+import org.apache.datasketches.hll.TgtHllType;
+import org.apache.datasketches.hll.Union;
 
 /** A compressed bitmap for 32-bit integer. */
 public class HllSketchUtil {
+
+    public static byte[] union(byte[] sketchBytes1, byte[] sketchBytes2) {
+        HllSketch heapify = HllSketch.heapify((byte[]) sketchBytes1);
+        org.apache.datasketches.hll.Union union = Union.heapify((byte[]) sketchBytes2);
+        union.update(heapify);
+        HllSketch result = union.getResult(TgtHllType.HLL_4);
+        return result.toCompactByteArray();
+    }
 
     @VisibleForTesting
     public static byte[] sketchOf(int... values) {

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldHllSketchAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldHllSketchAgg.java
@@ -19,10 +19,7 @@
 package org.apache.paimon.mergetree.compact.aggregate;
 
 import org.apache.paimon.types.VarBinaryType;
-
-import org.apache.datasketches.hll.HllSketch;
-import org.apache.datasketches.hll.TgtHllType;
-import org.apache.datasketches.hll.Union;
+import org.apache.paimon.utils.HllSketchUtil;
 
 /** HllSketch aggregate a field of a row. */
 public class FieldHllSketchAgg extends FieldAggregator {
@@ -50,10 +47,6 @@ public class FieldHllSketchAgg extends FieldAggregator {
             return accumulator == null ? inputField : accumulator;
         }
 
-        HllSketch heapify = HllSketch.heapify((byte[]) accumulator);
-        Union union = Union.heapify((byte[]) inputField);
-        union.update(heapify);
-        HllSketch result = union.getResult(TgtHllType.HLL_4);
-        return result.toCompactByteArray();
+        return HllSketchUtil.union((byte[]) accumulator, (byte[]) inputField);
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

Move hll util to paimon-commom from paimon-core, datasketches was shaded. To avoid class not found exception in runtime.

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
