### PR TITLE
[spark] Spark package should exclude zstd-jni

### DIFF
--- a/paimon-spark/paimon-spark-3.1/pom.xml
+++ b/paimon-spark/paimon-spark-3.1/pom.xml
@@ -232,6 +232,7 @@ under the License.
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <!-- Do no exclude zstd-jni since Spark3.1 depends on 1.4.8 which is not compatible with Paimon's -->
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>org.apache.paimon:paimon-spark-common</include>

--- a/paimon-spark/paimon-spark-3.2/pom.xml
+++ b/paimon-spark/paimon-spark-3.2/pom.xml
@@ -294,6 +294,14 @@ under the License.
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*</artifact>
+                                    <excludes>
+                                        <exclude>com/github/luben/zstd/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>org.apache.paimon:paimon-spark-common</include>

--- a/paimon-spark/paimon-spark-3.3/pom.xml
+++ b/paimon-spark/paimon-spark-3.3/pom.xml
@@ -289,6 +289,14 @@ under the License.
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*</artifact>
+                                    <excludes>
+                                        <exclude>com/github/luben/zstd/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>org.apache.paimon:paimon-spark-common</include>

--- a/paimon-spark/paimon-spark-3.4/pom.xml
+++ b/paimon-spark/paimon-spark-3.4/pom.xml
@@ -289,6 +289,14 @@ under the License.
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*</artifact>
+                                    <excludes>
+                                        <exclude>com/github/luben/zstd/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>org.apache.paimon:paimon-spark-common</include>

--- a/paimon-spark/paimon-spark-3.5/pom.xml
+++ b/paimon-spark/paimon-spark-3.5/pom.xml
@@ -281,6 +281,14 @@ under the License.
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*</artifact>
+                                    <excludes>
+                                        <exclude>com/github/luben/zstd/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>org.apache.paimon:paimon-spark-common</include>

--- a/paimon-spark/paimon-spark-common/pom.xml
+++ b/paimon-spark/paimon-spark-common/pom.xml
@@ -312,6 +312,14 @@ under the License.
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>org.apache.paimon:paimon-bundle</artifact>
+                                    <excludes>
+                                        <exclude>com/github/luben/zstd/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>org.apache.paimon:paimon-bundle</include>

--- a/paimon-spark/paimon-spark-common/pom.xml
+++ b/paimon-spark/paimon-spark-common/pom.xml
@@ -312,14 +312,6 @@ under the License.
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <filters>
-                                <filter>
-                                    <artifact>org.apache.paimon:paimon-bundle</artifact>
-                                    <excludes>
-                                        <exclude>com/github/luben/zstd/**</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>org.apache.paimon:paimon-bundle</include>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Different Spark branch uses different zstd-jni version, so it's better to use Spark's zstd-jni to avoid conflict. The reason why Paimon includes zstd-jni is: Flink uses airlift to support zstd so Flink distribution does not include zstd-jni.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
manually test, after this pr did not include `com/github/luben/zstd`
![image](https://github.com/user-attachments/assets/1bfe606c-46fc-49c5-99d9-7662e4ed5255)


### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
