### PR TITLE
[spark] Support nested col pruning

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/types/ArrayType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/ArrayType.java
@@ -57,6 +57,10 @@ public final class ArrayType extends DataType {
         return elementType;
     }
 
+    public DataType newElementType(DataType newElementType) {
+        return new ArrayType(isNullable(), newElementType);
+    }
+
     @Override
     public int defaultSize() {
         return elementType.defaultSize();
@@ -94,6 +98,21 @@ public final class ArrayType extends DataType {
         }
         ArrayType arrayType = (ArrayType) o;
         return elementType.equals(arrayType.elementType);
+    }
+
+    @Override
+    public boolean isPrunedFrom(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        ArrayType arrayType = (ArrayType) o;
+        return elementType.isPrunedFrom(arrayType.elementType);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/types/MapType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/MapType.java
@@ -74,6 +74,10 @@ public class MapType extends DataType {
         return new MapType(isNullable, keyType.copy(), valueType.copy());
     }
 
+    public DataType newValueType(DataType valueType) {
+        return new MapType(isNullable(), keyType, valueType);
+    }
+
     @Override
     public String asSQLString() {
         return withNullability(FORMAT, keyType.asSQLString(), valueType.asSQLString());
@@ -103,6 +107,21 @@ public class MapType extends DataType {
         }
         MapType mapType = (MapType) o;
         return keyType.equals(mapType.keyType) && valueType.equals(mapType.valueType);
+    }
+
+    @Override
+    public boolean isPrunedFrom(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        MapType mapType = (MapType) o;
+        return keyType.equals(mapType.keyType) && valueType.isPrunedFrom(mapType.valueType);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/types/MapType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/MapType.java
@@ -74,8 +74,8 @@ public class MapType extends DataType {
         return new MapType(isNullable, keyType.copy(), valueType.copy());
     }
 
-    public DataType newValueType(DataType valueType) {
-        return new MapType(isNullable(), keyType, valueType);
+    public DataType newKeyValueType(DataType newKeyType, DataType newValueType) {
+        return new MapType(isNullable(), newKeyType, newValueType);
     }
 
     @Override
@@ -121,7 +121,7 @@ public class MapType extends DataType {
             return false;
         }
         MapType mapType = (MapType) o;
-        return keyType.equals(mapType.keyType) && valueType.isPrunedFrom(mapType.valueType);
+        return keyType.isPrunedFrom(mapType.keyType) && valueType.isPrunedFrom(mapType.valueType);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/types/RowType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/RowType.java
@@ -122,6 +122,15 @@ public final class RowType extends DataType {
         return false;
     }
 
+    public boolean containsField(int fieldId) {
+        for (DataField field : fields) {
+            if (field.id() == fieldId) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public boolean notContainsField(String fieldName) {
         return !containsField(fieldName);
     }
@@ -134,6 +143,15 @@ public final class RowType extends DataType {
         }
 
         throw new RuntimeException("Cannot find field: " + fieldName);
+    }
+
+    public DataField getField(int fieldId) {
+        for (DataField field : fields) {
+            if (field.id() == fieldId) {
+                return field;
+            }
+        }
+        throw new RuntimeException("Cannot find field by field id: " + fieldId);
     }
 
     public int getFieldIndexByFieldId(int fieldId) {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/BulkFormatMapping.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/BulkFormatMapping.java
@@ -178,7 +178,10 @@ public class BulkFormatMapping {
                     return d.copy(newFields);
                 case MAP:
                     return ((MapType) dataType)
-                            .newValueType(
+                            .newKeyValueType(
+                                    pruneDataType(
+                                            ((MapType) readType).getKeyType(),
+                                            ((MapType) dataType).getKeyType()),
                                     pruneDataType(
                                             ((MapType) readType).getValueType(),
                                             ((MapType) dataType).getValueType()));

--- a/paimon-core/src/main/java/org/apache/paimon/utils/BulkFormatMapping.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/BulkFormatMapping.java
@@ -26,7 +26,10 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.schema.IndexCastMapping;
 import org.apache.paimon.schema.SchemaEvolutionUtil;
 import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.RowType;
 
 import javax.annotation.Nullable;
@@ -37,7 +40,6 @@ import java.util.List;
 import java.util.function.Function;
 
 import static org.apache.paimon.predicate.PredicateBuilder.excludePredicateWithFields;
-import static org.apache.paimon.utils.Preconditions.checkState;
 
 /** Class with index mapping and bulk format. */
 public class BulkFormatMapping {
@@ -152,25 +154,43 @@ public class BulkFormatMapping {
                         .filter(f -> f.id() == dataField.id())
                         .findFirst()
                         .ifPresent(
-                                f -> {
-                                    if (f.type() instanceof RowType) {
-                                        RowType tableFieldType = (RowType) f.type();
-                                        RowType dataFieldType = (RowType) dataField.type();
-                                        checkState(tableFieldType.isPrunedFrom(dataFieldType));
-                                        // Since the nested type schema evolution is not supported,
-                                        // directly copy the fields from tableField's type to
-                                        // dataField's type.
-                                        // todo: support nested type schema evolutions.
+                                field ->
                                         readDataFields.add(
                                                 dataField.newType(
-                                                        dataFieldType.copy(
-                                                                tableFieldType.getFields())));
-                                    } else {
-                                        readDataFields.add(dataField);
-                                    }
-                                });
+                                                        pruneDataType(
+                                                                field.type(), dataField.type()))));
             }
             return readDataFields;
+        }
+
+        private DataType pruneDataType(DataType readType, DataType dataType) {
+            switch (readType.getTypeRoot()) {
+                case ROW:
+                    RowType r = (RowType) readType;
+                    RowType d = (RowType) dataType;
+                    ArrayList<DataField> newFields = new ArrayList<>();
+                    for (DataField rf : r.getFields()) {
+                        if (d.containsField(rf.id())) {
+                            DataField df = d.getField(rf.id());
+                            newFields.add(df.newType(pruneDataType(rf.type(), df.type())));
+                        }
+                    }
+                    return d.copy(newFields);
+                case MAP:
+                    return ((MapType) dataType)
+                            .newValueType(
+                                    pruneDataType(
+                                            ((MapType) readType).getValueType(),
+                                            ((MapType) dataType).getValueType()));
+                case ARRAY:
+                    return ((ArrayType) dataType)
+                            .newElementType(
+                                    pruneDataType(
+                                            ((ArrayType) readType).getElementType(),
+                                            ((ArrayType) dataType).getElementType()));
+                default:
+                    return dataType;
+            }
         }
 
         private List<Predicate> readFilters(

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
@@ -199,7 +199,7 @@ public class ParquetReaderFactory implements FormatReaderFactory {
                         mapGroup.getRepetition(),
                         mapGroup.getName(),
                         MAP_REPEATED_NAME,
-                        keyValue.getType(MAP_KEY_NAME),
+                        clipParquetType(mapType.getKeyType(), keyValue.getType(MAP_KEY_NAME)),
                         keyValue.containsField(MAP_VALUE_NAME)
                                 ? clipParquetType(
                                         mapType.getValueType(), keyValue.getType(MAP_VALUE_NAME))

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetSchemaConverter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetSchemaConverter.java
@@ -47,6 +47,9 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 public class ParquetSchemaConverter {
 
     static final String MAP_REPEATED_NAME = "key_value";
+    static final String MAP_KEY_NAME = "key";
+    static final String MAP_VALUE_NAME = "value";
+    static final String LIST_NAME = "list";
     static final String LIST_ELEMENT_NAME = "element";
 
     public static MessageType convertToParquetMessageType(String name, RowType rowType) {
@@ -149,8 +152,8 @@ public class ParquetSchemaConverter {
                         repetition,
                         name,
                         MAP_REPEATED_NAME,
-                        convertToParquetType("key", keyType),
-                        convertToParquetType("value", mapType.getValueType()));
+                        convertToParquetType(MAP_KEY_NAME, keyType),
+                        convertToParquetType(MAP_VALUE_NAME, mapType.getValueType()));
             case MULTISET:
                 MultisetType multisetType = (MultisetType) type;
                 DataType elementType = multisetType.getElementType();
@@ -163,8 +166,8 @@ public class ParquetSchemaConverter {
                         repetition,
                         name,
                         MAP_REPEATED_NAME,
-                        convertToParquetType("key", elementType),
-                        convertToParquetType("value", new IntType(false)));
+                        convertToParquetType(MAP_KEY_NAME, elementType),
+                        convertToParquetType(MAP_VALUE_NAME, new IntType(false)));
             case ROW:
                 RowType rowType = (RowType) type;
                 return new GroupType(repetition, name, convertToParquetTypes(rowType));

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetSplitReaderUtil.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetSplitReaderUtil.java
@@ -370,12 +370,12 @@ public class ParquetSplitReaderUtil {
     }
 
     public static List<ParquetField> buildFieldsList(
-            List<DataField> childrens, List<String> fieldNames, MessageColumnIO columnIO) {
+            List<DataField> children, List<String> fieldNames, MessageColumnIO columnIO) {
         List<ParquetField> list = new ArrayList<>();
-        for (int i = 0; i < childrens.size(); i++) {
+        for (int i = 0; i < children.size(); i++) {
             list.add(
                     constructField(
-                            childrens.get(i), lookupColumnByName(columnIO, fieldNames.get(i))));
+                            children.get(i), lookupColumnByName(columnIO, fieldNames.get(i))));
         }
         return list;
     }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkTypeUtils.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkTypeUtils.java
@@ -104,7 +104,9 @@ public class SparkTypeUtils {
             org.apache.spark.sql.types.MapType s =
                     (org.apache.spark.sql.types.MapType) sparkDataType;
             MapType p = (MapType) paimonDataType;
-            return p.newValueType(prunePaimonType(s.valueType(), p.getValueType()));
+            return p.newKeyValueType(
+                    prunePaimonType(s.keyType(), p.getKeyType()),
+                    prunePaimonType(s.valueType(), p.getValueType()));
         } else if (sparkDataType instanceof org.apache.spark.sql.types.ArrayType) {
             org.apache.spark.sql.types.ArrayType s =
                     (org.apache.spark.sql.types.ArrayType) sparkDataType;

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkTypeUtils.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkTypeUtils.java
@@ -81,6 +81,40 @@ public class SparkTypeUtils {
         return SparkToPaimonTypeVisitor.visit(dataType);
     }
 
+    /**
+     * Prune Paimon `RowType` by required Spark `StructType`, use this method instead of {@link
+     * #toPaimonType(DataType)} when need to retain the field id.
+     */
+    public static RowType prunePaimonRowType(StructType requiredStructType, RowType rowType) {
+        return (RowType) prunePaimonType(requiredStructType, rowType);
+    }
+
+    private static org.apache.paimon.types.DataType prunePaimonType(
+            DataType sparkDataType, org.apache.paimon.types.DataType paimonDataType) {
+        if (sparkDataType instanceof StructType) {
+            StructType s = (StructType) sparkDataType;
+            RowType p = (RowType) paimonDataType;
+            List<DataField> newFields = new ArrayList<>();
+            for (StructField field : s.fields()) {
+                DataField f = p.getField(field.name());
+                newFields.add(f.newType(prunePaimonType(field.dataType(), f.type())));
+            }
+            return p.copy(newFields);
+        } else if (sparkDataType instanceof org.apache.spark.sql.types.MapType) {
+            org.apache.spark.sql.types.MapType s =
+                    (org.apache.spark.sql.types.MapType) sparkDataType;
+            MapType p = (MapType) paimonDataType;
+            return p.newValueType(prunePaimonType(s.valueType(), p.getValueType()));
+        } else if (sparkDataType instanceof org.apache.spark.sql.types.ArrayType) {
+            org.apache.spark.sql.types.ArrayType s =
+                    (org.apache.spark.sql.types.ArrayType) sparkDataType;
+            ArrayType r = (ArrayType) paimonDataType;
+            return r.newElementType(prunePaimonType(s.elementType(), r.getElementType()));
+        } else {
+            return paimonDataType;
+        }
+    }
+
     private static class PaimonToSparkTypeVisitor extends DataTypeDefaultVisitor<DataType> {
 
         private static final PaimonToSparkTypeVisitor INSTANCE = new PaimonToSparkTypeVisitor();

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -60,7 +60,8 @@ abstract class PaimonBaseScan(
   private lazy val paimonMetricsRegistry: SparkMetricRegistry = SparkMetricRegistry()
 
   lazy val requiredStatsSchema: StructType = {
-    val fieldNames = requiredTableFields.map(_.name) ++ reservedFilters.flatMap(_.references)
+    val fieldNames =
+      readTableRowType.getFields.asScala.map(_.name) ++ reservedFilters.flatMap(_.references)
     StructType(tableSchema.filter(field => fieldNames.contains(field.name)))
   }
 

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/PaimonQueryTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/PaimonQueryTest.scala
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Assertions
 import java.util
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
 
 class PaimonQueryTest extends PaimonSparkTestBase {
   import testImplicits._
@@ -216,6 +217,82 @@ class PaimonQueryTest extends PaimonSparkTestBase {
           }
 
       }
+  }
+
+  test("Paimon Query: query nested cols") {
+    fileFormats.foreach {
+      fileFormat =>
+        bucketModes.foreach {
+          bucketMode =>
+            val bucketProp = if (bucketMode != -1) {
+              s", 'bucket-key'='name', 'bucket' = '$bucketMode' "
+            } else {
+              ""
+            }
+            withTable("students") {
+              sql(s"""
+                     |CREATE TABLE students (
+                     |  name STRING,
+                     |  course STRUCT<course_name: STRING, grade: DOUBLE>,
+                     |  teacher STRUCT<name: STRING, address: STRUCT<street: STRING, city: STRING>>,
+                     |  m MAP<STRING, STRUCT<s:STRING, i INT, d: DOUBLE>>,
+                     |  l ARRAY<STRUCT<s:STRING, i INT, d: DOUBLE>>,
+                     |  s STRUCT<s1: STRING, s2: MAP<STRING, STRUCT<s:STRING, i INT, a: ARRAY<STRUCT<s:STRING, i INT, d: DOUBLE>>>>>
+                     |) USING paimon
+                     |TBLPROPERTIES ('file.format'='$fileFormat' $bucketProp)
+                     |""".stripMargin)
+
+              sql(s"""
+                     |INSERT INTO students VALUES (
+                     |  'Alice',
+                     |  STRUCT('Math', 85.0),
+                     |  STRUCT('John', STRUCT('Street 1', 'City 1')),
+                     |  MAP('k1', STRUCT('s1', 1, 1.0), 'k2', STRUCT('s11', 11, 11.0)),
+                     |  ARRAY(STRUCT('s1', 1, 1.0), STRUCT('s11', 11, 11.0)),
+                     |  STRUCT('a', MAP('k1', STRUCT('s1', 1, ARRAY(STRUCT('s1', 1, 1.0))), 'k3', STRUCT('s11', 11, ARRAY(STRUCT('s11', 11, 11.0))))))
+                     |""".stripMargin)
+
+              sql(s"""
+                     |INSERT INTO students VALUES (
+                     |  'Bob',
+                     |  STRUCT('Biology', 92.0),
+                     |  STRUCT('Jane', STRUCT('Street 2', 'City 2')),
+                     |  MAP('k2', STRUCT('s2', 2, 2.0)),
+                     |  ARRAY(STRUCT('s2', 2, 2.0), STRUCT('s22', 22, 22.0)),
+                     |  STRUCT('b', MAP('k2', STRUCT('s22', 22, ARRAY(STRUCT('s22', 22, 22.0))))))
+                     |""".stripMargin)
+
+              sql(s"""
+                     |INSERT INTO students VALUES (
+                     |  'Cathy',
+                     |  STRUCT('History', 95.0),
+                     |  STRUCT('Jane', STRUCT('Street 3', 'City 3')),
+                     |  MAP('k1', STRUCT('s3', 3, 3.0), 'k2', STRUCT('s33', 33, 33.0)),
+                     |  ARRAY(STRUCT('s3', 3, 3.0)),
+                     |  STRUCT('c', MAP('k1', STRUCT('s3', 3, ARRAY(STRUCT('s3', 3, 3.0))), 'k2', STRUCT('s33', 33, ARRAY(STRUCT('s33', 33, 33.0))))))
+                     |""".stripMargin)
+
+              val res = ListBuffer[Row]()
+              res.append(
+                Row(85.0, "Alice", Row("Street 1", "City 1"), "Math", 1.0, "s1", 11.0, "s11", null))
+              res.append(
+                Row(92.0, "Bob", Row("Street 2", "City 2"), "Biology", null, null, 22.0, "s22", 22))
+              res.append(
+                Row(95.0, "Cathy", Row("Street 3", "City 3"), "History", 3.0, "s3", null, null, 33))
+              checkAnswer(
+                sql(s"""
+                       |SELECT
+                       |  course.grade, name, teacher.address, course.course_name,
+                       |  m['k1'].d, m['k1'].s,
+                       |  l[1].d, l[1].s,
+                       |  s.s2['k2'].a[0].i
+                       |FROM students ORDER BY name
+                       |""".stripMargin),
+                res
+              )
+            }
+        }
+    }
   }
 
   private def getAllFiles(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

to #4209, Support nested col pruning,  e.g.

```sql
CREATE TABLE students (
    name STRING,
    age INT,
    course STRUCT<course_name: STRING, grade: DOUBLE>
) USING paimon;
```

```sql
SELECT course.grade FROM students;
```

will only obtain `course.grade` from colume-storage-format (parquet, orc)

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
