### PR TITLE
[hotfix] fix unspecified value parameter when using PaimonMetadataColumn.get method

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -113,12 +113,15 @@ abstract class PaimonBaseScan(
     inputPartitions
   }
 
+  final def partitionType: StructType = {
+    SparkTypeUtils.toSparkPartitionType(table)
+  }
+
   override def readSchema(): StructType = {
     StructType(requiredTableFields ++ metadataFields)
   }
 
   override def toBatch: Batch = {
-    val partitionType = SparkTypeUtils.toSparkPartitionType(table)
     val metadataColumns =
       metadataFields.map(field => PaimonMetadataColumn.get(field.name, partitionType))
     PaimonBatch(lazyInputPartitions, readBuilder, metadataColumns)

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonStatistics.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonStatistics.scala
@@ -75,7 +75,7 @@ case class PaimonStatistics[T <: PaimonBaseScan](scan: T) extends Statistics {
 
     val metadataSchemaSize = scan.metadataFields.map {
       field =>
-        val dataField = PaimonMetadataColumn.get(field.name).toPaimonDataField
+        val dataField = PaimonMetadataColumn.get(field.name, scan.partitionType).toPaimonDataField
         getSizeForField(dataField)
     }.sum
     val metadataSizeInBytes = paimonStats.mergedRecordCount().getAsLong * metadataSchemaSize


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
 fix unspecified value parameter when using PaimonMetadataColumn.get method

![image](https://github.com/user-attachments/assets/1d9ce3d8-d014-4ba1-b4e4-329c001dec08)

https://github.com/apache/paimon/actions/runs/10933145723/job/30351130554#step:4:4636

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
