### PR TITLE
[core] Improve error message for concurrent snapshot expiration

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/Snapshot.java
+++ b/paimon-core/src/main/java/org/apache/paimon/Snapshot.java
@@ -29,8 +29,12 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgn
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nullable;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
@@ -61,6 +65,7 @@ import java.util.Objects;
 @Public
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Snapshot {
+    private static final Logger LOG = LoggerFactory.getLogger(Snapshot.class);
 
     public static final long FIRST_SNAPSHOT_ID = 1;
 
@@ -357,6 +362,16 @@ public class Snapshot {
     public static Snapshot fromPath(FileIO fileIO, Path path) {
         try {
             return Snapshot.fromJson(fileIO.readFileUtf8(path));
+        } catch (FileNotFoundException e) {
+            String errorMessage =
+                    String.format(
+                            "Snapshot file %s does not exist. "
+                                    + "It might have been expired by other jobs operating on this table. "
+                                    + "In this case, you can avoid concurrent modification issues by configuring "
+                                    + "write-only = true and use a dedicated compaction job, or configuring "
+                                    + "different expiration thresholds for different jobs.",
+                            path);
+            throw new RuntimeException(errorMessage, e);
         } catch (IOException e) {
             throw new RuntimeException("Fails to read snapshot from path " + path, e);
         }

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -369,7 +369,9 @@ public class SnapshotManagerTest {
         localFileIO.deleteQuietly(snapshotManager.snapshotPath(3));
         thread.join();
 
-        assertThat(exception.get()).hasMessageContaining("Fails to read snapshot from path");
+        assertThat(exception.get())
+                .hasMessageFindingMatch("Snapshot file .* does not exist")
+                .hasMessageContaining("dedicated compaction job");
     }
 
     @Test


### PR DESCRIPTION
### Purpose

This PR adds a more detailed error message to the snapshot expiration process, showing users a possible cause of the FileNotFoundException they may face and the recommended solution to it.

### Tests

A UT has been added to verify the error message in case of concurrent snapshot expiration.

### API and Format

This PR does not affect API or format.

### Documentation

This change does not need documentation
