### PR TITLE
[doc] Factor out most recent Flink version to docs config, and bump it

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -43,6 +43,9 @@ pygmentsUseClasses = true
   # The branch for this version of Apache Paimon
   Branch = "master"
 
+  # The most recent supported Apache Flink version
+  FlinkVersion = "1.20"
+
   # The github repository for Apache Paimon
   Repo = "//github.com/apache/paimon"
 

--- a/docs/content/program-api/flink-api.md
+++ b/docs/content/program-api/flink-api.md
@@ -41,21 +41,21 @@ Maven dependency:
 ```xml
 <dependency>
   <groupId>org.apache.paimon</groupId>
-  <artifactId>paimon-flink-1.17</artifactId>
+  <artifactId>paimon-flink-{{< param FlinkVersion >}}</artifactId>
   <version>{{< version >}}</version>
 </dependency>
 
 <dependency>
   <groupId>org.apache.flink</groupId>
   <artifactId>flink-table-api-java-bridge</artifactId>
-  <version>1.17.0</version>
+  <version>{{< param FlinkVersion >}}.0</version>
   <scope>provided</scope>
 </dependency>
 ```
 
 Or download the jar file:
-{{< stable >}}[Paimon Flink](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-flink-1.17/{{< version >}}/paimon-flink-1.17-{{< version >}}.jar).{{< /stable >}}
-{{< unstable >}}[Paimon Flink](https://repository.apache.org/snapshots/org/apache/paimon/paimon-flink-1.17/{{< version >}}/).{{< /unstable >}}
+{{< stable >}}[Paimon Flink](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-flink-{{< param FlinkVersion >}}/{{< version >}}/paimon-flink-{{< param FlinkVersion >}}-{{< version >}}.jar).{{< /stable >}}
+{{< unstable >}}[Paimon Flink](https://repository.apache.org/snapshots/org/apache/paimon/paimon-flink-{{< param FlinkVersion >}}/{{< version >}}/).{{< /unstable >}}
 
 Please choose your Flink version.
 


### PR DESCRIPTION
Documentation 

### Purpose

The doc page about programmatic Flink API doesn't refer to the latest paimon-flink-_flink_version_ package. This PR factors out the version and bumps it to 1.20.0

### Tests

built the site and tested the page locally

### API and Format

NA

### Documentation

NA