### PR TITLE
[flink] Fix debezium avro deserialization topic variable assignment

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaDebeziumAvroDeserializationSchema.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaDebeziumAvroDeserializationSchema.java
@@ -40,14 +40,12 @@ public class KafkaDebeziumAvroDeserializationSchema
 
     private static final long serialVersionUID = 1L;
 
-    private final String topic;
     private final String schemaRegistryUrl;
 
     /** The deserializer to deserialize Debezium Avro data. */
     private ConfluentAvroDeserializationSchema avroDeserializer;
 
     public KafkaDebeziumAvroDeserializationSchema(Configuration cdcSourceConfig) {
-        this.topic = KafkaActionUtils.findOneTopic(cdcSourceConfig);
         this.schemaRegistryUrl = cdcSourceConfig.getString(SCHEMA_REGISTRY_URL);
     }
 
@@ -67,6 +65,7 @@ public class KafkaDebeziumAvroDeserializationSchema
             initAvroDeserializer();
         }
 
+        String topic = message.topic();
         GenericContainerWithVersion keyContainerWithVersion =
                 this.avroDeserializer.deserialize(topic, true, message.key());
         GenericContainerWithVersion valueContainerWithVersion =


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx
The topic variable should be assigned from kafka `ConsumerRecord` in debezium avro deserialization.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
