### PR TITLE
[flink] Fix partition filter mismatch the column index

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RewriteFileIndexProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RewriteFileIndexProcedure.java
@@ -81,7 +81,9 @@ public class RewriteFileIndexProcedure extends ProcedureBase {
                                             p ->
                                                     PredicateBuilder.partition(
                                                             p,
-                                                            table.rowType(),
+                                                            ((FileStoreTable) table)
+                                                                    .schema()
+                                                                    .logicalPartitionType(),
                                                             CoreOptions.PARTITION_DEFAULT_NAME
                                                                     .defaultValue()))
                                     .toArray(Predicate[]::new));


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close https://github.com/apache/paimon/issues/4004

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
