### PR TITLE
[spark] Support push down aggregate with group by partition column

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkInternalRow.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkInternalRow.java
@@ -59,6 +59,8 @@ import org.apache.spark.sql.types.VarcharType;
 import org.apache.spark.unsafe.types.CalendarInterval;
 import org.apache.spark.unsafe.types.UTF8String;
 
+import java.util.Objects;
+
 import static org.apache.paimon.utils.InternalRowUtils.copyInternalRow;
 
 /** Spark {@link org.apache.spark.sql.catalyst.InternalRow} to wrap {@link InternalRow}. */
@@ -244,6 +246,25 @@ public class SparkInternalRow extends org.apache.spark.sql.catalyst.InternalRow 
 
         throw new UnsupportedOperationException("Unsupported data type " + dataType.simpleString());
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SparkInternalRow that = (SparkInternalRow) o;
+        return Objects.equals(rowType, that.rowType) && Objects.equals(row, that.row);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rowType, row);
+    }
+
+    // ================== static methods =========================================
 
     public static Object fromPaimon(Object o, DataType type) {
         if (o == null) {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkTypeUtils.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkTypeUtils.java
@@ -60,13 +60,17 @@ public class SparkTypeUtils {
 
     private SparkTypeUtils() {}
 
-    public static StructType toSparkPartitionType(Table table) {
+    public static RowType toPartitionType(Table table) {
         int[] projections = table.rowType().getFieldIndices(table.partitionKeys());
         List<DataField> partitionTypes = new ArrayList<>();
         for (int i : projections) {
             partitionTypes.add(table.rowType().getFields().get(i));
         }
-        return (StructType) SparkTypeUtils.fromPaimonType(new RowType(false, partitionTypes));
+        return new RowType(false, partitionTypes);
+    }
+
+    public static StructType toSparkPartitionType(Table table) {
+        return (StructType) SparkTypeUtils.fromPaimonType(toPartitionType(table));
     }
 
     public static StructType fromPaimonRowType(RowType type) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
If the aggregate all group by keys are from partition columns, we can support push down it. It makes user to get every partition (or with partition filter) row count fast. 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
add test

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
