### PR TITLE
[spark] Support migrate database procedure for spark

### DIFF
--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -140,7 +140,7 @@ This section introduce all available spark procedures about paimon.
             <li>options_map: Options map for adding key-value options which is a map.</li>
             <li>parallelism: the parallelism for migrate process, default is core numbers of machine.</li>
       </td>
-      <td>CALL sys.migrate_database(source_type => 'hive', db => 'db01', options => 'file.format=parquet', options_map => map('k1','v1'), parallelism => 6)</td>
+      <td>CALL sys.migrate_database(source_type => 'hive', database => 'db01', options => 'file.format=parquet', options_map => map('k1','v1'), parallelism => 6)</td>
     </tr>
     <tr>
       <td>migrate_table</td>

--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -131,6 +131,18 @@ This section introduce all available spark procedures about paimon.
       </td>
     </tr>
     <tr>
+      <td>migrate_database</td>
+      <td>
+         Migrate hive table to a paimon table. Arguments:
+            <li>source_type: the origin table's type to be migrated, such as hive. Cannot be empty.</li>
+            <li>database: name of the origin database to be migrated. Cannot be empty.</li>
+            <li>options: the table options of the paimon table to migrate.</li>
+            <li>options_map: Options map for adding key-value options which is a map.</li>
+            <li>parallelism: the parallelism for migrate process, default is core numbers of machine.</li>
+      </td>
+      <td>CALL sys.migrate_table(source_type => 'hive', table => 'default.T', options => 'file.format=parquet', options_map => map('k1','v1'), parallelism => 6)</td>
+    </tr>
+    <tr>
       <td>migrate_table</td>
       <td>
          Migrate hive table to a paimon table. Arguments:

--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -140,7 +140,7 @@ This section introduce all available spark procedures about paimon.
             <li>options_map: Options map for adding key-value options which is a map.</li>
             <li>parallelism: the parallelism for migrate process, default is core numbers of machine.</li>
       </td>
-      <td>CALL sys.migrate_database(source_type => 'hive', table => 'db', options => 'file.format=parquet', options_map => map('k1','v1'), parallelism => 6)</td>
+      <td>CALL sys.migrate_database(source_type => 'hive', db => 'db01', options => 'file.format=parquet', options_map => map('k1','v1'), parallelism => 6)</td>
     </tr>
     <tr>
       <td>migrate_table</td>

--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -140,7 +140,7 @@ This section introduce all available spark procedures about paimon.
             <li>options_map: Options map for adding key-value options which is a map.</li>
             <li>parallelism: the parallelism for migrate process, default is core numbers of machine.</li>
       </td>
-      <td>CALL sys.migrate_table(source_type => 'hive', table => 'default.T', options => 'file.format=parquet', options_map => map('k1','v1'), parallelism => 6)</td>
+      <td>CALL sys.migrate_database(source_type => 'hive', table => 'db', options => 'file.format=parquet', options_map => map('k1','v1'), parallelism => 6)</td>
     </tr>
     <tr>
       <td>migrate_table</td>

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
@@ -23,11 +23,15 @@ import org.apache.paimon.migrate.Migrator;
 import org.apache.paimon.utils.ParameterUtils;
 
 import org.apache.flink.table.procedure.ProcedureContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 /** Migrate procedure to migrate all hive tables in database to paimon table. */
 public class MigrateDatabaseProcedure extends ProcedureBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MigrateDatabaseProcedure.class);
 
     @Override
     public String identifier() {
@@ -54,12 +58,25 @@ public class MigrateDatabaseProcedure extends ProcedureBase {
                         Runtime.getRuntime().availableProcessors(),
                         ParameterUtils.parseCommaSeparatedKeyValues(properties));
 
-        for (Migrator migrator : migrators) {
-            migrator.executeMigrate();
-            migrator.renameTable(false);
-        }
+        int errorCount = 0;
+        int successCount = 0;
 
-        return new String[] {"Success"};
+        for (Migrator migrator : migrators) {
+            try {
+                migrator.executeMigrate();
+                migrator.renameTable(false);
+                successCount++;
+            } catch (Exception e) {
+                errorCount++;
+                LOG.error("Call migrate_database error:" + e.getMessage());
+            }
+        }
+        String retStr =
+                String.format(
+                        "migrate database is finished, success cnt: %s , failed cnt: %s",
+                        String.valueOf(successCount), String.valueOf(errorCount));
+
+        return new String[] {retStr};
     }
 
     public String[] call(
@@ -78,11 +95,24 @@ public class MigrateDatabaseProcedure extends ProcedureBase {
                         p,
                         ParameterUtils.parseCommaSeparatedKeyValues(properties));
 
-        for (Migrator migrator : migrators) {
-            migrator.executeMigrate();
-            migrator.renameTable(false);
-        }
+        int errorCount = 0;
+        int successCount = 0;
 
-        return new String[] {"Success"};
+        for (Migrator migrator : migrators) {
+            try {
+                migrator.executeMigrate();
+                migrator.renameTable(false);
+                successCount++;
+            } catch (Exception e) {
+                errorCount++;
+                LOG.error("Call migrate_database error:" + e.getMessage());
+            }
+        }
+        String retStr =
+                String.format(
+                        "migrate database is finished, success cnt: %s , failed cnt: %s",
+                        String.valueOf(successCount), String.valueOf(errorCount));
+
+        return new String[] {retStr};
     }
 }

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
@@ -58,24 +58,7 @@ public class MigrateDatabaseProcedure extends ProcedureBase {
                         Runtime.getRuntime().availableProcessors(),
                         ParameterUtils.parseCommaSeparatedKeyValues(properties));
 
-        int errorCount = 0;
-        int successCount = 0;
-
-        for (Migrator migrator : migrators) {
-            try {
-                migrator.executeMigrate();
-                migrator.renameTable(false);
-                successCount++;
-            } catch (Exception e) {
-                errorCount++;
-                LOG.error("Call migrate_database error:" + e.getMessage());
-            }
-        }
-        String retStr =
-                String.format(
-                        "migrate database is finished, success cnt: %s , failed cnt: %s",
-                        String.valueOf(successCount), String.valueOf(errorCount));
-
+        String retStr = handleMigrators(migrators);
         return new String[] {retStr};
     }
 
@@ -95,6 +78,11 @@ public class MigrateDatabaseProcedure extends ProcedureBase {
                         p,
                         ParameterUtils.parseCommaSeparatedKeyValues(properties));
 
+        String retStr = handleMigrators(migrators);
+        return new String[] {retStr};
+    }
+
+    public String handleMigrators(List<Migrator> migrators) {
         int errorCount = 0;
         int successCount = 0;
 
@@ -112,7 +100,6 @@ public class MigrateDatabaseProcedure extends ProcedureBase {
                 String.format(
                         "migrate database is finished, success cnt: %s , failed cnt: %s",
                         String.valueOf(successCount), String.valueOf(errorCount));
-
-        return new String[] {retStr};
+        return retStr;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateDatabaseProcedure.java
@@ -26,11 +26,15 @@ import org.apache.flink.table.annotation.ArgumentHint;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.annotation.ProcedureHint;
 import org.apache.flink.table.procedure.ProcedureContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 /** Migrate procedure to migrate all hive tables in database to paimon table. */
 public class MigrateDatabaseProcedure extends ProcedureBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MigrateDatabaseProcedure.class);
 
     @Override
     public String identifier() {
@@ -64,11 +68,24 @@ public class MigrateDatabaseProcedure extends ProcedureBase {
                         p,
                         ParameterUtils.parseCommaSeparatedKeyValues(properties));
 
-        for (Migrator migrator : migrators) {
-            migrator.executeMigrate();
-            migrator.renameTable(false);
-        }
+        int errorCount = 0;
+        int successCount = 0;
 
-        return new String[] {"Success"};
+        for (Migrator migrator : migrators) {
+            try {
+                migrator.executeMigrate();
+                migrator.renameTable(false);
+                successCount++;
+            } catch (Exception e) {
+                errorCount++;
+                LOG.error("Call migrate_database error:" + e.getMessage());
+            }
+        }
+        String retStr =
+                String.format(
+                        "migrate database is finished, success cnt: %s , failed cnt: %s",
+                        String.valueOf(successCount), String.valueOf(errorCount));
+
+        return new String[] {retStr};
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkProcedures.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkProcedures.java
@@ -18,24 +18,7 @@
 
 package org.apache.paimon.spark;
 
-import org.apache.paimon.spark.procedure.CompactProcedure;
-import org.apache.paimon.spark.procedure.CreateBranchProcedure;
-import org.apache.paimon.spark.procedure.CreateTagFromTimestampProcedure;
-import org.apache.paimon.spark.procedure.CreateTagProcedure;
-import org.apache.paimon.spark.procedure.DeleteBranchProcedure;
-import org.apache.paimon.spark.procedure.DeleteTagProcedure;
-import org.apache.paimon.spark.procedure.ExpirePartitionsProcedure;
-import org.apache.paimon.spark.procedure.ExpireSnapshotsProcedure;
-import org.apache.paimon.spark.procedure.FastForwardProcedure;
-import org.apache.paimon.spark.procedure.MarkPartitionDoneProcedure;
-import org.apache.paimon.spark.procedure.MigrateFileProcedure;
-import org.apache.paimon.spark.procedure.MigrateTableProcedure;
-import org.apache.paimon.spark.procedure.Procedure;
-import org.apache.paimon.spark.procedure.ProcedureBuilder;
-import org.apache.paimon.spark.procedure.RemoveOrphanFilesProcedure;
-import org.apache.paimon.spark.procedure.RepairProcedure;
-import org.apache.paimon.spark.procedure.ResetConsumerProcedure;
-import org.apache.paimon.spark.procedure.RollbackProcedure;
+import org.apache.paimon.spark.procedure.*;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 
@@ -66,6 +49,7 @@ public class SparkProcedures {
         procedureBuilders.put("create_branch", CreateBranchProcedure::builder);
         procedureBuilders.put("delete_branch", DeleteBranchProcedure::builder);
         procedureBuilders.put("compact", CompactProcedure::builder);
+        procedureBuilders.put("migrate_database", MigrateDatabaseProcedure::builder);
         procedureBuilders.put("migrate_table", MigrateTableProcedure::builder);
         procedureBuilders.put("migrate_file", MigrateFileProcedure::builder);
         procedureBuilders.put("remove_orphan_files", RemoveOrphanFilesProcedure::builder);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkProcedures.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkProcedures.java
@@ -18,7 +18,25 @@
 
 package org.apache.paimon.spark;
 
-import org.apache.paimon.spark.procedure.*;
+import org.apache.paimon.spark.procedure.CompactProcedure;
+import org.apache.paimon.spark.procedure.CreateBranchProcedure;
+import org.apache.paimon.spark.procedure.CreateTagFromTimestampProcedure;
+import org.apache.paimon.spark.procedure.CreateTagProcedure;
+import org.apache.paimon.spark.procedure.DeleteBranchProcedure;
+import org.apache.paimon.spark.procedure.DeleteTagProcedure;
+import org.apache.paimon.spark.procedure.ExpirePartitionsProcedure;
+import org.apache.paimon.spark.procedure.ExpireSnapshotsProcedure;
+import org.apache.paimon.spark.procedure.FastForwardProcedure;
+import org.apache.paimon.spark.procedure.MarkPartitionDoneProcedure;
+import org.apache.paimon.spark.procedure.MigrateDatabaseProcedure;
+import org.apache.paimon.spark.procedure.MigrateFileProcedure;
+import org.apache.paimon.spark.procedure.MigrateTableProcedure;
+import org.apache.paimon.spark.procedure.Procedure;
+import org.apache.paimon.spark.procedure.ProcedureBuilder;
+import org.apache.paimon.spark.procedure.RemoveOrphanFilesProcedure;
+import org.apache.paimon.spark.procedure.RepairProcedure;
+import org.apache.paimon.spark.procedure.ResetConsumerProcedure;
+import org.apache.paimon.spark.procedure.RollbackProcedure;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateDatabaseProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateDatabaseProcedure.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.procedure;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.migrate.Migrator;
+import org.apache.paimon.spark.catalog.WithPaimonCatalog;
+import org.apache.paimon.spark.utils.TableMigrationUtils;
+import org.apache.paimon.utils.ParameterUtils;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.util.MapData;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.spark.sql.types.DataTypes.*;
+
+/**
+ * Migrate database procedure. Usage:
+ *
+ * <pre><code>
+ *  CALL sys.migrate_database(source_type => 'hive', database => 'db01', options => 'x1=y1,x2=y2')
+ * </code></pre>
+ */
+public class MigrateDatabaseProcedure extends BaseProcedure {
+
+    private static final ProcedureParameter[] PARAMETERS =
+            new ProcedureParameter[] {
+                ProcedureParameter.required("source_type", StringType),
+                ProcedureParameter.required("database", StringType),
+                ProcedureParameter.optional("options", StringType),
+                ProcedureParameter.optional(
+                        "options_map", DataTypes.createMapType(StringType, StringType)),
+                ProcedureParameter.optional("parallelism", IntegerType),
+            };
+
+    private static final StructType OUTPUT_TYPE =
+            new StructType(
+                    new StructField[] {
+                        new StructField("result", DataTypes.BooleanType, true, Metadata.empty())
+                    });
+
+    protected MigrateDatabaseProcedure(TableCatalog tableCatalog) {
+        super(tableCatalog);
+    }
+
+    @Override
+    public ProcedureParameter[] parameters() {
+        return PARAMETERS;
+    }
+
+    @Override
+    public StructType outputType() {
+        return OUTPUT_TYPE;
+    }
+
+    @Override
+    public InternalRow[] call(InternalRow args) {
+        String format = args.getString(0);
+        String database = args.getString(1);
+        String properties = args.isNullAt(2) ? null : args.getString(2);
+        MapData mapData = args.isNullAt(3) ? null : args.getMap(3);
+        Map<String, String> optionMap = mapDataToHashMap(mapData);
+        int parallelism =
+                args.isNullAt(4) ? Runtime.getRuntime().availableProcessors() : args.getInt(4);
+
+        Catalog paimonCatalog = ((WithPaimonCatalog) tableCatalog()).paimonCatalog();
+
+        Map<String, String> options = ParameterUtils.parseCommaSeparatedKeyValues(properties);
+        options.putAll(optionMap);
+
+        try {
+            List<Migrator> migrators =
+                    TableMigrationUtils.getImporters(
+                            format, paimonCatalog, database, parallelism, options);
+
+            for (Migrator migrator : migrators) {
+                migrator.executeMigrate();
+                migrator.renameTable(false);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Call migrate_database error: " + e.getMessage(), e);
+        }
+
+        return new InternalRow[] {newInternalRow(true)};
+    }
+
+    public static Map<String, String> mapDataToHashMap(MapData mapData) {
+        HashMap<String, String> map = new HashMap<>();
+        if (mapData != null) {
+            for (int index = 0; index < mapData.numElements(); index++) {
+                map.put(
+                        mapData.keyArray().getUTF8String(index).toString(),
+                        mapData.valueArray().getUTF8String(index).toString());
+            }
+        }
+        return map;
+    }
+
+    public static ProcedureBuilder builder() {
+        return new BaseProcedure.Builder<MigrateDatabaseProcedure>() {
+            @Override
+            public MigrateDatabaseProcedure doBuild() {
+                return new MigrateDatabaseProcedure(tableCatalog());
+            }
+        };
+    }
+
+    @Override
+    public String description() {
+        return "MigrateDatabaseProcedure";
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateDatabaseProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateDatabaseProcedure.java
@@ -36,7 +36,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.spark.sql.types.DataTypes.*;
+import static org.apache.spark.sql.types.DataTypes.IntegerType;
+import static org.apache.spark.sql.types.DataTypes.StringType;
 
 /**
  * Migrate database procedure. Usage:

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/utils/TableMigrationUtils.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/utils/TableMigrationUtils.java
@@ -24,6 +24,7 @@ import org.apache.paimon.hive.HiveCatalog;
 import org.apache.paimon.hive.migrate.HiveMigrator;
 import org.apache.paimon.migrate.Migrator;
 
+import java.util.List;
 import java.util.Map;
 
 /** Migration util to choose importer according to connector. */
@@ -56,6 +57,27 @@ public class TableMigrationUtils {
                         options);
             default:
                 throw new UnsupportedOperationException("Unsupported connector " + connector);
+        }
+    }
+
+    public static List<Migrator> getImporters(
+            String connector,
+            Catalog catalog,
+            String sourceDatabase,
+            Integer parallelism,
+            Map<String, String> options) {
+        switch (connector) {
+            case "hive":
+                if (catalog instanceof CachingCatalog) {
+                    catalog = ((CachingCatalog) catalog).wrapped();
+                }
+                if (!(catalog instanceof HiveCatalog)) {
+                    throw new IllegalArgumentException("Only support Hive Catalog");
+                }
+                return HiveMigrator.databaseMigrators(
+                        (HiveCatalog) catalog, sourceDatabase, options, parallelism);
+            default:
+                throw new UnsupportedOperationException("Don't support connector " + connector);
         }
     }
 }

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateDatabaseProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/MigrateDatabaseProcedureTest.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.procedure
+
+import org.apache.paimon.spark.PaimonHiveTestBase
+
+import org.apache.spark.sql.Row
+class MigrateDatabaseProcedureTest extends PaimonHiveTestBase {
+  Seq("parquet", "orc", "avro").foreach(
+    format => {
+      test(s"Paimon migrate database procedure: migrate $format non-partitioned database") {
+        withTable("hive_tbl", "hive_tbl1") {
+          // create hive table
+          spark.sql(s"""
+                       |CREATE TABLE hive_tbl (id STRING, name STRING, pt STRING)
+                       |USING $format
+                       |""".stripMargin)
+
+          spark.sql(s"""
+                       |CREATE TABLE hive_tbl1 (id STRING, name STRING, pt STRING)
+                       |USING $format
+                       |""".stripMargin)
+
+          var rows0 = spark.sql("SHOW CREATE TABLE hive_tbl").collect()
+          assert(!rows0.apply(0).toString().contains("USING paimon"))
+
+          rows0 = spark.sql("SHOW CREATE TABLE hive_tbl1").collect()
+          assert(!rows0.apply(0).toString().contains("USING paimon"))
+
+          spark.sql(s"INSERT INTO hive_tbl VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
+
+          spark.sql(
+            s"CALL sys.migrate_database(source_type => 'hive', database => '$hiveDbName', options => 'file.format=$format')")
+
+          checkAnswer(
+            spark.sql(s"SELECT * FROM hive_tbl ORDER BY id"),
+            Row("1", "a", "p1") :: Row("2", "b", "p2") :: Nil)
+
+          var rows1 = spark.sql("SHOW CREATE TABLE hive_tbl").collect()
+          assert(rows1.apply(0).toString().contains("USING paimon"))
+
+          rows1 = spark.sql("SHOW CREATE TABLE hive_tbl1").collect()
+          assert(rows1.apply(0).toString().contains("USING paimon"))
+
+        }
+      }
+    })
+
+  Seq("parquet", "orc", "avro").foreach(
+    format => {
+      test(
+        s"Paimon migrate database procedure: migrate $format database with setting parallelism") {
+        withTable("hive_tbl_01", "hive_tbl_02") {
+          // create hive table
+          spark.sql(s"""
+                       |CREATE TABLE hive_tbl_01 (id STRING, name STRING, pt STRING)
+                       |USING $format
+                       |""".stripMargin)
+
+          spark.sql(s"""
+                       |CREATE TABLE hive_tbl_02 (id STRING, name STRING, pt STRING)
+                       |USING $format
+                       |""".stripMargin)
+
+          var rows0 = spark.sql("SHOW CREATE TABLE hive_tbl_01").collect()
+          assert(!rows0.apply(0).toString().contains("USING paimon"))
+
+          rows0 = spark.sql("SHOW CREATE TABLE hive_tbl_02").collect()
+          assert(!rows0.apply(0).toString().contains("USING paimon"))
+
+          spark.sql(s"INSERT INTO hive_tbl_01 VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
+
+          spark.sql(
+            s"CALL sys.migrate_database(source_type => 'hive', database => '$hiveDbName', options => 'file.format=$format', parallelism => 6)")
+
+          checkAnswer(
+            spark.sql(s"SELECT * FROM hive_tbl_01 ORDER BY id"),
+            Row("1", "a", "p1") :: Row("2", "b", "p2") :: Nil)
+
+          var rows1 = spark.sql("SHOW CREATE TABLE hive_tbl_01").collect()
+          assert(rows1.apply(0).toString().contains("USING paimon"))
+
+          rows1 = spark.sql("SHOW CREATE TABLE hive_tbl_02").collect()
+          assert(rows1.apply(0).toString().contains("USING paimon"))
+        }
+      }
+    })
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

Currently spark side not support migrate_database procedure which can improve user to migrate their tables, this pr is aimed to support it.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
