### PR TITLE
[flink] Remove Flink state from write-only writers

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
@@ -104,6 +104,9 @@ public interface FileStoreWrite<T> extends Restorable<List<FileStoreWrite.State<
      */
     void write(BinaryRow partition, int bucket, T data) throws Exception;
 
+    /** If this writer will actually perform compactions. */
+    boolean hasCompaction();
+
     /**
      * Compact data stored in given partition and bucket. Note that compaction process is only
      * submitted and may not be completed when the method returns.

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -235,9 +235,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
             ExecutorService compactExecutor,
             Levels levels,
             @Nullable DeletionVectorsMaintainer dvMaintainer) {
-        if (options.writeOnly()) {
-            return new NoopCompactManager();
-        } else {
+        if (hasCompaction()) {
             Comparator<InternalRow> keyComparator = keyComparatorSupplier.get();
             @Nullable FieldsComparator userDefinedSeqComparator = udsComparatorSupplier.get();
             CompactRewriter rewriter =
@@ -261,6 +259,8 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                             : compactionMetrics.createReporter(partition, bucket),
                     dvMaintainer,
                     options.prepareCommitWaitCompaction());
+        } else {
+            return new NoopCompactManager();
         }
     }
 
@@ -387,6 +387,11 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                 lookupStoreFactory,
                 bfGenerator(options),
                 lookupFileCache);
+    }
+
+    @Override
+    public boolean hasCompaction() {
+        return !options.writeOnly();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
@@ -225,6 +225,10 @@ public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State
                 record.row());
     }
 
+    public boolean hasCompaction() {
+        return write.hasCompaction();
+    }
+
     @Override
     public void compact(BinaryRow partition, int bucket, boolean fullCompaction) throws Exception {
         write.compact(partition, bucket, fullCompaction);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AsyncLookupSinkWrite.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AsyncLookupSinkWrite.java
@@ -22,6 +22,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.operation.AbstractFileStoreWrite;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.Preconditions;
 
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -91,6 +92,8 @@ public class AsyncLookupSinkWrite extends StoreSinkWriteImpl {
                                 partitions.getKey(), bucket, new byte[0]));
             }
         }
-        state.put(tableName, ACTIVE_BUCKETS_STATE_NAME, activeBucketsList);
+        Preconditions.checkNotNull(
+                        state, "State is null for AsyncLookupSinkWrite. This is unexpected.")
+                .put(tableName, ACTIVE_BUCKETS_STATE_NAME, activeBucketsList);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -135,22 +135,22 @@ public abstract class FlinkSink<T> implements Serializable {
                             metricGroup);
                 };
             }
-        }
 
-        if (coreOptions.needLookup() && !coreOptions.prepareCommitWaitCompaction()) {
-            return (table, commitUser, state, ioManager, memoryPool, metricGroup) -> {
-                assertNoSinkMaterializer.run();
-                return new AsyncLookupSinkWrite(
-                        table,
-                        commitUser,
-                        state,
-                        ioManager,
-                        ignorePreviousFiles,
-                        waitCompaction,
-                        isStreaming,
-                        memoryPool,
-                        metricGroup);
-            };
+            if (coreOptions.needLookup() && !coreOptions.prepareCommitWaitCompaction()) {
+                return (table, commitUser, state, ioManager, memoryPool, metricGroup) -> {
+                    assertNoSinkMaterializer.run();
+                    return new AsyncLookupSinkWrite(
+                            table,
+                            commitUser,
+                            state,
+                            ioManager,
+                            ignorePreviousFiles,
+                            waitCompaction,
+                            isStreaming,
+                            memoryPool,
+                            metricGroup);
+                };
+            }
         }
 
         return (table, commitUser, state, ioManager, memoryPool, metricGroup) -> {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/GlobalFullCompactionSinkWrite.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/GlobalFullCompactionSinkWrite.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.SinkRecord;
+import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.SnapshotManager;
 
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -253,7 +254,10 @@ public class GlobalFullCompactionSinkWrite extends StoreSinkWriteImpl {
                                 bucket.f0, bucket.f1, longToBytes(entry.getKey())));
             }
         }
-        state.put(tableName, WRITTEN_BUCKETS_STATE_NAME, writtenBucketList);
+        Preconditions.checkNotNull(
+                        state,
+                        "State is null for GlobalFullCompactionSinkWrite. This is unexpected.")
+                .put(tableName, WRITTEN_BUCKETS_STATE_NAME, writtenBucketList);
     }
 
     private static byte[] longToBytes(long l) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWrite.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWrite.java
@@ -87,7 +87,7 @@ public interface StoreSinkWrite {
         StoreSinkWrite provide(
                 FileStoreTable table,
                 String commitUser,
-                StoreSinkWriteState state,
+                @Nullable StoreSinkWriteState state,
                 IOManager ioManager,
                 @Nullable MemorySegmentPool memoryPool,
                 @Nullable MetricGroup metricGroup);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
@@ -33,6 +33,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.SinkRecord;
 import org.apache.paimon.table.sink.TableWriteImpl;
+import org.apache.paimon.utils.Preconditions;
 
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -154,6 +155,7 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
                         .withIgnorePreviousFiles(ignorePreviousFiles)
                         .withExecutionMode(isStreamingMode)
                         .withBucketMode(table.bucketMode());
+        Preconditions.checkArgument(tableWrite.hasCompaction() == (state != null));
 
         if (metricGroup != null) {
             tableWrite.withMetricRegistry(new FlinkMetricRegistry(metricGroup));

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/FlinkSinkTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/FlinkSinkTest.java
@@ -103,7 +103,8 @@ public class FlinkSinkTest {
                         null,
                         null,
                         null);
-        operator.initStateAndWriter(context, (a, b, c) -> true, new IOManagerAsync(), "123");
+        operator.initStateAndWriterWithState(
+                context, (a, b, c) -> true, new IOManagerAsync(), "123");
         return ((KeyValueFileStoreWrite) ((StoreSinkWriteImpl) operator.write).write.getWrite())
                 .bufferSpillable();
     }


### PR DESCRIPTION
### Purpose

Currently Paimon writer operators in Flink have states, which record the `commitUser` (for all writers) and the list of active buckets (for lookup or full-compaction changelog producer). These states prevent a writer object to be closed too early and cause conflicts.

However for write-only writers, because they only create new files, there is no conflict. So for these writers we can remove Flink state. This optimization is also useful for bounded stream jobs, because when chaining source and write operator together, if some source parallelism have finished, checkpoint cannot be performed if there are union list states in the operators which are still running.

### Tests

Existing tests should cover this change.

### API and Format

No format changes.

### Documentation

No new feature.
