### PR TITLE
[flink] Set default parallelism for sink in cases where AQE not supported

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -53,30 +53,22 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
     public void testAQEWithWriteManifest() {
         batchSql("ALTER TABLE T SET ('write-manifest-cache' = '1 mb')");
         batchSql("INSERT INTO T VALUES (1, 11, 111), (2, 22, 222)");
-        assertThatThrownBy(() -> batchSql("INSERT INTO T SELECT a, b, c FROM T GROUP BY a,b,c"))
-                .hasMessageContaining(
-                        "Paimon Sink with [Write Manifest Cache] does not support Flink's Adaptive Parallelism mode.");
-
-        // work fine
-        batchSql(
-                "INSERT INTO T /*+ OPTIONS('sink.parallelism'='1') */ SELECT a, b, c FROM T GROUP BY a,b,c");
-
-        // work fine too
-        batchSql("ALTER TABLE T SET ('write-manifest-cache' = '0 b')");
         batchSql("INSERT INTO T SELECT a, b, c FROM T GROUP BY a,b,c");
+        assertThat(batchSql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(
+                        Row.of(1, 11, 111),
+                        Row.of(2, 22, 222),
+                        Row.of(1, 11, 111),
+                        Row.of(2, 22, 222));
     }
 
     @Test
     public void testAQEWithDynamicBucket() {
         batchSql("CREATE TABLE IF NOT EXISTS D_T (a INT PRIMARY KEY NOT ENFORCED, b INT, c INT)");
         batchSql("INSERT INTO T VALUES (1, 11, 111), (2, 22, 222)");
-        assertThatThrownBy(() -> batchSql("INSERT INTO D_T SELECT a, b, c FROM T GROUP BY a,b,c"))
-                .hasMessageContaining(
-                        "Paimon Sink with [Dynamic Bucket Mode] does not support Flink's Adaptive Parallelism mode.");
-
-        // work fine
-        batchSql(
-                "INSERT INTO D_T /*+ OPTIONS('sink.parallelism'='1') */ SELECT a, b, c FROM T GROUP BY a,b,c");
+        batchSql("INSERT INTO D_T SELECT a, b, c FROM T GROUP BY a,b,c");
+        assertThat(batchSql("SELECT * FROM D_T"))
+                .containsExactlyInAnyOrder(Row.of(1, 11, 111), Row.of(2, 22, 222));
     }
 
     @Test


### PR DESCRIPTION
### Purpose

This PR provides default parallelism configuration for sink operators, in cases where undefined/adaptive parallelism has not been supported.

### Tests

Existing UTs are modified to verify that the cases mentioned above can function correctly now.

### API and Format

No API or format is changed

### Documentation

No documentation needed. The existing unsupported cases had not been documented, so no modification needed for documents.
