### PR TITLE
[core] Refactor FormatWriter interface to remove flush

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/format/FormatWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FormatWriter.java
@@ -20,10 +20,11 @@ package org.apache.paimon.format;
 
 import org.apache.paimon.data.InternalRow;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 /** The writer that writes records. */
-public interface FormatWriter {
+public interface FormatWriter extends Closeable {
 
     /**
      * Adds an element to the encoder. The encoder may temporarily buffer the element, or
@@ -37,29 +38,6 @@ public interface FormatWriter {
      *     stream throws an exception.
      */
     void addElement(InternalRow element) throws IOException;
-
-    /**
-     * Flushes all intermediate buffered data to the output stream. It is expected that flushing
-     * often may reduce the efficiency of the encoding.
-     *
-     * @throws IOException Thrown if the encoder cannot be flushed, or if the output stream throws
-     *     an exception.
-     */
-    void flush() throws IOException;
-
-    /**
-     * Finishes the writing. This must flush all internal buffer, finish encoding, and write
-     * footers.
-     *
-     * <p>The writer is not expected to handle any more records via {@link #addElement(InternalRow)}
-     * after this method is called.
-     *
-     * <p><b>Important:</b> This method MUST NOT close the stream that the writer writes to. Closing
-     * the stream is expected to happen through the invoker of this method afterwards.
-     *
-     * @throws IOException Thrown if the finalization fails.
-     */
-    void finish() throws IOException;
 
     /**
      * Check if the writer has reached the <code>targetSize</code>.

--- a/paimon-common/src/test/java/org/apache/paimon/format/FormatReadWriteTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/format/FormatReadWriteTest.java
@@ -91,8 +91,7 @@ public abstract class FormatReadWriteTest {
         writer.addElement(GenericRow.of(1, 1L));
         writer.addElement(GenericRow.of(2, 2L));
         writer.addElement(GenericRow.of(3, null));
-        writer.flush();
-        writer.finish();
+        writer.close();
         out.close();
 
         RecordReader<InternalRow> reader =
@@ -120,8 +119,7 @@ public abstract class FormatReadWriteTest {
         PositionOutputStream out = fileIO.newOutputStream(file, false);
         FormatWriter writer = format.createWriterFactory(rowType).create(out, "zstd");
         writer.addElement(expected);
-        writer.flush();
-        writer.finish();
+        writer.close();
         out.close();
 
         RecordReader<InternalRow> reader =

--- a/paimon-common/src/test/java/org/apache/paimon/format/SimpleColStatsExtractorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/format/SimpleColStatsExtractorTest.java
@@ -89,7 +89,7 @@ public abstract class SimpleColStatsExtractorTest {
         for (GenericRow row : data) {
             writer.addElement(row);
         }
-        writer.finish();
+        writer.close();
 
         SimpleStatsCollector collector = new SimpleStatsCollector(rowType, stats);
         for (GenericRow row : data) {

--- a/paimon-core/src/main/java/org/apache/paimon/io/SingleFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/SingleFileWriter.java
@@ -145,13 +145,11 @@ public abstract class SingleFileWriter<T, R> implements FileWriter<T, R> {
         }
 
         try {
-            writer.flush();
-            writer.finish();
-
+            writer.close();
             out.flush();
             out.close();
         } catch (IOException e) {
-            LOG.warn("Exception occurs when closing file " + path + ". Cleaning up.", e);
+            LOG.warn("Exception occurs when closing file {}. Cleaning up.", path, e);
             abort();
             throw e;
         } finally {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
@@ -148,14 +148,10 @@ public class ObjectsFile<T> implements SimpleFileReader<T> {
         Path path = pathFactory.newPath();
         try {
             try (PositionOutputStream out = fileIO.newOutputStream(path, false)) {
-                FormatWriter writer = writerFactory.create(out, compression);
-                try {
+                try (FormatWriter writer = writerFactory.create(out, compression)) {
                     while (records.hasNext()) {
                         writer.addElement(serializer.toRow(records.next()));
                     }
-                } finally {
-                    writer.flush();
-                    writer.finish();
                 }
             }
             return path.getName();

--- a/paimon-core/src/test/java/org/apache/paimon/FileFormatTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/FileFormatTest.java
@@ -68,7 +68,7 @@ public class FileFormatTest {
         for (InternalRow row : expected) {
             writer.addElement(row);
         }
-        writer.finish();
+        writer.close();
         out.close();
 
         // read

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/ChangelogMergeTreeRewriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/ChangelogMergeTreeRewriterTest.java
@@ -193,14 +193,13 @@ public class ChangelogMergeTreeRewriterTest {
 
     private KeyValueFileWriterFactory createWriterFactory(
             Path path, RowType keyType, RowType valueType) {
-        String formatIdentifier = "avro";
         return KeyValueFileWriterFactory.builder(
                         LocalFileIO.create(),
                         0,
                         keyType,
                         valueType,
-                        new FlushingFileFormat(formatIdentifier),
-                        Collections.singletonMap(formatIdentifier, createNonPartFactory(path)),
+                        new FlushingFileFormat("avro"),
+                        Collections.singletonMap("avro", createNonPartFactory(path)),
                         VALUE_128_MB.getBytes())
                 .build(BinaryRow.EMPTY_ROW, 0, new CoreOptions(new Options()));
     }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/ContainsLevelsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/ContainsLevelsTest.java
@@ -216,15 +216,14 @@ public class ContainsLevelsTest {
 
     private KeyValueFileWriterFactory createWriterFactory() {
         Path path = new Path(tempDir.toUri().toString());
-        String identifier = "avro";
         Map<String, FileStorePathFactory> pathFactoryMap = new HashMap<>();
-        pathFactoryMap.put(identifier, createNonPartFactory(path));
+        pathFactoryMap.put("avro", createNonPartFactory(path));
         return KeyValueFileWriterFactory.builder(
                         FileIOFinder.find(path),
                         0,
                         keyType,
                         rowType,
-                        new FlushingFileFormat(identifier),
+                        new FlushingFileFormat("avro"),
                         pathFactoryMap,
                         VALUE_128_MB.getBytes())
                 .build(BinaryRow.EMPTY_ROW, 0, new CoreOptions(new Options()));

--- a/paimon-format/src/main/java/org/apache/paimon/format/avro/AvroBulkWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/avro/AvroBulkWriter.java
@@ -20,10 +20,11 @@ package org.apache.paimon.format.avro;
 
 import org.apache.avro.file.DataFileWriter;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 /** A simple writer implementation that wraps an Avro {@link DataFileWriter}. */
-public class AvroBulkWriter<T> {
+public class AvroBulkWriter<T> implements Closeable {
 
     /** The underlying Avro writer. */
     private final DataFileWriter<T> dataFileWriter;
@@ -45,7 +46,8 @@ public class AvroBulkWriter<T> {
         dataFileWriter.flush();
     }
 
-    public void finish() throws IOException {
+    @Override
+    public void close() throws IOException {
         dataFileWriter.close();
     }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/avro/AvroFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/avro/AvroFileFormat.java
@@ -141,13 +141,8 @@ public class AvroFileFormat extends FileFormat {
                 }
 
                 @Override
-                public void flush() throws IOException {
-                    writer.flush();
-                }
-
-                @Override
-                public void finish() throws IOException {
-                    writer.finish();
+                public void close() throws IOException {
+                    writer.close();
                 }
 
                 @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/writer/OrcBulkWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/writer/OrcBulkWriter.java
@@ -54,13 +54,11 @@ public class OrcBulkWriter implements FormatWriter {
     public void addElement(InternalRow element) throws IOException {
         vectorizer.vectorize(element, rowBatch);
         if (rowBatch.size == rowBatch.getMaxSize()) {
-            writer.addRowBatch(rowBatch);
-            rowBatch.reset();
+            flush();
         }
     }
 
-    @Override
-    public void flush() throws IOException {
+    private void flush() throws IOException {
         if (rowBatch.size != 0) {
             writer.addRowBatch(rowBatch);
             rowBatch.reset();
@@ -68,7 +66,7 @@ public class OrcBulkWriter implements FormatWriter {
     }
 
     @Override
-    public void finish() throws IOException {
+    public void close() throws IOException {
         flush();
         writer.close();
     }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/ParquetBulkWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/ParquetBulkWriter.java
@@ -48,12 +48,7 @@ public class ParquetBulkWriter implements FormatWriter {
     }
 
     @Override
-    public void flush() {
-        // nothing we can do here
-    }
-
-    @Override
-    public void finish() throws IOException {
+    public void close() throws IOException {
         parquetWriter.close();
     }
 

--- a/paimon-format/src/test/java/org/apache/paimon/format/BulkFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/BulkFileFormatTest.java
@@ -75,7 +75,7 @@ public class BulkFileFormatTest {
         for (InternalRow row : expected) {
             writer.addElement(row);
         }
-        writer.finish();
+        writer.close();
         out.close();
 
         // read

--- a/paimon-format/src/test/java/org/apache/paimon/format/avro/AvroFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/avro/AvroFileFormatTest.java
@@ -116,8 +116,7 @@ public class AvroFileFormatTest {
             for (int i = 0; i < 1000000; i++) {
                 writer.addElement(GenericRow.of(i));
             }
-            writer.flush();
-            writer.finish();
+            writer.close();
         }
 
         try (RecordReader<InternalRow> reader =

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/writer/OrcZstdTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/writer/OrcZstdTest.java
@@ -109,7 +109,7 @@ class OrcZstdTest {
                                     UUID.randomUUID().toString() + random.nextInt()));
             formatWriter.addElement(element);
         }
-        formatWriter.finish();
+        formatWriter.close();
         OrcFile.ReaderOptions readerOptions = OrcFile.readerOptions(new Configuration());
         Reader reader =
                 OrcFile.createReader(new org.apache.hadoop.fs.Path(path.toString()), readerOptions);

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetColumnVectorTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetColumnVectorTest.java
@@ -605,8 +605,7 @@ public class ParquetColumnVectorTest {
         for (InternalRow row : rows) {
             writer.addElement(row);
         }
-        writer.flush();
-        writer.finish();
+        writer.close();
 
         ParquetReaderFactory readerFactory =
                 new ParquetReaderFactory(new Options(), rowType, 1024, FilterCompat.NOOP);

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetReadWriteTest.java
@@ -498,8 +498,7 @@ public class ParquetReadWriteTest {
             writer.addElement(row);
         }
 
-        writer.flush();
-        writer.finish();
+        writer.close();
         return path;
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
1. Remove `FormatWriter.flush`, it is useless.
2. Rename `finish` to `close`. 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
