### PR TITLE
[spark] Support v2 write with overwrite

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkFilterConverter.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkFilterConverter.java
@@ -166,6 +166,11 @@ public class SparkFilterConverter {
         return convertLiteral(fieldIndex(field), value);
     }
 
+    public String convertString(String field, Object value) {
+        Object literal = convertLiteral(field, value);
+        return literal == null ? null : literal.toString();
+    }
+
     private int fieldIndex(String field) {
         int index = rowType.getFieldIndex(field);
         // TODO: support nested field

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkWriteBuilder.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkWriteBuilder.scala
@@ -21,18 +21,70 @@ package org.apache.paimon.spark
 import org.apache.paimon.options.Options
 import org.apache.paimon.table.FileStoreTable
 
+import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.connector.write.{SupportsOverwrite, WriteBuilder}
-import org.apache.spark.sql.sources.{And, Filter}
+import org.apache.spark.sql.sources.{AlwaysFalse, AlwaysTrue, And, EqualNullSafe, EqualTo, Filter, Not, Or}
+
+import scala.collection.JavaConverters._
 
 private class SparkWriteBuilder(table: FileStoreTable, options: Options)
   extends WriteBuilder
-  with SupportsOverwrite {
+  with SupportsOverwrite
+  with SQLConfHelper {
 
   private var saveMode: SaveMode = InsertInto
 
   override def build = new SparkWrite(table, saveMode, options)
 
+  private def failWithReason(filter: Filter): Unit = {
+    throw new RuntimeException(
+      s"Only support Overwrite filters with Equal and EqualNullSafe, but got: $filter")
+  }
+
+  private def validateFilter(filter: Filter): Unit = filter match {
+    case And(left, right) =>
+      validateFilter(left)
+      validateFilter(right)
+    case _: Or => failWithReason(filter)
+    case _: Not => failWithReason(filter)
+    case e: EqualTo if e.references.length == 1 && !e.value.isInstanceOf[Filter] =>
+    case e: EqualNullSafe if e.references.length == 1 && !e.value.isInstanceOf[Filter] =>
+    case _: AlwaysTrue | _: AlwaysFalse =>
+    case _ => failWithReason(filter)
+  }
+
+  // `SupportsOverwrite#canOverwrite` is added since Spark 3.4.0.
+  // We do this checking by self to work with previous Spark version.
+  private def failIfCanNotOverwrite(filters: Array[Filter]): Unit = {
+    // For now, we only support overwrite with two cases:
+    // - overwrite with partition columns to be compatible with v1 insert overwrite
+    //   See [[org.apache.spark.sql.catalyst.analysis.Analyzer.ResolveInsertInto#staticDeleteExpression]].
+    // - truncate-like overwrite and the filter is always true.
+    //
+    // Fast fail for other custom filters which through v2 write interface, e.g.,
+    // `dataframe.writeTo(T).overwrite(...)`
+    val partitionRowType = table.schema.logicalPartitionType()
+    val partitionNames = partitionRowType.getFieldNames.asScala
+    val allReferences = filters.flatMap(_.references)
+    val containsDataColumn = allReferences.exists {
+      reference => !partitionNames.exists(conf.resolver.apply(reference, _))
+    }
+    if (containsDataColumn) {
+      throw new RuntimeException(
+        s"Only support Overwrite filters on partition column ${partitionNames.mkString(
+            ", ")}, but got ${filters.mkString(", ")}.")
+    }
+    if (allReferences.distinct.length < allReferences.length) {
+      // fail with `part = 1 and part = 2`
+      throw new RuntimeException(
+        s"Only support Overwrite with one filter for each partition column, but got ${filters.mkString(", ")}.")
+    }
+    filters.foreach(validateFilter)
+  }
+
   override def overwrite(filters: Array[Filter]): WriteBuilder = {
+    failIfCanNotOverwrite(filters)
+
     val conjunctiveFilters = if (filters.nonEmpty) {
       Some(filters.reduce((l, r) => And(l, r)))
     } else {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonAnalysis.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonAnalysis.scala
@@ -122,8 +122,7 @@ class PaimonAnalysis(session: SparkSession) extends Rule[LogicalPlan] {
         .mkString(", ")
       // There are seme unknown column names
       throw new RuntimeException(
-        s"Cannot write incompatible data for the table `${table.name}`, due to unknown column names: ${extraCols
-            .mkString(", ")}.")
+        s"Cannot write incompatible data for the table `${table.name}`, due to unknown column names: $extraCols.")
     }
     Project(reorderedCols, query)
   }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/WriteIntoPaimonTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/WriteIntoPaimonTable.scala
@@ -76,7 +76,7 @@ case class WriteIntoPaimonTable(
         } else if (isTruncate(filter.get)) {
           Map.empty[String, String]
         } else {
-          convertFilterToMap(filter.get, table.schema.logicalPartitionType())
+          convertPartitionFilterToMap(filter.get, table.schema.logicalPartitionType())
         }
       case DynamicOverWrite =>
         dynamicPartitionOverwriteMode = true


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This pr supports v2 write with overwrite, e.g.:

```sql
spark.range(2).writeTo("t").overwrite(col("id") === 'b')
```

Before this pr, it would throw: `Only EqualNullSafe should be used when run INSERT OVERWRITE`

This pr only support overwrite on partition column with `Equal` and `EqualNullSafe` to be compatible with v1 write overwrite.


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
add test

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
