### PR TITLE
[WIP][core] cut StoreSinkWriteState when write unaware bucket table

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperator.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperator.java
@@ -27,7 +27,7 @@ import org.apache.paimon.flink.sink.PrepareCommitOperator;
 import org.apache.paimon.flink.sink.StateUtils;
 import org.apache.paimon.flink.sink.StoreSinkWrite;
 import org.apache.paimon.flink.sink.StoreSinkWriteImpl;
-import org.apache.paimon.flink.sink.StoreSinkWriteState;
+import org.apache.paimon.flink.sink.StoreSinkWriteWithUnionListState;
 import org.apache.paimon.memory.HeapMemorySegmentPool;
 import org.apache.paimon.memory.MemoryPoolFactory;
 import org.apache.paimon.options.Options;
@@ -68,7 +68,7 @@ public class CdcRecordStoreMultiWriteOperator
     private MemoryPoolFactory memoryPoolFactory;
     private Catalog catalog;
     private Map<Identifier, FileStoreTable> tables;
-    private StoreSinkWriteState state;
+    private StoreSinkWriteWithUnionListState state;
     private Map<Identifier, StoreSinkWrite> writes;
     private String commitUser;
     private ExecutorService compactExecutor;
@@ -98,7 +98,9 @@ public class CdcRecordStoreMultiWriteOperator
                         context, "commit_user_state", String.class, initialCommitUser);
 
         // TODO: should use CdcRecordMultiChannelComputer to filter
-        state = new StoreSinkWriteState(context, (tableName, partition, bucket) -> true);
+        state =
+                new StoreSinkWriteWithUnionListState(
+                        context, (tableName, partition, bucket) -> true);
         tables = new HashMap<>();
         writes = new HashMap<>();
         compactExecutor =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AbstractRowDataStoreWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AbstractRowDataStoreWriteOperator.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.flink.log.LogWriteCallback;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.SinkRecord;
+
+import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.api.common.functions.util.FunctionUtils;
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.streaming.util.functions.StreamingFunctionUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A abstract {@link PrepareCommitOperator} to write {@link InternalRow}. Record schema is fixed.
+ */
+public abstract class AbstractRowDataStoreWriteOperator extends TableWriteOperator<InternalRow> {
+
+    private static final long serialVersionUID = 3L;
+
+    @Nullable private final LogSinkFunction logSinkFunction;
+    private transient SimpleContext sinkContext;
+    @Nullable private transient LogWriteCallback logCallback;
+
+    /** We listen to this ourselves because we don't have an {@link InternalTimerService}. */
+    private long currentWatermark = Long.MIN_VALUE;
+
+    public AbstractRowDataStoreWriteOperator(
+            FileStoreTable table,
+            @Nullable LogSinkFunction logSinkFunction,
+            StoreSinkWrite.Provider storeSinkWriteProvider,
+            String initialCommitUser) {
+        super(table, storeSinkWriteProvider, initialCommitUser);
+        this.logSinkFunction = logSinkFunction;
+    }
+
+    @Override
+    public void setup(
+            StreamTask<?, ?> containingTask,
+            StreamConfig config,
+            Output<StreamRecord<Committable>> output) {
+        super.setup(containingTask, config, output);
+        if (logSinkFunction != null) {
+            FunctionUtils.setFunctionRuntimeContext(logSinkFunction, getRuntimeContext());
+        }
+    }
+
+    @Override
+    public void initializeState(StateInitializationContext context) throws Exception {
+        super.initializeState(context);
+
+        if (logSinkFunction != null) {
+            StreamingFunctionUtils.restoreFunctionState(context, logSinkFunction);
+        }
+
+        initStateAndWriter(
+                context,
+                stateFilter,
+                getContainingTask().getEnvironment().getIOManager(),
+                commitUser);
+    }
+
+    @Override
+    protected boolean containLogSystem() {
+        return logSinkFunction != null;
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+
+        this.sinkContext = new SimpleContext(getProcessingTimeService());
+        if (logSinkFunction != null) {
+            // to stay compatible with Flink 1.18-
+            if (logSinkFunction instanceof RichFunction) {
+                RichFunction richFunction = (RichFunction) logSinkFunction;
+                richFunction.open(new Configuration());
+            }
+
+            logCallback = new LogWriteCallback();
+            logSinkFunction.setWriteCallback(logCallback);
+        }
+    }
+
+    @Override
+    public void processWatermark(Watermark mark) throws Exception {
+        super.processWatermark(mark);
+
+        this.currentWatermark = mark.getTimestamp();
+        if (logSinkFunction != null) {
+            logSinkFunction.writeWatermark(
+                    new org.apache.flink.api.common.eventtime.Watermark(mark.getTimestamp()));
+        }
+    }
+
+    @Override
+    public void processElement(StreamRecord<InternalRow> element) throws Exception {
+        sinkContext.timestamp = element.hasTimestamp() ? element.getTimestamp() : null;
+
+        SinkRecord record;
+        try {
+            record = write.write(element.getValue());
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+
+        if (record != null && logSinkFunction != null) {
+            // write to log store, need to preserve original pk (which includes partition fields)
+            SinkRecord logRecord = write.toLogRecord(record);
+            logSinkFunction.invoke(logRecord, sinkContext);
+        }
+    }
+
+    @Override
+    public void snapshotState(StateSnapshotContext context) throws Exception {
+        super.snapshotState(context);
+
+        if (logSinkFunction != null) {
+            StreamingFunctionUtils.snapshotFunctionState(
+                    context, getOperatorStateBackend(), logSinkFunction);
+        }
+    }
+
+    @Override
+    public void finish() throws Exception {
+        super.finish();
+
+        if (logSinkFunction != null) {
+            logSinkFunction.finish();
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+
+        if (logSinkFunction != null) {
+            FunctionUtils.closeFunction(logSinkFunction);
+        }
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        super.notifyCheckpointComplete(checkpointId);
+
+        if (logSinkFunction instanceof CheckpointListener) {
+            ((CheckpointListener) logSinkFunction).notifyCheckpointComplete(checkpointId);
+        }
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) throws Exception {
+        super.notifyCheckpointAborted(checkpointId);
+
+        if (logSinkFunction instanceof CheckpointListener) {
+            ((CheckpointListener) logSinkFunction).notifyCheckpointAborted(checkpointId);
+        }
+    }
+
+    @Override
+    protected List<Committable> prepareCommit(boolean waitCompaction, long checkpointId)
+            throws IOException {
+        List<Committable> committables = super.prepareCommit(waitCompaction, checkpointId);
+
+        if (logCallback != null) {
+            try {
+                Objects.requireNonNull(logSinkFunction).flush();
+            } catch (Exception e) {
+                throw new IOException(e);
+            }
+            logCallback
+                    .offsets()
+                    .forEach(
+                            (k, v) ->
+                                    committables.add(
+                                            new Committable(
+                                                    checkpointId,
+                                                    Committable.Kind.LOG_OFFSET,
+                                                    new LogOffsetCommittable(k, v))));
+        }
+
+        return committables;
+    }
+
+    private class SimpleContext implements SinkFunction.Context {
+
+        @Nullable private Long timestamp;
+
+        private final ProcessingTimeService processingTimeService;
+
+        public SimpleContext(ProcessingTimeService processingTimeService) {
+            this.processingTimeService = processingTimeService;
+        }
+
+        @Override
+        public long currentProcessingTime() {
+            return processingTimeService.getCurrentProcessingTime();
+        }
+
+        @Override
+        public long currentWatermark() {
+            return currentWatermark;
+        }
+
+        @Override
+        public Long timestamp() {
+            return timestamp;
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AsyncLookupSinkWrite.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AsyncLookupSinkWrite.java
@@ -62,9 +62,7 @@ public class AsyncLookupSinkWrite extends StoreSinkWriteImpl {
                 isStreaming,
                 memoryPool,
                 metricGroup);
-
         this.tableName = table.name();
-
         List<StoreSinkWriteState.StateValue> activeBucketsStateValues =
                 state.get(tableName, ACTIVE_BUCKETS_STATE_NAME);
         if (activeBucketsStateValues != null) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/GlobalFullCompactionSinkWrite.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/GlobalFullCompactionSinkWrite.java
@@ -55,7 +55,6 @@ public class GlobalFullCompactionSinkWrite extends StoreSinkWriteImpl {
     private static final Logger LOG = LoggerFactory.getLogger(GlobalFullCompactionSinkWrite.class);
 
     private final int deltaCommits;
-
     private final String tableName;
     private final SnapshotManager snapshotManager;
 
@@ -86,9 +85,7 @@ public class GlobalFullCompactionSinkWrite extends StoreSinkWriteImpl {
                 isStreaming,
                 memoryPool,
                 metricGroup);
-
         this.deltaCommits = deltaCommits;
-
         this.tableName = table.name();
         this.snapshotManager = table.snapshotManager();
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
@@ -103,7 +103,7 @@ public class MultiTablesStoreCompactOperator
                         context, "commit_user_state", String.class, initialCommitUser);
 
         state =
-                new StoreSinkWriteState(
+                new StoreSinkWriteWithUnionListState(
                         context,
                         (tableName, partition, bucket) ->
                                 ChannelComputer.select(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataStoreUnawareBucketWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataStoreUnawareBucketWriteOperator.java
@@ -16,27 +16,25 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.flink.sink.cdc;
+package org.apache.paimon.flink.sink;
 
-import org.apache.paimon.flink.sink.PrepareCommitOperator;
-import org.apache.paimon.flink.sink.StateValueFilter;
-import org.apache.paimon.flink.sink.StoreSinkWrite;
-import org.apache.paimon.flink.sink.StoreSinkWriteState;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.types.RowKind;
 
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.state.StateInitializationContext;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
-/** A {@link PrepareCommitOperator} to write {@link CdcRecord} to unaware-bucket mode table. */
-public class CdcUnawareBucketWriteOperator extends AbstractCdcRecordStoreWriteOperator {
+import javax.annotation.Nullable;
 
-    public CdcUnawareBucketWriteOperator(
+/** A {@link PrepareCommitOperator} to write {@link InternalRow}. Record schema is fixed. */
+public class RowDataStoreUnawareBucketWriteOperator extends AbstractRowDataStoreWriteOperator {
+
+    public RowDataStoreUnawareBucketWriteOperator(
             FileStoreTable table,
+            @Nullable LogSinkFunction logSinkFunction,
             StoreSinkWrite.Provider storeSinkWriteProvider,
             String initialCommitUser) {
-        super(table, storeSinkWriteProvider, initialCommitUser);
+        super(table, logSinkFunction, storeSinkWriteProvider, initialCommitUser);
     }
 
     @Override
@@ -54,13 +52,5 @@ public class CdcUnawareBucketWriteOperator extends AbstractCdcRecordStoreWriteOp
                         ioManager,
                         memoryPool,
                         getMetricGroup());
-    }
-
-    @Override
-    public void processElement(StreamRecord<CdcRecord> element) throws Exception {
-        // only accepts INSERT record
-        if (element.getValue().kind() == RowKind.INSERT) {
-            super.processElement(element);
-        }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataStoreWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataStoreWriteOperator.java
@@ -19,218 +19,48 @@
 package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.flink.log.LogWriteCallback;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.table.sink.SinkRecord;
 
-import org.apache.flink.api.common.functions.RichFunction;
-import org.apache.flink.api.common.functions.util.FunctionUtils;
-import org.apache.flink.api.common.state.CheckpointListener;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
-import org.apache.flink.streaming.api.functions.sink.SinkFunction;
-import org.apache.flink.streaming.api.graph.StreamConfig;
-import org.apache.flink.streaming.api.operators.InternalTimerService;
-import org.apache.flink.streaming.api.operators.Output;
-import org.apache.flink.streaming.api.watermark.Watermark;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
-import org.apache.flink.streaming.runtime.tasks.StreamTask;
-import org.apache.flink.streaming.util.functions.StreamingFunctionUtils;
 
 import javax.annotation.Nullable;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Objects;
-
-/** A {@link PrepareCommitOperator} to write {@link InternalRow}. Record schema is fixed. */
-public class RowDataStoreWriteOperator extends TableWriteOperator<InternalRow> {
+/**
+ * A {@link PrepareCommitOperator} to write {@link InternalRow} with StoreSinkWriteState. Record
+ * schema is fixed.
+ */
+public class RowDataStoreWriteOperator extends AbstractRowDataStoreWriteOperator {
 
     private static final long serialVersionUID = 3L;
 
-    @Nullable private final LogSinkFunction logSinkFunction;
-    private transient SimpleContext sinkContext;
-    @Nullable private transient LogWriteCallback logCallback;
-
-    /** We listen to this ourselves because we don't have an {@link InternalTimerService}. */
-    private long currentWatermark = Long.MIN_VALUE;
+    private transient StoreSinkWriteState state;
 
     public RowDataStoreWriteOperator(
             FileStoreTable table,
             @Nullable LogSinkFunction logSinkFunction,
             StoreSinkWrite.Provider storeSinkWriteProvider,
             String initialCommitUser) {
-        super(table, storeSinkWriteProvider, initialCommitUser);
-        this.logSinkFunction = logSinkFunction;
+        super(table, logSinkFunction, storeSinkWriteProvider, initialCommitUser);
     }
 
     @Override
-    public void setup(
-            StreamTask<?, ?> containingTask,
-            StreamConfig config,
-            Output<StreamRecord<Committable>> output) {
-        super.setup(containingTask, config, output);
-        if (logSinkFunction != null) {
-            FunctionUtils.setFunctionRuntimeContext(logSinkFunction, getRuntimeContext());
-        }
-    }
-
-    @Override
-    public void initializeState(StateInitializationContext context) throws Exception {
-        super.initializeState(context);
-
-        if (logSinkFunction != null) {
-            StreamingFunctionUtils.restoreFunctionState(context, logSinkFunction);
-        }
-    }
-
-    @Override
-    protected boolean containLogSystem() {
-        return logSinkFunction != null;
-    }
-
-    @Override
-    public void open() throws Exception {
-        super.open();
-
-        this.sinkContext = new SimpleContext(getProcessingTimeService());
-        if (logSinkFunction != null) {
-            // to stay compatible with Flink 1.18-
-            if (logSinkFunction instanceof RichFunction) {
-                RichFunction richFunction = (RichFunction) logSinkFunction;
-                richFunction.open(new Configuration());
-            }
-
-            logCallback = new LogWriteCallback();
-            logSinkFunction.setWriteCallback(logCallback);
-        }
-    }
-
-    @Override
-    public void processWatermark(Watermark mark) throws Exception {
-        super.processWatermark(mark);
-
-        this.currentWatermark = mark.getTimestamp();
-        if (logSinkFunction != null) {
-            logSinkFunction.writeWatermark(
-                    new org.apache.flink.api.common.eventtime.Watermark(mark.getTimestamp()));
-        }
-    }
-
-    @Override
-    public void processElement(StreamRecord<InternalRow> element) throws Exception {
-        sinkContext.timestamp = element.hasTimestamp() ? element.getTimestamp() : null;
-
-        SinkRecord record;
-        try {
-            record = write.write(element.getValue());
-        } catch (Exception e) {
-            throw new IOException(e);
-        }
-
-        if (record != null && logSinkFunction != null) {
-            // write to log store, need to preserve original pk (which includes partition fields)
-            SinkRecord logRecord = write.toLogRecord(record);
-            logSinkFunction.invoke(logRecord, sinkContext);
-        }
+    protected void initStateAndWriter(
+            StateInitializationContext context,
+            StateValueFilter stateFilter,
+            IOManager ioManager,
+            String commitUser)
+            throws Exception {
+        state = new StoreSinkWriteWithUnionListState(context, stateFilter);
+        write =
+                storeSinkWriteProvider.provide(
+                        table, commitUser, state, ioManager, memoryPool, getMetricGroup());
     }
 
     @Override
     public void snapshotState(StateSnapshotContext context) throws Exception {
         super.snapshotState(context);
-
-        if (logSinkFunction != null) {
-            StreamingFunctionUtils.snapshotFunctionState(
-                    context, getOperatorStateBackend(), logSinkFunction);
-        }
-    }
-
-    @Override
-    public void finish() throws Exception {
-        super.finish();
-
-        if (logSinkFunction != null) {
-            logSinkFunction.finish();
-        }
-    }
-
-    @Override
-    public void close() throws Exception {
-        super.close();
-
-        if (logSinkFunction != null) {
-            FunctionUtils.closeFunction(logSinkFunction);
-        }
-    }
-
-    @Override
-    public void notifyCheckpointComplete(long checkpointId) throws Exception {
-        super.notifyCheckpointComplete(checkpointId);
-
-        if (logSinkFunction instanceof CheckpointListener) {
-            ((CheckpointListener) logSinkFunction).notifyCheckpointComplete(checkpointId);
-        }
-    }
-
-    @Override
-    public void notifyCheckpointAborted(long checkpointId) throws Exception {
-        super.notifyCheckpointAborted(checkpointId);
-
-        if (logSinkFunction instanceof CheckpointListener) {
-            ((CheckpointListener) logSinkFunction).notifyCheckpointAborted(checkpointId);
-        }
-    }
-
-    @Override
-    protected List<Committable> prepareCommit(boolean waitCompaction, long checkpointId)
-            throws IOException {
-        List<Committable> committables = super.prepareCommit(waitCompaction, checkpointId);
-
-        if (logCallback != null) {
-            try {
-                Objects.requireNonNull(logSinkFunction).flush();
-            } catch (Exception e) {
-                throw new IOException(e);
-            }
-            logCallback
-                    .offsets()
-                    .forEach(
-                            (k, v) ->
-                                    committables.add(
-                                            new Committable(
-                                                    checkpointId,
-                                                    Committable.Kind.LOG_OFFSET,
-                                                    new LogOffsetCommittable(k, v))));
-        }
-
-        return committables;
-    }
-
-    private class SimpleContext implements SinkFunction.Context {
-
-        @Nullable private Long timestamp;
-
-        private final ProcessingTimeService processingTimeService;
-
-        public SimpleContext(ProcessingTimeService processingTimeService) {
-            this.processingTimeService = processingTimeService;
-        }
-
-        @Override
-        public long currentProcessingTime() {
-            return processingTimeService.getCurrentProcessingTime();
-        }
-
-        @Override
-        public long currentWatermark() {
-            return currentWatermark;
-        }
-
-        @Override
-        public Long timestamp() {
-            return timestamp;
-        }
+        state.snapshotState();
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowUnawareBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowUnawareBucketSink.java
@@ -39,6 +39,7 @@ public class RowUnawareBucketSink extends UnawareBucketSink<InternalRow> {
     @Override
     protected OneInputStreamOperator<InternalRow, Committable> createWriteOperator(
             StoreSinkWrite.Provider writeProvider, String commitUser) {
-        return new RowDataStoreWriteOperator(table, logSinkFunction, writeProvider, commitUser);
+        return new RowDataStoreUnawareBucketWriteOperator(
+                table, logSinkFunction, writeProvider, commitUser);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StateValueFilter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StateValueFilter.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.data.BinaryRow;
+
+/**
+ * Given the table name, partition and bucket of a {@link StoreSinkWriteState.StateValue} in a union
+ * list state, decide whether to keep this {@link StoreSinkWriteState.StateValue} in this subtask.
+ */
+public interface StateValueFilter {
+
+    boolean filter(String tableName, BinaryRow partition, int bucket);
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCompactOperator.java
@@ -99,13 +99,13 @@ public class StoreCompactOperator extends PrepareCommitOperator<RowData, Committ
     @VisibleForTesting
     void initStateAndWriter(
             StateInitializationContext context,
-            StoreSinkWriteState.StateValueFilter stateFilter,
+            StateValueFilter stateFilter,
             IOManager ioManager,
             String commitUser)
             throws Exception {
         // We put state and write init in this method for convenient testing. Without construct a
         // runtime context, we can test to construct a writer here
-        state = new StoreSinkWriteState(context, stateFilter);
+        state = new StoreSinkWriteWithUnionListState(context, stateFilter);
 
         write =
                 storeSinkWriteProvider.provide(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteState.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteState.java
@@ -19,24 +19,9 @@
 package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.utils.SerializationUtils;
 
-import org.apache.flink.api.common.state.ListState;
-import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.base.IntSerializer;
-import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
-import org.apache.flink.api.java.tuple.Tuple5;
-import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
-import org.apache.flink.runtime.state.StateInitializationContext;
-
-import javax.annotation.Nullable;
-
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 /**
  * States for {@link StoreSinkWrite}s.
@@ -46,74 +31,24 @@ import java.util.Map;
  */
 public class StoreSinkWriteState {
 
-    private final StateValueFilter stateValueFilter;
-
-    private final ListState<Tuple5<String, String, byte[], Integer, byte[]>> listState;
-    private final Map<String, Map<String, List<StateValue>>> map;
+    protected final StateValueFilter stateValueFilter;
 
     @SuppressWarnings("unchecked")
-    public StoreSinkWriteState(
-            StateInitializationContext context, StateValueFilter stateValueFilter)
-            throws Exception {
+    public StoreSinkWriteState(StateValueFilter stateValueFilter) throws Exception {
         this.stateValueFilter = stateValueFilter;
-        TupleSerializer<Tuple5<String, String, byte[], Integer, byte[]>> listStateSerializer =
-                new TupleSerializer<>(
-                        (Class<Tuple5<String, String, byte[], Integer, byte[]>>)
-                                (Class<?>) Tuple5.class,
-                        new TypeSerializer[] {
-                            StringSerializer.INSTANCE,
-                            StringSerializer.INSTANCE,
-                            BytePrimitiveArraySerializer.INSTANCE,
-                            IntSerializer.INSTANCE,
-                            BytePrimitiveArraySerializer.INSTANCE
-                        });
-        listState =
-                context.getOperatorStateStore()
-                        .getUnionListState(
-                                new ListStateDescriptor<>(
-                                        "paimon_store_sink_write_state", listStateSerializer));
-
-        map = new HashMap<>();
-        for (Tuple5<String, String, byte[], Integer, byte[]> tuple : listState.get()) {
-            BinaryRow partition = SerializationUtils.deserializeBinaryRow(tuple.f2);
-            if (stateValueFilter.filter(tuple.f0, partition, tuple.f3)) {
-                map.computeIfAbsent(tuple.f0, k -> new HashMap<>())
-                        .computeIfAbsent(tuple.f1, k -> new ArrayList<>())
-                        .add(new StateValue(partition, tuple.f3, tuple.f4));
-            }
-        }
     }
 
     public StateValueFilter stateValueFilter() {
         return stateValueFilter;
     }
 
-    public @Nullable List<StateValue> get(String tableName, String key) {
-        Map<String, List<StateValue>> innerMap = map.get(tableName);
-        return innerMap == null ? null : innerMap.get(key);
+    List<StateValue> get(String tableName, String key) {
+        return Collections.emptyList();
     }
 
-    public void put(String tableName, String key, List<StateValue> stateValues) {
-        map.computeIfAbsent(tableName, k -> new HashMap<>()).put(key, stateValues);
-    }
+    void put(String tableName, String key, List<StoreSinkWriteState.StateValue> stateValues) {}
 
-    public void snapshotState() throws Exception {
-        List<Tuple5<String, String, byte[], Integer, byte[]>> list = new ArrayList<>();
-        for (Map.Entry<String, Map<String, List<StateValue>>> tables : map.entrySet()) {
-            for (Map.Entry<String, List<StateValue>> entry : tables.getValue().entrySet()) {
-                for (StateValue stateValue : entry.getValue()) {
-                    list.add(
-                            Tuple5.of(
-                                    tables.getKey(),
-                                    entry.getKey(),
-                                    SerializationUtils.serializeBinaryRow(stateValue.partition()),
-                                    stateValue.bucket(),
-                                    stateValue.value()));
-                }
-            }
-        }
-        listState.update(list);
-    }
+    void snapshotState() throws Exception {}
 
     /**
      * A state value for {@link StoreSinkWrite}. All state values should be given a partition and a
@@ -142,14 +77,5 @@ public class StoreSinkWriteState {
         public byte[] value() {
             return value;
         }
-    }
-
-    /**
-     * Given the table name, partition and bucket of a {@link StateValue} in a union list state,
-     * decide whether to keep this {@link StateValue} in this subtask.
-     */
-    public interface StateValueFilter {
-
-        boolean filter(String tableName, BinaryRow partition, int bucket);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteWithUnionListState.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteWithUnionListState.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.utils.SerializationUtils;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
+import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
+import org.apache.flink.runtime.state.StateInitializationContext;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * States for {@link StoreSinkWrite}s.
+ *
+ * <p>States are positioned first by table name and then by key name. This class should be initiated
+ * in a sink operator and then given to {@link StoreSinkWrite}.
+ */
+public class StoreSinkWriteWithUnionListState extends StoreSinkWriteState {
+
+    private final ListState<Tuple5<String, String, byte[], Integer, byte[]>> listState;
+    private final Map<String, Map<String, List<StateValue>>> map;
+
+    @SuppressWarnings("unchecked")
+    public StoreSinkWriteWithUnionListState(
+            StateInitializationContext context, StateValueFilter stateValueFilter)
+            throws Exception {
+        super(stateValueFilter);
+        TupleSerializer<Tuple5<String, String, byte[], Integer, byte[]>> listStateSerializer =
+                new TupleSerializer<>(
+                        (Class<Tuple5<String, String, byte[], Integer, byte[]>>)
+                                (Class<?>) Tuple5.class,
+                        new TypeSerializer[] {
+                            StringSerializer.INSTANCE,
+                            StringSerializer.INSTANCE,
+                            BytePrimitiveArraySerializer.INSTANCE,
+                            IntSerializer.INSTANCE,
+                            BytePrimitiveArraySerializer.INSTANCE
+                        });
+        listState =
+                context.getOperatorStateStore()
+                        .getUnionListState(
+                                new ListStateDescriptor<>(
+                                        "paimon_store_sink_write_state", listStateSerializer));
+
+        map = new HashMap<>();
+        for (Tuple5<String, String, byte[], Integer, byte[]> tuple : listState.get()) {
+            BinaryRow partition = SerializationUtils.deserializeBinaryRow(tuple.f2);
+            if (stateValueFilter.filter(tuple.f0, partition, tuple.f3)) {
+                map.computeIfAbsent(tuple.f0, k -> new HashMap<>())
+                        .computeIfAbsent(tuple.f1, k -> new ArrayList<>())
+                        .add(new StateValue(partition, tuple.f3, tuple.f4));
+            }
+        }
+    }
+
+    @Override
+    public @Nullable List<StateValue> get(String tableName, String key) {
+        Map<String, List<StateValue>> innerMap = map.get(tableName);
+        return innerMap == null ? null : innerMap.get(key);
+    }
+
+    @Override
+    public void put(String tableName, String key, List<StateValue> stateValues) {
+        map.computeIfAbsent(tableName, k -> new HashMap<>()).put(key, stateValues);
+    }
+
+    @Override
+    public void snapshotState() throws Exception {
+        List<Tuple5<String, String, byte[], Integer, byte[]>> list = new ArrayList<>();
+        for (Map.Entry<String, Map<String, List<StateValue>>> tables : map.entrySet()) {
+            for (Map.Entry<String, List<StateValue>> entry : tables.getValue().entrySet()) {
+                for (StateValue stateValue : entry.getValue()) {
+                    list.add(
+                            Tuple5.of(
+                                    tables.getKey(),
+                                    entry.getKey(),
+                                    SerializationUtils.serializeBinaryRow(stateValue.partition()),
+                                    stateValue.bucket(),
+                                    stateValue.value()));
+                }
+            }
+        }
+        listState.update(list);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreCompactOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreCompactOperatorTest.java
@@ -52,7 +52,7 @@ public class StoreCompactOperatorTest extends TableTestBase {
                 new CompactRememberStoreWrite(streamingMode);
         StoreCompactOperator storeCompactOperator =
                 new StoreCompactOperator(
-                        (FileStoreTable) getTableDefault(),
+                        getTableDefault(),
                         (table, commitUser, state, ioManager, memoryPool, metricGroup) ->
                                 compactRememberStoreWrite,
                         "10086");

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/WriterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/WriterOperatorTest.java
@@ -339,17 +339,17 @@ public class WriterOperatorTest {
                         options);
         TableCommitImpl commit = fileStoreTable.newCommit(commitUser);
 
-        RowDataStoreWriteOperator rowDataStoreWriteOperator =
+        RowDataStoreWriteOperator rowDataStoreWriteOperatorWithState =
                 getStoreSinkWriteOperator(fileStoreTable);
         OneInputStreamOperatorTestHarness<InternalRow, Committable> harness =
-                createHarness(rowDataStoreWriteOperator);
+                createHarness(rowDataStoreWriteOperatorWithState);
 
         TypeSerializer<Committable> serializer =
                 new CommittableTypeInfo().createSerializer(new ExecutionConfig());
         harness.setup(serializer);
         harness.open();
 
-        OperatorMetricGroup metricGroup = rowDataStoreWriteOperator.getMetricGroup();
+        OperatorMetricGroup metricGroup = rowDataStoreWriteOperatorWithState.getMetricGroup();
         MetricGroup writerBufferMetricGroup =
                 metricGroup
                         .addGroup("paimon")


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Now, when Flink bounded stream write to Paimon table. If the following conditions are met, checkpoint fail will occur, because paimon writer use flink UnionlistState.
1、If Source Operator is chained with Paimon writer Operater.
2、Some source Task has finished.

The exception is :  
Caused by: org.apache.flink.runtime.checkpoint.FinishedTaskStateProvider$PartialFinishingNotSupportedByStateException: The vertex Source: SaroSource_ST_cf20240619200315_saro_mirror_mainsearch_result_table_c_d20240821200837_0[1136] -> Calc[1137] -> Map -> Writer(write-only) : mainse_result_stream_append_table_20240828 (id = 717c7b8afebbfb7137f6f0f99beb2a94) has used UnionListState, but part of its tasks has called operators' finish method.


After discuss, I have try cut StoreSinkWriteState when write unaware bucket table. But after test write to unaware bucket table, I failed.
So, who can help me.

This is my code logical:

![image](https://github.com/user-attachments/assets/7229b2a8-d9a7-4608-915d-1f0fad89affb)

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
