### PR TITLE
[core] Optimize UnawareAppendTableCompactionCoordinator to avoid OOM

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinator.java
@@ -46,7 +46,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -421,17 +420,17 @@ public class UnawareAppendTableCompactionCoordinator {
         @Nullable
         public ManifestEntry next() {
             while (true) {
-                if (currentIterator == null || !currentIterator.hasNext()) {
-                    assignNewIterator();
-                }
                 if (currentIterator == null) {
-                    return null;
+                    assignNewIterator();
+                    if (currentIterator == null) {
+                        return null;
+                    }
                 }
-                try {
+
+                if (currentIterator.hasNext()) {
                     return currentIterator.next();
-                } catch (NoSuchElementException e) {
-                    currentIterator = null;
                 }
+                currentIterator = null;
             }
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
@@ -38,6 +38,7 @@ import org.apache.paimon.utils.Filter;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -110,6 +111,8 @@ public interface FileStoreScan {
     List<PartitionEntry> readPartitionEntries();
 
     List<BucketEntry> readBucketEntries();
+
+    Iterator<ManifestEntry> readFileIterator();
 
     default List<BinaryRow> listPartitions() {
         return readPartitionEntries().stream()

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
@@ -39,6 +39,7 @@ import org.apache.paimon.utils.SnapshotManager;
 
 import javax.annotation.Nullable;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -102,6 +103,8 @@ public interface SnapshotReader {
     List<PartitionEntry> partitionEntries();
 
     List<BucketEntry> bucketEntries();
+
+    Iterator<ManifestEntry> readFileIterator();
 
     /** Result plan of this scan. */
     interface Plan extends TableScan.Plan {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
@@ -56,6 +56,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -361,6 +362,11 @@ public class SnapshotReaderImpl implements SnapshotReader {
     @Override
     public List<BucketEntry> bucketEntries() {
         return scan.readBucketEntries();
+    }
+
+    @Override
+    public Iterator<ManifestEntry> readFileIterator() {
+        return scan.readFileIterator();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
@@ -70,6 +70,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -381,6 +382,11 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
         @Override
         public List<BucketEntry> bucketEntries() {
             return wrapped.bucketEntries();
+        }
+
+        @Override
+        public Iterator<ManifestEntry> readFileIterator() {
+            return wrapped.readFileIterator();
         }
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyTableCompactionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyTableCompactionTest.java
@@ -131,7 +131,7 @@ public class AppendOnlyTableCompactionTest {
         commit(messages);
         tableSchema = tableSchema.copy(singletonMap("target-file-size", "1 b"));
         recreate();
-        assertThat(compactionCoordinator.plan()).isEmpty();
+        assertThat(compactionCoordinator.filesIterator().next()).isNull();
     }
 
     @Test
@@ -143,7 +143,9 @@ public class AppendOnlyTableCompactionTest {
         for (int i = 90; i < 100; i++) {
             count += i;
             commit(writeCommit(i));
-            commit(doCompact(compactionCoordinator.run()));
+            List<UnawareAppendCompactionTask> tasks = compactionCoordinator.run();
+            assertThat(tasks).hasSizeGreaterThan(0);
+            commit(doCompact(tasks));
             // scan the file generated itself
             assertThat(compactionCoordinator.scan()).isTrue();
             assertThat(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
If the table is very large and has many partitions, it can lead to putting too many ManifestEntries directly into memory, causing JVM OOM, and this situation is difficult to recover, with almost no means available at present.

So in this PR, the process of Plan is changed to Iterator mode, so that Compact can be safely performed regardless of the size of the table.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
