### PR TITLE
[flink] Remove state from append only unaware bucket writer

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -214,7 +214,6 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
                 result.add(committable);
 
                 if (committable.isEmpty()) {
-
                     if (writerCleanChecker.apply(writerContainer)) {
                         // Clear writer if no update, and if its latest modification has committed.
                         //
@@ -246,6 +245,10 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
         return result;
     }
 
+    // This abstract function returns a whole function (instead of just a boolean value),
+    // because we do not want to introduce `commitUser` into this base class.
+    //
+    // For writers with no conflicts, `commitUser` might be some random value.
     protected abstract Function<WriterContainer<T>, Boolean> createWriterCleanChecker();
 
     protected static <T>

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Function;
 
 import static org.apache.paimon.io.DataFileMeta.getMaxSequenceNumber;
 
@@ -64,7 +65,6 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractFileStoreWrite.class);
 
-    private final String commitUser;
     protected final SnapshotManager snapshotManager;
     private final FileStoreScan scan;
     private final int writerNumberMax;
@@ -85,14 +85,12 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
     private boolean isInsertOnly;
 
     protected AbstractFileStoreWrite(
-            String commitUser,
             SnapshotManager snapshotManager,
             FileStoreScan scan,
             @Nullable IndexMaintainer.Factory<T> indexFactory,
             @Nullable DeletionVectorsMaintainer.Factory dvMaintainerFactory,
             String tableName,
             int writerNumberMax) {
-        this.commitUser = commitUser;
         this.snapshotManager = snapshotManager;
         this.scan = scan;
         this.indexFactory = indexFactory;
@@ -169,7 +167,7 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
     @Override
     public List<CommitMessage> prepareCommit(boolean waitCompaction, long commitIdentifier)
             throws Exception {
-        long latestCommittedIdentifier;
+        Function<WriterContainer<T>, Boolean> writerCleanChecker;
         if (writers.values().stream()
                         .map(Map::values)
                         .flatMap(Collection::stream)
@@ -177,20 +175,10 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
                         .max()
                         .orElse(Long.MIN_VALUE)
                 == Long.MIN_VALUE) {
-            // Optimization for the first commit.
-            //
-            // If this is the first commit, no writer has previous modified commit, so the value of
-            // `latestCommittedIdentifier` does not matter.
-            //
-            // Without this optimization, we may need to scan through all snapshots only to find
-            // that there is no previous snapshot by this user, which is very inefficient.
-            latestCommittedIdentifier = Long.MIN_VALUE;
+            // If this is the first commit, no writer should be cleaned.
+            writerCleanChecker = writerContainer -> false;
         } else {
-            latestCommittedIdentifier =
-                    snapshotManager
-                            .latestSnapshotOfUser(commitUser)
-                            .map(Snapshot::commitIdentifier)
-                            .orElse(Long.MIN_VALUE);
+            writerCleanChecker = createWriterCleanChecker();
         }
 
         List<CommitMessage> result = new ArrayList<>();
@@ -226,14 +214,8 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
                 result.add(committable);
 
                 if (committable.isEmpty()) {
-                    // Condition 1: There is no more record waiting to be committed. Note that the
-                    // condition is < (instead of <=), because each commit identifier may have
-                    // multiple snapshots. We must make sure all snapshots of this identifier are
-                    // committed.
-                    // Condition 2: No compaction is in progress. That is, no more changelog will be
-                    // produced.
-                    if (writerContainer.lastModifiedCommitIdentifier < latestCommittedIdentifier
-                            && !writerContainer.writer.isCompacting()) {
+
+                    if (writerCleanChecker.apply(writerContainer)) {
                         // Clear writer if no update, and if its latest modification has committed.
                         //
                         // We need a mechanism to clear writers, otherwise there will be more and
@@ -242,12 +224,10 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
                             LOG.debug(
                                     "Closing writer for partition {}, bucket {}. "
                                             + "Writer's last modified identifier is {}, "
-                                            + "while latest committed identifier is {}, "
-                                            + "current commit identifier is {}.",
+                                            + "while current commit identifier is {}.",
                                     partition,
                                     bucket,
                                     writerContainer.lastModifiedCommitIdentifier,
-                                    latestCommittedIdentifier,
                                     commitIdentifier);
                         }
                         writerContainer.writer.close();
@@ -264,6 +244,37 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
         }
 
         return result;
+    }
+
+    protected abstract Function<WriterContainer<T>, Boolean> createWriterCleanChecker();
+
+    protected static <T>
+            Function<WriterContainer<T>, Boolean> createConflictAwareWriterCleanChecker(
+                    String commitUser, SnapshotManager snapshotManager) {
+        long latestCommittedIdentifier =
+                snapshotManager
+                        .latestSnapshotOfUser(commitUser)
+                        .map(Snapshot::commitIdentifier)
+                        .orElse(Long.MIN_VALUE);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Latest committed identifier is {}", latestCommittedIdentifier);
+        }
+
+        // Condition 1: There is no more record waiting to be committed. Note that the
+        // condition is < (instead of <=), because each commit identifier may have
+        // multiple snapshots. We must make sure all snapshots of this identifier are
+        // committed.
+        //
+        // Condition 2: No compaction is in progress. That is, no more changelog will be
+        // produced.
+        return writerContainer ->
+                writerContainer.lastModifiedCommitIdentifier < latestCommittedIdentifier
+                        && !writerContainer.writer.isCompacting();
+    }
+
+    protected static <T>
+            Function<WriterContainer<T>, Boolean> createNoConflictAwareWriterCleanChecker() {
+        return writerContainer -> true;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
@@ -139,7 +139,7 @@ public abstract class AppendOnlyFileStoreWrite extends MemoryFileStoreWrite<Inte
             int bucket,
             List<DataFileMeta> restoredFiles,
             ExecutorService compactExecutor,
-            @javax.annotation.Nullable DeletionVectorsMaintainer dvMaintainer);
+            @Nullable DeletionVectorsMaintainer dvMaintainer);
 
     public List<DataFileMeta> compactRewrite(
             BinaryRow partition,

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFixedBucketFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFixedBucketFileStoreWrite.java
@@ -75,7 +75,7 @@ public class AppendOnlyFixedBucketFileStoreWrite extends AppendOnlyFileStoreWrit
             int bucket,
             List<DataFileMeta> restoredFiles,
             ExecutorService compactExecutor,
-            @javax.annotation.Nullable DeletionVectorsMaintainer dvMaintainer) {
+            @Nullable DeletionVectorsMaintainer dvMaintainer) {
         if (options.writeOnly()) {
             return new NoopCompactManager();
         } else {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFixedBucketFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFixedBucketFileStoreWrite.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.operation;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.append.BucketedAppendCompactManager;
+import org.apache.paimon.compact.CompactManager;
+import org.apache.paimon.compact.NoopCompactManager;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.deletionvectors.DeletionVector;
+import org.apache.paimon.deletionvectors.DeletionVectorsMaintainer;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.SnapshotManager;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
+
+/** {@link AppendOnlyFileStoreWrite} for {@link org.apache.paimon.table.BucketMode#HASH_FIXED}. */
+public class AppendOnlyFixedBucketFileStoreWrite extends AppendOnlyFileStoreWrite {
+
+    private final String commitUser;
+
+    public AppendOnlyFixedBucketFileStoreWrite(
+            FileIO fileIO,
+            RawFileSplitRead read,
+            long schemaId,
+            String commitUser,
+            RowType rowType,
+            FileStorePathFactory pathFactory,
+            SnapshotManager snapshotManager,
+            FileStoreScan scan,
+            CoreOptions options,
+            @Nullable DeletionVectorsMaintainer.Factory dvMaintainerFactory,
+            String tableName) {
+        super(
+                fileIO,
+                read,
+                schemaId,
+                rowType,
+                pathFactory,
+                snapshotManager,
+                scan,
+                options,
+                dvMaintainerFactory,
+                tableName);
+        this.commitUser = commitUser;
+    }
+
+    @Override
+    protected CompactManager getCompactManager(
+            BinaryRow partition,
+            int bucket,
+            List<DataFileMeta> restoredFiles,
+            ExecutorService compactExecutor,
+            @javax.annotation.Nullable DeletionVectorsMaintainer dvMaintainer) {
+        if (options.writeOnly()) {
+            return new NoopCompactManager();
+        } else {
+            Function<String, DeletionVector> dvFactory =
+                    dvMaintainer != null
+                            ? f -> dvMaintainer.deletionVectorOf(f).orElse(null)
+                            : null;
+            return new BucketedAppendCompactManager(
+                    compactExecutor,
+                    restoredFiles,
+                    dvMaintainer,
+                    options.compactionMinFileNum(),
+                    options.compactionMaxFileNum().orElse(5),
+                    options.targetFileSize(false),
+                    files -> compactRewrite(partition, bucket, dvFactory, files),
+                    compactionMetrics == null
+                            ? null
+                            : compactionMetrics.createReporter(partition, bucket));
+        }
+    }
+
+    @Override
+    protected Function<WriterContainer<InternalRow>, Boolean> createWriterCleanChecker() {
+        return createConflictAwareWriterCleanChecker(commitUser, snapshotManager);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyUnawareBucketFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyUnawareBucketFileStoreWrite.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.operation;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.compact.CompactManager;
+import org.apache.paimon.compact.NoopCompactManager;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.deletionvectors.DeletionVectorsMaintainer;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.SnapshotManager;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
+
+/**
+ * {@link AppendOnlyFileStoreWrite} for {@link org.apache.paimon.table.BucketMode#BUCKET_UNAWARE}.
+ */
+public class AppendOnlyUnawareBucketFileStoreWrite extends AppendOnlyFileStoreWrite {
+
+    public AppendOnlyUnawareBucketFileStoreWrite(
+            FileIO fileIO,
+            RawFileSplitRead read,
+            long schemaId,
+            RowType rowType,
+            FileStorePathFactory pathFactory,
+            SnapshotManager snapshotManager,
+            FileStoreScan scan,
+            CoreOptions options,
+            @Nullable DeletionVectorsMaintainer.Factory dvMaintainerFactory,
+            String tableName) {
+        super(
+                fileIO,
+                read,
+                schemaId,
+                rowType,
+                pathFactory,
+                snapshotManager,
+                scan,
+                options,
+                dvMaintainerFactory,
+                tableName);
+        super.withIgnorePreviousFiles(true);
+    }
+
+    @Override
+    protected CompactManager getCompactManager(
+            BinaryRow partition,
+            int bucket,
+            List<DataFileMeta> restoredFiles,
+            ExecutorService compactExecutor,
+            @Nullable DeletionVectorsMaintainer dvMaintainer) {
+        return new NoopCompactManager();
+    }
+
+    @Override
+    public void withIgnorePreviousFiles(boolean ignorePrevious) {
+        // in unaware bucket mode, we need all writers to be empty
+        super.withIgnorePreviousFiles(true);
+    }
+
+    @Override
+    protected Function<WriterContainer<InternalRow>, Boolean> createWriterCleanChecker() {
+        return createNoConflictAwareWriterCleanChecker();
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -83,6 +83,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.apache.paimon.CoreOptions.ChangelogProducer.FULL_COMPACTION;
@@ -106,6 +107,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
     private final RowType keyType;
     private final RowType valueType;
     private final RowType partitionType;
+    private final String commitUser;
     @Nullable private final RecordLevelExpire recordLevelExpire;
     @Nullable private Cache<String, LookupFile> lookupFileCache;
 
@@ -131,7 +133,6 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
             KeyValueFieldsExtractor extractor,
             String tableName) {
         super(
-                commitUser,
                 snapshotManager,
                 scan,
                 options,
@@ -142,6 +143,8 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
         this.partitionType = partitionType;
         this.keyType = keyType;
         this.valueType = valueType;
+        this.commitUser = commitUser;
+
         this.udsComparatorSupplier = udsComparatorSupplier;
         this.readerFactoryBuilder =
                 KeyValueFileReaderFactory.builder(
@@ -387,6 +390,11 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                 lookupStoreFactory,
                 bfGenerator(options),
                 lookupFileCache);
+    }
+
+    @Override
+    protected Function<WriterContainer<KeyValue>, Boolean> createWriterCleanChecker() {
+        return createConflictAwareWriterCleanChecker(commitUser, snapshotManager);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/operation/MemoryFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/MemoryFileStoreWrite.java
@@ -59,7 +59,6 @@ public abstract class MemoryFileStoreWrite<T> extends AbstractFileStoreWrite<T> 
     private WriterBufferMetric writerBufferMetric;
 
     public MemoryFileStoreWrite(
-            String commitUser,
             SnapshotManager snapshotManager,
             FileStoreScan scan,
             CoreOptions options,
@@ -67,7 +66,6 @@ public abstract class MemoryFileStoreWrite<T> extends AbstractFileStoreWrite<T> 
             @Nullable DeletionVectorsMaintainer.Factory dvMaintainerFactory,
             String tableName) {
         super(
-                commitUser,
                 snapshotManager,
                 scan,
                 indexFactory,

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperator.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperator.java
@@ -28,6 +28,7 @@ import org.apache.paimon.flink.sink.StateUtils;
 import org.apache.paimon.flink.sink.StoreSinkWrite;
 import org.apache.paimon.flink.sink.StoreSinkWriteImpl;
 import org.apache.paimon.flink.sink.StoreSinkWriteState;
+import org.apache.paimon.flink.sink.StoreSinkWriteStateImpl;
 import org.apache.paimon.memory.HeapMemorySegmentPool;
 import org.apache.paimon.memory.MemoryPoolFactory;
 import org.apache.paimon.options.Options;
@@ -98,7 +99,7 @@ public class CdcRecordStoreMultiWriteOperator
                         context, "commit_user_state", String.class, initialCommitUser);
 
         // TODO: should use CdcRecordMultiChannelComputer to filter
-        state = new StoreSinkWriteState(context, (tableName, partition, bucket) -> true);
+        state = new StoreSinkWriteStateImpl(context, (tableName, partition, bucket) -> true);
         tables = new HashMap<>();
         writes = new HashMap<>();
         compactExecutor =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
@@ -95,15 +95,15 @@ public class MultiTablesStoreCompactOperator
 
         catalog = catalogLoader.load();
 
-        // Each job can only have one user name and this name must be consistent across restarts.
-        // We cannot use job id as commit user name here because user may change job id by creating
+        // Each job can only have one username and this name must be consistent across restarts.
+        // We cannot use job id as commit username here because user may change job id by creating
         // a savepoint, stop the job and then resume from savepoint.
         commitUser =
                 StateUtils.getSingleValueFromState(
                         context, "commit_user_state", String.class, initialCommitUser);
 
         state =
-                new StoreSinkWriteState(
+                new StoreSinkWriteStateImpl(
                         context,
                         (tableName, partition, bucket) ->
                                 ChannelComputer.select(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/NoopStoreSinkWriteState.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/NoopStoreSinkWriteState.java
@@ -20,7 +20,6 @@ package org.apache.paimon.flink.sink;
 
 import javax.annotation.Nullable;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -42,11 +41,13 @@ public class NoopStoreSinkWriteState implements StoreSinkWriteState {
 
     @Override
     public @Nullable List<StateValue> get(String tableName, String key) {
-        return Collections.emptyList();
+        throw new UnsupportedOperationException();
     }
 
     @Override
-    public void put(String tableName, String key, List<StateValue> stateValues) {}
+    public void put(String tableName, String key, List<StateValue> stateValues) {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
     public void snapshotState() throws Exception {}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/NoopStoreSinkWriteState.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/NoopStoreSinkWriteState.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link StoreSinkWriteState} which stores nothing. Currently only used for append only unaware
+ * bucket table writers.
+ */
+public class NoopStoreSinkWriteState implements StoreSinkWriteState {
+
+    private final StateValueFilter stateValueFilter;
+
+    public NoopStoreSinkWriteState(StateValueFilter stateValueFilter) {
+        this.stateValueFilter = stateValueFilter;
+    }
+
+    @Override
+    public StateValueFilter stateValueFilter() {
+        return stateValueFilter;
+    }
+
+    @Override
+    public @Nullable List<StateValue> get(String tableName, String key) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void put(String tableName, String key, List<StateValue> stateValues) {}
+
+    @Override
+    public void snapshotState() throws Exception {}
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowUnawareBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowUnawareBucketSink.java
@@ -51,6 +51,13 @@ public class RowUnawareBucketSink extends UnawareBucketSink<InternalRow> {
                 // needed.
                 return new NoopStoreSinkWriteState(stateFilter);
             }
+
+            @Override
+            protected String getCommitUser(StateInitializationContext context) throws Exception {
+                // No conflicts will occur in append only unaware bucket writer, so commitUser does
+                // not matter.
+                return commitUser;
+            }
         };
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowUnawareBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowUnawareBucketSink.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink.sink;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.table.FileStoreTable;
 
+import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 
 import java.util.Map;
@@ -39,6 +40,17 @@ public class RowUnawareBucketSink extends UnawareBucketSink<InternalRow> {
     @Override
     protected OneInputStreamOperator<InternalRow, Committable> createWriteOperator(
             StoreSinkWrite.Provider writeProvider, String commitUser) {
-        return new RowDataStoreWriteOperator(table, logSinkFunction, writeProvider, commitUser);
+        return new RowDataStoreWriteOperator(table, logSinkFunction, writeProvider, commitUser) {
+
+            @Override
+            protected StoreSinkWriteState createState(
+                    StateInitializationContext context,
+                    StoreSinkWriteState.StateValueFilter stateFilter)
+                    throws Exception {
+                // No conflicts will occur in append only unaware bucket writer, so no state is
+                // needed.
+                return new NoopStoreSinkWriteState(stateFilter);
+            }
+        };
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWrite.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWrite.java
@@ -84,6 +84,10 @@ public interface StoreSinkWrite {
     @FunctionalInterface
     interface Provider extends Serializable {
 
+        /**
+         * TODO: The argument list has become too complicated. Build {@link TableWriteImpl} directly
+         * in caller and simplify the argument list.
+         */
         StoreSinkWrite provide(
                 FileStoreTable table,
                 String commitUser,
@@ -97,6 +101,10 @@ public interface StoreSinkWrite {
     @FunctionalInterface
     interface WithWriteBufferProvider extends Serializable {
 
+        /**
+         * TODO: The argument list has become too complicated. Build {@link TableWriteImpl} directly
+         * in caller and simplify the argument list.
+         */
         StoreSinkWrite provide(
                 FileStoreTable table,
                 String commitUser,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteStateImpl.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteStateImpl.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.utils.SerializationUtils;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
+import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
+import org.apache.flink.runtime.state.StateInitializationContext;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Default implementation for {@link StoreSinkWriteState}.
+ *
+ * <p>States are positioned first by table name and then by key name. This class should be initiated
+ * in a sink operator and then given to {@link StoreSinkWrite}.
+ */
+public class StoreSinkWriteStateImpl implements StoreSinkWriteState {
+
+    private final StoreSinkWriteState.StateValueFilter stateValueFilter;
+
+    private final ListState<Tuple5<String, String, byte[], Integer, byte[]>> listState;
+    private final Map<String, Map<String, List<StoreSinkWriteState.StateValue>>> map;
+
+    @SuppressWarnings("unchecked")
+    public StoreSinkWriteStateImpl(
+            StateInitializationContext context,
+            StoreSinkWriteState.StateValueFilter stateValueFilter)
+            throws Exception {
+        this.stateValueFilter = stateValueFilter;
+        TupleSerializer<Tuple5<String, String, byte[], Integer, byte[]>> listStateSerializer =
+                new TupleSerializer<>(
+                        (Class<Tuple5<String, String, byte[], Integer, byte[]>>)
+                                (Class<?>) Tuple5.class,
+                        new TypeSerializer[] {
+                            StringSerializer.INSTANCE,
+                            StringSerializer.INSTANCE,
+                            BytePrimitiveArraySerializer.INSTANCE,
+                            IntSerializer.INSTANCE,
+                            BytePrimitiveArraySerializer.INSTANCE
+                        });
+        listState =
+                context.getOperatorStateStore()
+                        .getUnionListState(
+                                new ListStateDescriptor<>(
+                                        "paimon_store_sink_write_state", listStateSerializer));
+
+        map = new HashMap<>();
+        for (Tuple5<String, String, byte[], Integer, byte[]> tuple : listState.get()) {
+            BinaryRow partition = SerializationUtils.deserializeBinaryRow(tuple.f2);
+            if (stateValueFilter.filter(tuple.f0, partition, tuple.f3)) {
+                map.computeIfAbsent(tuple.f0, k -> new HashMap<>())
+                        .computeIfAbsent(tuple.f1, k -> new ArrayList<>())
+                        .add(new StoreSinkWriteState.StateValue(partition, tuple.f3, tuple.f4));
+            }
+        }
+    }
+
+    @Override
+    public StoreSinkWriteState.StateValueFilter stateValueFilter() {
+        return stateValueFilter;
+    }
+
+    @Override
+    public @Nullable List<StoreSinkWriteState.StateValue> get(String tableName, String key) {
+        Map<String, List<StoreSinkWriteState.StateValue>> innerMap = map.get(tableName);
+        return innerMap == null ? null : innerMap.get(key);
+    }
+
+    public void put(
+            String tableName, String key, List<StoreSinkWriteState.StateValue> stateValues) {
+        map.computeIfAbsent(tableName, k -> new HashMap<>()).put(key, stateValues);
+    }
+
+    public void snapshotState() throws Exception {
+        List<Tuple5<String, String, byte[], Integer, byte[]>> list = new ArrayList<>();
+        for (Map.Entry<String, Map<String, List<StoreSinkWriteState.StateValue>>> tables :
+                map.entrySet()) {
+            for (Map.Entry<String, List<StoreSinkWriteState.StateValue>> entry :
+                    tables.getValue().entrySet()) {
+                for (StoreSinkWriteState.StateValue stateValue : entry.getValue()) {
+                    list.add(
+                            Tuple5.of(
+                                    tables.getKey(),
+                                    entry.getKey(),
+                                    SerializationUtils.serializeBinaryRow(stateValue.partition()),
+                                    stateValue.bucket(),
+                                    stateValue.value()));
+                }
+            }
+        }
+        listState.update(list);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/TableWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/TableWriteOperator.java
@@ -38,7 +38,7 @@ public abstract class TableWriteOperator<IN> extends PrepareCommitOperator<IN, C
     private final StoreSinkWrite.Provider storeSinkWriteProvider;
     private final String initialCommitUser;
 
-    protected transient StoreSinkWriteState state;
+    private transient StoreSinkWriteState state;
     protected transient StoreSinkWrite write;
 
     public TableWriteOperator(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
@@ -18,9 +18,6 @@
 
 package org.apache.paimon.flink;
 
-import org.apache.flink.runtime.state.FunctionInitializationContext;
-import org.apache.flink.runtime.state.FunctionSnapshotContext;
-import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.Path;

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
@@ -381,7 +381,6 @@ public class UnawareBucketAppendOnlyTableITCase extends CatalogITCaseBase {
         tEnv.executeSql("INSERT INTO append_table SELECT id, 'test' FROM S").await();
         assertThat(batchSql("SELECT * FROM append_table"))
                 .containsExactlyInAnyOrder(Row.of(1, "test"), Row.of(2, "test"));
-        System.out.println(table.snapshotManager().latestSnapshotId());
     }
 
     private static class TestStatelessWriterSource extends RichParallelSourceFunction<Integer> {


### PR DESCRIPTION
### Purpose

Currently Paimon writer operators in Flink have states, which record the `commitUser` (for all writers) and the list of active buckets (for lookup or full-compaction changelog producer). These states prevent a writer object to be closed too early and cause conflicts.

However for append only unaware bucket writers, because they only create new files, there is no conflict. So for these writers we can remove Flink state. This optimization is also useful for bounded stream jobs, because when chaining source and write operator together, if some source parallelism have finished, checkpoint cannot be performed if there are union list states in the operators which are still running.

### Tests

IT case.

### API and Format

No format changes.

### Documentation

No new feature.
