### PR TITLE
[core] fix query schema throw exception when specifying schema_id does not exist

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -554,6 +554,19 @@ public class SchemaManager implements Serializable {
         }
     }
 
+    /** Check if a schema exists. */
+    public boolean schemaExists(long id) {
+        Path path = toSchemaPath(id);
+        try {
+            return fileIO.exists(path);
+        } catch (IOException e) {
+            throw new RuntimeException(
+                    String.format(
+                            "Failed to determine if schema '%s' exists in path %s.", id, path),
+                    e);
+        }
+    }
+
     public static TableSchema fromPath(FileIO fileIO, Path path) {
         try {
             return JsonSerdeUtil.fromJson(fileIO.readFileUtf8(path), TableSchema.class);

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SchemasTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SchemasTable.java
@@ -225,10 +225,12 @@ public class SchemasTable implements ReadonlyTable {
             SchemaManager manager = new SchemaManager(fileIO, location, branch);
 
             Collection<TableSchema> tableSchemas = Collections.emptyList();
-            if (predicate != null && predicate.function() instanceof Equal) {
-                Object equalValue = predicate.literals().get(0);
-                if (equalValue instanceof Long) {
-                    tableSchemas = Collections.singletonList(manager.schema((Long) equalValue));
+            if (predicate != null
+                    && predicate.function() instanceof Equal
+                    && predicate.literals().get(0) instanceof Long) {
+                Long equalValue = (Long) predicate.literals().get(0);
+                if (manager.schemaExists(equalValue)) {
+                    tableSchemas = Collections.singletonList(manager.schema(equalValue));
                 }
             } else {
                 tableSchemas = manager.listAll();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -257,6 +257,12 @@ public class CatalogTableITCase extends CatalogITCaseBase {
                                 + "{\"id\":1,\"name\":\"b\",\"type\":\"INT\"},"
                                 + "{\"id\":2,\"name\":\"c\",\"type\":\"STRING\"}], [], [\"a\"], "
                                 + "{\"a.aa.aaa\":\"val1\",\"b.bb.bbb\":\"val2\"}, ]]");
+
+        result =
+                sql(
+                        "SELECT schema_id, fields, partition_keys, "
+                                + "primary_keys, options, `comment` FROM T$schemas where schema_id = 5");
+        assertThat(result.toString()).isEqualTo("[]");
     }
 
     @Test


### PR DESCRIPTION

### Purpose

Before getting schema from SchemaManager , we should determine if a schema exists.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
