### PR TITLE
[e2e] Fix kafka consumer concurrent exception

### DIFF
--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/E2eTestBase.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/E2eTestBase.java
@@ -190,7 +190,7 @@ public abstract class E2eTestBase {
                 "cat >" + TEST_DATA_DIR + "/" + filename + " <<EOF\n" + content + "EOF\n");
     }
 
-    protected void createKafkaTopic(String topicName, int partitionNum)
+    protected synchronized void createKafkaTopic(String topicName, int partitionNum)
             throws IOException, InterruptedException {
         assert withKafka;
         ContainerState kafka = environment.getContainerByServiceName("kafka-1").get();

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionITCaseBase.java
@@ -227,7 +227,8 @@ public abstract class KafkaActionITCaseBase extends CdcActionITCaseBase {
         }
     }
 
-    private synchronized void logTopicPartitionStatus(Map<String, TopicDescription> topicDescriptions) {
+    private synchronized void logTopicPartitionStatus(
+            Map<String, TopicDescription> topicDescriptions) {
         List<TopicPartition> partitions = new ArrayList<>();
         topicDescriptions.forEach(
                 (topic, description) ->

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionITCaseBase.java
@@ -227,7 +227,7 @@ public abstract class KafkaActionITCaseBase extends CdcActionITCaseBase {
         }
     }
 
-    private void logTopicPartitionStatus(Map<String, TopicDescription> topicDescriptions) {
+    private synchronized void logTopicPartitionStatus(Map<String, TopicDescription> topicDescriptions) {
         List<TopicPartition> partitions = new ArrayList<>();
         topicDescriptions.forEach(
                 (topic, description) ->


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

Fix concurrent exception while building E2E Flink Test / Flink CDC

> Error: Exception in thread "Debug Logging Timer" java.lang.RuntimeException: Failed to execute logging action
      at org.apache.paimon.flink.action.cdc.kafka.KafkaActionITCaseBase$2.run(KafkaActionITCaseBase.java:206)
      at java.util.TimerThread.mainLoop(Timer.java:555)
      at java.util.TimerThread.run(Timer.java:505)
Caused by: java.util.ConcurrentModificationException: KafkaConsumer is not safe for multi-threaded access
      at org.apache.kafka.clients.consumer.KafkaConsumer.acquire(KafkaConsumer.java:2490)
      at org.apache.kafka.clients.consumer.KafkaConsumer.acquireAndEnsureOpen(KafkaConsumer.java:2474)
      at org.apache.kafka.clients.consumer.KafkaConsumer.beginningOffsets(KafkaConsumer.java:2175)
      at org.apache.kafka.clients.consumer.KafkaConsumer.beginningOffsets(KafkaConsumer.java:2154)
      at org.apache.paimon.flink.action.cdc.kafka.KafkaActionITCaseBase.logTopicPartitionStatus(KafkaActionITCaseBase.java:242)
      at org.apache.paimon.flink.action.cdc.kafka.KafkaActionITCaseBase.lambda$setup$0(KafkaActionITCaseBase.java:179)
      at org.apache.paimon.flink.action.cdc.kafka.KafkaActionITCaseBase$2.run(KafkaActionITCaseBase.java:204)
      ... 2 more

### Tests

<!-- List UT and IT cases to verify this change -->
No

### API and Format

<!-- Does this change affect API or storage format -->
No
### Documentation

<!-- Does this change introduce a new feature -->
No