### PR TITLE
[core] Sort the expired partitions and add max_expires param

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionExpireStrategy.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionExpireStrategy.java
@@ -26,6 +26,7 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.RowDataToObjectArrayConverter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,14 @@ public abstract class PartitionExpireStrategy {
             map.put(partitionKeys.get(i), array[i].toString());
         }
         return map;
+    }
+
+    public List<String> toPartitionValue(Object[] array) {
+        List<String> list = new ArrayList<>();
+        for (int i = 0; i < partitionKeys.size(); i++) {
+            list.add(array[i].toString());
+        }
+        return list;
     }
 
     public Object[] convertPartition(BinaryRow partition) {

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionExpireStrategy.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionExpireStrategy.java
@@ -43,7 +43,7 @@ public abstract class PartitionExpireStrategy {
     }
 
     public Map<String, String> toPartitionString(Object[] array) {
-        Map<String, String> map = new LinkedHashMap<>();
+        Map<String, String> map = new LinkedHashMap<>(partitionKeys.size());
         for (int i = 0; i < partitionKeys.size(); i++) {
             map.put(partitionKeys.get(i), array[i].toString());
         }
@@ -51,7 +51,7 @@ public abstract class PartitionExpireStrategy {
     }
 
     public List<String> toPartitionValue(Object[] array) {
-        List<String> list = new ArrayList<>();
+        List<String> list = new ArrayList<>(partitionKeys.size());
         for (int i = 0; i < partitionKeys.size(); i++) {
             list.add(array[i].toString());
         }

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/ExpirePartitionsProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/ExpirePartitionsProcedure.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.procedure;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.FileStore;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.metastore.MetastoreClient;
+import org.apache.paimon.operation.PartitionExpire;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.TimeUtils;
+
+import org.apache.flink.table.procedure.ProcedureContext;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.paimon.partition.PartitionExpireStrategy.createPartitionExpireStrategy;
+
+/** A procedure to expire partitions. */
+public class ExpirePartitionsProcedure extends ProcedureBase {
+
+    public static final String IDENTIFIER = "expire_partitions";
+
+    @Override
+    public String identifier() {
+        return IDENTIFIER;
+    }
+
+    public String[] call(
+            ProcedureContext procedureContext,
+            String tableId,
+            String expirationTime,
+            String timestampFormatter,
+            String timestampPattern,
+            String expireStrategy)
+            throws Catalog.TableNotExistException {
+        return call(
+                procedureContext,
+                tableId,
+                expirationTime,
+                timestampFormatter,
+                timestampPattern,
+                expireStrategy,
+                null);
+    }
+
+    public String[] call(
+            ProcedureContext procedureContext,
+            String tableId,
+            String expirationTime,
+            String timestampFormatter,
+            String timestampPattern,
+            String expireStrategy,
+            Integer maxExpires)
+            throws Catalog.TableNotExistException {
+        FileStoreTable fileStoreTable = (FileStoreTable) table(tableId);
+        FileStore fileStore = fileStoreTable.store();
+        Map<String, String> map = new HashMap<>();
+        map.put(CoreOptions.PARTITION_EXPIRATION_STRATEGY.key(), expireStrategy);
+        map.put(CoreOptions.PARTITION_TIMESTAMP_FORMATTER.key(), timestampFormatter);
+        map.put(CoreOptions.PARTITION_TIMESTAMP_PATTERN.key(), timestampPattern);
+
+        PartitionExpire partitionExpire =
+                new PartitionExpire(
+                        TimeUtils.parseDuration(expirationTime),
+                        Duration.ofMillis(0L),
+                        createPartitionExpireStrategy(
+                                CoreOptions.fromMap(map), fileStore.partitionType()),
+                        fileStore.newScan(),
+                        fileStore.newCommit(""),
+                        Optional.ofNullable(
+                                        fileStoreTable
+                                                .catalogEnvironment()
+                                                .metastoreClientFactory())
+                                .map(MetastoreClient.Factory::create)
+                                .orElse(null));
+        if (maxExpires != null) {
+            partitionExpire.withMaxExpires(maxExpires);
+        }
+        List<Map<String, String>> expired = partitionExpire.expire(Long.MAX_VALUE);
+        return expired == null || expired.isEmpty()
+                ? new String[] {"No expired partitions."}
+                : expired.stream()
+                        .map(
+                                x -> {
+                                    String r = x.toString();
+                                    return r.substring(1, r.length() - 1);
+                                })
+                        .toArray(String[]::new);
+    }
+}

--- a/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/procedure/ProcedurePositionalArgumentsITCase.java
+++ b/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/procedure/ProcedurePositionalArgumentsITCase.java
@@ -244,7 +244,10 @@ public class ProcedurePositionalArgumentsITCase extends CatalogITCaseBase {
         sql("INSERT INTO T VALUES ('1', '2024-06-01')");
         sql("INSERT INTO T VALUES ('2', '9024-06-01')");
         assertThat(read(table)).containsExactlyInAnyOrder("1:2024-06-01", "2:9024-06-01");
-        sql("CALL sys.expire_partitions('default.T', '1 d', 'yyyy-MM-dd', '$dt', 'values-time')");
+        assertThat(
+                        sql(
+                                "CALL sys.expire_partitions('default.T', '1 d', 'yyyy-MM-dd', '$dt', 'values-time')"))
+                .containsExactly(Row.of("dt=2024-06-01"));
         assertThat(read(table)).containsExactlyInAnyOrder("2:9024-06-01");
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ExpirePartitionsProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ExpirePartitionsProcedure.java
@@ -63,6 +63,10 @@ public class ExpirePartitionsProcedure extends ProcedureBase {
                         name = "expire_strategy",
                         type = @DataTypeHint("STRING"),
                         isOptional = true),
+                @ArgumentHint(
+                        name = "max_expires",
+                        type = @DataTypeHint("INTEGER"),
+                        isOptional = true)
             })
     public @DataTypeHint("ROW< expired_partitions STRING>") Row[] call(
             ProcedureContext procedureContext,
@@ -70,7 +74,8 @@ public class ExpirePartitionsProcedure extends ProcedureBase {
             String expirationTime,
             String timestampFormatter,
             String timestampPattern,
-            String expireStrategy)
+            String expireStrategy,
+            Integer maxExpires)
             throws Catalog.TableNotExistException {
         FileStoreTable fileStoreTable = (FileStoreTable) table(tableId);
         FileStore fileStore = fileStoreTable.store();
@@ -93,6 +98,9 @@ public class ExpirePartitionsProcedure extends ProcedureBase {
                                                 .metastoreClientFactory())
                                 .map(MetastoreClient.Factory::create)
                                 .orElse(null));
+        if (maxExpires != null) {
+            partitionExpire.withMaxExpires(maxExpires);
+        }
         List<Map<String, String>> expired = partitionExpire.expire(Long.MAX_VALUE);
         return expired == null || expired.isEmpty()
                 ? new Row[] {Row.of("No expired partitions.")}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpirePartitionsProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpirePartitionsProcedureITCase.java
@@ -399,7 +399,7 @@ public class ExpirePartitionsProcedureITCase extends CatalogITCaseBase {
                         "dt=2024-06-02, hm=02:00");
 
         assertThat(read(table, consumerReadResult))
-                .containsExactly("4:2024-06-03:01:00", "Never-expire:9999-09-09:99:99");
+                .containsExactlyInAnyOrder("4:2024-06-03:01:00", "Never-expire:9999-09-09:99:99");
     }
 
     /** Return a list of expired partitions. */


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
- The result of expire_partitions is out of order, sort it.
- Add max_expires param to limit the expired partitions number at one time.

before:
![image](https://github.com/user-attachments/assets/3eccb863-04c2-4439-9876-b4c591215b69)

after:
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/b9f70657-3ff7-4634-b6f7-0a0c40f890fc">



<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
