### PR TITLE
[core] Optimize IncrementalStartingScanner to randomlyExecute

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/ManifestReadThreadPool.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ManifestReadThreadPool.java
@@ -20,6 +20,7 @@ package org.apache.paimon.utils;
 
 import javax.annotation.Nullable;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.Function;
@@ -50,5 +51,12 @@ public class ManifestReadThreadPool {
             Function<U, List<T>> processor, List<U> input, @Nullable Integer threadNum) {
         ThreadPoolExecutor executor = getExecutorService(threadNum);
         return ThreadPoolUtils.sequentialBatchedExecute(executor, processor, input, threadNum);
+    }
+
+    /** This method aims to parallel process tasks with randomly but return values sequentially. */
+    public static <T, U> Iterator<T> randomlyExecute(
+            Function<U, List<T>> processor, List<U> input, @Nullable Integer threadNum) {
+        ThreadPoolExecutor executor = getExecutorService(threadNum);
+        return ThreadPoolUtils.randomlyExecute(executor, processor, input);
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Sequence batch should not be used; it only optimizes memory, and we only need to return the results in order.

Randomly execution can improve performance.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
