### PR TITLE
[cdc] paimon cdc support snapshot mode

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBActionUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBActionUtils.java
@@ -58,6 +58,7 @@ public class MongoDBActionUtils {
     private static final String INITIAL_MODE = "initial";
     private static final String LATEST_OFFSET_MODE = "latest-offset";
     private static final String TIMESTAMP_MODE = "timestamp";
+    private static final String SNAPSHOT_MODE = "snapshot";
 
     public static final ConfigOption<String> FIELD_NAME =
             ConfigOptions.key("field.name")
@@ -128,8 +129,14 @@ public class MongoDBActionUtils {
                         StartupOptions.timestamp(
                                 mongodbConfig.get(SourceOptions.SCAN_STARTUP_TIMESTAMP_MILLIS)));
                 break;
+            case SNAPSHOT_MODE:
+                sourceBuilder.startupOptions(StartupOptions.snapshot());
+                break;
             default:
-                throw new IllegalArgumentException("Unsupported startup mode: " + startupMode);
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Unknown scan.startup.mode='%s'. Valid scan.startup.mode for MongoDB CDC are [initial, latest-offset, timestamp, snapshot]",
+                                startupMode));
         }
 
         Map<String, Object> customConverterConfigs = new HashMap<>();

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionUtils.java
@@ -213,6 +213,13 @@ public class MySqlActionUtils {
             sourceBuilder.startupOptions(
                     StartupOptions.timestamp(
                             mySqlConfig.get(MySqlSourceOptions.SCAN_STARTUP_TIMESTAMP_MILLIS)));
+        } else if ("snapshot".equalsIgnoreCase(startupMode)) {
+            sourceBuilder.startupOptions(StartupOptions.snapshot());
+        } else {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Unknown scan.startup.mode='%s'. Valid scan.startup.mode for MySQL CDC are [initial, earliest-offset, latest-offset, specific-offset, timestamp, snapshot]",
+                            startupMode));
         }
 
         Properties jdbcProperties = new Properties();

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresActionUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresActionUtils.java
@@ -167,6 +167,13 @@ public class PostgresActionUtils {
             sourceBuilder.startupOptions(StartupOptions.initial());
         } else if ("latest-offset".equalsIgnoreCase(startupMode)) {
             sourceBuilder.startupOptions(StartupOptions.latest());
+        } else if ("snapshot".equalsIgnoreCase(startupMode)) {
+            sourceBuilder.startupOptions(StartupOptions.snapshot());
+        } else {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Unknown scan.startup.mode='%s'. Valid scan.startup.mode for Postgres CDC are [initial, latest-offset, snapshot]",
+                            startupMode));
         }
 
         Properties debeziumProperties = new Properties();

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
@@ -1478,4 +1478,23 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
             waitForResult(expected, table, rowType, primaryKeys);
         }
     }
+
+    @Test
+    @Timeout(60)
+    public void testUnknowMysqlScanStartupMode() {
+        String scanStartupMode = "abc";
+        Map<String, String> mySqlConfig = getBasicMySqlConfig();
+        mySqlConfig.put("database-name", DATABASE_NAME);
+        mySqlConfig.put("table-name", "schema_evolution_multiple");
+        mySqlConfig.put("scan.startup.mode", scanStartupMode);
+
+        MySqlSyncTableAction action = syncTableActionBuilder(mySqlConfig).build();
+        assertThatThrownBy(action::run)
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class,
+                                "Unknown scan.startup.mode='"
+                                        + scanStartupMode
+                                        + "'. Valid scan.startup.mode for MySQL CDC are [initial, earliest-offset, latest-offset, specific-offset, timestamp, snapshot]"));
+    }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Currently paimon cdc does not support scan.startup.mode=snapshot, but flink-cdc 3.x(mysql、pg、mongdb cdc) already supports shapshot mode
![image](https://github.com/user-attachments/assets/cf93a743-25ac-4da0-8bc9-21f580902e3e)


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
