### PR TITLE
[core] Avoid loading zstd-jni collisions

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/compression/ZstdBlockCompressor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/compression/ZstdBlockCompressor.java
@@ -21,7 +21,6 @@ package org.apache.paimon.compression;
 import com.github.luben.zstd.RecyclingBufferPool;
 import com.github.luben.zstd.ZstdOutputStream;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -56,8 +55,10 @@ public class ZstdBlockCompressor implements BlockCompressor {
     public int compress(byte[] src, int srcOff, int srcLen, byte[] dst, int dstOff)
             throws BufferCompressionException {
         ByteArrayOutputStream stream = new ByteArrayOutputStream(dst, dstOff);
+        // Using two-argument constructors to avoid zstd-jni collisions
         try (ZstdOutputStream zstdStream =
-                new ZstdOutputStream(stream, RecyclingBufferPool.INSTANCE, level)) {
+                new ZstdOutputStream(stream, RecyclingBufferPool.INSTANCE)) {
+            zstdStream.setLevel(level);
             zstdStream.setWorkers(0);
             zstdStream.write(src, srcOff, srcLen);
         } catch (IOException e) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #4197 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
