### PR TITLE
[core]Support ignoring specified fields while generating -U, +U changelog for the same record

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -75,6 +75,12 @@ under the License.
             <td>Whether to generate -U, +U changelog for the same record. This configuration is only valid for the changelog-producer is lookup or full-compaction.</td>
         </tr>
         <tr>
+            <td><h5>changelog-producer.row-deduplicate-ignore-fields</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Fields that are ignored for comparison while generating -U, +U changelog for the same record. This configuration is only valid for the changelog-producer.row-deduplicate is true.</td>
+        </tr>
+        <tr>
             <td><h5>changelog.num-retained.max</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>

--- a/paimon-codegen/src/main/scala/org/apache/paimon/codegen/EqualiserCodeGenerator.scala
+++ b/paimon-codegen/src/main/scala/org/apache/paimon/codegen/EqualiserCodeGenerator.scala
@@ -40,6 +40,7 @@ class EqualiserCodeGenerator(fieldTypes: Array[DataType], fields: Array[Int]) {
     val ctx = new CodeGeneratorContext
     val className = newName(name)
 
+    val containsIgnoreFields = fieldTypes.length > fields.length
     val equalsMethodCodes = for (idx <- fields) yield generateEqualsMethod(ctx, idx)
     val equalsMethodCalls = for (idx <- fields) yield {
       val methodName = getEqualsMethodName(idx)
@@ -57,7 +58,7 @@ class EqualiserCodeGenerator(fieldTypes: Array[DataType], fields: Array[Int]) {
 
           @Override
           public boolean equals($ROW_DATA $LEFT_INPUT, $ROW_DATA $RIGHT_INPUT) {
-            if ($LEFT_INPUT instanceof $BINARY_ROW && $RIGHT_INPUT instanceof $BINARY_ROW) {
+            if ($LEFT_INPUT instanceof $BINARY_ROW && $RIGHT_INPUT instanceof $BINARY_ROW && !$containsIgnoreFields) {
               return $LEFT_INPUT.equals($RIGHT_INPUT);
             }
 

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1783,7 +1783,7 @@ public class CoreOptions implements Serializable {
         return options.get(CHANGELOG_PRODUCER_ROW_DEDUPLICATE);
     }
 
-    public List<String> changelogRowDeduplicateIgnoreSequenceField() {
+    public List<String> changelogRowDeduplicateIgnoreFields() {
         return options.getOptional(CHANGELOG_PRODUCER_ROW_DEDUPLICATE_IGNORE_FIELDS)
                 .map(s -> Arrays.asList(s.split(",")))
                 .orElse(Collections.emptyList());

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -560,6 +560,13 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Whether to generate -U, +U changelog for the same record. This configuration is only valid for the changelog-producer is lookup or full-compaction.");
 
+    public static final ConfigOption<String> CHANGELOG_PRODUCER_ROW_DEDUPLICATE_IGNORE_FIELDS =
+            key("changelog-producer.row-deduplicate-ignore-fields")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Fields that are ignored for comparison while generating -U, +U changelog for the same record. This configuration is only valid for the changelog-producer.row-deduplicate is true.");
+
     @Immutable
     public static final ConfigOption<String> SEQUENCE_FIELD =
             key("sequence.field")
@@ -1774,6 +1781,12 @@ public class CoreOptions implements Serializable {
 
     public boolean changelogRowDeduplicate() {
         return options.get(CHANGELOG_PRODUCER_ROW_DEDUPLICATE);
+    }
+
+    public List<String> changelogRowDeduplicateIgnoreSequenceField() {
+        return options.getOptional(CHANGELOG_PRODUCER_ROW_DEDUPLICATE_IGNORE_FIELDS)
+                .map(s -> Arrays.asList(s.split(",")))
+                .orElse(Collections.emptyList());
     }
 
     public boolean scanPlanSortPartition() {

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -40,10 +40,10 @@ import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.CatalogEnvironment;
 import org.apache.paimon.types.RowType;
-import org.apache.paimon.utils.ChangelogDeduplicateEqualiserSupplier;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.KeyComparatorSupplier;
 import org.apache.paimon.utils.UserDefinedSeqComparator;
+import org.apache.paimon.utils.ValueEqualiserSupplier;
 
 import java.util.Comparator;
 import java.util.HashMap;
@@ -52,7 +52,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.IntStream;
 
 import static org.apache.paimon.predicate.PredicateBuilder.and;
 import static org.apache.paimon.predicate.PredicateBuilder.pickTransformFieldMapping;
@@ -68,7 +67,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
     private final RowType valueType;
     private final KeyValueFieldsExtractor keyValueFieldsExtractor;
     private final Supplier<Comparator<InternalRow>> keyComparatorSupplier;
-    private final Supplier<RecordEqualiser> valueEqualiserSupplier;
+    private final Supplier<RecordEqualiser> logDedupEqualSupplier;
     private final MergeFunctionFactory<KeyValue> mfFactory;
     private final String tableName;
 
@@ -94,13 +93,11 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
         this.keyValueFieldsExtractor = keyValueFieldsExtractor;
         this.mfFactory = mfFactory;
         this.keyComparatorSupplier = new KeyComparatorSupplier(keyType);
-        List<String> ignoreFields = options.changelogRowDeduplicateIgnoreSequenceField();
-        int[] projection =
+        List<String> ignoreFields = options.changelogRowDeduplicateIgnoreFields();
+        this.logDedupEqualSupplier =
                 options.changelogRowDeduplicate() && !ignoreFields.isEmpty()
-                        ? getProjectionWithIgnoreFields(valueType, ignoreFields)
-                        : null;
-        this.valueEqualiserSupplier =
-                new ChangelogDeduplicateEqualiserSupplier(valueType, projection);
+                        ? ValueEqualiserSupplier.fromIgnoreFields(valueType, ignoreFields)
+                        : new ValueEqualiserSupplier(valueType);
         this.tableName = tableName;
     }
 
@@ -181,7 +178,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                 valueType,
                 keyComparatorSupplier,
                 () -> UserDefinedSeqComparator.create(valueType, options),
-                valueEqualiserSupplier,
+                logDedupEqualSupplier,
                 mfFactory,
                 pathFactory(),
                 format2PathFactory(),
@@ -249,13 +246,5 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
     @Override
     public Comparator<InternalRow> newKeyComparator() {
         return keyComparatorSupplier.get();
-    }
-
-    private int[] getProjectionWithIgnoreFields(RowType rowType, List<String> ignoreFields) {
-        List<String> fieldNames = rowType.getFieldNames();
-        IntStream projectionStream = IntStream.range(0, rowType.getFieldCount());
-        return projectionStream
-                .filter(idx -> !ignoreFields.contains(fieldNames.get(idx)))
-                .toArray();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ChangelogDeduplicateEqualiserSupplier.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ChangelogDeduplicateEqualiserSupplier.java
@@ -28,18 +28,29 @@ import java.util.function.Supplier;
 import static org.apache.paimon.codegen.CodeGenUtils.newRecordEqualiser;
 
 /** A {@link Supplier} that returns the equaliser for the file store value. */
-public class ValueEqualiserSupplier implements SerializableSupplier<RecordEqualiser> {
+public class ChangelogDeduplicateEqualiserSupplier
+        implements SerializableSupplier<RecordEqualiser> {
 
     private static final long serialVersionUID = 1L;
 
     private final List<DataType> fieldTypes;
 
-    public ValueEqualiserSupplier(RowType keyType) {
+    private final int[] projection;
+
+    public ChangelogDeduplicateEqualiserSupplier(RowType keyType) {
         this.fieldTypes = keyType.getFieldTypes();
+        this.projection = null;
+    }
+
+    public ChangelogDeduplicateEqualiserSupplier(RowType keyType, int[] projection) {
+        this.fieldTypes = keyType.getFieldTypes();
+        this.projection = projection;
     }
 
     @Override
     public RecordEqualiser get() {
-        return newRecordEqualiser(fieldTypes);
+        return this.projection == null
+                ? newRecordEqualiser(fieldTypes)
+                : newRecordEqualiser(fieldTypes, projection);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ValueEqualiserSupplier.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ValueEqualiserSupplier.java
@@ -22,14 +22,16 @@ import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
 import static org.apache.paimon.codegen.CodeGenUtils.newRecordEqualiser;
 
 /** A {@link Supplier} that returns the equaliser for the file store value. */
-public class ChangelogDeduplicateEqualiserSupplier
-        implements SerializableSupplier<RecordEqualiser> {
+public class ValueEqualiserSupplier implements SerializableSupplier<RecordEqualiser> {
 
     private static final long serialVersionUID = 1L;
 
@@ -37,12 +39,12 @@ public class ChangelogDeduplicateEqualiserSupplier
 
     private final int[] projection;
 
-    public ChangelogDeduplicateEqualiserSupplier(RowType keyType) {
+    public ValueEqualiserSupplier(RowType keyType) {
         this.fieldTypes = keyType.getFieldTypes();
         this.projection = null;
     }
 
-    public ChangelogDeduplicateEqualiserSupplier(RowType keyType, int[] projection) {
+    public ValueEqualiserSupplier(RowType keyType, int[] projection) {
         this.fieldTypes = keyType.getFieldTypes();
         this.projection = projection;
     }
@@ -52,5 +54,19 @@ public class ChangelogDeduplicateEqualiserSupplier
         return this.projection == null
                 ? newRecordEqualiser(fieldTypes)
                 : newRecordEqualiser(fieldTypes, projection);
+    }
+
+    public static ValueEqualiserSupplier fromIgnoreFields(
+            RowType rowType, @Nullable List<String> ignoreFields) {
+        int[] projection = getProjectionWithIgnoreFields(rowType, ignoreFields);
+        return new ValueEqualiserSupplier(rowType, projection);
+    }
+
+    private static int[] getProjectionWithIgnoreFields(RowType rowType, List<String> ignoreFields) {
+        List<String> fieldNames = rowType.getFieldNames();
+        IntStream projectionStream = IntStream.range(0, rowType.getFieldCount());
+        return projectionStream
+                .filter(idx -> !ignoreFields.contains(fieldNames.get(idx)))
+                .toArray();
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
@@ -29,9 +29,11 @@ import org.apache.paimon.mergetree.compact.aggregate.FieldAggregator;
 import org.apache.paimon.mergetree.compact.aggregate.FieldLastValueAgg;
 import org.apache.paimon.mergetree.compact.aggregate.FieldSumAgg;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.ChangelogDeduplicateEqualiserSupplier;
 import org.apache.paimon.utils.UserDefinedSeqComparator;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
@@ -41,11 +43,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.IntStream;
 
 import static org.apache.paimon.io.DataFileTestUtils.row;
 import static org.apache.paimon.types.RowKind.DELETE;
@@ -212,6 +216,77 @@ public class LookupChangelogMergeFunctionWrapperTest {
         assertThat(kv).isNotNull();
         assertThat(kv.valueKind()).isEqualTo(INSERT);
         assertThat(kv.value().getInt(0)).isEqualTo(2);
+    }
+
+    @Test
+    public void testDeduplicateIgnoreSequenceField() {
+        Map<InternalRow, KeyValue> highLevel = new HashMap<>();
+        RowType valueType =
+                RowType.builder()
+                        .fields(
+                                new DataType[] {DataTypes.INT(), DataTypes.INT()},
+                                new String[] {"f0", "f1"})
+                        .build();
+        UserDefinedSeqComparator userDefinedSeqComparator =
+                UserDefinedSeqComparator.create(
+                        valueType, CoreOptions.fromMap(ImmutableMap.of("sequence.field", "f1")));
+        assert userDefinedSeqComparator != null;
+        List<String> ignoreFields = Collections.singletonList("f1");
+        List<String> fieldNames = valueType.getFieldNames();
+        IntStream projectionStream = IntStream.range(0, valueType.getFieldCount());
+        int[] projection =
+                projectionStream
+                        .filter(idx -> !ignoreFields.contains(fieldNames.get(idx)))
+                        .toArray();
+        ChangelogDeduplicateEqualiserSupplier changelogDeduplicateEqualiserSupplier =
+                new ChangelogDeduplicateEqualiserSupplier(valueType, projection);
+        LookupChangelogMergeFunctionWrapper function =
+                new LookupChangelogMergeFunctionWrapper(
+                        LookupMergeFunction.wrap(
+                                DeduplicateMergeFunction.factory(),
+                                RowType.of(DataTypes.INT()),
+                                valueType),
+                        highLevel::get,
+                        changelogDeduplicateEqualiserSupplier.get(),
+                        true,
+                        LookupStrategy.from(false, true, false, false),
+                        null,
+                        userDefinedSeqComparator);
+
+        // With level-0 'insert' record, with level-x (x > 0) same record. Notice that sequence
+        // fields in records are different.
+        function.reset();
+        function.add(new KeyValue().replace(row(1), 1, INSERT, row(1, 1)).setLevel(2));
+        function.add(new KeyValue().replace(row(1), 2, INSERT, row(1, 2)).setLevel(0));
+        ChangelogResult result = function.getResult();
+        assertThat(result).isNotNull();
+        List<KeyValue> changelogs = result.changelogs();
+        assertThat(changelogs).isEmpty();
+        KeyValue kv = result.result();
+        assertThat(kv).isNotNull();
+        assertThat(kv.valueKind()).isEqualTo(INSERT);
+        assertThat(kv.value().getInt(0)).isEqualTo(1);
+        assertThat(kv.value().getInt(1)).isEqualTo(2);
+
+        // With level-0 'insert' record, with level-x (x > 0) different record.
+        function.reset();
+        function.add(new KeyValue().replace(row(1), 1, INSERT, row(1, 1)).setLevel(1));
+        function.add(new KeyValue().replace(row(1), 2, INSERT, row(2, 2)).setLevel(0));
+        result = function.getResult();
+        assertThat(result).isNotNull();
+        changelogs = result.changelogs();
+        assertThat(changelogs).hasSize(2);
+        assertThat(changelogs.get(0).valueKind()).isEqualTo(UPDATE_BEFORE);
+        assertThat(changelogs.get(0).value().getInt(0)).isEqualTo(1);
+        assertThat(changelogs.get(0).value().getInt(1)).isEqualTo(1);
+        assertThat(changelogs.get(1).valueKind()).isEqualTo(UPDATE_AFTER);
+        assertThat(changelogs.get(1).value().getInt(0)).isEqualTo(2);
+        assertThat(changelogs.get(1).value().getInt(1)).isEqualTo(2);
+        kv = result.result();
+        assertThat(kv).isNotNull();
+        assertThat(kv.valueKind()).isEqualTo(INSERT);
+        assertThat(kv.value().getInt(0)).isEqualTo(2);
+        assertThat(kv.value().getInt(1)).isEqualTo(2);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Change-Id: Ida465e4902f13592df552be731da1530fdeaaeb0

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #4095

<!-- What is the purpose of the change -->
Support  specifying fields that are ignored for comparison while generating -U, +U changelog for the same record. I will use the changelog-producer.row-deduplicate-ignore-fields to decide which fields are ignored.This configuration is only valid for the changelog-producer.row-deduplicate is true.
### Tests

<!-- List UT and IT cases to verify this change -->
Add UT in LookupChangelogMergeFunctionWrapperTest.java

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
