### PR TITLE
[common][flink] Add support for complex types in kafka debezium avro cdc action

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/types/DataField.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DataField.java
@@ -153,4 +153,20 @@ public final class DataField implements Serializable {
     public String toString() {
         return asSQLString();
     }
+
+    /**
+     * When the order of the same field is different, its ID may also be different, so the
+     * comparison should not include the ID.
+     */
+    public static boolean dataFieldEqualsIgnoreId(DataField dataField1, DataField dataField2) {
+        if (dataField1 == dataField2) {
+            return true;
+        } else if (dataField1 != null && dataField2 != null) {
+            return Objects.equals(dataField1.name(), dataField2.name())
+                    && Objects.equals(dataField1.type(), dataField2.type())
+                    && Objects.equals(dataField1.description(), dataField2.description());
+        } else {
+            return false;
+        }
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/types/RowType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/RowType.java
@@ -174,7 +174,17 @@ public final class RowType extends DataType {
             return false;
         }
         RowType rowType = (RowType) o;
-        return fields.equals(rowType.fields);
+        // For nested RowTypes e.g. DataField.dataType = RowType we need to ignoreIds as they can be
+        // different
+        if (fields.size() != rowType.fields.size()) {
+            return false;
+        }
+        for (int i = 0; i < fields.size(); ++i) {
+            if (!DataField.dataFieldEqualsIgnoreId(fields.get(i), rowType.fields.get(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/utils/BinaryStringUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/BinaryStringUtils.java
@@ -336,11 +336,11 @@ public class BinaryStringUtils {
                 break;
             case 6: // microseconds
                 millis = epoch / 1000;
-                nanosOfMillis = (int)((epoch % 1000) * 1000);
+                nanosOfMillis = (int) ((epoch % 1000) * 1000);
                 break;
             case 9: // nanoseconds
                 millis = epoch / 1_000_000;
-                nanosOfMillis = (int)(epoch % 1_000_000);
+                nanosOfMillis = (int) (epoch % 1_000_000);
                 break;
             default:
                 throw new RuntimeException("Unsupported precision: " + precision);

--- a/paimon-common/src/main/java/org/apache/paimon/utils/BinaryStringUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/BinaryStringUtils.java
@@ -319,7 +319,7 @@ public class BinaryStringUtils {
         return DateTimeUtils.parseTimestampData(input.toString(), precision, timeZone);
     }
 
-    // Helper method to convert milliseconds to Timestamp with the provided precision.
+    // Helper method to convert epoch to Timestamp with the provided precision.
     private static Timestamp fromMillisToTimestamp(long epoch, int precision) {
         // Calculate milliseconds and nanoseconds from epoch based on precision
         long millis;

--- a/paimon-common/src/main/java/org/apache/paimon/utils/BinaryStringUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/BinaryStringUtils.java
@@ -25,6 +25,8 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeChecks;
 
 import java.time.DateTimeException;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.TimeZone;
@@ -32,6 +34,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.paimon.data.BinaryString.fromString;
+import static org.apache.paimon.data.Timestamp.fromLocalDateTime;
 import static org.apache.paimon.types.DataTypeRoot.BINARY;
 import static org.apache.paimon.types.DataTypeRoot.CHAR;
 
@@ -306,6 +309,10 @@ public class BinaryStringUtils {
     /** Used by {@code CAST(x as TIMESTAMP)}. */
     public static Timestamp toTimestamp(BinaryString input, int precision)
             throws DateTimeException {
+        if (StringUtils.isNumeric(input.toString())) {
+            long millis = toLong(input);
+            return fromMillisToTimestamp(millis, precision);
+        }
         return DateTimeUtils.parseTimestampData(input.toString(), precision);
     }
 
@@ -313,6 +320,25 @@ public class BinaryStringUtils {
     public static Timestamp toTimestamp(BinaryString input, int precision, TimeZone timeZone)
             throws DateTimeException {
         return DateTimeUtils.parseTimestampData(input.toString(), precision, timeZone);
+    }
+
+    // Helper method to convert milliseconds to Timestamp with the provided precision.
+    private static Timestamp fromMillisToTimestamp(long millis, int precision) {
+        // Calculate seconds and nanoseconds from the millis
+        long seconds = millis / 1000;
+        int nanos = (int) ((millis % 1000) * 1_000_000);
+
+        // Adjust the nanoseconds to the specified precision
+        if (precision < 9) {
+            nanos =
+                    (int)
+                            (Math.floor(nanos / Math.pow(10, 9 - precision))
+                                    * Math.pow(10, 9 - precision));
+        }
+
+        // Create a LocalDateTime from the seconds and nanoseconds
+        LocalDateTime dateTime = LocalDateTime.ofEpochSecond(seconds, nanos, ZoneOffset.UTC);
+        return fromLocalDateTime(dateTime);
     }
 
     public static BinaryString toCharacterString(BinaryString strData, DataType type) {

--- a/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
@@ -172,7 +172,7 @@ public class TypeUtils {
                     List<Object> resultList = new ArrayList<>();
                     for (JsonNode elementNode : arrayNode) {
                         if (!elementNode.isNull()) {
-                            String elementJson = elementNode.asText();
+                            String elementJson = elementNode.toString();
                             Object elementObject =
                                     castFromStringInternal(elementJson, elementType, isCdcValue);
                             resultList.add(elementObject);
@@ -224,7 +224,7 @@ public class TypeUtils {
                                         if (!entry.getValue().isNull()) {
                                             value =
                                                     castFromStringInternal(
-                                                            entry.getValue().asText(),
+                                                            entry.getValue().toString(),
                                                             valueType,
                                                             isCdcValue);
                                         }
@@ -252,7 +252,7 @@ public class TypeUtils {
                         DataField field = rowType.getFields().get(pos);
                         JsonNode fieldNode = rowNode.get(field.name());
                         if (fieldNode != null && !fieldNode.isNull()) {
-                            String fieldJson = fieldNode.asText();
+                            String fieldJson = fieldNode.toString();
                             Object fieldObject =
                                     castFromStringInternal(fieldJson, field.type(), isCdcValue);
                             genericRow.setField(pos, fieldObject);

--- a/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
@@ -21,6 +21,8 @@ package org.apache.paimon.utils;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericMap;
+import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
@@ -28,16 +30,27 @@ import org.apache.paimon.types.DataTypeChecks;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.LocalZonedTimestampType;
+import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.VarCharType;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 
@@ -47,6 +60,8 @@ import static org.apache.paimon.types.DataTypeFamily.CHARACTER_STRING;
 
 /** Type related helper functions. */
 public class TypeUtils {
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Logger LOG = LoggerFactory.getLogger(TypeUtils.class);
 
     public static RowType concat(RowType left, RowType right) {
         RowType.Builder builder = RowType.builder();
@@ -152,21 +167,93 @@ public class TypeUtils {
             case ARRAY:
                 ArrayType arrayType = (ArrayType) type;
                 DataType elementType = arrayType.getElementType();
-                if (elementType instanceof VarCharType) {
-                    if (s.startsWith("[")) {
-                        s = s.substring(1);
+                try {
+                    JsonNode arrayNode = OBJECT_MAPPER.readTree(s);
+                    List<Object> resultList = new ArrayList<>();
+                    for (JsonNode elementNode : arrayNode) {
+                        if (!elementNode.isNull()) {
+                            String elementJson = elementNode.toString();
+                            Object elementObject =
+                                    castFromStringInternal(elementJson, elementType, isCdcValue);
+                            resultList.add(elementObject);
+                        } else {
+                            resultList.add(null);
+                        }
                     }
-                    if (s.endsWith("]")) {
-                        s = s.substring(0, s.length() - 1);
+                    return new GenericArray(resultList.toArray());
+                } catch (JsonProcessingException e) {
+                    LOG.info(
+                            String.format(
+                                    "Failed to parse ARRAY for type %s with value %s", type, s),
+                            e);
+                    return new GenericArray(new int[] {});
+                } catch (Exception e) {
+                    throw new RuntimeException(
+                            String.format("Failed to parse Json String %s", s), e);
+                }
+            case MAP:
+                MapType mapType = (MapType) type;
+                DataType keyType = mapType.getKeyType();
+                DataType valueType = mapType.getValueType();
+                try {
+                    JsonNode mapNode = OBJECT_MAPPER.readTree(s);
+                    Map<Object, Object> resultMap = new HashMap<>();
+                    mapNode.fields()
+                            .forEachRemaining(
+                                    entry -> {
+                                        Object key =
+                                                castFromStringInternal(
+                                                        entry.getKey(), keyType, isCdcValue);
+                                        Object value = null;
+                                        if (!entry.getValue().isNull()) {
+                                            value =
+                                                    castFromStringInternal(
+                                                            entry.getValue().toString(),
+                                                            valueType,
+                                                            isCdcValue);
+                                        }
+                                        resultMap.put(key, value);
+                                    });
+                    return new GenericMap(resultMap);
+                } catch (JsonProcessingException e) {
+                    LOG.info(
+                            String.format("Failed to parse MAP for type %s with value %s", type, s),
+                            e);
+                    return new GenericMap(Collections.emptyMap());
+                } catch (Exception e) {
+                    throw new RuntimeException(
+                            String.format("Failed to parse Json String %s", s), e);
+                }
+            case ROW:
+                RowType rowType = (RowType) type;
+                try {
+                    JsonNode rowNode = OBJECT_MAPPER.readTree(s);
+                    GenericRow genericRow =
+                            new GenericRow(
+                                    rowType.getFields()
+                                            .size()); // TODO: What about RowKind? always +I?
+                    for (int pos = 0; pos < rowType.getFields().size(); ++pos) {
+                        DataField field = rowType.getFields().get(pos);
+                        JsonNode fieldNode = rowNode.get(field.name());
+                        if (fieldNode != null && !fieldNode.isNull()) {
+                            String fieldJson = fieldNode.toString();
+                            Object fieldObject =
+                                    castFromStringInternal(fieldJson, field.type(), isCdcValue);
+                            genericRow.setField(pos, fieldObject);
+                        } else {
+                            genericRow.setField(pos, null); // Handle null fields
+                        }
                     }
-                    String[] ss = s.split(",");
-                    BinaryString[] binaryStrings = new BinaryString[ss.length];
-                    for (int i = 0; i < ss.length; i++) {
-                        binaryStrings[i] = BinaryString.fromString(ss[i]);
-                    }
-                    return new GenericArray(binaryStrings);
-                } else {
-                    throw new UnsupportedOperationException("Unsupported type " + type);
+                    return genericRow;
+                } catch (JsonProcessingException e) {
+                    LOG.info(
+                            String.format(
+                                    "Failed to parse ROW for type  %s  with value  %s", type, s),
+                            e);
+                    return new GenericRow(0);
+                } catch (Exception e) {
+                    throw new RuntimeException(
+                            String.format("Failed to parse Json String %s", s), e);
                 }
             default:
                 throw new UnsupportedOperationException("Unsupported type " + type);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumSchemaUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumSchemaUtils.java
@@ -111,7 +111,6 @@ public class DebeziumSchemaUtils {
                     }
                 },
                 origin,
-                false,
                 serverTimeZone);
     }
 
@@ -134,7 +133,6 @@ public class DebeziumSchemaUtils {
                 typeMapping,
                 () -> (ByteBuffer) ((GenericRecord) origin).get(Geometry.WKB_FIELD),
                 origin,
-                true,
                 serverTimeZone);
     }
 
@@ -146,7 +144,6 @@ public class DebeziumSchemaUtils {
             TypeMapping typeMapping,
             Supplier<ByteBuffer> geometryGetter,
             Object origin,
-            boolean isAvro,
             ZoneId serverTimeZone) {
         if (rawValue == null) {
             return null;
@@ -247,7 +244,10 @@ public class DebeziumSchemaUtils {
                 throw new IllegalArgumentException(
                         String.format("Failed to convert %s to geometry JSON.", rawValue), e);
             }
-        } else if (isAvro) {
+        } else if ((origin instanceof GenericData.Record)
+                || (origin instanceof GenericData.Array)
+                || (origin instanceof Map)
+                || (origin instanceof List)) {
             Object convertedObject = convertAvroObjectToJsonCompatible(origin);
             try {
                 transformed = OBJECT_MAPPER.writer().writeValueAsString(convertedObject);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/RichEventParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/RichEventParser.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 
 /** A {@link EventParser} for {@link RichCdcRecord}. */
 public class RichEventParser implements EventParser<RichCdcRecord> {
@@ -48,24 +47,12 @@ public class RichEventParser implements EventParser<RichCdcRecord> {
                             // When the order of the same field is different, its ID may also be
                             // different,
                             // so the comparison should not include the ID.
-                            if (!dataFieldEqualsIgnoreId(previous, dataField)) {
+                            if (!DataField.dataFieldEqualsIgnoreId(previous, dataField)) {
                                 previousDataFields.put(dataField.name(), dataField);
                                 change.add(dataField);
                             }
                         });
         return change;
-    }
-
-    private boolean dataFieldEqualsIgnoreId(DataField dataField1, DataField dataField2) {
-        if (dataField1 == dataField2) {
-            return true;
-        } else if (dataField1 != null && dataField2 != null) {
-            return Objects.equals(dataField1.name(), dataField2.name())
-                    && Objects.equals(dataField1.type(), dataField2.type())
-                    && Objects.equals(dataField1.description(), dataField2.description());
-        } else {
-            return false;
-        }
     }
 
     @Override


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
@umeshdangat has an outstanding PR which was updated after PR by @zhuangchong was merged. That PR: https://github.com/apache/paimon/pull/3323

The above patch allows consuming data from avro data from kafka into paimon but it doesnt support complex avro types. This PR achieves that. The original PR https://github.com/zhuangchong/flink-table-store/pull/1 was pointing to @zhuangchong branch to clearly show the changes only relavant to supporting complex avro types.

This PR fixes the failing E2E tests for PR: https://github.com/apache/paimon/pull/3931

Copying the note from PR: https://github.com/apache/paimon/pull/3931

> One issue is CdcSourceRecord contains Map<String, String> thus the current somewhat tedious approach is to deserialize avro complex types into json strings and then read them back from json strings rather than changing CdcSourceRecord Map<String, Object> to support value as Object. It would be a much larger change looking at the code changes needed.
> 
> I had to update the DataField to add a method for dataFieldEqualsIgnoreId which already existing in RichEventParser. For nested RowType fields this becomes necessary (coming from nested avro records) as when a DataField.type= RowType we cannot simply do equals on all data fields as they contain Id as well and it fails the equality, although there is no schema change.

@JingsongLi @zhuangchong let us know what you think.

cc: @umeshdangat

<!-- Linking this pull request to the issue -->
Linked issue: close xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
