### PR TITLE
[hive] Sync primary-key/partition-key/bucket-id when sync to hms

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -521,6 +521,17 @@ public class HiveCatalog extends AbstractCatalog {
             tblProperties = convertToPropertiesPrefixKey(tableSchema.options(), HIVE_PREFIX);
         }
 
+        // add primary-key, partition-key, bucket-id to tblproperties
+        if (!tableSchema.primaryKeys().isEmpty()) {
+            tblProperties.put("primary-key", String.join(",", tableSchema.primaryKeys()));
+        }
+        if (!tableSchema.partitionKeys().isEmpty()) {
+            tblProperties.put("partition-key", String.join(",", tableSchema.partitionKeys()));
+        }
+        if (!tableSchema.bucketKeys().isEmpty()) {
+            tblProperties.put("bucket-id", String.join(",", tableSchema.bucketKeys()));
+        }
+
         Table table = newHmsTable(identifier, tblProperties);
         updateHmsTable(table, identifier, tableSchema);
         return table;

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -528,6 +528,7 @@ public class HiveCatalog extends AbstractCatalog {
             if (!tableSchema.bucketKeys().isEmpty()) {
                 tblProperties.put("bucket-id", String.join(",", tableSchema.bucketKeys()));
             }
+            tblProperties.put("bucket", String.valueOf(tableSchema.numBuckets()));
         } else {
             tblProperties = convertToPropertiesPrefixKey(tableSchema.options(), HIVE_PREFIX);
         }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -520,13 +520,16 @@ public class HiveCatalog extends AbstractCatalog {
 
             // add primary-key, partition-key, bucket-id to tblproperties
             if (!tableSchema.primaryKeys().isEmpty()) {
-                tblProperties.put(CoreOptions.PRIMARY_KEY.key(), String.join(",", tableSchema.primaryKeys()));
+                tblProperties.put(
+                        CoreOptions.PRIMARY_KEY.key(), String.join(",", tableSchema.primaryKeys()));
             }
             if (!tableSchema.partitionKeys().isEmpty()) {
-                tblProperties.put(CoreOptions.PARTITION.key(), String.join(",", tableSchema.partitionKeys()));
+                tblProperties.put(
+                        CoreOptions.PARTITION.key(), String.join(",", tableSchema.partitionKeys()));
             }
             if (!tableSchema.bucketKeys().isEmpty()) {
-                tblProperties.put(CoreOptions.BUCKET_KEY.key(), String.join(",", tableSchema.bucketKeys()));
+                tblProperties.put(
+                        CoreOptions.BUCKET_KEY.key(), String.join(",", tableSchema.bucketKeys()));
             }
             tblProperties.put(CoreOptions.BUCKET.key(), String.valueOf(tableSchema.numBuckets()));
         } else {

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -520,15 +520,15 @@ public class HiveCatalog extends AbstractCatalog {
 
             // add primary-key, partition-key, bucket-id to tblproperties
             if (!tableSchema.primaryKeys().isEmpty()) {
-                tblProperties.put("primary-key", String.join(",", tableSchema.primaryKeys()));
+                tblProperties.put(CoreOptions.PRIMARY_KEY.key(), String.join(",", tableSchema.primaryKeys()));
             }
             if (!tableSchema.partitionKeys().isEmpty()) {
-                tblProperties.put("partition-key", String.join(",", tableSchema.partitionKeys()));
+                tblProperties.put(CoreOptions.PARTITION.key(), String.join(",", tableSchema.partitionKeys()));
             }
             if (!tableSchema.bucketKeys().isEmpty()) {
-                tblProperties.put("bucket-id", String.join(",", tableSchema.bucketKeys()));
+                tblProperties.put(CoreOptions.BUCKET_KEY.key(), String.join(",", tableSchema.bucketKeys()));
             }
-            tblProperties.put("bucket", String.valueOf(tableSchema.numBuckets()));
+            tblProperties.put(CoreOptions.BUCKET.key(), String.valueOf(tableSchema.numBuckets()));
         } else {
             tblProperties = convertToPropertiesPrefixKey(tableSchema.options(), HIVE_PREFIX);
         }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -517,19 +517,19 @@ public class HiveCatalog extends AbstractCatalog {
         Map<String, String> tblProperties;
         if (syncAllProperties()) {
             tblProperties = new HashMap<>(tableSchema.options());
+
+            // add primary-key, partition-key, bucket-id to tblproperties
+            if (!tableSchema.primaryKeys().isEmpty()) {
+                tblProperties.put("primary-key", String.join(",", tableSchema.primaryKeys()));
+            }
+            if (!tableSchema.partitionKeys().isEmpty()) {
+                tblProperties.put("partition-key", String.join(",", tableSchema.partitionKeys()));
+            }
+            if (!tableSchema.bucketKeys().isEmpty()) {
+                tblProperties.put("bucket-id", String.join(",", tableSchema.bucketKeys()));
+            }
         } else {
             tblProperties = convertToPropertiesPrefixKey(tableSchema.options(), HIVE_PREFIX);
-        }
-
-        // add primary-key, partition-key, bucket-id to tblproperties
-        if (!tableSchema.primaryKeys().isEmpty()) {
-            tblProperties.put("primary-key", String.join(",", tableSchema.primaryKeys()));
-        }
-        if (!tableSchema.partitionKeys().isEmpty()) {
-            tblProperties.put("partition-key", String.join(",", tableSchema.partitionKeys()));
-        }
-        if (!tableSchema.bucketKeys().isEmpty()) {
-            tblProperties.put("bucket-id", String.join(",", tableSchema.bucketKeys()));
         }
 
         Table table = newHmsTable(identifier, tblProperties);

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -379,9 +379,10 @@ public abstract class HiveCatalogITCaseBase {
         tEnv.executeSql("USE CATALOG paimon_catalog_sync").await();
         tEnv.executeSql("USE test_db").await();
         tEnv.executeSql(
-                        "CREATE TABLE t01 ( aa INT, bb STRING, cc STRING, PRIMARY KEY (cc, aa) NOT ENFORCED) PARTITIONED BY (cc) WITH ('file.format' = 'avro')")
+                        "CREATE TABLE t01 ( aa INT, bb STRING, cc STRING, PRIMARY KEY (cc, aa) NOT ENFORCED) PARTITIONED BY (cc) WITH ('file.format' = 'avro', 'bucket' = '3')")
                 .await();
         // assert contain properties
+        List<String> descFormattedT01 = hiveShell.executeQuery("DESC FORMATTED t01");
         assertThat(
                         hiveShell
                                 .executeQuery("DESC FORMATTED t01")
@@ -404,6 +405,12 @@ public abstract class HiveCatalogITCaseBase {
                         hiveShell
                                 .executeQuery("DESC FORMATTED t01")
                                 .contains("\tbucket-id           \taa                  "))
+                .isTrue();
+
+        assertThat(
+                        hiveShell
+                                .executeQuery("DESC FORMATTED t01")
+                                .contains("\tbucket              \t3                   "))
                 .isTrue();
 
         tEnv.executeSql("ALTER TABLE t01 SET ( 'file.format' = 'parquet' )").await();
@@ -436,10 +443,11 @@ public abstract class HiveCatalogITCaseBase {
         tEnv.executeSql("USE CATALOG paimon_catalog_sync01").await();
         tEnv.executeSql("USE test_db").await();
         tEnv.executeSql(
-                        "CREATE TABLE t02 ( aa INT, bb STRING, cc STRING, PRIMARY KEY (cc, aa) NOT ENFORCED) PARTITIONED BY (cc) WITH ('file.format' = 'avro')")
+                        "CREATE TABLE t02 ( aa INT, bb STRING, cc STRING, PRIMARY KEY (cc, aa) NOT ENFORCED) PARTITIONED BY (cc) WITH ('file.format' = 'avro', 'bucket' = '3')")
                 .await();
 
         // assert not contain properties
+        List<String> descFormattedT02 = hiveShell.executeQuery("DESC FORMATTED t02");
         assertThat(
                         hiveShell
                                 .executeQuery("DESC FORMATTED t02")
@@ -462,6 +470,12 @@ public abstract class HiveCatalogITCaseBase {
                         hiveShell
                                 .executeQuery("DESC FORMATTED t02")
                                 .contains("\tbucket-id           \taa                  "))
+                .isFalse();
+
+        assertThat(
+                        hiveShell
+                                .executeQuery("DESC FORMATTED t02")
+                                .contains("\tbucket              \t3                   "))
                 .isFalse();
 
         tEnv.executeSql("ALTER TABLE t02 SET ( 'file.format' = 'parquet' )").await();

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -398,13 +398,13 @@ public abstract class HiveCatalogITCaseBase {
         assertThat(
                         hiveShell
                                 .executeQuery("DESC FORMATTED t01")
-                                .contains("\tpartition-key       \tcc                  "))
+                                .contains("\tpartition           \tcc                  "))
                 .isTrue();
 
         assertThat(
                         hiveShell
                                 .executeQuery("DESC FORMATTED t01")
-                                .contains("\tbucket-id           \taa                  "))
+                                .contains("\tbucket-key          \taa                  "))
                 .isTrue();
 
         assertThat(
@@ -463,13 +463,13 @@ public abstract class HiveCatalogITCaseBase {
         assertThat(
                         hiveShell
                                 .executeQuery("DESC FORMATTED t02")
-                                .contains("\tpartition-key       \tcc                  "))
+                                .contains("\tpartition           \tcc                  "))
                 .isFalse();
 
         assertThat(
                         hiveShell
                                 .executeQuery("DESC FORMATTED t02")
-                                .contains("\tbucket-id           \taa                  "))
+                                .contains("\tbucket-key          \taa                  "))
                 .isFalse();
 
         assertThat(

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -378,9 +378,22 @@ public abstract class HiveCatalogITCaseBase {
                 .await();
         tEnv.executeSql("USE CATALOG paimon_catalog_sync").await();
         tEnv.executeSql("USE test_db").await();
-        tEnv.executeSql("CREATE TABLE t01 ( aa INT, bb STRING ) WITH ( 'file.format' = 'avro' )")
+        tEnv.executeSql(
+                        "CREATE TABLE t01 ( aa INT, bb STRING, cc STRING, PRIMARY KEY (cc, aa)) PARTITIONED BY (cc) WITH ('file.format' = 'avro')")
                 .await();
         // assert contain properties
+        assertThat(
+                        hiveShell
+                                .executeQuery("DESC FORMATTED t01")
+                                .contains("\tfile.format         \tavro                "))
+                .isTrue();
+
+        assertThat(
+                        hiveShell
+                                .executeQuery("DESC FORMATTED t01")
+                                .contains("\tfile.format         \tavro                "))
+                .isTrue();
+
         assertThat(
                         hiveShell
                                 .executeQuery("DESC FORMATTED t01")


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

Follow up https://github.com/apache/paimon/pull/3973
currently primary-key partition-key bucket-id not sync to hms, add these info to properties when sync hms.
user condition is to show metadata in platform.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
