### PR TITLE
[flink][spark] make compaction completely asynchronous in dedicated compaction job

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactAction.java
@@ -124,6 +124,18 @@ public class CompactAction extends TableActionBase {
     private void buildForTraditionalCompaction(
             StreamExecutionEnvironment env, FileStoreTable table, boolean isStreaming)
             throws Exception {
+        if (isStreaming) {
+            // for completely asynchronous compaction
+            HashMap<String, String> dynamicOptions =
+                    new HashMap<String, String>() {
+                        {
+                            put(CoreOptions.NUM_SORTED_RUNS_STOP_TRIGGER.key(), "2147483647");
+                            put(CoreOptions.SORT_SPILL_THRESHOLD.key(), "10");
+                            put(CoreOptions.LOOKUP_WAIT.key(), "false");
+                        }
+                    };
+            table = table.copy(dynamicOptions);
+        }
         CompactorSourceBuilder sourceBuilder =
                 new CompactorSourceBuilder(identifier.getFullName(), table);
         CompactorSinkBuilder sinkBuilder = new CompactorSinkBuilder(table);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactDatabaseAction.java
@@ -235,6 +235,18 @@ public class CompactDatabaseAction extends ActionBase {
             String fullName,
             FileStoreTable table,
             boolean isStreaming) {
+        if (isStreaming) {
+            // for completely asynchronous compaction
+            HashMap<String, String> dynamicOptions =
+                    new HashMap<String, String>() {
+                        {
+                            put(CoreOptions.NUM_SORTED_RUNS_STOP_TRIGGER.key(), "2147483647");
+                            put(CoreOptions.SORT_SPILL_THRESHOLD.key(), "10");
+                            put(CoreOptions.LOOKUP_WAIT.key(), "false");
+                        }
+                    };
+            table = table.copy(dynamicOptions);
+        }
 
         CompactorSourceBuilder sourceBuilder =
                 new CompactorSourceBuilder(fullName, table)

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/MultiTablesCompactorUtil.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/MultiTablesCompactorUtil.java
@@ -62,20 +62,6 @@ public class MultiTablesCompactorUtil {
         }
     }
 
-    public static Map<String, String> partitionCompactOptions() {
-
-        return new HashMap<String, String>() {
-            {
-                put(CoreOptions.SCAN_TIMESTAMP_MILLIS.key(), null);
-                put(CoreOptions.SCAN_TIMESTAMP.key(), null);
-                put(CoreOptions.SCAN_FILE_CREATION_TIME_MILLIS.key(), null);
-                put(CoreOptions.SCAN_SNAPSHOT_ID.key(), null);
-                put(CoreOptions.SCAN_MODE.key(), CoreOptions.StartupMode.LATEST_FULL.toString());
-                put(CoreOptions.WRITE_ONLY.key(), "false");
-            }
-        };
-    }
-
     public static boolean shouldCompactTable(
             Identifier tableIdentifier, Pattern includingPattern, Pattern excludingPattern) {
         String paimonFullTableName = tableIdentifier.getFullName();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
make compaction completely asynchronous in dedicated compaction job
add dynamic options for tables in dedicated compaction job:
`num-sorted-run.stop-trigger = 2147483647`
`sort-spill-threshold = 10`
`lookup-wait = false`

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
