### PR TITLE
[cdc] Avoid duplicate schema file generation

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SynchronizationActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SynchronizationActionBase.java
@@ -198,6 +198,10 @@ public abstract class SynchronizationActionBase extends ActionBase {
                                         || Objects.equals(
                                                 oldOptions.get(entry.getKey()), entry.getValue()));
 
+        if (dynamicOptions.isEmpty()) {
+            return table;
+        }
+
         // alter the table dynamic options
         List<SchemaChange> optionChanges =
                 dynamicOptions.entrySet().stream()


### PR DESCRIPTION
### Purpose

When the Flink CDC job is restarted and the table options have not changed, avoid regenerating the schema file

### Tests

Existing tests should cover this change.


### API and Format

No format changes.

### Documentation

No new feature.