### PR TITLE
[doc] Fix clustering is only supported the bucket unaware append table.

### DIFF
--- a/docs/content/flink/sql-write.md
+++ b/docs/content/flink/sql-write.md
@@ -53,7 +53,7 @@ For multiple jobs to write the same table, you can refer to [dedicated compactio
 
 In Paimon, clustering is a feature that allows you to cluster data in your [Append Table]({{< ref "append-table/overview" >}})
 based on the values of certain columns during the write process. This organization of data can significantly enhance the efficiency of downstream
-tasks when reading the data, as it enables faster and more targeted data retrieval. This feature is only supported for [Append Table]({{< ref "append-table/overview" >}})
+tasks when reading the data, as it enables faster and more targeted data retrieval. This feature is only supported for [Append Table]({{< ref "append-table/overview" >}})(bucket = -1)
 and batch execution mode.
 
 To utilize clustering, you can specify the columns you want to cluster when creating or writing to a table. Here's a simple example of how to enable clustering:


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

According to the code display that clustering is only supported the bucket unaware append table.

<img width="988" alt="image" src="https://github.com/user-attachments/assets/d958ced2-20bf-457d-a68a-aafa577fd41b">


<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
