### PR TITLE
[spark] PaimonSplitScan supports column pruning and filter push down

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/KnownSplitsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/KnownSplitsTable.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table;
+
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.InnerTableRead;
+import org.apache.paimon.table.source.InnerTableScan;
+import org.apache.paimon.types.RowType;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A table to hold some known data splits. For now, it is only used by internal for Spark engine.
+ */
+public class KnownSplitsTable implements ReadonlyTable {
+    private final InnerTable origin;
+    private final DataSplit[] splits;
+
+    KnownSplitsTable(InnerTable origin, DataSplit[] splits) {
+        this.origin = origin;
+        this.splits = splits;
+    }
+
+    public static KnownSplitsTable create(InnerTable origin, DataSplit[] splits) {
+        return new KnownSplitsTable(origin, splits);
+    }
+
+    public DataSplit[] splits() {
+        return splits;
+    }
+
+    @Override
+    public String name() {
+        return origin.name();
+    }
+
+    @Override
+    public RowType rowType() {
+        return origin.rowType();
+    }
+
+    @Override
+    public List<String> primaryKeys() {
+        return origin.primaryKeys();
+    }
+
+    @Override
+    public List<String> partitionKeys() {
+        return origin.partitionKeys();
+    }
+
+    @Override
+    public Map<String, String> options() {
+        return origin.options();
+    }
+
+    @Override
+    public InnerTableRead newRead() {
+        return origin.newRead();
+    }
+
+    // ===== unused method ===========================================
+
+    @Override
+    public InnerTableScan newScan() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Table copy(Map<String, String> dynamicOptions) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/paimon-spark/paimon-spark-3.1/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-3.1/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -29,6 +29,6 @@ case class PaimonScan(
     requiredSchema: StructType,
     filters: Seq[Predicate],
     reservedFilters: Seq[Filter],
-    pushDownLimit: Option[Int],
+    override val pushDownLimit: Option[Int],
     disableBucketedScan: Boolean = false)
   extends PaimonBaseScan(table, requiredSchema, filters, reservedFilters, pushDownLimit)

--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -34,7 +34,7 @@ case class PaimonScan(
     requiredSchema: StructType,
     filters: Seq[Predicate],
     reservedFilters: Seq[Filter],
-    pushDownLimit: Option[Int],
+    override val pushDownLimit: Option[Int],
     disableBucketedScan: Boolean = false)
   extends PaimonBaseScan(table, requiredSchema, filters, reservedFilters, pushDownLimit)
   with SupportsRuntimeFiltering {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/ColumnPruningAndPushDown.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/ColumnPruningAndPushDown.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark
+
+import org.apache.paimon.predicate.{Predicate, PredicateBuilder}
+import org.apache.paimon.spark.schema.PaimonMetadataColumn
+import org.apache.paimon.table.Table
+import org.apache.paimon.table.source.ReadBuilder
+import org.apache.paimon.types.RowType
+
+import org.apache.spark.sql.connector.read.Scan
+import org.apache.spark.sql.types.StructType
+
+trait ColumnPruningAndPushDown extends Scan {
+  def table: Table
+  def requiredSchema: StructType
+  def filters: Seq[Predicate]
+  def pushDownLimit: Option[Int] = None
+
+  val tableRowType: RowType = table.rowType
+  val tableSchema: StructType = SparkTypeUtils.fromPaimonRowType(tableRowType)
+
+  final def partitionType: StructType = {
+    SparkTypeUtils.toSparkPartitionType(table)
+  }
+
+  private[paimon] val (requiredTableFields, metadataFields) = {
+    val nameToField = tableSchema.map(field => (field.name, field)).toMap
+    val _tableFields = requiredSchema.flatMap(field => nameToField.get(field.name))
+    val _metadataFields =
+      requiredSchema
+        .filterNot(field => tableSchema.fieldNames.contains(field.name))
+        .filter(field => PaimonMetadataColumn.SUPPORTED_METADATA_COLUMNS.contains(field.name))
+    (_tableFields, _metadataFields)
+  }
+
+  lazy val readBuilder: ReadBuilder = {
+    val _readBuilder = table.newReadBuilder()
+    val projection =
+      requiredTableFields.map(field => tableSchema.fieldNames.indexOf(field.name)).toArray
+    _readBuilder.withProjection(projection)
+    if (filters.nonEmpty) {
+      val pushedPredicate = PredicateBuilder.and(filters: _*)
+      _readBuilder.withFilter(pushedPredicate)
+    }
+    pushDownLimit.foreach(_readBuilder.withLimit)
+    _readBuilder
+  }
+
+  final def metadataColumns: Seq[PaimonMetadataColumn] = {
+    metadataFields.map(field => PaimonMetadataColumn.get(field.name, partitionType))
+  }
+
+  override def readSchema(): StructType = {
+    StructType(requiredTableFields ++ metadataFields)
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -20,14 +20,12 @@ package org.apache.paimon.spark
 
 import org.apache.paimon.{stats, CoreOptions}
 import org.apache.paimon.annotation.VisibleForTesting
-import org.apache.paimon.predicate.{Predicate, PredicateBuilder}
+import org.apache.paimon.predicate.Predicate
 import org.apache.paimon.spark.metric.SparkMetricRegistry
-import org.apache.paimon.spark.schema.PaimonMetadataColumn
 import org.apache.paimon.spark.sources.PaimonMicroBatchStream
 import org.apache.paimon.spark.statistics.StatisticsHelper
 import org.apache.paimon.table.{DataTable, FileStoreTable, Table}
-import org.apache.paimon.table.source.{InnerTableScan, ReadBuilder, Split}
-import org.apache.paimon.types.RowType
+import org.apache.paimon.table.source.{InnerTableScan, Split}
 
 import org.apache.spark.sql.connector.metric.{CustomMetric, CustomTaskMetric}
 import org.apache.spark.sql.connector.read.{Batch, Scan, Statistics, SupportsReportStatistics}
@@ -48,21 +46,8 @@ abstract class PaimonBaseScan(
   extends Scan
   with SupportsReportStatistics
   with ScanHelper
+  with ColumnPruningAndPushDown
   with StatisticsHelper {
-
-  val tableRowType: RowType = table.rowType
-
-  private lazy val tableSchema = SparkTypeUtils.fromPaimonRowType(tableRowType)
-
-  private[paimon] val (requiredTableFields, metadataFields) = {
-    val nameToField = tableSchema.map(field => (field.name, field)).toMap
-    val _tableFields = requiredSchema.flatMap(field => nameToField.get(field.name))
-    val _metadataFields =
-      requiredSchema
-        .filterNot(field => tableSchema.fieldNames.contains(field.name))
-        .filter(field => PaimonMetadataColumn.SUPPORTED_METADATA_COLUMNS.contains(field.name))
-    (_tableFields, _metadataFields)
-  }
 
   protected var runtimeFilters: Array[Filter] = Array.empty
 
@@ -77,21 +62,6 @@ abstract class PaimonBaseScan(
   lazy val requiredStatsSchema: StructType = {
     val fieldNames = requiredTableFields.map(_.name) ++ reservedFilters.flatMap(_.references)
     StructType(tableSchema.filter(field => fieldNames.contains(field.name)))
-  }
-
-  lazy val readBuilder: ReadBuilder = {
-    val _readBuilder = table.newReadBuilder()
-
-    val projection =
-      requiredTableFields.map(field => tableSchema.fieldNames.indexOf(field.name)).toArray
-    _readBuilder.withProjection(projection)
-    if (filters.nonEmpty) {
-      val pushedPredicate = PredicateBuilder.and(filters: _*)
-      _readBuilder.withFilter(pushedPredicate)
-    }
-    pushDownLimit.foreach(_readBuilder.withLimit)
-
-    _readBuilder
   }
 
   @VisibleForTesting
@@ -113,17 +83,7 @@ abstract class PaimonBaseScan(
     inputPartitions
   }
 
-  final def partitionType: StructType = {
-    SparkTypeUtils.toSparkPartitionType(table)
-  }
-
-  override def readSchema(): StructType = {
-    StructType(requiredTableFields ++ metadataFields)
-  }
-
   override def toBatch: Batch = {
-    val metadataColumns =
-      metadataFields.map(field => PaimonMetadataColumn.get(field.name, partitionType))
     PaimonBatch(lazyInputPartitions, readBuilder, metadataColumns)
   }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -36,7 +36,7 @@ case class PaimonScan(
     requiredSchema: StructType,
     filters: Seq[Predicate],
     reservedFilters: Seq[Filter],
-    pushDownLimit: Option[Int],
+    override val pushDownLimit: Option[Int],
     bucketedScanDisabled: Boolean = false)
   extends PaimonBaseScan(table, requiredSchema, filters, reservedFilters, pushDownLimit)
   with SupportsRuntimeFiltering

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonSplitScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonSplitScan.scala
@@ -19,35 +19,50 @@
 package org.apache.paimon.spark
 
 import org.apache.paimon.CoreOptions
-import org.apache.paimon.spark.schema.PaimonMetadataColumn
-import org.apache.paimon.table.Table
+import org.apache.paimon.predicate.Predicate
+import org.apache.paimon.table.{KnownSplitsTable, Table}
 import org.apache.paimon.table.source.{DataSplit, Split}
 
 import org.apache.spark.sql.connector.read.{Batch, Scan}
 import org.apache.spark.sql.types.StructType
 
+class PaimonSplitScanBuilder(table: KnownSplitsTable) extends PaimonBaseScanBuilder(table) {
+  override def build(): Scan = {
+    PaimonSplitScan(table, table.splits(), requiredSchema, pushed.map(_._2))
+  }
+}
+
 /** For internal use only. */
 case class PaimonSplitScan(
     table: Table,
     dataSplits: Array[DataSplit],
-    metadataColumns: Seq[PaimonMetadataColumn] = Seq.empty)
-  extends Scan
+    requiredSchema: StructType,
+    filters: Seq[Predicate])
+  extends ColumnPruningAndPushDown
   with ScanHelper {
 
   override val coreOptions: CoreOptions = CoreOptions.fromMap(table.options())
 
-  override def readSchema(): StructType = SparkTypeUtils.fromPaimonRowType(table.rowType())
-
   override def toBatch: Batch = {
     PaimonBatch(
       getInputPartitions(dataSplits.asInstanceOf[Array[Split]]),
-      table.newReadBuilder,
+      readBuilder,
       metadataColumns)
+  }
+
+  override def description(): String = {
+    val pushedFiltersStr = if (filters.nonEmpty) {
+      ", PushedFilters: [" + filters.mkString(",") + "]"
+    } else {
+      ""
+    }
+    s"PaimonSplitScan: [${table.name}]" + pushedFiltersStr
   }
 }
 
 object PaimonSplitScan {
   def apply(table: Table, dataSplits: Array[DataSplit]): PaimonSplitScan = {
-    new PaimonSplitScan(table, dataSplits)
+    val requiredSchema = SparkTypeUtils.fromPaimonRowType(table.rowType)
+    new PaimonSplitScan(table, dataSplits, requiredSchema, Seq.empty)
   }
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkTable.scala
@@ -21,7 +21,7 @@ package org.apache.paimon.spark
 import org.apache.paimon.CoreOptions
 import org.apache.paimon.options.Options
 import org.apache.paimon.spark.schema.PaimonMetadataColumn
-import org.apache.paimon.table.{DataTable, FileStoreTable, Table}
+import org.apache.paimon.table.{DataTable, FileStoreTable, KnownSplitsTable, Table}
 import org.apache.paimon.utils.StringUtils
 
 import org.apache.spark.sql.connector.catalog.{MetadataColumn, SupportsMetadataColumns, SupportsRead, SupportsWrite, TableCapability, TableCatalog}
@@ -91,7 +91,12 @@ case class SparkTable(table: Table)
   }
 
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
-    new PaimonScanBuilder(table.copy(options.asCaseSensitiveMap))
+    table match {
+      case t: KnownSplitsTable =>
+        new PaimonSplitScanBuilder(t)
+      case _ =>
+        new PaimonScanBuilder(table.copy(options.asCaseSensitiveMap))
+    }
   }
 
   override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonTable.scala
@@ -110,7 +110,8 @@ case class MergeIntoPaimonTable(
         createNewScanPlan(
           candidateDataSplits,
           targetOnlyCondition.getOrElse(TrueLiteral),
-          relation))
+          relation,
+          metadataCols))
       val ds = constructChangedRows(
         sparkSession,
         filteredRelation,

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonTable.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.{Column, Dataset, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, BasePredicate, EqualTo, Expression, Literal, Or, UnsafeProjection}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, BasePredicate, Expression, Literal, UnsafeProjection}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.expressions.codegen.GeneratePredicate
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -110,8 +110,7 @@ case class MergeIntoPaimonTable(
         createNewScanPlan(
           candidateDataSplits,
           targetOnlyCondition.getOrElse(TrueLiteral),
-          relation,
-          metadataCols))
+          relation))
       val ds = constructChangedRows(
         sparkSession,
         filteredRelation,

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/UpdatePaimonTableCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/UpdatePaimonTableCommand.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.PaimonUtils.createDataset
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, If}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.logical.{Assignment, Filter, Project, SupportsSubquery}
-import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2ScanRelation}
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.functions.lit
 
 case class UpdatePaimonTableCommand(
@@ -138,10 +138,7 @@ case class UpdatePaimonTableCommand(
         new Column(update).as(origin.name, origin.metadata)
     }
 
-    val toUpdateScanRelation = Compatibility.createDataSourceV2ScanRelation(
-      relation,
-      PaimonSplitScan(table, touchedDataSplits),
-      relation.output)
+    val toUpdateScanRelation = createNewRelation(touchedDataSplits, relation)
     val newPlan = if (condition == TrueLiteral) {
       toUpdateScanRelation
     } else {
@@ -153,7 +150,7 @@ case class UpdatePaimonTableCommand(
 
   private def writeUpdatedAndUnchangedData(
       sparkSession: SparkSession,
-      toUpdateScanRelation: DataSourceV2ScanRelation): Seq[CommitMessage] = {
+      toUpdateScanRelation: DataSourceV2Relation): Seq[CommitMessage] = {
     val updateColumns = updateExpressions.zip(relation.output).map {
       case (update, origin) =>
         val updated = if (condition == TrueLiteral) {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/UpdatePaimonTableCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/UpdatePaimonTableCommand.scala
@@ -18,8 +18,6 @@
 
 package org.apache.paimon.spark.commands
 
-import org.apache.paimon.spark.PaimonSplitScan
-import org.apache.paimon.spark.catalyst.Compatibility
 import org.apache.paimon.spark.catalyst.analysis.AssignmentAlignmentHelper
 import org.apache.paimon.spark.leafnode.PaimonLeafRunnableCommand
 import org.apache.paimon.spark.schema.SparkSystemColumns.ROW_KIND_COL

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/spark/paimon/Utils.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/spark/paimon/Utils.scala
@@ -18,6 +18,7 @@
 
 package org.apache.spark.paimon
 
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.util.{Utils => SparkUtils}
 
 import java.io.File
@@ -29,4 +30,7 @@ object Utils {
 
   def createTempDir: File = SparkUtils.createTempDir()
 
+  def waitUntilEventEmpty(spark: SparkSession): Unit = {
+    spark.sparkContext.listenerBus.waitUntilEmpty()
+  }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

`PaimonSplitScan` is built for internal scan with update/delete/mergeinto. It is used to generate deletion vector, collect touched files, etc. The main usage is to select some metadata columns based on target table, e.g., row index, file path. That says, it does not need to load data columns.

This pr makes `PaimonSplitScan` support column pruning and filter push down to improve performance:
1. introduce `KnownSplitsTable`, it is a `ReadonlyTable` and hold some known data splits
2. introduce `PaimonSplitScanBuilder`, it is used when the table is the `KnownSplitsTable` and build `PaimonSplitScan`

For example:
```
update test set c1 = 9 where c2 = 'a';
```

before:
```
(1) BatchScan default.test
Output [5]: [c1#197, c2#198, c3#199, c4#200, __paimon_file_path#205]
class org.apache.paimon.spark.PaimonSplitScan

(2) Filter [codegen id : 1]
Input [5]: [c1#197, c2#198, c3#199, c4#200, __paimon_file_path#205]
Condition : (c2#198 = a)

(3) Project [codegen id : 1]
Output [1]: [__paimon_file_path#205]
Input [5]: [c1#197, c2#198, c3#199, c4#200, __paimon_file_path#205]
```

after:

```
(1) BatchScan default.test
Output [2]: [c2#137, __paimon_file_path#144]
PaimonSplitScan: [test], PushedFilters: [Equal(c2, a)]

(2) Filter [codegen id : 1]
Input [2]: [c2#137, __paimon_file_path#144]
Condition : (c2#137 = a)

(3) Project [codegen id : 1]
Output [1]: [__paimon_file_path#144]
Input [2]: [c2#137, __paimon_file_path#144]
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
Pass CI

### API and Format

<!-- Does this change affect API or storage format -->
No

### Documentation

<!-- Does this change introduce a new feature -->
