### PR TITLE
[flink] Supports creating tags from snapshots watermark.

### DIFF
--- a/docs/content/flink/procedures.md
+++ b/docs/content/flink/procedures.md
@@ -142,6 +142,26 @@ All available procedures are listed below.
          CALL sys.create_tag_from_timestamp(`table` => 'default.T', `tag` => 'my_tag', `timestamp` => 1724404318750, time_retained => '1 d')
       </td>
    </tr>
+    <tr>
+      <td>create_tag_from_watermark</td>
+      <td>
+         -- Create a tag from the first snapshot whose watermark greater than the specified timestamp.<br/>
+         CALL [catalog.]sys.create_tag_from_watermark('identifier', 'tagName', watermark, time_retained)
+      </td>
+      <td>
+         To create a tag based on given watermark timestamp. Arguments:
+            <li>identifier: the target table identifier. Cannot be empty.</li>
+            <li>tag: name of the new tag.</li>
+            <li>timestamp (Long): Find the first snapshot whose watermark greater than this timestamp.</li>
+            <li>time_retained : The maximum time retained for newly created tags.</li>
+      </td>
+      <td>
+         -- for Flink 1.18<br/>
+         CALL sys.create_tag_from_watermark('default.T', 'my_tag', 1724404318750, '1 d')
+         -- for Flink 1.19 and later<br/>
+         CALL sys.create_tag_from_watermark(`table` => 'default.T', `tag` => 'my_tag', `timestamp` => 1724404318750, time_retained => '1 d')
+      </td>
+   </tr>
    <tr>
       <td>delete_tag</td>
       <td>

--- a/docs/content/flink/procedures.md
+++ b/docs/content/flink/procedures.md
@@ -152,14 +152,14 @@ All available procedures are listed below.
          To create a tag based on given watermark timestamp. Arguments:
             <li>identifier: the target table identifier. Cannot be empty.</li>
             <li>tag: name of the new tag.</li>
-            <li>timestamp (Long): Find the first snapshot whose watermark greater than this timestamp.</li>
+            <li>watermark (Long): Find the first snapshot whose watermark greater than the specified watermark.</li>
             <li>time_retained : The maximum time retained for newly created tags.</li>
       </td>
       <td>
          -- for Flink 1.18<br/>
          CALL sys.create_tag_from_watermark('default.T', 'my_tag', 1724404318750, '1 d')
          -- for Flink 1.19 and later<br/>
-         CALL sys.create_tag_from_watermark(`table` => 'default.T', `tag` => 'my_tag', `timestamp` => 1724404318750, time_retained => '1 d')
+         CALL sys.create_tag_from_watermark(`table` => 'default.T', `tag` => 'my_tag', `watermark` => 1724404318750, time_retained => '1 d')
       </td>
    </tr>
    <tr>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateTagFromWatermarkProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateTagFromWatermarkProcedure.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.procedure;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.SnapshotManager;
+import org.apache.paimon.utils.SnapshotNotExistException;
+import org.apache.paimon.utils.TimeUtils;
+
+import org.apache.flink.table.annotation.ArgumentHint;
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.ProcedureHint;
+import org.apache.flink.table.procedure.ProcedureContext;
+import org.apache.flink.types.Row;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.Set;
+
+/** The procedure supports creating tags from snapshots watermark. */
+public class CreateTagFromWatermarkProcedure extends ProcedureBase {
+
+    public static final String IDENTIFIER = "create_tag_from_watermark";
+
+    @ProcedureHint(
+            argument = {
+                @ArgumentHint(name = "table", type = @DataTypeHint("STRING")),
+                @ArgumentHint(name = "tag", type = @DataTypeHint(value = "STRING")),
+                @ArgumentHint(name = "timestamp", type = @DataTypeHint("bigint")),
+                @ArgumentHint(
+                        name = "time_retained",
+                        type = @DataTypeHint("STRING"),
+                        isOptional = true),
+            })
+    @DataTypeHint("ROW< tagName STRING, snapshot BIGINT, `commit_time` BIGINT, `watermark` STRING>")
+    public Row[] call(
+            ProcedureContext procedureContext,
+            String tableId,
+            String tagName,
+            Long timestamp,
+            @Nullable String timeRetained)
+            throws Catalog.TableNotExistException {
+        FileStoreTable fileStoreTable = (FileStoreTable) table(tableId);
+        SnapshotManager snapshotManager = fileStoreTable.snapshotManager();
+
+        Snapshot snapshot = snapshotManager.laterOrEqualWatermark(timestamp);
+
+        Set<Snapshot> sortedTagsSnapshots = fileStoreTable.tagManager().tags().keySet();
+
+        for (Snapshot tagSnapshot : sortedTagsSnapshots) {
+            if (tagSnapshot.watermark() != null && timestamp <= tagSnapshot.watermark()) {
+                if (snapshot == null
+                        || snapshot.watermark() == null
+                        || tagSnapshot.watermark() < snapshot.watermark()) {
+                    snapshot = tagSnapshot;
+                }
+                break;
+            }
+        }
+
+        SnapshotNotExistException.checkNotNull(
+                snapshot,
+                String.format(
+                        "Could not find any snapshot whose watermark later than %s.", timestamp));
+
+        fileStoreTable.createTag(tagName, snapshot.id(), toDuration(timeRetained));
+
+        return new Row[] {
+            Row.of(
+                    tagName,
+                    snapshot.id(),
+                    snapshot.timeMillis(),
+                    String.valueOf(snapshot.watermark()))
+        };
+    }
+
+    @Nullable
+    private static Duration toDuration(@Nullable String s) {
+        if (s == null) {
+            return null;
+        }
+
+        return TimeUtils.parseDuration(s);
+    }
+
+    @Override
+    public String identifier() {
+        return IDENTIFIER;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/resources/META-INF/services/org.apache.paimon.factories.Factory
+++ b/paimon-flink/paimon-flink-common/src/main/resources/META-INF/services/org.apache.paimon.factories.Factory
@@ -43,6 +43,7 @@ org.apache.paimon.flink.procedure.CompactProcedure
 org.apache.paimon.flink.procedure.RewriteFileIndexProcedure
 org.apache.paimon.flink.procedure.CreateTagProcedure
 org.apache.paimon.flink.procedure.CreateTagFromTimestampProcedure
+org.apache.paimon.flink.procedure.CreateTagFromWatermarkProcedure
 org.apache.paimon.flink.procedure.DeleteTagProcedure
 org.apache.paimon.flink.procedure.CreateBranchProcedure
 org.apache.paimon.flink.procedure.DeleteBranchProcedure

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CreateTagFromWatermarkProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CreateTagFromWatermarkProcedureITCase.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.procedure;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.flink.CatalogITCaseBase;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.SnapshotNotExistException;
+
+import org.apache.flink.types.Row;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+
+/** IT Case for {@link CreateTagFromWatermarkProcedure}. */
+public class CreateTagFromWatermarkProcedureITCase extends CatalogITCaseBase {
+
+    @Test
+    public void testCreatTagsFromSnapshotsWatermark() throws Exception {
+        sql(
+                "CREATE TABLE T ("
+                        + " k STRING,"
+                        + " dt STRING,"
+                        + " PRIMARY KEY (k, dt) NOT ENFORCED"
+                        + ") PARTITIONED BY (dt) WITH ("
+                        + " 'bucket' = '1'"
+                        + ")");
+        // create snapshot 1 with watermark Long.MIN_VALUE.
+        sql("insert into T values('k1', '2024-01-02')");
+
+        assertThatException()
+                .isThrownBy(
+                        () ->
+                                sql(
+                                        "CALL sys.create_tag_from_watermark("
+                                                + "`table` => 'default.T',"
+                                                + "`tag` => 'tag1',"
+                                                + "`timestamp` => %s )",
+                                        1000))
+                .withRootCauseInstanceOf(SnapshotNotExistException.class)
+                .withMessageContaining(
+                        "Could not find any snapshot whose watermark later than %s.", 1000);
+
+        // create snapshot 2 with watermark 1000.
+        sql(
+                "insert into T/*+ OPTIONS('end-input.watermark'= '1000') */ values('k2', '2024-01-02')");
+        // create snapshot 3 with watermark 2000.
+        sql(
+                "insert into T/*+ OPTIONS('end-input.watermark'= '2000') */ values('k3', '2024-01-02')");
+
+        FileStoreTable table = paimonTable("T");
+
+        long watermark1 = table.snapshotManager().snapshot(1).watermark();
+
+        Snapshot snapshot2 = table.snapshotManager().snapshot(2);
+        long commitTime2 = snapshot2.timeMillis();
+        long watermark2 = snapshot2.watermark();
+
+        Snapshot snapshot3 = table.snapshotManager().snapshot(3);
+        long commitTime3 = snapshot3.timeMillis();
+        long watermark3 = snapshot3.watermark();
+
+        assertThat(watermark1 == Long.MIN_VALUE).isTrue();
+        assertThat(watermark2 == 1000).isTrue();
+        assertThat(watermark3 == 2000).isTrue();
+
+        assertThat(
+                        sql(
+                                        "CALL sys.create_tag_from_watermark("
+                                                + "`table` => 'default.T',"
+                                                + "`tag` => 'tag2',"
+                                                + "`timestamp` => %s)",
+                                        watermark2 - 1)
+                                .stream()
+                                .map(Row::toString))
+                .containsExactlyInAnyOrder(
+                        String.format("+I[tag2, 2, %s, %s]", commitTime2, watermark2));
+
+        assertThat(
+                        sql(
+                                        "CALL sys.create_tag_from_watermark("
+                                                + "`table` => 'default.T',"
+                                                + "`tag` => 'tag3',"
+                                                + "`timestamp` => %s)",
+                                        watermark2 + 1)
+                                .stream()
+                                .map(Row::toString))
+                .containsExactlyInAnyOrder(
+                        String.format("+I[tag3, 3, %s, %s]", commitTime3, watermark3));
+
+        assertThatException()
+                .isThrownBy(
+                        () ->
+                                sql(
+                                        "CALL sys.create_tag_from_watermark("
+                                                + "`table` => 'default.T',"
+                                                + "`tag` => 'tag4',"
+                                                + "`timestamp` => %s )",
+                                        watermark3 + 1))
+                .withRootCauseInstanceOf(SnapshotNotExistException.class)
+                .withMessageContaining(
+                        "Could not find any snapshot whose watermark later than %s.",
+                        watermark3 + 1);
+    }
+
+    @Test
+    public void testCreatTagsFromTagsWatermark() throws Exception {
+        sql(
+                "CREATE TABLE T ("
+                        + " k STRING,"
+                        + " dt STRING,"
+                        + " PRIMARY KEY (k, dt) NOT ENFORCED"
+                        + ") PARTITIONED BY (dt) WITH ("
+                        + " 'bucket' = '1'"
+                        + ")");
+
+        sql(
+                "insert into T/*+ OPTIONS('end-input.watermark'= '1000') */ values('k2', '2024-01-02')");
+
+        sql("CALL sys.create_tag('default.T', 'tag1', 1)");
+
+        // make snapshot-1 expire.
+        sql(
+                "insert into T/*+ OPTIONS('end-input.watermark'= '2000',"
+                        + " 'snapshot.num-retained.max' = '1',"
+                        + " 'snapshot.num-retained.min' = '1') */"
+                        + " values('k2', '2024-01-02')");
+
+        FileStoreTable table = paimonTable("T");
+
+        assertThat(table.snapshotManager().snapshotExists(1)).isFalse();
+
+        Snapshot tagSnapshot1 = table.tagManager().taggedSnapshot("tag1");
+
+        long tagsCommitTime = tagSnapshot1.timeMillis();
+        long tagsWatermark = tagSnapshot1.watermark();
+
+        Snapshot snapshot2 = table.snapshotManager().snapshot(2);
+        long commitTime2 = snapshot2.timeMillis();
+        long watermark2 = snapshot2.watermark();
+
+        assertThat(tagsWatermark == 1000).isTrue();
+        assertThat(watermark2 == 2000).isTrue();
+
+        // create tag from tag1 that snapshot is 1.
+        assertThat(
+                        sql(
+                                        "CALL sys.create_tag_from_watermark("
+                                                + "`table` => 'default.T',"
+                                                + "`tag` => 'tag2',"
+                                                + "`timestamp` => %s)",
+                                        tagsWatermark - 1)
+                                .stream()
+                                .map(Row::toString))
+                .containsExactlyInAnyOrder(
+                        String.format("+I[tag2, 1, %s, %s]", tagsCommitTime, tagsWatermark));
+
+        assertThat(
+                        sql(
+                                        "CALL sys.create_tag_from_watermark("
+                                                + "`table` => 'default.T',"
+                                                + "`tag` => 'tag3',"
+                                                + "`timestamp` => %s)",
+                                        watermark2 - 1)
+                                .stream()
+                                .map(Row::toString))
+                .containsExactlyInAnyOrder(
+                        String.format("+I[tag3, 2, %s, %s]", commitTime2, watermark2));
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CreateTagFromWatermarkProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CreateTagFromWatermarkProcedureITCase.java
@@ -52,7 +52,7 @@ public class CreateTagFromWatermarkProcedureITCase extends CatalogITCaseBase {
                                         "CALL sys.create_tag_from_watermark("
                                                 + "`table` => 'default.T',"
                                                 + "`tag` => 'tag1',"
-                                                + "`timestamp` => %s )",
+                                                + "`watermark` => %s )",
                                         1000))
                 .withRootCauseInstanceOf(SnapshotNotExistException.class)
                 .withMessageContaining(
@@ -86,7 +86,7 @@ public class CreateTagFromWatermarkProcedureITCase extends CatalogITCaseBase {
                                         "CALL sys.create_tag_from_watermark("
                                                 + "`table` => 'default.T',"
                                                 + "`tag` => 'tag2',"
-                                                + "`timestamp` => %s)",
+                                                + "`watermark` => %s)",
                                         watermark2 - 1)
                                 .stream()
                                 .map(Row::toString))
@@ -98,7 +98,7 @@ public class CreateTagFromWatermarkProcedureITCase extends CatalogITCaseBase {
                                         "CALL sys.create_tag_from_watermark("
                                                 + "`table` => 'default.T',"
                                                 + "`tag` => 'tag3',"
-                                                + "`timestamp` => %s)",
+                                                + "`watermark` => %s)",
                                         watermark2 + 1)
                                 .stream()
                                 .map(Row::toString))
@@ -112,7 +112,7 @@ public class CreateTagFromWatermarkProcedureITCase extends CatalogITCaseBase {
                                         "CALL sys.create_tag_from_watermark("
                                                 + "`table` => 'default.T',"
                                                 + "`tag` => 'tag4',"
-                                                + "`timestamp` => %s )",
+                                                + "`watermark` => %s )",
                                         watermark3 + 1))
                 .withRootCauseInstanceOf(SnapshotNotExistException.class)
                 .withMessageContaining(
@@ -165,7 +165,7 @@ public class CreateTagFromWatermarkProcedureITCase extends CatalogITCaseBase {
                                         "CALL sys.create_tag_from_watermark("
                                                 + "`table` => 'default.T',"
                                                 + "`tag` => 'tag2',"
-                                                + "`timestamp` => %s)",
+                                                + "`watermark` => %s)",
                                         tagsWatermark - 1)
                                 .stream()
                                 .map(Row::toString))
@@ -177,7 +177,7 @@ public class CreateTagFromWatermarkProcedureITCase extends CatalogITCaseBase {
                                         "CALL sys.create_tag_from_watermark("
                                                 + "`table` => 'default.T',"
                                                 + "`tag` => 'tag3',"
-                                                + "`timestamp` => %s)",
+                                                + "`watermark` => %s)",
                                         watermark2 - 1)
                                 .stream()
                                 .map(Row::toString))


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked pr:  #4051 

Add procedure to support creating tag from snapshots watermark.

```CALL [catalog.]sys.create_tag_from_watermark('identifier', 'tagName', watermark, time_retained)```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
