### PR TITLE
[core] Filter data file while executing local orphan clean

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -106,7 +106,8 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
         // delete unused files
         candidateDeletes.removeAll(usedFiles);
         candidateDeletes.stream().map(candidates::get).forEach(fileCleaner);
-        deleteFiles.addAll(candidateDeletes.stream().map(candidates::get).collect(Collectors.toList()));
+        deleteFiles.addAll(
+                candidateDeletes.stream().map(candidates::get).collect(Collectors.toList()));
 
         return deleteFiles;
     }
@@ -161,8 +162,8 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
                                     dataFiles.add(f.fileName());
                                 }
                                 f.extraFiles().stream()
-                                    .filter(candidateDeletes::contains)
-                                    .forEach(dataFiles::add);
+                                        .filter(candidateDeletes::contains)
+                                        .forEach(dataFiles::add);
                             });
         }
         return dataFiles;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -118,7 +118,7 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
         ManifestFile manifestFile =
                 table.switchToBranch(branch).store().manifestFileFactory().create();
         try {
-            List<String> manifests = new ArrayList<>();
+            Set<String> manifests = new HashSet<>();
             collectWithoutDataFile(branch, usedFiles::add, manifests::add);
             usedFiles.addAll(retryReadingDataFiles(manifestFile, manifests));
         } catch (IOException e) {
@@ -148,8 +148,8 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
         return result;
     }
 
-    private List<String> retryReadingDataFiles(
-            ManifestFile manifestFile, List<String> manifestNames) throws IOException {
+    private List<String> retryReadingDataFiles(ManifestFile manifestFile, Set<String> manifestNames)
+            throws IOException {
         List<String> dataFiles = new ArrayList<>();
         for (String manifestName : manifestNames) {
             retryReadingFiles(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -65,6 +65,8 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
 
     private final List<Path> deleteFiles;
 
+    private Set<String> candidateDeletes;
+
     public LocalOrphanFilesClean(FileStoreTable table) {
         this(table, System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1));
     }
@@ -93,6 +95,7 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
         if (candidates.isEmpty()) {
             return deleteFiles;
         }
+        candidateDeletes = new HashSet<>(candidates.keySet());
 
         // find used files
         Set<String> usedFiles =
@@ -101,10 +104,9 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
                         .collect(Collectors.toSet());
 
         // delete unused files
-        Set<String> deleted = new HashSet<>(candidates.keySet());
-        deleted.removeAll(usedFiles);
-        deleted.stream().map(candidates::get).forEach(fileCleaner);
-        deleteFiles.addAll(deleted.stream().map(candidates::get).collect(Collectors.toList()));
+        candidateDeletes.removeAll(usedFiles);
+        candidateDeletes.stream().map(candidates::get).forEach(fileCleaner);
+        deleteFiles.addAll(candidateDeletes.stream().map(candidates::get).collect(Collectors.toList()));
 
         return deleteFiles;
     }
@@ -155,8 +157,12 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
                     .map(ManifestEntry::file)
                     .forEach(
                             f -> {
-                                dataFiles.add(f.fileName());
-                                dataFiles.addAll(f.extraFiles());
+                                if (candidateDeletes.contains(f.fileName())) {
+                                    dataFiles.add(f.fileName());
+                                }
+                                f.extraFiles().stream()
+                                    .filter(candidateDeletes::contains)
+                                    .forEach(dataFiles::add);
                             });
         }
         return dataFiles;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -108,6 +108,7 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
         candidateDeletes.stream().map(candidates::get).forEach(fileCleaner);
         deleteFiles.addAll(
                 candidateDeletes.stream().map(candidates::get).collect(Collectors.toList()));
+        candidateDeletes.clear();
 
         return deleteFiles;
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->
Local Remove Orphan Files OOM always occurred when collecting data file meta. Because  data files in tables may be large (could reach tens of millions or more). 

Relatively speaking, the number of candidate files is not large (ten thousand or hundreds of thousands).

So we can just collect data file meta in candidate files to reduce the probability of OOM occurrence.


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
