### PR TITLE
[flink] partial-update merge engine support batch deletion using flink sql

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1942,6 +1942,10 @@ public class CoreOptions implements Serializable {
                 .orElse(Collections.emptyList());
     }
 
+    public boolean partialUpdateRemoveRecordOnDelete() {
+        return options.get(PARTIAL_UPDATE_REMOVE_RECORD_ON_DELETE);
+    }
+
     public Optional<String> rowkindField() {
         return options.getOptional(ROWKIND_FIELD);
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/SupportsRowLevelOperationFlinkTableSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/SupportsRowLevelOperationFlinkTableSink.java
@@ -187,7 +187,6 @@ public abstract class SupportsRowLevelOperationFlinkTableSink extends FlinkTable
 
         CoreOptions coreOptions = CoreOptions.fromMap(table.options());
         if (coreOptions.mergeEngine() == DEDUPLICATE
-                || coreOptions.ignoreDelete()
                 || (coreOptions.mergeEngine() == PARTIAL_UPDATE
                         && coreOptions.partialUpdateRemoveRecordOnDelete())) {
             return;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/SupportsRowLevelOperationFlinkTableSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/SupportsRowLevelOperationFlinkTableSink.java
@@ -185,11 +185,18 @@ public abstract class SupportsRowLevelOperationFlinkTableSink extends FlinkTable
                             table.getClass().getName()));
         }
 
-        MergeEngine mergeEngine = CoreOptions.fromMap(table.options()).mergeEngine();
-        if (mergeEngine != DEDUPLICATE) {
-            throw new UnsupportedOperationException(
-                    String.format("Merge engine %s can not support batch delete.", mergeEngine));
+        CoreOptions coreOptions = CoreOptions.fromMap(table.options());
+        if (coreOptions.mergeEngine() == DEDUPLICATE
+                || coreOptions.ignoreDelete()
+                || (coreOptions.mergeEngine() == PARTIAL_UPDATE
+                        && coreOptions.partialUpdateRemoveRecordOnDelete())) {
+            return;
         }
+
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Merge engine %s can not support batch delete.",
+                        coreOptions.mergeEngine()));
     }
 
     private boolean canPushDownDeleteFilter() {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
partial-update merge engine support batch deletion using flink sql


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PartialUpdateITCase#testRemoveRecordOnDelete

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
