### PR TITLE
[core] Introduce bucket entries to optimize Spark compact

### DIFF
--- a/docs/content/maintenance/system-tables.md
+++ b/docs/content/maintenance/system-tables.md
@@ -309,6 +309,22 @@ SELECT * FROM my_table$partitions;
 */
 ```
 
+### Buckets Table
+
+You can query the bucket files of the table.
+
+```sql
+SELECT * FROM my_table$buckets;
+
+/*
++---------------+--------+----------------+--------------------+--------------------+------------------------+
+|  partition    | bucket |   record_count |  file_size_in_bytes|          file_count|        last_update_time|
++---------------+--------+----------------+--------------------+--------------------+------------------------+
+|  [1]          |   0    |           1    |             645    |                1   | 2024-06-24 10:25:57.400|
++---------------+--------+----------------+--------------------+--------------------+------------------------+
+*/
+```
+
 ## Global System Table
 
 Global system tables contain the statistical information of all the tables exists in paimon. For convenient of searching, we create a reference system database called `sys`.

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/BucketEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/BucketEntry.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.manifest;
+
+import org.apache.paimon.annotation.Public;
+import org.apache.paimon.data.BinaryRow;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** Entry representing a bucket. */
+@Public
+public class BucketEntry {
+
+    private final BinaryRow partition;
+    private final int bucket;
+    private final long recordCount;
+    private final long fileSizeInBytes;
+    private final long fileCount;
+    private final long lastFileCreationTime;
+
+    public BucketEntry(
+            BinaryRow partition,
+            int bucket,
+            long recordCount,
+            long fileSizeInBytes,
+            long fileCount,
+            long lastFileCreationTime) {
+        this.partition = partition;
+        this.bucket = bucket;
+        this.recordCount = recordCount;
+        this.fileSizeInBytes = fileSizeInBytes;
+        this.fileCount = fileCount;
+        this.lastFileCreationTime = lastFileCreationTime;
+    }
+
+    public BinaryRow partition() {
+        return partition;
+    }
+
+    public int bucket() {
+        return bucket;
+    }
+
+    public long recordCount() {
+        return recordCount;
+    }
+
+    public long fileSizeInBytes() {
+        return fileSizeInBytes;
+    }
+
+    public long fileCount() {
+        return fileCount;
+    }
+
+    public long lastFileCreationTime() {
+        return lastFileCreationTime;
+    }
+
+    public BucketEntry merge(BucketEntry entry) {
+        return new BucketEntry(
+                partition,
+                bucket,
+                recordCount + entry.recordCount,
+                fileSizeInBytes + entry.fileSizeInBytes,
+                fileCount + entry.fileCount,
+                Math.max(lastFileCreationTime, entry.lastFileCreationTime));
+    }
+
+    public static BucketEntry fromManifestEntry(ManifestEntry entry) {
+        PartitionEntry partitionEntry = PartitionEntry.fromManifestEntry(entry);
+        return new BucketEntry(
+                partitionEntry.partition(),
+                entry.bucket(),
+                partitionEntry.recordCount(),
+                partitionEntry.fileSizeInBytes(),
+                partitionEntry.fileCount(),
+                partitionEntry.lastFileCreationTime());
+    }
+
+    public static Collection<BucketEntry> merge(Collection<ManifestEntry> fileEntries) {
+        Map<BinaryRow, BucketEntry> buckets = new HashMap<>();
+        for (ManifestEntry entry : fileEntries) {
+            BucketEntry bucketEntry = fromManifestEntry(entry);
+            buckets.compute(
+                    entry.partition(),
+                    (part, old) -> old == null ? bucketEntry : old.merge(bucketEntry));
+        }
+        return buckets.values();
+    }
+
+    public static void merge(Collection<BucketEntry> from, Map<BinaryRow, BucketEntry> to) {
+        for (BucketEntry entry : from) {
+            to.compute(entry.partition(), (part, old) -> old == null ? entry : old.merge(entry));
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BucketEntry that = (BucketEntry) o;
+        return recordCount == that.recordCount
+                && fileSizeInBytes == that.fileSizeInBytes
+                && fileCount == that.fileCount
+                && lastFileCreationTime == that.lastFileCreationTime
+                && bucket == that.bucket
+                && Objects.equals(partition, that.partition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                partition, bucket, recordCount, fileSizeInBytes, fileCount, lastFileCreationTime);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/BucketEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/BucketEntry.java
@@ -20,6 +20,7 @@ package org.apache.paimon.manifest;
 
 import org.apache.paimon.annotation.Public;
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.utils.Pair;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -98,19 +99,22 @@ public class BucketEntry {
     }
 
     public static Collection<BucketEntry> merge(Collection<ManifestEntry> fileEntries) {
-        Map<BinaryRow, BucketEntry> buckets = new HashMap<>();
+        Map<Pair<BinaryRow, Integer>, BucketEntry> buckets = new HashMap<>();
         for (ManifestEntry entry : fileEntries) {
             BucketEntry bucketEntry = fromManifestEntry(entry);
             buckets.compute(
-                    entry.partition(),
+                    Pair.of(entry.partition(), entry.bucket()),
                     (part, old) -> old == null ? bucketEntry : old.merge(bucketEntry));
         }
         return buckets.values();
     }
 
-    public static void merge(Collection<BucketEntry> from, Map<BinaryRow, BucketEntry> to) {
+    public static void merge(
+            Collection<BucketEntry> from, Map<Pair<BinaryRow, Integer>, BucketEntry> to) {
         for (BucketEntry entry : from) {
-            to.compute(entry.partition(), (part, old) -> old == null ? entry : old.merge(entry));
+            to.compute(
+                    Pair.of(entry.partition(), entry.bucket),
+                    (part, old) -> old == null ? entry : old.merge(entry));
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -272,7 +272,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
     @Override
     public List<BucketEntry> readBucketEntries() {
         List<ManifestFileMeta> manifests = readManifests().getRight();
-        Map<BinaryRow, BucketEntry> buckets = new ConcurrentHashMap<>();
+        Map<Pair<BinaryRow, Integer>, BucketEntry> buckets = new ConcurrentHashMap<>();
         Consumer<ManifestFileMeta> processor =
                 m -> BucketEntry.merge(BucketEntry.merge(readManifestFileMeta(m)), buckets);
         randomlyOnlyExecute(getExecutorService(scanManifestParallelism), processor, manifests);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
@@ -21,6 +21,7 @@ package org.apache.paimon.operation;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.BucketEntry;
 import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.manifest.ManifestEntry;
@@ -97,6 +98,8 @@ public interface FileStoreScan {
     List<SimpleFileEntry> readSimpleEntries();
 
     List<PartitionEntry> readPartitionEntries();
+
+    List<BucketEntry> readBucketEntries();
 
     default List<BinaryRow> listPartitions() {
         return readPartitionEntries().stream()

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
@@ -21,6 +21,7 @@ package org.apache.paimon.table.source.snapshot;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.manifest.BucketEntry;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.metrics.MetricRegistry;
@@ -87,6 +88,8 @@ public interface SnapshotReader {
     List<BinaryRow> partitions();
 
     List<PartitionEntry> partitionEntries();
+
+    List<BucketEntry> bucketEntries();
 
     /** Result plan of this scan. */
     interface Plan extends TableScan.Plan {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
@@ -27,6 +27,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.BucketEntry;
 import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.PartitionEntry;
@@ -333,6 +334,11 @@ public class SnapshotReaderImpl implements SnapshotReader {
     @Override
     public List<PartitionEntry> partitionEntries() {
         return scan.readPartitionEntries();
+    }
+
+    @Override
+    public List<BucketEntry> bucketEntries() {
+        return scan.readBucketEntries();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
@@ -27,6 +27,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.manifest.BucketEntry;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFileMeta;
@@ -358,6 +359,11 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
         @Override
         public List<PartitionEntry> partitionEntries() {
             return snapshotReader.partitionEntries();
+        }
+
+        @Override
+        public List<BucketEntry> bucketEntries() {
+            return snapshotReader.bucketEntries();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/CompactBucketsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/CompactBucketsTable.java
@@ -66,11 +66,12 @@ import static org.apache.paimon.utils.SerializationUtils.newBytesType;
 import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
 
 /**
- * A table to produce modified partitions and buckets for each snapshot.
+ * A table to produce modified partitions and buckets (also including files in streaming mode) for
+ * each snapshot.
  *
  * <p>Only used internally by dedicated compact job sources.
  */
-public class BucketsTable implements DataTable, ReadonlyTable {
+public class CompactBucketsTable implements DataTable, ReadonlyTable {
 
     private static final long serialVersionUID = 1L;
 
@@ -98,12 +99,12 @@ public class BucketsTable implements DataTable, ReadonlyTable {
                         "_TABLE_NAME"
                     });
 
-    public BucketsTable(FileStoreTable wrapped, boolean isContinuous) {
+    public CompactBucketsTable(FileStoreTable wrapped, boolean isContinuous) {
         this(wrapped, isContinuous, null);
     }
 
     // if need to specify the database of a table, use this method
-    public BucketsTable(FileStoreTable wrapped, boolean isContinuous, String databaseName) {
+    public CompactBucketsTable(FileStoreTable wrapped, boolean isContinuous, String databaseName) {
         this.wrapped = wrapped;
         this.isContinuous = isContinuous;
         this.databaseName = databaseName;
@@ -156,7 +157,8 @@ public class BucketsTable implements DataTable, ReadonlyTable {
 
     @Override
     public DataTable switchToBranch(String branchName) {
-        return new BucketsTable(wrapped.switchToBranch(branchName), isContinuous, databaseName);
+        return new CompactBucketsTable(
+                wrapped.switchToBranch(branchName), isContinuous, databaseName);
     }
 
     @Override
@@ -205,8 +207,8 @@ public class BucketsTable implements DataTable, ReadonlyTable {
     }
 
     @Override
-    public BucketsTable copy(Map<String, String> dynamicOptions) {
-        return new BucketsTable(wrapped.copy(dynamicOptions), isContinuous, databaseName);
+    public CompactBucketsTable copy(Map<String, String> dynamicOptions) {
+        return new CompactBucketsTable(wrapped.copy(dynamicOptions), isContinuous, databaseName);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
@@ -42,6 +42,7 @@ import static org.apache.paimon.table.system.AggregationFieldsTable.AGGREGATION_
 import static org.apache.paimon.table.system.AllTableOptionsTable.ALL_TABLE_OPTIONS;
 import static org.apache.paimon.table.system.AuditLogTable.AUDIT_LOG;
 import static org.apache.paimon.table.system.BranchesTable.BRANCHES;
+import static org.apache.paimon.table.system.BucketsTable.BUCKETS;
 import static org.apache.paimon.table.system.CatalogOptionsTable.CATALOG_OPTIONS;
 import static org.apache.paimon.table.system.ConsumersTable.CONSUMERS;
 import static org.apache.paimon.table.system.FilesTable.FILES;
@@ -67,6 +68,7 @@ public class SystemTableLoader {
                     .put(OPTIONS, OptionsTable::new)
                     .put(SCHEMAS, SchemasTable::new)
                     .put(PARTITIONS, PartitionsTable::new)
+                    .put(BUCKETS, BucketsTable::new)
                     .put(AUDIT_LOG, AuditLogTable::new)
                     .put(FILES, FilesTable::new)
                     .put(TAGS, TagsTable::new)

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/BucketsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/BucketsTableTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.system;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.SchemaUtils;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.types.DataTypes;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.paimon.catalog.Catalog.SYSTEM_TABLE_SPLITTER;
+import static org.apache.paimon.table.system.BucketsTable.BUCKETS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link BucketsTable}. */
+public class BucketsTableTest extends TableTestBase {
+
+    private Table bucketsTable;
+
+    @BeforeEach
+    public void before() throws Exception {
+        String tableName = "MyTable";
+        FileIO fileIO = LocalFileIO.create();
+        Path tablePath = new Path(String.format("%s/%s.db/%s", warehouse, database, tableName));
+        Schema schema =
+                Schema.newBuilder()
+                        .column("pk", DataTypes.INT())
+                        .column("pt", DataTypes.INT())
+                        .column("col1", DataTypes.INT())
+                        .partitionKeys("pt")
+                        .primaryKey("pk", "pt")
+                        .option("bucket", "2")
+                        .build();
+        TableSchema tableSchema =
+                SchemaUtils.forceCommit(new SchemaManager(fileIO, tablePath), schema);
+        FileStoreTable table =
+                FileStoreTableFactory.create(LocalFileIO.create(), tablePath, tableSchema);
+
+        bucketsTable = catalog.getTable(identifier(tableName + SYSTEM_TABLE_SPLITTER + BUCKETS));
+
+        write(table, GenericRow.of(1, 1, 1), GenericRow.of(1, 2, 5));
+        write(table, GenericRow.of(1, 1, 3), GenericRow.of(1, 2, 4));
+    }
+
+    @Test
+    public void testBucketsTable() throws Exception {
+        assertThat(read(bucketsTable, new int[][] {{0}, {1}, {2}, {4}}))
+                .containsExactlyInAnyOrder(
+                        GenericRow.of(BinaryString.fromString("[1]"), 0, 2L, 2L),
+                        GenericRow.of(BinaryString.fromString("[2]"), 0, 2L, 2L));
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/MultiAwareBucketTableScan.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/MultiAwareBucketTableScan.java
@@ -24,7 +24,7 @@ import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.StreamTableScan;
-import org.apache.paimon.table.system.BucketsTable;
+import org.apache.paimon.table.system.CompactBucketsTable;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 
@@ -44,7 +44,7 @@ import static org.apache.paimon.flink.utils.MultiTablesCompactorUtil.compactOpti
  */
 public class MultiAwareBucketTableScan extends MultiTableScanBase<Tuple2<Split, String>> {
 
-    protected transient Map<Identifier, BucketsTable> tablesMap;
+    protected transient Map<Identifier, CompactBucketsTable> tablesMap;
     protected transient Map<Identifier, StreamTableScan> scansMap;
 
     public MultiAwareBucketTableScan(
@@ -87,8 +87,9 @@ public class MultiAwareBucketTableScan extends MultiTableScanBase<Tuple2<Split, 
     @Override
     public void addScanTable(FileStoreTable fileStoreTable, Identifier identifier) {
         if (fileStoreTable.bucketMode() != BucketMode.BUCKET_UNAWARE) {
-            BucketsTable bucketsTable =
-                    new BucketsTable(fileStoreTable, isStreaming, identifier.getDatabaseName())
+            CompactBucketsTable bucketsTable =
+                    new CompactBucketsTable(
+                                    fileStoreTable, isStreaming, identifier.getDatabaseName())
                             .copy(compactOptions(isStreaming));
             tablesMap.put(identifier, bucketsTable);
             scansMap.put(identifier, bucketsTable.newReadBuilder().newStreamScan());

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/BucketsRowChannelComputer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/BucketsRowChannelComputer.java
@@ -20,13 +20,13 @@ package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.table.sink.ChannelComputer;
-import org.apache.paimon.table.system.BucketsTable;
+import org.apache.paimon.table.system.CompactBucketsTable;
 
 import org.apache.flink.table.data.RowData;
 
 import static org.apache.paimon.utils.SerializationUtils.deserializeBinaryRow;
 
-/** {@link ChannelComputer} to partition {@link RowData} from {@link BucketsTable}. */
+/** {@link ChannelComputer} to partition {@link RowData} from {@link CompactBucketsTable}. */
 public class BucketsRowChannelComputer implements ChannelComputer<RowData> {
 
     private transient int numberOfChannels;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CombinedTableCompactorSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CombinedTableCompactorSourceBuilder.java
@@ -25,7 +25,7 @@ import org.apache.paimon.flink.source.operator.CombinedAwareBatchSourceFunction;
 import org.apache.paimon.flink.source.operator.CombinedAwareStreamingSourceFunction;
 import org.apache.paimon.flink.source.operator.CombinedUnawareBatchSourceFunction;
 import org.apache.paimon.flink.source.operator.CombinedUnawareStreamingSourceFunction;
-import org.apache.paimon.table.system.BucketsTable;
+import org.apache.paimon.table.system.CompactBucketsTable;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Preconditions;
 
@@ -85,7 +85,7 @@ public class CombinedTableCompactorSourceBuilder {
 
     public DataStream<RowData> buildAwareBucketTableSource() {
         Preconditions.checkArgument(env != null, "StreamExecutionEnvironment should not be null.");
-        RowType produceType = BucketsTable.getRowType();
+        RowType produceType = CompactBucketsTable.getRowType();
         if (isContinuous) {
             return CombinedAwareStreamingSourceFunction.buildSource(
                     env,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/MultiTablesReadOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/MultiTablesReadOperator.java
@@ -29,7 +29,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
-import org.apache.paimon.table.system.BucketsTable;
+import org.apache.paimon.table.system.CompactBucketsTable;
 import org.apache.paimon.utils.CloseableIterator;
 import org.apache.paimon.utils.Preconditions;
 
@@ -80,7 +80,7 @@ public class MultiTablesReadOperator extends AbstractStreamOperator<RowData>
 
     private transient Catalog catalog;
     private transient IOManager ioManager;
-    private transient Map<Identifier, BucketsTable> tablesMap;
+    private transient Map<Identifier, CompactBucketsTable> tablesMap;
     private transient Map<Identifier, TableRead> readsMap;
     private transient StreamRecord<RowData> reuseRecord;
     private transient FlinkRowData reuseRow;
@@ -132,7 +132,7 @@ public class MultiTablesReadOperator extends AbstractStreamOperator<RowData>
     }
 
     private TableRead getTableRead(Identifier tableId) {
-        BucketsTable table = tablesMap.get(tableId);
+        CompactBucketsTable table = tablesMap.get(tableId);
         if (table == null) {
             try {
                 Table newTable = catalog.getTable(tableId);
@@ -141,7 +141,7 @@ public class MultiTablesReadOperator extends AbstractStreamOperator<RowData>
                         "Only FileStoreTable supports compact action. The table type is '%s'.",
                         newTable.getClass().getName());
                 table =
-                        new BucketsTable(
+                        new CompactBucketsTable(
                                         (FileStoreTable) newTable,
                                         isStreaming,
                                         tableId.getDatabaseName())
@@ -156,7 +156,7 @@ public class MultiTablesReadOperator extends AbstractStreamOperator<RowData>
         return readsMap.get(tableId);
     }
 
-    private Map<BinaryRow, Long> getPartitionInfo(BucketsTable table) {
+    private Map<BinaryRow, Long> getPartitionInfo(CompactBucketsTable table) {
         List<PartitionEntry> partitions = table.newSnapshotReader().partitionEntries();
 
         return partitions.stream()

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -264,9 +264,8 @@ public class CompactProcedure extends BaseProcedure {
         Set<BinaryRow> partitionToBeCompacted =
                 getHistoryPartition(snapshotReader, partitionIdleTime);
         List<Pair<byte[], Integer>> partitionBuckets =
-                snapshotReader.read().splits().stream()
-                        .map(split -> (DataSplit) split)
-                        .map(dataSplit -> Pair.of(dataSplit.partition(), dataSplit.bucket()))
+                snapshotReader.bucketEntries().stream()
+                        .map(entry -> Pair.of(entry.partition(), entry.bucket()))
                         .distinct()
                         .filter(pair -> partitionToBeCompacted.contains(pair.getKey()))
                         .map(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Now Spark Bucketed table Compact will plan all files to know the buckets. We can introduce `BucketEntry` just like `PartitionEntry` to reduce memory usage.

This PR:
1. Introduce bucket entries to optimize Spark compact
2. Add BucketsTable system table to show bucket information.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

1. Existed tests.
2. `BucketsTableTest`.

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
