### PR TITLE
[core] Add Table.uuid method

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -633,6 +633,7 @@ public abstract class AbstractCatalog implements Catalog {
                         });
     }
 
+    /** Table metadata. */
     protected static class TableMeta {
 
         private final TableSchema schema;

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -479,9 +479,8 @@ public abstract class AbstractCatalog implements Catalog {
         return new TableMeta(getDataTableSchema(identifier), null);
     }
 
-    protected TableSchema getDataTableSchema(Identifier identifier) throws TableNotExistException {
-        throw new UnsupportedOperationException();
-    }
+    protected abstract TableSchema getDataTableSchema(Identifier identifier)
+            throws TableNotExistException;
 
     /** Get metastore client factory for the table specified by {@code identifier}. */
     public Optional<MetastoreClient.Factory> metastoreClientFactory(
@@ -642,6 +641,15 @@ public abstract class AbstractCatalog implements Catalog {
         public TableMeta(TableSchema schema, @Nullable String uuid) {
             this.schema = schema;
             this.uuid = uuid;
+        }
+
+        public TableSchema schema() {
+            return schema;
+        }
+
+        @Nullable
+        public String uuid() {
+            return uuid;
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -433,7 +433,7 @@ public abstract class AbstractCatalog implements Catalog {
                         tableMeta.uuid,
                         Lock.factory(
                                 lockFactory().orElse(null), lockContext().orElse(null), identifier),
-                        metastoreClientFactory(identifier, tableSchema).orElse(null),
+                        metastoreClientFactory(identifier, tableMeta.schema).orElse(null),
                         lineageMetaFactory));
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -168,6 +168,14 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
     }
 
     @Override
+    public String uuid() {
+        if (catalogEnvironment.uuid() != null) {
+            return catalogEnvironment.uuid();
+        }
+        return fullName();
+    }
+
+    @Override
     public Optional<Statistics> statistics() {
         Snapshot snapshot = TimeTravelUtil.resolveSnapshot(this);
         if (snapshot != null) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -172,7 +172,8 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
         if (catalogEnvironment.uuid() != null) {
             return catalogEnvironment.uuid();
         }
-        return fullName();
+        long earliestCreationTime = schemaManager().earliestCreationTime();
+        return fullName() + "." + earliestCreationTime;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
@@ -36,28 +36,36 @@ public class CatalogEnvironment implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Nullable private final Identifier identifier;
+    @Nullable private final String uuid;
     private final Lock.Factory lockFactory;
     @Nullable private final MetastoreClient.Factory metastoreClientFactory;
     @Nullable private final LineageMetaFactory lineageMetaFactory;
 
     public CatalogEnvironment(
             @Nullable Identifier identifier,
+            @Nullable String uuid,
             Lock.Factory lockFactory,
             @Nullable MetastoreClient.Factory metastoreClientFactory,
             @Nullable LineageMetaFactory lineageMetaFactory) {
         this.identifier = identifier;
+        this.uuid = uuid;
         this.lockFactory = lockFactory;
         this.metastoreClientFactory = metastoreClientFactory;
         this.lineageMetaFactory = lineageMetaFactory;
     }
 
     public static CatalogEnvironment empty() {
-        return new CatalogEnvironment(null, Lock.emptyFactory(), null, null);
+        return new CatalogEnvironment(null, null, Lock.emptyFactory(), null, null);
     }
 
     @Nullable
     public Identifier identifier() {
         return identifier;
+    }
+
+    @Nullable
+    public String uuid() {
+        return uuid;
     }
 
     public Lock.Factory lockFactory() {

--- a/paimon-core/src/main/java/org/apache/paimon/table/DelegatedFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/DelegatedFileStoreTable.java
@@ -73,6 +73,11 @@ public abstract class DelegatedFileStoreTable implements FileStoreTable {
     }
 
     @Override
+    public String uuid() {
+        return wrapped.uuid();
+    }
+
+    @Override
     public SnapshotReader newSnapshotReader() {
         return wrapped.newSnapshotReader();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/Table.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/Table.java
@@ -56,6 +56,11 @@ public interface Table extends Serializable {
         return name();
     }
 
+    /** UUID of the table. */
+    default String uuid() {
+        return fullName();
+    }
+
     /** Returns the row type of this table. */
     RowType rowType();
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/Table.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/Table.java
@@ -52,11 +52,15 @@ public interface Table extends Serializable {
     /** A name to identify this table. */
     String name();
 
+    /** Full name of the table, default is database.tableName. */
     default String fullName() {
         return name();
     }
 
-    /** UUID of the table. */
+    /**
+     * UUID of the table, metastore can provide the true UUID of this table, default is the full
+     * name.
+     */
     default String uuid() {
         return fullName();
     }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -948,4 +948,16 @@ public abstract class CatalogTestBase {
                 .isInstanceOf(Catalog.TableNotExistException.class);
         assertThat(catalog.getTable(newIdentifier)).isInstanceOf(FormatTable.class);
     }
+
+    @Test
+    public void testTableUUID() throws Exception {
+        catalog.createDatabase("test_db", false);
+        Identifier identifier = Identifier.create("test_db", "test_table");
+        catalog.createTable(identifier, DEFAULT_TABLE_SCHEMA, false);
+        Table table = catalog.getTable(identifier);
+        String uuid = table.uuid();
+        assertThat(uuid).startsWith(identifier.getFullName() + ".");
+        assertThat(Long.parseLong(uuid.substring((identifier.getFullName() + ".").length())))
+                .isGreaterThan(0);
+    }
 }

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -70,6 +70,11 @@ public class HiveCatalogTest extends CatalogTestBase {
         catalog = new HiveCatalog(fileIO, hiveConf, metastoreClientClass, warehouse);
     }
 
+    @Override
+    protected void assertUUID(String uuid, Identifier identifier) {
+        assertThat(uuid).startsWith(identifier.getFullName() + ".");
+    }
+
     @Test
     @Override
     public void testListDatabasesWhenNoDatabases() {

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -70,11 +70,6 @@ public class HiveCatalogTest extends CatalogTestBase {
         catalog = new HiveCatalog(fileIO, hiveConf, metastoreClientClass, warehouse);
     }
 
-    @Override
-    protected void assertUUID(String uuid, Identifier identifier) {
-        assertThat(uuid).startsWith(identifier.getFullName() + ".");
-    }
-
     @Test
     @Override
     public void testListDatabasesWhenNoDatabases() {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Add Table.uuid method for table uniq id, this can be used like some RBAC support.
- for filesystem catalog, uuid is db + tableName + schema-createTime.
- for hive catalog, uuid is db + tableName + createTime.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
