### PR TITLE
[flink] Emit event time lag should not increase when no new records are read

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
@@ -203,6 +203,7 @@ public class OperatorSourceTest {
                                         readerOperatorMetricGroup, "currentEmitEventTimeLag")
                                 .getValue())
                 .isEqualTo(-1L);
+
         harness.processElement(new StreamRecord<>(splits.get(0)));
         assertThat(
                         (Long)
@@ -211,13 +212,22 @@ public class OperatorSourceTest {
                                                 "currentFetchEventTimeLag")
                                         .getValue())
                 .isGreaterThan(0);
+        long emitEventTimeLag =
+                (Long)
+                        TestingMetricUtils.getGauge(
+                                        readerOperatorMetricGroup, "currentEmitEventTimeLag")
+                                .getValue();
+        assertThat(emitEventTimeLag).isGreaterThan(0);
+
+        // wait for a while and read metrics again, metrics should not change
+        Thread.sleep(100);
         assertThat(
                         (Long)
                                 TestingMetricUtils.getGauge(
                                                 readerOperatorMetricGroup,
                                                 "currentEmitEventTimeLag")
                                         .getValue())
-                .isGreaterThan(0);
+                .isEqualTo(emitEventTimeLag);
     }
 
     private <T> T testReadSplit(


### PR DESCRIPTION
### Purpose

Currently for source with consumers, `currentEmitEventTimeLag` will continue to increase even if no new records are read. According to the definition of this metrics, this time lag is the different between the event time and the emit time of the last record.

This PR fixes the issue by sticking to the definition of the metrics.

### Tests

Unit tests.

### API and Format

No format changes.

### Documentation

No new feature.
