### PR TITLE
[core] FileBasedBloomFilter should not be pass private member to cache manager.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/FileBasedBloomFilter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/FileBasedBloomFilter.java
@@ -58,12 +58,13 @@ public class FileBasedBloomFilter {
         // we should refresh cache in LRU, but we cannot refresh everytime, it is costly.
         // so we introduce a refresh count to reduce refresh
         if (accessCount == REFRESH_COUNT || filter.getMemorySegment() == null) {
+            final BloomFilter bloomFilter = filter;
             MemorySegment segment =
                     cacheManager.getPage(
                             CacheKey.forPosition(input.file(), readOffset, readLength),
                             key -> input.readPosition(readOffset, readLength),
-                            key -> filter.unsetMemorySegment());
-            filter.setMemorySegment(segment, 0);
+                            key -> bloomFilter.unsetMemorySegment());
+            bloomFilter.setMemorySegment(segment, 0);
             accessCount = 0;
         }
         return filter.testHash(hash);


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Cache manager cause out of memory while lookup merge

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
