### PR TITLE
[cdc] paimon cdc database sync support computed columns

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/ComputedColumnUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/ComputedColumnUtils.java
@@ -37,7 +37,10 @@ public class ComputedColumnUtils {
         return buildComputedColumns(computedColumnArgs, physicFields, true);
     }
 
-    /** The caseSensitive only affects check. We don't change field names at building phase. */
+    /**
+     * Filter computed columns based on table columns, The caseSensitive only affects check. We
+     * don't change field names at building phase.
+     */
     public static List<ComputedColumn> buildComputedColumns(
             List<String> computedColumnArgs, List<DataField> physicFields, boolean caseSensitive) {
         Map<String, DataType> typeMapping =
@@ -69,12 +72,15 @@ public class ComputedColumnUtils {
             String[] args = expression.substring(left + 1, right).split(",");
             checkArgument(args.length >= 1, "Computed column needs at least one argument.");
 
-            computedColumns.add(
-                    new ComputedColumn(
-                            columnName,
-                            Expression.create(typeMapping, caseSensitive, exprName, args)));
+            String fieldReference = caseSensitive ? args[0] : args[0].toLowerCase();
+            // The cast function is constant function and doesn't reference the columns of the table
+            if ("cast".equals(exprName) || typeMapping.containsKey(fieldReference)) {
+                computedColumns.add(
+                        new ComputedColumn(
+                                columnName,
+                                Expression.create(typeMapping, caseSensitive, exprName, args)));
+            }
         }
-
         return computedColumns;
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/MessageQueueSchemaUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/MessageQueueSchemaUtils.java
@@ -26,7 +26,6 @@ import org.apache.paimon.schema.Schema;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -59,8 +58,7 @@ public class MessageQueueSchemaUtils {
         int retry = 0;
         int retryInterval = 1000;
 
-        AbstractRecordParser recordParser =
-                dataFormat.createParser(typeMapping, Collections.emptyList());
+        AbstractRecordParser recordParser = dataFormat.createParser(typeMapping);
 
         while (true) {
             Optional<Schema> schema =

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionFactoryBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionFactoryBase.java
@@ -22,8 +22,10 @@ import org.apache.paimon.flink.action.Action;
 import org.apache.paimon.flink.action.ActionFactory;
 import org.apache.paimon.flink.action.MultipleParameterToolAdapter;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
+import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.COMPUTED_COLUMN;
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.EXCLUDING_TABLES;
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.INCLUDING_TABLES;
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.MULTIPLE_TABLE_PARTITION_KEYS;
@@ -68,6 +70,11 @@ public abstract class SyncDatabaseActionFactoryBase<T extends SyncDatabaseAction
         if (params.has(TYPE_MAPPING)) {
             String[] options = params.get(TYPE_MAPPING).split(",");
             action.withTypeMapping(TypeMapping.parse(options));
+        }
+
+        if (params.has(COMPUTED_COLUMN)) {
+            action.withComputedColumnArgs(
+                    new ArrayList<>(params.getMultiParameter(COMPUTED_COLUMN)));
         }
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncJobHandler.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncJobHandler.java
@@ -38,7 +38,6 @@ import org.apache.flink.connector.pulsar.common.config.PulsarOptions;
 import org.apache.flink.connector.pulsar.source.PulsarSourceOptions;
 import org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions;
 
-import java.util.List;
 import java.util.Map;
 
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.KAFKA_CONF;
@@ -197,22 +196,18 @@ public class SyncJobHandler {
     }
 
     public FlatMapFunction<CdcSourceRecord, RichCdcMultiplexRecord> provideRecordParser(
-            List<ComputedColumn> computedColumns,
-            TypeMapping typeMapping,
-            CdcMetadataConverter[] metadataConverters) {
+            TypeMapping typeMapping, CdcMetadataConverter[] metadataConverters) {
         switch (sourceType) {
             case MYSQL:
-                return new MySqlRecordParser(
-                        cdcSourceConfig, computedColumns, typeMapping, metadataConverters);
+                return new MySqlRecordParser(cdcSourceConfig, typeMapping, metadataConverters);
             case POSTGRES:
-                return new PostgresRecordParser(
-                        cdcSourceConfig, computedColumns, typeMapping, metadataConverters);
+                return new PostgresRecordParser(cdcSourceConfig, typeMapping, metadataConverters);
             case KAFKA:
             case PULSAR:
                 DataFormat dataFormat = provideDataFormat();
-                return dataFormat.createParser(typeMapping, computedColumns);
+                return dataFormat.createParser(typeMapping);
             case MONGODB:
-                return new MongoDBRecordParser(computedColumns, cdcSourceConfig);
+                return new MongoDBRecordParser(cdcSourceConfig);
             default:
                 throw new UnsupportedOperationException("Unknown source type " + sourceType);
         }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionBase.java
@@ -157,13 +157,14 @@ public abstract class SyncTableActionBase extends SynchronizationActionBase {
 
     @Override
     protected FlatMapFunction<CdcSourceRecord, RichCdcMultiplexRecord> recordParse() {
-        return syncJobHandler.provideRecordParser(computedColumns, typeMapping, metadataConverters);
+        return syncJobHandler.provideRecordParser(typeMapping, metadataConverters);
     }
 
     @Override
     protected EventParser.Factory<RichCdcMultiplexRecord> buildEventParserFactory() {
         boolean caseSensitive = this.allowUpperCase;
-        return () -> new RichCdcMultiplexRecordEventParser(caseSensitive);
+        List<String> computedColumnArgs = this.computedColumnArgs;
+        return () -> new RichCdcMultiplexRecordEventParser(caseSensitive, computedColumnArgs);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/TableNameConverter.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/TableNameConverter.java
@@ -58,4 +58,8 @@ public class TableNameConverter implements Serializable {
                                 + originIdentifier.getObjectName();
         return convert(rawName);
     }
+
+    public boolean isCaseSensitive() {
+        return caseSensitive;
+    }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/AbstractDataFormat.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/AbstractDataFormat.java
@@ -19,14 +19,12 @@
 package org.apache.paimon.flink.action.cdc.format;
 
 import org.apache.paimon.flink.action.cdc.CdcSourceRecord;
-import org.apache.paimon.flink.action.cdc.ComputedColumn;
 import org.apache.paimon.flink.action.cdc.TypeMapping;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.connectors.kafka.KafkaDeserializationSchema;
 
-import java.util.List;
 import java.util.function.Function;
 
 /** Data format common implementation of {@link DataFormat}. */
@@ -44,9 +42,8 @@ public abstract class AbstractDataFormat implements DataFormat {
             pulsarDeserializer();
 
     @Override
-    public AbstractRecordParser createParser(
-            TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
-        return parser().createParser(typeMapping, computedColumns);
+    public AbstractRecordParser createParser(TypeMapping typeMapping) {
+        return parser().createParser(typeMapping);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/AbstractJsonRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/AbstractJsonRecordParser.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.flink.action.cdc.format;
 
 import org.apache.paimon.flink.action.cdc.CdcSourceRecord;
-import org.apache.paimon.flink.action.cdc.ComputedColumn;
 import org.apache.paimon.flink.action.cdc.TypeMapping;
 import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecord;
 import org.apache.paimon.types.DataTypes;
@@ -63,8 +62,8 @@ public abstract class AbstractJsonRecordParser extends AbstractRecordParser {
 
     protected JsonNode root;
 
-    public AbstractJsonRecordParser(TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
-        super(typeMapping, computedColumns);
+    public AbstractJsonRecordParser(TypeMapping typeMapping) {
+        super(typeMapping);
     }
 
     protected void setRoot(CdcSourceRecord record) {
@@ -103,7 +102,6 @@ public abstract class AbstractJsonRecordParser extends AbstractRecordParser {
                                             }
                                             return Objects.toString(entry.getValue());
                                         }));
-        evalComputedColumns(rowData, rowTypeBuilder);
         return rowData;
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/AbstractRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/AbstractRecordParser.java
@@ -19,14 +19,12 @@
 package org.apache.paimon.flink.action.cdc.format;
 
 import org.apache.paimon.flink.action.cdc.CdcSourceRecord;
-import org.apache.paimon.flink.action.cdc.ComputedColumn;
 import org.apache.paimon.flink.action.cdc.TypeMapping;
 import org.apache.paimon.flink.sink.cdc.CdcRecord;
 import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecord;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowKind;
-import org.apache.paimon.types.RowType;
 
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.util.Collector;
@@ -55,11 +53,9 @@ public abstract class AbstractRecordParser
     protected static final String FIELD_TABLE = "table";
     protected static final String FIELD_DATABASE = "database";
     protected final TypeMapping typeMapping;
-    protected final List<ComputedColumn> computedColumns;
 
-    public AbstractRecordParser(TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
+    public AbstractRecordParser(TypeMapping typeMapping) {
         this.typeMapping = typeMapping;
-        this.computedColumns = computedColumns;
     }
 
     @Nullable
@@ -111,18 +107,6 @@ public abstract class AbstractRecordParser
     }
 
     protected abstract List<String> extractPrimaryKeys();
-
-    /** generate values for computed columns. */
-    protected void evalComputedColumns(
-            Map<String, String> rowData, RowType.Builder rowTypeBuilder) {
-        computedColumns.forEach(
-                computedColumn -> {
-                    rowData.put(
-                            computedColumn.columnName(),
-                            computedColumn.eval(rowData.get(computedColumn.fieldReference())));
-                    rowTypeBuilder.field(computedColumn.columnName(), computedColumn.columnType());
-                });
-    }
 
     /** Handle case sensitivity here. */
     protected RichCdcMultiplexRecord createRecord(

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/DataFormat.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/DataFormat.java
@@ -19,14 +19,11 @@
 package org.apache.paimon.flink.action.cdc.format;
 
 import org.apache.paimon.flink.action.cdc.CdcSourceRecord;
-import org.apache.paimon.flink.action.cdc.ComputedColumn;
 import org.apache.paimon.flink.action.cdc.TypeMapping;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.connectors.kafka.KafkaDeserializationSchema;
-
-import java.util.List;
 
 /**
  * Supports the message queue's data format and provides definitions for the message queue's record
@@ -38,11 +35,9 @@ public interface DataFormat {
      * Creates a new instance of {@link AbstractRecordParser} for this data format with the
      * specified configurations.
      *
-     * @param computedColumns List of computed columns to be considered by the parser.
      * @return A new instance of {@link AbstractRecordParser}.
      */
-    AbstractRecordParser createParser(
-            TypeMapping typeMapping, List<ComputedColumn> computedColumns);
+    AbstractRecordParser createParser(TypeMapping typeMapping);
 
     KafkaDeserializationSchema<CdcSourceRecord> createKafkaDeserializer(
             Configuration cdcSourceConfig);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/canal/CanalRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/canal/CanalRecordParser.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.flink.action.cdc.format.canal;
 
-import org.apache.paimon.flink.action.cdc.ComputedColumn;
 import org.apache.paimon.flink.action.cdc.TypeMapping;
 import org.apache.paimon.flink.action.cdc.format.AbstractJsonRecordParser;
 import org.apache.paimon.flink.action.cdc.mysql.MySqlTypeUtils;
@@ -84,8 +83,8 @@ public class CanalRecordParser extends AbstractJsonRecordParser {
         return !isNull(node) && node.asBoolean();
     }
 
-    public CanalRecordParser(TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
-        super(typeMapping, computedColumns);
+    public CanalRecordParser(TypeMapping typeMapping) {
+        super(typeMapping);
     }
 
     @Override
@@ -179,8 +178,6 @@ public class CanalRecordParser extends AbstractJsonRecordParser {
                 rowData.put(entry.getKey(), Objects.toString(entry.getValue(), null));
             }
         }
-
-        evalComputedColumns(rowData, rowTypeBuilder);
         return rowData;
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumAvroRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumAvroRecordParser.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.flink.action.cdc.format.debezium;
 
 import org.apache.paimon.flink.action.cdc.CdcSourceRecord;
-import org.apache.paimon.flink.action.cdc.ComputedColumn;
 import org.apache.paimon.flink.action.cdc.TypeMapping;
 import org.apache.paimon.flink.action.cdc.format.AbstractRecordParser;
 import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecord;
@@ -74,8 +73,8 @@ public class DebeziumAvroRecordParser extends AbstractRecordParser {
     private GenericRecord keyRecord;
     private GenericRecord valueRecord;
 
-    public DebeziumAvroRecordParser(TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
-        super(typeMapping, computedColumns);
+    public DebeziumAvroRecordParser(TypeMapping typeMapping) {
+        super(typeMapping);
     }
 
     @Override
@@ -157,8 +156,6 @@ public class DebeziumAvroRecordParser extends AbstractRecordParser {
             resultMap.put(fieldName, transformed);
             rowTypeBuilder.field(fieldName, avroToPaimonDataType(schema));
         }
-
-        evalComputedColumns(resultMap, rowTypeBuilder);
         return resultMap;
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumJsonRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumJsonRecordParser.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.flink.action.cdc.format.debezium;
 
 import org.apache.paimon.flink.action.cdc.CdcSourceRecord;
-import org.apache.paimon.flink.action.cdc.ComputedColumn;
 import org.apache.paimon.flink.action.cdc.TypeMapping;
 import org.apache.paimon.flink.action.cdc.format.AbstractJsonRecordParser;
 import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecord;
@@ -82,8 +81,8 @@ public class DebeziumJsonRecordParser extends AbstractJsonRecordParser {
     private final Map<String, String> classNames = new HashMap<>();
     private final Map<String, Map<String, String>> parameters = new HashMap<>();
 
-    public DebeziumJsonRecordParser(TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
-        super(typeMapping, computedColumns);
+    public DebeziumJsonRecordParser(TypeMapping typeMapping) {
+        super(typeMapping);
     }
 
     @Override
@@ -210,9 +209,6 @@ public class DebeziumJsonRecordParser extends AbstractJsonRecordParser {
                     DebeziumSchemaUtils.toDataType(
                             debeziumType, className, parameters.get(fieldName)));
         }
-
-        evalComputedColumns(resultMap, rowTypeBuilder);
-
         return resultMap;
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/json/JsonRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/json/JsonRecordParser.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.flink.action.cdc.format.json;
 
-import org.apache.paimon.flink.action.cdc.ComputedColumn;
 import org.apache.paimon.flink.action.cdc.TypeMapping;
 import org.apache.paimon.flink.action.cdc.format.AbstractJsonRecordParser;
 import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecord;
@@ -36,8 +35,8 @@ import java.util.List;
  */
 public class JsonRecordParser extends AbstractJsonRecordParser {
 
-    public JsonRecordParser(TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
-        super(typeMapping, computedColumns);
+    public JsonRecordParser(TypeMapping typeMapping) {
+        super(typeMapping);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/maxwell/MaxwellRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/maxwell/MaxwellRecordParser.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.flink.action.cdc.format.maxwell;
 
-import org.apache.paimon.flink.action.cdc.ComputedColumn;
 import org.apache.paimon.flink.action.cdc.TypeMapping;
 import org.apache.paimon.flink.action.cdc.format.AbstractJsonRecordParser;
 import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecord;
@@ -50,8 +49,8 @@ public class MaxwellRecordParser extends AbstractJsonRecordParser {
     private static final String OP_UPDATE = "update";
     private static final String OP_DELETE = "delete";
 
-    public MaxwellRecordParser(TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
-        super(typeMapping, computedColumns);
+    public MaxwellRecordParser(TypeMapping typeMapping) {
+        super(typeMapping);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/ogg/OggRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/ogg/OggRecordParser.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.flink.action.cdc.format.ogg;
 
 import org.apache.paimon.catalog.Identifier;
-import org.apache.paimon.flink.action.cdc.ComputedColumn;
 import org.apache.paimon.flink.action.cdc.TypeMapping;
 import org.apache.paimon.flink.action.cdc.format.AbstractJsonRecordParser;
 import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecord;
@@ -58,8 +57,8 @@ public class OggRecordParser extends AbstractJsonRecordParser {
     private static final String OP_INSERT = "I";
     private static final String OP_DELETE = "D";
 
-    public OggRecordParser(TypeMapping typeMapping, List<ComputedColumn> computedColumns) {
-        super(typeMapping, computedColumns);
+    public OggRecordParser(TypeMapping typeMapping) {
+        super(typeMapping);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/strategy/Mongo4VersionStrategy.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/strategy/Mongo4VersionStrategy.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.flink.action.cdc.mongodb.strategy;
 
-import org.apache.paimon.flink.action.cdc.ComputedColumn;
 import org.apache.paimon.flink.sink.cdc.CdcRecord;
 import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecord;
 import org.apache.paimon.types.DataField;
@@ -50,17 +49,12 @@ public class Mongo4VersionStrategy implements MongoVersionStrategy {
     private final String databaseName;
     private final String collection;
     private final Configuration mongodbConfig;
-    private final List<ComputedColumn> computedColumns;
 
     public Mongo4VersionStrategy(
-            String databaseName,
-            String collection,
-            List<ComputedColumn> computedColumns,
-            Configuration mongodbConfig) {
+            String databaseName, String collection, Configuration mongodbConfig) {
         this.databaseName = databaseName;
         this.collection = collection;
         this.mongodbConfig = mongodbConfig;
-        this.computedColumns = computedColumns;
     }
 
     /**
@@ -124,8 +118,7 @@ public class Mongo4VersionStrategy implements MongoVersionStrategy {
     private RichCdcMultiplexRecord processRecord(JsonNode fullDocument, RowKind rowKind)
             throws JsonProcessingException {
         RowType.Builder rowTypeBuilder = RowType.builder();
-        Map<String, String> record =
-                getExtractRow(fullDocument, rowTypeBuilder, computedColumns, mongodbConfig);
+        Map<String, String> record = getExtractRow(fullDocument, rowTypeBuilder, mongodbConfig);
         List<DataField> fields = rowTypeBuilder.build().getFields();
 
         return new RichCdcMultiplexRecord(

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlRecordParser.java
@@ -20,7 +20,6 @@ package org.apache.paimon.flink.action.cdc.mysql;
 
 import org.apache.paimon.flink.action.cdc.CdcMetadataConverter;
 import org.apache.paimon.flink.action.cdc.CdcSourceRecord;
-import org.apache.paimon.flink.action.cdc.ComputedColumn;
 import org.apache.paimon.flink.action.cdc.TypeMapping;
 import org.apache.paimon.flink.action.cdc.format.debezium.DebeziumSchemaUtils;
 import org.apache.paimon.flink.action.cdc.mysql.format.DebeziumEvent;
@@ -74,7 +73,6 @@ public class MySqlRecordParser implements FlatMapFunction<CdcSourceRecord, RichC
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ZoneId serverTimeZone;
-    private final List<ComputedColumn> computedColumns;
     private final TypeMapping typeMapping;
     private final boolean isDebeziumSchemaCommentsEnabled;
     private DebeziumEvent root;
@@ -88,10 +86,8 @@ public class MySqlRecordParser implements FlatMapFunction<CdcSourceRecord, RichC
 
     public MySqlRecordParser(
             Configuration mySqlConfig,
-            List<ComputedColumn> computedColumns,
             TypeMapping typeMapping,
             CdcMetadataConverter[] metadataConverters) {
-        this.computedColumns = computedColumns;
         this.typeMapping = typeMapping;
         this.metadataConverters = metadataConverters;
         objectMapper
@@ -245,13 +241,6 @@ public class MySqlRecordParser implements FlatMapFunction<CdcSourceRecord, RichC
                             objectValue,
                             serverTimeZone);
             resultMap.put(fieldName, newValue);
-        }
-
-        // generate values of computed columns
-        for (ComputedColumn computedColumn : computedColumns) {
-            resultMap.put(
-                    computedColumn.columnName(),
-                    computedColumn.eval(resultMap.get(computedColumn.fieldReference())));
         }
 
         for (CdcMetadataConverter metadataConverter : metadataConverters) {

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
@@ -24,6 +24,7 @@ import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.action.Action;
 import org.apache.paimon.flink.action.cdc.CdcActionCommonUtils;
 import org.apache.paimon.flink.action.cdc.CdcSourceRecord;
+import org.apache.paimon.flink.action.cdc.ComputedColumn;
 import org.apache.paimon.flink.action.cdc.SyncDatabaseActionBase;
 import org.apache.paimon.flink.action.cdc.SyncJobHandler;
 import org.apache.paimon.flink.action.cdc.TableNameConverter;
@@ -43,7 +44,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -53,6 +53,7 @@ import java.util.stream.Collectors;
 import static org.apache.paimon.flink.action.MultiTablesSinkMode.DIVIDED;
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.schemaCompatible;
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.tableList;
+import static org.apache.paimon.flink.action.cdc.ComputedColumnUtils.buildComputedColumns;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /**
@@ -144,12 +145,15 @@ public class MySqlSyncDatabaseAction extends SyncDatabaseActionBase {
                     Identifier.create(
                             database, tableNameConverter.convert(tableInfo.toPaimonTableName()));
             FileStoreTable table;
+            List<ComputedColumn> computedColumns =
+                    buildComputedColumns(computedColumnArgs, tableInfo.schema().fields());
+
             Schema fromMySql =
                     CdcActionCommonUtils.buildPaimonSchema(
                             identifier.getFullName(),
                             partitionKeys,
                             primaryKeys,
-                            Collections.emptyList(),
+                            computedColumns,
                             tableConfig,
                             tableInfo.schema(),
                             metadataConverters,

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresRecordParser.java
@@ -20,7 +20,6 @@ package org.apache.paimon.flink.action.cdc.postgres;
 
 import org.apache.paimon.flink.action.cdc.CdcMetadataConverter;
 import org.apache.paimon.flink.action.cdc.CdcSourceRecord;
-import org.apache.paimon.flink.action.cdc.ComputedColumn;
 import org.apache.paimon.flink.action.cdc.TypeMapping;
 import org.apache.paimon.flink.action.cdc.mysql.format.DebeziumEvent;
 import org.apache.paimon.flink.sink.cdc.CdcRecord;
@@ -84,7 +83,6 @@ public class PostgresRecordParser
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ZoneId serverTimeZone;
-    private final List<ComputedColumn> computedColumns;
     private final TypeMapping typeMapping;
 
     private DebeziumEvent root;
@@ -96,10 +94,8 @@ public class PostgresRecordParser
 
     public PostgresRecordParser(
             Configuration postgresConfig,
-            List<ComputedColumn> computedColumns,
             TypeMapping typeMapping,
             CdcMetadataConverter[] metadataConverters) {
-        this.computedColumns = computedColumns;
         this.typeMapping = typeMapping;
         this.metadataConverters = metadataConverters;
         objectMapper
@@ -347,13 +343,6 @@ public class PostgresRecordParser
             }
 
             resultMap.put(fieldName, newValue);
-        }
-
-        // generate values of computed columns
-        for (ComputedColumn computedColumn : computedColumns) {
-            resultMap.put(
-                    computedColumn.columnName(),
-                    computedColumn.eval(resultMap.get(computedColumn.fieldReference())));
         }
 
         for (CdcMetadataConverter metadataConverter : metadataConverters) {

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcSinkBuilder.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcSinkBuilder.java
@@ -98,7 +98,9 @@ public class CdcSinkBuilder<T> {
 
         SingleOutputStreamOperator<CdcRecord> parsed =
                 input.forward()
-                        .process(new CdcParsingProcessFunction<>(parserFactory))
+                        .process(
+                                new CdcParsingProcessFunction<>(
+                                        parserFactory, dataTable.schema().fields()))
                         .name("Side Output")
                         .setParallelism(input.getParallelism());
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/EventParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/EventParser.java
@@ -70,4 +70,7 @@ public interface EventParser<T> {
 
         EventParser<T> create();
     }
+
+    /** generate values for computed columns. */
+    void evalComputedColumns(List<DataField> fields);
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/RichEventParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/RichEventParser.java
@@ -76,4 +76,7 @@ public class RichEventParser implements EventParser<RichCdcRecord> {
             return Collections.emptyList();
         }
     }
+
+    @Override
+    public void evalComputedColumns(List<DataField> fields) {}
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/CdcActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/CdcActionITCaseBase.java
@@ -383,6 +383,7 @@ public class CdcActionITCaseBase extends ActionITCaseBase {
         private final List<String> primaryKeys = new ArrayList<>();
         private final List<String> metadataColumn = new ArrayList<>();
         protected Map<String, String> partitionKeyMultiple = new HashMap<>();
+        private final List<String> computedColumnArgs = new ArrayList<>();
 
         public SyncDatabaseActionBuilder(Class<T> clazz, Map<String, String> sourceConfig) {
             this.clazz = clazz;
@@ -462,6 +463,16 @@ public class CdcActionITCaseBase extends ActionITCaseBase {
             return this;
         }
 
+        public SyncDatabaseActionBuilder<T> withComputedColumnArgs(String... computedColumnArgs) {
+            return withComputedColumnArgs(Arrays.asList(computedColumnArgs));
+        }
+
+        public SyncDatabaseActionBuilder<T> withComputedColumnArgs(
+                List<String> computedColumnArgs) {
+            this.computedColumnArgs.addAll(computedColumnArgs);
+            return this;
+        }
+
         public T build() {
             List<String> args =
                     new ArrayList<>(
@@ -489,6 +500,7 @@ public class CdcActionITCaseBase extends ActionITCaseBase {
             args.addAll(mapToArgs("--multiple-table-partition-keys", partitionKeyMultiple));
             args.addAll(listToArgs("--primary-keys", primaryKeys));
             args.addAll(listToArgs("--metadata-column", metadataColumn));
+            args.addAll(listToMultiArgs("--computed_column", computedColumnArgs));
 
             return createAction(clazz, args);
         }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaMaxwellSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaMaxwellSyncDatabaseActionITCase.java
@@ -72,4 +72,10 @@ public class KafkaMaxwellSyncDatabaseActionITCase extends KafkaSyncDatabaseActio
     public void testIncludingAndExcludingTables() throws Exception {
         testIncludingAndExcludingTables(MAXWELL);
     }
+
+    @Test
+    @Timeout(60)
+    public void testComputedColumn() throws Exception {
+        testComputedColumn(MAXWELL);
+    }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaOggSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaOggSyncDatabaseActionITCase.java
@@ -77,4 +77,10 @@ public class KafkaOggSyncDatabaseActionITCase extends KafkaSyncDatabaseActionITC
     public void testCaseInsensitive() throws Exception {
         testCaseInsensitive(OGG);
     }
+
+    @Test
+    @Timeout(60)
+    public void testComputedColumn() throws Exception {
+        testComputedColumn(OGG);
+    }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBSyncDatabaseActionITCase.java
@@ -321,4 +321,66 @@ public class MongoDBSyncDatabaseActionITCase extends MongoDBActionITCaseBase {
         Map<String, String> tableOptions = table.options();
         assertThat(tableOptions).containsAllEntriesOf(tableConfig);
     }
+
+    @Test
+    @Timeout(60)
+    public void testComputedColumnInMongoDB() throws Exception {
+        String dbName = database + UUID.randomUUID();
+        writeRecordsToMongoDB("test-data-5", dbName, "database");
+        Map<String, String> mongodbConfig = getBasicMongoDBConfig();
+        mongodbConfig.put("database", dbName);
+        MongoDBSyncDatabaseAction action =
+                syncDatabaseActionBuilder(mongodbConfig)
+                        .withTableConfig(getBasicTableConfig())
+                        .withCatalogConfig(
+                                Collections.singletonMap(
+                                        FileSystemCatalogOptions.CASE_SENSITIVE.key(), "false"))
+                        .withComputedColumnArgs(
+                                "_substring=substring(country,2)", "_substring=substring(kind,3)")
+                        .build();
+        runActionWithDefaultEnv(action);
+
+        waitingTables("t3");
+        FileStoreTable table1 = getFileStoreTable("t3");
+        writeRecordsToMongoDB("test-data-6", dbName, "database");
+        waitingTables("t4");
+        FileStoreTable table2 = getFileStoreTable("t4");
+
+        RowType rowType1 =
+                RowType.of(
+                        new DataType[] {
+                            DataTypes.STRING().notNull(),
+                            DataTypes.STRING(),
+                            DataTypes.STRING(),
+                            DataTypes.STRING(),
+                            DataTypes.STRING()
+                        },
+                        new String[] {"_id", "country", "languages", "religions", "_substring"});
+        List<String> primaryKeys1 = Collections.singletonList("_id");
+        List<String> expected1 =
+                Arrays.asList(
+                        "+I[610000000000000000000101, Switzerland, Italian, {\"f\":\"v\",\"n\":null}, itzerland]",
+                        "+I[610000000000000000000102, Switzerland, Italian, , itzerland]",
+                        "+I[610000000000000000000103, Switzerland, [\"Italian\"], , itzerland]");
+        waitForResult(expected1, table1, rowType1, primaryKeys1);
+
+        RowType rowType2 =
+                RowType.of(
+                        new DataType[] {
+                            DataTypes.STRING().notNull(),
+                            DataTypes.STRING(),
+                            DataTypes.STRING(),
+                            DataTypes.STRING(),
+                            DataTypes.STRING(),
+                            DataTypes.STRING()
+                        },
+                        new String[] {"_id", "kind", "etag", "pageinfo", "items", "_substring"});
+        List<String> primaryKeys2 = Collections.singletonList("_id");
+        List<String> expected2 =
+                Arrays.asList(
+                        "+I[610000000000000000000101, youtube#videoListResponse, \\\"79S54kzisD_9SOTfQLu_0TVQSpY/mYlS4-ghMGhc1wTFCwoQl3IYDZc\\\", {\"totalResults\":1,\"resultsPerPage\":1}, [{\"kind\":\"youtube#video\",\"etag\":\"\\\\\\\"79S54kzisD_9SOTfQLu_0TVQSpY/A4foLs-VO317Po_ulY6b5mSimZA\\\\\\\"\",\"id\":\"wHkPb68dxEw\",\"statistics\":{\"viewCount\":\"9211\",\"likeCount\":\"79\",\"dislikeCount\":\"11\",\"favoriteCount\":\"0\",\"commentCount\":\"29\"},\"topicDetails\":{\"topicIds\":[\"/m/02mjmr\"],\"relevantTopicIds\":[\"/m/0cnfvd\",\"/m/01jdpf\"]}}], tube#videoListResponse]",
+                        "+I[610000000000000000000102, youtube#videoListResponse, \\\"79S54kzisD_9SOTfQLu_0TVQSpY/mYlS4-ghMGhc1wTFCwoQl3IYDZc\\\", page, [{\"kind\":\"youtube#video\",\"etag\":\"\\\\\\\"79S54kzisD_9SOTfQLu_0TVQSpY/A4foLs-VO317Po_ulY6b5mSimZA\\\\\\\"\",\"id\":\"wHkPb68dxEw\",\"statistics\":{\"viewCount\":\"9211\",\"likeCount\":\"79\",\"dislikeCount\":\"11\",\"favoriteCount\":\"0\",\"commentCount\":\"29\"},\"topicDetails\":{\"topicIds\":[\"/m/02mjmr\"],\"relevantTopicIds\":[\"/m/0cnfvd\",\"/m/01jdpf\"]}}], tube#videoListResponse]",
+                        "+I[610000000000000000000103, youtube#videoListResponse, \\\"79S54kzisD_9SOTfQLu_0TVQSpY/mYlS4-ghMGhc1wTFCwoQl3IYDZc\\\", {\"pagehit\":{\"kind\":\"youtube#video\"},\"totalResults\":1,\"resultsPerPage\":1}, [{\"kind\":\"youtube#video\",\"etag\":\"\\\\\\\"79S54kzisD_9SOTfQLu_0TVQSpY/A4foLs-VO317Po_ulY6b5mSimZA\\\\\\\"\",\"id\":\"wHkPb68dxEw\",\"statistics\":{\"viewCount\":\"9211\",\"likeCount\":\"79\",\"dislikeCount\":\"11\",\"favoriteCount\":\"0\",\"commentCount\":\"29\"},\"topicDetails\":{\"topicIds\":[\"/m/02mjmr\"],\"relevantTopicIds\":[\"/m/0cnfvd\",\"/m/01jdpf\"]}}], tube#videoListResponse]");
+        waitForResult(expected2, table2, rowType2, primaryKeys2);
+    }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/TestCdcEventParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/TestCdcEventParser.java
@@ -48,4 +48,7 @@ public class TestCdcEventParser implements EventParser<TestCdcEvent> {
     public List<CdcRecord> parseRecords() {
         return ObjectUtils.coalesce(raw.records(), Collections.emptyList());
     }
+
+    @Override
+    public void evalComputedColumns(List<DataField> fields) {}
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/computedcolumn/canal-data-1.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/computedcolumn/canal-data-1.txt
@@ -16,26 +16,5 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.flink.action.cdc.format;
-
-import org.apache.paimon.flink.action.cdc.TypeMapping;
-
-/**
- * Represents a factory for creating instances of {@link AbstractRecordParser}.
- *
- * <p>This interface provides a method to create a new RecordParser with specific configurations
- * such as case sensitivity, table name conversion, and computed columns.
- *
- * @see AbstractRecordParser
- */
-@FunctionalInterface
-public interface RecordParserFactory {
-
-    /**
-     * Creates a new instance of {@link AbstractRecordParser} with the specified configurations.
-     *
-     * @param typeMapping Data type mapping options.
-     * @return A new instance of {@link AbstractRecordParser}.
-     */
-    AbstractRecordParser createParser(TypeMapping typeMapping);
-}
+{"data":[{"_id":"1","_date":"2023-03-23","_timestamp":"2022-01-01 14:30:00"}],"database":"paimon_sync_table","es":1683006706000,"id":92,"isDdl":false,"mysqlType":{"_id":"INT","_date":"DATE","_timestamp":"TIMESTAMP"},"old":null,"pkNames":["_id"],"sql":"","sqlType":{"_id":4,"_date":91,"_timestamp":95},"table":"test_computed_column1","ts":1683006706728,"type":"INSERT"}
+{"data":[{"_id":"2","_date":"2024-03-23"}],"database":"paimon_sync_table","es":1683006706000,"id":92,"isDdl":false,"mysqlType":{"_id":"INT","_date":"DATE"},"old":null,"pkNames":["_id"],"sql":"","sqlType":{"_id":4,"_date":91},"table":"test_computed_column2","ts":1683006706728,"type":"INSERT"}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/maxwell/database/computedcolumn/topic0/maxwell-data-1.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/maxwell/database/computedcolumn/topic0/maxwell-data-1.txt
@@ -16,26 +16,5 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.flink.action.cdc.format;
-
-import org.apache.paimon.flink.action.cdc.TypeMapping;
-
-/**
- * Represents a factory for creating instances of {@link AbstractRecordParser}.
- *
- * <p>This interface provides a method to create a new RecordParser with specific configurations
- * such as case sensitivity, table name conversion, and computed columns.
- *
- * @see AbstractRecordParser
- */
-@FunctionalInterface
-public interface RecordParserFactory {
-
-    /**
-     * Creates a new instance of {@link AbstractRecordParser} with the specified configurations.
-     *
-     * @param typeMapping Data type mapping options.
-     * @return A new instance of {@link AbstractRecordParser}.
-     */
-    AbstractRecordParser createParser(TypeMapping typeMapping);
-}
+{"database":"paimon_sync_database_computedcolumn","table":"t1","type":"insert","ts":1596684883,"xid":7125,"xoffset":0,"data":{"id":101,"name":"scooter","description":"Small 2-wheel scooter","weight":3.14},"primary_key_columns": ["id"]}
+{"database":"paimon_sync_database_computedcolumn","table":"t1","type":"insert","ts":1596684883,"xid":7125,"xoffset":1,"data":{"id":102,"name":"car battery","description":"12V car battery","weight":8.1},"primary_key_columns": ["id"]}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/maxwell/database/computedcolumn/topic0/maxwell-data-2.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/maxwell/database/computedcolumn/topic0/maxwell-data-2.txt
@@ -16,26 +16,5 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.flink.action.cdc.format;
-
-import org.apache.paimon.flink.action.cdc.TypeMapping;
-
-/**
- * Represents a factory for creating instances of {@link AbstractRecordParser}.
- *
- * <p>This interface provides a method to create a new RecordParser with specific configurations
- * such as case sensitivity, table name conversion, and computed columns.
- *
- * @see AbstractRecordParser
- */
-@FunctionalInterface
-public interface RecordParserFactory {
-
-    /**
-     * Creates a new instance of {@link AbstractRecordParser} with the specified configurations.
-     *
-     * @param typeMapping Data type mapping options.
-     * @return A new instance of {@link AbstractRecordParser}.
-     */
-    AbstractRecordParser createParser(TypeMapping typeMapping);
-}
+{"database":"paimon_sync_database_computedcolumn","table":"t1","type":"insert","ts":1596684883,"xid":7125,"xoffset":2,"data":{"id":103,"name":"12-pack drill bits","description":"12-pack of drill bits with sizes ranging from #40 to #3","weight":0.8,"age":19},"primary_key_columns": ["id"]}
+{"database":"paimon_sync_database_computedcolumn","table":"t1","type":"insert","ts":1596684883,"xid":7125,"xoffset":3,"data":{"id":104,"name":"hammer","description":"12oz carpenter's hammer","weight":0.75,"age":25},"primary_key_columns": ["id"]}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/maxwell/database/computedcolumn/topic1/maxwell-data-1.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/maxwell/database/computedcolumn/topic1/maxwell-data-1.txt
@@ -16,26 +16,5 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.flink.action.cdc.format;
-
-import org.apache.paimon.flink.action.cdc.TypeMapping;
-
-/**
- * Represents a factory for creating instances of {@link AbstractRecordParser}.
- *
- * <p>This interface provides a method to create a new RecordParser with specific configurations
- * such as case sensitivity, table name conversion, and computed columns.
- *
- * @see AbstractRecordParser
- */
-@FunctionalInterface
-public interface RecordParserFactory {
-
-    /**
-     * Creates a new instance of {@link AbstractRecordParser} with the specified configurations.
-     *
-     * @param typeMapping Data type mapping options.
-     * @return A new instance of {@link AbstractRecordParser}.
-     */
-    AbstractRecordParser createParser(TypeMapping typeMapping);
-}
+{"database":"paimon_sync_database_computedcolumn","table":"t2","type":"insert","ts":1596684883,"xid":7125,"xoffset":2,"data":{"id":103,"name":"12-pack drill bits","description":"12-pack of drill bits with sizes ranging from #40 to #3","weight":0.8},"primary_key_columns": ["id"]}
+{"database":"paimon_sync_database_computedcolumn","table":"t2","type":"insert","ts":1596684883,"xid":7125,"xoffset":3,"data":{"id":104,"name":"hammer","description":"12oz carpenter's hammer","weight":0.75},"primary_key_columns": ["id"]}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/maxwell/database/computedcolumn/topic1/maxwell-data-2.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/maxwell/database/computedcolumn/topic1/maxwell-data-2.txt
@@ -16,26 +16,5 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.flink.action.cdc.format;
-
-import org.apache.paimon.flink.action.cdc.TypeMapping;
-
-/**
- * Represents a factory for creating instances of {@link AbstractRecordParser}.
- *
- * <p>This interface provides a method to create a new RecordParser with specific configurations
- * such as case sensitivity, table name conversion, and computed columns.
- *
- * @see AbstractRecordParser
- */
-@FunctionalInterface
-public interface RecordParserFactory {
-
-    /**
-     * Creates a new instance of {@link AbstractRecordParser} with the specified configurations.
-     *
-     * @param typeMapping Data type mapping options.
-     * @return A new instance of {@link AbstractRecordParser}.
-     */
-    AbstractRecordParser createParser(TypeMapping typeMapping);
-}
+{"database":"paimon_sync_database_computedcolumn","table":"t2","type":"insert","ts":1596684883,"xid":7125,"xoffset":2,"data":{"id":103,"name":"12-pack drill bits","description":"12-pack of drill bits with sizes ranging from #40 to #3","weight":0.8,"address":"Beijing"},"primary_key_columns": ["id"]}
+{"database":"paimon_sync_database_computedcolumn","table":"t2","type":"insert","ts":1596684883,"xid":7125,"xoffset":3,"data":{"id":104,"name":"hammer","description":"12oz carpenter's hammer","weight":0.75,"address":"Shanghai"},"primary_key_columns": ["id"]}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/ogg/database/computedcolumn/topic0/ogg-data-1.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/ogg/database/computedcolumn/topic0/ogg-data-1.txt
@@ -16,26 +16,5 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.flink.action.cdc.format;
-
-import org.apache.paimon.flink.action.cdc.TypeMapping;
-
-/**
- * Represents a factory for creating instances of {@link AbstractRecordParser}.
- *
- * <p>This interface provides a method to create a new RecordParser with specific configurations
- * such as case sensitivity, table name conversion, and computed columns.
- *
- * @see AbstractRecordParser
- */
-@FunctionalInterface
-public interface RecordParserFactory {
-
-    /**
-     * Creates a new instance of {@link AbstractRecordParser} with the specified configurations.
-     *
-     * @param typeMapping Data type mapping options.
-     * @return A new instance of {@link AbstractRecordParser}.
-     */
-    AbstractRecordParser createParser(TypeMapping typeMapping);
-}
+{"table":"PAIMON_SYNC_DATABASE_COMPUTEDCOLUMN.t1","pos":"00000000000000000000143","primary_keys":["id"],"after":{"id":101,"name":"scooter","description":"Small 2-wheel scooter","weight":3.14},"op_type":"I", "current_ts":"2020-05-13T13:39:35.766000", "op_ts":"2020-05-13 15:40:06.000000"}
+{"table":"PAIMON_SYNC_DATABASE_COMPUTEDCOLUMN.t1","pos":"00000000000000000000144","primary_keys":["id"],"after":{"id":102,"name":"car battery","description":"12V car battery","weight":8.1},"op_type":"I","op_ts":"2020-05-13 15:40:07.000000"}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/ogg/database/computedcolumn/topic0/ogg-data-2.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/ogg/database/computedcolumn/topic0/ogg-data-2.txt
@@ -16,26 +16,5 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.flink.action.cdc.format;
-
-import org.apache.paimon.flink.action.cdc.TypeMapping;
-
-/**
- * Represents a factory for creating instances of {@link AbstractRecordParser}.
- *
- * <p>This interface provides a method to create a new RecordParser with specific configurations
- * such as case sensitivity, table name conversion, and computed columns.
- *
- * @see AbstractRecordParser
- */
-@FunctionalInterface
-public interface RecordParserFactory {
-
-    /**
-     * Creates a new instance of {@link AbstractRecordParser} with the specified configurations.
-     *
-     * @param typeMapping Data type mapping options.
-     * @return A new instance of {@link AbstractRecordParser}.
-     */
-    AbstractRecordParser createParser(TypeMapping typeMapping);
-}
+{"table":"PAIMON_SYNC_DATABASE_COMPUTEDCOLUMN.t1","pos":"00000000000000000000145","primary_keys":["id"],"after":{"id":103,"name":"12-pack drill bits","description":"12-pack of drill bits with sizes ranging from #40 to #3","weight":0.8,"age":19},"op_type":"I","op_ts":"2020-05-13 15:40:07.000000"}
+{"table":"PAIMON_SYNC_DATABASE_COMPUTEDCOLUMN.t1","pos":"00000000000000000000146","primary_keys":["id"],"after":{"id":104,"name":"hammer","description":"12oz carpenter's hammer","weight":0.75,"age":25},"op_type":"I","op_ts":"2020-05-13 15:40:07.000000"}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/ogg/database/computedcolumn/topic1/ogg-data-1.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/ogg/database/computedcolumn/topic1/ogg-data-1.txt
@@ -16,26 +16,5 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.flink.action.cdc.format;
-
-import org.apache.paimon.flink.action.cdc.TypeMapping;
-
-/**
- * Represents a factory for creating instances of {@link AbstractRecordParser}.
- *
- * <p>This interface provides a method to create a new RecordParser with specific configurations
- * such as case sensitivity, table name conversion, and computed columns.
- *
- * @see AbstractRecordParser
- */
-@FunctionalInterface
-public interface RecordParserFactory {
-
-    /**
-     * Creates a new instance of {@link AbstractRecordParser} with the specified configurations.
-     *
-     * @param typeMapping Data type mapping options.
-     * @return A new instance of {@link AbstractRecordParser}.
-     */
-    AbstractRecordParser createParser(TypeMapping typeMapping);
-}
+{"table":"PAIMON_SYNC_DATABASE_COMPUTEDCOLUMN.t2","pos":"00000000000000000000145","primary_keys":["id"],"after":{"id":103,"name":"12-pack drill bits","description":"12-pack of drill bits with sizes ranging from #40 to #3","weight":0.8},"op_type":"I","op_ts":"2020-05-13 15:40:07.000000"}
+{"table":"PAIMON_SYNC_DATABASE_COMPUTEDCOLUMN.t2","pos":"00000000000000000000146","primary_keys":["id"],"after":{"id":104,"name":"hammer","description":"12oz carpenter's hammer","weight":0.75},"op_type":"I","op_ts":"2020-05-13 15:40:07.000000"}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/ogg/database/computedcolumn/topic1/ogg-data-2.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/ogg/database/computedcolumn/topic1/ogg-data-2.txt
@@ -16,26 +16,5 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.flink.action.cdc.format;
-
-import org.apache.paimon.flink.action.cdc.TypeMapping;
-
-/**
- * Represents a factory for creating instances of {@link AbstractRecordParser}.
- *
- * <p>This interface provides a method to create a new RecordParser with specific configurations
- * such as case sensitivity, table name conversion, and computed columns.
- *
- * @see AbstractRecordParser
- */
-@FunctionalInterface
-public interface RecordParserFactory {
-
-    /**
-     * Creates a new instance of {@link AbstractRecordParser} with the specified configurations.
-     *
-     * @param typeMapping Data type mapping options.
-     * @return A new instance of {@link AbstractRecordParser}.
-     */
-    AbstractRecordParser createParser(TypeMapping typeMapping);
-}
+{"table":"PAIMON_SYNC_DATABASE_COMPUTEDCOLUMN.t2","pos":"00000000000000000000145","primary_keys":["id"],"after":{"id":103,"name":"12-pack drill bits","description":"12-pack of drill bits with sizes ranging from #40 to #3","weight":0.8,"address":"Beijing"},"op_type":"I","op_ts":"2020-05-13 15:40:07.000000"}
+{"table":"PAIMON_SYNC_DATABASE_COMPUTEDCOLUMN.t2","pos":"00000000000000000000146","primary_keys":["id"],"after":{"id":104,"name":"hammer","description":"12oz carpenter's hammer","weight":0.75,"address":"Shanghai"},"op_type":"I","op_ts":"2020-05-13 15:40:07.000000"}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/mysql/sync_database_setup.sql
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/mysql/sync_database_setup.sql
@@ -514,3 +514,23 @@ CREATE TABLE t2 (
     v1 VARCHAR(10),
     PRIMARY KEY (k)
 );
+
+-- ################################################################################
+--  computedColumn
+-- ################################################################################
+CREATE DATABASE test_computed_column;
+USE test_computed_column;
+
+CREATE TABLE t1 (
+   pk INT,
+   _date DATE,
+   _datetime DATETIME,
+   _timestamp TIMESTAMP,
+   PRIMARY KEY (pk)
+);
+
+CREATE TABLE t2 (
+   pk INT,
+   _date DATE,
+   PRIMARY KEY (pk)
+);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Currently, there are still many paimon users who need to support computed columns when synchronizing multiple tables in the entire database. This PR will implement this feature.

If the referenced columned column exists in the table, the columned column function will be triggered. For example,
```
Table A column:
col1 col2 col3 create_sys_tm

Table B column:
col1 col4 col4 create_sys_tm

Define the calculated function:
--computed_column="_substring=substring(col3,2), pt=date_format(create_sys_tm,yyyyMMdd)"

The final table structure is as follows:
Table A column:
col1 col2 col3 _substring pt

Table B column:
col1 col4 col4 pt
```

The main changes of PR:
Move the implementation of xxxRecordParser#evalComputedColumns down to RichCdcMultiplexRecordEventParser#evalComputedColumns

### Tests

MySqlSyncDatabaseTableListITCase#testComputedColumn

MongoDBSyncDatabaseActionITCase#testComputedColumn

KafkaOggSyncDatabaseActionITCase#testComputedColumn

KafkaMaxwellSyncDatabaseActionITCase#testComputedColumn

KafkaCanalSyncDatabaseActionITCase#testComputedColumn

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
