### PR TITLE
[arrow] Pass arrow reader last value by serializer to binary row

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/converter/Arrow2PaimonVectorConverter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/converter/Arrow2PaimonVectorConverter.java
@@ -69,6 +69,7 @@ import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;
 import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
@@ -112,7 +113,7 @@ public interface Arrow2PaimonVectorConverter {
 
                         @Override
                         public Bytes getBytes(int index) {
-                            byte[] bytes = ((VarCharVector) vector).get(index);
+                            byte[] bytes = ((FixedSizeBinaryVector) vector).get(index);
                             return new Bytes(bytes, 0, bytes.length) {
                                 @Override
                                 public byte[] getBytes() {

--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/converter/Arrow2PaimonVectorConverter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/converter/Arrow2PaimonVectorConverter.java
@@ -113,7 +113,13 @@ public interface Arrow2PaimonVectorConverter {
 
                         @Override
                         public Bytes getBytes(int index) {
-                            byte[] bytes = ((FixedSizeBinaryVector) vector).get(index);
+                            byte[] bytes;
+                            if (vector instanceof FixedSizeBinaryVector) {
+                                bytes = ((FixedSizeBinaryVector) vector).get(index);
+                            } else {
+                                bytes = ((VarCharVector) vector).get(index);
+                            }
+
                             return new Bytes(bytes, 0, bytes.length) {
                                 @Override
                                 public byte[] getBytes() {

--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/reader/ArrowBatchReader.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/reader/ArrowBatchReader.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.columnar.ColumnVector;
 import org.apache.paimon.data.columnar.ColumnarRow;
 import org.apache.paimon.data.columnar.VectorizedColumnBatch;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 
@@ -36,11 +37,13 @@ import java.util.List;
 /** Reader from a {@link VectorSchemaRoot} to paimon rows. */
 public class ArrowBatchReader {
 
+    private final InternalRowSerializer internalRowSerializer;
     private final VectorizedColumnBatch batch;
     private final Arrow2PaimonVectorConverter[] convertors;
     private final RowType projectedRowType;
 
     public ArrowBatchReader(RowType rowType) {
+        this.internalRowSerializer = new InternalRowSerializer(rowType);
         ColumnVector[] columnVectors = new ColumnVector[rowType.getFieldCount()];
         this.convertors = new Arrow2PaimonVectorConverter[rowType.getFieldCount()];
         this.batch = new VectorizedColumnBatch(columnVectors);
@@ -85,7 +88,9 @@ public class ArrowBatchReader {
                     public InternalRow next() {
                         columnarRow.setRowId(position);
                         position++;
-                        return columnarRow;
+                        return position == rowCount
+                                ? internalRowSerializer.toBinaryRow(columnarRow)
+                                : columnarRow;
                     }
                 };
     }

--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/reader/ArrowBatchReader.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/reader/ArrowBatchReader.java
@@ -88,6 +88,8 @@ public class ArrowBatchReader {
                     public InternalRow next() {
                         columnarRow.setRowId(position);
                         position++;
+                        // when pk merge, the last value will be referenced by maxKey. If reader
+                        // close, the maxKey will be useless. We must avoid this situation
                         return position == rowCount
                                 ? internalRowSerializer.toBinaryRow(columnarRow)
                                 : columnarRow;

--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatCWriter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatCWriter.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.arrow.vector;
+
+import org.apache.paimon.arrow.ArrowUtils;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.types.RowType;
+
+import org.apache.arrow.c.ArrowArray;
+import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+
+/**
+ * This writer could flush to c struct, but you need to release it, except it has been released in c
+ * code.
+ */
+public class ArrowFormatCWriter implements AutoCloseable {
+
+    private final ArrowArray array;
+    private final ArrowSchema schema;
+    private final ArrowFormatWriter realWriter;
+
+    public ArrowFormatCWriter(RowType rowType, int writeBatchSize) {
+        this.realWriter = new ArrowFormatWriter(rowType, writeBatchSize);
+        RootAllocator allocator = realWriter.getAllocator();
+        array = ArrowArray.allocateNew(allocator);
+        schema = ArrowSchema.allocateNew(allocator);
+    }
+
+    public boolean write(InternalRow currentRow) {
+        return realWriter.write(currentRow);
+    }
+
+    public ArrowCStruct flush() {
+        realWriter.flush();
+        VectorSchemaRoot vectorSchemaRoot = realWriter.getVectorSchemaRoot();
+        return ArrowUtils.serializeToCStruct(vectorSchemaRoot, array, schema);
+    }
+
+    public boolean empty() {
+        return realWriter.empty();
+    }
+
+    // if c++ code release this, we don't need to release again (release twice may cause a problem)
+    public void release() {
+        array.release();
+        schema.release();
+    }
+
+    @Override
+    public void close() {
+        array.close();
+        schema.close();
+        realWriter.close();
+    }
+
+    public VectorSchemaRoot getVectorSchemaRoot() {
+        return realWriter.getVectorSchemaRoot();
+    }
+
+    public RootAllocator getAllocator() {
+        return realWriter.getAllocator();
+    }
+}

--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatWriter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatWriter.java
@@ -92,10 +92,14 @@ public class ArrowFormatWriter implements AutoCloseable {
         return rowId == 0;
     }
 
-    @Override
-    public void close() {
+    // if c++ code release this, we don't need to release again (release twice may cause a problem)
+    public void release() {
         array.release();
         schema.release();
+    }
+
+    @Override
+    public void close() {
         array.close();
         schema.close();
         vectorSchemaRoot.close();

--- a/paimon-arrow/src/test/java/org/apache/paimon/arrow/vector/ArrowFormatWriterTest.java
+++ b/paimon-arrow/src/test/java/org/apache/paimon/arrow/vector/ArrowFormatWriterTest.java
@@ -112,6 +112,7 @@ public class ArrowFormatWriterTest {
                             .isEqualTo(fieldGetter.getFieldOrNull(expectec));
                 }
             }
+            writer.release();
         }
     }
 
@@ -154,6 +155,7 @@ public class ArrowFormatWriterTest {
                             .isEqualTo(fieldGetter.getFieldOrNull(expectec));
                 }
             }
+            writer.release();
         }
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

When merge, the last value will be referenced by maxKey. If reader close, the maxKey will be useless. We must avoid this situation

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
