### PR TITLE
Remove StringUtils#isBlank which is same with #isNullOrWhitespaceOnly

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexOptions.java
@@ -71,7 +71,7 @@ public class FileIndexOptions {
                                     key.length() - fileIndexColumnSuffix.length());
                     String[] names = entry.getValue().split(",");
                     for (String name : names) {
-                        if (StringUtils.isBlank(name)) {
+                        if (StringUtils.isNullOrWhitespaceOnly(name)) {
                             throw new IllegalArgumentException(
                                     "Wrong option in " + key + ", should not have empty column");
                         }

--- a/paimon-common/src/main/java/org/apache/paimon/security/SecurityConfiguration.java
+++ b/paimon-common/src/main/java/org/apache/paimon/security/SecurityConfiguration.java
@@ -83,11 +83,12 @@ public class SecurityConfiguration {
     }
 
     public boolean isLegal() {
-        if (StringUtils.isBlank(keytab) != StringUtils.isBlank(principal)) {
+        if (StringUtils.isNullOrWhitespaceOnly(keytab)
+                != StringUtils.isNullOrWhitespaceOnly(principal)) {
             return false;
         }
 
-        if (!StringUtils.isBlank(keytab)) {
+        if (!StringUtils.isNullOrWhitespaceOnly(keytab)) {
             File keytabFile = new File(keytab);
             return keytabFile.exists() && keytabFile.isFile() && keytabFile.canRead();
         }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ParameterUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ParameterUtils.java
@@ -36,7 +36,7 @@ public class ParameterUtils {
 
     public static Map<String, String> parseCommaSeparatedKeyValues(String keyValues) {
         Map<String, String> kvs = new HashMap<>();
-        if (!StringUtils.isBlank(keyValues)) {
+        if (!StringUtils.isNullOrWhitespaceOnly(keyValues)) {
             for (String kvString : keyValues.split(",")) {
                 parseKeyValueString(kvs, kvString);
             }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/StringUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/StringUtils.java
@@ -329,7 +329,7 @@ public class StringUtils {
      * </pre>
      *
      * <p>NOTE: This method changed in Lang version 2.0. It no longer trims the CharSequence. That
-     * functionality is available in isBlank().
+     * functionality is available in isNullOrWhitespaceOnly().
      *
      * @param cs the CharSequence to check, may be null
      * @return {@code true} if the CharSequence is empty or null
@@ -536,19 +536,6 @@ public class StringUtils {
             }
         }
         return buf.toString();
-    }
-
-    public static boolean isBlank(String str) {
-        int strLen;
-        if (str == null || (strLen = str.length()) == 0) {
-            return true;
-        }
-        for (int i = 0; i < strLen; i++) {
-            if ((!Character.isWhitespace(str.charAt(i)))) {
-                return false;
-            }
-        }
-        return true;
     }
 
     public static String quote(String str) {

--- a/paimon-core/src/main/java/org/apache/paimon/consumer/ConsumerManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/consumer/ConsumerManager.java
@@ -58,7 +58,8 @@ public class ConsumerManager implements Serializable {
     public ConsumerManager(FileIO fileIO, Path tablePath, String branchName) {
         this.fileIO = fileIO;
         this.tablePath = tablePath;
-        this.branch = StringUtils.isBlank(branchName) ? DEFAULT_MAIN_BRANCH : branchName;
+        this.branch =
+                StringUtils.isNullOrWhitespaceOnly(branchName) ? DEFAULT_MAIN_BRANCH : branchName;
     }
 
     public Optional<Consumer> consumer(String consumerId) {

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -93,7 +93,7 @@ public class SchemaManager implements Serializable {
     public SchemaManager(FileIO fileIO, Path tableRoot, String branch) {
         this.fileIO = fileIO;
         this.tableRoot = tableRoot;
-        this.branch = StringUtils.isBlank(branch) ? DEFAULT_MAIN_BRANCH : branch;
+        this.branch = StringUtils.isNullOrWhitespaceOnly(branch) ? DEFAULT_MAIN_BRANCH : branch;
     }
 
     public SchemaManager copyWithBranch(String branchName) {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/BranchManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/BranchManager.java
@@ -92,7 +92,10 @@ public class BranchManager {
                 String.format(
                         "Branch name '%s' is the default branch and cannot be used.",
                         DEFAULT_MAIN_BRANCH));
-        checkArgument(!StringUtils.isBlank(branchName), "Branch name '%s' is blank.", branchName);
+        checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(branchName),
+                "Branch name '%s' is blank.",
+                branchName);
         checkArgument(!branchExists(branchName), "Branch name '%s' already exists.", branchName);
         checkArgument(
                 !branchName.chars().allMatch(Character::isDigit),
@@ -120,7 +123,10 @@ public class BranchManager {
                 String.format(
                         "Branch name '%s' is the default branch and cannot be created.",
                         DEFAULT_MAIN_BRANCH));
-        checkArgument(!StringUtils.isBlank(branchName), "Branch name '%s' is blank.", branchName);
+        checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(branchName),
+                "Branch name '%s' is blank.",
+                branchName);
         checkArgument(!branchExists(branchName), "Branch name '%s' already exists.", branchName);
         checkArgument(tagManager.tagExists(tagName), "Tag name '%s' not exists.", tagName);
         checkArgument(
@@ -185,7 +191,10 @@ public class BranchManager {
                 !branchName.equals(DEFAULT_MAIN_BRANCH),
                 "Branch name '%s' do not use in fast-forward.",
                 branchName);
-        checkArgument(!StringUtils.isBlank(branchName), "Branch name '%s' is blank.", branchName);
+        checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(branchName),
+                "Branch name '%s' is blank.",
+                branchName);
         checkArgument(branchExists(branchName), "Branch name '%s' doesn't exist.", branchName);
 
         Long earliestSnapshotId = snapshotManager.copyWithBranch(branchName).earliestSnapshotId();

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -79,7 +79,8 @@ public class SnapshotManager implements Serializable {
     public SnapshotManager(FileIO fileIO, Path tablePath, String branchName) {
         this.fileIO = fileIO;
         this.tablePath = tablePath;
-        this.branch = StringUtils.isBlank(branchName) ? DEFAULT_MAIN_BRANCH : branchName;
+        this.branch =
+                StringUtils.isNullOrWhitespaceOnly(branchName) ? DEFAULT_MAIN_BRANCH : branchName;
     }
 
     public SnapshotManager copyWithBranch(String branchName) {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -71,7 +71,7 @@ public class TagManager {
     public TagManager(FileIO fileIO, Path tablePath, String branch) {
         this.fileIO = fileIO;
         this.tablePath = tablePath;
-        this.branch = StringUtils.isBlank(branch) ? DEFAULT_MAIN_BRANCH : branch;
+        this.branch = StringUtils.isNullOrWhitespaceOnly(branch) ? DEFAULT_MAIN_BRANCH : branch;
     }
 
     public TagManager copyWithBranch(String branchName) {
@@ -94,7 +94,8 @@ public class TagManager {
             String tagName,
             @Nullable Duration timeRetained,
             List<TagCallback> callbacks) {
-        checkArgument(!StringUtils.isBlank(tagName), "Tag name '%s' is blank.", tagName);
+        checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(tagName), "Tag name '%s' is blank.", tagName);
 
         // When timeRetained is not defined, please do not write the tagCreatorTime field,
         // as this will cause older versions (<= 0.7) of readers to be unable to read this
@@ -160,7 +161,8 @@ public class TagManager {
             TagDeletion tagDeletion,
             SnapshotManager snapshotManager,
             List<TagCallback> callbacks) {
-        checkArgument(!StringUtils.isBlank(tagName), "Tag name '%s' is blank.", tagName);
+        checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(tagName), "Tag name '%s' is blank.", tagName);
         checkArgument(tagExists(tagName), "Tag '%s' doesn't exist.", tagName);
 
         Snapshot taggedSnapshot = taggedSnapshot(tagName);

--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/cdc/MySqlCdcE2eTestBase.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/cdc/MySqlCdcE2eTestBase.java
@@ -292,11 +292,15 @@ public abstract class MySqlCdcE2eTestBase extends E2eTestBase {
             throws Exception {
 
         String partitionKeysStr =
-                StringUtils.isBlank(partitionKeys) ? "" : "--partition-keys " + partitionKeys;
+                StringUtils.isNullOrWhitespaceOnly(partitionKeys)
+                        ? ""
+                        : "--partition-keys " + partitionKeys;
         String primaryKeysStr =
-                StringUtils.isBlank(primaryKeys) ? "" : "--primary-keys " + primaryKeys;
+                StringUtils.isNullOrWhitespaceOnly(primaryKeys)
+                        ? ""
+                        : "--primary-keys " + primaryKeys;
         String typeMappingStr =
-                StringUtils.isBlank(typeMappingOptions)
+                StringUtils.isNullOrWhitespaceOnly(typeMappingOptions)
                         ? ""
                         : "--type-mapping " + typeMappingOptions;
         String tableStr = action.equals(ACTION_SYNC_TABLE) ? "--table ts_table" : "";

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CompactDatabaseProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CompactDatabaseProcedure.java
@@ -126,10 +126,10 @@ public class CompactDatabaseProcedure extends ProcedureBase {
                         .includingTables(nullable(includingTables))
                         .excludingTables(nullable(excludingTables))
                         .withDatabaseCompactMode(nullable(mode));
-        if (!StringUtils.isBlank(tableOptions)) {
+        if (!StringUtils.isNullOrWhitespaceOnly(tableOptions)) {
             action.withTableOptions(parseCommaSeparatedKeyValues(tableOptions));
         }
-        if (!StringUtils.isBlank(partitionIdleTime)) {
+        if (!StringUtils.isNullOrWhitespaceOnly(partitionIdleTime)) {
             action.withPartitionIdleTime(TimeUtils.parseDuration(partitionIdleTime));
         }
 

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
@@ -123,7 +123,7 @@ public class CompactProcedure extends ProcedureBase {
         String warehouse = catalog.warehouse();
         Map<String, String> catalogOptions = catalog.options();
         Map<String, String> tableConf =
-                StringUtils.isBlank(tableOptions)
+                StringUtils.isNullOrWhitespaceOnly(tableOptions)
                         ? Collections.emptyMap()
                         : ParameterUtils.parseCommaSeparatedKeyValues(tableOptions);
         Identifier identifier = Identifier.fromString(tableId);
@@ -137,13 +137,13 @@ public class CompactProcedure extends ProcedureBase {
                             identifier.getObjectName(),
                             catalogOptions,
                             tableConf);
-            if (!(StringUtils.isBlank(partitionIdleTime))) {
+            if (!(StringUtils.isNullOrWhitespaceOnly(partitionIdleTime))) {
                 action.withPartitionIdleTime(TimeUtils.parseDuration(partitionIdleTime));
             }
             jobName = "Compact Job";
         } else if (!orderStrategy.isEmpty() && !orderByColumns.isEmpty()) {
             Preconditions.checkArgument(
-                    StringUtils.isBlank(partitionIdleTime),
+                    StringUtils.isNullOrWhitespaceOnly(partitionIdleTime),
                     "sort compact do not support 'partition_idle_time'.");
             action =
                     new SortCompactAction(
@@ -160,11 +160,11 @@ public class CompactProcedure extends ProcedureBase {
                     "You must specify 'order strategy' and 'order by columns' both.");
         }
 
-        if (!(StringUtils.isBlank(partitions))) {
+        if (!(StringUtils.isNullOrWhitespaceOnly(partitions))) {
             action.withPartitions(ParameterUtils.getPartitions(partitions.split(";")));
         }
 
-        if (!StringUtils.isBlank(whereSql)) {
+        if (!StringUtils.isNullOrWhitespaceOnly(whereSql)) {
             action.withWhereSql(whereSql);
         }
 

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
@@ -65,7 +65,7 @@ public class RemoveOrphanFilesProcedure extends ProcedureBase {
         List<OrphanFilesClean> tableCleans =
                 OrphanFilesClean.createOrphanFilesCleans(catalog, databaseName, tableName);
 
-        if (!StringUtils.isBlank(olderThan)) {
+        if (!StringUtils.isNullOrWhitespaceOnly(olderThan)) {
             tableCleans.forEach(clean -> clean.olderThan(olderThan));
         }
 

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/RewriteFileIndexProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/RewriteFileIndexProcedure.java
@@ -67,7 +67,9 @@ public class RewriteFileIndexProcedure extends ProcedureBase {
         Table table = catalog.getTable(Identifier.fromString(sourceTablePath));
 
         List<Map<String, String>> partitionList =
-                StringUtils.isBlank(partitions) ? null : getPartitions(partitions.split(";"));
+                StringUtils.isNullOrWhitespaceOnly(partitions)
+                        ? null
+                        : getPartitions(partitions.split(";"));
 
         Predicate partitionPredicate;
         if (partitionList != null) {

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresRecordParser.java
@@ -188,7 +188,7 @@ public class PostgresRecordParser
                     return DataTypes.DECIMAL(precision, scale);
                 } else if (Bits.LOGICAL_NAME.equals(field.name())) {
                     String stringifyLength = field.parameters().get("length").asText();
-                    if (StringUtils.isBlank(stringifyLength)) {
+                    if (StringUtils.isNullOrWhitespaceOnly(stringifyLength)) {
                         return DataTypes.BOOLEAN();
                     }
                     Integer length = Integer.valueOf(stringifyLength);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CloneAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CloneAction.java
@@ -38,7 +38,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
-import static org.apache.paimon.utils.StringUtils.isBlank;
+import static org.apache.paimon.utils.StringUtils.isNullOrWhitespaceOnly;
 
 /** The Latest Snapshot clone action for Flink. */
 public class CloneAction extends ActionBase {
@@ -69,7 +69,9 @@ public class CloneAction extends ActionBase {
         checkNotNull(targetWarehouse, "targetWarehouse must not be null.");
 
         this.parallelism =
-                isBlank(parallelismStr) ? env.getParallelism() : Integer.parseInt(parallelismStr);
+                isNullOrWhitespaceOnly(parallelismStr)
+                        ? env.getParallelism()
+                        : Integer.parseInt(parallelismStr);
 
         this.sourceCatalogConfig = new HashMap<>();
         if (!sourceCatalogConfig.isEmpty()) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/CloneSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/CloneSourceBuilder.java
@@ -76,15 +76,15 @@ public class CloneSourceBuilder {
     private DataStream<Tuple2<String, String>> build(Catalog sourceCatalog) throws Exception {
         List<Tuple2<String, String>> result = new ArrayList<>();
 
-        if (StringUtils.isBlank(database)) {
+        if (StringUtils.isNullOrWhitespaceOnly(database)) {
             checkArgument(
-                    StringUtils.isBlank(tableName),
+                    StringUtils.isNullOrWhitespaceOnly(tableName),
                     "tableName must be blank when database is null.");
             checkArgument(
-                    StringUtils.isBlank(targetDatabase),
+                    StringUtils.isNullOrWhitespaceOnly(targetDatabase),
                     "targetDatabase must be blank when clone all tables in a catalog.");
             checkArgument(
-                    StringUtils.isBlank(targetTableName),
+                    StringUtils.isNullOrWhitespaceOnly(targetTableName),
                     "targetTableName must be blank when clone all tables in a catalog.");
             for (String db : sourceCatalog.listDatabases()) {
                 for (String table : sourceCatalog.listTables(db)) {
@@ -92,22 +92,22 @@ public class CloneSourceBuilder {
                     result.add(new Tuple2<>(s, s));
                 }
             }
-        } else if (StringUtils.isBlank(tableName)) {
+        } else if (StringUtils.isNullOrWhitespaceOnly(tableName)) {
             checkArgument(
-                    !StringUtils.isBlank(targetDatabase),
+                    !StringUtils.isNullOrWhitespaceOnly(targetDatabase),
                     "targetDatabase must not be blank when clone all tables in a database.");
             checkArgument(
-                    StringUtils.isBlank(targetTableName),
+                    StringUtils.isNullOrWhitespaceOnly(targetTableName),
                     "targetTableName must be blank when clone all tables in a catalog.");
             for (String table : sourceCatalog.listTables(database)) {
                 result.add(new Tuple2<>(database + "." + table, targetDatabase + "." + table));
             }
         } else {
             checkArgument(
-                    !StringUtils.isBlank(targetDatabase),
+                    !StringUtils.isNullOrWhitespaceOnly(targetDatabase),
                     "targetDatabase must not be blank when clone a table.");
             checkArgument(
-                    !StringUtils.isBlank(targetTableName),
+                    !StringUtils.isNullOrWhitespaceOnly(targetTableName),
                     "targetTableName must not be blank when clone a table.");
             result.add(
                     new Tuple2<>(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactDatabaseProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactDatabaseProcedure.java
@@ -102,10 +102,10 @@ public class CompactDatabaseProcedure extends ProcedureBase {
                         .includingTables(nullable(includingTables))
                         .excludingTables(nullable(excludingTables))
                         .withDatabaseCompactMode(nullable(mode));
-        if (!StringUtils.isBlank(tableOptions)) {
+        if (!StringUtils.isNullOrWhitespaceOnly(tableOptions)) {
             action.withTableOptions(parseCommaSeparatedKeyValues(tableOptions));
         }
-        if (!StringUtils.isBlank(partitionIdleTime)) {
+        if (!StringUtils.isNullOrWhitespaceOnly(partitionIdleTime)) {
             action.withPartitionIdleTime(TimeUtils.parseDuration(partitionIdleTime));
         }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
@@ -34,7 +34,7 @@ import java.util.Map;
 
 import static org.apache.paimon.utils.ParameterUtils.getPartitions;
 import static org.apache.paimon.utils.ParameterUtils.parseCommaSeparatedKeyValues;
-import static org.apache.paimon.utils.StringUtils.isBlank;
+import static org.apache.paimon.utils.StringUtils.isNullOrWhitespaceOnly;
 
 /** Compact procedure. */
 public class CompactProcedure extends ProcedureBase {
@@ -73,13 +73,13 @@ public class CompactProcedure extends ProcedureBase {
         String warehouse = catalog.warehouse();
         Map<String, String> catalogOptions = catalog.options();
         Map<String, String> tableConf =
-                isBlank(tableOptions)
+                isNullOrWhitespaceOnly(tableOptions)
                         ? Collections.emptyMap()
                         : parseCommaSeparatedKeyValues(tableOptions);
         Identifier identifier = Identifier.fromString(tableId);
         CompactAction action;
         String jobName;
-        if (isBlank(orderStrategy) && isBlank(orderByColumns)) {
+        if (isNullOrWhitespaceOnly(orderStrategy) && isNullOrWhitespaceOnly(orderByColumns)) {
             action =
                     new CompactAction(
                             warehouse,
@@ -87,13 +87,14 @@ public class CompactProcedure extends ProcedureBase {
                             identifier.getObjectName(),
                             catalogOptions,
                             tableConf);
-            if (!isBlank(partitionIdleTime)) {
+            if (!isNullOrWhitespaceOnly(partitionIdleTime)) {
                 action.withPartitionIdleTime(TimeUtils.parseDuration(partitionIdleTime));
             }
             jobName = "Compact Job";
-        } else if (!isBlank(orderStrategy) && !isBlank(orderByColumns)) {
+        } else if (!isNullOrWhitespaceOnly(orderStrategy)
+                && !isNullOrWhitespaceOnly(orderByColumns)) {
             Preconditions.checkArgument(
-                    isBlank(partitionIdleTime),
+                    isNullOrWhitespaceOnly(partitionIdleTime),
                     "sort compact do not support 'partition_idle_time'.");
             action =
                     new SortCompactAction(
@@ -110,11 +111,11 @@ public class CompactProcedure extends ProcedureBase {
                     "You must specify 'order strategy' and 'order by columns' both.");
         }
 
-        if (!(isBlank(partitions))) {
+        if (!(isNullOrWhitespaceOnly(partitions))) {
             action.withPartitions(getPartitions(partitions.split(";")));
         }
 
-        if (!isBlank(where)) {
+        if (!isNullOrWhitespaceOnly(where)) {
             action.withWhereSql(where);
         }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ProcedureBase.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ProcedureBase.java
@@ -62,7 +62,7 @@ public abstract class ProcedureBase implements Procedure, Factory {
 
     @Nullable
     protected String nullable(String arg) {
-        return StringUtils.isBlank(arg) ? null : arg;
+        return StringUtils.isNullOrWhitespaceOnly(arg) ? null : arg;
     }
 
     protected String[] execute(
@@ -103,7 +103,7 @@ public abstract class ProcedureBase implements Procedure, Factory {
     }
 
     protected Map<String, String> optionalConfigMap(String configStr) {
-        if (StringUtils.isBlank(configStr)) {
+        if (StringUtils.isNullOrWhitespaceOnly(configStr)) {
             return Collections.emptyMap();
         }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
@@ -76,7 +76,7 @@ public class RemoveOrphanFilesProcedure extends ProcedureBase {
         List<OrphanFilesClean> tableCleans =
                 OrphanFilesClean.createOrphanFilesCleans(catalog, databaseName, tableName);
 
-        if (!StringUtils.isBlank(olderThan)) {
+        if (!StringUtils.isNullOrWhitespaceOnly(olderThan)) {
             tableCleans.forEach(clean -> clean.olderThan(olderThan));
         }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RepairProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RepairProcedure.java
@@ -56,7 +56,7 @@ public class RepairProcedure extends ProcedureBase {
             })
     public String[] call(ProcedureContext procedureContext, String identifier)
             throws Catalog.DatabaseNotExistException, Catalog.TableNotExistException {
-        if (StringUtils.isBlank(identifier)) {
+        if (StringUtils.isNullOrWhitespaceOnly(identifier)) {
             catalog.repairCatalog();
             return new String[] {"Success"};
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RewriteFileIndexProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RewriteFileIndexProcedure.java
@@ -74,7 +74,9 @@ public class RewriteFileIndexProcedure extends ProcedureBase {
         Table table = catalog.getTable(Identifier.fromString(sourceTablePath));
 
         List<Map<String, String>> partitionList =
-                StringUtils.isBlank(partitions) ? null : getPartitions(partitions.split(";"));
+                StringUtils.isNullOrWhitespaceOnly(partitions)
+                        ? null
+                        : getPartitions(partitions.split(";"));
 
         Predicate partitionPredicate;
         if (partitionList != null) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RollbackToProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RollbackToProcedure.java
@@ -56,7 +56,7 @@ public class RollbackToProcedure extends ProcedureBase {
             ProcedureContext procedureContext, String tableId, String tagName, Long snapshotId)
             throws Catalog.TableNotExistException {
         Table table = catalog.getTable(Identifier.fromString(tableId));
-        if (!StringUtils.isBlank(tagName)) {
+        if (!StringUtils.isNullOrWhitespaceOnly(tagName)) {
             table.rollbackTo(tagName);
         } else {
             table.rollbackTo(snapshotId);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -164,7 +164,7 @@ public class CompactProcedure extends BaseProcedure {
                             table.partitionKeys());
                     DataSourceV2Relation relation = createRelation(tableIdent);
                     Expression condition = null;
-                    if (!StringUtils.isBlank(finalWhere)) {
+                    if (!StringUtils.isNullOrWhitespaceOnly(finalWhere)) {
                         condition = ExpressionUtils.resolveFilter(spark(), relation, finalWhere);
                         checkArgument(
                                 ExpressionUtils.isValidPredicate(
@@ -178,7 +178,7 @@ public class CompactProcedure extends BaseProcedure {
 
                     Map<String, String> dynamicOptions = new HashMap<>();
                     dynamicOptions.put(CoreOptions.WRITE_ONLY.key(), "false");
-                    if (!StringUtils.isBlank(options)) {
+                    if (!StringUtils.isNullOrWhitespaceOnly(options)) {
                         dynamicOptions.putAll(ParameterUtils.parseCommaSeparatedKeyValues(options));
                     }
                     table = table.copy(dynamicOptions);
@@ -202,7 +202,7 @@ public class CompactProcedure extends BaseProcedure {
     }
 
     private boolean blank(InternalRow args, int index) {
-        return args.isNullAt(index) || StringUtils.isBlank(args.getString(index));
+        return args.isNullAt(index) || StringUtils.isNullOrWhitespaceOnly(args.getString(index));
     }
 
     private boolean execute(

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedure.java
@@ -111,7 +111,7 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
         }
 
         String olderThan = args.isNullAt(1) ? null : args.getString(1);
-        if (!StringUtils.isBlank(olderThan)) {
+        if (!StringUtils.isNullOrWhitespaceOnly(olderThan)) {
             tableCleans.forEach(clean -> clean.olderThan(olderThan));
         }
 

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RepairProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RepairProcedure.java
@@ -69,7 +69,7 @@ public class RepairProcedure extends BaseProcedure {
         Catalog paimonCatalog = ((WithPaimonCatalog) tableCatalog()).paimonCatalog();
         String identifier = args.getString(0);
         try {
-            if (StringUtils.isBlank(identifier)) {
+            if (StringUtils.isNullOrWhitespaceOnly(identifier)) {
                 paimonCatalog.repairCatalog();
                 return new InternalRow[] {newInternalRow(true)};
             }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
StringUtils#isBlank is redundant, and it's not as clear as isNullOrWhitespaceOnly.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
