### PR TITLE
[core] fix the issue of incorrect filtering in filterWholeBucketAllFiles.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreScan.java
@@ -39,7 +39,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.paimon.CoreOptions.MergeEngine.AGGREGATE;
 import static org.apache.paimon.CoreOptions.MergeEngine.FIRST_ROW;
+import static org.apache.paimon.CoreOptions.MergeEngine.PARTIAL_UPDATE;
 
 /** {@link FileStoreScan} for {@link KeyValueFileStore}. */
 public class KeyValueFileStoreScan extends AbstractFileStoreScan {
@@ -173,6 +175,11 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
     }
 
     private List<ManifestEntry> filterWholeBucketAllFiles(List<ManifestEntry> entries) {
+        if (!deletionVectorsEnabled
+                && (mergeEngine == PARTIAL_UPDATE || mergeEngine == AGGREGATE)) {
+            return entries;
+        }
+
         // entries come from the same bucket, if any of it doesn't meet the request, we could
         // filter the bucket.
         for (ManifestEntry entry : entries) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PartialUpdateITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PartialUpdateITCase.java
@@ -80,6 +80,10 @@ public class PartialUpdateITCase extends CatalogITCaseBase {
 
         // projection
         assertThat(batchSql("SELECT a FROM T")).containsExactlyInAnyOrder(Row.of(4));
+
+        // filter
+        assertThat(batchSql("SELECT * FROM T where b = 5 and c = '6'"))
+                .containsExactlyInAnyOrder(Row.of(1, 2, 4, 5, "6"));
     }
 
     @Test


### PR DESCRIPTION
[core] fix the issue of incorrect filtering in filterWholeBucketAllFiles.

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #4065

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
