### PR TITLE
[core] disable streaming read of ReadOptimizedTable which has primary-key.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ReadOptimizedTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ReadOptimizedTable.java
@@ -137,6 +137,10 @@ public class ReadOptimizedTable implements DataTable, ReadonlyTable {
 
     @Override
     public StreamDataTableScan newStreamScan() {
+        if (wrapped.schema().primaryKeys().size() > 0) {
+            throw new UnsupportedOperationException(
+                    "Unsupported streaming scan for read optimized table");
+        }
         return new DataTableStreamScan(
                 coreOptions(),
                 newSnapshotReader(),


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #4191

<!-- What is the purpose of the change -->
[core] disable streaming read of ReadOptimizedTable which has primary-key.
### Tests

<!-- List UT and IT cases to verify this change -->

1. org.apache.paimon.table.PrimaryKeyFileStoreTableTest#testStreamingReadOptimizedTable

### API and Format

<!-- Does this change affect API or storage format -->
No
### Documentation

<!-- Does this change introduce a new feature -->
No