### PR TITLE
[core] optimize snapshot system table when specifying snapshot_id

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/FlinkGenericCatalogITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/FlinkGenericCatalogITCase.java
@@ -136,6 +136,13 @@ public class FlinkGenericCatalogITCase extends AbstractTestBaseJUnit4 {
                 sql("SELECT snapshot_id, schema_id, commit_kind FROM paimon_t$snapshots");
 
         assertThat(result).containsExactly(Row.of(1L, 0L, "APPEND"), Row.of(2L, 0L, "APPEND"));
+
+        // check filter with snapshot_id
+        List<Row> result1 =
+                sql(
+                        "SELECT snapshot_id, schema_id, commit_kind FROM paimon_t$snapshots where snapshot_id=2");
+
+        assertThat(result1).containsExactly(Row.of(2L, 0L, "APPEND"));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx
Currently select * from T$snapshots where snapshot_id=xxx would scan all snapshot file(call snapshotManager##snapshotsWithinRange which not push down), which would cost more IO when snapshot number is large. so add filter predicate to optizime it maybe necessary.

after the pr select * from T$snapshots where snapshot_id=xxx would scan snapshot file only once.
![image](https://github.com/user-attachments/assets/6506a958-6942-446e-96c8-96e68d3dc807)


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
