### PR TITLE
[core] Make BatchFileStoreWrite(old name BatchWriter) extends FileStoreWrite<InternalRow> to expose its level.

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/OneElementFieldVectorGenerator.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/OneElementFieldVectorGenerator.java
@@ -39,8 +39,8 @@ public class OneElementFieldVectorGenerator implements AutoCloseable {
 
     public OneElementFieldVectorGenerator(
             BufferAllocator bufferAllocator, DataField dataField, Object value) {
-        fieldVector = createVector(dataField, bufferAllocator, false);
-        writer =
+        this.fieldVector = createVector(dataField, bufferAllocator, false);
+        this.writer =
                 dataField
                         .type()
                         .accept(ArrowFieldWriterFactoryVisitor.INSTANCE)
@@ -49,7 +49,7 @@ public class OneElementFieldVectorGenerator implements AutoCloseable {
         row.setField(0, value);
     }
 
-    FieldVector get(int rowCount) {
+    public FieldVector get(int rowCount) {
         if (rowCount > pos) {
             for (int i = pos; i < rowCount; i++) {
                 writer.write(i, row, 0);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
@@ -64,7 +64,7 @@ import java.util.function.Function;
 
 /** {@link FileStoreWrite} for {@link AppendOnlyFileStore}. */
 public class AppendOnlyFileStoreWrite extends MemoryFileStoreWrite<InternalRow>
-        implements BatchWriter {
+        implements BatchFileStoreWrite {
 
     private static final Logger LOG = LoggerFactory.getLogger(AppendOnlyFileStoreWrite.class);
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/BatchFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/BatchFileStoreWrite.java
@@ -19,10 +19,11 @@
 package org.apache.paimon.operation;
 
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.BatchRecords;
 
 /** Whether the writer could write batch. */
-public interface BatchWriter {
+public interface BatchFileStoreWrite extends FileStoreWrite<InternalRow> {
 
     /**
      * Write the batch data to the store according to the partition and bucket.

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
@@ -28,7 +28,7 @@ import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.memory.MemoryPoolFactory;
 import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.metrics.MetricRegistry;
-import org.apache.paimon.operation.BatchWriter;
+import org.apache.paimon.operation.BatchFileStoreWrite;
 import org.apache.paimon.operation.FileStoreWrite;
 import org.apache.paimon.operation.FileStoreWrite.State;
 import org.apache.paimon.table.BucketMode;
@@ -154,8 +154,8 @@ public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State
 
     @Override
     public void writeBatch(BinaryRow partition, int bucket, BatchRecords batch) throws Exception {
-        if (write instanceof BatchWriter) {
-            ((BatchWriter) write).writeBatch(partition, bucket, batch);
+        if (write instanceof BatchFileStoreWrite) {
+            ((BatchFileStoreWrite) write).writeBatch(partition, bucket, batch);
         } else {
             for (InternalRow row : batch) {
                 write(row, bucket);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
BatchFileStoreWrite should be extends FileStoreWrite
<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
