### PR TITLE
[flink] Small changelog files can now be compacted into big files

### DIFF
--- a/docs/content/maintenance/write-performance.md
+++ b/docs/content/maintenance/write-performance.md
@@ -160,3 +160,16 @@ You can use fine-grained-resource-management of Flink to increase committer heap
 1. Configure Flink Configuration `cluster.fine-grained-resource-management.enabled: true`. (This is default after Flink 1.18)
 2. Configure Paimon Table Options: `sink.committer-memory`, for example 300 MB, depends on your `TaskManager`.
    (`sink.committer-cpu` is also supported)
+
+## Changelog Compaction
+
+If Flink's checkpoint interval is short (for example, 30 seconds) and the number of buckets is large,
+each snapshot may produce lots of small changelog files.
+Too many files may put a burden on the distributed storage cluster.
+
+In order to compact small changelog files into large ones, you can set the table option `changelog.compact.parallelism`.
+This option will add a compact operator after the writer operator, which copies changelog files into large ones.
+If the parallelism becomes larger, file copying will become faster.
+However, the number of resulting files will also become larger.
+As file copying is fast in most storage system,
+we suggest that you start experimenting with `'changelog.compact.parallelism' = '1'` and increase the value if needed.

--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -27,6 +27,12 @@ under the License.
     </thead>
     <tbody>
         <tr>
+            <td><h5>changelog.compact.parallelism</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>Compact several changelog files from the same partition into one file, in order to decrease the number of small files. This property sets the parallelism of the compact operator. More parallelism means faster file copy, however the number of resulting files will also become larger.</td>
+        </tr>
+        <tr>
             <td><h5>end-input.watermark</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Long</td>

--- a/paimon-common/src/main/java/org/apache/paimon/utils/IOUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/IOUtils.java
@@ -38,7 +38,7 @@ public final class IOUtils {
     private static final Logger LOG = LoggerFactory.getLogger(IOUtils.class);
 
     /** The block size for byte operations in byte. */
-    private static final int BLOCKSIZE = 4096;
+    public static final int BLOCKSIZE = 4096;
 
     // ------------------------------------------------------------------------
     //  Byte copy operations

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -404,6 +404,17 @@ public class FlinkConnectorOptions {
                     .withDescription(
                             "Optional endInput watermark used in case of batch mode or bounded stream.");
 
+    public static final ConfigOption<Integer> CHANGELOG_COMPACT_PARALLELISM =
+            key("changelog.compact.parallelism")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Compact several changelog files from the same partition into one file, "
+                                    + "in order to decrease the number of small files. "
+                                    + "This property sets the parallelism of the compact operator. "
+                                    + "More parallelism means faster file copy, "
+                                    + "however the number of resulting files will also become larger.");
+
     public static List<ConfigOption<?>> getOptions() {
         final Field[] fields = FlinkConnectorOptions.class.getFields();
         final List<ConfigOption<?>> list = new ArrayList<>(fields.length);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/changelog/ChangelogCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/changelog/ChangelogCompactOperator.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.compact.changelog;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.flink.compact.changelog.format.CompactedChangelogReadOnlyFormat;
+import org.apache.paimon.flink.sink.Committable;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.io.CompactIncrement;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.DataFilePathFactory;
+import org.apache.paimon.io.DataIncrement;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.CommitMessageImpl;
+import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.IOUtils;
+import org.apache.paimon.utils.Preconditions;
+
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Operator to compact several changelog files from the same partition into one file, in order to
+ * reduce the number of small files.
+ */
+public class ChangelogCompactOperator extends AbstractStreamOperator<Committable>
+        implements OneInputStreamOperator<Committable, Committable>, BoundedOneInput {
+
+    private final FileStoreTable table;
+
+    private transient FileStorePathFactory pathFactory;
+    private transient long checkpointId;
+    private transient Map<BinaryRow, OutputStream> outputStreams;
+    private transient Map<BinaryRow, List<Result>> results;
+
+    public ChangelogCompactOperator(FileStoreTable table) {
+        this.table = table;
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+
+        pathFactory = table.store().pathFactory();
+        checkpointId = Long.MIN_VALUE;
+        outputStreams = new HashMap<>();
+        results = new HashMap<>();
+    }
+
+    @Override
+    public void processElement(StreamRecord<Committable> record) throws Exception {
+        Committable committable = record.getValue();
+        checkpointId = Math.max(checkpointId, committable.checkpointId());
+        if (committable.kind() != Committable.Kind.FILE) {
+            output.collect(record);
+            return;
+        }
+
+        CommitMessageImpl message = (CommitMessageImpl) committable.wrappedCommittable();
+        if (message.newFilesIncrement().changelogFiles().isEmpty()
+                && message.compactIncrement().changelogFiles().isEmpty()) {
+            output.collect(record);
+            return;
+        }
+
+        // copy changelogs from the same partition into one file
+        DataFilePathFactory dataFilePathFactory =
+                pathFactory.createDataFilePathFactory(message.partition(), message.bucket());
+        for (DataFileMeta meta : message.newFilesIncrement().changelogFiles()) {
+            copyFile(
+                    dataFilePathFactory.toPath(meta.fileName()),
+                    message.partition(),
+                    message.bucket(),
+                    false,
+                    meta);
+        }
+        for (DataFileMeta meta : message.compactIncrement().changelogFiles()) {
+            copyFile(
+                    dataFilePathFactory.toPath(meta.fileName()),
+                    message.partition(),
+                    message.bucket(),
+                    true,
+                    meta);
+        }
+
+        // send commit message without changelog files
+        CommitMessageImpl newMessage =
+                new CommitMessageImpl(
+                        message.partition(),
+                        message.bucket(),
+                        new DataIncrement(
+                                message.newFilesIncrement().newFiles(),
+                                message.newFilesIncrement().deletedFiles(),
+                                Collections.emptyList()),
+                        new CompactIncrement(
+                                message.compactIncrement().compactBefore(),
+                                message.compactIncrement().compactAfter(),
+                                Collections.emptyList()),
+                        message.indexIncrement());
+        Committable newCommittable =
+                new Committable(committable.checkpointId(), Committable.Kind.FILE, newMessage);
+        if (record.hasTimestamp()) {
+            output.collect(new StreamRecord<>(newCommittable, record.getTimestamp()));
+        } else {
+            output.collect(new StreamRecord<>(newCommittable));
+        }
+    }
+
+    private void copyFile(
+            Path path, BinaryRow partition, int bucket, boolean isCompactResult, DataFileMeta meta)
+            throws Exception {
+        if (!outputStreams.containsKey(partition)) {
+            Path outputPath =
+                    new Path(path.getParent(), "tmp-compacted-changelog-" + UUID.randomUUID());
+            outputStreams.put(
+                    partition,
+                    new OutputStream(
+                            outputPath, table.fileIO().newOutputStream(outputPath, false)));
+        }
+
+        OutputStream outputStream = outputStreams.get(partition);
+        long offset = outputStream.out.getPos();
+        try (SeekableInputStream in = table.fileIO().newInputStream(path)) {
+            IOUtils.copyBytes(in, outputStream.out, IOUtils.BLOCKSIZE, false);
+        }
+        table.fileIO().deleteQuietly(path);
+        results.computeIfAbsent(partition, p -> new ArrayList<>())
+                .add(
+                        new Result(
+                                bucket,
+                                isCompactResult,
+                                meta,
+                                offset,
+                                outputStream.out.getPos() - offset));
+
+        if (outputStream.out.getPos() >= table.coreOptions().targetFileSize(false)) {
+            flushPartition(partition);
+        }
+    }
+
+    @Override
+    public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+        flushAllPartitions();
+    }
+
+    @Override
+    public void endInput() throws Exception {
+        flushAllPartitions();
+    }
+
+    private void flushAllPartitions() throws Exception {
+        List<BinaryRow> partitions = new ArrayList<>(outputStreams.keySet());
+        for (BinaryRow partition : partitions) {
+            flushPartition(partition);
+        }
+    }
+
+    private void flushPartition(BinaryRow partition) throws Exception {
+        OutputStream outputStream = outputStreams.get(partition);
+        outputStream.out.close();
+
+        Result baseResult = results.get(partition).get(0);
+        Preconditions.checkArgument(baseResult.offset == 0);
+        DataFilePathFactory dataFilePathFactory =
+                pathFactory.createDataFilePathFactory(partition, baseResult.bucket);
+        // see Java docs of `CompactedChangelogFormatReaderFactory`
+        String realName =
+                "compacted-changelog-"
+                        + UUID.randomUUID()
+                        + "$"
+                        + baseResult.bucket
+                        + "-"
+                        + baseResult.length;
+        table.fileIO()
+                .rename(
+                        outputStream.path,
+                        dataFilePathFactory.toPath(
+                                realName
+                                        + "."
+                                        + CompactedChangelogReadOnlyFormat.getIdentifier(
+                                                baseResult.meta.fileFormat())));
+
+        Map<Integer, List<Result>> grouped = new HashMap<>();
+        for (Result result : results.get(partition)) {
+            grouped.computeIfAbsent(result.bucket, b -> new ArrayList<>()).add(result);
+        }
+
+        for (Map.Entry<Integer, List<Result>> entry : grouped.entrySet()) {
+            List<DataFileMeta> newFilesChangelog = new ArrayList<>();
+            List<DataFileMeta> compactChangelog = new ArrayList<>();
+            for (Result result : entry.getValue()) {
+                // see Java docs of `CompactedChangelogFormatReaderFactory`
+                String name =
+                        (result.offset == 0
+                                        ? realName
+                                        : realName + "-" + result.offset + "-" + result.length)
+                                + "."
+                                + CompactedChangelogReadOnlyFormat.getIdentifier(
+                                        result.meta.fileFormat());
+                if (result.isCompactResult) {
+                    compactChangelog.add(result.meta.rename(name));
+                } else {
+                    newFilesChangelog.add(result.meta.rename(name));
+                }
+            }
+
+            CommitMessageImpl newMessage =
+                    new CommitMessageImpl(
+                            partition,
+                            entry.getKey(),
+                            new DataIncrement(
+                                    Collections.emptyList(),
+                                    Collections.emptyList(),
+                                    newFilesChangelog),
+                            new CompactIncrement(
+                                    Collections.emptyList(),
+                                    Collections.emptyList(),
+                                    compactChangelog));
+            Committable newCommittable =
+                    new Committable(checkpointId, Committable.Kind.FILE, newMessage);
+            output.collect(new StreamRecord<>(newCommittable));
+        }
+
+        outputStreams.remove(partition);
+        results.remove(partition);
+    }
+
+    @Override
+    public void close() throws Exception {
+        for (Map.Entry<BinaryRow, OutputStream> entry : outputStreams.entrySet()) {
+            OutputStream outputStream = entry.getValue();
+            try {
+                outputStream.out.close();
+            } catch (Exception e) {
+                LOG.warn("Failed to close output stream for file " + outputStream.path, e);
+            }
+            table.fileIO().deleteQuietly(outputStream.path);
+        }
+
+        outputStreams.clear();
+        results.clear();
+    }
+
+    private static class OutputStream {
+
+        private final Path path;
+        private final PositionOutputStream out;
+
+        private OutputStream(Path path, PositionOutputStream out) {
+            this.path = path;
+            this.out = out;
+        }
+    }
+
+    private static class Result {
+
+        private final int bucket;
+        private final boolean isCompactResult;
+        private final DataFileMeta meta;
+        private final long offset;
+        private final long length;
+
+        private Result(
+                int bucket, boolean isCompactResult, DataFileMeta meta, long offset, long length) {
+            this.bucket = bucket;
+            this.isCompactResult = isCompactResult;
+            this.meta = meta;
+            this.offset = offset;
+            this.length = length;
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/changelog/format/CompactedChangelogFormatReaderFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/changelog/format/CompactedChangelogFormatReaderFactory.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.compact.changelog.format;
+
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.format.FormatReaderFactory;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.FileStatus;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.reader.RecordReader;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+/**
+ * {@link FormatReaderFactory} for compacted changelog.
+ *
+ * <p><b>File Name Protocol</b>
+ *
+ * <p>There are two kinds of file name. In the following description, <code>bid1</code> and <code>
+ * bid2</code> are bucket id, <code>off</code> is offset, <code>len1</code> and <code>len2</code>
+ * are lengths.
+ *
+ * <ul>
+ *   <li><code>bucket-bid1/compacted-changelog-xxx$bid1-len1</code>: This is the real file name. If
+ *       this file name is recorded in manifest file meta, reader should read the bytes of this file
+ *       starting from offset <code>0</code> with length <code>len1</code>.
+ *   <li><code>bucket-bid2/compacted-changelog-xxx$bid1-len1-off-len2</code>: This is the fake file
+ *       name. Reader should read the bytes of file <code>
+ *       bucket-bid1/compacted-changelog-xxx$bid1-len1</code> starting from offset <code>off</code>
+ *       with length <code>len2</code>.
+ * </ul>
+ */
+public class CompactedChangelogFormatReaderFactory implements FormatReaderFactory {
+
+    private final FormatReaderFactory wrapped;
+
+    public CompactedChangelogFormatReaderFactory(FormatReaderFactory wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public RecordReader<InternalRow> createReader(Context context) throws IOException {
+        OffsetReadOnlyFileIO fileIO = new OffsetReadOnlyFileIO(context.fileIO());
+        long length = decodePath(context.filePath()).length;
+
+        return wrapped.createReader(
+                new Context() {
+
+                    @Override
+                    public FileIO fileIO() {
+                        return fileIO;
+                    }
+
+                    @Override
+                    public Path filePath() {
+                        return context.filePath();
+                    }
+
+                    @Override
+                    public long fileSize() {
+                        return length;
+                    }
+                });
+    }
+
+    private static DecodeResult decodePath(Path path) {
+        String[] nameAndFormat = path.getName().split("\\.");
+        String[] names = nameAndFormat[0].split("\\$");
+        String[] split = names[1].split("-");
+        if (split.length == 2) {
+            return new DecodeResult(path, 0, Long.parseLong(split[1]));
+        } else {
+            Path realPath =
+                    new Path(
+                            path.getParent().getParent(),
+                            "bucket-"
+                                    + split[0]
+                                    + "/"
+                                    + names[0]
+                                    + "$"
+                                    + split[0]
+                                    + "-"
+                                    + split[1]
+                                    + "."
+                                    + nameAndFormat[1]);
+            return new DecodeResult(realPath, Long.parseLong(split[2]), Long.parseLong(split[3]));
+        }
+    }
+
+    private static class DecodeResult {
+
+        private final Path path;
+        private final long offset;
+        private final long length;
+
+        private DecodeResult(Path path, long offset, long length) {
+            this.path = path;
+            this.offset = offset;
+            this.length = length;
+        }
+    }
+
+    private static class OffsetReadOnlyFileIO implements FileIO {
+
+        private final FileIO wrapped;
+
+        private OffsetReadOnlyFileIO(FileIO wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public boolean isObjectStore() {
+            return wrapped.isObjectStore();
+        }
+
+        @Override
+        public void configure(CatalogContext context) {
+            wrapped.configure(context);
+        }
+
+        @Override
+        public SeekableInputStream newInputStream(Path path) throws IOException {
+            DecodeResult result = decodePath(path);
+            return new OffsetSeekableInputStream(
+                    wrapped.newInputStream(result.path), result.offset, result.length);
+        }
+
+        @Override
+        public PositionOutputStream newOutputStream(Path path, boolean overwrite)
+                throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public FileStatus getFileStatus(Path path) throws IOException {
+            DecodeResult result = decodePath(path);
+            FileStatus status = wrapped.getFileStatus(result.path);
+
+            return new FileStatus() {
+
+                @Override
+                public long getLen() {
+                    return result.length;
+                }
+
+                @Override
+                public boolean isDir() {
+                    return status.isDir();
+                }
+
+                @Override
+                public Path getPath() {
+                    return path;
+                }
+
+                @Override
+                public long getModificationTime() {
+                    return status.getModificationTime();
+                }
+            };
+        }
+
+        @Override
+        public FileStatus[] listStatus(Path path) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean exists(Path path) throws IOException {
+            return wrapped.exists(decodePath(path).path);
+        }
+
+        @Override
+        public boolean delete(Path path, boolean recursive) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean mkdirs(Path path) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean rename(Path src, Path dst) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class OffsetSeekableInputStream extends SeekableInputStream {
+
+        private final SeekableInputStream wrapped;
+        private final long offset;
+        private final long length;
+
+        private OffsetSeekableInputStream(SeekableInputStream wrapped, long offset, long length)
+                throws IOException {
+            this.wrapped = wrapped;
+            this.offset = offset;
+            this.length = length;
+            wrapped.seek(offset);
+        }
+
+        @Override
+        public void seek(long desired) throws IOException {
+            wrapped.seek(offset + desired);
+        }
+
+        @Override
+        public long getPos() throws IOException {
+            return wrapped.getPos() - offset;
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (getPos() >= length) {
+                throw new EOFException();
+            }
+            return wrapped.read();
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            long realLen = Math.min(len, length - getPos());
+            return wrapped.read(b, off, (int) realLen);
+        }
+
+        @Override
+        public void close() throws IOException {
+            wrapped.close();
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/changelog/format/CompactedChangelogReadOnlyFormat.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/changelog/format/CompactedChangelogReadOnlyFormat.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.compact.changelog.format;
+
+import org.apache.paimon.format.FileFormat;
+import org.apache.paimon.format.FileFormatFactory;
+import org.apache.paimon.format.FormatReaderFactory;
+import org.apache.paimon.format.FormatWriterFactory;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.types.RowType;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+
+/** {@link FileFormat} for compacted changelog. */
+public class CompactedChangelogReadOnlyFormat extends FileFormat {
+
+    private final FileFormat wrapped;
+
+    protected CompactedChangelogReadOnlyFormat(String formatIdentifier, FileFormat wrapped) {
+        super(formatIdentifier);
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public FormatReaderFactory createReaderFactory(
+            RowType projectedRowType, @Nullable List<Predicate> filters) {
+        return new CompactedChangelogFormatReaderFactory(
+                wrapped.createReaderFactory(projectedRowType, filters));
+    }
+
+    @Override
+    public FormatWriterFactory createWriterFactory(RowType type) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void validateDataFields(RowType rowType) {
+        wrapped.validateDataFields(rowType);
+    }
+
+    public static String getIdentifier(String wrappedFormat) {
+        return "cc-" + wrappedFormat;
+    }
+
+    static class AbstractFactory implements FileFormatFactory {
+
+        private final String format;
+
+        AbstractFactory(String format) {
+            this.format = format;
+        }
+
+        @Override
+        public String identifier() {
+            return getIdentifier(format);
+        }
+
+        @Override
+        public FileFormat create(FormatContext formatContext) {
+            return new CompactedChangelogReadOnlyFormat(
+                    getIdentifier(format), FileFormat.fromIdentifier(format, formatContext));
+        }
+    }
+
+    /** {@link FileFormatFactory} for compacted changelog, with orc as the real format. */
+    public static class OrcFactory extends AbstractFactory {
+
+        public OrcFactory() {
+            super("orc");
+        }
+    }
+
+    /** {@link FileFormatFactory} for compacted changelog, with parquet as the real format. */
+    public static class ParquetFactory extends AbstractFactory {
+
+        public ParquetFactory() {
+            super("parquet");
+        }
+    }
+
+    /** {@link FileFormatFactory} for compacted changelog, with avro as the real format. */
+    public static class AvroFactory extends AbstractFactory {
+
+        public AvroFactory() {
+            super("avro");
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/resources/META-INF/services/org.apache.paimon.format.FileFormatFactory
+++ b/paimon-flink/paimon-flink-common/src/main/resources/META-INF/services/org.apache.paimon.format.FileFormatFactory
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.paimon.flink.compact.changelog.format.CompactedChangelogReadOnlyFormat$OrcFactory
+org.apache.paimon.flink.compact.changelog.format.CompactedChangelogReadOnlyFormat$ParquetFactory
+org.apache.paimon.flink.compact.changelog.format.CompactedChangelogReadOnlyFormat$AvroFactory

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PrimaryKeyFileStoreTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PrimaryKeyFileStoreTableITCase.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -48,6 +49,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -297,9 +299,7 @@ public class PrimaryKeyFileStoreTableITCase extends AbstractTestBase {
     public void testBatchJobWithConflictAndRestart() throws Exception {
         TableEnvironment tEnv = tableEnvironmentBuilder().batchMode().allowRestart(10).build();
         tEnv.executeSql(
-                "CREATE CATALOG mycat WITH ( 'type' = 'paimon', 'warehouse' = '"
-                        + getTempDirPath()
-                        + "' )");
+                "CREATE CATALOG mycat WITH ( 'type' = 'paimon', 'warehouse' = '" + path + "' )");
         tEnv.executeSql("USE CATALOG mycat");
         tEnv.executeSql(
                 "CREATE TABLE t ( k INT, v INT, PRIMARY KEY (k) NOT ENFORCED ) "
@@ -327,6 +327,115 @@ public class PrimaryKeyFileStoreTableITCase extends AbstractTestBase {
                 assertThat(row.getField(1)).isNotEqualTo((int) row.getField(0) * 10);
             }
         }
+    }
+
+    @Test
+    @Timeout(120)
+    public void testChangelogCompact() throws Exception {
+        TableEnvironment bEnv = tableEnvironmentBuilder().batchMode().build();
+        String catalogDdl =
+                "CREATE CATALOG mycat WITH ( 'type' = 'paimon', 'warehouse' = '" + path + "' )";
+        bEnv.executeSql(catalogDdl);
+        bEnv.executeSql("USE CATALOG mycat");
+        bEnv.executeSql(
+                "CREATE TABLE t ( pt INT, k INT, v INT, PRIMARY KEY (pt, k) NOT ENFORCED ) "
+                        + "PARTITIONED BY (pt) "
+                        + "WITH ("
+                        + "    'bucket' = '2',\n"
+                        + "    'changelog-producer' = 'lookup',\n"
+                        + "    'changelog.compact.parallelism' = '1',\n"
+                        + "    'snapshot.num-retained.min' = '3',\n"
+                        + "    'snapshot.num-retained.max' = '3'\n"
+                        + ")");
+
+        TableEnvironment sEnv =
+                tableEnvironmentBuilder().streamingMode().checkpointIntervalMs(1000).build();
+        sEnv.executeSql(catalogDdl);
+        sEnv.executeSql("USE CATALOG mycat");
+
+        List<String> values = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            values.add(String.format("(0, %d, %d)", i, i));
+            values.add(String.format("(1, %d, %d)", i, i));
+        }
+        bEnv.executeSql("INSERT INTO t VALUES " + String.join(", ", values)).await();
+
+        List<String> compactedChangelogs2 = listAllFilesWithPrefix("compacted-changelog-");
+        assertThat(compactedChangelogs2).hasSize(2);
+        assertThat(listAllFilesWithPrefix("changelog-")).isEmpty();
+
+        List<Row> expected = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            expected.add(Row.ofKind(RowKind.INSERT, 0, i, i));
+            expected.add(Row.ofKind(RowKind.INSERT, 1, i, i));
+        }
+        assertStreamingResult(
+                sEnv.executeSql("SELECT * FROM t /*+ OPTIONS('scan.snapshot-id' = '1') */"),
+                expected);
+
+        values.clear();
+        for (int i = 0; i < 100; i++) {
+            values.add(String.format("(0, %d, %d)", i, i + 1));
+            values.add(String.format("(1, %d, %d)", i, i + 1));
+        }
+        bEnv.executeSql("INSERT INTO t VALUES " + String.join(", ", values)).await();
+
+        assertThat(listAllFilesWithPrefix("compacted-changelog-")).hasSize(4);
+        assertThat(listAllFilesWithPrefix("changelog-")).isEmpty();
+
+        for (int i = 0; i < 100; i++) {
+            expected.add(Row.ofKind(RowKind.UPDATE_BEFORE, 0, i, i));
+            expected.add(Row.ofKind(RowKind.UPDATE_BEFORE, 1, i, i));
+            expected.add(Row.ofKind(RowKind.UPDATE_AFTER, 0, i, i + 1));
+            expected.add(Row.ofKind(RowKind.UPDATE_AFTER, 1, i, i + 1));
+        }
+        assertStreamingResult(
+                sEnv.executeSql("SELECT * FROM t /*+ OPTIONS('scan.snapshot-id' = '1') */"),
+                expected);
+
+        values.clear();
+        for (int i = 0; i < 100; i++) {
+            values.add(String.format("(0, %d, %d)", i, i + 2));
+            values.add(String.format("(1, %d, %d)", i, i + 2));
+        }
+        bEnv.executeSql("INSERT INTO t VALUES " + String.join(", ", values)).await();
+
+        assertThat(listAllFilesWithPrefix("compacted-changelog-")).hasSize(4);
+        assertThat(listAllFilesWithPrefix("changelog-")).isEmpty();
+        LocalFileIO fileIO = LocalFileIO.create();
+        for (String p : compactedChangelogs2) {
+            assertThat(fileIO.exists(new Path(p))).isFalse();
+        }
+
+        expected = expected.subList(200, 600);
+        for (int i = 0; i < 100; i++) {
+            expected.add(Row.ofKind(RowKind.UPDATE_BEFORE, 0, i, i + 1));
+            expected.add(Row.ofKind(RowKind.UPDATE_BEFORE, 1, i, i + 1));
+            expected.add(Row.ofKind(RowKind.UPDATE_AFTER, 0, i, i + 2));
+            expected.add(Row.ofKind(RowKind.UPDATE_AFTER, 1, i, i + 2));
+        }
+        assertStreamingResult(
+                sEnv.executeSql("SELECT * FROM t /*+ OPTIONS('scan.snapshot-id' = '1') */"),
+                expected);
+    }
+
+    private List<String> listAllFilesWithPrefix(String prefix) throws Exception {
+        try (Stream<java.nio.file.Path> stream = Files.walk(java.nio.file.Paths.get(path))) {
+            return stream.filter(Files::isRegularFile)
+                    .filter(p -> p.getFileName().toString().startsWith(prefix))
+                    .map(java.nio.file.Path::toString)
+                    .collect(Collectors.toList());
+        }
+    }
+
+    private void assertStreamingResult(TableResult result, List<Row> expected) throws Exception {
+        List<Row> actual = new ArrayList<>();
+        try (CloseableIterator<Row> it = result.collect()) {
+            while (actual.size() < expected.size() && it.hasNext()) {
+                actual.add(it.next());
+            }
+        }
+        assertThat(actual).hasSameElementsAs(expected);
     }
 
     // ------------------------------------------------------------------------
@@ -482,14 +591,17 @@ public class PrimaryKeyFileStoreTableITCase extends AbstractTestBase {
                 tEnv,
                 numProducers,
                 enableFailure,
-                "'bucket' = '4',"
-                        + String.format(
-                                "'write-buffer-size' = '%s',",
-                                random.nextBoolean() ? "512kb" : "1mb")
-                        + "'changelog-producer' = 'lookup',"
-                        + String.format("'lookup-wait' = '%s',", random.nextBoolean())
-                        + String.format(
-                                "'deletion-vectors.enabled' = '%s'", enableDeletionVectors));
+                String.format(
+                        "'bucket' = '4', "
+                                + "'writer-buffer-size' = '%s', "
+                                + "'changelog-producer' = 'lookup', "
+                                + "'lookup-wait' = '%s', "
+                                + "'deletion-vectors.enabled' = '%s', "
+                                + "'changelog.compact.parallelism' = '%s'",
+                        random.nextBoolean() ? "512kb" : "1mb",
+                        random.nextBoolean(),
+                        enableDeletionVectors,
+                        random.nextInt(1, 3)));
 
         // sleep for a random amount of time to check
         // if we can first read complete records then read incremental records correctly


### PR DESCRIPTION
### Purpose

Currently, changelog files are not compacted. If Flink's checkpoint interval is short (for example, 30 seconds) and the number of buckets is large, each snapshot may produce lots of small changelog files. Too many files may put a burden on the distributed storage cluster.

This PR introduces a new feature to compact small changelog files into large ones.

### Tests

IT cases.

### API and Format

Introduces a special file format for compacted changelogs.

### Documentation

Document is also added.
