### PR TITLE
[hive] HiveMigrator support set parallelism for procedures

### DIFF
--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -142,7 +142,7 @@ This section introduce all available spark procedures about paimon.
             <li>options_map: Options map for adding key-value options which is a map.</li>
             <li>parallelism: the parallelism for migrate process, default is core numbers of machine.</li>
       </td>
-      <td>CALL sys.migrate_table(source_type => 'hive', table => 'default.T', options => 'file.format=parquet', options_map => map('k1','v1'), parallelism => '6')</td>
+      <td>CALL sys.migrate_table(source_type => 'hive', table => 'default.T', options => 'file.format=parquet', options_map => map('k1','v1'), parallelism => 6)</td>
     </tr>
     <tr>
       <td>migrate_file</td>
@@ -154,7 +154,7 @@ This section introduce all available spark procedures about paimon.
             <li>delete_origin: If had set target_table, can set delete_origin to decide whether delete the origin table metadata from hms after migrate. Default is true</li>
             <li>parallelism: the parallelism for migrate process, default is core numbers of machine.</li>
       </td>
-      <td>CALL sys.migrate_file(source_type => 'hive', table => 'default.T', delete_origin => true, parallelism => '6')</td>
+      <td>CALL sys.migrate_file(source_type => 'hive', table => 'default.T', delete_origin => true, parallelism => 6)</td>
     </tr>
     <tr>
       <td>remove_orphan_files</td>

--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -139,9 +139,10 @@ This section introduce all available spark procedures about paimon.
             <li>options: the table options of the paimon table to migrate.</li>
             <li>target_table: name of the target paimon table to migrate. If not set would keep the same name with origin table</li>
             <li>delete_origin: If had set target_table, can set delete_origin to decide whether delete the origin table metadata from hms after migrate. Default is true</li>
-            <li>options_map: Options map for adding key-value options which is a map.</li>      
+            <li>options_map: Options map for adding key-value options which is a map.</li>
+            <li>parallelism: the parallelism for migrate process, default is core numbers of machine.</li>
       </td>
-      <td>CALL sys.migrate_table(source_type => 'hive', table => 'default.T', options => 'file.format=parquet', options_map => map('k1','v1'))</td>
+      <td>CALL sys.migrate_table(source_type => 'hive', table => 'default.T', options => 'file.format=parquet', options_map => map('k1','v1'), parallelism => '6')</td>
     </tr>
     <tr>
       <td>migrate_file</td>
@@ -151,8 +152,9 @@ This section introduce all available spark procedures about paimon.
             <li>source_table: name of the origin table to migrate. Cannot be empty.</li>
             <li>target_table: name of the target table to be migrated. Cannot be empty.</li>
             <li>delete_origin: If had set target_table, can set delete_origin to decide whether delete the origin table metadata from hms after migrate. Default is true</li>
+            <li>parallelism: the parallelism for migrate process, default is core numbers of machine.</li>
       </td>
-      <td>CALL sys.migrate_file(source_type => 'hive', table => 'default.T', delete_origin => true)</td>
+      <td>CALL sys.migrate_file(source_type => 'hive', table => 'default.T', delete_origin => true, parallelism => '6')</td>
     </tr>
     <tr>
       <td>remove_orphan_files</td>

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink.procedure;
 import org.apache.paimon.flink.utils.TableMigrationUtils;
 import org.apache.paimon.migrate.Migrator;
 import org.apache.paimon.utils.ParameterUtils;
+import org.apache.paimon.utils.StringUtils;
 
 import org.apache.flink.table.procedure.ProcedureContext;
 
@@ -51,6 +52,34 @@ public class MigrateDatabaseProcedure extends ProcedureBase {
                         connector,
                         catalog,
                         sourceDatabasePath,
+                        Runtime.getRuntime().availableProcessors(),
+                        ParameterUtils.parseCommaSeparatedKeyValues(properties));
+
+        for (Migrator migrator : migrators) {
+            migrator.executeMigrate();
+            migrator.renameTable(false);
+        }
+
+        return new String[] {"Success"};
+    }
+
+    public String[] call(
+            ProcedureContext procedureContext,
+            String connector,
+            String sourceDatabasePath,
+            String properties,
+            String parallelism)
+            throws Exception {
+        Integer p =
+                StringUtils.isNumeric(parallelism)
+                        ? Runtime.getRuntime().availableProcessors()
+                        : Integer.parseInt(parallelism);
+        List<Migrator> migrators =
+                TableMigrationUtils.getImporters(
+                        connector,
+                        catalog,
+                        sourceDatabasePath,
+                        p,
                         ParameterUtils.parseCommaSeparatedKeyValues(properties));
 
         for (Migrator migrator : migrators) {

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
@@ -21,7 +21,6 @@ package org.apache.paimon.flink.procedure;
 import org.apache.paimon.flink.utils.TableMigrationUtils;
 import org.apache.paimon.migrate.Migrator;
 import org.apache.paimon.utils.ParameterUtils;
-import org.apache.paimon.utils.StringUtils;
 
 import org.apache.flink.table.procedure.ProcedureContext;
 
@@ -68,12 +67,9 @@ public class MigrateDatabaseProcedure extends ProcedureBase {
             String connector,
             String sourceDatabasePath,
             String properties,
-            String parallelism)
+            Integer parallelism)
             throws Exception {
-        Integer p =
-                !StringUtils.isNumeric(parallelism)
-                        ? Runtime.getRuntime().availableProcessors()
-                        : Integer.parseInt(parallelism);
+        Integer p = parallelism == null ? Runtime.getRuntime().availableProcessors() : parallelism;
         List<Migrator> migrators =
                 TableMigrationUtils.getImporters(
                         connector,

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
@@ -71,7 +71,7 @@ public class MigrateDatabaseProcedure extends ProcedureBase {
             String parallelism)
             throws Exception {
         Integer p =
-                StringUtils.isNumeric(parallelism)
+                !StringUtils.isNumeric(parallelism)
                         ? Runtime.getRuntime().availableProcessors()
                         : Integer.parseInt(parallelism);
         List<Migrator> migrators =

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MigrateFileProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MigrateFileProcedure.java
@@ -21,7 +21,6 @@ package org.apache.paimon.flink.procedure;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.utils.TableMigrationUtils;
 import org.apache.paimon.migrate.Migrator;
-import org.apache.paimon.utils.StringUtils;
 
 import org.apache.flink.table.procedure.ProcedureContext;
 
@@ -72,12 +71,9 @@ public class MigrateFileProcedure extends ProcedureBase {
             String sourceTablePath,
             String targetPaimonTablePath,
             boolean deleteOrigin,
-            String parallelism)
+            Integer parallelism)
             throws Exception {
-        Integer p =
-                !StringUtils.isNumeric(parallelism)
-                        ? Runtime.getRuntime().availableProcessors()
-                        : Integer.parseInt(parallelism);
+        Integer p = parallelism == null ? Runtime.getRuntime().availableProcessors() : parallelism;
         migrateHandle(connector, sourceTablePath, targetPaimonTablePath, deleteOrigin, p);
         return new String[] {"Success"};
     }

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MigrateFileProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MigrateFileProcedure.java
@@ -75,7 +75,7 @@ public class MigrateFileProcedure extends ProcedureBase {
             String parallelism)
             throws Exception {
         Integer p =
-                StringUtils.isNumeric(parallelism)
+                !StringUtils.isNumeric(parallelism)
                         ? Runtime.getRuntime().availableProcessors()
                         : Integer.parseInt(parallelism);
         migrateHandle(connector, sourceTablePath, targetPaimonTablePath, deleteOrigin, p);

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MigrateTableProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MigrateTableProcedure.java
@@ -62,6 +62,35 @@ public class MigrateTableProcedure extends ProcedureBase {
                         sourceTableId.getObjectName(),
                         targetTableId.getDatabaseName(),
                         targetTableId.getObjectName(),
+                        Runtime.getRuntime().availableProcessors(),
+                        ParameterUtils.parseCommaSeparatedKeyValues(properties))
+                .executeMigrate();
+
+        LOG.info("Last step: rename " + targetTableId + " to " + sourceTableId);
+        catalog.renameTable(targetTableId, sourceTableId, false);
+        return new String[] {"Success"};
+    }
+
+    public String[] call(
+            ProcedureContext procedureContext,
+            String connector,
+            String sourceTablePath,
+            String properties,
+            Integer parallelism)
+            throws Exception {
+        String targetPaimonTablePath = sourceTablePath + PAIMON_SUFFIX;
+
+        Identifier sourceTableId = Identifier.fromString(sourceTablePath);
+        Identifier targetTableId = Identifier.fromString(targetPaimonTablePath);
+
+        TableMigrationUtils.getImporter(
+                        connector,
+                        catalog,
+                        sourceTableId.getDatabaseName(),
+                        sourceTableId.getObjectName(),
+                        targetTableId.getDatabaseName(),
+                        targetTableId.getObjectName(),
+                        parallelism,
                         ParameterUtils.parseCommaSeparatedKeyValues(properties))
                 .executeMigrate();
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateDatabaseAction.java
@@ -29,7 +29,7 @@ public class MigrateDatabaseAction extends ActionBase {
     private final String connector;
     private final String hiveDatabaseName;
     private final String tableProperties;
-    private final String parallelism;
+    private final Integer parallelism;
 
     public MigrateDatabaseAction(
             String connector,
@@ -37,7 +37,7 @@ public class MigrateDatabaseAction extends ActionBase {
             String hiveDatabaseName,
             Map<String, String> catalogConfig,
             String tableProperties,
-            String parallelism) {
+            Integer parallelism) {
         super(warehouse, catalogConfig);
         this.connector = connector;
         this.hiveDatabaseName = hiveDatabaseName;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateDatabaseAction.java
@@ -29,17 +29,20 @@ public class MigrateDatabaseAction extends ActionBase {
     private final String connector;
     private final String hiveDatabaseName;
     private final String tableProperties;
+    private final String parallelism;
 
     public MigrateDatabaseAction(
             String connector,
             String warehouse,
             String hiveDatabaseName,
             Map<String, String> catalogConfig,
-            String tableProperties) {
+            String tableProperties,
+            String parallelism) {
         super(warehouse, catalogConfig);
         this.connector = connector;
         this.hiveDatabaseName = hiveDatabaseName;
         this.tableProperties = tableProperties;
+        this.parallelism = parallelism;
     }
 
     @Override
@@ -47,6 +50,10 @@ public class MigrateDatabaseAction extends ActionBase {
         MigrateDatabaseProcedure migrateDatabaseProcedure = new MigrateDatabaseProcedure();
         migrateDatabaseProcedure.withCatalog(catalog);
         migrateDatabaseProcedure.call(
-                new DefaultProcedureContext(env), connector, hiveDatabaseName, tableProperties);
+                new DefaultProcedureContext(env),
+                connector,
+                hiveDatabaseName,
+                tableProperties,
+                parallelism);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateDatabaseActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateDatabaseActionFactory.java
@@ -42,7 +42,7 @@ public class MigrateDatabaseActionFactory implements ActionFactory {
         String sourceHiveDatabase = params.get(DATABASE);
         Map<String, String> catalogConfig = optionalConfigMap(params, CATALOG_CONF);
         String tableConf = params.get(OPTIONS);
-        String parallelism = params.get(PARALLELISM);
+        Integer parallelism = Integer.parseInt(params.get(PARALLELISM));
 
         MigrateDatabaseAction migrateDatabaseAction =
                 new MigrateDatabaseAction(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateDatabaseActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateDatabaseActionFactory.java
@@ -28,6 +28,7 @@ public class MigrateDatabaseActionFactory implements ActionFactory {
 
     private static final String SOURCE_TYPE = "source_type";
     private static final String OPTIONS = "options";
+    private static final String PARALLELISM = "parallelism";
 
     @Override
     public String identifier() {
@@ -41,10 +42,16 @@ public class MigrateDatabaseActionFactory implements ActionFactory {
         String sourceHiveDatabase = params.get(DATABASE);
         Map<String, String> catalogConfig = optionalConfigMap(params, CATALOG_CONF);
         String tableConf = params.get(OPTIONS);
+        String parallelism = params.get(PARALLELISM);
 
         MigrateDatabaseAction migrateDatabaseAction =
                 new MigrateDatabaseAction(
-                        connector, warehouse, sourceHiveDatabase, catalogConfig, tableConf);
+                        connector,
+                        warehouse,
+                        sourceHiveDatabase,
+                        catalogConfig,
+                        tableConf,
+                        parallelism);
         return Optional.of(migrateDatabaseAction);
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateFileAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateFileAction.java
@@ -32,6 +32,7 @@ public class MigrateFileAction extends ActionBase {
     private final String targetTable;
     private final String tableProperties;
     private boolean deleteOrigin;
+    private String parallelism;
 
     public MigrateFileAction(
             String connector,
@@ -40,13 +41,15 @@ public class MigrateFileAction extends ActionBase {
             String targetTable,
             boolean deleteOrigin,
             Map<String, String> catalogConfig,
-            String tableProperties) {
+            String tableProperties,
+            String parallelism) {
         super(warehouse, catalogConfig);
         this.connector = connector;
         this.sourceTable = sourceTable;
         this.targetTable = targetTable;
         this.deleteOrigin = deleteOrigin;
         this.tableProperties = tableProperties;
+        this.parallelism = parallelism;
     }
 
     @Override
@@ -58,6 +61,7 @@ public class MigrateFileAction extends ActionBase {
                 connector,
                 sourceTable,
                 targetTable,
-                deleteOrigin);
+                deleteOrigin,
+                parallelism);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateFileAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateFileAction.java
@@ -32,7 +32,7 @@ public class MigrateFileAction extends ActionBase {
     private final String targetTable;
     private final String tableProperties;
     private boolean deleteOrigin;
-    private String parallelism;
+    private Integer parallelism;
 
     public MigrateFileAction(
             String connector,
@@ -42,7 +42,7 @@ public class MigrateFileAction extends ActionBase {
             boolean deleteOrigin,
             Map<String, String> catalogConfig,
             String tableProperties,
-            String parallelism) {
+            Integer parallelism) {
         super(warehouse, catalogConfig);
         this.connector = connector;
         this.sourceTable = sourceTable;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateFileActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateFileActionFactory.java
@@ -35,6 +35,7 @@ public class MigrateFileActionFactory implements ActionFactory {
     private static final String DELETE_ORIGIN = "delete_origin";
 
     private static final String OPTIONS = "options";
+    private static final String PARALLELISM = "parallelism";
 
     @Override
     public String identifier() {
@@ -50,6 +51,7 @@ public class MigrateFileActionFactory implements ActionFactory {
         boolean deleteOrigin = Boolean.parseBoolean(params.get(DELETE_ORIGIN));
         Map<String, String> catalogConfig = optionalConfigMap(params, CATALOG_CONF);
         String tableConf = params.get(OPTIONS);
+        String parallelism = params.get(PARALLELISM);
 
         MigrateFileAction migrateFileAction =
                 new MigrateFileAction(
@@ -59,7 +61,8 @@ public class MigrateFileActionFactory implements ActionFactory {
                         targetTable,
                         deleteOrigin,
                         catalogConfig,
-                        tableConf);
+                        tableConf,
+                        parallelism);
         return Optional.of(migrateFileAction);
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateFileActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateFileActionFactory.java
@@ -51,7 +51,7 @@ public class MigrateFileActionFactory implements ActionFactory {
         boolean deleteOrigin = Boolean.parseBoolean(params.get(DELETE_ORIGIN));
         Map<String, String> catalogConfig = optionalConfigMap(params, CATALOG_CONF);
         String tableConf = params.get(OPTIONS);
-        String parallelism = params.get(PARALLELISM);
+        Integer parallelism = Integer.parseInt(params.get(PARALLELISM));
 
         MigrateFileAction migrateFileAction =
                 new MigrateFileAction(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateTableAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateTableAction.java
@@ -30,7 +30,7 @@ public class MigrateTableAction extends ActionBase {
     private final String connector;
     private final String hiveTableFullName;
     private final String tableProperties;
-    private final String parallelism;
+    private final Integer parallelism;
 
     public MigrateTableAction(
             String connector,
@@ -38,7 +38,7 @@ public class MigrateTableAction extends ActionBase {
             String hiveTableFullName,
             Map<String, String> catalogConfig,
             String tableProperties,
-            String parallelism) {
+            Integer parallelism) {
         super(warehouse, catalogConfig);
         this.connector = connector;
         this.hiveTableFullName = hiveTableFullName;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateTableAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateTableAction.java
@@ -30,17 +30,20 @@ public class MigrateTableAction extends ActionBase {
     private final String connector;
     private final String hiveTableFullName;
     private final String tableProperties;
+    private final String parallelism;
 
     public MigrateTableAction(
             String connector,
             String warehouse,
             String hiveTableFullName,
             Map<String, String> catalogConfig,
-            String tableProperties) {
+            String tableProperties,
+            String parallelism) {
         super(warehouse, catalogConfig);
         this.connector = connector;
         this.hiveTableFullName = hiveTableFullName;
         this.tableProperties = tableProperties;
+        this.parallelism = parallelism;
     }
 
     @Override
@@ -48,6 +51,10 @@ public class MigrateTableAction extends ActionBase {
         MigrateTableProcedure migrateTableProcedure = new MigrateTableProcedure();
         migrateTableProcedure.withCatalog(catalog);
         migrateTableProcedure.call(
-                new DefaultProcedureContext(env), connector, hiveTableFullName, tableProperties);
+                new DefaultProcedureContext(env),
+                connector,
+                hiveTableFullName,
+                tableProperties,
+                parallelism);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateTableActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateTableActionFactory.java
@@ -42,7 +42,7 @@ public class MigrateTableActionFactory implements ActionFactory {
         String sourceHiveTable = params.get(TABLE);
         Map<String, String> catalogConfig = optionalConfigMap(params, CATALOG_CONF);
         String tableConf = params.get(OPTIONS);
-        String parallelism = params.get(PARALLELISM);
+        Integer parallelism = Integer.parseInt(params.get(PARALLELISM));
 
         MigrateTableAction migrateTableAction =
                 new MigrateTableAction(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateTableActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateTableActionFactory.java
@@ -28,6 +28,7 @@ public class MigrateTableActionFactory implements ActionFactory {
 
     private static final String SOURCE_TYPE = "source_type";
     private static final String OPTIONS = "options";
+    private static final String PARALLELISM = "parallelism";
 
     @Override
     public String identifier() {
@@ -41,10 +42,16 @@ public class MigrateTableActionFactory implements ActionFactory {
         String sourceHiveTable = params.get(TABLE);
         Map<String, String> catalogConfig = optionalConfigMap(params, CATALOG_CONF);
         String tableConf = params.get(OPTIONS);
+        String parallelism = params.get(PARALLELISM);
 
         MigrateTableAction migrateTableAction =
                 new MigrateTableAction(
-                        connector, warehouse, sourceHiveTable, catalogConfig, tableConf);
+                        connector,
+                        warehouse,
+                        sourceHiveTable,
+                        catalogConfig,
+                        tableConf,
+                        parallelism);
         return Optional.of(migrateTableAction);
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
@@ -57,7 +57,7 @@ public class MigrateDatabaseProcedure extends ProcedureBase {
             throws Exception {
         properties = notnull(properties);
         Integer p =
-                StringUtils.isNumeric(parallelism)
+                !StringUtils.isNumeric(parallelism)
                         ? Runtime.getRuntime().availableProcessors()
                         : Integer.parseInt(parallelism);
         List<Migrator> migrators =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
@@ -21,7 +21,6 @@ package org.apache.paimon.flink.procedure;
 import org.apache.paimon.flink.utils.TableMigrationUtils;
 import org.apache.paimon.migrate.Migrator;
 import org.apache.paimon.utils.ParameterUtils;
-import org.apache.paimon.utils.StringUtils;
 
 import org.apache.flink.table.annotation.ArgumentHint;
 import org.apache.flink.table.annotation.DataTypeHint;
@@ -45,7 +44,7 @@ public class MigrateDatabaseProcedure extends ProcedureBase {
                 @ArgumentHint(name = "options", type = @DataTypeHint("STRING"), isOptional = true),
                 @ArgumentHint(
                         name = "parallelism",
-                        type = @DataTypeHint("STRING"),
+                        type = @DataTypeHint("Integer"),
                         isOptional = true)
             })
     public String[] call(
@@ -53,13 +52,10 @@ public class MigrateDatabaseProcedure extends ProcedureBase {
             String connector,
             String sourceDatabasePath,
             String properties,
-            String parallelism)
+            Integer parallelism)
             throws Exception {
         properties = notnull(properties);
-        Integer p =
-                !StringUtils.isNumeric(parallelism)
-                        ? Runtime.getRuntime().availableProcessors()
-                        : Integer.parseInt(parallelism);
+        Integer p = parallelism == null ? Runtime.getRuntime().availableProcessors() : parallelism;
         List<Migrator> migrators =
                 TableMigrationUtils.getImporters(
                         connector,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateFileProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateFileProcedure.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink.procedure;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.utils.TableMigrationUtils;
 import org.apache.paimon.migrate.Migrator;
+import org.apache.paimon.utils.StringUtils;
 
 import org.apache.flink.table.annotation.ArgumentHint;
 import org.apache.flink.table.annotation.DataTypeHint;
@@ -45,6 +46,10 @@ public class MigrateFileProcedure extends ProcedureBase {
                 @ArgumentHint(
                         name = "delete_origin",
                         type = @DataTypeHint("BOOLEAN"),
+                        isOptional = true),
+                @ArgumentHint(
+                        name = "parallelism",
+                        type = @DataTypeHint("STRING"),
                         isOptional = true)
             })
     public String[] call(
@@ -52,12 +57,17 @@ public class MigrateFileProcedure extends ProcedureBase {
             String connector,
             String sourceTablePath,
             String targetPaimonTablePath,
-            Boolean deleteOrigin)
+            Boolean deleteOrigin,
+            String parallelism)
             throws Exception {
         if (deleteOrigin == null) {
             deleteOrigin = true;
         }
-        migrateHandle(connector, sourceTablePath, targetPaimonTablePath, deleteOrigin);
+        Integer p =
+                StringUtils.isNumeric(parallelism)
+                        ? Runtime.getRuntime().availableProcessors()
+                        : Integer.parseInt(parallelism);
+        migrateHandle(connector, sourceTablePath, targetPaimonTablePath, deleteOrigin, p);
         return new String[] {"Success"};
     }
 
@@ -65,7 +75,8 @@ public class MigrateFileProcedure extends ProcedureBase {
             String connector,
             String sourceTablePath,
             String targetPaimonTablePath,
-            boolean deleteOrigin)
+            boolean deleteOrigin,
+            Integer parallelism)
             throws Exception {
         Identifier sourceTableId = Identifier.fromString(sourceTablePath);
         Identifier targetTableId = Identifier.fromString(targetPaimonTablePath);
@@ -83,6 +94,7 @@ public class MigrateFileProcedure extends ProcedureBase {
                         sourceTableId.getObjectName(),
                         targetTableId.getDatabaseName(),
                         targetTableId.getObjectName(),
+                        parallelism,
                         Collections.emptyMap());
         importer.deleteOriginTable(deleteOrigin);
         importer.executeMigrate();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateFileProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateFileProcedure.java
@@ -21,7 +21,6 @@ package org.apache.paimon.flink.procedure;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.utils.TableMigrationUtils;
 import org.apache.paimon.migrate.Migrator;
-import org.apache.paimon.utils.StringUtils;
 
 import org.apache.flink.table.annotation.ArgumentHint;
 import org.apache.flink.table.annotation.DataTypeHint;
@@ -49,7 +48,7 @@ public class MigrateFileProcedure extends ProcedureBase {
                         isOptional = true),
                 @ArgumentHint(
                         name = "parallelism",
-                        type = @DataTypeHint("STRING"),
+                        type = @DataTypeHint("Integer"),
                         isOptional = true)
             })
     public String[] call(
@@ -58,15 +57,12 @@ public class MigrateFileProcedure extends ProcedureBase {
             String sourceTablePath,
             String targetPaimonTablePath,
             Boolean deleteOrigin,
-            String parallelism)
+            Integer parallelism)
             throws Exception {
         if (deleteOrigin == null) {
             deleteOrigin = true;
         }
-        Integer p =
-                !StringUtils.isNumeric(parallelism)
-                        ? Runtime.getRuntime().availableProcessors()
-                        : Integer.parseInt(parallelism);
+        Integer p = parallelism == null ? Runtime.getRuntime().availableProcessors() : parallelism;
         migrateHandle(connector, sourceTablePath, targetPaimonTablePath, deleteOrigin, p);
         return new String[] {"Success"};
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateFileProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateFileProcedure.java
@@ -64,7 +64,7 @@ public class MigrateFileProcedure extends ProcedureBase {
             deleteOrigin = true;
         }
         Integer p =
-                StringUtils.isNumeric(parallelism)
+                !StringUtils.isNumeric(parallelism)
                         ? Runtime.getRuntime().availableProcessors()
                         : Integer.parseInt(parallelism);
         migrateHandle(connector, sourceTablePath, targetPaimonTablePath, deleteOrigin, p);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateTableProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateTableProcedure.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink.procedure;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.utils.TableMigrationUtils;
 import org.apache.paimon.utils.ParameterUtils;
+import org.apache.paimon.utils.StringUtils;
 
 import org.apache.flink.table.annotation.ArgumentHint;
 import org.apache.flink.table.annotation.DataTypeHint;
@@ -45,13 +46,18 @@ public class MigrateTableProcedure extends ProcedureBase {
             argument = {
                 @ArgumentHint(name = "connector", type = @DataTypeHint("STRING")),
                 @ArgumentHint(name = "source_table", type = @DataTypeHint("STRING")),
-                @ArgumentHint(name = "options", type = @DataTypeHint("STRING"), isOptional = true)
+                @ArgumentHint(name = "options", type = @DataTypeHint("STRING"), isOptional = true),
+                @ArgumentHint(
+                        name = "parallelism",
+                        type = @DataTypeHint("STRING"),
+                        isOptional = true)
             })
     public String[] call(
             ProcedureContext procedureContext,
             String connector,
             String sourceTablePath,
-            String properties)
+            String properties,
+            String parallelism)
             throws Exception {
         properties = notnull(properties);
 
@@ -60,6 +66,11 @@ public class MigrateTableProcedure extends ProcedureBase {
         Identifier sourceTableId = Identifier.fromString(sourceTablePath);
         Identifier targetTableId = Identifier.fromString(targetPaimonTablePath);
 
+        Integer p =
+                StringUtils.isNumeric(parallelism)
+                        ? Runtime.getRuntime().availableProcessors()
+                        : Integer.parseInt(parallelism);
+
         TableMigrationUtils.getImporter(
                         connector,
                         catalog,
@@ -67,6 +78,7 @@ public class MigrateTableProcedure extends ProcedureBase {
                         sourceTableId.getObjectName(),
                         targetTableId.getDatabaseName(),
                         targetTableId.getObjectName(),
+                        p,
                         ParameterUtils.parseCommaSeparatedKeyValues(properties))
                 .executeMigrate();
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateTableProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateTableProcedure.java
@@ -21,7 +21,6 @@ package org.apache.paimon.flink.procedure;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.utils.TableMigrationUtils;
 import org.apache.paimon.utils.ParameterUtils;
-import org.apache.paimon.utils.StringUtils;
 
 import org.apache.flink.table.annotation.ArgumentHint;
 import org.apache.flink.table.annotation.DataTypeHint;
@@ -49,7 +48,7 @@ public class MigrateTableProcedure extends ProcedureBase {
                 @ArgumentHint(name = "options", type = @DataTypeHint("STRING"), isOptional = true),
                 @ArgumentHint(
                         name = "parallelism",
-                        type = @DataTypeHint("STRING"),
+                        type = @DataTypeHint("Integer"),
                         isOptional = true)
             })
     public String[] call(
@@ -57,7 +56,7 @@ public class MigrateTableProcedure extends ProcedureBase {
             String connector,
             String sourceTablePath,
             String properties,
-            String parallelism)
+            Integer parallelism)
             throws Exception {
         properties = notnull(properties);
 
@@ -66,10 +65,7 @@ public class MigrateTableProcedure extends ProcedureBase {
         Identifier sourceTableId = Identifier.fromString(sourceTablePath);
         Identifier targetTableId = Identifier.fromString(targetPaimonTablePath);
 
-        Integer p =
-                !StringUtils.isNumeric(parallelism)
-                        ? Runtime.getRuntime().availableProcessors()
-                        : Integer.parseInt(parallelism);
+        Integer p = parallelism == null ? Runtime.getRuntime().availableProcessors() : parallelism;
 
         TableMigrationUtils.getImporter(
                         connector,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateTableProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateTableProcedure.java
@@ -67,7 +67,7 @@ public class MigrateTableProcedure extends ProcedureBase {
         Identifier targetTableId = Identifier.fromString(targetPaimonTablePath);
 
         Integer p =
-                StringUtils.isNumeric(parallelism)
+                !StringUtils.isNumeric(parallelism)
                         ? Runtime.getRuntime().availableProcessors()
                         : Integer.parseInt(parallelism);
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/TableMigrationUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/TableMigrationUtils.java
@@ -37,6 +37,7 @@ public class TableMigrationUtils {
             String souceTableName,
             String targetDatabase,
             String targetTableName,
+            Integer parallelism,
             Map<String, String> options) {
         switch (connector) {
             case "hive":
@@ -52,6 +53,7 @@ public class TableMigrationUtils {
                         souceTableName,
                         targetDatabase,
                         targetTableName,
+                        parallelism,
                         options);
             default:
                 throw new UnsupportedOperationException("Don't support connector " + connector);
@@ -59,7 +61,11 @@ public class TableMigrationUtils {
     }
 
     public static List<Migrator> getImporters(
-            String connector, Catalog catalog, String sourceDatabase, Map<String, String> options) {
+            String connector,
+            Catalog catalog,
+            String sourceDatabase,
+            Integer parallelism,
+            Map<String, String> options) {
         switch (connector) {
             case "hive":
                 if (catalog instanceof CachingCatalog) {
@@ -69,7 +75,7 @@ public class TableMigrationUtils {
                     throw new IllegalArgumentException("Only support Hive Catalog");
                 }
                 return HiveMigrator.databaseMigrators(
-                        (HiveCatalog) catalog, sourceDatabase, options);
+                        (HiveCatalog) catalog, sourceDatabase, options, parallelism);
             default:
                 throw new UnsupportedOperationException("Don't support connector " + connector);
         }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
@@ -60,15 +60,16 @@ import java.util.stream.Collectors;
 
 import static org.apache.paimon.hive.HiveTypeUtils.toPaimonType;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
-import static org.apache.paimon.utils.ThreadPoolUtils.createCachedThreadPool;
 
 /** Migrate hive table to paimon table. */
 public class HiveMigrator implements Migrator {
 
     private static final Logger LOG = LoggerFactory.getLogger(HiveMigrator.class);
 
-    private static final ThreadPoolExecutor EXECUTOR =
-            createCachedThreadPool(Runtime.getRuntime().availableProcessors(), "HIVE_MIGRATOR");
+    //    private static final ThreadPoolExecutor EXECUTOR =
+    //            createCachedThreadPool(Runtime.getRuntime().availableProcessors(),
+    // "HIVE_MIGRATOR");
+    private ThreadPoolExecutor executor;
 
     private static final Predicate<FileStatus> HIDDEN_PATH_FILTER =
             p -> !p.getPath().getName().startsWith("_") && !p.getPath().getName().startsWith(".");
@@ -84,6 +85,7 @@ public class HiveMigrator implements Migrator {
     private final String targetTable;
     private final CoreOptions coreOptions;
     private Boolean delete = true;
+    private Integer parallelism;
 
     public HiveMigrator(
             HiveCatalog hiveCatalog,
@@ -91,6 +93,7 @@ public class HiveMigrator implements Migrator {
             String sourceTable,
             String targetDatabase,
             String targetTable,
+            Integer parallelism,
             Map<String, String> options) {
         this.hiveCatalog = hiveCatalog;
         this.fileIO = hiveCatalog.fileIO();
@@ -99,11 +102,15 @@ public class HiveMigrator implements Migrator {
         this.sourceTable = sourceTable;
         this.targetDatabase = targetDatabase;
         this.targetTable = targetTable;
+        this.parallelism = parallelism;
         this.coreOptions = new CoreOptions(options);
     }
 
     public static List<Migrator> databaseMigrators(
-            HiveCatalog hiveCatalog, String sourceDatabase, Map<String, String> options) {
+            HiveCatalog hiveCatalog,
+            String sourceDatabase,
+            Map<String, String> options,
+            Integer parallelism) {
         IMetaStoreClient client = hiveCatalog.getHmsClient();
         try {
             return client.getAllTables(sourceDatabase).stream()
@@ -115,6 +122,7 @@ public class HiveMigrator implements Migrator {
                                             sourceTable,
                                             sourceDatabase,
                                             sourceTable + PAIMON_SUFFIX,
+                                            parallelism,
                                             options))
                     .collect(Collectors.toList());
         } catch (TException e) {
@@ -175,7 +183,7 @@ public class HiveMigrator implements Migrator {
             }
 
             List<Future<CommitMessage>> futures =
-                    tasks.stream().map(EXECUTOR::submit).collect(Collectors.toList());
+                    tasks.stream().map(executor::submit).collect(Collectors.toList());
             List<CommitMessage> commitMessages = new ArrayList<>();
             try {
                 for (Future<CommitMessage> future : futures) {

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
@@ -60,15 +60,12 @@ import java.util.stream.Collectors;
 
 import static org.apache.paimon.hive.HiveTypeUtils.toPaimonType;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.ThreadPoolUtils.createCachedThreadPool;
 
 /** Migrate hive table to paimon table. */
 public class HiveMigrator implements Migrator {
 
     private static final Logger LOG = LoggerFactory.getLogger(HiveMigrator.class);
-
-    //    private static final ThreadPoolExecutor EXECUTOR =
-    //            createCachedThreadPool(Runtime.getRuntime().availableProcessors(),
-    // "HIVE_MIGRATOR");
     private ThreadPoolExecutor executor;
 
     private static final Predicate<FileStatus> HIDDEN_PATH_FILTER =
@@ -104,6 +101,7 @@ public class HiveMigrator implements Migrator {
         this.targetTable = targetTable;
         this.parallelism = parallelism;
         this.coreOptions = new CoreOptions(options);
+        this.executor = createCachedThreadPool(parallelism, "HIVE_MIGRATOR");
     }
 
     public static List<Migrator> databaseMigrators(

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateDatabaseProcedureITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateDatabaseProcedureITCase.java
@@ -258,7 +258,7 @@ public class MigrateDatabaseProcedureITCase extends ActionITCaseBase {
                         "my_database",
                         catalogConf,
                         "",
-                        "");
+                        6);
         migrateDatabaseAction.run();
 
         tEnv.executeSql(

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateDatabaseProcedureITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateDatabaseProcedureITCase.java
@@ -130,7 +130,7 @@ public class MigrateDatabaseProcedureITCase extends ActionITCaseBase {
             tEnv.executeSql(
                             "CALL sys.migrate_database(connector => 'hive', source_database => 'my_database', options => 'file.format="
                                     + format
-                                    + "')")
+                                    + "', parallelism => 6)")
                     .await();
         } else {
             tEnv.executeSql(

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateDatabaseProcedureITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateDatabaseProcedureITCase.java
@@ -257,6 +257,7 @@ public class MigrateDatabaseProcedureITCase extends ActionITCaseBase {
                         System.getProperty(HiveConf.ConfVars.METASTOREWAREHOUSE.varname),
                         "my_database",
                         catalogConf,
+                        "",
                         "");
         migrateDatabaseAction.run();
 

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateFileProcedureITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateFileProcedureITCase.java
@@ -170,7 +170,7 @@ public class MigrateFileProcedureITCase extends ActionITCaseBase {
                         false,
                         catalogConf,
                         "",
-                        "");
+                        6);
         migrateFileAction.run();
 
         tEnv.useCatalog("HIVE");

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateFileProcedureITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateFileProcedureITCase.java
@@ -169,6 +169,7 @@ public class MigrateFileProcedureITCase extends ActionITCaseBase {
                         "default.paimontable02",
                         false,
                         catalogConf,
+                        "",
                         "");
         migrateFileAction.run();
 

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateTableProcedureITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateTableProcedureITCase.java
@@ -192,7 +192,7 @@ public class MigrateTableProcedureITCase extends ActionITCaseBase {
                         "default.hivetable",
                         catalogConf,
                         "",
-                        "");
+                        6);
         migrateTableAction.run();
 
         tEnv.executeSql(

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateTableProcedureITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateTableProcedureITCase.java
@@ -191,6 +191,7 @@ public class MigrateTableProcedureITCase extends ActionITCaseBase {
                         System.getProperty(HiveConf.ConfVars.METASTOREWAREHOUSE.varname),
                         "default.hivetable",
                         catalogConf,
+                        "",
                         "");
         migrateTableAction.run();
 

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateFileProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateFileProcedure.java
@@ -49,7 +49,8 @@ public class MigrateFileProcedure extends BaseProcedure {
                 ProcedureParameter.required("source_type", StringType),
                 ProcedureParameter.required("source_table", StringType),
                 ProcedureParameter.required("target_table", StringType),
-                ProcedureParameter.optional("delete_origin", BooleanType)
+                ProcedureParameter.optional("delete_origin", BooleanType),
+                ProcedureParameter.optional("parallelism", BooleanType)
             };
 
     private static final StructType OUTPUT_TYPE =
@@ -78,6 +79,10 @@ public class MigrateFileProcedure extends BaseProcedure {
         String sourceTable = args.getString(1);
         String targetTable = args.getString(2);
         boolean deleteNeed = args.isNullAt(3) ? true : args.getBoolean(3);
+        int parallelism =
+                args.isNullAt(4)
+                        ? Runtime.getRuntime().availableProcessors()
+                        : Integer.parseInt(args.getString(6));
 
         Identifier sourceTableId = Identifier.fromString(sourceTable);
         Identifier targetTableId = Identifier.fromString(targetTable);
@@ -98,6 +103,7 @@ public class MigrateFileProcedure extends BaseProcedure {
                             sourceTableId.getObjectName(),
                             targetTableId.getDatabaseName(),
                             targetTableId.getObjectName(),
+                            parallelism,
                             Collections.emptyMap());
 
             migrator.deleteOriginTable(deleteNeed);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateFileProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateFileProcedure.java
@@ -81,7 +81,7 @@ public class MigrateFileProcedure extends BaseProcedure {
         String targetTable = args.getString(2);
         boolean deleteNeed = args.isNullAt(3) ? true : args.getBoolean(3);
         int parallelism =
-                args.isNullAt(4) ? Runtime.getRuntime().availableProcessors() : args.getInt(6);
+                args.isNullAt(4) ? Runtime.getRuntime().availableProcessors() : args.getInt(4);
 
         Identifier sourceTableId = Identifier.fromString(sourceTable);
         Identifier targetTableId = Identifier.fromString(targetTable);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateFileProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateFileProcedure.java
@@ -33,6 +33,7 @@ import org.apache.spark.sql.types.StructType;
 import java.util.Collections;
 
 import static org.apache.spark.sql.types.DataTypes.BooleanType;
+import static org.apache.spark.sql.types.DataTypes.IntegerType;
 import static org.apache.spark.sql.types.DataTypes.StringType;
 
 /**
@@ -50,7 +51,7 @@ public class MigrateFileProcedure extends BaseProcedure {
                 ProcedureParameter.required("source_table", StringType),
                 ProcedureParameter.required("target_table", StringType),
                 ProcedureParameter.optional("delete_origin", BooleanType),
-                ProcedureParameter.optional("parallelism", BooleanType)
+                ProcedureParameter.optional("parallelism", IntegerType)
             };
 
     private static final StructType OUTPUT_TYPE =
@@ -80,9 +81,7 @@ public class MigrateFileProcedure extends BaseProcedure {
         String targetTable = args.getString(2);
         boolean deleteNeed = args.isNullAt(3) ? true : args.getBoolean(3);
         int parallelism =
-                args.isNullAt(4)
-                        ? Runtime.getRuntime().availableProcessors()
-                        : Integer.parseInt(args.getString(6));
+                args.isNullAt(4) ? Runtime.getRuntime().availableProcessors() : args.getInt(6);
 
         Identifier sourceTableId = Identifier.fromString(sourceTable);
         Identifier targetTableId = Identifier.fromString(targetTable);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateTableProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateTableProcedure.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.spark.sql.types.DataTypes.BooleanType;
+import static org.apache.spark.sql.types.DataTypes.IntegerType;
 import static org.apache.spark.sql.types.DataTypes.StringType;
 
 /**
@@ -60,7 +61,7 @@ public class MigrateTableProcedure extends BaseProcedure {
                 ProcedureParameter.optional("target_table", StringType),
                 ProcedureParameter.optional(
                         "options_map", DataTypes.createMapType(StringType, StringType)),
-                ProcedureParameter.optional("parallelism", StringType),
+                ProcedureParameter.optional("parallelism", IntegerType),
             };
 
     private static final StructType OUTPUT_TYPE =
@@ -93,9 +94,7 @@ public class MigrateTableProcedure extends BaseProcedure {
         MapData mapData = args.isNullAt(5) ? null : args.getMap(5);
         Map<String, String> optionMap = mapDataToHashMap(mapData);
         int parallelism =
-                args.isNullAt(6)
-                        ? Runtime.getRuntime().availableProcessors()
-                        : Integer.parseInt(args.getString(6));
+                args.isNullAt(6) ? Runtime.getRuntime().availableProcessors() : args.getInt(6);
 
         Identifier sourceTableId = Identifier.fromString(sourceTable);
         Identifier tmpTableId =

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateTableProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateTableProcedure.java
@@ -121,9 +121,6 @@ public class MigrateTableProcedure extends BaseProcedure {
                             options);
 
             migrator.deleteOriginTable(deleteNeed);
-
-            // setup parallelism for executor
-            migrator.setParallelism(parallelism);
             migrator.executeMigrate();
             if (StringUtils.isEmpty(targetTable)) {
                 paimonCatalog.renameTable(tmpTableId, sourceTableId, false);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/utils/TableMigrationUtils.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/utils/TableMigrationUtils.java
@@ -36,6 +36,7 @@ public class TableMigrationUtils {
             String sourceTableName,
             String targetDatabase,
             String targetTableName,
+            Integer parallelism,
             Map<String, String> options) {
         switch (connector) {
             case "hive":
@@ -51,6 +52,7 @@ public class TableMigrationUtils {
                         sourceTableName,
                         targetDatabase,
                         targetTableName,
+                        parallelism,
                         options);
             default:
                 throw new UnsupportedOperationException("Unsupported connector " + connector);

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -48,6 +48,29 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
 
   Seq("parquet", "orc", "avro").foreach(
     format => {
+      test(
+        s"Paimon migrate table procedure: migrate $format non-partitioned table with setting parallelism") {
+        withTable("hive_tbl_01") {
+          // create hive table
+          spark.sql(s"""
+                       |CREATE TABLE hive_tbl_01 (id STRING, name STRING, pt STRING)
+                       |USING $format
+                       |""".stripMargin)
+
+          spark.sql(s"INSERT INTO hive_tbl_01 VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
+
+          spark.sql(
+            s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl_01', options => 'file.format=$format', parallelism => 6)")
+
+          checkAnswer(
+            spark.sql(s"SELECT * FROM hive_tbl_01 ORDER BY id"),
+            Row("1", "a", "p1") :: Row("2", "b", "p2") :: Nil)
+        }
+      }
+    })
+
+  Seq("parquet", "orc", "avro").foreach(
+    format => {
       test(s"Paimon migrate table procedure: migrate $format table with options_map") {
         withTable("hive_tbl") {
           // create hive table


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx
Currently migrate table/file/database cannot set thread parallelism, user can not overclock cpu to improve migrate speed or reduce cpu cost for avoid impacting other process in machine , this pr is support parallelism change.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
