### PR TITLE
[doc] remove currentEmitEventTimeLag metric

### DIFF
--- a/docs/content/maintenance/metrics.md
+++ b/docs/content/maintenance/metrics.md
@@ -335,7 +335,6 @@ When using Flink to read and write, Paimon has implemented some key standard Fli
     </thead>
     <tbody>
         <tr>
-
             <td>currentFetchEventTimeLag</td>
             <td>Flink Source Operator</td>
             <td>Gauge</td>

--- a/docs/content/maintenance/metrics.md
+++ b/docs/content/maintenance/metrics.md
@@ -335,6 +335,7 @@ When using Flink to read and write, Paimon has implemented some key standard Fli
     </thead>
     <tbody>
         <tr>
+
             <td>currentFetchEventTimeLag</td>
             <td>Flink Source Operator</td>
             <td>Gauge</td>

--- a/docs/content/maintenance/metrics.md
+++ b/docs/content/maintenance/metrics.md
@@ -335,12 +335,6 @@ When using Flink to read and write, Paimon has implemented some key standard Fli
     </thead>
     <tbody>
         <tr>
-            <td>currentEmitEventTimeLag</td>
-            <td>Flink Source Operator</td>
-            <td>Gauge</td>
-            <td>Time difference between sending the record out of source and file creation.</td>
-        </tr>
-        <tr>
             <td>currentFetchEventTimeLag</td>
             <td>Flink Source Operator</td>
             <td>Gauge</td>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
currentEmitEventTimeLag has been deleted in the latest cdc version
https://github.com/apache/flink-cdc/issues/2403

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
