### PR TITLE
[core] Support stream read with delay duration

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -648,6 +648,12 @@ This config option does not affect the default filesystem metastore.</td>
             <td>Optional snapshot id used in case of "from-snapshot" or "from-snapshot-full" scan mode</td>
         </tr>
         <tr>
+            <td><h5>scan.stream.delay.read.duration</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>The delay duration of stream read when scan snapshots</td>
+        </tr>
+        <tr>
             <td><h5>scan.tag-name</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -648,10 +648,10 @@ This config option does not affect the default filesystem metastore.</td>
             <td>Optional snapshot id used in case of "from-snapshot" or "from-snapshot-full" scan mode</td>
         </tr>
         <tr>
-            <td><h5>scan.stream.delay.read.duration</h5></td>
+            <td><h5>streaming.read.snapshot.delay</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
-            <td>The delay duration of stream read when scan snapshots</td>
+            <td>The delay duration of stream read when scan incremental snapshots.</td>
         </tr>
         <tr>
             <td><h5>scan.tag-name</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -659,10 +659,11 @@ public class CoreOptions implements Serializable {
                                     + "We can consider downsize it when we encounter an out of memory exception while scanning");
 
     public static final ConfigOption<Duration> SCAN_DELAY_READ_DURATION =
-            key("scan.stream.delay.read.duration")
+            key("streaming.read.snapshot.delay")
                     .durationType()
                     .noDefaultValue()
-                    .withDescription("The delay duration of stream read when scan snapshots");
+                    .withDescription(
+                            "The delay duration of stream read when scan incremental snapshots.");
 
     @ExcludeFromDocumentation("Confused without log system")
     public static final ConfigOption<LogConsistency> LOG_CONSISTENCY =

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -658,7 +658,7 @@ public class CoreOptions implements Serializable {
                                     + "Note: Scale-up this parameter will increase memory usage while scanning manifest files. "
                                     + "We can consider downsize it when we encounter an out of memory exception while scanning");
 
-    public static final ConfigOption<Duration> SCAN_DELAY_READ_DURATION =
+    public static final ConfigOption<Duration> STREAMING_READ_SNAPSHOT_DELAY =
             key("streaming.read.snapshot.delay")
                     .durationType()
                     .noDefaultValue()
@@ -1853,8 +1853,8 @@ public class CoreOptions implements Serializable {
         return options.get(SCAN_MANIFEST_PARALLELISM);
     }
 
-    public Duration scanDelayDuration() {
-        return options.get(SCAN_DELAY_READ_DURATION);
+    public Duration streamingReadDelay() {
+        return options.get(STREAMING_READ_SNAPSHOT_DELAY);
     }
 
     public Integer dynamicBucketInitialBuckets() {

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -658,6 +658,12 @@ public class CoreOptions implements Serializable {
                                     + "Note: Scale-up this parameter will increase memory usage while scanning manifest files. "
                                     + "We can consider downsize it when we encounter an out of memory exception while scanning");
 
+    public static final ConfigOption<Duration> SCAN_DELAY_READ_DURATION =
+            key("scan.stream.delay.read.duration")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription("The delay duration of stream read when scan snapshots");
+
     @ExcludeFromDocumentation("Confused without log system")
     public static final ConfigOption<LogConsistency> LOG_CONSISTENCY =
             key("log.consistency")
@@ -1844,6 +1850,10 @@ public class CoreOptions implements Serializable {
 
     public Integer scanManifestParallelism() {
         return options.get(SCAN_MANIFEST_PARALLELISM);
+    }
+
+    public Duration scanDelayDuration() {
+        return options.get(SCAN_DELAY_READ_DURATION);
     }
 
     public Integer dynamicBucketInitialBuckets() {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
@@ -149,7 +149,6 @@ public class DataTableStreamScan extends AbstractDataTableScan implements Stream
             } else {
                 nextSnapshotId = currentSnapshotId + 1;
             }
-
             isFullPhaseEnd =
                     boundedChecker.shouldEndInput(snapshotManager.snapshot(currentSnapshotId));
             return scannedResult.plan();

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
@@ -182,8 +182,8 @@ public class DataTableStreamScan extends AbstractDataTableScan implements Stream
                 throw new EndOfScanException();
             }
 
-            if (checkDelaySnapshot(nextSnapshotId)) {
-                continue;
+            if (shouldDelaySnapshot(nextSnapshotId)) {
+                return SnapshotNotExistPlan.INSTANCE;
             }
 
             // first check changes of overwrite
@@ -207,7 +207,7 @@ public class DataTableStreamScan extends AbstractDataTableScan implements Stream
         }
     }
 
-    private boolean checkDelaySnapshot(long snapshotId) {
+    private boolean shouldDelaySnapshot(long snapshotId) {
         if (scanDelayMillis == null) {
             return false;
         }
@@ -260,7 +260,9 @@ public class DataTableStreamScan extends AbstractDataTableScan implements Stream
     }
 
     private Long getScanDelayMillis() {
-        return options.scanDelayDuration() == null ? null : options.scanDelayDuration().toMillis();
+        return options.streamingReadDelay() == null
+                ? null
+                : options.streamingReadDelay().toMillis();
     }
 
     @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
@@ -183,12 +183,7 @@ public class DataTableStreamScan extends AbstractDataTableScan implements Stream
             }
 
             if (shouldDelaySnapshot(nextSnapshotId)) {
-                try {
-                    Thread.sleep(this.scanDelayMillis);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-                continue;
+                return SnapshotNotExistPlan.INSTANCE;
             }
 
             // first check changes of overwrite

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
@@ -183,7 +183,12 @@ public class DataTableStreamScan extends AbstractDataTableScan implements Stream
             }
 
             if (shouldDelaySnapshot(nextSnapshotId)) {
-                return SnapshotNotExistPlan.INSTANCE;
+                try {
+                    Thread.sleep(this.scanDelayMillis);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                continue;
             }
 
             // first check changes of overwrite

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
@@ -150,20 +150,11 @@ public class DataTableStreamScan extends AbstractDataTableScan implements Stream
                 nextSnapshotId = currentSnapshotId + 1;
             }
 
-            if (checkDelaySnapshot(nextSnapshotId)) {
-                // reset nextSnapshotId for tryFirstPlan
-                nextSnapshotId = null;
-                return SnapshotNotExistPlan.INSTANCE;
-            }
             isFullPhaseEnd =
                     boundedChecker.shouldEndInput(snapshotManager.snapshot(currentSnapshotId));
             return scannedResult.plan();
         } else if (result instanceof StartingScanner.NextSnapshot) {
             nextSnapshotId = ((StartingScanner.NextSnapshot) result).nextSnapshotId();
-            if (checkDelaySnapshot(nextSnapshotId)) {
-                return SnapshotNotExistPlan.INSTANCE;
-            }
-
             isFullPhaseEnd =
                     snapshotManager.snapshotExists(nextSnapshotId - 1)
                             && boundedChecker.shouldEndInput(

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/StartupModeTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/StartupModeTest.java
@@ -232,7 +232,7 @@ public class StartupModeTest extends ScannerTestBase {
     public void testStartFromSnapshotWithDelayDuration() throws Exception {
         Map<String, String> properties = new HashMap<>();
         properties.put(CoreOptions.SCAN_SNAPSHOT_ID.key(), "2");
-        properties.put(CoreOptions.SCAN_DELAY_READ_DURATION.key(), "5 s");
+        properties.put(CoreOptions.STREAMING_READ_SNAPSHOT_DELAY.key(), "5 s");
         initializeTable(StartupMode.FROM_SNAPSHOT, properties);
         initializeTestData(); // initialize 3 commits
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/StartupModeTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/StartupModeTest.java
@@ -239,18 +239,16 @@ public class StartupModeTest extends ScannerTestBase {
         // streaming Mode
         StreamTableScan dataTableScan = table.newStreamScan();
         TableScan.Plan firstPlan = dataTableScan.plan();
-
-        long startTime = System.currentTimeMillis();
-        TableScan.Plan secondPlan = dataTableScan.plan();
-        long endTime = System.currentTimeMillis();
-        long duration = endTime - startTime;
-
-        // delay stream read time is 5000 mills
-        assertThat(duration).isGreaterThan(4500);
-        assertThat(duration).isLessThan(5500);
-
         assertThat(firstPlan.splits()).isEmpty();
-        assertThat(secondPlan.splits())
+
+        Thread.sleep(3000);
+        TableScan.Plan secondPlan = dataTableScan.plan();
+        assertThat(secondPlan.splits()).isEmpty();
+
+        Thread.sleep(5000);
+        TableScan.Plan thirdPlan = dataTableScan.plan();
+
+        assertThat(thirdPlan.splits())
                 .isEqualTo(snapshotReader.withSnapshot(2).withMode(ScanMode.DELTA).read().splits());
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Support stream read with delay duration.
real user scenario is algorithm partital update, user use lake table join hbase/redis dim table, but dim table update is delay, so need delay read for stream lake table. this pr is aim to support it with add an option to control the delay time.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
