### PR TITLE
[core] Async record reader should only work with .orc exactly

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
@@ -107,7 +107,7 @@ public class KeyValueFileReaderFactory implements FileReaderFactory<KeyValue> {
 
     public RecordReader<KeyValue> createRecordReader(
             long schemaId, String fileName, long fileSize, int level) throws IOException {
-        if (fileSize >= asyncThreshold && fileName.endsWith("orc")) {
+        if (fileSize >= asyncThreshold && fileName.endsWith(".orc")) {
             return new AsyncRecordReader<>(
                     () -> createRecordReader(schemaId, fileName, level, false, 2, fileSize));
         }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Async record reader should only work with .orc exactly

Only orc reader batch could be put in queue.
Others like parquet or other kind of orc, reuse the batch

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
