### PR TITLE
[spark] Support distributed orphan file clean for spark

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/orphan/SparkOrphanFilesClean.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/orphan/SparkOrphanFilesClean.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.orphan;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.fs.FileStatus;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.ManifestFile;
+import org.apache.paimon.manifest.ManifestFileMeta;
+import org.apache.paimon.operation.OrphanFilesClean;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.utils.Pair;
+import org.apache.paimon.utils.SerializableConsumer;
+
+import org.apache.spark.SparkContext;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.util.CollectionAccumulator;
+import org.apache.spark.util.LongAccumulator;
+
+import javax.annotation.Nullable;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import scala.Tuple2;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Spark {@link OrphanFilesClean}, it will submit a job for a table. */
+public class SparkOrphanFilesClean extends OrphanFilesClean {
+
+    @Nullable protected final Integer parallelism;
+
+    public SparkOrphanFilesClean(
+            FileStoreTable table,
+            long olderThanMillis,
+            SerializableConsumer<Path> fileCleaner,
+            @Nullable Integer parallelism) {
+        super(table, olderThanMillis, fileCleaner);
+        this.parallelism = parallelism;
+    }
+
+    public static long executeDatabaseOrphanFiles(
+            JavaSparkContext ctx,
+            Catalog catalog,
+            long olderThanMillis,
+            SerializableConsumer<Path> fileCleaner,
+            @Nullable Integer parallelism,
+            String databaseName,
+            @Nullable String tableName)
+            throws Catalog.DatabaseNotExistException, Catalog.TableNotExistException {
+        Long cleanTotal = 0L;
+        List<String> tableNames = Collections.singletonList(tableName);
+        if (tableName == null || "*".equals(tableName)) {
+            tableNames = catalog.listTables(databaseName);
+        }
+
+        for (String t : tableNames) {
+            Identifier identifier = new Identifier(databaseName, t);
+            Table table = catalog.getTable(identifier);
+            checkArgument(
+                    table instanceof FileStoreTable,
+                    "Only FileStoreTable supports remove-orphan-files action. The table type is '%s'.",
+                    table.getClass().getName());
+
+            Long cleanNums =
+                    new SparkOrphanFilesClean(
+                                    (FileStoreTable) table,
+                                    olderThanMillis,
+                                    fileCleaner,
+                                    parallelism)
+                            .doOrphanClean(ctx);
+            cleanTotal += cleanNums;
+        }
+        return cleanTotal;
+    }
+
+    @Nullable
+    public Long doOrphanClean(JavaSparkContext ctx) {
+        int parallelism = this.parallelism == null ? ctx.defaultParallelism() : this.parallelism;
+        ctx.getConf().set("spark.default.parallelism", String.valueOf(parallelism));
+        SparkContext sc = ctx.sc();
+
+        List<String> branches = validBranches();
+
+        // snapshot and changelog files are the root of everything, so they are handled specially
+        // here, and subsequently, we will not count their orphan files.
+        AtomicLong deletedInLocal = new AtomicLong(0);
+        cleanSnapshotDir(branches, p -> deletedInLocal.incrementAndGet());
+
+        // branch and manifest file
+        CollectionAccumulator<Pair<String, String>> pairsAccumulator =
+                sc.collectionAccumulator("manifest-output");
+        LongAccumulator emitted = sc.longAccumulator();
+
+        JavaRDD<String> usedManifestFiles =
+                ctx.parallelize(branches)
+                        .mapPartitions(
+                                iterator -> {
+                                    ArrayList<Pair> pairs = new ArrayList<>();
+                                    while (iterator.hasNext()) {
+                                        String branch = iterator.next();
+                                        for (Snapshot snapshot : safelyGetAllSnapshots(branch)) {
+                                            pairs.add(Pair.of(branch, snapshot.toJson()));
+                                        }
+                                    }
+                                    return pairs.iterator();
+                                })
+                        .repartition(parallelism)
+                        .mapPartitions(
+                                iterator -> {
+                                    List<String> collect = new ArrayList<String>();
+                                    while (iterator.hasNext()) {
+                                        Pair pair = iterator.next();
+                                        String branch = (String) pair.getLeft();
+
+                                        Snapshot snapshot =
+                                                Snapshot.fromJson((String) pair.getRight());
+                                        Consumer<ManifestFileMeta> manifestConsumer =
+                                                manifest -> {
+                                                    Pair<String, String> pair0 =
+                                                            Pair.of(branch, manifest.fileName());
+                                                    pairsAccumulator.add(pair0);
+                                                };
+                                        collectWithoutDataFile(
+                                                branch, snapshot, collect::add, manifestConsumer);
+                                    }
+                                    return collect.iterator();
+                                });
+        usedManifestFiles.collect();
+
+        JavaRDD<String> usedFiles =
+                ctx.parallelize(pairsAccumulator.value(), parallelism)
+                        .keyBy(pair -> pair.getLeft().toString() + ":" + pair.getRight().toString())
+                        .mapPartitions(
+                                iterator -> {
+                                    Set<Pair<String, String>> manifests = new HashSet<>();
+                                    while (iterator.hasNext()) {
+                                        Tuple2<String, Pair<String, String>> value =
+                                                iterator.next();
+                                        manifests.add(value._2());
+                                    }
+                                    Map<String, ManifestFile> branchManifests = new HashMap<>();
+                                    ArrayList<String> output = new ArrayList<>();
+                                    for (Pair<String, String> pair : manifests) {
+                                        ManifestFile manifestFile =
+                                                branchManifests.computeIfAbsent(
+                                                        pair.getLeft(),
+                                                        key ->
+                                                                table.switchToBranch(key)
+                                                                        .store()
+                                                                        .manifestFileFactory()
+                                                                        .create());
+                                        retryReadingFiles(
+                                                        () ->
+                                                                manifestFile.readWithIOException(
+                                                                        pair.getRight()),
+                                                        Collections.<ManifestEntry>emptyList())
+                                                .forEach(
+                                                        f -> {
+                                                            List<String> files = new ArrayList<>();
+                                                            files.add(f.fileName());
+                                                            files.addAll(f.file().extraFiles());
+                                                            files.forEach(file -> output.add(file));
+                                                        });
+                                    }
+                                    return output.iterator();
+                                });
+
+        usedFiles = usedFiles.union(usedManifestFiles);
+
+        List<String> fileDirs =
+                listPaimonFileDirs().stream()
+                        .map(Path::toUri)
+                        .map(Object::toString)
+                        .collect(Collectors.toList());
+
+        JavaRDD<String> candidates =
+                ctx.parallelize(fileDirs)
+                        .mapPartitions(
+                                iterator -> {
+                                    ArrayList<String> output = new ArrayList<>();
+                                    while (iterator.hasNext()) {
+                                        String dir = iterator.next();
+                                        for (FileStatus fileStatus :
+                                                tryBestListingDirs(new Path(dir))) {
+                                            if (oldEnough(fileStatus)) {
+                                                output.add(fileStatus.getPath().toUri().toString());
+                                            }
+                                        }
+                                    }
+                                    return output.iterator();
+                                });
+        JavaPairRDD<String, Object> resultRdd =
+                usedFiles
+                        .keyBy(k -> k)
+                        .cogroup(candidates.keyBy(path -> new Path(path).getName()))
+                        .mapValues(
+                                tuple -> {
+                                    Set<String> used = new HashSet<>();
+                                    Iterator<String> usedStrs = tuple._1.iterator();
+                                    Iterator<String> pathStrs = tuple._2.iterator();
+
+                                    if (!usedStrs.hasNext()) {
+                                        String value = pathStrs.next();
+                                        Path path = new Path(value);
+                                        fileCleaner.accept(path);
+                                        LOG.info("Dry clean: {}", path);
+                                        emitted.add(1L);
+                                    }
+
+                                    return null;
+                                });
+
+        // call action
+        resultRdd.collect();
+        return emitted.value() + deletedInLocal.get();
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/orphan/SparkOrphanFilesClean.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/orphan/SparkOrphanFilesClean.java
@@ -41,7 +41,14 @@ import org.apache.spark.util.LongAccumulator;
 
 import javax.annotation.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedureTest.scala
@@ -52,7 +52,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
     fileIO.tryToWriteAtomic(orphanFile2, "b")
 
     // by default, no file deleted
-    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Nil)
+    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row("0") :: Nil)
 
     val orphanFile2ModTime = fileIO.getFileStatus(orphanFile2).getModificationTime
     val older_than1 = DateTimeUtils.formatLocalDateTime(
@@ -63,7 +63,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
 
     checkAnswer(
       spark.sql(s"CALL sys.remove_orphan_files(table => 'T', older_than => '$older_than1')"),
-      Row(orphanFile1.toUri.getPath) :: Nil)
+      Row("1") :: Nil)
 
     val older_than2 = DateTimeUtils.formatLocalDateTime(
       DateTimeUtils.toLocalDateTime(System.currentTimeMillis()),
@@ -71,7 +71,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
 
     checkAnswer(
       spark.sql(s"CALL sys.remove_orphan_files(table => 'T', older_than => '$older_than2')"),
-      Row(orphanFile2.toUri.getPath) :: Nil)
+      Row("1") :: Nil)
   }
 
   test("Paimon procedure: dry run remove orphan files") {
@@ -95,7 +95,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
     fileIO.writeFile(orphanFile2, "b", true)
 
     // by default, no file deleted
-    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Nil)
+    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row("0") :: Nil)
 
     val older_than = DateTimeUtils.formatLocalDateTime(
       DateTimeUtils.toLocalDateTime(System.currentTimeMillis()),
@@ -104,7 +104,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
     checkAnswer(
       spark.sql(
         s"CALL sys.remove_orphan_files(table => 'T', older_than => '$older_than', dry_run => true)"),
-      Row(orphanFile1.toUri.getPath) :: Row(orphanFile2.toUri.getPath) :: Nil
+      Row("2") :: Nil
     )
   }
 
@@ -142,7 +142,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
     fileIO2.tryToWriteAtomic(orphanFile22, "b")
 
     // by default, no file deleted
-    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'test.*')"), Nil)
+    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'test.*')"), Row("0") :: Nil)
 
     val orphanFile12ModTime = fileIO1.getFileStatus(orphanFile12).getModificationTime
     val older_than1 = DateTimeUtils.formatLocalDateTime(
@@ -153,7 +153,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
 
     checkAnswer(
       spark.sql(s"CALL sys.remove_orphan_files(table => 'test.*', older_than => '$older_than1')"),
-      Row(orphanFile11.toUri.getPath) :: Row(orphanFile21.toUri.getPath) :: Nil
+      Row("2") :: Nil
     )
 
     val older_than2 = DateTimeUtils.formatLocalDateTime(
@@ -162,7 +162,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
 
     checkAnswer(
       spark.sql(s"CALL sys.remove_orphan_files(table => 'test.*', older_than => '$older_than2')"),
-      Row(orphanFile12.toUri.getPath) :: Row(orphanFile22.toUri.getPath) :: Nil
+      Row("2") :: Nil
     )
   }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close https://github.com/apache/paimon/issues/4184

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
RemoveOrphanFilesProcedureTest

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
