### PR TITLE
[core] Optimize multiple commit to reduce conflicts

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -251,7 +251,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             Map<String, String> properties,
             boolean checkAppendFiles) {
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Ready to commit\n" + committable.toString());
+            LOG.debug("Ready to commit\n{}", committable.toString());
         }
 
         long started = System.nanoTime();
@@ -712,29 +712,40 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             String branchName,
             @Nullable String statsFileName) {
         int cnt = 0;
+        RetryResult retryResult = null;
         while (true) {
             Snapshot latestSnapshot = snapshotManager.latestSnapshot();
             cnt++;
             if (cnt >= commitMaxRetries) {
+                if (retryResult != null) {
+                    retryResult.cleanAll();
+                }
                 throw new RuntimeException(
                         String.format(
                                 "Commit failed after %s attempts, there maybe exist commit conflicts between multiple jobs.",
                                 commitMaxRetries));
             }
-            if (tryCommitOnce(
-                    tableFiles,
-                    changelogFiles,
-                    indexFiles,
-                    identifier,
-                    watermark,
-                    logOffsets,
-                    commitKind,
-                    latestSnapshot,
-                    conflictCheck,
-                    branchName,
-                    statsFileName)) {
+
+            CommitResult result =
+                    tryCommitOnce(
+                            retryResult,
+                            tableFiles,
+                            changelogFiles,
+                            indexFiles,
+                            identifier,
+                            watermark,
+                            logOffsets,
+                            commitKind,
+                            latestSnapshot,
+                            conflictCheck,
+                            branchName,
+                            statsFileName);
+
+            if (result.isSuccess()) {
                 break;
             }
+
+            retryResult = (RetryResult) result;
         }
         return cnt;
     }
@@ -789,27 +800,35 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             changesWithOverwrite.addAll(changes);
             indexChangesWithOverwrite.addAll(indexFiles);
 
-            if (tryCommitOnce(
-                    changesWithOverwrite,
-                    Collections.emptyList(),
-                    indexChangesWithOverwrite,
-                    identifier,
-                    watermark,
-                    logOffsets,
-                    Snapshot.CommitKind.OVERWRITE,
-                    latestSnapshot,
-                    mustConflictCheck(),
-                    branchName,
-                    null)) {
+            CommitResult result =
+                    tryCommitOnce(
+                            null,
+                            changesWithOverwrite,
+                            Collections.emptyList(),
+                            indexChangesWithOverwrite,
+                            identifier,
+                            watermark,
+                            logOffsets,
+                            Snapshot.CommitKind.OVERWRITE,
+                            latestSnapshot,
+                            mustConflictCheck(),
+                            branchName,
+                            null);
+
+            if (result.isSuccess()) {
                 break;
             }
+
+            RetryResult retryResult = (RetryResult) result;
+            retryResult.cleanAll();
         }
         return cnt;
     }
 
     @VisibleForTesting
-    boolean tryCommitOnce(
-            List<ManifestEntry> tableFiles,
+    CommitResult tryCommitOnce(
+            @Nullable RetryResult retryResult,
+            List<ManifestEntry> deltaFiles,
             List<ManifestEntry> changelogFiles,
             List<IndexManifestEntry> indexFiles,
             long identifier,
@@ -830,7 +849,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Ready to commit table files to snapshot {}", newSnapshotId);
-            for (ManifestEntry entry : tableFiles) {
+            for (ManifestEntry entry : deltaFiles) {
                 LOG.debug("  * {}", entry);
             }
             LOG.debug("Ready to commit changelog to snapshot {}", newSnapshotId);
@@ -842,27 +861,31 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         if (latestSnapshot != null && conflictCheck.shouldCheck(latestSnapshot.id())) {
             // latestSnapshotId is different from the snapshot id we've checked for conflicts,
             // so we have to check again
-            noConflictsOrFail(latestSnapshot.commitUser(), latestSnapshot, tableFiles);
+            try {
+                noConflictsOrFail(latestSnapshot.commitUser(), latestSnapshot, deltaFiles);
+            } catch (Exception e) {
+                if (retryResult != null) {
+                    retryResult.cleanAll();
+                }
+                throw e;
+            }
         }
 
         Snapshot newSnapshot;
-        String previousChangesListName = null;
-        String newChangesListName = null;
-        String changelogListName = null;
-        String newIndexManifest = null;
-        List<ManifestFileMeta> oldMetas = new ArrayList<>();
-        List<ManifestFileMeta> newMetas = new ArrayList<>();
-        List<ManifestFileMeta> changelogMetas = new ArrayList<>();
+        String baseManifestList = null;
+        String deltaManifestList = null;
+        String changelogManifestList = null;
+        String oldIndexManifest = null;
+        String indexManifest = null;
+        List<ManifestFileMeta> mergeBeforeManifests = new ArrayList<>();
+        List<ManifestFileMeta> mergeAfterManifests = new ArrayList<>();
         try {
             long previousTotalRecordCount = 0L;
             Long currentWatermark = watermark;
-            String previousIndexManifest = null;
             if (latestSnapshot != null) {
                 previousTotalRecordCount = scan.totalRecordCount(latestSnapshot);
-                List<ManifestFileMeta> previousManifests =
-                        manifestList.readDataManifests(latestSnapshot);
                 // read all previous manifest files
-                oldMetas.addAll(previousManifests);
+                mergeBeforeManifests = manifestList.readDataManifests(latestSnapshot);
                 // read the last snapshot to complete the bucket's offsets when logOffsets does not
                 // contain all buckets
                 Map<Integer, Long> latestLogOffsets = latestSnapshot.logOffsets();
@@ -876,41 +899,76 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                                     ? latestWatermark
                                     : Math.max(currentWatermark, latestWatermark);
                 }
-                previousIndexManifest = latestSnapshot.indexManifest();
+                oldIndexManifest = latestSnapshot.indexManifest();
             }
-            // merge manifest files with changes
-            newMetas.addAll(
-                    ManifestFileMerger.merge(
-                            oldMetas,
-                            manifestFile,
-                            manifestTargetSize.getBytes(),
-                            manifestMergeMinCount,
-                            manifestFullCompactionSize.getBytes(),
-                            partitionType,
-                            manifestReadParallelism));
-            previousChangesListName = manifestList.write(newMetas);
+
+            // try to merge old manifest files to create base manifest list
+            boolean needsManifestMerge = true;
+            if (retryResult != null) {
+                Set<String> retryMergeBefore =
+                        retryResult.mergeBeforeManifests.stream()
+                                .map(ManifestFileMeta::fileName)
+                                .collect(Collectors.toSet());
+                List<ManifestFileMeta> manifestsFromOther =
+                        mergeBeforeManifests.stream()
+                                .filter(m -> !retryMergeBefore.remove(m.fileName()))
+                                .collect(Collectors.toList());
+                if (retryMergeBefore.isEmpty()) {
+                    needsManifestMerge = false;
+                    // copy this to avoid wrong clean for retryResult
+                    mergeAfterManifests = new ArrayList<>(retryResult.mergeAfterManifests);
+                    mergeAfterManifests.addAll(manifestsFromOther);
+                    LOG.info("Reusing manifest merging for retry.");
+                } else {
+                    retryResult.cleanManifestMerge();
+                }
+            }
+            if (needsManifestMerge) {
+                mergeAfterManifests =
+                        ManifestFileMerger.merge(
+                                mergeBeforeManifests,
+                                manifestFile,
+                                manifestTargetSize.getBytes(),
+                                manifestMergeMinCount,
+                                manifestFullCompactionSize.getBytes(),
+                                partitionType,
+                                manifestReadParallelism);
+            }
+            baseManifestList = manifestList.write(mergeAfterManifests);
 
             // the added records subtract the deleted records from
-            long deltaRecordCount = recordCountAdd(tableFiles) - recordCountDelete(tableFiles);
+            long deltaRecordCount = recordCountAdd(deltaFiles) - recordCountDelete(deltaFiles);
             long totalRecordCount = previousTotalRecordCount + deltaRecordCount;
 
-            // write new changes into manifest files
-            List<ManifestFileMeta> newChangesManifests = manifestFile.write(tableFiles);
-            newMetas.addAll(newChangesManifests);
-            newChangesListName = manifestList.write(newChangesManifests);
+            // write new delta files into manifest files
+            deltaManifestList =
+                    retryResult == null
+                            ? manifestList.write(manifestFile.write(deltaFiles))
+                            : retryResult.deltaManifestList;
 
             // write changelog into manifest files
             if (!changelogFiles.isEmpty()) {
-                changelogMetas.addAll(manifestFile.write(changelogFiles));
-                changelogListName = manifestList.write(changelogMetas);
+                changelogManifestList =
+                        retryResult == null
+                                ? manifestList.write(manifestFile.write(changelogFiles))
+                                : retryResult.changelogManifestList;
             }
 
             // write new index manifest
-            String indexManifest =
-                    indexManifestFile.writeIndexFiles(
-                            previousIndexManifest, indexFiles, bucketMode);
-            if (!Objects.equals(indexManifest, previousIndexManifest)) {
-                newIndexManifest = indexManifest;
+            boolean rewriteIndexManifest = true;
+            if (retryResult != null) {
+                if (Objects.equals(oldIndexManifest, retryResult.oldIndexManifest)) {
+                    rewriteIndexManifest = false;
+                    indexManifest = retryResult.newIndexManifest;
+                    LOG.info("Reusing index manifest {} for retry.", indexManifest);
+                } else {
+                    retryResult.cleanIndexManifest();
+                }
+            }
+
+            if (rewriteIndexManifest) {
+                indexManifest =
+                        indexManifestFile.writeIndexFiles(oldIndexManifest, indexFiles, bucketMode);
             }
 
             long latestSchemaId = schemaManager.latest().get().id();
@@ -935,9 +993,9 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     new Snapshot(
                             newSnapshotId,
                             latestSchemaId,
-                            previousChangesListName,
-                            newChangesListName,
-                            changelogListName,
+                            baseManifestList,
+                            deltaManifestList,
+                            changelogManifestList,
                             indexManifest,
                             commitUser,
                             identifier,
@@ -951,14 +1009,21 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                             statsFileName);
         } catch (Throwable e) {
             // fails when preparing for commit, we should clean up
-            cleanUpTmpManifests(
-                    previousChangesListName,
-                    newChangesListName,
-                    changelogListName,
-                    newIndexManifest,
-                    oldMetas,
-                    newMetas,
-                    changelogMetas);
+            if (retryResult != null) {
+                retryResult.cleanAll();
+            }
+            RetryResult newResult =
+                    new RetryResult(
+                            deltaManifestList,
+                            changelogManifestList,
+                            oldIndexManifest,
+                            indexManifest,
+                            mergeBeforeManifests,
+                            mergeAfterManifests);
+            newResult.cleanAll();
+            if (baseManifestList != null) {
+                manifestList.delete(baseManifestList);
+            }
             throw new RuntimeException(
                     String.format(
                             "Exception occurs when preparing snapshot #%d (path %s) by user %s "
@@ -1023,8 +1088,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                                 identifier,
                                 commitKind.name()));
             }
-            commitCallbacks.forEach(callback -> callback.call(tableFiles, newSnapshot));
-            return true;
+            commitCallbacks.forEach(callback -> callback.call(deltaFiles, newSnapshot));
+            return new SuccessResult();
         }
 
         // atomic rename fails, clean up and try again
@@ -1040,15 +1105,16 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         identifier,
                         commitKind.name(),
                         commitTime));
-        cleanUpTmpManifests(
-                previousChangesListName,
-                newChangesListName,
-                changelogListName,
-                newIndexManifest,
-                oldMetas,
-                newMetas,
-                changelogMetas);
-        return false;
+        if (baseManifestList != null) {
+            manifestList.delete(baseManifestList);
+        }
+        return new RetryResult(
+                deltaManifestList,
+                changelogManifestList,
+                oldIndexManifest,
+                indexManifest,
+                mergeBeforeManifests,
+                mergeAfterManifests);
     }
 
     @SafeVarargs
@@ -1070,11 +1136,11 @@ public class FileStoreCommitImpl implements FileStoreCommit {
     }
 
     private void noConflictsOrFail(
-            String baseCommitUser, Snapshot latestSnapshot, List<ManifestEntry> changes) {
+            String baseCommitUser, Snapshot latestSnapshot, List<ManifestEntry> deltaFiles) {
         noConflictsOrFail(
                 baseCommitUser,
-                readAllEntriesFromChangedPartitions(latestSnapshot, changes),
-                SimpleFileEntry.from(changes));
+                readAllEntriesFromChangedPartitions(latestSnapshot, deltaFiles),
+                SimpleFileEntry.from(deltaFiles));
     }
 
     private void noConflictsOrFail(
@@ -1276,40 +1342,6 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         }
     }
 
-    private void cleanUpTmpManifests(
-            String previousChangesListName,
-            String newChangesListName,
-            String changelogListName,
-            String newIndexManifest,
-            List<ManifestFileMeta> oldMetas,
-            List<ManifestFileMeta> newMetas,
-            List<ManifestFileMeta> changelogMetas) {
-        // clean up newly created manifest list
-        if (previousChangesListName != null) {
-            manifestList.delete(previousChangesListName);
-        }
-        if (newChangesListName != null) {
-            manifestList.delete(newChangesListName);
-        }
-        if (changelogListName != null) {
-            manifestList.delete(changelogListName);
-        }
-        if (newIndexManifest != null) {
-            indexManifestFile.delete(newIndexManifest);
-        }
-        // clean up newly merged manifest files
-        Set<ManifestFileMeta> oldMetaSet = new HashSet<>(oldMetas); // for faster searching
-        for (ManifestFileMeta suspect : newMetas) {
-            if (!oldMetaSet.contains(suspect)) {
-                manifestList.delete(suspect.fileName());
-            }
-        }
-        // clean up changelog manifests
-        for (ManifestFileMeta meta : changelogMetas) {
-            manifestList.delete(meta.fileName());
-        }
-    }
-
     @Override
     public void close() {
         for (CommitCallback callback : commitCallbacks) {
@@ -1362,5 +1394,105 @@ public class FileStoreCommitImpl implements FileStoreCommit {
     @VisibleForTesting
     static ConflictCheck mustConflictCheck() {
         return latestSnapshot -> true;
+    }
+
+    private interface CommitResult {
+        boolean isSuccess();
+    }
+
+    private static class SuccessResult implements CommitResult {
+
+        @Override
+        public boolean isSuccess() {
+            return true;
+        }
+    }
+
+    private class RetryResult implements CommitResult {
+
+        private final String deltaManifestList;
+        private final String changelogManifestList;
+
+        private final String oldIndexManifest;
+        private final String newIndexManifest;
+
+        private final List<ManifestFileMeta> mergeBeforeManifests;
+        private final List<ManifestFileMeta> mergeAfterManifests;
+
+        private RetryResult(
+                String deltaManifestList,
+                String changelogManifestList,
+                String oldIndexManifest,
+                String newIndexManifest,
+                List<ManifestFileMeta> mergeBeforeManifests,
+                List<ManifestFileMeta> mergeAfterManifests) {
+            this.deltaManifestList = deltaManifestList;
+            this.changelogManifestList = changelogManifestList;
+            this.oldIndexManifest = oldIndexManifest;
+            this.newIndexManifest = newIndexManifest;
+            this.mergeBeforeManifests = mergeBeforeManifests;
+            this.mergeAfterManifests = mergeAfterManifests;
+        }
+
+        private void cleanAll() {
+            cleanManifestList(deltaManifestList);
+            cleanManifestList(changelogManifestList);
+            cleanIndexManifest();
+            cleanManifestMerge();
+        }
+
+        private void cleanManifestList(String toBeDelete) {
+            if (toBeDelete != null) {
+                for (ManifestFileMeta manifest : manifestList.read(toBeDelete)) {
+                    manifestFile.delete(manifest.fileName());
+                }
+                manifestList.delete(toBeDelete);
+            }
+        }
+
+        private void cleanIndexManifest() {
+            if (newIndexManifest != null && !Objects.equals(oldIndexManifest, newIndexManifest)) {
+                indexManifestFile.delete(newIndexManifest);
+            }
+        }
+
+        private void cleanManifestMerge() {
+            Set<String> oldMetaSet =
+                    mergeBeforeManifests.stream()
+                            .map(ManifestFileMeta::fileName)
+                            .collect(Collectors.toSet());
+            for (ManifestFileMeta suspect : mergeAfterManifests) {
+                if (!oldMetaSet.contains(suspect.fileName())) {
+                    manifestFile.delete(suspect.fileName());
+                }
+            }
+        }
+
+        @Override
+        public boolean isSuccess() {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "{"
+                    + "deltaManifestList='"
+                    + deltaManifestList
+                    + '\''
+                    + ", changelogManifestList='"
+                    + changelogManifestList
+                    + '\''
+                    + ", oldIndexManifest='"
+                    + oldIndexManifest
+                    + '\''
+                    + ", newIndexManifest='"
+                    + newIndexManifest
+                    + '\''
+                    + ", mergeBeforeManifests="
+                    + mergeBeforeManifests
+                    + ", mergeAfterManifests="
+                    + mergeAfterManifests
+                    + '}';
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
@@ -122,7 +122,7 @@ public class ObjectsFile<T> implements SimpleFileReader<T> {
         try {
             return readWithIOException(fileName, fileSize, loadFilter, readFilter);
         } catch (IOException e) {
-            throw new RuntimeException("Failed to read manifest list " + fileName, e);
+            throw new RuntimeException("Failed to read " + fileName, e);
         }
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
@@ -789,6 +789,7 @@ public class FileDeletionTest {
         // commit
         try (FileStoreCommitImpl commit = store.newCommit()) {
             commit.tryCommitOnce(
+                    null,
                     delete,
                     Collections.emptyList(),
                     Collections.emptyList(),

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -238,6 +238,8 @@ public class FileStoreCommitTest {
 
         testRandomConcurrent(
                 dataPerThread,
+                // overwrite cannot produce changelog
+                // so only enable it when changelog producer is none
                 changelogProducer == CoreOptions.ChangelogProducer.NONE,
                 failing,
                 changelogProducer);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
At present, if the number of files is very large and the commit interval is relatively small, and multiple jobs are written simultaneously, there will be serious competition, and even retry failures (more than ten times will fail).

This is because the data files conflicts checking may be triggered at present, which requires a relatively long time to read data files from old snapshot. If other jobs commit at this time, and repeated commit may still fail because of repeated conflicts checking.

This is very wasteful. We can actually reuse the base files, we can just read incremental files and merge it to last time base files.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
