### PR TITLE
[spark] Add string length check for char while writing

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonAnalysis.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonAnalysis.scala
@@ -182,7 +182,7 @@ class PaimonAnalysis(session: SparkSession) extends Rule[LogicalPlan] {
       case _ =>
         cast(attr, targetAttr.dataType)
     }
-    Alias(withStrLenCheck(expr, targetAttr.metadata), targetAttr.name)(explicitMetadata =
+    Alias(stringLengthCheck(expr, targetAttr.metadata), targetAttr.name)(explicitMetadata =
       Option(targetAttr.metadata))
   }
 
@@ -246,7 +246,7 @@ class PaimonAnalysis(session: SparkSession) extends Rule[LogicalPlan] {
       sourceFieldName: String,
       targetField: StructField): NamedExpression = {
     Alias(
-      withStrLenCheck(
+      stringLengthCheck(
         cast(GetStructField(parent, i, Option(sourceFieldName)), targetField.dataType),
         targetField.metadata),
       targetField.name)(explicitMetadata = Option(targetField.metadata))
@@ -275,7 +275,7 @@ class PaimonAnalysis(session: SparkSession) extends Rule[LogicalPlan] {
     cast
   }
 
-  private def withStrLenCheck(expr: Expression, metadata: Metadata): Expression = {
+  private def stringLengthCheck(expr: Expression, metadata: Metadata): Expression = {
     if (!conf.charVarcharAsString) {
       CharVarcharUtils
         .getRawType(metadata)

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
@@ -163,16 +163,9 @@ abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
     Assertions.assertEquals(
       ColStats.newColStats(12, 2, null, null, 1, 15, 15),
       colStats.get("binary"))
-    // From Spark 3.4, the written char col is padded
-    if (gteqSpark3_4) {
-      Assertions.assertEquals(
-        ColStats.newColStats(13, 4, null, null, 0, 20, 20),
-        colStats.get("char_col"))
-    } else {
-      Assertions.assertEquals(
-        ColStats.newColStats(13, 4, null, null, 0, 4, 8),
-        colStats.get("char_col"))
-    }
+    Assertions.assertEquals(
+      ColStats.newColStats(13, 4, null, null, 0, 20, 20),
+      colStats.get("char_col"))
     Assertions.assertEquals(
       ColStats.newColStats(14, 4, null, null, 0, 4, 8),
       colStats.get("varchar_col"))
@@ -234,15 +227,9 @@ abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
     Assertions.assertEquals(
       ColStats.newColStats(12, 3, null, null, 1, 13, 15),
       colStats.get("binary"))
-    if (gteqSpark3_4) {
-      Assertions.assertEquals(
-        ColStats.newColStats(13, 5, null, null, 0, 20, 20),
-        colStats.get("char_col"))
-    } else {
-      Assertions.assertEquals(
-        ColStats.newColStats(13, 5, null, null, 0, 7, 16),
-        colStats.get("char_col"))
-    }
+    Assertions.assertEquals(
+      ColStats.newColStats(13, 5, null, null, 0, 20, 20),
+      colStats.get("char_col"))
     Assertions.assertEquals(
       ColStats.newColStats(14, 5, null, null, 0, 7, 16),
       colStats.get("varchar_col"))

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/InsertOverwriteTableTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/InsertOverwriteTableTestBase.scala
@@ -73,7 +73,7 @@ abstract class InsertOverwriteTableTestBase extends PaimonSparkTestBase {
                   Row(3, 3.3d, "Paimon", "pt2") :: Nil
               )
 
-              // BY NAME statementis supported since Spark3.5
+              // BY NAME statements supported since Spark3.5
               if (gteqSpark3_5) {
                 sql("INSERT OVERWRITE TABLE t1 BY NAME SELECT col3, col2, col4, col1 FROM t1")
                 // null for non-specified column


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

for char we should auto pad to respect conf.charVarcharAsString when writing

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
