### PR TITLE
[core] Reduce unnecessary manifest reading during orphan clean

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -92,6 +92,9 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
 
         // delete candidate files
         Map<String, Path> candidates = getCandidateDeletingFiles();
+        if (candidates.isEmpty()) {
+            return deleteFiles;
+        }
 
         // find used files
         Set<String> usedFiles =


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->
Read manifest to find used files will cost time, if the candidates is empty, we don't need to do that

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
