### PR TITLE
[core] Fix serialize name _DELETION_VECTORS_RANGES conflict

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMeta.java
@@ -53,7 +53,7 @@ public class IndexFileMeta {
                             new DataField(3, "_ROW_COUNT", new BigIntType(false)),
                             new DataField(
                                     4,
-                                    "_DELETION_VECTORS_RANGES",
+                                    "_DELETIONS_VECTORS_RANGES",
                                     new ArrayType(
                                             true,
                                             RowType.of(

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestEntry.java
@@ -56,7 +56,7 @@ public class IndexManifestEntry {
                             new DataField(6, "_ROW_COUNT", new BigIntType(false)),
                             new DataField(
                                     7,
-                                    "_DELETION_VECTORS_RANGES",
+                                    "_DELETIONS_VECTORS_RANGES",
                                     new ArrayType(
                                             true,
                                             RowType.of(

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestEntry.java
@@ -56,7 +56,7 @@ public class IndexManifestEntry {
                             new DataField(6, "_ROW_COUNT", new BigIntType(false)),
                             new DataField(
                                     7,
-                                    "_DELETIONS_VECTORS_RANGES",
+                                    "_DELETION_VECTORS_RANGES",
                                     new ArrayType(
                                             true,
                                             RowType.of(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
As described in issue #4182, keeping the name `_DELETIONS_VECTORS_RANGES` in Class `IndexManifestEntry`

<!-- Linking this pull request to the issue -->
Linked issue: close #4182

<!-- What is the purpose of the change -->

### Tests
No
<!-- List UT and IT cases to verify this change -->

### API and Format
No
<!-- Does this change affect API or storage format -->

### Documentation
No
<!-- Does this change introduce a new feature -->
