### PR TITLE
[core] Support async refresh for PrimaryKeyPartialLookupTable

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/Levels.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/Levels.java
@@ -86,8 +86,8 @@ public class Levels {
                 "Number of files stored in Levels does not equal to the size of inputFiles. This is unexpected.");
     }
 
-    public TreeSet<DataFileMeta> level0() {
-        return level0;
+    public synchronized TreeSet<DataFileMeta> level0() {
+        return new TreeSet<>(level0);
     }
 
     public void addDropFileCallback(DropFileCallback callback) {
@@ -99,9 +99,9 @@ public class Levels {
         level0.add(file);
     }
 
-    public SortedRun runOfLevel(int level) {
+    public synchronized SortedRun runOfLevel(int level) {
         checkArgument(level > 0, "Level0 does not have one single sorted run.");
-        return levels.get(level - 1);
+        return SortedRun.fromSorted(levels.get(level - 1).files());
     }
 
     public int numberOfLevels() {
@@ -159,7 +159,7 @@ public class Levels {
         return runs;
     }
 
-    public void update(List<DataFileMeta> before, List<DataFileMeta> after) {
+    public synchronized void update(List<DataFileMeta> before, List<DataFileMeta> after) {
         Map<Integer, List<DataFileMeta>> groupedBefore = groupByLevel(before);
         Map<Integer, List<DataFileMeta>> groupedAfter = groupByLevel(after);
         for (int i = 0; i < numberOfLevels(); i++) {

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/LookupFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/LookupFile.java
@@ -117,10 +117,12 @@ public class LookupFile {
 
     private static void removalCallback(String file, LookupFile lookupFile, RemovalCause cause) {
         if (lookupFile != null) {
-            try {
-                lookupFile.close(cause);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
+            synchronized (file) {
+                try {
+                    lookupFile.close(cause);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
             }
         }
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/AsyncRefreshLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/AsyncRefreshLookupTable.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.lookup;
+
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.ExecutorThreadFactory;
+import org.apache.paimon.utils.ExecutorUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.paimon.flink.FlinkConnectorOptions.LOOKUP_REFRESH_ASYNC;
+import static org.apache.paimon.flink.FlinkConnectorOptions.LOOKUP_REFRESH_ASYNC_PENDING_SNAPSHOT_COUNT;
+
+/** A {@link LookupTable} supports async refresh. */
+public abstract class AsyncRefreshLookupTable implements LookupTable {
+    private static final Logger LOG = LoggerFactory.getLogger(AsyncRefreshLookupTable.class);
+    private final FileStoreTable table;
+
+    private final int maxPendingSnapshotCount;
+
+    @Nullable private ExecutorService refreshExecutor;
+
+    private final AtomicReference<Exception> cachedException;
+
+    private Future<?> refreshFuture;
+
+    protected final boolean refreshAsync;
+
+    public AsyncRefreshLookupTable(FileStoreTable table) {
+        Options options = Options.fromMap(table.options());
+        this.table = table;
+        this.refreshAsync = options.get(LOOKUP_REFRESH_ASYNC);
+        this.cachedException = new AtomicReference<>();
+        this.maxPendingSnapshotCount = options.get(LOOKUP_REFRESH_ASYNC_PENDING_SNAPSHOT_COUNT);
+    }
+
+    protected void init() throws Exception {
+        this.refreshExecutor =
+                this.refreshAsync
+                        ? Executors.newSingleThreadExecutor(
+                                new ExecutorThreadFactory(
+                                        String.format(
+                                                "%s-lookup-refresh",
+                                                Thread.currentThread().getName())))
+                        : null;
+    }
+
+    @Override
+    public void refresh() throws Exception {
+        if (refreshExecutor == null) {
+            doRefresh(false);
+            return;
+        }
+
+        Long latestSnapshotId = table.snapshotManager().latestSnapshotId();
+        Long nextSnapshotId = nextSnapshotId();
+        if (latestSnapshotId != null
+                && nextSnapshotId != null
+                && latestSnapshotId - nextSnapshotId > maxPendingSnapshotCount) {
+            LOG.warn(
+                    "The latest snapshot id {} is much greater than the next snapshot id {} for {}}, "
+                            + "you may need to increase the parallelism of lookup operator.",
+                    latestSnapshotId,
+                    nextSnapshotId,
+                    maxPendingSnapshotCount);
+            if (refreshFuture != null) {
+                // Wait the previous refresh task to be finished.
+                refreshFuture.get();
+            }
+            doRefresh(false);
+        } else {
+            refreshAsync();
+        }
+    }
+
+    private void refreshAsync() {
+        Future<?> currentFuture = null;
+        try {
+            currentFuture =
+                    refreshExecutor.submit(
+                            () -> {
+                                try {
+                                    doRefresh(true);
+                                } catch (Exception e) {
+                                    LOG.error("Refresh lookup table {} failed", table.name(), e);
+                                    cachedException.set(e);
+                                }
+                            });
+        } catch (RejectedExecutionException e) {
+            LOG.warn("Add refresh task for lookup table {} failed", table.name(), e);
+        }
+        if (currentFuture != null) {
+            refreshFuture = currentFuture;
+        }
+    }
+
+    public abstract void doRefresh(boolean refreshCache) throws Exception;
+
+    public abstract Long nextSnapshotId();
+
+    @VisibleForTesting
+    public Future<?> getRefreshFuture() {
+        return refreshFuture;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (refreshExecutor != null) {
+            ExecutorUtils.gracefulShutdown(1L, TimeUnit.MINUTES, refreshExecutor);
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyPartialLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyPartialLookupTable.java
@@ -56,7 +56,7 @@ import static org.apache.paimon.table.BucketMode.POSTPONE_BUCKET;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Lookup table for primary key which supports to read the LSM tree directly. */
-public class PrimaryKeyPartialLookupTable implements LookupTable {
+public class PrimaryKeyPartialLookupTable extends AsyncRefreshLookupTable {
 
     private final QueryExecutorFactory executorFactory;
     @Nullable private final ProjectedRow keyRearrange;
@@ -71,6 +71,7 @@ public class PrimaryKeyPartialLookupTable implements LookupTable {
 
     private PrimaryKeyPartialLookupTable(
             QueryExecutorFactory executorFactory, FileStoreTable table, List<String> joinKey) {
+        super(table);
         this.executorFactory = executorFactory;
         if (table.bucketMode() != BucketMode.HASH_FIXED) {
             throw new UnsupportedOperationException(
@@ -127,8 +128,13 @@ public class PrimaryKeyPartialLookupTable implements LookupTable {
 
     @Override
     public void open() throws Exception {
+        init();
+        doRefresh(false);
+    }
+
+    protected void init() throws Exception {
+        super.init();
         this.queryExecutor = executorFactory.create(specificPartition, cacheRowFilter);
-        refresh();
     }
 
     @Override
@@ -166,8 +172,8 @@ public class PrimaryKeyPartialLookupTable implements LookupTable {
     }
 
     @Override
-    public void refresh() {
-        queryExecutor.refresh();
+    public void doRefresh(boolean refreshCache) {
+        queryExecutor.refresh(refreshCache);
     }
 
     @Override
@@ -175,10 +181,18 @@ public class PrimaryKeyPartialLookupTable implements LookupTable {
         this.cacheRowFilter = filter;
     }
 
+    public Long nextSnapshotId() {
+        return queryExecutor.nextSnapshotId();
+    }
+
     @Override
     public void close() throws IOException {
-        if (queryExecutor != null) {
-            queryExecutor.close();
+        try {
+            super.close();
+        } finally {
+            if (queryExecutor != null) {
+                queryExecutor.close();
+            }
         }
     }
 
@@ -220,7 +234,9 @@ public class PrimaryKeyPartialLookupTable implements LookupTable {
 
         InternalRow lookup(BinaryRow partition, int bucket, InternalRow key) throws IOException;
 
-        void refresh();
+        void refresh(boolean refreshCache);
+
+        Long nextSnapshotId();
     }
 
     static class LocalQueryExecutor implements QueryExecutor {
@@ -278,7 +294,7 @@ public class PrimaryKeyPartialLookupTable implements LookupTable {
         }
 
         @Override
-        public void refresh() {
+        public void refresh(boolean refreshCache) {
             while (true) {
                 List<Split> splits = scan.plan().splits();
                 log(splits);
@@ -288,19 +304,23 @@ public class PrimaryKeyPartialLookupTable implements LookupTable {
                 }
 
                 for (Split split : splits) {
-                    refreshSplit((DataSplit) split);
+                    refreshSplit((DataSplit) split, refreshCache);
                 }
             }
         }
 
         @VisibleForTesting
         void refreshSplit(DataSplit split) {
+            refreshSplit(split, false);
+        }
+
+        void refreshSplit(DataSplit split, boolean refreshCache) {
             BinaryRow partition = split.partition();
             int bucket = split.bucket();
             List<DataFileMeta> before = split.beforeFiles();
             List<DataFileMeta> after = split.dataFiles();
 
-            tableQuery.refreshFiles(partition, bucket, before, after);
+            tableQuery.refreshFiles(partition, bucket, before, after, refreshCache);
             Integer totalBuckets = split.totalBuckets();
             if (totalBuckets == null) {
                 // Just for compatibility with older versions
@@ -310,6 +330,11 @@ public class PrimaryKeyPartialLookupTable implements LookupTable {
                 totalBuckets = defaultNumBuckets;
             }
             numBuckets.put(partition, totalBuckets);
+        }
+
+        @Override
+        public Long nextSnapshotId() {
+            return scan.checkpoint();
         }
 
         @Override
@@ -359,7 +384,12 @@ public class PrimaryKeyPartialLookupTable implements LookupTable {
         }
 
         @Override
-        public void refresh() {}
+        public void refresh(boolean refreshCache) {}
+
+        @Override
+        public Long nextSnapshotId() {
+            return null;
+        }
 
         @Override
         public void close() throws IOException {


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3386

<!-- What is the purpose of the change -->
Support async refresh for PrimaryKeyPartialLookupTable. Async refresh files generated by new snapshots which are intervened with expired cached files. The total size of new generated lookup during one refresh will not greatly exceed the total size of expired lookup files.
### Tests

1. Added UT LookupTableTest#testAsyncRefreshPartialLookupTable 
2. Added UT LookupLevelsTest#testRefreshFiles
3. Added IT FileStoreLookupFunctionTest#testAsyncRefreshLookupTableNoError


### API and Format


### Documentation

