### PR TITLE
[core] Check consumer-id cannot be blank string

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1913,7 +1913,7 @@ public class CoreOptions implements Serializable {
 
     public String consumerId() {
         String consumerId = options.get(CONSUMER_ID);
-        if (consumerId != null && consumerId.length() == 0) {
+        if (StringUtils.isBlankString(consumerId)) {
             throw new RuntimeException("consumer id cannot be blank string");
         }
         return consumerId;

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1912,7 +1912,11 @@ public class CoreOptions implements Serializable {
     }
 
     public String consumerId() {
-        return options.get(CONSUMER_ID);
+        String consumerId = options.get(CONSUMER_ID);
+        if (consumerId != null && consumerId.length() == 0) {
+            throw new RuntimeException("consumer id cannot be blank string");
+        }
+        return consumerId;
     }
 
     public static StreamingReadMode streamReadType(Options options) {

--- a/paimon-common/src/main/java/org/apache/paimon/utils/StringUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/StringUtils.java
@@ -551,6 +551,13 @@ public class StringUtils {
         return true;
     }
 
+    public static boolean isBlankString(String str) {
+        if (str != null && str.length() == 0) {
+            return true;
+        }
+        return false;
+    }
+
     public static String quote(String str) {
         return "`" + str + "`";
     }

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -668,6 +668,32 @@ public abstract class FileStoreTableTestBase {
     }
 
     @Test
+    public void testConsumerIdNotBlank() throws Exception {
+        FileStoreTable table =
+                createFileStoreTable(
+                        options -> {
+                            options.set(CoreOptions.CONSUMER_ID, "");
+                            options.set(SNAPSHOT_NUM_RETAINED_MIN, 3);
+                            options.set(SNAPSHOT_NUM_RETAINED_MAX, 3);
+                        });
+
+        StreamWriteBuilder writeBuilder = table.newStreamWriteBuilder();
+        StreamTableWrite write = writeBuilder.newWrite();
+        StreamTableCommit commit = writeBuilder.newCommit();
+
+        ReadBuilder readBuilder = table.newReadBuilder();
+        StreamTableScan scan = readBuilder.newStreamScan();
+        TableRead read = readBuilder.newRead();
+
+        write.write(rowData(1, 10, 100L));
+        commit.commit(0, write.prepareCommit(true, 0));
+
+        // assert can't set consumer-id to blank string
+        assertThatThrownBy(() -> getResult(read, scan.plan().splits(), STREAMING_ROW_TO_STRING))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
     public void testConsumeId() throws Exception {
         FileStoreTable table =
                 createFileStoreTable(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

Currently paimon not restrict consumer-id cannot be a blank string which may not fitable, this pr is aim to fix it.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
