### PR TITLE
[flink] Fix that cannot create table with empty fallback branch

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatCWriter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatCWriter.java
@@ -37,8 +37,8 @@ public class ArrowFormatCWriter implements AutoCloseable {
     private final ArrowSchema schema;
     private final ArrowFormatWriter realWriter;
 
-    public ArrowFormatCWriter(RowType rowType, int writeBatchSize) {
-        this.realWriter = new ArrowFormatWriter(rowType, writeBatchSize);
+    public ArrowFormatCWriter(RowType rowType, int writeBatchSize, boolean allowUpperCase) {
+        this.realWriter = new ArrowFormatWriter(rowType, writeBatchSize, allowUpperCase);
         RootAllocator allocator = realWriter.getAllocator();
         array = ArrowArray.allocateNew(allocator);
         schema = ArrowSchema.allocateNew(allocator);

--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatWriter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatWriter.java
@@ -39,10 +39,10 @@ public class ArrowFormatWriter implements AutoCloseable {
     private final RootAllocator allocator;
     private int rowId;
 
-    public ArrowFormatWriter(RowType rowType, int writeBatchSize) {
+    public ArrowFormatWriter(RowType rowType, int writeBatchSize, boolean allowUpperCase) {
         allocator = new RootAllocator();
 
-        vectorSchemaRoot = ArrowUtils.createVectorSchemaRoot(rowType, allocator, false);
+        vectorSchemaRoot = ArrowUtils.createVectorSchemaRoot(rowType, allocator, allowUpperCase);
 
         fieldWriters = new ArrowFieldWriter[rowType.getFieldCount()];
 

--- a/paimon-arrow/src/test/java/org/apache/paimon/arrow/vector/ArrowFormatWriterTest.java
+++ b/paimon-arrow/src/test/java/org/apache/paimon/arrow/vector/ArrowFormatWriterTest.java
@@ -84,7 +84,7 @@ public class ArrowFormatWriterTest {
 
     @Test
     public void testWrite() {
-        try (ArrowFormatWriter writer = new ArrowFormatWriter(PRIMITIVE_TYPE, 4096)) {
+        try (ArrowFormatWriter writer = new ArrowFormatWriter(PRIMITIVE_TYPE, 4096, true)) {
             List<InternalRow> list = new ArrayList<>();
             List<InternalRow.FieldGetter> fieldGetters = new ArrayList<>();
 
@@ -118,7 +118,7 @@ public class ArrowFormatWriterTest {
 
     @Test
     public void testReadWithSchemaMessUp() {
-        try (ArrowFormatWriter writer = new ArrowFormatWriter(PRIMITIVE_TYPE, 4096)) {
+        try (ArrowFormatWriter writer = new ArrowFormatWriter(PRIMITIVE_TYPE, 4096, true)) {
             List<InternalRow> list = new ArrayList<>();
             List<InternalRow.FieldGetter> fieldGetters = new ArrayList<>();
 
@@ -160,7 +160,7 @@ public class ArrowFormatWriterTest {
 
     @Test
     public void testArrowBundleRecords() {
-        try (ArrowFormatWriter writer = new ArrowFormatWriter(PRIMITIVE_TYPE, 4096)) {
+        try (ArrowFormatWriter writer = new ArrowFormatWriter(PRIMITIVE_TYPE, 4096, true)) {
             List<InternalRow> list = new ArrayList<>();
             List<InternalRow.FieldGetter> fieldGetters = new ArrayList<>();
 
@@ -192,7 +192,7 @@ public class ArrowFormatWriterTest {
 
     @Test
     public void testCWriter() {
-        try (ArrowFormatCWriter writer = new ArrowFormatCWriter(PRIMITIVE_TYPE, 4096)) {
+        try (ArrowFormatCWriter writer = new ArrowFormatCWriter(PRIMITIVE_TYPE, 4096, true)) {
             List<InternalRow> list = new ArrayList<>();
             List<InternalRow.FieldGetter> fieldGetters = new ArrayList<>();
 

--- a/paimon-arrow/src/test/java/org/apache/paimon/arrow/vector/ArrowFormatWriterTest.java
+++ b/paimon-arrow/src/test/java/org/apache/paimon/arrow/vector/ArrowFormatWriterTest.java
@@ -84,7 +84,7 @@ public class ArrowFormatWriterTest {
 
     @Test
     public void testWrite() {
-        try (ArrowFormatWriter writer = new ArrowFormatWriter(PRIMITIVE_TYPE, 4096, true)) {
+        try (ArrowFormatWriter writer = new ArrowFormatWriter(PRIMITIVE_TYPE, 4096, false)) {
             List<InternalRow> list = new ArrayList<>();
             List<InternalRow.FieldGetter> fieldGetters = new ArrayList<>();
 
@@ -118,7 +118,7 @@ public class ArrowFormatWriterTest {
 
     @Test
     public void testReadWithSchemaMessUp() {
-        try (ArrowFormatWriter writer = new ArrowFormatWriter(PRIMITIVE_TYPE, 4096, true)) {
+        try (ArrowFormatWriter writer = new ArrowFormatWriter(PRIMITIVE_TYPE, 4096, false)) {
             List<InternalRow> list = new ArrayList<>();
             List<InternalRow.FieldGetter> fieldGetters = new ArrayList<>();
 
@@ -160,7 +160,7 @@ public class ArrowFormatWriterTest {
 
     @Test
     public void testArrowBundleRecords() {
-        try (ArrowFormatWriter writer = new ArrowFormatWriter(PRIMITIVE_TYPE, 4096, true)) {
+        try (ArrowFormatWriter writer = new ArrowFormatWriter(PRIMITIVE_TYPE, 4096, false)) {
             List<InternalRow> list = new ArrayList<>();
             List<InternalRow.FieldGetter> fieldGetters = new ArrayList<>();
 
@@ -192,7 +192,7 @@ public class ArrowFormatWriterTest {
 
     @Test
     public void testCWriter() {
-        try (ArrowFormatCWriter writer = new ArrowFormatCWriter(PRIMITIVE_TYPE, 4096, true)) {
+        try (ArrowFormatCWriter writer = new ArrowFormatCWriter(PRIMITIVE_TYPE, 4096, false)) {
             List<InternalRow> list = new ArrayList<>();
             List<InternalRow.FieldGetter> fieldGetters = new ArrayList<>();
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BranchSqlITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BranchSqlITCase.java
@@ -280,6 +280,16 @@ public class BranchSqlITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testEmptyFallbackBranch() throws Exception {
+        sql("CREATE TABLE t (a INT, v STRING)");
+        sql("INSERT INTO t VALUES (1, 'apple'), (2, 'banana')");
+        sql("ALTER TABLE t SET ( 'scan.fallback-branch' = 'empty_branch' )");
+
+        assertThat(collectResult("SELECT * FROM t"))
+                .containsExactlyInAnyOrder("+I[1, apple]", "+I[2, banana]");
+    }
+
+    @Test
     public void testFallbackBranchBatchRead() throws Exception {
         sql(
                 "CREATE TABLE t ( pt INT NOT NULL, k INT NOT NULL, v STRING ) PARTITIONED BY (pt) WITH ( 'bucket' = '-1' )");


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The problem is in method `FileStoreTable#create`, if options contain `scan.fallback-branch` and the branch is empty, get schema from `SchemaManager` will get noting.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
