### PR TITLE
[core] Fix caching catalog case sensitive

### DIFF
--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -39,7 +39,7 @@ under the License.
             <td>Controls whether the catalog will cache databases, tables and manifests.</td>
         </tr>
         <tr>
-            <td><h5>cache-case-sensitive</h5></td>
+            <td><h5>cache.case-sensitive</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Indicates the caching catalog is case sensitive or not.</td>

--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -39,6 +39,12 @@ under the License.
             <td>Controls whether the catalog will cache databases, tables and manifests.</td>
         </tr>
         <tr>
+            <td><h5>cache-case-sensitive</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Indicates the caching catalog is case sensitive or not.</td>
+        </tr>
+        <tr>
             <td><h5>cache.expiration-interval</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -98,6 +98,12 @@ public class CatalogOptions {
                     .withDescription(
                             "Controls whether the catalog will cache databases, tables and manifests.");
 
+    public static final ConfigOption<Boolean> CACHE_CASE_SENSITIVE =
+            ConfigOptions.key("cache.case-sensitive")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("Indicates the caching catalog is case sensitive or not.");
+
     public static final ConfigOption<Duration> CACHE_EXPIRATION_INTERVAL_MS =
             key("cache.expiration-interval")
                     .durationType()

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Identifier.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Identifier.java
@@ -159,6 +159,19 @@ public class Identifier implements Serializable {
                 "%c%s%c.%c%s%c", escapeChar, database, escapeChar, escapeChar, object, escapeChar);
     }
 
+    public Identifier toLowerCase() {
+        splitObjectName();
+        return new Identifier(
+                database.toLowerCase(),
+                table.toLowerCase(),
+                branch == null ? branch : branch.toLowerCase(),
+                systemTable == null ? systemTable : systemTable.toLowerCase());
+    }
+
+    public Identifier withoutSystemTable() {
+        return new Identifier(database, table, branch, null);
+    }
+
     public static Identifier create(String db, String object) {
         return new Identifier(db, object);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/TestableCachingCatalog.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/TestableCachingCatalog.java
@@ -36,7 +36,7 @@ public class TestableCachingCatalog extends CachingCatalog {
     private final Duration cacheExpirationInterval;
 
     public TestableCachingCatalog(Catalog catalog, Duration expirationInterval, Ticker ticker) {
-        super(catalog, expirationInterval, MemorySize.ZERO, Long.MAX_VALUE, ticker);
+        super(catalog, expirationInterval, true, MemorySize.ZERO, Long.MAX_VALUE, ticker);
         this.cacheExpirationInterval = expirationInterval;
     }
 

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -80,15 +80,15 @@ public class SparkCatalog extends SparkBaseCatalog implements SupportFunction {
         Map<String, String> newOptions = new HashMap<>(options.asCaseSensitiveMap());
         SessionState sessionState = SparkSession.active().sessionState();
 
-        CatalogContext catalogContext =
-                CatalogContext.create(Options.fromMap(options), sessionState.newHadoopConf());
-
-        // if spark is case-insensitive, set allow upper case to catalog
+        // If spark is case-insensitive, set allow upper case to catalog.
+        // The reason is that, we do not support uppercase if is case insensitive,
+        // but the Spark default behavior is case insensitive.
         if (!sessionState.conf().caseSensitiveAnalysis()) {
             newOptions.put(ALLOW_UPPER_CASE.key(), "true");
         }
-        options = new CaseInsensitiveStringMap(newOptions);
 
+        CatalogContext catalogContext =
+                CatalogContext.create(Options.fromMap(newOptions), sessionState.newHadoopConf());
         this.catalog = CatalogFactory.createCatalog(catalogContext);
         this.defaultDatabase =
                 options.getOrDefault(DEFAULT_DATABASE.key(), DEFAULT_DATABASE.defaultValue());

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkGenericCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkGenericCatalog.java
@@ -61,7 +61,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import static org.apache.paimon.options.CatalogOptions.ALLOW_UPPER_CASE;
 import static org.apache.paimon.options.CatalogOptions.METASTORE;
 import static org.apache.paimon.options.CatalogOptions.WAREHOUSE;
 import static org.apache.paimon.spark.SparkCatalogOptions.CREATE_UNDERLYING_SESSION_CATALOG;
@@ -285,12 +284,6 @@ public class SparkGenericCatalog extends SparkBaseCatalog implements CatalogExte
         Map<String, String> newOptions = new HashMap<>(options.asCaseSensitiveMap());
         fillAliyunConfigurations(newOptions, hadoopConf);
         fillCommonConfigurations(newOptions, sqlConf);
-
-        // if spark is case-insensitive, set allow upper case to catalog
-        if (!sqlConf.caseSensitiveAnalysis()) {
-            newOptions.put(ALLOW_UPPER_CASE.key(), "true");
-        }
-
         return new CaseInsensitiveStringMap(newOptions);
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The CacaingCatalog should respect the wrapped catalog case sensitive, otherwise it would case wrong result.

```
create table t (c1 int);
drop table T;
create table t (c1 int);

[TABLE_OR_VIEW_ALREADY_EXISTS] Cannot create table or view `default`.`T` because it already exists.
```

This pr adds a new option `cache.case-sensitive` to choose the caching catalog case sensitive.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
add test

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
