### PR TITLE
[spark] Fix the loadTable of SparkSource can't recognize correct catalog

### DIFF
--- a/docs/layouts/shortcodes/generated/spark_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/spark_connector_configuration.html
@@ -74,5 +74,17 @@ under the License.
             <td>Boolean</td>
             <td>If true, allow to merge data types if the two types meet the rules for explicit casting.</td>
         </tr>
+        <tr>
+            <td><h5>database</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>String</td>
+            <td>The read or write database name.</td>
+        </tr>
+        <tr>
+            <td><h5>table</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>String</td>
+            <td>The read or write table name.</td>
+        </tr>
     </tbody>
 </table>

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
@@ -25,6 +25,18 @@ import static org.apache.paimon.options.ConfigOptions.key;
 /** Options for spark connector. */
 public class SparkConnectorOptions {
 
+    public static final ConfigOption<String> DATABASE =
+            key("database")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The read or write database name.");
+
+    public static final ConfigOption<String> TABLE =
+            key("table")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The read or write table name.");
+
     public static final ConfigOption<Boolean> MERGE_SCHEMA =
             key("write.merge-schema")
                     .booleanType()


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx
Fix the loadTable of SparkSource can't recognize correct catalog as below case
`dataset.format("paimon").options(...).save();`

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
