### PR TITLE
[core] Introduce withReadType in ReadBuilder

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/table/SystemFields.java
+++ b/paimon-common/src/main/java/org/apache/paimon/table/SystemFields.java
@@ -43,6 +43,7 @@ public class SystemFields {
     public static final DataField LEVEL =
             new DataField(Integer.MAX_VALUE - 3, "_LEVEL", DataTypes.INT().notNull());
 
+    // only used by AuditLogTable
     public static final DataField ROW_KIND =
             new DataField(
                     Integer.MAX_VALUE - 4, "rowkind", new VarCharType(VarCharType.MAX_LENGTH));

--- a/paimon-common/src/main/java/org/apache/paimon/table/SystemFields.java
+++ b/paimon-common/src/main/java/org/apache/paimon/table/SystemFields.java
@@ -20,6 +20,7 @@ package org.apache.paimon.table;
 
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.VarCharType;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -42,8 +43,12 @@ public class SystemFields {
     public static final DataField LEVEL =
             new DataField(Integer.MAX_VALUE - 3, "_LEVEL", DataTypes.INT().notNull());
 
+    public static final DataField ROW_KIND =
+            new DataField(
+                    Integer.MAX_VALUE - 4, "rowkind", new VarCharType(VarCharType.MAX_LENGTH));
+
     public static final Set<String> SYSTEM_FIELD_NAMES =
-            Stream.of(SEQUENCE_NUMBER.name(), VALUE_KIND.name(), LEVEL.name())
+            Stream.of(SEQUENCE_NUMBER.name(), VALUE_KIND.name(), LEVEL.name(), ROW_KIND.name())
                     .collect(Collectors.toSet());
 
     public static boolean isSystemField(int fieldId) {

--- a/paimon-common/src/main/java/org/apache/paimon/types/DataField.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DataField.java
@@ -148,7 +148,7 @@ public final class DataField implements Serializable {
                 && Objects.equals(description, field.description);
     }
 
-    public boolean subsetOf(DataField field) {
+    public boolean prunedFrom(DataField field) {
         if (this == field) {
             return true;
         }
@@ -157,7 +157,7 @@ public final class DataField implements Serializable {
         }
         return Objects.equals(id, field.id)
                 && Objects.equals(name, field.name)
-                && type.subsetOf(field.type)
+                && type.prunedFrom(field.type)
                 && Objects.equals(description, field.description);
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/types/DataField.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DataField.java
@@ -148,7 +148,7 @@ public final class DataField implements Serializable {
                 && Objects.equals(description, field.description);
     }
 
-    public boolean prunedFrom(DataField field) {
+    public boolean isPrunedFrom(DataField field) {
         if (this == field) {
             return true;
         }
@@ -157,7 +157,7 @@ public final class DataField implements Serializable {
         }
         return Objects.equals(id, field.id)
                 && Objects.equals(name, field.name)
-                && type.prunedFrom(field.type)
+                && type.isPrunedFrom(field.type)
                 && Objects.equals(description, field.description);
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/types/DataField.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DataField.java
@@ -84,6 +84,10 @@ public final class DataField implements Serializable {
         return new DataField(id, newName, type, description);
     }
 
+    public DataField newType(DataType newType) {
+        return new DataField(id, name, newType, description);
+    }
+
     public DataField newDescription(String newDescription) {
         return new DataField(id, name, type, newDescription);
     }
@@ -141,6 +145,19 @@ public final class DataField implements Serializable {
         return Objects.equals(id, field.id)
                 && Objects.equals(name, field.name)
                 && Objects.equals(type, field.type)
+                && Objects.equals(description, field.description);
+    }
+
+    public boolean subsetOf(DataField field) {
+        if (this == field) {
+            return true;
+        }
+        if (field == null) {
+            return false;
+        }
+        return Objects.equals(id, field.id)
+                && Objects.equals(name, field.name)
+                && type.subsetOf(field.type)
                 && Objects.equals(description, field.description);
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/types/DataType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DataType.java
@@ -145,7 +145,13 @@ public abstract class DataType implements Serializable {
         return isNullable == that.isNullable && typeRoot == that.typeRoot;
     }
 
-    public boolean subsetOf(Object o) {
+    /**
+     * Determine whether the current type is the result of the target type after pruning (e.g.
+     * select some fields for a nested type) or just the same.
+     *
+     * @param o the target data type
+     */
+    public boolean prunedFrom(Object o) {
         return equals(o);
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/types/DataType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DataType.java
@@ -145,6 +145,10 @@ public abstract class DataType implements Serializable {
         return isNullable == that.isNullable && typeRoot == that.typeRoot;
     }
 
+    public boolean subsetOf(Object o) {
+        return equals(o);
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(isNullable, typeRoot);

--- a/paimon-common/src/main/java/org/apache/paimon/types/DataType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DataType.java
@@ -147,7 +147,7 @@ public abstract class DataType implements Serializable {
 
     /**
      * Determine whether the current type is the result of the target type after pruning (e.g.
-     * select some fields for a nested type) or just the same.
+     * select some fields from a nested type) or just the same.
      *
      * @param o the target data type
      */

--- a/paimon-common/src/main/java/org/apache/paimon/types/DataType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DataType.java
@@ -151,7 +151,7 @@ public abstract class DataType implements Serializable {
      *
      * @param o the target data type
      */
-    public boolean prunedFrom(Object o) {
+    public boolean isPrunedFrom(Object o) {
         return equals(o);
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/types/RowType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/RowType.java
@@ -191,7 +191,7 @@ public final class RowType extends DataType {
     }
 
     @Override
-    public boolean prunedFrom(Object o) {
+    public boolean isPrunedFrom(Object o) {
         if (this == o) {
             return true;
         }
@@ -203,7 +203,7 @@ public final class RowType extends DataType {
         }
         RowType rowType = (RowType) o;
         for (DataField field : fields) {
-            if (!field.prunedFrom(rowType.getField(field.name()))) {
+            if (!field.isPrunedFrom(rowType.getField(field.name()))) {
                 return false;
             }
         }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ProjectedRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ProjectedRow.java
@@ -26,6 +26,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
 
 import java.util.Arrays;
 
@@ -213,6 +214,13 @@ public class ProjectedRow implements InternalRow {
      */
     public static ProjectedRow from(int[] projection) {
         return new ProjectedRow(projection);
+    }
+
+    public static ProjectedRow from(RowType readType, RowType tableType) {
+        return new ProjectedRow(
+                readType.getFields().stream()
+                        .mapToInt(field -> tableType.getFieldIndexByFieldId(field.id()))
+                        .toArray());
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
@@ -33,31 +33,26 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.partition.PartitionUtils;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
-import org.apache.paimon.schema.IndexCastMapping;
 import org.apache.paimon.schema.KeyValueFieldsExtractor;
-import org.apache.paimon.schema.SchemaEvolutionUtil;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.AsyncRecordReader;
 import org.apache.paimon.utils.BulkFormatMapping;
+import org.apache.paimon.utils.BulkFormatMapping.BulkFormatMappingBuilder;
 import org.apache.paimon.utils.FileStorePathFactory;
-import org.apache.paimon.utils.Pair;
-import org.apache.paimon.utils.Projection;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
-
-import static org.apache.paimon.predicate.PredicateBuilder.excludePredicateWithFields;
 
 /** Factory to create {@link RecordReader}s for reading {@link KeyValue} files. */
 public class KeyValueFileReaderFactory implements FileReaderFactory<KeyValue> {
@@ -192,13 +187,10 @@ public class KeyValueFileReaderFactory implements FileReaderFactory<KeyValue> {
         private final FileFormatDiscover formatDiscover;
         private final FileStorePathFactory pathFactory;
         private final KeyValueFieldsExtractor extractor;
-        private final int[][] fullKeyProjection;
         private final CoreOptions options;
 
-        private int[][] keyProjection;
-        private int[][] valueProjection;
-        private RowType projectedKeyType;
-        private RowType projectedValueType;
+        private RowType readKeyType;
+        private RowType readValueType;
 
         private Builder(
                 FileIO fileIO,
@@ -218,12 +210,10 @@ public class KeyValueFileReaderFactory implements FileReaderFactory<KeyValue> {
             this.formatDiscover = formatDiscover;
             this.pathFactory = pathFactory;
             this.extractor = extractor;
-
-            this.fullKeyProjection = Projection.range(0, keyType.getFieldCount()).toNestedIndexes();
             this.options = options;
-            this.keyProjection = fullKeyProjection;
-            this.valueProjection = Projection.range(0, valueType.getFieldCount()).toNestedIndexes();
-            applyProjection();
+
+            this.readKeyType = keyType;
+            this.readValueType = valueType;
         }
 
         public Builder copyWithoutProjection() {
@@ -239,15 +229,13 @@ public class KeyValueFileReaderFactory implements FileReaderFactory<KeyValue> {
                     options);
         }
 
-        public Builder withKeyProjection(int[][] projection) {
-            keyProjection = projection;
-            applyProjection();
+        public Builder withReadKeyType(RowType readKeyType) {
+            this.readKeyType = readKeyType;
             return this;
         }
 
-        public Builder withValueProjection(int[][] projection) {
-            valueProjection = projection;
-            applyProjection();
+        public Builder withReadValueType(RowType readValueType) {
+            this.readValueType = readValueType;
             return this;
         }
 
@@ -255,8 +243,8 @@ public class KeyValueFileReaderFactory implements FileReaderFactory<KeyValue> {
             return keyType;
         }
 
-        public RowType projectedValueType() {
-            return projectedValueType;
+        public RowType readValueType() {
+            return readValueType;
         }
 
         public KeyValueFileReaderFactory build(
@@ -270,141 +258,33 @@ public class KeyValueFileReaderFactory implements FileReaderFactory<KeyValue> {
                 DeletionVector.Factory dvFactory,
                 boolean projectKeys,
                 @Nullable List<Predicate> filters) {
-            int[][] keyProjection = projectKeys ? this.keyProjection : fullKeyProjection;
-            RowType projectedKeyType = projectKeys ? this.projectedKeyType : keyType;
+            RowType finalReadKeyType = projectKeys ? this.readKeyType : keyType;
+            Function<TableSchema, List<DataField>> fieldsExtractor =
+                    (schema) -> {
+                        List<DataField> dataKeyFields = extractor.keyFields(schema);
+                        List<DataField> dataValueFields = extractor.valueFields(schema);
+                        return KeyValue.createKeyValueFields(dataKeyFields, dataValueFields);
+                    };
+            List<DataField> readTableFields =
+                    KeyValue.createKeyValueFields(
+                            finalReadKeyType.getFields(), readValueType.getFields());
 
             return new KeyValueFileReaderFactory(
                     fileIO,
                     schemaManager,
                     schema,
-                    projectedKeyType,
-                    projectedValueType,
+                    finalReadKeyType,
+                    readValueType,
                     new BulkFormatMappingBuilder(
-                            formatDiscover, extractor, keyProjection, valueProjection, filters),
+                            formatDiscover, readTableFields, fieldsExtractor, filters),
                     pathFactory.createDataFilePathFactory(partition, bucket),
                     options.fileReaderAsyncThreshold().getBytes(),
                     partition,
                     dvFactory);
         }
 
-        private void applyProjection() {
-            projectedKeyType = Projection.of(keyProjection).project(keyType);
-            projectedValueType = Projection.of(valueProjection).project(valueType);
-        }
-
         public FileIO fileIO() {
             return fileIO;
-        }
-    }
-
-    /** Builder to build {@link BulkFormatMapping}. */
-    private static class BulkFormatMappingBuilder {
-
-        private final FileFormatDiscover formatDiscover;
-        private final KeyValueFieldsExtractor extractor;
-        private final int[][] keyProjection;
-        private final int[][] valueProjection;
-        @Nullable private final List<Predicate> filters;
-
-        private BulkFormatMappingBuilder(
-                FileFormatDiscover formatDiscover,
-                KeyValueFieldsExtractor extractor,
-                int[][] keyProjection,
-                int[][] valueProjection,
-                @Nullable List<Predicate> filters) {
-            this.formatDiscover = formatDiscover;
-            this.extractor = extractor;
-            this.keyProjection = keyProjection;
-            this.valueProjection = valueProjection;
-            this.filters = filters;
-        }
-
-        public BulkFormatMapping build(
-                String formatIdentifier, TableSchema tableSchema, TableSchema dataSchema) {
-            List<DataField> tableKeyFields = extractor.keyFields(tableSchema);
-            List<DataField> tableValueFields = extractor.valueFields(tableSchema);
-            int[][] tableProjection =
-                    KeyValue.project(keyProjection, valueProjection, tableKeyFields.size());
-
-            List<DataField> dataKeyFields = extractor.keyFields(dataSchema);
-            List<DataField> dataValueFields = extractor.valueFields(dataSchema);
-
-            RowType keyType = new RowType(dataKeyFields);
-            RowType valueType = new RowType(dataValueFields);
-            RowType dataRecordType = KeyValue.schema(keyType, valueType);
-
-            int[][] dataKeyProjection =
-                    SchemaEvolutionUtil.createDataProjection(
-                            tableKeyFields, dataKeyFields, keyProjection);
-            int[][] dataValueProjection =
-                    SchemaEvolutionUtil.createDataProjection(
-                            tableValueFields, dataValueFields, valueProjection);
-            int[][] dataProjection =
-                    KeyValue.project(dataKeyProjection, dataValueProjection, dataKeyFields.size());
-
-            /*
-             * We need to create index mapping on projection instead of key and value separately
-             * here, for example
-             *
-             * <ul>
-             *   <li>the table key fields: 1->d, 3->a, 4->b, 5->c
-             *   <li>the data key fields: 1->a, 2->b, 3->c
-             * </ul>
-             *
-             * <p>The value fields of table and data are 0->value_count, the key and value
-             * projections are as follows
-             *
-             * <ul>
-             *   <li>table key projection: [0, 1, 2, 3], value projection: [0], data projection: [0,
-             *       1, 2, 3, 4, 5, 6] which 4/5 is seq/kind and 6 is value
-             *   <li>data key projection: [0, 1, 2], value projection: [0], data projection: [0, 1,
-             *       2, 3, 4, 5] where 3/4 is seq/kind and 5 is value
-             * </ul>
-             *
-             * <p>We will get value index mapping null from above and we can't create projection
-             * index mapping based on key and value index mapping any more.
-             */
-            IndexCastMapping indexCastMapping =
-                    SchemaEvolutionUtil.createIndexCastMapping(
-                            Projection.of(tableProjection).toTopLevelIndexes(),
-                            tableKeyFields,
-                            tableValueFields,
-                            Projection.of(dataProjection).toTopLevelIndexes(),
-                            dataKeyFields,
-                            dataValueFields);
-
-            List<Predicate> dataFilters =
-                    tableSchema.id() == dataSchema.id()
-                            ? filters
-                            : SchemaEvolutionUtil.createDataFilters(
-                                    tableSchema.fields(), dataSchema.fields(), filters);
-            // Skip pushing down partition filters to reader
-            List<Predicate> nonPartitionFilters =
-                    excludePredicateWithFields(
-                            dataFilters, new HashSet<>(dataSchema.partitionKeys()));
-
-            Pair<int[], RowType> partitionPair = null;
-            if (!dataSchema.partitionKeys().isEmpty()) {
-                Pair<int[], int[][]> partitionMapping =
-                        PartitionUtils.constructPartitionMapping(
-                                dataRecordType, dataSchema.partitionKeys(), dataProjection);
-                // is partition fields are not selected, we just do nothing.
-                if (partitionMapping != null) {
-                    dataProjection = partitionMapping.getRight();
-                    partitionPair =
-                            Pair.of(
-                                    partitionMapping.getLeft(),
-                                    dataSchema.projectedLogicalRowType(dataSchema.partitionKeys()));
-                }
-            }
-            RowType projectedRowType = Projection.of(dataProjection).project(dataRecordType);
-            return new BulkFormatMapping(
-                    indexCastMapping.getIndexMapping(),
-                    indexCastMapping.getCastMapping(),
-                    partitionPair,
-                    formatDiscover
-                            .discover(formatIdentifier)
-                            .createReaderFactory(projectedRowType, nonPartitionFilters));
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
@@ -260,7 +260,7 @@ public class KeyValueFileReaderFactory implements FileReaderFactory<KeyValue> {
                 @Nullable List<Predicate> filters) {
             RowType finalReadKeyType = projectKeys ? this.readKeyType : keyType;
             Function<TableSchema, List<DataField>> fieldsExtractor =
-                    (schema) -> {
+                    schema -> {
                         List<DataField> dataKeyFields = extractor.keyFields(schema);
                         List<DataField> dataValueFields = extractor.valueFields(schema);
                         return KeyValue.createKeyValueFields(dataKeyFields, dataValueFields);

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeFunctionFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeFunctionFactory.java
@@ -32,6 +32,7 @@ public interface MergeFunctionFactory<T> extends Serializable {
 
     MergeFunction<T> create(@Nullable int[][] projection);
 
+    // todo: replace projection with rowType
     default AdjustedProjection adjustProjection(@Nullable int[][] projection) {
         return new AdjustedProjection(projection, null);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DefaultValueAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DefaultValueAssigner.java
@@ -34,7 +34,6 @@ import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.VarCharType;
-import org.apache.paimon.utils.Projection;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,20 +51,20 @@ public class DefaultValueAssigner {
 
     private boolean needToAssign;
 
-    private int[][] project;
+    private RowType readRowType;
     private DefaultValueRow defaultValueRow;
 
     private DefaultValueAssigner(Map<String, String> defaultValues, RowType rowType) {
         this.defaultValues = defaultValues;
-        this.needToAssign = defaultValues.size() > 0;
+        this.needToAssign = !defaultValues.isEmpty();
         this.rowType = rowType;
     }
 
-    public DefaultValueAssigner handleProject(int[][] project) {
-        this.project = project;
-        if (project != null) {
-            List<String> projected = Projection.of(project).project(rowType).getFieldNames();
-            needToAssign = defaultValues.keySet().stream().anyMatch(projected::contains);
+    public DefaultValueAssigner handleReadRowType(RowType readRowType) {
+        this.readRowType = readRowType;
+        if (readRowType != null) {
+            List<String> requiredFieldNames = readRowType.getFieldNames();
+            needToAssign = defaultValues.keySet().stream().anyMatch(requiredFieldNames::contains);
         }
         return this;
     }
@@ -90,8 +89,8 @@ public class DefaultValueAssigner {
     @VisibleForTesting
     DefaultValueRow createDefaultValueRow() {
         List<DataField> fields;
-        if (project != null) {
-            fields = Projection.of(project).project(rowType).getFields();
+        if (readRowType != null) {
+            fields = readRowType.getFields();
         } else {
             fields = rowType.getFields();
         }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DefaultValueAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DefaultValueAssigner.java
@@ -35,6 +35,8 @@ import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.VarCharType;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +53,7 @@ public class DefaultValueAssigner {
 
     private boolean needToAssign;
 
-    private RowType readRowType;
+    private @Nullable RowType readRowType;
     private DefaultValueRow defaultValueRow;
 
     private DefaultValueAssigner(Map<String, String> defaultValues, RowType rowType) {
@@ -62,10 +64,8 @@ public class DefaultValueAssigner {
 
     public DefaultValueAssigner handleReadRowType(RowType readRowType) {
         this.readRowType = readRowType;
-        if (readRowType != null) {
-            List<String> requiredFieldNames = readRowType.getFieldNames();
-            needToAssign = defaultValues.keySet().stream().anyMatch(requiredFieldNames::contains);
-        }
+        List<String> requiredFieldNames = readRowType.getFieldNames();
+        needToAssign = defaultValues.keySet().stream().anyMatch(requiredFieldNames::contains);
         return this;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -310,7 +310,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                 lookupReaderFactory =
                         readerFactoryBuilder
                                 .copyWithoutProjection()
-                                .withValueProjection(new int[0][])
+                                .withReadValueType(RowType.of())
                                 .build(partition, bucket, dvFactory);
                 processor = new ContainsValueProcessor();
                 wrapperFactory = new FirstRowMergeFunctionWrapperFactory();

--- a/paimon-core/src/main/java/org/apache/paimon/operation/MergeFileSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/MergeFileSplitRead.java
@@ -120,17 +120,14 @@ public class MergeFileSplitRead implements SplitRead<KeyValue> {
         return tableSchema;
     }
 
-    public MergeFileSplitRead withReadKeyType(@Nullable RowType readKeyType) {
+    public MergeFileSplitRead withReadKeyType(RowType readKeyType) {
         readerFactoryBuilder.withReadKeyType(readKeyType);
         this.readKeyType = readKeyType;
         return this;
     }
 
     @Override
-    public MergeFileSplitRead withReadType(@Nullable RowType readType) {
-        if (readType == null) {
-            return this;
-        }
+    public MergeFileSplitRead withReadType(RowType readType) {
         // todo: replace projectedFields with readType
         int[][] projectedFields =
                 Arrays.stream(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/MergeFileSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/MergeFileSplitRead.java
@@ -78,7 +78,7 @@ public class MergeFileSplitRead implements SplitRead<KeyValue> {
     private final MergeSorter mergeSorter;
     private final List<String> sequenceFields;
 
-    @Nullable private int[][] keyProjectedFields;
+    @Nullable private RowType readKeyType;
 
     @Nullable private List<Predicate> filtersForKeys;
 
@@ -108,12 +108,6 @@ public class MergeFileSplitRead implements SplitRead<KeyValue> {
         this.sequenceFields = options.sequenceField();
     }
 
-    public MergeFileSplitRead withKeyProjection(@Nullable int[][] projectedFields) {
-        readerFactoryBuilder.withKeyProjection(projectedFields);
-        this.keyProjectedFields = projectedFields;
-        return this;
-    }
-
     public Comparator<InternalRow> keyComparator() {
         return keyComparator;
     }
@@ -122,12 +116,22 @@ public class MergeFileSplitRead implements SplitRead<KeyValue> {
         return mergeSorter;
     }
 
+    public MergeFileSplitRead withReadKeyType(@Nullable RowType readKeyType) {
+        readerFactoryBuilder.withReadKeyType(readKeyType);
+        this.readKeyType = readKeyType;
+        return this;
+    }
+
     @Override
-    public MergeFileSplitRead withProjection(@Nullable int[][] projectedFields) {
-        if (projectedFields == null) {
+    public MergeFileSplitRead withReadType(@Nullable RowType readType) {
+        if (readType == null) {
             return this;
         }
-
+        // todo: replace projectedFields with reedType
+        int[][] projectedFields =
+                Arrays.stream(readType.toProjection())
+                        .mapToObj(i -> new int[] {i})
+                        .toArray(int[][]::new);
         int[][] newProjectedFields = projectedFields;
         if (sequenceFields.size() > 0) {
             // make sure projection contains sequence fields
@@ -151,8 +155,11 @@ public class MergeFileSplitRead implements SplitRead<KeyValue> {
         this.pushdownProjection = projection.pushdownProjection;
         this.outerProjection = projection.outerProjection;
         if (pushdownProjection != null) {
-            readerFactoryBuilder.withValueProjection(pushdownProjection);
-            mergeSorter.setProjectedValueType(readerFactoryBuilder.projectedValueType());
+            RowType pushdownRowType =
+                    readType.buildWithNewProjection(
+                            Arrays.stream(pushdownProjection).mapToInt(arr -> arr[0]).toArray());
+            readerFactoryBuilder.withReadValueType(pushdownRowType);
+            mergeSorter.setProjectedValueType(pushdownRowType);
         }
 
         if (newProjectedFields != projectedFields) {
@@ -304,11 +311,11 @@ public class MergeFileSplitRead implements SplitRead<KeyValue> {
     }
 
     private RecordReader<KeyValue> projectKey(RecordReader<KeyValue> reader) {
-        if (keyProjectedFields == null) {
+        if (readKeyType == null) {
             return reader;
         }
 
-        ProjectedRow projectedRow = ProjectedRow.from(keyProjectedFields);
+        ProjectedRow projectedRow = ProjectedRow.from(readKeyType.toProjection());
         return reader.transform(kv -> kv.replaceKey(projectedRow.replaceRow(kv.key())));
     }
 
@@ -323,6 +330,6 @@ public class MergeFileSplitRead implements SplitRead<KeyValue> {
     @Nullable
     public UserDefinedSeqComparator createUdsComparator() {
         return UserDefinedSeqComparator.create(
-                readerFactoryBuilder.projectedValueType(), sequenceFields);
+                readerFactoryBuilder.readValueType(), sequenceFields);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/RawFileSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/RawFileSplitRead.java
@@ -92,7 +92,7 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
         this.pathFactory = pathFactory;
         this.bulkFormatMappings = new HashMap<>();
         this.fileIndexReadEnabled = fileIndexReadEnabled;
-        this.readRowType = schema.logicalRowType();
+        this.readRowType = rowType;
     }
 
     @Override
@@ -106,10 +106,8 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
     }
 
     @Override
-    public SplitRead<InternalRow> withReadType(@Nullable RowType readRowType) {
-        if (readRowType != null) {
-            this.readRowType = readRowType;
-        }
+    public SplitRead<InternalRow> withReadType(RowType readRowType) {
+        this.readRowType = readRowType;
         return this;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/RawFileSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/RawFileSplitRead.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.operation;
 
-import org.apache.paimon.casting.CastFieldGetter;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.deletionvectors.ApplyDeletionVectorReader;
@@ -27,7 +26,6 @@ import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.format.FileFormatDiscover;
 import org.apache.paimon.format.FormatKey;
 import org.apache.paimon.format.FormatReaderContext;
-import org.apache.paimon.format.FormatReaderFactory;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFilePathFactory;
@@ -39,17 +37,15 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.EmptyRecordReader;
 import org.apache.paimon.reader.ReaderSupplier;
 import org.apache.paimon.reader.RecordReader;
-import org.apache.paimon.schema.IndexCastMapping;
-import org.apache.paimon.schema.SchemaEvolutionUtil;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.BulkFormatMapping;
+import org.apache.paimon.utils.BulkFormatMapping.BulkFormatMappingBuilder;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.IOExceptionSupplier;
-import org.apache.paimon.utils.Pair;
-import org.apache.paimon.utils.Projection;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,11 +55,10 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
-import static org.apache.paimon.predicate.PredicateBuilder.excludePredicateWithFields;
 import static org.apache.paimon.predicate.PredicateBuilder.splitAnd;
 
 /** A {@link SplitRead} to read raw file directly from {@link DataSplit}. */
@@ -76,11 +71,10 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
     private final TableSchema schema;
     private final FileFormatDiscover formatDiscover;
     private final FileStorePathFactory pathFactory;
-    private final Map<FormatKey, RawFileBulkFormatMapping> bulkFormatMappings;
+    private final Map<FormatKey, BulkFormatMapping> bulkFormatMappings;
     private final boolean fileIndexReadEnabled;
 
-    private int[][] projection;
-
+    private RowType readRowType;
     @Nullable private List<Predicate> filters;
 
     public RawFileSplitRead(
@@ -98,8 +92,7 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
         this.pathFactory = pathFactory;
         this.bulkFormatMappings = new HashMap<>();
         this.fileIndexReadEnabled = fileIndexReadEnabled;
-
-        this.projection = Projection.range(0, rowType.getFieldCount()).toNestedIndexes();
+        this.readRowType = schema.logicalRowType();
     }
 
     @Override
@@ -113,9 +106,9 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
     }
 
     @Override
-    public RawFileSplitRead withProjection(int[][] projectedFields) {
-        if (projectedFields != null) {
-            projection = projectedFields;
+    public SplitRead<InternalRow> withReadType(@Nullable RowType readRowType) {
+        if (readRowType != null) {
+            this.readRowType = readRowType;
         }
         return this;
     }
@@ -154,13 +147,29 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
                 pathFactory.createDataFilePathFactory(partition, bucket);
         List<ReaderSupplier<InternalRow>> suppliers = new ArrayList<>();
 
+        List<DataField> readTableFields = readRowType.getFields();
+        BulkFormatMappingBuilder bulkFormatMappingBuilder =
+                new BulkFormatMappingBuilder(
+                        formatDiscover, readTableFields, TableSchema::fields, filters);
+
         for (int i = 0; i < files.size(); i++) {
             DataFileMeta file = files.get(i);
             String formatIdentifier = DataFilePathFactory.formatIdentifier(file.fileName());
-            RawFileBulkFormatMapping bulkFormatMapping =
+            long schemaId = file.schemaId();
+
+            Supplier<BulkFormatMapping> formatSupplier =
+                    () ->
+                            bulkFormatMappingBuilder.build(
+                                    formatIdentifier,
+                                    schema,
+                                    schemaId == schema.id()
+                                            ? schema
+                                            : schemaManager.schema(schemaId));
+
+            BulkFormatMapping bulkFormatMapping =
                     bulkFormatMappings.computeIfAbsent(
                             new FormatKey(file.schemaId(), formatIdentifier),
-                            this::createBulkFormatMapping);
+                            key -> formatSupplier.get());
 
             IOExceptionSupplier<DeletionVector> dvFactory =
                     dvFactories == null ? null : dvFactories.get(i);
@@ -177,65 +186,11 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
         return ConcatRecordReader.create(suppliers);
     }
 
-    private RawFileBulkFormatMapping createBulkFormatMapping(FormatKey key) {
-        TableSchema tableSchema = schema;
-        TableSchema dataSchema =
-                key.schemaId == schema.id() ? schema : schemaManager.schema(key.schemaId);
-
-        // projection to data schema
-        int[][] dataProjection =
-                SchemaEvolutionUtil.createDataProjection(
-                        tableSchema.fields(), dataSchema.fields(), projection);
-
-        IndexCastMapping indexCastMapping =
-                SchemaEvolutionUtil.createIndexCastMapping(
-                        Projection.of(projection).toTopLevelIndexes(),
-                        tableSchema.fields(),
-                        Projection.of(dataProjection).toTopLevelIndexes(),
-                        dataSchema.fields());
-
-        List<Predicate> dataFilters =
-                this.schema.id() == key.schemaId
-                        ? filters
-                        : SchemaEvolutionUtil.createDataFilters(
-                                tableSchema.fields(), dataSchema.fields(), filters);
-        // Skip pushing down partition filters to reader
-        List<Predicate> nonPartitionFilters =
-                excludePredicateWithFields(dataFilters, new HashSet<>(dataSchema.partitionKeys()));
-
-        Pair<int[], RowType> partitionPair = null;
-        if (!dataSchema.partitionKeys().isEmpty()) {
-            Pair<int[], int[][]> partitionMapping =
-                    PartitionUtils.constructPartitionMapping(dataSchema, dataProjection);
-            // if partition fields are not selected, we just do nothing
-            if (partitionMapping != null) {
-                dataProjection = partitionMapping.getRight();
-                partitionPair =
-                        Pair.of(
-                                partitionMapping.getLeft(),
-                                dataSchema.projectedLogicalRowType(dataSchema.partitionKeys()));
-            }
-        }
-
-        RowType projectedRowType =
-                Projection.of(dataProjection).project(dataSchema.logicalRowType());
-
-        return new RawFileBulkFormatMapping(
-                indexCastMapping.getIndexMapping(),
-                indexCastMapping.getCastMapping(),
-                partitionPair,
-                formatDiscover
-                        .discover(key.format)
-                        .createReaderFactory(projectedRowType, nonPartitionFilters),
-                dataSchema,
-                dataFilters);
-    }
-
     private RecordReader<InternalRow> createFileReader(
             BinaryRow partition,
             DataFileMeta file,
             DataFilePathFactory dataFilePathFactory,
-            RawFileBulkFormatMapping bulkFormatMapping,
+            BulkFormatMapping bulkFormatMapping,
             IOExceptionSupplier<DeletionVector> dvFactory)
             throws IOException {
         if (fileIndexReadEnabled) {
@@ -267,32 +222,5 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
             return new ApplyDeletionVectorReader(fileRecordReader, deletionVector);
         }
         return fileRecordReader;
-    }
-
-    /** Bulk format mapping with data schema and data filters. */
-    private static class RawFileBulkFormatMapping extends BulkFormatMapping {
-
-        private final TableSchema dataSchema;
-        private final List<Predicate> dataFilters;
-
-        public RawFileBulkFormatMapping(
-                int[] indexMapping,
-                CastFieldGetter[] castMapping,
-                Pair<int[], RowType> partitionPair,
-                FormatReaderFactory bulkFormat,
-                TableSchema dataSchema,
-                List<Predicate> dataFilters) {
-            super(indexMapping, castMapping, partitionPair, bulkFormat);
-            this.dataSchema = dataSchema;
-            this.dataFilters = dataFilters;
-        }
-
-        public TableSchema getDataSchema() {
-            return dataSchema;
-        }
-
-        public List<Predicate> getDataFilters() {
-            return dataFilters;
-        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/SplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/SplitRead.java
@@ -22,6 +22,7 @@ import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.IOFunction;
 
 import javax.annotation.Nullable;
@@ -39,7 +40,7 @@ public interface SplitRead<T> {
 
     SplitRead<T> withIOManager(@Nullable IOManager ioManager);
 
-    SplitRead<T> withProjection(@Nullable int[][] projectedFields);
+    SplitRead<T> withReadType(@Nullable RowType readType);
 
     SplitRead<T> withFilter(@Nullable Predicate predicate);
 
@@ -62,8 +63,8 @@ public interface SplitRead<T> {
             }
 
             @Override
-            public SplitRead<R> withProjection(@Nullable int[][] projectedFields) {
-                read.withProjection(projectedFields);
+            public SplitRead<R> withReadType(@Nullable RowType readType) {
+                read.withReadType(readType);
                 return this;
             }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/SplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/SplitRead.java
@@ -40,7 +40,7 @@ public interface SplitRead<T> {
 
     SplitRead<T> withIOManager(@Nullable IOManager ioManager);
 
-    SplitRead<T> withReadType(@Nullable RowType readType);
+    SplitRead<T> withReadType(RowType readType);
 
     SplitRead<T> withFilter(@Nullable Predicate predicate);
 
@@ -63,7 +63,7 @@ public interface SplitRead<T> {
             }
 
             @Override
-            public SplitRead<R> withReadType(@Nullable RowType readType) {
+            public SplitRead<R> withReadType(RowType readType) {
                 read.withReadType(readType);
                 return this;
             }

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaEvolutionUtil.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaEvolutionUtil.java
@@ -381,7 +381,7 @@ public class SchemaEvolutionUtil {
             } else {
                 DataField tableField = tableFields.get(i);
                 DataField dataField = dataFields.get(dataIndex);
-                if (tableField.type().copy(true).subsetOf(dataField.type().copy(true))) {
+                if (dataField.type().equalsIgnoreNullable(tableField.type())) {
                     // Create getter with index i and projected row data will convert to underlying
                     // data
                     converterMapping[i] =

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaEvolutionUtil.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaEvolutionUtil.java
@@ -29,7 +29,6 @@ import org.apache.paimon.predicate.PredicateReplaceVisitor;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
-import org.apache.paimon.types.DataTypeFamily;
 import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.MultisetType;
 import org.apache.paimon.types.RowType;
@@ -351,56 +350,6 @@ public class SchemaEvolutionUtil {
     }
 
     /**
-     * Create converter mapping from table fields to underlying data fields. For example, the table
-     * and data fields are as follows
-     *
-     * <ul>
-     *   <li>table fields: 1->c INT, 6->b STRING, 3->a BIGINT
-     *   <li>data fields: 1->a BIGINT, 3->c DOUBLE
-     * </ul>
-     *
-     * <p>We can get the column types (1->a BIGINT), (3->c DOUBLE) from data fields for (1->c INT)
-     * and (3->a BIGINT) in table fields through index mapping [0, -1, 1], then compare the data
-     * type and create converter mapping.
-     *
-     * <p>/// TODO should support nest index mapping when nest schema evolution is supported.
-     *
-     * @param tableFields the fields of table
-     * @param dataFields the fields of underlying data
-     * @param indexMapping the index mapping from table fields to data fields
-     * @return the index mapping
-     */
-    @Nullable
-    public static CastExecutor<?, ?>[] createConvertMapping(
-            List<DataField> tableFields, List<DataField> dataFields, int[] indexMapping) {
-        CastExecutor<?, ?>[] converterMapping = new CastExecutor<?, ?>[tableFields.size()];
-        boolean castExist = false;
-        for (int i = 0; i < tableFields.size(); i++) {
-            int dataIndex = indexMapping == null ? i : indexMapping[i];
-            if (dataIndex < 0) {
-                converterMapping[i] = CastExecutors.identityCastExecutor();
-            } else {
-                DataField tableField = tableFields.get(i);
-                DataField dataField = dataFields.get(dataIndex);
-                if (dataField.type().equalsIgnoreNullable(tableField.type())) {
-                    converterMapping[i] = CastExecutors.identityCastExecutor();
-                } else {
-                    // TODO support column type evolution in nested type
-                    checkState(
-                            !tableField.type().is(DataTypeFamily.CONSTRUCTED),
-                            "Only support column type evolution in atomic data type.");
-                    converterMapping[i] =
-                            checkNotNull(
-                                    CastExecutors.resolve(dataField.type(), tableField.type()));
-                    castExist = true;
-                }
-            }
-        }
-
-        return castExist ? converterMapping : null;
-    }
-
-    /**
      * Create getter and casting mapping from table fields to underlying data fields with given
      * index mapping. For example, the table and data fields are as follows
      *
@@ -432,7 +381,7 @@ public class SchemaEvolutionUtil {
             } else {
                 DataField tableField = tableFields.get(i);
                 DataField dataField = dataFields.get(dataIndex);
-                if (dataField.type().equalsIgnoreNullable(tableField.type())) {
+                if (tableField.type().copy(true).subsetOf(dataField.type().copy(true))) {
                     // Create getter with index i and projected row data will convert to underlying
                     // data
                     converterMapping[i] =

--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -42,6 +42,7 @@ import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.SplitGenerator;
 import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Preconditions;
 
 import java.io.IOException;
@@ -119,8 +120,8 @@ class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
             }
 
             @Override
-            public void projection(int[][] projection) {
-                read.withProjection(projection);
+            public void applyReadType(RowType readType) {
+                read.withReadType(readType);
             }
 
             @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
@@ -349,9 +349,9 @@ public class FallbackReadFileStoreTable extends DelegatedFileStoreTable {
         }
 
         @Override
-        public InnerTableRead withProjection(int[][] projection) {
-            mainRead.withProjection(projection);
-            fallbackRead.withProjection(projection);
+        public InnerTableRead withReadType(RowType readType) {
+            mainRead.withReadType(readType);
+            fallbackRead.withReadType(readType);
             return this;
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/query/LocalTableQuery.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/query/LocalTableQuery.java
@@ -195,11 +195,9 @@ public class LocalTableQuery implements TableQuery {
         }
     }
 
-    // todo: replace it with withReadType
     @Override
-    public LocalTableQuery withValueProjection(int[][] projection) {
-        this.readerFactoryBuilder.withReadValueType(
-                rowType.project(projection).copyAndSetOriginalRowType(rowType));
+    public LocalTableQuery withValueProjection(int[] projection) {
+        this.readerFactoryBuilder.withReadValueType(rowType.project(projection));
         return this;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/query/TableQuery.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/query/TableQuery.java
@@ -21,7 +21,6 @@ package org.apache.paimon.table.query;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
-import org.apache.paimon.utils.Projection;
 
 import javax.annotation.Nullable;
 
@@ -31,11 +30,8 @@ import java.io.IOException;
 /** A query of Table to perform lookup. */
 public interface TableQuery extends Closeable {
 
-    default TableQuery withValueProjection(int[] projection) {
-        return withValueProjection(Projection.of(projection).toNestedIndexes());
-    }
-
-    TableQuery withValueProjection(int[][] projection);
+    // todo: replace it with withReadType
+    TableQuery withValueProjection(int[] projection);
 
     InternalRowSerializer createValueSerializer();
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
@@ -72,7 +72,7 @@ public abstract class AbstractDataTableRead<T> implements InnerTableRead {
     }
 
     @Override
-    public final InnerTableRead withProjection(int[][] projection) {
+    public final InnerTableRead withProjection(int[] projection) {
         if (projection == null) {
             return this;
         }
@@ -81,9 +81,8 @@ public abstract class AbstractDataTableRead<T> implements InnerTableRead {
 
     @Override
     public final InnerTableRead withReadType(RowType readType) {
-        this.readType = readType.copyAndSetOriginalRowType(schema.logicalRowType());
-        this.defaultValueAssigner.handleReadRowType(this.readType);
-        applyReadType(this.readType);
+        this.defaultValueAssigner.handleReadRowType(readType);
+        applyReadType(readType);
         return this;
     }
 
@@ -107,8 +106,9 @@ public abstract class AbstractDataTableRead<T> implements InnerTableRead {
 
         Predicate predicate = this.predicate;
         if (readType != null) {
+            int[] projection = schema.logicalRowType().getFieldIndices(readType.getFieldNames());
             Optional<Predicate> optional =
-                    predicate.visit(new PredicateProjectionConverter(readType.toProjection()));
+                    predicate.visit(new PredicateProjectionConverter(projection));
             if (!optional.isPresent()) {
                 return reader;
             }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
@@ -81,6 +81,7 @@ public abstract class AbstractDataTableRead<T> implements InnerTableRead {
 
     @Override
     public final InnerTableRead withReadType(RowType readType) {
+        this.readType = readType;
         this.defaultValueAssigner.handleReadRowType(readType);
         applyReadType(readType);
         return this;

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableRead.java
@@ -22,7 +22,6 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.types.RowType;
 
-import java.util.Arrays;
 import java.util.List;
 
 /** Inner {@link TableRead} contains filter and projection push down. */
@@ -37,20 +36,12 @@ public interface InnerTableRead extends TableRead {
 
     InnerTableRead withFilter(Predicate predicate);
 
-    /** Use {@link #withReadType(RowType)}, remove it once no usage. */
+    /** Use {@link #withReadType(RowType)} instead. */
     @Deprecated
     default InnerTableRead withProjection(int[] projection) {
         if (projection == null) {
             return this;
         }
-        int[][] nestedProjection =
-                Arrays.stream(projection).mapToObj(i -> new int[] {i}).toArray(int[][]::new);
-        return withProjection(nestedProjection);
-    }
-
-    /** Use {@link #withReadType(RowType)}, remove it once no usage. */
-    @Deprecated
-    default InnerTableRead withProjection(int[][] projection) {
         throw new UnsupportedOperationException();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableRead.java
@@ -20,6 +20,7 @@ package org.apache.paimon.table.source;
 
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.types.RowType;
 
 import java.util.Arrays;
 import java.util.List;
@@ -36,6 +37,8 @@ public interface InnerTableRead extends TableRead {
 
     InnerTableRead withFilter(Predicate predicate);
 
+    /** Use {@link #withReadType(RowType)}, remove it once no usage. */
+    @Deprecated
     default InnerTableRead withProjection(int[] projection) {
         if (projection == null) {
             return this;
@@ -45,7 +48,15 @@ public interface InnerTableRead extends TableRead {
         return withProjection(nestedProjection);
     }
 
-    InnerTableRead withProjection(int[][] projection);
+    /** Use {@link #withReadType(RowType)}, remove it once no usage. */
+    @Deprecated
+    default InnerTableRead withProjection(int[][] projection) {
+        throw new UnsupportedOperationException();
+    }
+
+    default InnerTableRead withReadType(RowType readType) {
+        throw new UnsupportedOperationException();
+    }
 
     default InnerTableRead forceKeepDelete() {
         return this;

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
@@ -32,6 +32,7 @@ import org.apache.paimon.table.source.splitread.IncrementalDiffReadProvider;
 import org.apache.paimon.table.source.splitread.MergeFileSplitReadProvider;
 import org.apache.paimon.table.source.splitread.RawFileSplitReadProvider;
 import org.apache.paimon.table.source.splitread.SplitReadProvider;
+import org.apache.paimon.types.RowType;
 
 import javax.annotation.Nullable;
 
@@ -48,7 +49,7 @@ public final class KeyValueTableRead extends AbstractDataTableRead<KeyValue> {
 
     private final List<SplitReadProvider> readProviders;
 
-    private int[][] projection = null;
+    private RowType readType = null;
     private boolean forceKeepDelete = false;
     private Predicate predicate = null;
     private IOManager ioManager = null;
@@ -80,13 +81,13 @@ public final class KeyValueTableRead extends AbstractDataTableRead<KeyValue> {
         if (forceKeepDelete) {
             read = read.forceKeepDelete();
         }
-        read.withProjection(projection).withFilter(predicate).withIOManager(ioManager);
+        read.withReadType(readType).withFilter(predicate).withIOManager(ioManager);
     }
 
     @Override
-    public void projection(int[][] projection) {
-        initialized().forEach(r -> r.withProjection(projection));
-        this.projection = projection;
+    public void applyReadType(RowType readType) {
+        initialized().forEach(r -> r.withReadType(readType));
+        this.readType = readType;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
@@ -49,7 +49,7 @@ public final class KeyValueTableRead extends AbstractDataTableRead<KeyValue> {
 
     private final List<SplitReadProvider> readProviders;
 
-    private RowType readType = null;
+    @Nullable private RowType readType = null;
     private boolean forceKeepDelete = false;
     private Predicate predicate = null;
     private IOManager ioManager = null;
@@ -81,7 +81,10 @@ public final class KeyValueTableRead extends AbstractDataTableRead<KeyValue> {
         if (forceKeepDelete) {
             read = read.forceKeepDelete();
         }
-        read.withReadType(readType).withFilter(predicate).withIOManager(ioManager);
+        if (readType != null) {
+            read = read.withReadType(readType);
+        }
+        read.withFilter(predicate).withIOManager(ioManager);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
@@ -119,11 +119,13 @@ public interface ReadBuilder extends Serializable {
      */
     ReadBuilder withReadType(RowType readType);
 
-    /** Apply projection to the reader, Use {@link #withReadType(RowType)} instead. */
-    @Deprecated
+    /**
+     * Apply projection to the reader, if you need nested row pruning, use {@link
+     * #withReadType(RowType)} instead.
+     */
     ReadBuilder withProjection(int[] projection);
 
-    /** Apply projection to the reader, Use {@link #withReadType(RowType)} instead. */
+    /** Apply projection to the reader, only support top level projection. */
     @Deprecated
     default ReadBuilder withProjection(int[][] projection) {
         if (projection == null) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
@@ -121,18 +121,19 @@ public interface ReadBuilder extends Serializable {
 
     /** Apply projection to the reader, Use {@link #withReadType(RowType)} instead. */
     @Deprecated
-    default ReadBuilder withProjection(int[] projection) {
-        if (projection == null) {
-            return this;
-        }
-        int[][] nestedProjection =
-                Arrays.stream(projection).mapToObj(i -> new int[] {i}).toArray(int[][]::new);
-        return withProjection(nestedProjection);
-    }
+    ReadBuilder withProjection(int[] projection);
 
     /** Apply projection to the reader, Use {@link #withReadType(RowType)} instead. */
     @Deprecated
-    ReadBuilder withProjection(int[][] projection);
+    default ReadBuilder withProjection(int[][] projection) {
+        if (projection == null) {
+            return this;
+        }
+        if (Arrays.stream(projection).anyMatch(arr -> arr.length > 1)) {
+            throw new IllegalStateException("Not support nested projection");
+        }
+        return withProjection(Arrays.stream(projection).mapToInt(arr -> arr[0]).toArray());
+    }
 
     /** the row number pushed down. */
     ReadBuilder withLimit(int limit);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
@@ -112,9 +112,9 @@ public interface ReadBuilder extends Serializable {
     ReadBuilder withBucketFilter(Filter<Integer> bucketFilter);
 
     /**
-     * Push row type to the reader, support nested row pruning.
+     * Push read row type to the reader, support nested row pruning.
      *
-     * @param readType read row type, can be a subset of {@link Table#rowType()}
+     * @param readType read row type, can be a pruned type from {@link Table#rowType()}
      * @since 1.0.0
      */
     ReadBuilder withReadType(RowType readType);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -87,7 +87,7 @@ public class ReadBuilderImpl implements ReadBuilder {
     public ReadBuilder withReadType(RowType readType) {
         RowType tableRowType = table.rowType();
         checkState(
-                readType.subsetOf(tableRowType),
+                readType.prunedFrom(tableRowType),
                 "read row type must be subset of table row type, read row type: %s, table row type: %s",
                 readType,
                 tableRowType);
@@ -96,7 +96,7 @@ public class ReadBuilderImpl implements ReadBuilder {
     }
 
     @Override
-    public ReadBuilder withProjection(int[][] projection) {
+    public ReadBuilder withProjection(int[] projection) {
         if (projection == null) {
             return this;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -90,7 +90,7 @@ public class ReadBuilderImpl implements ReadBuilder {
         RowType tableRowType = table.rowType();
         checkState(
                 readType.prunedFrom(tableRowType),
-                "read row type must be subset of table row type, read row type: %s, table row type: %s",
+                "read row type must be a pruned type from table row type, read row type: %s, table row type: %s",
                 readType,
                 tableRowType);
         this.readType = readType;

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -24,6 +24,8 @@ import org.apache.paimon.table.InnerTable;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
 
+import javax.annotation.Nullable;
+
 import java.util.Map;
 import java.util.Objects;
 
@@ -47,7 +49,7 @@ public class ReadBuilderImpl implements ReadBuilder {
 
     private Filter<Integer> bucketFilter;
 
-    private RowType readType;
+    private @Nullable RowType readType;
 
     public ReadBuilderImpl(InnerTable table) {
         this.table = table;

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -23,10 +23,7 @@ import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.table.InnerTable;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
-import org.apache.paimon.utils.Projection;
-import org.apache.paimon.utils.TypeUtils;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 
@@ -40,7 +37,6 @@ public class ReadBuilderImpl implements ReadBuilder {
     private final InnerTable table;
 
     private Predicate filter;
-    private int[][] projection;
 
     private Integer limit = null;
 
@@ -50,6 +46,8 @@ public class ReadBuilderImpl implements ReadBuilder {
     private Map<String, String> partitionSpec;
 
     private Filter<Integer> bucketFilter;
+
+    private RowType readType;
 
     public ReadBuilderImpl(InnerTable table) {
         this.table = table;
@@ -62,10 +60,11 @@ public class ReadBuilderImpl implements ReadBuilder {
 
     @Override
     public RowType readType() {
-        if (projection == null) {
+        if (readType != null) {
+            return readType;
+        } else {
             return table.rowType();
         }
-        return TypeUtils.project(table.rowType(), Projection.of(projection).toTopLevelIndexes());
     }
 
     @Override
@@ -85,9 +84,23 @@ public class ReadBuilderImpl implements ReadBuilder {
     }
 
     @Override
-    public ReadBuilder withProjection(int[][] projection) {
-        this.projection = projection;
+    public ReadBuilder withReadType(RowType readType) {
+        RowType tableRowType = table.rowType();
+        checkState(
+                readType.subsetOf(tableRowType),
+                "read row type must be subset of table row type, read row type: %s, table row type: %s",
+                readType,
+                tableRowType);
+        this.readType = readType;
         return this;
+    }
+
+    @Override
+    public ReadBuilder withProjection(int[][] projection) {
+        if (projection == null) {
+            return this;
+        }
+        return withReadType(table.rowType().project(projection));
     }
 
     @Override
@@ -147,8 +160,8 @@ public class ReadBuilderImpl implements ReadBuilder {
     @Override
     public TableRead newRead() {
         InnerTableRead read = table.newRead().withFilter(filter);
-        if (projection != null) {
-            read.withProjection(projection);
+        if (readType != null) {
+            read.withReadType(readType);
         }
         return read;
     }
@@ -164,13 +177,13 @@ public class ReadBuilderImpl implements ReadBuilder {
         ReadBuilderImpl that = (ReadBuilderImpl) o;
         return Objects.equals(table.name(), that.table.name())
                 && Objects.equals(filter, that.filter)
-                && Arrays.deepEquals(projection, that.projection);
+                && Objects.equals(readType, that.readType);
     }
 
     @Override
     public int hashCode() {
         int result = Objects.hash(table.name(), filter);
-        result = 31 * result + Arrays.deepHashCode(projection);
+        result = 31 * result + Objects.hash(readType);
         return result;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -89,7 +89,7 @@ public class ReadBuilderImpl implements ReadBuilder {
     public ReadBuilder withReadType(RowType readType) {
         RowType tableRowType = table.rowType();
         checkState(
-                readType.prunedFrom(tableRowType),
+                readType.isPrunedFrom(tableRowType),
                 "read row type must be a pruned type from table row type, read row type: %s, table row type: %s",
                 readType,
                 tableRowType);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalChangelogReadProvider.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalChangelogReadProvider.java
@@ -26,6 +26,7 @@ import org.apache.paimon.operation.ReverseReader;
 import org.apache.paimon.operation.SplitRead;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.IOFunction;
 import org.apache.paimon.utils.LazyField;
 
@@ -52,7 +53,7 @@ public class IncrementalChangelogReadProvider implements SplitReadProvider {
     }
 
     private SplitRead<InternalRow> create(Supplier<MergeFileSplitRead> supplier) {
-        final MergeFileSplitRead read = supplier.get().withKeyProjection(new int[0][]);
+        final MergeFileSplitRead read = supplier.get().withReadKeyType(RowType.of());
         IOFunction<DataSplit, RecordReader<InternalRow>> convertedFactory =
                 split -> {
                     RecordReader<KeyValue> reader =

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
@@ -104,7 +104,8 @@ public class IncrementalDiffSplitRead implements SplitRead<InternalRow> {
                         mergeRead.mergeSorter(),
                         forceKeepDelete);
         if (readType != null) {
-            ProjectedRow projectedRow = ProjectedRow.from(readType.toProjection());
+            ProjectedRow projectedRow =
+                    ProjectedRow.from(readType, mergeRead.tableSchema().logicalRowType());
             reader = reader.transform(kv -> kv.replaceValue(projectedRow.replaceRow(kv.value())));
         }
         return KeyValueTableRead.unwrap(reader);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
@@ -72,7 +72,7 @@ public class IncrementalDiffSplitRead implements SplitRead<InternalRow> {
     }
 
     @Override
-    public SplitRead<InternalRow> withReadType(@Nullable RowType readType) {
+    public SplitRead<InternalRow> withReadType(RowType readType) {
         this.readType = readType;
         return this;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/MergeFileSplitReadProvider.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/MergeFileSplitReadProvider.java
@@ -22,6 +22,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.operation.MergeFileSplitRead;
 import org.apache.paimon.operation.SplitRead;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.LazyField;
 
 import java.util.function.Consumer;
@@ -47,7 +48,7 @@ public class MergeFileSplitReadProvider implements SplitReadProvider {
     }
 
     private SplitRead<InternalRow> create(Supplier<MergeFileSplitRead> supplier) {
-        final MergeFileSplitRead read = supplier.get().withKeyProjection(new int[0][]);
+        final MergeFileSplitRead read = supplier.get().withReadKeyType(RowType.of());
         return SplitRead.convert(read, split -> unwrap(read.createReader(split)));
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AllTableOptionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AllTableOptionsTable.java
@@ -156,7 +156,7 @@ public class AllTableOptionsTable implements ReadonlyTable {
     private static class AllTableOptionsRead implements InnerTableRead {
 
         private final FileIO fileIO;
-        private int[][] projection;
+        private RowType readType;
 
         public AllTableOptionsRead(FileIO fileIO) {
             this.fileIO = fileIO;
@@ -168,8 +168,8 @@ public class AllTableOptionsTable implements ReadonlyTable {
         }
 
         @Override
-        public InnerTableRead withProjection(int[][] projection) {
-            this.projection = projection;
+        public InnerTableRead withReadType(RowType readType) {
+            this.readType = readType;
             return this;
         }
 
@@ -185,10 +185,14 @@ public class AllTableOptionsTable implements ReadonlyTable {
             }
             Map<String, Map<String, Path>> location = ((AllTableSplit) split).allTablePaths;
             Iterator<InternalRow> rows = toRow(options(fileIO, location));
-            if (projection != null) {
+            if (readType != null) {
                 rows =
                         Iterators.transform(
-                                rows, row -> ProjectedRow.from(projection).replaceRow(row));
+                                rows,
+                                row ->
+                                        ProjectedRow.from(
+                                                        readType, AggregationFieldsTable.TABLE_TYPE)
+                                                .replaceRow(row));
             }
             return new IteratorRecordReader<>(rows);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/BranchesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/BranchesTable.java
@@ -175,7 +175,7 @@ public class BranchesTable implements ReadonlyTable {
     private static class BranchesRead implements InnerTableRead {
 
         private final FileIO fileIO;
-        private int[][] projection;
+        private RowType readType;
 
         public BranchesRead(FileIO fileIO) {
             this.fileIO = fileIO;
@@ -188,8 +188,8 @@ public class BranchesTable implements ReadonlyTable {
         }
 
         @Override
-        public InnerTableRead withProjection(int[][] projection) {
-            this.projection = projection;
+        public InnerTableRead withReadType(RowType readType) {
+            this.readType = readType;
             return this;
         }
 
@@ -213,10 +213,13 @@ public class BranchesTable implements ReadonlyTable {
                 throw new UncheckedIOException(e);
             }
 
-            if (projection != null) {
+            if (readType != null) {
                 rows =
                         Iterators.transform(
-                                rows, row -> ProjectedRow.from(projection).replaceRow(row));
+                                rows,
+                                row ->
+                                        ProjectedRow.from(readType, BranchesTable.TABLE_TYPE)
+                                                .replaceRow(row));
             }
 
             return new IteratorRecordReader<>(rows);

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/BucketsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/BucketsTable.java
@@ -146,7 +146,7 @@ public class BucketsTable implements ReadonlyTable {
 
         private final FileStoreTable fileStoreTable;
 
-        private int[][] projection;
+        private RowType readType;
 
         public BucketsRead(FileStoreTable table) {
             this.fileStoreTable = table;
@@ -159,8 +159,8 @@ public class BucketsTable implements ReadonlyTable {
         }
 
         @Override
-        public InnerTableRead withProjection(int[][] projection) {
-            this.projection = projection;
+        public InnerTableRead withReadType(RowType readType) {
+            this.readType = readType;
             return this;
         }
 
@@ -187,10 +187,13 @@ public class BucketsTable implements ReadonlyTable {
             }
 
             Iterator<InternalRow> iterator = results.iterator();
-            if (projection != null) {
+            if (readType != null) {
                 iterator =
                         Iterators.transform(
-                                iterator, row -> ProjectedRow.from(projection).replaceRow(row));
+                                iterator,
+                                row ->
+                                        ProjectedRow.from(readType, BucketsTable.TABLE_TYPE)
+                                                .replaceRow(row));
             }
             return new IteratorRecordReader<>(iterator);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/CatalogOptionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/CatalogOptionsTable.java
@@ -144,7 +144,7 @@ public class CatalogOptionsTable implements ReadonlyTable {
 
     private static class CatalogOptionsRead implements InnerTableRead {
 
-        private int[][] projection;
+        private RowType readType;
 
         @Override
         public InnerTableRead withFilter(Predicate predicate) {
@@ -152,8 +152,8 @@ public class CatalogOptionsTable implements ReadonlyTable {
         }
 
         @Override
-        public InnerTableRead withProjection(int[][] projection) {
-            this.projection = projection;
+        public InnerTableRead withReadType(RowType readType) {
+            this.readType = readType;
             return this;
         }
 
@@ -171,10 +171,13 @@ public class CatalogOptionsTable implements ReadonlyTable {
                     Iterators.transform(
                             ((CatalogOptionsSplit) split).catalogOptions.entrySet().iterator(),
                             this::toRow);
-            if (projection != null) {
+            if (readType != null) {
                 rows =
                         Iterators.transform(
-                                rows, row -> ProjectedRow.from(projection).replaceRow(row));
+                                rows,
+                                row ->
+                                        ProjectedRow.from(readType, CatalogOptionsTable.TABLE_TYPE)
+                                                .replaceRow(row));
             }
             return new IteratorRecordReader<>(rows);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/CompactBucketsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/CompactBucketsTable.java
@@ -231,11 +231,6 @@ public class CompactBucketsTable implements DataTable, ReadonlyTable {
         }
 
         @Override
-        public InnerTableRead withProjection(int[][] projection) {
-            throw new UnsupportedOperationException("BucketsRead does not support projection");
-        }
-
-        @Override
         public TableRead withIOManager(IOManager ioManager) {
             return this;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ConsumersTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ConsumersTable.java
@@ -163,7 +163,7 @@ public class ConsumersTable implements ReadonlyTable {
     private class ConsumersRead implements InnerTableRead {
 
         private final FileIO fileIO;
-        private int[][] projection;
+        private RowType readType;
 
         public ConsumersRead(FileIO fileIO) {
             this.fileIO = fileIO;
@@ -175,8 +175,8 @@ public class ConsumersTable implements ReadonlyTable {
         }
 
         @Override
-        public InnerTableRead withProjection(int[][] projection) {
-            this.projection = projection;
+        public InnerTableRead withReadType(RowType readType) {
+            this.readType = readType;
             return this;
         }
 
@@ -194,10 +194,13 @@ public class ConsumersTable implements ReadonlyTable {
             Map<String, Long> consumers = new ConsumerManager(fileIO, location, branch).consumers();
             Iterator<InternalRow> rows =
                     Iterators.transform(consumers.entrySet().iterator(), this::toRow);
-            if (projection != null) {
+            if (readType != null) {
                 rows =
                         Iterators.transform(
-                                rows, row -> ProjectedRow.from(projection).replaceRow(row));
+                                rows,
+                                row ->
+                                        ProjectedRow.from(readType, ConsumersTable.TABLE_TYPE)
+                                                .replaceRow(row));
             }
             return new IteratorRecordReader<>(rows);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/FileMonitorTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/FileMonitorTable.java
@@ -214,11 +214,6 @@ public class FileMonitorTable implements DataTable, ReadonlyTable {
         }
 
         @Override
-        public InnerTableRead withProjection(int[][] projection) {
-            throw new UnsupportedOperationException("BucketsRead does not support projection");
-        }
-
-        @Override
         public TableRead withIOManager(IOManager ioManager) {
             return this;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/FilesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/FilesTable.java
@@ -276,7 +276,7 @@ public class FilesTable implements ReadonlyTable {
 
         private final FileStoreTable storeTable;
 
-        private int[][] projection;
+        private RowType readType;
 
         private FilesRead(SchemaManager schemaManager, FileStoreTable fileStoreTable) {
             this.schemaManager = schemaManager;
@@ -290,8 +290,8 @@ public class FilesTable implements ReadonlyTable {
         }
 
         @Override
-        public InnerTableRead withProjection(int[][] projection) {
-            this.projection = projection;
+        public InnerTableRead withReadType(RowType readType) {
+            this.readType = readType;
             return this;
         }
 
@@ -356,10 +356,13 @@ public class FilesTable implements ReadonlyTable {
                                                 simpleStatsConverters)));
             }
             Iterator<InternalRow> rows = Iterators.concat(iteratorList.iterator());
-            if (projection != null) {
+            if (readType != null) {
                 rows =
                         Iterators.transform(
-                                rows, row -> ProjectedRow.from(projection).replaceRow(row));
+                                rows,
+                                row ->
+                                        ProjectedRow.from(readType, FilesTable.TABLE_TYPE)
+                                                .replaceRow(row));
             }
             return new IteratorRecordReader<>(rows);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ManifestsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ManifestsTable.java
@@ -139,7 +139,7 @@ public class ManifestsTable implements ReadonlyTable {
 
     private static class ManifestsRead implements InnerTableRead {
 
-        private int[][] projection;
+        private RowType readType;
 
         private final FileStoreTable dataTable;
 
@@ -154,8 +154,8 @@ public class ManifestsTable implements ReadonlyTable {
         }
 
         @Override
-        public InnerTableRead withProjection(int[][] projection) {
-            this.projection = projection;
+        public InnerTableRead withReadType(RowType readType) {
+            this.readType = readType;
             return this;
         }
 
@@ -173,10 +173,13 @@ public class ManifestsTable implements ReadonlyTable {
 
             Iterator<InternalRow> rows =
                     Iterators.transform(manifestFileMetas.iterator(), this::toRow);
-            if (projection != null) {
+            if (readType != null) {
                 rows =
                         Iterators.transform(
-                                rows, row -> ProjectedRow.from(projection).replaceRow(row));
+                                rows,
+                                row ->
+                                        ProjectedRow.from(readType, ManifestsTable.TABLE_TYPE)
+                                                .replaceRow(row));
             }
             return new IteratorRecordReader<>(rows);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/OptionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/OptionsTable.java
@@ -159,7 +159,7 @@ public class OptionsTable implements ReadonlyTable {
     private class OptionsRead implements InnerTableRead {
 
         private final FileIO fileIO;
-        private int[][] projection;
+        private RowType readType;
 
         public OptionsRead(FileIO fileIO) {
             this.fileIO = fileIO;
@@ -171,8 +171,8 @@ public class OptionsTable implements ReadonlyTable {
         }
 
         @Override
-        public InnerTableRead withProjection(int[][] projection) {
-            this.projection = projection;
+        public InnerTableRead withReadType(RowType readType) {
+            this.readType = readType;
             return this;
         }
 
@@ -190,10 +190,13 @@ public class OptionsTable implements ReadonlyTable {
             Iterator<InternalRow> rows =
                     Iterators.transform(
                             options(fileIO, location, branch).entrySet().iterator(), this::toRow);
-            if (projection != null) {
+            if (readType != null) {
                 rows =
                         Iterators.transform(
-                                rows, row -> ProjectedRow.from(projection).replaceRow(row));
+                                rows,
+                                row ->
+                                        ProjectedRow.from(readType, OptionsTable.TABLE_TYPE)
+                                                .replaceRow(row));
             }
             return new IteratorRecordReader<>(rows);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/PartitionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/PartitionsTable.java
@@ -146,7 +146,7 @@ public class PartitionsTable implements ReadonlyTable {
 
         private final FileStoreTable fileStoreTable;
 
-        private int[][] projection;
+        private RowType readType;
 
         public PartitionsRead(FileStoreTable table) {
             this.fileStoreTable = table;
@@ -159,8 +159,8 @@ public class PartitionsTable implements ReadonlyTable {
         }
 
         @Override
-        public InnerTableRead withProjection(int[][] projection) {
-            this.projection = projection;
+        public InnerTableRead withReadType(RowType readType) {
+            this.readType = readType;
             return this;
         }
 
@@ -187,10 +187,13 @@ public class PartitionsTable implements ReadonlyTable {
             }
 
             Iterator<InternalRow> iterator = results.iterator();
-            if (projection != null) {
+            if (readType != null) {
                 iterator =
                         Iterators.transform(
-                                iterator, row -> ProjectedRow.from(projection).replaceRow(row));
+                                iterator,
+                                row ->
+                                        ProjectedRow.from(readType, PartitionsTable.TABLE_TYPE)
+                                                .replaceRow(row));
             }
             return new IteratorRecordReader<>(iterator);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SchemasTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SchemasTable.java
@@ -199,7 +199,7 @@ public class SchemasTable implements ReadonlyTable {
     private class SchemasRead implements InnerTableRead {
 
         private final FileIO fileIO;
-        private int[][] projection;
+        private RowType readType;
 
         private Optional<Long> optionalFilterSchemaIdMax = Optional.empty();
         private Optional<Long> optionalFilterSchemaIdMin = Optional.empty();
@@ -260,8 +260,8 @@ public class SchemasTable implements ReadonlyTable {
         }
 
         @Override
-        public InnerTableRead withProjection(int[][] projection) {
-            this.projection = projection;
+        public InnerTableRead withReadType(RowType readType) {
+            this.readType = readType;
             return this;
         }
 
@@ -282,10 +282,13 @@ public class SchemasTable implements ReadonlyTable {
             Collection<TableSchema> tableSchemas =
                     manager.listWithRange(optionalFilterSchemaIdMax, optionalFilterSchemaIdMin);
             Iterator<InternalRow> rows = Iterators.transform(tableSchemas.iterator(), this::toRow);
-            if (projection != null) {
+            if (readType != null) {
                 rows =
                         Iterators.transform(
-                                rows, row -> ProjectedRow.from(projection).replaceRow(row));
+                                rows,
+                                row ->
+                                        ProjectedRow.from(readType, SchemasTable.TABLE_TYPE)
+                                                .replaceRow(row));
             }
             return new IteratorRecordReader<>(rows);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SnapshotsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SnapshotsTable.java
@@ -203,7 +203,7 @@ public class SnapshotsTable implements ReadonlyTable {
     private class SnapshotsRead implements InnerTableRead {
 
         private final FileIO fileIO;
-        private int[][] projection;
+        private RowType readType;
         private Optional<Long> optionalFilterSnapshotIdMax = Optional.empty();
         private Optional<Long> optionalFilterSnapshotIdMin = Optional.empty();
 
@@ -267,8 +267,8 @@ public class SnapshotsTable implements ReadonlyTable {
         }
 
         @Override
-        public InnerTableRead withProjection(int[][] projection) {
-            this.projection = projection;
+        public InnerTableRead withReadType(RowType readType) {
+            this.readType = readType;
             return this;
         }
 
@@ -289,10 +289,13 @@ public class SnapshotsTable implements ReadonlyTable {
                             optionalFilterSnapshotIdMax, optionalFilterSnapshotIdMin);
 
             Iterator<InternalRow> rows = Iterators.transform(snapshots, this::toRow);
-            if (projection != null) {
+            if (readType != null) {
                 rows =
                         Iterators.transform(
-                                rows, row -> ProjectedRow.from(projection).replaceRow(row));
+                                rows,
+                                row ->
+                                        ProjectedRow.from(readType, SnapshotsTable.TABLE_TYPE)
+                                                .replaceRow(row));
             }
             return new IteratorRecordReader<>(rows);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/TagsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/TagsTable.java
@@ -188,7 +188,7 @@ public class TagsTable implements ReadonlyTable {
     private class TagsRead implements InnerTableRead {
 
         private final FileIO fileIO;
-        private int[][] projection;
+        private RowType readType;
 
         public TagsRead(FileIO fileIO) {
             this.fileIO = fileIO;
@@ -201,8 +201,8 @@ public class TagsTable implements ReadonlyTable {
         }
 
         @Override
-        public InnerTableRead withProjection(int[][] projection) {
-            this.projection = projection;
+        public InnerTableRead withReadType(RowType readType) {
+            this.readType = readType;
             return this;
         }
 
@@ -237,10 +237,13 @@ public class TagsTable implements ReadonlyTable {
 
             Iterator<InternalRow> rows =
                     Iterators.transform(nameToSnapshot.entrySet().iterator(), this::toRow);
-            if (projection != null) {
+            if (readType != null) {
                 rows =
                         Iterators.transform(
-                                rows, row -> ProjectedRow.from(projection).replaceRow(row));
+                                rows,
+                                row ->
+                                        ProjectedRow.from(readType, TagsTable.TABLE_TYPE)
+                                                .replaceRow(row));
             }
             return new IteratorRecordReader<>(rows);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/BulkFormatMapping.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/BulkFormatMapping.java
@@ -156,7 +156,7 @@ public class BulkFormatMapping {
                                     if (f.type() instanceof RowType) {
                                         RowType tableFieldType = (RowType) f.type();
                                         RowType dataFieldType = (RowType) dataField.type();
-                                        checkState(tableFieldType.subsetOf(dataFieldType));
+                                        checkState(tableFieldType.prunedFrom(dataFieldType));
                                         // Since the nested type schema evolution is not supported,
                                         // directly copy the fields from tableField's type to
                                         // dataField's type.

--- a/paimon-core/src/main/java/org/apache/paimon/utils/BulkFormatMapping.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/BulkFormatMapping.java
@@ -19,10 +19,25 @@
 package org.apache.paimon.utils;
 
 import org.apache.paimon.casting.CastFieldGetter;
+import org.apache.paimon.format.FileFormatDiscover;
 import org.apache.paimon.format.FormatReaderFactory;
+import org.apache.paimon.partition.PartitionUtils;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.schema.IndexCastMapping;
+import org.apache.paimon.schema.SchemaEvolutionUtil;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 
 import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.apache.paimon.predicate.PredicateBuilder.excludePredicateWithFields;
+import static org.apache.paimon.utils.Preconditions.checkState;
 
 /** Class with index mapping and bulk format. */
 public class BulkFormatMapping {
@@ -31,16 +46,22 @@ public class BulkFormatMapping {
     @Nullable private final CastFieldGetter[] castMapping;
     @Nullable private final Pair<int[], RowType> partitionPair;
     private final FormatReaderFactory bulkFormat;
+    private final TableSchema dataSchema;
+    private final List<Predicate> dataFilters;
 
     public BulkFormatMapping(
             @Nullable int[] indexMapping,
             @Nullable CastFieldGetter[] castMapping,
             @Nullable Pair<int[], RowType> partitionPair,
-            FormatReaderFactory bulkFormat) {
+            FormatReaderFactory bulkFormat,
+            TableSchema dataSchema,
+            List<Predicate> dataFilters) {
         this.indexMapping = indexMapping;
         this.castMapping = castMapping;
         this.bulkFormat = bulkFormat;
         this.partitionPair = partitionPair;
+        this.dataSchema = dataSchema;
+        this.dataFilters = dataFilters;
     }
 
     @Nullable
@@ -60,5 +81,109 @@ public class BulkFormatMapping {
 
     public FormatReaderFactory getReaderFactory() {
         return bulkFormat;
+    }
+
+    public TableSchema getDataSchema() {
+        return dataSchema;
+    }
+
+    public List<Predicate> getDataFilters() {
+        return dataFilters;
+    }
+
+    /** Builder for {@link BulkFormatMapping}. */
+    public static class BulkFormatMappingBuilder {
+
+        private final FileFormatDiscover formatDiscover;
+        private final List<DataField> readTableFields;
+        private final Function<TableSchema, List<DataField>> fieldsExtractor;
+        @Nullable private final List<Predicate> filters;
+
+        public BulkFormatMappingBuilder(
+                FileFormatDiscover formatDiscover,
+                List<DataField> readTableFields,
+                Function<TableSchema, List<DataField>> fieldsExtractor,
+                @Nullable List<Predicate> filters) {
+            this.formatDiscover = formatDiscover;
+            this.readTableFields = readTableFields;
+            this.fieldsExtractor = fieldsExtractor;
+            this.filters = filters;
+        }
+
+        public BulkFormatMapping build(
+                String formatIdentifier, TableSchema tableSchema, TableSchema dataSchema) {
+
+            List<DataField> readDataFields = readDataFields(dataSchema);
+
+            // build index cast mapping
+            IndexCastMapping indexCastMapping =
+                    SchemaEvolutionUtil.createIndexCastMapping(readTableFields, readDataFields);
+
+            // build partition mapping and filter partition fields
+            Pair<Pair<int[], RowType>, List<DataField>>
+                    partitionMappingAndFieldsWithoutPartitionPair =
+                            PartitionUtils.constructPartitionMapping(dataSchema, readDataFields);
+            Pair<int[], RowType> partitionMapping =
+                    partitionMappingAndFieldsWithoutPartitionPair.getLeft();
+
+            // build read row type
+            RowType readDataRowType =
+                    new RowType(partitionMappingAndFieldsWithoutPartitionPair.getRight());
+
+            // build read filters
+            List<Predicate> readFilters = readFilters(filters, tableSchema, dataSchema);
+
+            return new BulkFormatMapping(
+                    indexCastMapping.getIndexMapping(),
+                    indexCastMapping.getCastMapping(),
+                    partitionMapping,
+                    formatDiscover
+                            .discover(formatIdentifier)
+                            .createReaderFactory(readDataRowType, readFilters),
+                    dataSchema,
+                    readFilters);
+        }
+
+        private List<DataField> readDataFields(TableSchema dataSchema) {
+            List<DataField> dataFields = fieldsExtractor.apply(dataSchema);
+            List<DataField> readDataFields = new ArrayList<>();
+            for (DataField dataField : dataFields) {
+                readTableFields.stream()
+                        .filter(f -> f.id() == dataField.id())
+                        .findFirst()
+                        .ifPresent(
+                                f -> {
+                                    if (f.type() instanceof RowType) {
+                                        RowType tableFieldType = (RowType) f.type();
+                                        RowType dataFieldType = (RowType) dataField.type();
+                                        checkState(tableFieldType.subsetOf(dataFieldType));
+                                        // Since the nested type schema evolution is not supported,
+                                        // directly copy the fields from tableField's type to
+                                        // dataField's type.
+                                        // todo: support nested type schema evolutions.
+                                        readDataFields.add(
+                                                dataField.newType(
+                                                        dataFieldType.copy(
+                                                                tableFieldType.getFields())));
+                                    } else {
+                                        readDataFields.add(dataField);
+                                    }
+                                });
+            }
+            return readDataFields;
+        }
+
+        private List<Predicate> readFilters(
+                List<Predicate> filters, TableSchema tableSchema, TableSchema dataSchema) {
+            List<Predicate> dataFilters =
+                    tableSchema.id() == dataSchema.id()
+                            ? filters
+                            : SchemaEvolutionUtil.createDataFilters(
+                                    tableSchema.fields(), dataSchema.fields(), filters);
+
+            // Skip pushing down partition filters to reader.
+            return excludePredicateWithFields(
+                    dataFilters, new HashSet<>(dataSchema.partitionKeys()));
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/BulkFormatMapping.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/BulkFormatMapping.java
@@ -156,7 +156,7 @@ public class BulkFormatMapping {
                                     if (f.type() instanceof RowType) {
                                         RowType tableFieldType = (RowType) f.type();
                                         RowType dataFieldType = (RowType) dataField.type();
-                                        checkState(tableFieldType.prunedFrom(dataFieldType));
+                                        checkState(tableFieldType.isPrunedFrom(dataFieldType));
                                         // Since the nested type schema evolution is not supported,
                                         // directly copy the fields from tableField's type to
                                         // dataField's type.

--- a/paimon-core/src/test/java/org/apache/paimon/TestKeyValueGenerator.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestKeyValueGenerator.java
@@ -30,10 +30,10 @@ import org.apache.paimon.schema.KeyValueFieldsExtractor;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.SchemaEvolutionTableTestBase;
+import org.apache.paimon.table.SystemFields;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
-import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
@@ -70,53 +70,36 @@ public class TestKeyValueGenerator {
     // * comment: string, length from 10 to 1000
     public static final RowType DEFAULT_ROW_TYPE =
             RowType.of(
-                    new DataType[] {
-                        new VarCharType(false, 8),
-                        new IntType(false),
-                        new IntType(false),
-                        new BigIntType(false),
-                        new BigIntType(),
-                        new ArrayType(new IntType()),
-                        new VarCharType(Integer.MAX_VALUE)
-                    },
-                    new String[] {
-                        "dt", "hr", "shopId", "orderId", "itemId", "priceAmount", "comment"
-                    });
+                    new DataField(0, "dt", new VarCharType(false, 8)),
+                    new DataField(1, "hr", new IntType(false)),
+                    new DataField(2, "shopId", new IntType(false)),
+                    new DataField(3, "orderId", new BigIntType(false)),
+                    new DataField(4, "itemId", new BigIntType()),
+                    new DataField(5, "priceAmount", new ArrayType(new IntType())),
+                    new DataField(6, "comment", new VarCharType(Integer.MAX_VALUE)));
     public static final RowType DEFAULT_PART_TYPE =
             new RowType(DEFAULT_ROW_TYPE.getFields().subList(0, 2));
 
     public static final RowType SINGLE_PARTITIONED_ROW_TYPE =
-            RowType.of(
-                    new DataType[] {
-                        new VarCharType(false, 8),
-                        new IntType(false),
-                        new BigIntType(false),
-                        new BigIntType(),
-                        new ArrayType(new IntType()),
-                        new VarCharType(Integer.MAX_VALUE)
-                    },
-                    new String[] {"dt", "shopId", "orderId", "itemId", "priceAmount", "comment"});
+            DEFAULT_ROW_TYPE.project("dt", "shopId", "orderId", "itemId", "priceAmount", "comment");
+
     public static final RowType SINGLE_PARTITIONED_PART_TYPE =
             RowType.of(SINGLE_PARTITIONED_ROW_TYPE.getTypeAt(0));
 
     public static final RowType NON_PARTITIONED_ROW_TYPE =
-            RowType.of(
-                    new DataType[] {
-                        new IntType(false),
-                        new BigIntType(false),
-                        new BigIntType(),
-                        new ArrayType(new IntType()),
-                        new VarCharType(Integer.MAX_VALUE)
-                    },
-                    new String[] {"shopId", "orderId", "itemId", "priceAmount", "comment"});
+            DEFAULT_ROW_TYPE.project("shopId", "orderId", "itemId", "priceAmount", "comment");
     public static final RowType NON_PARTITIONED_PART_TYPE = RowType.of();
 
     public static final List<String> KEY_NAME_LIST = Arrays.asList("shopId", "orderId");
 
     public static final RowType KEY_TYPE =
             RowType.of(
-                    new DataType[] {new IntType(false), new BigIntType(false)},
-                    new String[] {"key_shopId", "key_orderId"});
+                    new DataField(
+                            2 + SystemFields.KEY_FIELD_ID_START, "key_shopId", new IntType(false)),
+                    new DataField(
+                            3 + SystemFields.KEY_FIELD_ID_START,
+                            "key_orderId",
+                            new BigIntType(false)));
 
     public static final InternalRowSerializer DEFAULT_ROW_SERIALIZER =
             new InternalRowSerializer(DEFAULT_ROW_TYPE);
@@ -407,7 +390,13 @@ public class TestKeyValueGenerator {
         public List<DataField> keyFields(TableSchema schema) {
             return schema.fields().stream()
                     .filter(f -> KEY_NAME_LIST.contains(f.name()))
-                    .map(f -> new DataField(f.id(), "key_" + f.name(), f.type(), f.description()))
+                    .map(
+                            f ->
+                                    new DataField(
+                                            f.id() + SystemFields.KEY_FIELD_ID_START,
+                                            "key_" + f.name(),
+                                            f.type(),
+                                            f.description()))
                     .collect(Collectors.toList());
         }
 

--- a/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
@@ -37,11 +37,7 @@ import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.reader.RecordReaderIterator;
 import org.apache.paimon.stats.StatsTestUtils;
-import org.apache.paimon.types.BigIntType;
-import org.apache.paimon.types.DataType;
-import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowType;
-import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.utils.CloseableIterator;
 import org.apache.paimon.utils.FailingFileIO;
 import org.apache.paimon.utils.FileStorePathFactory;
@@ -150,7 +146,7 @@ public class KeyValueFileReadWriteTest {
     }
 
     @Test
-    public void testKeyProjection() throws Exception {
+    public void testReadKeyType() throws Exception {
         DataFileTestDataGenerator.Data data = gen.next();
         KeyValueFileWriterFactory writerFactory = createWriterFactory(tempDir.toString(), "avro");
         DataFileMetaSerializer serializer = new DataFileMetaSerializer();
@@ -162,15 +158,10 @@ public class KeyValueFileReadWriteTest {
         List<DataFileMeta> actualMetas = writer.result();
 
         // projection: (shopId, orderId) -> (orderId)
+        RowType readKeyType = KEY_TYPE.project("key_orderId");
         KeyValueFileReaderFactory readerFactory =
-                createReaderFactory(tempDir.toString(), "avro", new int[][] {new int[] {1}}, null);
-        RowType projectedKeyType =
-                RowType.builder()
-                        .fields(
-                                new DataType[] {new BigIntType(false)},
-                                new String[] {"key_orderId"})
-                        .build();
-        InternalRowSerializer projectedKeySerializer = new InternalRowSerializer(projectedKeyType);
+                createReaderFactory(tempDir.toString(), "avro", readKeyType, null);
+        InternalRowSerializer projectedKeySerializer = new InternalRowSerializer(readKeyType);
         assertData(
                 data,
                 actualMetas,
@@ -188,7 +179,7 @@ public class KeyValueFileReadWriteTest {
     }
 
     @Test
-    public void testValueProjection() throws Exception {
+    public void testReadValueType() throws Exception {
         DataFileTestDataGenerator.Data data = gen.next();
         KeyValueFileWriterFactory writerFactory = createWriterFactory(tempDir.toString(), "avro");
         DataFileMetaSerializer serializer = new DataFileMetaSerializer();
@@ -202,23 +193,10 @@ public class KeyValueFileReadWriteTest {
         // projection:
         // (dt, hr, shopId, orderId, itemId, priceAmount, comment) ->
         // (shopId, itemId, dt, hr)
+        RowType readValueType = DEFAULT_ROW_TYPE.project("shopId", "itemId", "dt", "hr");
         KeyValueFileReaderFactory readerFactory =
-                createReaderFactory(
-                        tempDir.toString(),
-                        "avro",
-                        null,
-                        new int[][] {new int[] {2}, new int[] {4}, new int[] {0}, new int[] {1}});
-        RowType projectedValueType =
-                RowType.of(
-                        new DataType[] {
-                            new IntType(false),
-                            new BigIntType(),
-                            new VarCharType(false, 8),
-                            new IntType(false)
-                        },
-                        new String[] {"shopId", "itemId", "dt", "hr"});
-        InternalRowSerializer projectedValueSerializer =
-                new InternalRowSerializer(projectedValueType);
+                createReaderFactory(tempDir.toString(), "avro", null, readValueType);
+        InternalRowSerializer projectedValueSerializer = new InternalRowSerializer(readValueType);
         assertData(
                 data,
                 actualMetas,
@@ -283,7 +261,7 @@ public class KeyValueFileReadWriteTest {
     }
 
     private KeyValueFileReaderFactory createReaderFactory(
-            String pathStr, String format, int[][] keyProjection, int[][] valueProjection) {
+            String pathStr, String format, RowType readKeyType, RowType readValueType) {
         Path path = new Path(pathStr);
         FileIO fileIO = FileIOFinder.find(path);
         FileStorePathFactory pathFactory = createNonPartFactory(path);
@@ -298,11 +276,11 @@ public class KeyValueFileReadWriteTest {
                         pathFactory,
                         new TestKeyValueGenerator.TestKeyValueFieldsExtractor(),
                         new CoreOptions(new HashMap<>()));
-        if (keyProjection != null) {
-            builder.withKeyProjection(keyProjection);
+        if (readKeyType != null) {
+            builder.withReadKeyType(readKeyType);
         }
-        if (valueProjection != null) {
-            builder.withValueProjection(valueProjection);
+        if (readValueType != null) {
+            builder.withReadValueType(readValueType);
         }
         return builder.build(BinaryRow.EMPTY_ROW, 0, DeletionVector.emptyFactory());
     }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/DefaultValueAssignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/DefaultValueAssignerTest.java
@@ -29,7 +29,7 @@ import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
-import org.apache.paimon.utils.Projection;
+import org.apache.paimon.types.RowType;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.Lists;
 
@@ -83,10 +83,9 @@ class DefaultValueAssignerTest {
     @Test
     public void testGeneralRow() {
         DefaultValueAssigner defaultValueAssigner = DefaultValueAssigner.create(tableSchema);
-        int[] projection = tableSchema.projection(Lists.newArrayList("col5", "col4", "col0"));
-        Projection top = Projection.of(projection);
-        int[][] nest = top.toNestedIndexes();
-        defaultValueAssigner = defaultValueAssigner.handleProject(nest);
+        RowType readRowType =
+                tableSchema.projectedLogicalRowType(Lists.newArrayList("col5", "col4", "col0"));
+        defaultValueAssigner = defaultValueAssigner.handleReadRowType(readRowType);
         InternalRow row = defaultValueAssigner.createDefaultValueRow().defaultValueRow();
         assertThat(String.format("%s|%s|%s", row.getString(0), row.getString(1), row.getString(2)))
                 .isEqualTo("1|0|null");

--- a/paimon-core/src/test/java/org/apache/paimon/operation/MergeFileSplitReadTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/MergeFileSplitReadTest.java
@@ -143,7 +143,7 @@ public class MergeFileSplitReadTest {
         List<KeyValue> readData =
                 writeThenRead(
                         data,
-                        readKeyType.copyAndSetOriginalRowType(rowType),
+                        readKeyType,
                         null,
                         projectedKeySerializer,
                         valueSerializer,
@@ -203,9 +203,8 @@ public class MergeFileSplitReadTest {
                 writeThenRead(
                         data,
                         null,
-                        TestKeyValueGenerator.DEFAULT_ROW_TYPE
-                                .project("shopId", "itemId", "dt", "hr")
-                                .copyAndSetOriginalRowType(TestKeyValueGenerator.DEFAULT_ROW_TYPE),
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE.project(
+                                "shopId", "itemId", "dt", "hr"),
                         TestKeyValueGenerator.KEY_SERIALIZER,
                         projectedValueSerializer,
                         store,

--- a/paimon-core/src/test/java/org/apache/paimon/operation/MergeFileSplitReadTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/MergeFileSplitReadTest.java
@@ -96,17 +96,23 @@ public class MergeFileSplitReadTest {
         // remove zero occurrence, it might be merged and discarded by the merge tree
         expected.entrySet().removeIf(e -> e.getValue() == 0);
 
-        RowType partitionType = RowType.of(new DataType[] {new IntType(false)}, new String[] {"c"});
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {
+                            new IntType(false),
+                            new IntType(false),
+                            new IntType(false),
+                            new BigIntType(false)
+                        },
+                        new String[] {"a", "b", "c", "count"});
+
+        RowType partitionType = rowType.project("c");
         InternalRowSerializer partitionSerializer = new InternalRowSerializer(partitionType);
         List<String> keyNames = Arrays.asList("a", "b", "c");
-        RowType keyType =
-                RowType.of(
-                        new DataType[] {new IntType(false), new IntType(false), new IntType(false)},
-                        keyNames.toArray(new String[0]));
-        RowType projectedKeyType = RowType.of(new IntType(false), new IntType(false));
-        InternalRowSerializer projectedKeySerializer = new InternalRowSerializer(projectedKeyType);
-        RowType valueType =
-                RowType.of(new DataType[] {new BigIntType(false)}, new String[] {"count"});
+        RowType keyType = rowType.project(keyNames);
+        RowType readKeyType = rowType.project("b", "a");
+        InternalRowSerializer projectedKeySerializer = new InternalRowSerializer(readKeyType);
+        RowType valueType = rowType.project("count");
         InternalRowSerializer valueSerializer = new InternalRowSerializer(valueType);
 
         TestFileStore store =
@@ -137,7 +143,7 @@ public class MergeFileSplitReadTest {
         List<KeyValue> readData =
                 writeThenRead(
                         data,
-                        new int[][] {new int[] {1}, new int[] {0}},
+                        readKeyType.copyAndSetOriginalRowType(rowType),
                         null,
                         projectedKeySerializer,
                         valueSerializer,
@@ -197,7 +203,9 @@ public class MergeFileSplitReadTest {
                 writeThenRead(
                         data,
                         null,
-                        new int[][] {new int[] {2}, new int[] {4}, new int[] {0}, new int[] {1}},
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE
+                                .project("shopId", "itemId", "dt", "hr")
+                                .copyAndSetOriginalRowType(TestKeyValueGenerator.DEFAULT_ROW_TYPE),
                         TestKeyValueGenerator.KEY_SERIALIZER,
                         projectedValueSerializer,
                         store,
@@ -213,8 +221,8 @@ public class MergeFileSplitReadTest {
 
     private List<KeyValue> writeThenRead(
             List<KeyValue> data,
-            int[][] keyProjection,
-            int[][] valueProjection,
+            RowType readKeyType,
+            RowType readValueType,
             InternalRowSerializer projectedKeySerializer,
             InternalRowSerializer projectedValueSerializer,
             TestFileStore store,
@@ -227,11 +235,11 @@ public class MergeFileSplitReadTest {
                 scan.withSnapshot(snapshotId).plan().files().stream()
                         .collect(Collectors.groupingBy(ManifestEntry::partition));
         MergeFileSplitRead read = store.newRead();
-        if (keyProjection != null) {
-            read.withKeyProjection(keyProjection);
+        if (readKeyType != null) {
+            read.withReadKeyType(readKeyType);
         }
-        if (valueProjection != null) {
-            read.withProjection(valueProjection);
+        if (readValueType != null) {
+            read.withReadType(readValueType);
         }
 
         List<KeyValue> result = new ArrayList<>();

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -905,7 +905,8 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
     }
 
     @Override
-    protected FileStoreTable createFileStoreTable(Consumer<Options> configure) throws Exception {
+    protected FileStoreTable createFileStoreTable(Consumer<Options> configure, RowType rowType)
+            throws Exception {
         Options conf = new Options();
         conf.set(CoreOptions.PATH, tablePath.toString());
         configure.accept(conf);
@@ -916,7 +917,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                 SchemaUtils.forceCommit(
                         new SchemaManager(LocalFileIO.create(), tablePath),
                         new Schema(
-                                ROW_TYPE.getFields(),
+                                rowType.getFields(),
                                 Collections.singletonList("pt"),
                                 Collections.emptyList(),
                                 conf.toMap(),

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -30,6 +30,7 @@ import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.JoinedRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.FileStatus;
@@ -387,6 +388,51 @@ public abstract class FileStoreTableTestBase {
                         .splits();
         assertThat(splits.size()).isEqualTo(1);
         assertThat(((DataSplit) splits.get(0)).bucket()).isEqualTo(1);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {"avro", "orc", "parquet"})
+    public void testReadRowType(String format) throws Exception {
+        RowType writeType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "pt", DataTypes.INT()),
+                        DataTypes.FIELD(1, "a", DataTypes.INT()),
+                        DataTypes.FIELD(2, "f0", DataTypes.INT()),
+                        DataTypes.FIELD(
+                                3,
+                                "f1",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD(4, "f0", DataTypes.INT()),
+                                        DataTypes.FIELD(5, "f1", DataTypes.INT()),
+                                        DataTypes.FIELD(6, "f2", DataTypes.INT()))));
+
+        FileStoreTable table =
+                createFileStoreTable(conf -> conf.setString(FILE_FORMAT.key(), format), writeType);
+
+        try (StreamTableWrite write = table.newWrite(commitUser);
+                InnerTableCommit commit = table.newCommit(commitUser)) {
+            write.write(GenericRow.of(0, 0, 0, GenericRow.of(10, 11, 12)));
+            commit.commit(0, write.prepareCommit(true, 0));
+        }
+
+        RowType readType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(
+                                3,
+                                "f1",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD(6, "f2", DataTypes.INT()),
+                                        DataTypes.FIELD(4, "f0", DataTypes.INT()))));
+
+        ReadBuilder readBuilder = table.newReadBuilder().withReadType(readType);
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        List<InternalRow> result = new ArrayList<>();
+        try (RecordReader<InternalRow> reader = readBuilder.newRead().createReader(splits.get(0))) {
+            InternalRowSerializer serializer = new InternalRowSerializer(readType);
+            reader.forEachRemaining(row -> result.add(serializer.copy(row)));
+        }
+
+        assertThat(result).containsExactly(GenericRow.of(GenericRow.of(12, 10)));
     }
 
     protected void innerTestWithShard(FileStoreTable table) throws Exception {
@@ -1220,7 +1266,7 @@ public abstract class FileStoreTableTestBase {
     }
 
     @Test
-    public void testfastForward() throws Exception {
+    public void testFastForward() throws Exception {
         FileStoreTable table = createFileStoreTable();
         generateBranch(table);
         FileStoreTable tableBranch = createFileStoreTable(BRANCH_NAME);
@@ -1701,8 +1747,12 @@ public abstract class FileStoreTableTestBase {
         return createFileStoreTable(1);
     }
 
-    protected abstract FileStoreTable createFileStoreTable(Consumer<Options> configure)
-            throws Exception;
+    protected FileStoreTable createFileStoreTable(Consumer<Options> configure) throws Exception {
+        return createFileStoreTable(configure, ROW_TYPE);
+    }
+
+    protected abstract FileStoreTable createFileStoreTable(
+            Consumer<Options> configure, RowType rowType) throws Exception;
 
     protected abstract FileStoreTable createFileStoreTable(
             String branch, Consumer<Options> configure) throws Exception;

--- a/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
@@ -961,9 +961,10 @@ public class PrimaryKeyFileStoreTableTest extends FileStoreTableTestBase {
         result = getResult(read, toSplits(snapshotReader.read().dataSplits()), rowDataToString);
         assertThat(result).containsExactlyInAnyOrder("+I[+I, 1, 10, 100]");
 
-        // Read by projection
+        // Read by requiredType
+        RowType rowType = auditLogTable.rowType();
         snapshotReader = auditLogTable.newSnapshotReader();
-        read = auditLogTable.newRead().withProjection(new int[] {2, 0, 1});
+        read = auditLogTable.newRead().withReadType(rowType.project("a", "rowkind", "pt"));
         Function<InternalRow, String> projectToString1 =
                 row ->
                         internalRowToString(
@@ -974,9 +975,9 @@ public class PrimaryKeyFileStoreTableTest extends FileStoreTableTestBase {
         assertThat(result)
                 .containsExactlyInAnyOrder("+I[20, +I, 2]", "+I[30, +U, 1]", "+I[10, +I, 1]");
 
-        // Read by projection without row kind
+        // Read by requiredType without rowkind
         snapshotReader = auditLogTable.newSnapshotReader();
-        read = auditLogTable.newRead().withProjection(new int[] {2, 1});
+        read = auditLogTable.newRead().withReadType(rowType.project("a", "pt"));
         Function<InternalRow, String> projectToString2 =
                 row -> internalRowToString(row, DataTypes.ROW(DataTypes.INT(), DataTypes.INT()));
         result = getResult(read, toSplits(snapshotReader.read().dataSplits()), projectToString2);
@@ -1814,11 +1815,6 @@ public class PrimaryKeyFileStoreTableTest extends FileStoreTableTestBase {
     }
 
     @Override
-    protected FileStoreTable createFileStoreTable(Consumer<Options> configure) throws Exception {
-        return createFileStoreTable(configure, ROW_TYPE);
-    }
-
-    @Override
     protected FileStoreTable overwriteTestFileStoreTable() throws Exception {
         Options conf = new Options();
         conf.set(CoreOptions.PATH, tablePath.toString());
@@ -1835,7 +1831,8 @@ public class PrimaryKeyFileStoreTableTest extends FileStoreTableTestBase {
         return new PrimaryKeyFileStoreTable(FileIOFinder.find(tablePath), tablePath, tableSchema);
     }
 
-    private FileStoreTable createFileStoreTable(Consumer<Options> configure, RowType rowType)
+    @Override
+    protected FileStoreTable createFileStoreTable(Consumer<Options> configure, RowType rowType)
             throws Exception {
         Options options = new Options();
         options.set(CoreOptions.PATH, tablePath.toString());

--- a/paimon-core/src/test/java/org/apache/paimon/table/WritePreemptMemoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/WritePreemptMemoryTest.java
@@ -32,6 +32,7 @@ import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.types.RowType;
 
 import org.junit.jupiter.api.Test;
 
@@ -88,7 +89,8 @@ public class WritePreemptMemoryTest extends FileStoreTableTestBase {
     }
 
     @Override
-    protected FileStoreTable createFileStoreTable(Consumer<Options> configure) throws Exception {
+    protected FileStoreTable createFileStoreTable(Consumer<Options> configure, RowType rowType)
+            throws Exception {
         Options options = new Options();
         options.set(CoreOptions.BUCKET, 1);
         options.set(CoreOptions.PATH, tablePath.toString());
@@ -102,7 +104,7 @@ public class WritePreemptMemoryTest extends FileStoreTableTestBase {
                 SchemaUtils.forceCommit(
                         new SchemaManager(LocalFileIO.create(), tablePath),
                         new Schema(
-                                ROW_TYPE.getFields(),
+                                rowType.getFields(),
                                 Collections.singletonList("pt"),
                                 Arrays.asList("pt", "a"),
                                 options.toMap(),

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupCompactDiffRead.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupCompactDiffRead.java
@@ -31,6 +31,7 @@ import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.types.RowType;
 
 import java.io.IOException;
 
@@ -49,9 +50,9 @@ public class LookupCompactDiffRead extends AbstractDataTableRead<KeyValue> {
     }
 
     @Override
-    public void projection(int[][] projection) {
-        fullPhaseMergeRead.withProjection(projection);
-        incrementalDiffRead.withProjection(projection);
+    public void applyReadType(RowType readType) {
+        fullPhaseMergeRead.withReadType(readType);
+        incrementalDiffRead.withReadType(readType);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyPartialLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyPartialLookupTable.java
@@ -32,7 +32,6 @@ import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.StreamTableScan;
 import org.apache.paimon.utils.ProjectedRow;
-import org.apache.paimon.utils.Projection;
 
 import javax.annotation.Nullable;
 
@@ -187,7 +186,7 @@ public class PrimaryKeyPartialLookupTable implements LookupTable {
                 Set<Integer> requireCachedBucketIds) {
             this.tableQuery =
                     table.newLocalTableQuery()
-                            .withValueProjection(Projection.of(projection).toNestedIndexes())
+                            .withValueProjection(projection)
                             .withIOManager(new IOManagerImpl(tempPath.toString()));
 
             this.scan =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/query/RemoteTableQuery.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/query/RemoteTableQuery.java
@@ -30,7 +30,6 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.query.TableQuery;
 import org.apache.paimon.utils.ProjectedRow;
-import org.apache.paimon.utils.Projection;
 import org.apache.paimon.utils.TypeUtils;
 
 import javax.annotation.Nullable;
@@ -93,12 +92,7 @@ public class RemoteTableQuery implements TableQuery {
 
     @Override
     public RemoteTableQuery withValueProjection(int[] projection) {
-        return withValueProjection(Projection.of(projection).toNestedIndexes());
-    }
-
-    @Override
-    public RemoteTableQuery withValueProjection(int[][] projection) {
-        this.projection = Projection.of(projection).toTopLevelIndexes();
+        this.projection = projection;
         return this;
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

To #4209

#### public API

```java
 /**
   * Push row type to the reader, support nested row pruning.
   *
   * @param readType read row type, can be a subset of {@link Table#rowType()}
   * @since 1.0.0
   */
  ReadBuilder withReadType(RowType readType);
```

mark `ReadBuilder withProjection(int[][] projection)` and `ReadBuilder withProjection(int[] projection)` as `Deprecated`

#### how to use
```java
RowType writeType =
        DataTypes.ROW(
                DataTypes.FIELD(0, "pt", DataTypes.INT()),
                DataTypes.FIELD(1, "a", DataTypes.INT()),
                DataTypes.FIELD(2, "f0", DataTypes.INT()),
                DataTypes.FIELD(
                        3,
                        "f1",
                        DataTypes.ROW(
                                DataTypes.FIELD(4, "f0", DataTypes.INT()),
                                DataTypes.FIELD(5, "f1", DataTypes.INT()),
                                DataTypes.FIELD(6, "f2", DataTypes.INT()))));
// write
// GenericRow.of(0, 0, 0, GenericRow.of(10, 11, 12))


RowType readType =
        DataTypes.ROW(
                DataTypes.FIELD(
                        3,
                        "f1",
                        DataTypes.ROW(
                                DataTypes.FIELD(4, "f0", DataTypes.INT()),
                                DataTypes.FIELD(6, "f2", DataTypes.INT()))));

ReadBuilder readBuilder = table.newReadBuilder().withReadType(readType);

// read
// GenericRow.of(GenericRow.of(10, 12))
```

