### PR TITLE
[core] skip clean tag manifest file if exception

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.Predicate;
@@ -235,8 +236,21 @@ public class TagManager {
         }
 
         // delete manifests
-        tagDeletion.cleanUnusedManifests(
-                taggedSnapshot, tagDeletion.manifestSkippingSet(skippedSnapshots));
+        success = true;
+        Set<String> manifestSkippingSet = null;
+        try {
+            manifestSkippingSet = tagDeletion.manifestSkippingSet(skippedSnapshots);
+        } catch (Exception e) {
+            LOG.info(
+                    String.format(
+                            "Skip cleaning manifest files for tag of snapshot %s due to failed to build skipping set.",
+                            taggedSnapshot.id()),
+                    e);
+            success = false;
+        }
+        if (success) {
+            tagDeletion.cleanUnusedManifests(taggedSnapshot, manifestSkippingSet);
+        }
     }
 
     /** Check if a tag exists. */


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Now when clean tag file, skip datafile if exception happen.
Also skip clean manifest if exception happen.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
