### PR TITLE
[core] Support custom data file name prefix

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -309,6 +309,12 @@ under the License.
             <td>Define different file format for different level, you can add the conf like this: 'file.format.per.level' = '0:avro,3:parquet', if the file format for level is not provided, the default format which set by `file.format` will be used.</td>
         </tr>
         <tr>
+            <td><h5>file.prefix</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Specify the file name prefix of data files..</td>
+        </tr>
+        <tr>
             <td><h5>force-lookup</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -63,6 +63,12 @@ under the License.
             <td>Memory page size for caching.</td>
         </tr>
         <tr>
+            <td><h5>changelog-file.prefix</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Specify the file name prefix of changelog files.</td>
+        </tr>
+        <tr>
             <td><h5>changelog-producer</h5></td>
             <td style="word-wrap: break-word;">none</td>
             <td><p>Enum</p></td>
@@ -309,7 +315,7 @@ under the License.
             <td>Define different file format for different level, you can add the conf like this: 'file.format.per.level' = '0:avro,3:parquet', if the file format for level is not provided, the default format which set by `file.format` will be used.</td>
         </tr>
         <tr>
-            <td><h5>file.prefix</h5></td>
+            <td><h5>data-file.prefix</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
             <td>Specify the file name prefix of data files.</td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -312,7 +312,7 @@ under the License.
             <td><h5>file.prefix</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Specify the file name prefix of data files..</td>
+            <td>Specify the file name prefix of data files.</td>
         </tr>
         <tr>
             <td><h5>force-lookup</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -171,6 +171,12 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Default file compression zstd level. For higher compression rates, it can be configured to 9, but the read and write speed will significantly decrease.");
 
+    public static final ConfigOption<String> FILE_PREFIX =
+            key("file.prefix")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Specify the file name prefix of data files.");
+
     public static final ConfigOption<MemorySize> FILE_BLOCK_SIZE =
             key("file.block-size")
                     .memoryType()
@@ -1446,6 +1452,10 @@ public class CoreOptions implements Serializable {
 
     private static String normalizeFileFormat(String fileFormat) {
         return fileFormat.toLowerCase();
+    }
+
+    public String filePrefix() {
+        return options.get(FILE_PREFIX);
     }
 
     public String fieldsDefaultFunc() {

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -171,11 +171,17 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Default file compression zstd level. For higher compression rates, it can be configured to 9, but the read and write speed will significantly decrease.");
 
-    public static final ConfigOption<String> FILE_PREFIX =
-            key("file.prefix")
+    public static final ConfigOption<String> DATA_FILE_PREFIX =
+            key("data-file.prefix")
                     .stringType()
                     .noDefaultValue()
                     .withDescription("Specify the file name prefix of data files.");
+
+    public static final ConfigOption<String> CHANGELOG_FILE_PREFIX =
+            key("changelog-file.prefix")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Specify the file name prefix of changelog files.");
 
     public static final ConfigOption<MemorySize> FILE_BLOCK_SIZE =
             key("file.block-size")
@@ -1454,8 +1460,12 @@ public class CoreOptions implements Serializable {
         return fileFormat.toLowerCase();
     }
 
-    public String filePrefix() {
-        return options.get(FILE_PREFIX);
+    public String dataFilePrefix() {
+        return options.get(DATA_FILE_PREFIX);
+    }
+
+    public String changelogFilePrefix() {
+        return options.get(CHANGELOG_FILE_PREFIX);
     }
 
     public String fieldsDefaultFunc() {

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -103,7 +103,8 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 partitionType,
                 options.partitionDefaultName(),
                 options.fileFormat().getFormatIdentifier(),
-                options.filePrefix());
+                options.dataFilePrefix(),
+                options.changelogFilePrefix());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -102,7 +102,8 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 options.path(),
                 partitionType,
                 options.partitionDefaultName(),
-                options.fileFormat().getFormatIdentifier());
+                options.fileFormat().getFormatIdentifier(),
+                options.filePrefix());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -200,7 +200,8 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                                         partitionType,
                                         options.partitionDefaultName(),
                                         format,
-                                        options.filePrefix())));
+                                        options.dataFilePrefix(),
+                                        options.changelogFilePrefix())));
         return pathFactoryMap;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -199,7 +199,8 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                                         options.path(),
                                         partitionType,
                                         options.partitionDefaultName(),
-                                        format)));
+                                        format,
+                                        options.filePrefix())));
         return pathFactoryMap;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFilePathFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFilePathFactory.java
@@ -41,16 +41,21 @@ public class DataFilePathFactory {
 
     private final AtomicInteger pathCount;
     private final String formatIdentifier;
+    private final String filePrefix;
 
-    public DataFilePathFactory(Path parent, String formatIdentifier) {
+    public DataFilePathFactory(Path parent, String formatIdentifier, String filePrefix) {
         this.parent = parent;
         this.uuid = UUID.randomUUID().toString();
 
         this.pathCount = new AtomicInteger(0);
         this.formatIdentifier = formatIdentifier;
+        this.filePrefix = filePrefix;
     }
 
     public Path newPath() {
+        if (filePrefix != null) {
+            return newPath(filePrefix);
+        }
         return newPath(DATA_FILE_PREFIX);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFilePathFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFilePathFactory.java
@@ -20,6 +20,7 @@ package org.apache.paimon.io;
 
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.utils.StringUtils;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -30,9 +31,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 @ThreadSafe
 public class DataFilePathFactory {
 
-    public static final String DATA_FILE_PREFIX = "data-";
+    public static final String DEFAULT_DATA_FILE_PREFIX = "data-";
 
-    public static final String CHANGELOG_FILE_PREFIX = "changelog-";
+    public static final String DEFAULT_CHANGELOG_FILE_PREFIX = "changelog-";
 
     public static final String INDEX_PATH_SUFFIX = ".index";
 
@@ -41,26 +42,35 @@ public class DataFilePathFactory {
 
     private final AtomicInteger pathCount;
     private final String formatIdentifier;
-    private final String filePrefix;
+    private final String dataFilePrefix;
+    private final String changelogFilePrefix;
 
-    public DataFilePathFactory(Path parent, String formatIdentifier, String filePrefix) {
+    public DataFilePathFactory(
+            Path parent,
+            String formatIdentifier,
+            String dataFilePrefix,
+            String changelogFilePrefix) {
         this.parent = parent;
         this.uuid = UUID.randomUUID().toString();
 
         this.pathCount = new AtomicInteger(0);
         this.formatIdentifier = formatIdentifier;
-        this.filePrefix = filePrefix;
+        this.dataFilePrefix = dataFilePrefix;
+        this.changelogFilePrefix = changelogFilePrefix;
     }
 
     public Path newPath() {
-        if (filePrefix != null) {
-            return newPath(filePrefix);
+        if (!StringUtils.isBlank(dataFilePrefix)) {
+            return newPath(dataFilePrefix);
         }
-        return newPath(DATA_FILE_PREFIX);
+        return newPath(DEFAULT_DATA_FILE_PREFIX);
     }
 
     public Path newChangelogPath() {
-        return newPath(CHANGELOG_FILE_PREFIX);
+        if (!StringUtils.isBlank(changelogFilePrefix)) {
+            return newPath(changelogFilePrefix);
+        }
+        return newPath(DEFAULT_CHANGELOG_FILE_PREFIX);
     }
 
     private Path newPath(String prefix) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/MergeFileSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/MergeFileSplitRead.java
@@ -60,7 +60,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.paimon.io.DataFilePathFactory.CHANGELOG_FILE_PREFIX;
+import static org.apache.paimon.io.DataFilePathFactory.DEFAULT_CHANGELOG_FILE_PREFIX;
 import static org.apache.paimon.predicate.PredicateBuilder.containsFields;
 import static org.apache.paimon.predicate.PredicateBuilder.splitAnd;
 
@@ -314,7 +314,7 @@ public class MergeFileSplitRead implements SplitRead<KeyValue> {
 
     private Optional<String> changelogFile(DataFileMeta fileMeta) {
         for (String file : fileMeta.extraFiles()) {
-            if (file.startsWith(CHANGELOG_FILE_PREFIX)) {
+            if (file.startsWith(DEFAULT_CHANGELOG_FILE_PREFIX)) {
                 return Optional.of(file);
             }
         }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
@@ -41,6 +41,7 @@ public class FileStorePathFactory {
     private final String uuid;
     private final InternalRowPartitionComputer partitionComputer;
     private final String formatIdentifier;
+    private final String filePrefix;
 
     private final AtomicInteger manifestFileCount;
     private final AtomicInteger manifestListCount;
@@ -49,12 +50,17 @@ public class FileStorePathFactory {
     private final AtomicInteger statsFileCount;
 
     public FileStorePathFactory(
-            Path root, RowType partitionType, String defaultPartValue, String formatIdentifier) {
+            Path root,
+            RowType partitionType,
+            String defaultPartValue,
+            String formatIdentifier,
+            String filePrefix) {
         this.root = root;
         this.uuid = UUID.randomUUID().toString();
 
         this.partitionComputer = getPartitionComputer(partitionType, defaultPartValue);
         this.formatIdentifier = formatIdentifier;
+        this.filePrefix = filePrefix;
 
         this.manifestFileCount = new AtomicInteger(0);
         this.manifestListCount = new AtomicInteger(0);
@@ -97,7 +103,7 @@ public class FileStorePathFactory {
     }
 
     public DataFilePathFactory createDataFilePathFactory(BinaryRow partition, int bucket) {
-        return new DataFilePathFactory(bucketPath(partition, bucket), formatIdentifier);
+        return new DataFilePathFactory(bucketPath(partition, bucket), formatIdentifier, filePrefix);
     }
 
     public Path bucketPath(BinaryRow partition, int bucket) {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
@@ -41,7 +41,8 @@ public class FileStorePathFactory {
     private final String uuid;
     private final InternalRowPartitionComputer partitionComputer;
     private final String formatIdentifier;
-    private final String filePrefix;
+    private final String dataFilePrefix;
+    private final String changelogFilePrefix;
 
     private final AtomicInteger manifestFileCount;
     private final AtomicInteger manifestListCount;
@@ -54,13 +55,15 @@ public class FileStorePathFactory {
             RowType partitionType,
             String defaultPartValue,
             String formatIdentifier,
-            String filePrefix) {
+            String dataFilePrefix,
+            String changelogFilePrefix) {
         this.root = root;
         this.uuid = UUID.randomUUID().toString();
 
         this.partitionComputer = getPartitionComputer(partitionType, defaultPartValue);
         this.formatIdentifier = formatIdentifier;
-        this.filePrefix = filePrefix;
+        this.dataFilePrefix = dataFilePrefix;
+        this.changelogFilePrefix = changelogFilePrefix;
 
         this.manifestFileCount = new AtomicInteger(0);
         this.manifestListCount = new AtomicInteger(0);
@@ -103,7 +106,11 @@ public class FileStorePathFactory {
     }
 
     public DataFilePathFactory createDataFilePathFactory(BinaryRow partition, int bucket) {
-        return new DataFilePathFactory(bucketPath(partition, bucket), formatIdentifier, filePrefix);
+        return new DataFilePathFactory(
+                bucketPath(partition, bucket),
+                formatIdentifier,
+                dataFilePrefix,
+                changelogFilePrefix);
     }
 
     public Path bucketPath(BinaryRow partition, int bucket) {

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -520,7 +520,8 @@ public class AppendOnlyWriterTest {
     private DataFilePathFactory createPathFactory() {
         return new DataFilePathFactory(
                 new Path(tempDir + "/dt=" + PART + "/bucket-0"),
-                CoreOptions.FILE_FORMAT.defaultValue().toString());
+                CoreOptions.FILE_FORMAT.defaultValue().toString(),
+                CoreOptions.FILE_PREFIX.defaultValue());
     }
 
     private AppendOnlyWriter createEmptyWriter(long targetFileSize) {

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -521,7 +521,8 @@ public class AppendOnlyWriterTest {
         return new DataFilePathFactory(
                 new Path(tempDir + "/dt=" + PART + "/bucket-0"),
                 CoreOptions.FILE_FORMAT.defaultValue().toString(),
-                CoreOptions.FILE_PREFIX.defaultValue());
+                CoreOptions.DATA_FILE_PREFIX.defaultValue(),
+                CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue());
     }
 
     private AppendOnlyWriter createEmptyWriter(long targetFileSize) {

--- a/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
@@ -69,7 +69,8 @@ public class FileFormatSuffixTest extends KeyValueFileReadWriteTest {
                 new DataFilePathFactory(
                         new Path(tempDir + "/dt=1/bucket-1"),
                         format,
-                        CoreOptions.FILE_PREFIX.defaultValue());
+                        CoreOptions.DATA_FILE_PREFIX.defaultValue(),
+                        CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue());
         FileFormat fileFormat = FileFormat.fromIdentifier(format, new Options());
         LinkedList<DataFileMeta> toCompact = new LinkedList<>();
         CoreOptions options = new CoreOptions(new HashMap<>());

--- a/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
@@ -66,7 +66,10 @@ public class FileFormatSuffixTest extends KeyValueFileReadWriteTest {
         assertThat(path.toString().endsWith(format)).isTrue();
 
         DataFilePathFactory dataFilePathFactory =
-                new DataFilePathFactory(new Path(tempDir + "/dt=1/bucket-1"), format);
+                new DataFilePathFactory(
+                        new Path(tempDir + "/dt=1/bucket-1"),
+                        format,
+                        CoreOptions.FILE_PREFIX.defaultValue());
         FileFormat fileFormat = FileFormat.fromIdentifier(format, new Options());
         LinkedList<DataFileMeta> toCompact = new LinkedList<>();
         CoreOptions options = new CoreOptions(new HashMap<>());

--- a/paimon-core/src/test/java/org/apache/paimon/io/DataFilePathFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/DataFilePathFactoryTest.java
@@ -37,7 +37,8 @@ public class DataFilePathFactoryTest {
                 new DataFilePathFactory(
                         new Path(tempDir + "/bucket-123"),
                         CoreOptions.FILE_FORMAT.defaultValue().toString(),
-                        CoreOptions.FILE_PREFIX.defaultValue());
+                        CoreOptions.DATA_FILE_PREFIX.defaultValue(),
+                        CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue());
         String uuid = pathFactory.uuid();
 
         for (int i = 0; i < 20; i++) {
@@ -62,7 +63,8 @@ public class DataFilePathFactoryTest {
                 new DataFilePathFactory(
                         new Path(tempDir + "/dt=20211224/bucket-123"),
                         CoreOptions.FILE_FORMAT.defaultValue().toString(),
-                        CoreOptions.FILE_PREFIX.defaultValue());
+                        CoreOptions.DATA_FILE_PREFIX.defaultValue(),
+                        CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue());
         String uuid = pathFactory.uuid();
 
         for (int i = 0; i < 20; i++) {

--- a/paimon-core/src/test/java/org/apache/paimon/io/DataFilePathFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/DataFilePathFactoryTest.java
@@ -36,7 +36,8 @@ public class DataFilePathFactoryTest {
         DataFilePathFactory pathFactory =
                 new DataFilePathFactory(
                         new Path(tempDir + "/bucket-123"),
-                        CoreOptions.FILE_FORMAT.defaultValue().toString());
+                        CoreOptions.FILE_FORMAT.defaultValue().toString(),
+                        CoreOptions.FILE_PREFIX.defaultValue());
         String uuid = pathFactory.uuid();
 
         for (int i = 0; i < 20; i++) {
@@ -60,7 +61,8 @@ public class DataFilePathFactoryTest {
         DataFilePathFactory pathFactory =
                 new DataFilePathFactory(
                         new Path(tempDir + "/dt=20211224/bucket-123"),
-                        CoreOptions.FILE_FORMAT.defaultValue().toString());
+                        CoreOptions.FILE_FORMAT.defaultValue().toString(),
+                        CoreOptions.FILE_PREFIX.defaultValue());
         String uuid = pathFactory.uuid();
 
         for (int i = 0; i < 20; i++) {

--- a/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
@@ -248,7 +248,8 @@ public class KeyValueFileReadWriteTest {
                         path,
                         RowType.of(),
                         CoreOptions.PARTITION_DEFAULT_NAME.defaultValue(),
-                        format);
+                        format,
+                        CoreOptions.FILE_PREFIX.defaultValue());
         int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
         FileIO fileIO = FileIOFinder.find(path);
         Options options = new Options();
@@ -262,7 +263,8 @@ public class KeyValueFileReadWriteTest {
                         path,
                         RowType.of(),
                         CoreOptions.PARTITION_DEFAULT_NAME.defaultValue(),
-                        CoreOptions.FILE_FORMAT.defaultValue().toString()));
+                        CoreOptions.FILE_FORMAT.defaultValue().toString(),
+                        CoreOptions.FILE_PREFIX.defaultValue()));
 
         return KeyValueFileWriterFactory.builder(
                         fileIO,

--- a/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
@@ -249,7 +249,8 @@ public class KeyValueFileReadWriteTest {
                         RowType.of(),
                         CoreOptions.PARTITION_DEFAULT_NAME.defaultValue(),
                         format,
-                        CoreOptions.FILE_PREFIX.defaultValue());
+                        CoreOptions.DATA_FILE_PREFIX.defaultValue(),
+                        CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue());
         int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
         FileIO fileIO = FileIOFinder.find(path);
         Options options = new Options();
@@ -264,7 +265,8 @@ public class KeyValueFileReadWriteTest {
                         RowType.of(),
                         CoreOptions.PARTITION_DEFAULT_NAME.defaultValue(),
                         CoreOptions.FILE_FORMAT.defaultValue().toString(),
-                        CoreOptions.FILE_PREFIX.defaultValue()));
+                        CoreOptions.DATA_FILE_PREFIX.defaultValue(),
+                        CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue()));
 
         return KeyValueFileWriterFactory.builder(
                         fileIO,

--- a/paimon-core/src/test/java/org/apache/paimon/io/RollingFileWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/RollingFileWriterTest.java
@@ -73,7 +73,8 @@ public class RollingFileWriterTest {
                                                         new Path(tempDir + "/bucket-0"),
                                                         CoreOptions.FILE_FORMAT
                                                                 .defaultValue()
-                                                                .toString())
+                                                                .toString(),
+                                                        CoreOptions.FILE_PREFIX.defaultValue())
                                                 .newPath(),
                                         SCHEMA,
                                         fileFormat

--- a/paimon-core/src/test/java/org/apache/paimon/io/RollingFileWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/RollingFileWriterTest.java
@@ -74,7 +74,9 @@ public class RollingFileWriterTest {
                                                         CoreOptions.FILE_FORMAT
                                                                 .defaultValue()
                                                                 .toString(),
-                                                        CoreOptions.FILE_PREFIX.defaultValue())
+                                                        CoreOptions.DATA_FILE_PREFIX.defaultValue(),
+                                                        CoreOptions.CHANGELOG_FILE_PREFIX
+                                                                .defaultValue())
                                                 .newPath(),
                                         SCHEMA,
                                         fileFormat

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTestBase.java
@@ -133,7 +133,8 @@ public abstract class ManifestFileMetaTestBase {
                                 path,
                                 getPartitionType(),
                                 "default",
-                                CoreOptions.FILE_FORMAT.defaultValue()),
+                                CoreOptions.FILE_FORMAT.defaultValue(),
+                                CoreOptions.FILE_PREFIX.defaultValue()),
                         Long.MAX_VALUE,
                         null)
                 .create();

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTestBase.java
@@ -134,7 +134,8 @@ public abstract class ManifestFileMetaTestBase {
                                 getPartitionType(),
                                 "default",
                                 CoreOptions.FILE_FORMAT.defaultValue(),
-                                CoreOptions.FILE_PREFIX.defaultValue()),
+                                CoreOptions.DATA_FILE_PREFIX.defaultValue(),
+                                CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue()),
                         Long.MAX_VALUE,
                         null)
                 .create();

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileTest.java
@@ -101,7 +101,8 @@ public class ManifestFileTest {
                         DEFAULT_PART_TYPE,
                         "default",
                         CoreOptions.FILE_FORMAT.defaultValue().toString(),
-                        CoreOptions.FILE_PREFIX.defaultValue());
+                        CoreOptions.DATA_FILE_PREFIX.defaultValue(),
+                        CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue());
         int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
         FileIO fileIO = FileIOFinder.find(path);
         return new ManifestFile.Factory(

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileTest.java
@@ -100,7 +100,8 @@ public class ManifestFileTest {
                         path,
                         DEFAULT_PART_TYPE,
                         "default",
-                        CoreOptions.FILE_FORMAT.defaultValue().toString());
+                        CoreOptions.FILE_FORMAT.defaultValue().toString(),
+                        CoreOptions.FILE_PREFIX.defaultValue());
         int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
         FileIO fileIO = FileIOFinder.find(path);
         return new ManifestFile.Factory(

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestListTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestListTest.java
@@ -104,7 +104,8 @@ public class ManifestListTest {
                         path,
                         TestKeyValueGenerator.DEFAULT_PART_TYPE,
                         "default",
-                        CoreOptions.FILE_FORMAT.defaultValue().toString());
+                        CoreOptions.FILE_FORMAT.defaultValue().toString(),
+                        CoreOptions.FILE_PREFIX.defaultValue());
         return new ManifestList.Factory(FileIOFinder.find(path), avro, "zstd", pathFactory, null)
                 .create();
     }

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestListTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestListTest.java
@@ -105,7 +105,8 @@ public class ManifestListTest {
                         TestKeyValueGenerator.DEFAULT_PART_TYPE,
                         "default",
                         CoreOptions.FILE_FORMAT.defaultValue().toString(),
-                        CoreOptions.FILE_PREFIX.defaultValue());
+                        CoreOptions.DATA_FILE_PREFIX.defaultValue(),
+                        CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue());
         return new ManifestList.Factory(FileIOFinder.find(path), avro, "zstd", pathFactory, null)
                 .create();
     }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/ChangelogMergeTreeRewriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/ChangelogMergeTreeRewriterTest.java
@@ -137,12 +137,12 @@ public class ChangelogMergeTreeRewriterTest {
                                                             .toString()
                                                             .startsWith(
                                                                     DataFilePathFactory
-                                                                            .DATA_FILE_PREFIX)
+                                                                            .DEFAULT_DATA_FILE_PREFIX)
                                                     || p.getFileName()
                                                             .toString()
                                                             .startsWith(
                                                                     DataFilePathFactory
-                                                                            .CHANGELOG_FILE_PREFIX))
+                                                                            .DEFAULT_CHANGELOG_FILE_PREFIX))
                             .collect(Collectors.toList());
             Assertions.assertEquals(0, files.size());
         }
@@ -176,12 +176,12 @@ public class ChangelogMergeTreeRewriterTest {
                                                             .toString()
                                                             .startsWith(
                                                                     DataFilePathFactory
-                                                                            .DATA_FILE_PREFIX)
+                                                                            .DEFAULT_DATA_FILE_PREFIX)
                                                     || p.getFileName()
                                                             .toString()
                                                             .startsWith(
                                                                     DataFilePathFactory
-                                                                            .CHANGELOG_FILE_PREFIX))
+                                                                            .DEFAULT_CHANGELOG_FILE_PREFIX))
                             .collect(Collectors.toList());
             if (rewriteChangelog) {
                 Assertions.assertEquals(2, files.size()); // changelog + data file

--- a/paimon-core/src/test/java/org/apache/paimon/operation/OrphanFilesCleanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/OrphanFilesCleanTest.java
@@ -80,8 +80,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static org.apache.paimon.io.DataFilePathFactory.CHANGELOG_FILE_PREFIX;
-import static org.apache.paimon.io.DataFilePathFactory.DATA_FILE_PREFIX;
+import static org.apache.paimon.io.DataFilePathFactory.DEFAULT_CHANGELOG_FILE_PREFIX;
+import static org.apache.paimon.io.DataFilePathFactory.DEFAULT_DATA_FILE_PREFIX;
 import static org.apache.paimon.utils.BranchManager.branchPath;
 import static org.apache.paimon.utils.FileStorePathFactory.BUCKET_PATH_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -584,7 +584,10 @@ public class OrphanFilesCleanTest {
         List<Path> corruptedBuckets = randomlyPick(buckets);
         for (Path path : corruptedBuckets) {
             addNonUsedFiles(
-                    path, 1, Arrays.asList(DATA_FILE_PREFIX, CHANGELOG_FILE_PREFIX, "UNKNOWN-"));
+                    path,
+                    1,
+                    Arrays.asList(
+                            DEFAULT_DATA_FILE_PREFIX, DEFAULT_CHANGELOG_FILE_PREFIX, "UNKNOWN-"));
         }
         addedFiles += corruptedBuckets.size();
 

--- a/paimon-core/src/test/java/org/apache/paimon/utils/FileStorePathFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/FileStorePathFactoryTest.java
@@ -85,7 +85,8 @@ public class FileStorePathFactoryTest {
                                 new DataType[] {new VarCharType(10), new IntType()},
                                 new String[] {"dt", "hr"}),
                         "default",
-                        CoreOptions.FILE_FORMAT.defaultValue().toString());
+                        CoreOptions.FILE_FORMAT.defaultValue().toString(),
+                        CoreOptions.FILE_PREFIX.defaultValue());
 
         assertPartition("20211224", 16, pathFactory, "/dt=20211224/hr=16");
         assertPartition("20211224", null, pathFactory, "/dt=20211224/hr=default");
@@ -120,6 +121,7 @@ public class FileStorePathFactoryTest {
                 root,
                 RowType.builder().build(),
                 PARTITION_DEFAULT_NAME.defaultValue(),
-                CoreOptions.FILE_FORMAT.defaultValue().toString());
+                CoreOptions.FILE_FORMAT.defaultValue().toString(),
+                CoreOptions.FILE_PREFIX.defaultValue());
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/utils/FileStorePathFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/FileStorePathFactoryTest.java
@@ -86,7 +86,8 @@ public class FileStorePathFactoryTest {
                                 new String[] {"dt", "hr"}),
                         "default",
                         CoreOptions.FILE_FORMAT.defaultValue().toString(),
-                        CoreOptions.FILE_PREFIX.defaultValue());
+                        CoreOptions.DATA_FILE_PREFIX.defaultValue(),
+                        CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue());
 
         assertPartition("20211224", 16, pathFactory, "/dt=20211224/hr=16");
         assertPartition("20211224", null, pathFactory, "/dt=20211224/hr=default");
@@ -122,6 +123,7 @@ public class FileStorePathFactoryTest {
                 RowType.builder().build(),
                 PARTITION_DEFAULT_NAME.defaultValue(),
                 CoreOptions.FILE_FORMAT.defaultValue().toString(),
-                CoreOptions.FILE_PREFIX.defaultValue());
+                CoreOptions.DATA_FILE_PREFIX.defaultValue(),
+                CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue());
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
@@ -105,7 +105,8 @@ public class TestChangelogDataReadWrite {
                         tablePath,
                         RowType.of(new IntType()),
                         "default",
-                        CoreOptions.FILE_FORMAT.defaultValue().toString());
+                        CoreOptions.FILE_FORMAT.defaultValue().toString(),
+                        CoreOptions.FILE_PREFIX.defaultValue());
         this.snapshotManager = new SnapshotManager(LocalFileIO.create(), new Path(root));
         this.commitUser = UUID.randomUUID().toString();
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
@@ -106,7 +106,8 @@ public class TestChangelogDataReadWrite {
                         RowType.of(new IntType()),
                         "default",
                         CoreOptions.FILE_FORMAT.defaultValue().toString(),
-                        CoreOptions.FILE_PREFIX.defaultValue());
+                        CoreOptions.DATA_FILE_PREFIX.defaultValue(),
+                        CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue());
         this.snapshotManager = new SnapshotManager(LocalFileIO.create(), new Path(root));
         this.commitUser = UUID.randomUUID().toString();
     }

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFileIndexITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFileIndexITCase.java
@@ -72,7 +72,7 @@ public class SparkFileIndexITCase extends SparkWriteITCase {
 
     @BeforeAll
     public void startMetastoreAndSpark(@TempDir java.nio.file.Path tempDir) {
-        Path warehousePath = new Path("file:///" + tempDir.toString());
+        warehousePath = new Path("file:///" + tempDir.toString());
         spark =
                 SparkSession.builder()
                         .master("local[1]")

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFileIndexITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFileIndexITCase.java
@@ -128,7 +128,8 @@ public class SparkFileIndexITCase extends SparkWriteITCase {
                         tableRoot,
                         RowType.of(),
                         new CoreOptions(new Options()).partitionDefaultName(),
-                        CoreOptions.FILE_FORMAT.defaultValue().toString());
+                        CoreOptions.FILE_FORMAT.defaultValue().toString(),
+                        CoreOptions.FILE_PREFIX.defaultValue());
 
         Table table = fileSystemCatalog.getTable(Identifier.create("db", "T"));
         ReadBuilder readBuilder = table.newReadBuilder();

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFileIndexITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFileIndexITCase.java
@@ -129,7 +129,8 @@ public class SparkFileIndexITCase extends SparkWriteITCase {
                         RowType.of(),
                         new CoreOptions(new Options()).partitionDefaultName(),
                         CoreOptions.FILE_FORMAT.defaultValue().toString(),
-                        CoreOptions.FILE_PREFIX.defaultValue());
+                        CoreOptions.DATA_FILE_PREFIX.defaultValue(),
+                        CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue());
 
         Table table = fileSystemCatalog.getTable(Identifier.create("db", "T"));
         ReadBuilder readBuilder = table.newReadBuilder();

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkWriteWithKyroITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkWriteWithKyroITCase.java
@@ -31,7 +31,7 @@ public class SparkWriteWithKyroITCase extends SparkWriteITCase {
     @BeforeAll
     @Override
     public void startMetastoreAndSpark(@TempDir java.nio.file.Path tempDir) {
-        Path warehousePath = new Path("file:" + tempDir.toString());
+        warehousePath = new Path("file:" + tempDir.toString());
         spark =
                 SparkSession.builder()
                         .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Add conf `file.prefix` to control the file name prefix of data files.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
