### PR TITLE
[core] Check snapshot existence before expire

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -122,6 +122,17 @@ public class SnapshotManager implements Serializable {
         return Snapshot.fromPath(fileIO, snapshotPath);
     }
 
+    public Snapshot tryGetSnapshot(long snapshotId) throws FileNotFoundException {
+        try {
+            Path snapshotPath = snapshotPath(snapshotId);
+            return Snapshot.fromJson(fileIO.readFileUtf8(snapshotPath));
+        } catch (FileNotFoundException fileNotFoundException) {
+            throw fileNotFoundException;
+        } catch (IOException ioException) {
+            throw new RuntimeException(ioException);
+        }
+    }
+
     public Changelog changelog(long snapshotId) {
         Path changelogPath = longLivedChangelogPath(snapshotId);
         return Changelog.fromPath(fileIO, changelogPath);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
If there is two writing job directly aiming to two different partitions, then there'll come up a conflict while expiring snapshot. This should be avoided.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
