### PR TITLE
[core] ManifestReadThreadPool use config thread number first rather than core number

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/ManifestReadThreadPool.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ManifestReadThreadPool.java
@@ -47,6 +47,8 @@ public class ManifestReadThreadPool {
         } else {
             if (threadNum != null && threadNum > executorService.getMaximumPoolSize()) {
                 synchronized (ManifestReadThreadPool.class) {
+                    // we don't need to close previous pool
+                    // it is just cached pool
                     executorService = createCachedThreadPool(threadNum, THREAD_NAME);
                 }
             }


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Some things cpu cores are too big, we can use all the cpu in snapshot scanning.

So we'd better use configured thread number for scan first, if it not set, we use cpu core number.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
