### PR TITLE
[core] Introduce type option

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -883,6 +883,12 @@ If the data size allocated for the sorting task is uneven,which may lead to perf
             <td>Target size of a file.<ul><li>primary key table: the default value is 128 MB.</li><li>append table: the default value is 256 MB.</li></ul></td>
         </tr>
         <tr>
+            <td><h5>type</h5></td>
+            <td style="word-wrap: break-word;">table</td>
+            <td><p>Enum</p></td>
+            <td>Type of the table.<br /><br />Possible values:<ul><li>"table": Normal Paimon table.</li><li>"format-table": A file format table refers to a directory that contains multiple files of the same format.</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>write-buffer-for-append</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -87,6 +87,12 @@ public class CoreOptions implements Serializable {
 
     public static final String COLUMNS = "columns";
 
+    public static final ConfigOption<TableType> TYPE =
+            key("type")
+                    .enumType(TableType.class)
+                    .defaultValue(TableType.TABLE)
+                    .withDescription("Type of the table.");
+
     public static final ConfigOption<Integer> BUCKET =
             key("bucket")
                     .intType()

--- a/paimon-common/src/main/java/org/apache/paimon/TableType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/TableType.java
@@ -54,6 +54,6 @@ public enum TableType implements DescribedEnum {
                 return type;
             }
         }
-        throw new UnsupportedOperationException("Unknown type: " + name);
+        throw new UnsupportedOperationException("Unknown table type: " + name);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/TableType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/TableType.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon;
+
+import org.apache.paimon.options.description.DescribedEnum;
+import org.apache.paimon.options.description.InlineElement;
+
+import static org.apache.paimon.options.description.TextElement.text;
+
+/** Type of the table. */
+public enum TableType implements DescribedEnum {
+    TABLE("table", "Normal Paimon table."),
+    FORMAT_TABLE(
+            "format-table",
+            "A file format table refers to a directory that contains multiple files of the same format.");
+
+    private final String value;
+    private final String description;
+
+    TableType(String value, String description) {
+        this.value = value;
+        this.description = description;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public InlineElement getDescription() {
+        return text(description);
+    }
+
+    public static TableType fromString(String name) {
+        for (TableType type : TableType.values()) {
+            if (type.value.equals(name)) {
+                return type;
+            }
+        }
+        throw new UnsupportedOperationException("Unknown type: " + name);
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -20,7 +20,7 @@ package org.apache.paimon.options;
 
 import org.apache.paimon.options.description.Description;
 import org.apache.paimon.options.description.TextElement;
-import org.apache.paimon.table.TableType;
+import org.apache.paimon.table.CatalogTableType;
 
 import java.time.Duration;
 
@@ -48,10 +48,10 @@ public class CatalogOptions {
                     .noDefaultValue()
                     .withDescription("Uri of metastore server.");
 
-    public static final ConfigOption<TableType> TABLE_TYPE =
+    public static final ConfigOption<CatalogTableType> TABLE_TYPE =
             ConfigOptions.key("table.type")
-                    .enumType(TableType.class)
-                    .defaultValue(TableType.MANAGED)
+                    .enumType(CatalogTableType.class)
+                    .defaultValue(CatalogTableType.MANAGED)
                     .withDescription("Type of table.");
 
     public static final ConfigOption<Boolean> LOCK_ENABLED =

--- a/paimon-common/src/main/java/org/apache/paimon/table/CatalogTableType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/table/CatalogTableType.java
@@ -24,7 +24,7 @@ import org.apache.paimon.options.description.InlineElement;
 import static org.apache.paimon.options.description.TextElement.text;
 
 /** Enum of catalog table type. */
-public enum TableType implements DescribedEnum {
+public enum CatalogTableType implements DescribedEnum {
     MANAGED(
             "managed",
             "Paimon owned table where the entire lifecycle of the table data is managed."),
@@ -35,7 +35,7 @@ public enum TableType implements DescribedEnum {
     private final String value;
     private final String description;
 
-    TableType(String value, String description) {
+    CatalogTableType(String value, String description) {
         this.value = value;
         this.description = description;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalogFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalogFactory.java
@@ -20,7 +20,7 @@ package org.apache.paimon.catalog;
 
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
-import org.apache.paimon.table.TableType;
+import org.apache.paimon.table.CatalogTableType;
 
 import static org.apache.paimon.options.CatalogOptions.TABLE_TYPE;
 
@@ -36,7 +36,7 @@ public class FileSystemCatalogFactory implements CatalogFactory {
 
     @Override
     public Catalog create(FileIO fileIO, Path warehouse, CatalogContext context) {
-        if (!TableType.MANAGED.equals(context.options().get(TABLE_TYPE))) {
+        if (!CatalogTableType.MANAGED.equals(context.options().get(TABLE_TYPE))) {
             throw new IllegalArgumentException(
                     "Only managed table is supported in File system catalog.");
         }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogFactoryTest.java
@@ -21,7 +21,7 @@ package org.apache.paimon.catalog;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.options.Options;
-import org.apache.paimon.table.TableType;
+import org.apache.paimon.table.CatalogTableType;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
@@ -63,7 +63,7 @@ public class CatalogFactoryTest {
         Path root = new Path(path.toUri().toString());
         Options options = new Options();
         options.set(WAREHOUSE, new Path(root, "warehouse").toString());
-        options.set(TABLE_TYPE, TableType.EXTERNAL);
+        options.set(TABLE_TYPE, CatalogTableType.EXTERNAL);
         assertThatThrownBy(() -> CatalogFactory.createCatalog(CatalogContext.create(options)))
                 .hasMessageContaining("Only managed table is supported in File system catalog.");
     }

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/CatalogOptionsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/CatalogOptionsTableTest.java
@@ -27,8 +27,8 @@ import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.table.CatalogTableType;
 import org.apache.paimon.table.TableTestBase;
-import org.apache.paimon.table.TableType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,7 +54,7 @@ public class CatalogOptionsTableTest extends TableTestBase {
     @BeforeEach
     public void before() throws Exception {
         catalogOptions = new Options();
-        catalogOptions.set(CatalogOptions.TABLE_TYPE, TableType.MANAGED);
+        catalogOptions.set(CatalogOptions.TABLE_TYPE, CatalogTableType.MANAGED);
         catalogOptions.set("table-default.scan.infer-parallelism", "false");
         catalogOptions.set(CatalogOptions.WAREHOUSE, tempDir.toUri().toString());
         catalog = CatalogFactory.createCatalog(CatalogContext.create(catalogOptions));

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -40,9 +40,9 @@ import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.CatalogTableType;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FormatTable;
-import org.apache.paimon.table.TableType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 
@@ -491,11 +491,11 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     private boolean usingExternalTable() {
-        TableType tableType =
+        CatalogTableType tableType =
                 OptionsUtils.convertToEnum(
-                        hiveConf.get(TABLE_TYPE.key(), TableType.MANAGED.toString()),
-                        TableType.class);
-        return TableType.EXTERNAL.equals(tableType);
+                        hiveConf.get(TABLE_TYPE.key(), CatalogTableType.MANAGED.toString()),
+                        CatalogTableType.class);
+        return CatalogTableType.EXTERNAL.equals(tableType);
     }
 
     @Override
@@ -768,10 +768,10 @@ public class HiveCatalog extends AbstractCatalog {
 
     private Table newHmsTable(Identifier identifier, Map<String, String> tableParameters) {
         long currentTimeMillis = System.currentTimeMillis();
-        TableType tableType =
+        CatalogTableType tableType =
                 OptionsUtils.convertToEnum(
-                        hiveConf.get(TABLE_TYPE.key(), TableType.MANAGED.toString()),
-                        TableType.class);
+                        hiveConf.get(TABLE_TYPE.key(), CatalogTableType.MANAGED.toString()),
+                        CatalogTableType.class);
         Table table =
                 new Table(
                         identifier.getTableName(),
@@ -790,7 +790,7 @@ public class HiveCatalog extends AbstractCatalog {
         table.getParameters().put(TABLE_TYPE_PROP, PAIMON_TABLE_TYPE_VALUE.toUpperCase());
         table.getParameters()
                 .put(hive_metastoreConstants.META_TABLE_STORAGE, STORAGE_HANDLER_CLASS_NAME);
-        if (TableType.EXTERNAL.equals(tableType)) {
+        if (CatalogTableType.EXTERNAL.equals(tableType)) {
             table.getParameters().put("EXTERNAL", "TRUE");
         }
         return table;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
No we have multiple tables:
1. normal paimon table
2. format table
3. Flink materialized table

We can have a type option to describe this.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
