### PR TITLE
[core] Add batch record write interface for table.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/format/FormatWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FormatWriter.java
@@ -19,8 +19,10 @@
 package org.apache.paimon.format;
 
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.io.BatchRecords;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 
 /** The writer that writes records. */
 public interface FormatWriter {
@@ -46,6 +48,10 @@ public interface FormatWriter {
      *     an exception.
      */
     void flush() throws IOException;
+
+    default void writeBatch(BatchRecords batchRecords) throws IOException {
+        throw new UnsupportedEncodingException("Not supported.");
+    }
 
     /**
      * Finishes the writing. This must flush all internal buffer, finish encoding, and write

--- a/paimon-common/src/main/java/org/apache/paimon/io/BatchRecords.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/BatchRecords.java
@@ -16,29 +16,9 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.table.sink;
+package org.apache.paimon.io;
 
-import org.apache.paimon.annotation.Public;
-import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.io.BatchRecords;
+public interface BatchRecords {
 
-import java.util.List;
-
-/**
- * A {@link TableWrite} for batch processing. Recommended for one-time committing.
- *
- * @since 0.4.0
- */
-@Public
-public interface BatchTableWrite extends TableWrite {
-
-    /**
-     * Prepare commit for {@link TableCommit}. Collect incremental files for this write.
-     *
-     * @see BatchTableCommit#commit
-     */
-    List<CommitMessage> prepareCommit() throws Exception;
-
-    /** Write a batch records directly, not per row. */
-    void writeBatch(BinaryRow partition, BatchRecords batch) throws Exception;
+    long rowCount();
 }

--- a/paimon-common/src/main/java/org/apache/paimon/io/BatchRecords.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/BatchRecords.java
@@ -18,7 +18,10 @@
 
 package org.apache.paimon.io;
 
+/** Interface of Batch records. */
 public interface BatchRecords {
 
     long rowCount();
+
+    Object data();
 }

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -28,6 +28,7 @@ import org.apache.paimon.fileindex.FileIndexOptions;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.io.BatchRecords;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFilePathFactory;
@@ -170,6 +171,14 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
                 throw new RuntimeException("Mem table is too small to hold a single element.");
             }
         }
+    }
+
+    @Override
+    public void writeBatch(BatchRecords batchRecords) throws Exception {
+        if (sinkWriter instanceof BufferedSinkWriter) {
+            throw new RuntimeException("Not suppor BufferedSinkWriter.");
+        }
+        ((DirectSinkWriter) sinkWriter).writeBatch(batchRecords);
     }
 
     @Override
@@ -388,6 +397,14 @@ public class AppendOnlyWriter implements RecordWriter<InternalRow>, MemoryOwner 
                 writer = createRollingRowWriter();
             }
             writer.write(data);
+            return true;
+        }
+
+        public boolean writeBatch(BatchRecords batch) throws IOException {
+            if (writer == null) {
+                writer = createRollingRowWriter();
+            }
+            writer.writeBatch(batch);
             return true;
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/io/RollingFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/RollingFileWriter.java
@@ -95,6 +95,30 @@ public class RollingFileWriter<T, R> implements FileWriter<T, List<R>> {
         }
     }
 
+    public void writeBatch(BatchRecords batch) throws IOException {
+        try {
+            // Open the current writer if write the first record or roll over happen before.
+            if (currentWriter == null) {
+                openCurrentWriter();
+            }
+
+            currentWriter.writeBatch(batch);
+            recordCount += batch.rowCount();
+
+            if (rollingFile()) {
+                closeCurrentWriter();
+            }
+        } catch (Throwable e) {
+            LOG.warn(
+                    "Exception occurs when writing file "
+                            + (currentWriter == null ? null : currentWriter.path())
+                            + ". Cleaning up.",
+                    e);
+            abort();
+            throw e;
+        }
+    }
+
     private void openCurrentWriter() {
         currentWriter = writerFactory.get();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/io/SingleFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/SingleFileWriter.java
@@ -94,6 +94,15 @@ public abstract class SingleFileWriter<T, R> implements FileWriter<T, R> {
         writeImpl(record);
     }
 
+    public void writeBatch(BatchRecords batchRecords) throws IOException {
+        if (closed) {
+            throw new RuntimeException("Writer has already closed!");
+        }
+
+        writer.write(batchRecords);
+        recordCount += batchRecords.rowCount();
+    }
+
     protected InternalRow writeImpl(T record) throws IOException {
         if (closed) {
             throw new RuntimeException("Writer has already closed!");

--- a/paimon-core/src/main/java/org/apache/paimon/io/SingleFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/SingleFileWriter.java
@@ -99,7 +99,7 @@ public abstract class SingleFileWriter<T, R> implements FileWriter<T, R> {
             throw new RuntimeException("Writer has already closed!");
         }
 
-        writer.write(batchRecords);
+        writer.writeBatch(batchRecords);
         recordCount += batchRecords.rowCount();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -26,6 +26,7 @@ import org.apache.paimon.deletionvectors.DeletionVectorsMaintainer;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.index.IndexMaintainer;
+import org.apache.paimon.io.BatchRecords;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.IndexIncrement;
 import org.apache.paimon.manifest.ManifestEntry;
@@ -141,6 +142,12 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
         if (container.indexMaintainer != null) {
             container.indexMaintainer.notifyNewRecord(data);
         }
+    }
+
+    @Override
+    public void writeBatch(BinaryRow partition, int bucket, BatchRecords data) throws Exception {
+        WriterContainer<T> container = getWriterWrapper(partition, bucket);
+        container.writer.writeBatch(data);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.deletionvectors.DeletionVectorsMaintainer;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.index.IndexMaintainer;
+import org.apache.paimon.io.BatchRecords;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.memory.MemoryPoolFactory;
 import org.apache.paimon.memory.MemorySegmentPool;
@@ -103,6 +104,16 @@ public interface FileStoreWrite<T> extends Restorable<List<FileStoreWrite.State<
      * @throws Exception the thrown exception when writing the record
      */
     void write(BinaryRow partition, int bucket, T data) throws Exception;
+
+    /**
+     * Write the batch data to the store according to the partition and bucket.
+     *
+     * @param partition the partition of the data
+     * @param bucket the bucket id of the data
+     * @param data the given data
+     * @throws Exception the thrown exception when writing the record
+     */
+    void writeBatch(BinaryRow partition, int bucket, BatchRecords data) throws Exception;
 
     /**
      * Compact data stored in given partition and bucket. Note that compaction process is only

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/BatchTableWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/BatchTableWrite.java
@@ -40,5 +40,5 @@ public interface BatchTableWrite extends TableWrite {
     List<CommitMessage> prepareCommit() throws Exception;
 
     /** Write a batch records directly, not per row. */
-    void writeBatch(BinaryRow partition, BatchRecords batch) throws Exception;
+    void writeBatch(BinaryRow partition, int bucket, BatchRecords batch) throws Exception;
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
@@ -248,8 +248,8 @@ public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State
     }
 
     @Override
-    public void writeBatch(BinaryRow partition, BatchRecords batch) throws Exception {
-        write.writeBatch(partition, 0, batch);
+    public void writeBatch(BinaryRow partition, int bucket, BatchRecords batch) throws Exception {
+        write.writeBatch(partition, bucket, batch);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
@@ -23,6 +23,7 @@ import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.io.BatchRecords;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.memory.MemoryPoolFactory;
 import org.apache.paimon.memory.MemorySegmentPool;
@@ -244,6 +245,11 @@ public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State
         checkState(!batchCommitted, "BatchTableWrite only support one-time committing.");
         batchCommitted = true;
         return prepareCommit(true, BatchWriteBuilder.COMMIT_IDENTIFIER);
+    }
+
+    @Override
+    public void writeBatch(BinaryRow partition, BatchRecords batch) throws Exception {
+        write.writeBatch(partition, 0, batch);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/utils/RecordWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/RecordWriter.java
@@ -39,7 +39,7 @@ public interface RecordWriter<T> {
     /** Add a batch elemens to the writer. */
     default void writeBatch(BatchRecords record) throws Exception {
         throw new UnsupportedOperationException("Not supported");
-    };
+    }
 
     /**
      * Compact files related to the writer. Note that compaction process is only submitted and may

--- a/paimon-core/src/main/java/org/apache/paimon/utils/RecordWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/RecordWriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.utils;
 
+import org.apache.paimon.io.BatchRecords;
 import org.apache.paimon.io.DataFileMeta;
 
 import java.util.Collection;
@@ -34,6 +35,11 @@ public interface RecordWriter<T> {
 
     /** Add a key-value element to the writer. */
     void write(T record) throws Exception;
+
+    /** Add a batch elemens to the writer. */
+    default void writeBatch(BatchRecords record) throws Exception {
+        throw new UnsupportedOperationException("Not supported");
+    };
 
     /**
      * Compact files related to the writer. Note that compaction process is only submitted and may


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Other compute engine (which process batch mainly) may need to add a batch record in one time. Not per row processing

Situation like schema evolution should be considered.
<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
