### PR TITLE
[core] Interface writeBundle should be with existing statExtractor

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/io/StatsCollectingSingleFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/StatsCollectingSingleFileWriter.java
@@ -73,6 +73,15 @@ public abstract class StatsCollectingSingleFileWriter<T, R> extends SingleFileWr
         }
     }
 
+    @Override
+    public void writeBundle(BundleRecords bundle) throws IOException {
+        Preconditions.checkState(
+                simpleStatsExtractor != null,
+                "Can't write bundle without simpleStatsExtractor, we may lose all the statistical information");
+
+        super.writeBundle(bundle);
+    }
+
     public SimpleColStats[] fieldStats() throws IOException {
         Preconditions.checkState(closed, "Cannot access metric unless the writer is closed.");
         if (simpleStatsExtractor != null) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Add limit for writeBundle interface

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
