### PR TITLE
[core] Add commit max retries if commit failed

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -117,6 +117,12 @@ under the License.
             <td>Whether to force create snapshot on commit.</td>
         </tr>
         <tr>
+            <td><h5>commit.max-retries</h5></td>
+            <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
+            <td>Maximum number of retries when commit failed.</td>
+        </tr>
+        <tr>
             <td><h5>commit.user-prefix</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -493,6 +493,12 @@ public class CoreOptions implements Serializable {
                     .defaultValue(false)
                     .withDescription("Whether to force a compaction before commit.");
 
+    public static final ConfigOption<Integer> COMMIT_MAX_RETRIES =
+            key("commit.max-retries")
+                    .intType()
+                    .defaultValue(10)
+                    .withDescription("Maximum number of retries when commit failed.");
+
     public static final ConfigOption<Integer> COMPACTION_MAX_SIZE_AMPLIFICATION_PERCENT =
             key("compaction.max-size-amplification-percent")
                     .intType()
@@ -1734,6 +1740,10 @@ public class CoreOptions implements Serializable {
 
     public boolean commitForceCompact() {
         return options.get(COMMIT_FORCE_COMPACT);
+    }
+
+    public int commitMaxRetries() {
+        return options.get(COMMIT_MAX_RETRIES);
     }
 
     public int maxSizeAmplificationPercent() {

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -218,7 +218,8 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 newStatsFileHandler(),
                 bucketMode(),
                 options.scanManifestParallelism(),
-                callbacks);
+                callbacks,
+                options.commitMaxRetries());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -131,6 +131,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
     private final List<CommitCallback> commitCallbacks;
     private final StatsFileHandler statsFileHandler;
     private final BucketMode bucketMode;
+    private final int commitMaxRetries;
 
     @Nullable private Lock lock;
     private boolean ignoreEmptyCommit;
@@ -159,7 +160,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             StatsFileHandler statsFileHandler,
             BucketMode bucketMode,
             @Nullable Integer manifestReadParallelism,
-            List<CommitCallback> commitCallbacks) {
+            List<CommitCallback> commitCallbacks,
+            int commitMaxRetries) {
         this.fileIO = fileIO;
         this.schemaManager = schemaManager;
         this.commitUser = commitUser;
@@ -180,6 +182,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         this.branchName = branchName;
         this.manifestReadParallelism = manifestReadParallelism;
         this.commitCallbacks = commitCallbacks;
+        this.commitMaxRetries = commitMaxRetries;
 
         this.lock = null;
         this.ignoreEmptyCommit = true;
@@ -712,6 +715,12 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         while (true) {
             Snapshot latestSnapshot = snapshotManager.latestSnapshot();
             cnt++;
+            if (cnt >= commitMaxRetries) {
+                throw new RuntimeException(
+                        String.format(
+                                "Commit failed after %s attempts, there maybe exist commit conflicts between multiple jobs.",
+                                commitMaxRetries));
+            }
             if (tryCommitOnce(
                     tableFiles,
                     changelogFiles,
@@ -742,6 +751,12 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             Snapshot latestSnapshot = snapshotManager.latestSnapshot();
 
             cnt++;
+            if (cnt >= commitMaxRetries) {
+                throw new RuntimeException(
+                        String.format(
+                                "Commit failed after %s attempts, there maybe exist commit conflicts between multiple jobs.",
+                                commitMaxRetries));
+            }
             List<ManifestEntry> changesWithOverwrite = new ArrayList<>();
             List<IndexManifestEntry> indexChangesWithOverwrite = new ArrayList<>();
             if (latestSnapshot != null) {
@@ -805,6 +820,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             ConflictCheck conflictCheck,
             String branchName,
             @Nullable String newStatsFileName) {
+        long startMillis = System.currentTimeMillis();
         long newSnapshotId =
                 latestSnapshot == null ? Snapshot.FIRST_SNAPSHOT_ID : latestSnapshot.id() + 1;
         Path newSnapshotPath =
@@ -1012,12 +1028,18 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         }
 
         // atomic rename fails, clean up and try again
+        long commitTime = (System.currentTimeMillis() - startMillis) / 1000;
         LOG.warn(
                 String.format(
                         "Atomic commit failed for snapshot #%d (path %s) by user %s "
-                                + "with identifier %s and kind %s. "
+                                + "with identifier %s and kind %s after %s seconds. "
                                 + "Clean up and try again.",
-                        newSnapshotId, newSnapshotPath, commitUser, identifier, commitKind.name()));
+                        newSnapshotId,
+                        newSnapshotPath,
+                        commitUser,
+                        identifier,
+                        commitKind.name(),
+                        commitTime));
         cleanUpTmpManifests(
                 previousChangesListName,
                 newChangesListName,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

We write data with flink stream and run a dedicated compaction with flink. If the compaction commit message is too large and commit time is too long followed, commit will fail and enter an infinite loop.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
