### PR TITLE
[spark] Fix reported statistics does not do column pruning

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/types/ArrayType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/ArrayType.java
@@ -58,6 +58,11 @@ public final class ArrayType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return elementType.defaultSize();
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new ArrayType(isNullable, elementType.copy());
     }

--- a/paimon-common/src/main/java/org/apache/paimon/types/BigIntType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/BigIntType.java
@@ -42,6 +42,11 @@ public final class BigIntType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return 8;
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new BigIntType(isNullable);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/types/BinaryType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/BinaryType.java
@@ -66,6 +66,11 @@ public class BinaryType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return length;
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new BinaryType(isNullable, length);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/types/BooleanType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/BooleanType.java
@@ -41,6 +41,11 @@ public class BooleanType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return 1;
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new BooleanType(isNullable);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/types/CharType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/CharType.java
@@ -68,6 +68,11 @@ public class CharType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return length;
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new CharType(isNullable, length);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/types/DataType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DataType.java
@@ -104,6 +104,9 @@ public abstract class DataType implements Serializable {
         return typeRoot.getFamilies().contains(family);
     }
 
+    /** The default size of a value of this data type, used internally for size estimation. */
+    public abstract int defaultSize();
+
     /**
      * Returns a deep copy of this type with possibly different nullability.
      *

--- a/paimon-common/src/main/java/org/apache/paimon/types/DateType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DateType.java
@@ -45,6 +45,11 @@ public final class DateType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return 4;
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new DateType(isNullable);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/types/DecimalType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DecimalType.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.types;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.data.Decimal;
 
 import java.util.Objects;
 
@@ -84,6 +85,11 @@ public class DecimalType extends DataType {
 
     public int getScale() {
         return scale;
+    }
+
+    @Override
+    public int defaultSize() {
+        return Decimal.isCompact(precision) ? 8 : 16;
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/types/DoubleType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DoubleType.java
@@ -41,6 +41,11 @@ public class DoubleType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return 8;
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new DoubleType(isNullable);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/types/FloatType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/FloatType.java
@@ -42,6 +42,11 @@ public class FloatType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return 4;
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new FloatType(isNullable);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/types/IntType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/IntType.java
@@ -41,6 +41,11 @@ public class IntType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return 4;
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new IntType(isNullable);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/types/LocalZonedTimestampType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/LocalZonedTimestampType.java
@@ -76,6 +76,11 @@ public final class LocalZonedTimestampType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return 8;
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new LocalZonedTimestampType(isNullable, precision);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/types/MapType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/MapType.java
@@ -65,6 +65,11 @@ public class MapType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return keyType.defaultSize() + valueType.defaultSize();
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new MapType(isNullable, keyType.copy(), valueType.copy());
     }

--- a/paimon-common/src/main/java/org/apache/paimon/types/MultisetType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/MultisetType.java
@@ -62,6 +62,11 @@ public class MultisetType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return elementType.defaultSize() + 4;
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new MultisetType(isNullable, elementType);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/types/RowType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/RowType.java
@@ -132,6 +132,11 @@ public final class RowType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return fields.stream().mapToInt(f -> f.type().defaultSize()).sum();
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new RowType(
                 isNullable, fields.stream().map(DataField::copy).collect(Collectors.toList()));

--- a/paimon-common/src/main/java/org/apache/paimon/types/SmallIntType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/SmallIntType.java
@@ -41,6 +41,11 @@ public final class SmallIntType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return 2;
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new SmallIntType(isNullable);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/types/TimeType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/TimeType.java
@@ -73,6 +73,11 @@ public final class TimeType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return 4;
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new TimeType(isNullable, precision);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/types/TimestampType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/TimestampType.java
@@ -71,6 +71,11 @@ public class TimestampType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return 8;
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new TimestampType(isNullable, precision);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/types/TinyIntType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/TinyIntType.java
@@ -41,6 +41,11 @@ public class TinyIntType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return 1;
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new TinyIntType(isNullable);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/types/VarBinaryType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/VarBinaryType.java
@@ -68,6 +68,11 @@ public final class VarBinaryType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return length == MAX_LENGTH ? 20 : length;
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new VarBinaryType(isNullable, length);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/types/VarCharType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/VarCharType.java
@@ -72,6 +72,11 @@ public final class VarCharType extends DataType {
     }
 
     @Override
+    public int defaultSize() {
+        return length == MAX_LENGTH ? 20 : length;
+    }
+
+    @Override
     public DataType copy(boolean isNullable) {
         return new VarCharType(isNullable, length);
     }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -54,7 +54,7 @@ abstract class PaimonBaseScan(
 
   private lazy val tableSchema = SparkTypeUtils.fromPaimonRowType(tableRowType)
 
-  private val (tableFields, metadataFields) = {
+  private[paimon] val (requiredTableFields, metadataFields) = {
     val nameToField = tableSchema.map(field => (field.name, field)).toMap
     val _tableFields = requiredSchema.flatMap(field => nameToField.get(field.name))
     val _metadataFields =
@@ -75,14 +75,15 @@ abstract class PaimonBaseScan(
   private lazy val paimonMetricsRegistry: SparkMetricRegistry = SparkMetricRegistry()
 
   lazy val requiredStatsSchema: StructType = {
-    val fieldNames = tableFields.map(_.name) ++ reservedFilters.flatMap(_.references)
+    val fieldNames = requiredTableFields.map(_.name) ++ reservedFilters.flatMap(_.references)
     StructType(tableSchema.filter(field => fieldNames.contains(field.name)))
   }
 
   lazy val readBuilder: ReadBuilder = {
     val _readBuilder = table.newReadBuilder()
 
-    val projection = tableFields.map(field => tableSchema.fieldNames.indexOf(field.name)).toArray
+    val projection =
+      requiredTableFields.map(field => tableSchema.fieldNames.indexOf(field.name)).toArray
     _readBuilder.withProjection(projection)
     if (filters.nonEmpty) {
       val pushedPredicate = PredicateBuilder.and(filters: _*)
@@ -113,7 +114,7 @@ abstract class PaimonBaseScan(
   }
 
   override def readSchema(): StructType = {
-    StructType(tableFields ++ metadataFields)
+    StructType(requiredTableFields ++ metadataFields)
   }
 
   override def toBatch: Batch = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonStatistics.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonStatistics.scala
@@ -18,9 +18,9 @@
 
 package org.apache.paimon.spark
 
-import org.apache.paimon.stats
+import org.apache.paimon.spark.schema.PaimonMetadataColumn
 import org.apache.paimon.stats.ColStats
-import org.apache.paimon.types.DataType
+import org.apache.paimon.types.{DataField, DataType, RowType}
 
 import org.apache.spark.sql.PaimonUtils
 import org.apache.spark.sql.catalyst.plans.logical.ColumnStat
@@ -40,10 +40,53 @@ case class PaimonStatistics[T <: PaimonBaseScan](scan: T) extends Statistics {
 
   private lazy val paimonStats = if (scan.statistics.isPresent) scan.statistics.get() else null
 
-  lazy val paimonStatsEnabled: Boolean = paimonStats != null
+  lazy val paimonStatsEnabled: Boolean = {
+    paimonStats != null &&
+    paimonStats.mergedRecordSize().isPresent &&
+    paimonStats.mergedRecordCount().isPresent
+  }
 
-  override def sizeInBytes(): OptionalLong =
-    if (paimonStatsEnabled) paimonStats.mergedRecordSize() else OptionalLong.of(scannedTotalSize)
+  private def getSizeForField(field: DataField): Long = {
+    Option(paimonStats.colStats().get(field.name()))
+      .map(_.avgLen())
+      .filter(_.isPresent)
+      .map(_.getAsLong)
+      .getOrElse(field.`type`().defaultSize().toLong)
+  }
+
+  private def getSizeForRow(schema: RowType): Long = {
+    schema.getFields.asScala.map(field => getSizeForField(field)).sum
+  }
+
+  override def sizeInBytes(): OptionalLong = {
+    if (!paimonStatsEnabled) {
+      return OptionalLong.of(scannedTotalSize)
+    }
+
+    val wholeSchemaSize = getSizeForRow(scan.tableRowType)
+
+    val requiredDataSchemaSize = scan.requiredTableFields.map {
+      field =>
+        val dataField = scan.tableRowType.getField(field.name)
+        getSizeForField(dataField)
+    }.sum
+    val requiredDataSizeInBytes =
+      paimonStats.mergedRecordSize().getAsLong * (requiredDataSchemaSize.toDouble / wholeSchemaSize)
+
+    val metadataSchemaSize = scan.metadataFields.map {
+      field =>
+        val dataField = PaimonMetadataColumn.get(field.name).toPaimonDataField
+        getSizeForField(dataField)
+    }.sum
+    val metadataSizeInBytes = paimonStats.mergedRecordCount().getAsLong * metadataSchemaSize
+
+    val sizeInBytes = (requiredDataSizeInBytes + metadataSizeInBytes).toLong
+    // Avoid return 0 bytes if there are some valid rows.
+    // Avoid return too small size in bytes which may less than row count,
+    // note the compression ratio on disk is usually bigger than memory.
+    val normalized = Math.max(sizeInBytes, paimonStats.mergedRecordCount().getAsLong)
+    OptionalLong.of(normalized)
+  }
 
   override def numRows(): OptionalLong =
     if (paimonStatsEnabled) paimonStats.mergedRecordCount() else OptionalLong.of(rowCount)

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
@@ -430,7 +430,7 @@ abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
     spark.sql(s"INSERT INTO T VALUES (2, 2, 200, '${UUID.randomUUID().toString()}')")
     spark.sql(s"INSERT INTO T VALUES (3, 3, 300, '${UUID.randomUUID().toString()}')")
 
-    def checkStatistics(hasColStat: Boolean): Long = {
+    def checkStatistics(): Long = {
       val wholeSize2 = getScanStatistic("SELECT * FROM T")
       assert(wholeSize2.rowCount.get.toLong == 3)
       assert(wholeSize2.sizeInBytes.toLong > 0)
@@ -448,22 +448,14 @@ abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
       assert(oneColSize.sizeInBytes > 0 && oneColSize.sizeInBytes < wholeSize2.sizeInBytes)
       assert(threeColSize.sizeInBytes < wholeSize2.sizeInBytes)
       assert(threeColSize.sizeInBytes > oneColSize.sizeInBytes)
-
-      if (hasColStat) {
-        // It not always not equal but tests result show them are not equal
-        assert(oneColSize.sizeInBytes * 2 != threeColSize.sizeInBytes)
-      } else {
-        assert(oneColSize.sizeInBytes * 2 == threeColSize.sizeInBytes)
-      }
-
       wholeSize2.sizeInBytes.toLong
     }
 
     spark.sql("ANALYZE TABLE T COMPUTE STATISTICS")
-    val noColStat = checkStatistics(hasColStat = false)
+    val noColStat = checkStatistics()
 
     spark.sql("ANALYZE TABLE T COMPUTE STATISTICS FOR ALL COLUMNS")
-    val withColStat = checkStatistics(hasColStat = true)
+    val withColStat = checkStatistics()
 
     assert(withColStat == noColStat)
   }

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
@@ -30,6 +30,8 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assertions
 
+import java.util.UUID
+
 abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
 
   test("Paimon analyze: analyze table only") {
@@ -407,6 +409,63 @@ abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
           Assertions.assertEquals(4L, getScanStatistic(sqlText).rowCount.get.longValue())
         }
       })
+  }
+
+  test("Fix reported statistics does not do column pruning") {
+    spark.sql("""
+                |CREATE TABLE T (c1 INT, c2 INT, c3 LONG, c4 STRING)
+                |USING PAIMON
+                |TBLPROPERTIES ('primary-key'='c1')
+                |""".stripMargin)
+    spark.sql("ANALYZE TABLE T COMPUTE STATISTICS")
+
+    val wholeSize1 = getScanStatistic("SELECT * FROM T")
+    assert(wholeSize1.rowCount.get.toLong == 0)
+    assert(wholeSize1.sizeInBytes.toLong == 0)
+    val metadataSize1 = getScanStatistic("SELECT __paimon_row_index FROM T")
+    assert(metadataSize1.rowCount.get.toLong == 0)
+    assert(metadataSize1.sizeInBytes.toLong == 0)
+
+    spark.sql(s"INSERT INTO T VALUES (1, 1, 100, '${UUID.randomUUID().toString()}')")
+    spark.sql(s"INSERT INTO T VALUES (2, 2, 200, '${UUID.randomUUID().toString()}')")
+    spark.sql(s"INSERT INTO T VALUES (3, 3, 300, '${UUID.randomUUID().toString()}')")
+
+    def checkStatistics(hasColStat: Boolean): Long = {
+      val wholeSize2 = getScanStatistic("SELECT * FROM T")
+      assert(wholeSize2.rowCount.get.toLong == 3)
+      assert(wholeSize2.sizeInBytes.toLong > 0)
+      val wholeSizeWithMetadata = getScanStatistic("SELECT *, __paimon_file_path FROM T")
+      assert(wholeSizeWithMetadata.rowCount.get.toLong == 3)
+      assert(wholeSizeWithMetadata.sizeInBytes.toLong == wholeSize2.sizeInBytes.toLong + 20 * 3)
+
+      val oneColSize = getScanStatistic("SELECT c3 FROM T")
+      val threeColSize = getScanStatistic("SELECT c1, c2, c3 FROM T")
+      val longMetadataSize = getScanStatistic("SELECT __paimon_row_index FROM T")
+      assert(oneColSize.rowCount.get.toLong == 3)
+      assert(threeColSize.rowCount.get.toLong == 3)
+      assert(longMetadataSize.rowCount.get.toLong == 3)
+      assert(longMetadataSize.sizeInBytes == 8 * 3)
+      assert(oneColSize.sizeInBytes > 0 && oneColSize.sizeInBytes < wholeSize2.sizeInBytes)
+      assert(threeColSize.sizeInBytes < wholeSize2.sizeInBytes)
+      assert(threeColSize.sizeInBytes > oneColSize.sizeInBytes)
+
+      if (hasColStat) {
+        // It not always not equal but tests result show them are not equal
+        assert(oneColSize.sizeInBytes * 2 != threeColSize.sizeInBytes)
+      } else {
+        assert(oneColSize.sizeInBytes * 2 == threeColSize.sizeInBytes)
+      }
+
+      wholeSize2.sizeInBytes.toLong
+    }
+
+    spark.sql("ANALYZE TABLE T COMPUTE STATISTICS")
+    val noColStat = checkStatistics(hasColStat = false)
+
+    spark.sql("ANALYZE TABLE T COMPUTE STATISTICS FOR ALL COLUMNS")
+    val withColStat = checkStatistics(hasColStat = true)
+
+    assert(withColStat == noColStat)
   }
 
   protected def statsFileCount(tableLocation: Path, fileIO: FileIO): Int = {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
`SupportsReportStatistics#estimateStatistics` should report the statistics after do column pruning, filter push down. This pr fixes it does not do column pruning. In addition, we should consider the metadata column size.

Introduce `defaultSize` method for `DataType`, so that we can get the size in bytes without column statistics.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
add test

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
