### PR TITLE
[orc] Move config write.batch-size to CoreOptions

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -573,7 +573,7 @@ This config option does not affect the default filesystem metastore.</td>
             <td><h5>read.batch-size</h5></td>
             <td style="word-wrap: break-word;">1024</td>
             <td>Integer</td>
-            <td>Read batch size for orc and parquet.</td>
+            <td>Read batch size for any file format if it supports.</td>
         </tr>
         <tr>
             <td><h5>record-level.expire-time</h5></td>
@@ -899,6 +899,12 @@ If the data size allocated for the sorting task is uneven,which may lead to perf
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>If set to true, compactions and snapshot expiration will be skipped. This option is used along with dedicated compact jobs.</td>
+        </tr>
+        <tr>
+            <td><h5>write.batch-size</h5></td>
+            <td style="word-wrap: break-word;">1024</td>
+            <td>Integer</td>
+            <td>Write batch size for any file format if it supports.</td>
         </tr>
         <tr>
             <td><h5>zorder.var-length-contribution</h5></td>

--- a/docs/layouts/shortcodes/generated/orc_configuration.html
+++ b/docs/layouts/shortcodes/generated/orc_configuration.html
@@ -38,11 +38,5 @@ under the License.
             <td>Double</td>
             <td>If the number of distinct keys in a dictionary is greater than this fraction of the total number of non-null rows, turn off dictionary encoding in orc. Use 0 to always disable dictionary encoding. Use 1 to always use dictionary encoding.</td>
         </tr>
-        <tr>
-            <td><h5>orc.write.batch-size</h5></td>
-            <td style="word-wrap: break-word;">1024</td>
-            <td>Integer</td>
-            <td>write batch size for orc.</td>
-        </tr>
     </tbody>
 </table>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -878,7 +878,13 @@ public class CoreOptions implements Serializable {
             key("read.batch-size")
                     .intType()
                     .defaultValue(1024)
-                    .withDescription("Read batch size for orc and parquet.");
+                    .withDescription("Read batch size for any file format if it supports.");
+
+    public static final ConfigOption<Integer> WRITE_BATCH_SIZE =
+            key("write.batch-size")
+                    .intType()
+                    .defaultValue(1024)
+                    .withDescription("Write batch size for any file format if it supports.");
 
     public static final ConfigOption<String> CONSUMER_ID =
             key("consumer-id")

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -884,6 +884,7 @@ public class CoreOptions implements Serializable {
             key("write.batch-size")
                     .intType()
                     .defaultValue(1024)
+                    .withFallbackKeys("orc.write.batch-size")
                     .withDescription("Write batch size for any file format if it supports.");
 
     public static final ConfigOption<String> CONSUMER_ID =

--- a/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
@@ -76,7 +76,7 @@ public abstract class FileFormat {
 
     @VisibleForTesting
     public static FileFormat fromIdentifier(String identifier, Options options) {
-        return fromIdentifier(identifier, new FormatContext(options, 1024));
+        return fromIdentifier(identifier, new FormatContext(options, 1024, 1024));
     }
 
     /** Create a {@link FileFormat} from format identifier and format options. */
@@ -108,6 +108,7 @@ public abstract class FileFormat {
                 new FormatContext(
                         options.removePrefix(formatIdentifier + "."),
                         options.get(CoreOptions.READ_BATCH_SIZE),
+                        options.get(CoreOptions.WRITE_BATCH_SIZE),
                         options.get(CoreOptions.FILE_COMPRESSION_ZSTD_LEVEL),
                         options.get(CoreOptions.FILE_BLOCK_SIZE));
         return FileFormat.fromIdentifier(formatIdentifier, context);

--- a/paimon-common/src/main/java/org/apache/paimon/format/FileFormatFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FileFormatFactory.java
@@ -66,7 +66,7 @@ public interface FileFormatFactory {
             return readBatchSize;
         }
 
-        public int writeaBatchSize() {
+        public int writeBatchSize() {
             return writeBatchSize;
         }
 

--- a/paimon-common/src/main/java/org/apache/paimon/format/FileFormatFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FileFormatFactory.java
@@ -36,21 +36,24 @@ public interface FileFormatFactory {
 
         private final Options formatOptions;
         private final int readBatchSize;
+        private final int writeBatchSize;
         private final int zstdLevel;
         @Nullable private final MemorySize blockSize;
 
         @VisibleForTesting
-        public FormatContext(Options formatOptions, int readBatchSize) {
-            this(formatOptions, readBatchSize, 1, null);
+        public FormatContext(Options formatOptions, int readBatchSize, int writeBatchSize) {
+            this(formatOptions, readBatchSize, writeBatchSize, 1, null);
         }
 
         public FormatContext(
                 Options formatOptions,
                 int readBatchSize,
+                int writeBatchSize,
                 int zstdLevel,
                 @Nullable MemorySize blockSize) {
             this.formatOptions = formatOptions;
             this.readBatchSize = readBatchSize;
+            this.writeBatchSize = writeBatchSize;
             this.zstdLevel = zstdLevel;
             this.blockSize = blockSize;
         }
@@ -61,6 +64,10 @@ public interface FileFormatFactory {
 
         public int readBatchSize() {
             return readBatchSize;
+        }
+
+        public int writeaBatchSize() {
+            return writeBatchSize;
         }
 
         public int zstdLevel() {

--- a/paimon-format/src/main/java/org/apache/paimon/format/OrcOptions.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/OrcOptions.java
@@ -25,12 +25,6 @@ import static org.apache.paimon.options.ConfigOptions.key;
 /** Options for orc format. */
 public class OrcOptions {
 
-    public static final ConfigOption<Integer> ORC_WRITE_BATCH_SIZE =
-            key("orc.write.batch-size")
-                    .intType()
-                    .defaultValue(1024)
-                    .withDescription("write batch size for orc.");
-
     public static final ConfigOption<Integer> ORC_COLUMN_ENCODING_DIRECT =
             key("orc.column.encoding.direct")
                     .intType()

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormat.java
@@ -78,7 +78,7 @@ public class OrcFileFormat extends FileFormat {
         this.writerConf = new org.apache.hadoop.conf.Configuration();
         this.orcProperties.forEach((k, v) -> writerConf.set(k.toString(), v.toString()));
         this.readBatchSize = formatContext.readBatchSize();
-        this.writeBatchSize = formatContext.writeaBatchSize();
+        this.writeBatchSize = formatContext.writeBatchSize();
     }
 
     @VisibleForTesting

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormat.java
@@ -68,6 +68,7 @@ public class OrcFileFormat extends FileFormat {
     private final org.apache.hadoop.conf.Configuration readerConf;
     private final org.apache.hadoop.conf.Configuration writerConf;
     private final int readBatchSize;
+    private final int writeBatchSize;
 
     public OrcFileFormat(FormatContext formatContext) {
         super(IDENTIFIER);
@@ -77,6 +78,7 @@ public class OrcFileFormat extends FileFormat {
         this.writerConf = new org.apache.hadoop.conf.Configuration();
         this.orcProperties.forEach((k, v) -> writerConf.set(k.toString(), v.toString()));
         this.readBatchSize = formatContext.readBatchSize();
+        this.writeBatchSize = formatContext.writeaBatchSize();
     }
 
     @VisibleForTesting
@@ -140,7 +142,7 @@ public class OrcFileFormat extends FileFormat {
         Vectorizer<InternalRow> vectorizer =
                 new RowDataVectorizer(typeDescription.toString(), orcTypes);
 
-        return new OrcWriterFactory(vectorizer, orcProperties, writerConf);
+        return new OrcWriterFactory(vectorizer, orcProperties, writerConf, writeBatchSize);
     }
 
     private static Properties getOrcProperties(Options options, FormatContext formatContext) {

--- a/paimon-format/src/test/java/org/apache/paimon/format/avro/AvroFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/avro/AvroFileFormatTest.java
@@ -52,7 +52,7 @@ public class AvroFileFormatTest {
 
     @BeforeAll
     public static void before() {
-        fileFormat = new AvroFileFormat(new FormatContext(new Options(), 1024));
+        fileFormat = new AvroFileFormat(new FormatContext(new Options(), 1024, 1024));
     }
 
     @Test
@@ -106,7 +106,7 @@ public class AvroFileFormatTest {
     @Test
     void testReadRowPosition() throws IOException {
         RowType rowType = DataTypes.ROW(DataTypes.INT().notNull());
-        FileFormat format = new AvroFileFormat(new FormatContext(new Options(), 1024));
+        FileFormat format = new AvroFileFormat(new FormatContext(new Options(), 1024, 1024));
 
         LocalFileIO fileIO = LocalFileIO.create();
         Path file = new Path(new Path(tempPath.toUri()), UUID.randomUUID().toString());

--- a/paimon-format/src/test/java/org/apache/paimon/format/avro/AvroFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/avro/AvroFormatReadWriteTest.java
@@ -32,6 +32,6 @@ public class AvroFormatReadWriteTest extends FormatReadWriteTest {
 
     @Override
     protected FileFormat fileFormat() {
-        return new AvroFileFormat(new FileFormatFactory.FormatContext(new Options(), 1024));
+        return new AvroFileFormat(new FileFormatFactory.FormatContext(new Options(), 1024, 1024));
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFileFormatTest.java
@@ -39,7 +39,8 @@ public class OrcFileFormatTest {
     public void testAbsent() {
         Options options = new Options();
         options.setString("haha", "1");
-        OrcFileFormat orc = new OrcFileFormatFactory().create(new FormatContext(options, 1024));
+        OrcFileFormat orc =
+                new OrcFileFormatFactory().create(new FormatContext(options, 1024, 1024));
         assertThat(orc.orcProperties().getProperty(IDENTIFIER + ".haha", "")).isEqualTo("1");
     }
 
@@ -48,7 +49,8 @@ public class OrcFileFormatTest {
         Options options = new Options();
         options.setString("haha", "1");
         options.setString("compress", "zlib");
-        OrcFileFormat orc = new OrcFileFormatFactory().create(new FormatContext(options, 1024));
+        OrcFileFormat orc =
+                new OrcFileFormatFactory().create(new FormatContext(options, 1024, 1024));
         assertThat(orc.orcProperties().getProperty(IDENTIFIER + ".haha", "")).isEqualTo("1");
         assertThat(orc.orcProperties().getProperty(IDENTIFIER + ".compress", "")).isEqualTo("zlib");
     }
@@ -56,7 +58,7 @@ public class OrcFileFormatTest {
     @Test
     public void testSupportedDataTypes() {
         OrcFileFormat orc =
-                new OrcFileFormatFactory().create(new FormatContext(new Options(), 1024));
+                new OrcFileFormatFactory().create(new FormatContext(new Options(), 1024, 1024));
 
         int index = 0;
         List<DataField> dataFields = new ArrayList<DataField>();

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFormatReadWriteTest.java
@@ -32,6 +32,6 @@ public class OrcFormatReadWriteTest extends FormatReadWriteTest {
 
     @Override
     protected FileFormat fileFormat() {
-        return new OrcFileFormat(new FileFormatFactory.FormatContext(new Options(), 1024));
+        return new OrcFileFormat(new FileFormatFactory.FormatContext(new Options(), 1024, 1024));
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/writer/OrcBulkWriterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/writer/OrcBulkWriterTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.format.orc.writer;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.format.FormatWriter;
 import org.apache.paimon.format.FormatWriterFactory;
@@ -36,14 +37,12 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 
-import static org.apache.paimon.format.OrcOptions.ORC_WRITE_BATCH_SIZE;
-
 class OrcBulkWriterTest {
 
     @Test
     void testRowBatch(@TempDir java.nio.file.Path tempDir) throws IOException {
         Options options = new Options();
-        options.set(ORC_WRITE_BATCH_SIZE, 1);
+        options.set(CoreOptions.WRITE_BATCH_SIZE, 1);
         FileFormat orc = FileFormat.getFileFormat(options, "orc");
         Assertions.assertThat(orc).isInstanceOf(OrcFileFormat.class);
 

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/writer/OrcZstdTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/writer/OrcZstdTest.java
@@ -64,7 +64,7 @@ class OrcZstdTest {
         options.set("compression.zstd.level", "1");
         OrcFileFormat orc =
                 new OrcFileFormatFactory()
-                        .create(new FileFormatFactory.FormatContext(options, 1024));
+                        .create(new FileFormatFactory.FormatContext(options, 1024, 1024));
         Assertions.assertThat(orc).isInstanceOf(OrcFileFormat.class);
 
         Assertions.assertThat(orc.orcProperties().getProperty(IDENTIFIER + ".compress", ""))

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFileFormatTest.java
@@ -47,7 +47,7 @@ public class ParquetFileFormatTest {
     public void testAbsent() {
         Options options = new Options();
         ParquetFileFormat parquet =
-                new ParquetFileFormatFactory().create(new FormatContext(options, 1024));
+                new ParquetFileFormatFactory().create(new FormatContext(options, 1024, 1024));
         assertThat(parquet.formatOptions().getString(KEY1)).isEqualTo("absent");
     }
 
@@ -56,7 +56,7 @@ public class ParquetFileFormatTest {
         Options options = new Options();
         options.setString(KEY1.key(), "v1");
         ParquetFileFormat parquet =
-                new ParquetFileFormatFactory().create(new FormatContext(options, 1024));
+                new ParquetFileFormatFactory().create(new FormatContext(options, 1024, 1024));
         assertThat(parquet.formatOptions().getString(KEY1)).isEqualTo("v1");
     }
 
@@ -69,7 +69,8 @@ public class ParquetFileFormatTest {
                 new RowDataParquetBuilder(
                         new RowType(new ArrayList<>()),
                         getParquetConfiguration(
-                                new FormatContext(conf.removePrefix(IDENTIFIER + "."), 1024)));
+                                new FormatContext(
+                                        conf.removePrefix(IDENTIFIER + "."), 1024, 1024)));
         assertThat(builder.getCompression(null)).isEqualTo(lz4);
         assertThat(builder.getCompression("SNAPPY")).isEqualTo(lz4);
     }
@@ -77,7 +78,7 @@ public class ParquetFileFormatTest {
     @Test
     public void testSupportedDataFields() {
         ParquetFileFormat parquet =
-                new ParquetFileFormatFactory().create(new FormatContext(new Options(), 1024));
+                new ParquetFileFormatFactory().create(new FormatContext(new Options(), 1024, 1024));
 
         int index = 0;
         List<DataField> dataFields = new ArrayList<DataField>();

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
@@ -32,6 +32,7 @@ public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
 
     @Override
     protected FileFormat fileFormat() {
-        return new ParquetFileFormat(new FileFormatFactory.FormatContext(new Options(), 1024));
+        return new ParquetFileFormat(
+                new FileFormatFactory.FormatContext(new Options(), 1024, 1024));
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
write.batch-size should be in CoreOptions rather than OrcOptions.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
