### PR TITLE
[core] Fix 'Trying to access closed classloader' in Flink

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/ThreadPoolUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ThreadPoolUtils.java
@@ -120,8 +120,14 @@ public class ThreadPoolUtils {
     public static <U> void randomlyOnlyExecute(
             ExecutorService executor, Consumer<U> processor, Collection<U> input) {
         List<Future<?>> futures = new ArrayList<>(input.size());
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
         for (U u : input) {
-            futures.add(executor.submit(() -> processor.accept(u)));
+            futures.add(
+                    executor.submit(
+                            () -> {
+                                Thread.currentThread().setContextClassLoader(cl);
+                                processor.accept(u);
+                            }));
         }
         awaitAllFutures(futures);
     }
@@ -129,8 +135,14 @@ public class ThreadPoolUtils {
     public static <U, T> Iterator<T> randomlyExecute(
             ExecutorService executor, Function<U, List<T>> processor, Collection<U> input) {
         List<Future<List<T>>> futures = new ArrayList<>(input.size());
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
         for (U u : input) {
-            futures.add(executor.submit(() -> processor.apply(u)));
+            futures.add(
+                    executor.submit(
+                            () -> {
+                                Thread.currentThread().setContextClassLoader(cl);
+                                return processor.apply(u);
+                            }));
         }
         return futuresToIterIter(futures);
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This fixes:
https://github.com/apache/paimon/actions/runs/10645769652/job/29511901738

```
Caused by: java.lang.IllegalStateException: Trying to access closed classloader. Please check if you store classloaders directly or indirectly in static fields. If the stacktrace suggests that the leak occurs in a third party library and cannot be fixed immediately, you can disable this check with the configuration 'classloader.check-leaked-classloader'.
```

Flink will close previous classloader, so in the async thread pool, we should set thread classloader.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
