### PR TITLE
[flink] Set parallelismConfigured when setting parallelism of Transformation

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcSinkBuilder.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcSinkBuilder.java
@@ -111,7 +111,7 @@ public class CdcSinkBuilder<T> {
                                         identifier,
                                         catalogLoader))
                         .name("Schema Evolution");
-        schemaChangeProcessFunction.getTransformation().setParallelism(1);
+        schemaChangeProcessFunction.getTransformation().setParallelism(1, true);
         schemaChangeProcessFunction.getTransformation().setMaxParallelism(1);
 
         DataStream<CdcRecord> converted =

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
@@ -204,7 +204,7 @@ public class FlinkCdcSyncDatabaseSinkBuilder<T> {
                                             Identifier.create(database, table.name()),
                                             catalogLoader))
                             .name("Schema Evolution");
-            schemaChangeProcessFunction.getTransformation().setParallelism(1);
+            schemaChangeProcessFunction.getTransformation().setParallelism(1, true);
             schemaChangeProcessFunction.getTransformation().setMaxParallelism(1);
 
             DataStream<CdcRecord> parsedForTable =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/UnawareBucketCompactionTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/UnawareBucketCompactionTopoBuilder.java
@@ -144,11 +144,11 @@ public class UnawareBucketCompactionTopoBuilder {
                 new PartitionTransformation<>(
                         input.getTransformation(), new RebalancePartitioner<>());
         if (compactionWorkerParallelism != null) {
-            transformation.setParallelism(compactionWorkerParallelism);
+            transformation.setParallelism(compactionWorkerParallelism, true);
         } else {
             // cause source function for unaware-bucket table compaction has only one parallelism,
             // we need to set to default parallelism by hand.
-            transformation.setParallelism(env.getParallelism());
+            transformation.setParallelism(env.getParallelism(), false);
         }
         return new DataStream<>(env, transformation);
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkStreamPartitioner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkStreamPartitioner.java
@@ -73,7 +73,7 @@ public class FlinkStreamPartitioner<T> extends StreamPartitioner<T> {
         PartitionTransformation<T> partitioned =
                 new PartitionTransformation<>(input.getTransformation(), partitioner);
         if (parallelism != null) {
-            partitioned.setParallelism(parallelism);
+            partitioned.setParallelism(parallelism, true);
         }
         return new DataStream<>(input.getExecutionEnvironment(), partitioned);
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
@@ -304,7 +304,7 @@ public class FlinkSourceBuilder {
                                 FlinkConnectorOptions.STREAMING_READ_SHUFFLE_BUCKET_WITH_PARTITION),
                         bucketMode);
         if (parallelism != null) {
-            dataStream.getTransformation().setParallelism(parallelism);
+            dataStream.getTransformation().setParallelism(parallelism, true);
         }
         if (watermarkStrategy != null) {
             dataStream = dataStream.assignTimestampsAndWatermarks(watermarkStrategy);


### PR DESCRIPTION
### Purpose

Flink's `Transformation` has two `setParallelism` method, one is `setParallelism(int parallelism, boolean parallelismConfigured)`. Here `parallelismConfigured` means that if the parallelism is explicitly determined by user (or by Paimon) and should not be changed by Flink itself when optimizing.

This PR sets `parallelismConfigured` when setting parallelism to hint Flink whether it can change our parallelism or not.

### Tests

Existing tests should cover this change.

### API and Format

No format changes.

### Documentation

No new feature.
