### PR TITLE
[core] Manifest table query throw exception with range of snapshot when snapshot id not exist

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ManifestsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ManifestsTable.java
@@ -40,7 +40,11 @@ import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
-import org.apache.paimon.utils.*;
+import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.IteratorRecordReader;
+import org.apache.paimon.utils.ProjectedRow;
+import org.apache.paimon.utils.SerializationUtils;
+import org.apache.paimon.utils.SnapshotManager;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.Iterators;
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ManifestsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ManifestsTable.java
@@ -45,6 +45,7 @@ import org.apache.paimon.utils.IteratorRecordReader;
 import org.apache.paimon.utils.ProjectedRow;
 import org.apache.paimon.utils.SerializationUtils;
 import org.apache.paimon.utils.SnapshotManager;
+import org.apache.paimon.utils.SnapshotNotExistException;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.Iterators;
 
@@ -200,7 +201,7 @@ public class ManifestsTable implements ReadonlyTable {
             if (!snapshotManager.snapshotExists(snapshotId)) {
                 Long earliestSnapshotId = snapshotManager.earliestSnapshotId();
                 Long latestSnapshotId = snapshotManager.latestSnapshotId();
-                throw new RuntimeException(
+                throw new SnapshotNotExistException(
                         String.format(
                                 "Specified scan.snapshot-id %s is not exist, you can set it in range from %s to %s",
                                 snapshotId, earliestSnapshotId, latestSnapshotId));

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ManifestsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ManifestsTable.java
@@ -202,8 +202,8 @@ public class ManifestsTable implements ReadonlyTable {
                 Long latestSnapshotId = snapshotManager.latestSnapshotId();
                 throw new RuntimeException(
                         String.format(
-                                "scan.snapshot-id is not exist, you can set it in range from %s to %s",
-                                earliestSnapshotId, latestSnapshotId));
+                                "Specified scan.snapshot-id %s is not exist, you can set it in range from %s to %s",
+                                snapshotId, earliestSnapshotId, latestSnapshotId));
             }
             snapshot = snapshotManager.snapshot(snapshotId);
         } else if (snapshotId == null) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ManifestsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ManifestsTable.java
@@ -40,11 +40,7 @@ import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
-import org.apache.paimon.utils.FileStorePathFactory;
-import org.apache.paimon.utils.IteratorRecordReader;
-import org.apache.paimon.utils.ProjectedRow;
-import org.apache.paimon.utils.SerializationUtils;
-import org.apache.paimon.utils.SnapshotManager;
+import org.apache.paimon.utils.*;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.Iterators;
 
@@ -195,7 +191,16 @@ public class ManifestsTable implements ReadonlyTable {
         SnapshotManager snapshotManager = dataTable.snapshotManager();
         Long snapshotId = coreOptions.scanSnapshotId();
         Snapshot snapshot = null;
-        if (snapshotId != null && snapshotManager.snapshotExists(snapshotId)) {
+        if (snapshotId != null) {
+            // reminder user with snapshot id range
+            if (!snapshotManager.snapshotExists(snapshotId)) {
+                Long earliestSnapshotId = snapshotManager.earliestSnapshotId();
+                Long latestSnapshotId = snapshotManager.latestSnapshotId();
+                throw new RuntimeException(
+                        String.format(
+                                "scan.snapshot-id is not exist, you can set it in range from %s to %s",
+                                earliestSnapshotId, latestSnapshotId));
+            }
             snapshot = snapshotManager.snapshot(snapshotId);
         } else if (snapshotId == null) {
             snapshot = snapshotManager.latestSnapshot();

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
@@ -45,7 +45,8 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.apache.paimon.utils.FileStorePathFactoryTest.createNonPartFactory;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.assertThrows;
 
 /** Unit tests for {@link ManifestsTable}. */
 public class ManifestsTableTest extends TableTestBase {
@@ -118,8 +119,7 @@ public class ManifestsTableTest extends TableTestBase {
                 (ManifestsTable)
                         manifestsTable.copy(
                                 Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "3"));
-        List<InternalRow> result = read(manifestsTable);
-        assertThat(result).isEmpty();
+        assertThrows(RuntimeException.class, () -> read(manifestsTable));
     }
 
     private List<InternalRow> getExpectedResult(long snapshotId) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
@@ -36,8 +36,8 @@ import org.apache.paimon.table.Table;
 import org.apache.paimon.table.TableTestBase;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.utils.SnapshotManager;
-
 import org.apache.paimon.utils.SnapshotNotExistException;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
@@ -119,7 +119,10 @@ public class ManifestsTableTest extends TableTestBase {
                 (ManifestsTable)
                         manifestsTable.copy(
                                 Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "3"));
-        assertThrows(RuntimeException.class, () -> read(manifestsTable));
+        assertThrows(
+                "Specified scan.snapshot-id 3 is not exist, you can set it in range from 1 to 2",
+                RuntimeException.class,
+                () -> read(manifestsTable));
     }
 
     private List<InternalRow> getExpectedResult(long snapshotId) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
@@ -45,7 +45,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.apache.paimon.utils.FileStorePathFactoryTest.createNonPartFactory;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 
 /** Unit tests for {@link ManifestsTable}. */

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
@@ -37,6 +37,7 @@ import org.apache.paimon.table.TableTestBase;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.utils.SnapshotManager;
 
+import org.apache.paimon.utils.SnapshotNotExistException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -121,7 +122,7 @@ public class ManifestsTableTest extends TableTestBase {
                                 Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "3"));
         assertThrows(
                 "Specified scan.snapshot-id 3 is not exist, you can set it in range from 1 to 2",
-                RuntimeException.class,
+                SnapshotNotExistException.class,
                 () -> read(manifestsTable));
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.PartitionNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
 import org.apache.flink.types.Row;
+import org.assertj.core.api.AssertionsForInterfaceTypes;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
@@ -103,6 +104,37 @@ public class CatalogTableITCase extends CatalogITCaseBase {
                 sql(
                         "SELECT snapshot_id, schema_id, commit_kind FROM T$snapshots WHERE snapshot_id <= 2");
         assertThat(result).contains(Row.of(1L, 0L, "APPEND"), Row.of(2L, 0L, "APPEND"));
+    }
+
+    @Test
+    public void testManifestsTableWithSnapshotId() {
+        sql(String.format("CREATE TABLE T (id INT PRIMARY KEY NOT ENFORCED, name STRING)"));
+
+        sql("INSERT INTO T VALUES (1, '111111111'), (2, '2'), (3, '3'), (4, '4')");
+
+        sql("INSERT INTO T VALUES (2, '2_1'), (3, '3_1')");
+
+        sql("INSERT INTO T VALUES (2, '2_2'), (4, '4_1')");
+
+        AssertionsForInterfaceTypes.assertThat(batchSql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(
+                        Row.of(1, "111111111"),
+                        Row.of(2, "2_2"),
+                        Row.of(3, "3_1"),
+                        Row.of(4, "4_1"));
+        List<Row> result =
+                sql(
+                        "SELECT num_added_files, num_deleted_files, schema_id FROM T$manifests /*+ OPTIONS('scan.snapshot-id'='2') */");
+
+        assertThat(result).containsExactlyInAnyOrder(Row.of(1L, 0L, 0L), Row.of(1L, 0L, 0L));
+
+        assertThatThrownBy(
+                        () ->
+                                sql(
+                                        "SELECT num_added_files, num_deleted_files, schema_id FROM T$manifests /*+ OPTIONS('scan.snapshot-id'='6') */"))
+                .hasCauseInstanceOf(RuntimeException.class)
+                .hasRootCauseMessage(
+                        "scan.snapshot-id is not exist, you can set it in range from 1 to 3");
     }
 
     @Test


### PR DESCRIPTION
… 
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Currently user can only query table manifest info of snapshot from scan.snapshot-id, due to snapshot manager of table, some early snapshot would clean. So maybe need offer user about snapshot range when user query a snapshot id which not exist.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
