### PR TITLE
[fix][flink] Fix Iceberg compatible metadata cannot be read when data file format is parquet

### DIFF
--- a/docs/content/migration/iceberg-compatibility.md
+++ b/docs/content/migration/iceberg-compatibility.md
@@ -1,0 +1,373 @@
+---
+title: "Iceberg Compatibility"
+weight: 4
+type: docs
+aliases:
+- /migration/iceberg-compatibility.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Iceberg Compatibility
+
+Paimon supports generating Iceberg compatible metadata,
+so that Paimon tables can be consumed directly by Iceberg readers.
+
+## Enable Iceberg Compatibility
+
+Set the following table options, so that Paimon tables can generate Iceberg compatible metadata.
+
+<table class="table table-bordered">
+    <thead>
+    <tr>
+      <th class="text-left" style="width: 20%">Option</th>
+      <th class="text-left" style="width: 5%">Default</th>
+      <th class="text-left" style="width: 10%">Type</th>
+      <th class="text-left" style="width: 60%">Description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td><h5>metadata.iceberg.storage</h5></td>
+      <td style="word-wrap: break-word;">disabled</td>
+      <td>Enum</td>
+      <td>
+        When set, produce Iceberg metadata after a snapshot is committed, so that Iceberg readers can read Paimon's raw data files.
+        <ul>
+          <li>disabled: Disable Iceberg compatibility support.</li>
+          <li>table-location: Store Iceberg metadata in each table's directory.</li>
+          <li>hadoop-catalog: Store Iceberg metadata in a separate directory. This directory can be specified as the warehouse directory of an Iceberg Hadoop catalog.</li>
+        </ul>
+      </td>
+    </tr>
+    </tbody>
+</table>
+
+For most SQL users, we recommend setting `'metadata.iceberg.storage' = 'hadoop-catalog'`,
+so that all tables can be visited as an Iceberg warehouse.
+For Iceberg Java API users, you might consider setting `'metadata.iceberg.storage' = 'table-location'`,
+so you can visit each table with its table path.
+
+## Example: Query Paimon Append Only Tables with Iceberg Connector
+
+Let's walk through a simple example, where we query Paimon tables with Iceberg connectors in Flink and Spark.
+Before trying out this example, make sure that your compute engine already supports Iceberg.
+Please refer to Iceberg's document if you haven't set up Iceberg.
+* Flink: [Preparation when using Flink SQL Client](https://iceberg.apache.org/docs/latest/flink/#preparation-when-using-flink-sql-client)
+* Spark: [Using Iceberg in Spark 3](https://iceberg.apache.org/docs/latest/spark-getting-started/#using-iceberg-in-spark-3)
+
+Let's now create a Paimon append only table with Iceberg compatibility enabled and insert some data.
+
+{{< tabs "create-paimon-append-only-table" >}}
+
+{{< tab "Flink SQL" >}}
+```sql
+CREATE CATALOG paimon_catalog WITH (
+    'type' = 'paimon',
+    'warehouse' = '<path-to-warehouse>'
+);
+
+CREATE TABLE paimon_catalog.`default`.cities (
+    country STRING,
+    name STRING
+) WITH (
+    'metadata.iceberg.storage' = 'hadoop-catalog'
+);
+
+INSERT INTO paimon_catalog.`default`.cities VALUES ('usa', 'new york'), ('germany', 'berlin'), ('usa', 'chicago'), ('germany', 'hamburg');
+```
+{{< /tab >}}
+
+{{< tab "Spark SQL" >}}
+Start `spark-sql` with the following command line.
+
+```bash
+spark-sql --jars <path-to-paimon-jar> \
+    --conf spark.sql.catalog.paimon_catalog=org.apache.paimon.spark.SparkCatalog \
+    --conf spark.sql.catalog.paimon_catalog.warehouse=/tmp/sparkware \
+    --packages org.apache.iceberg:iceberg-spark-runtime-<iceberg-version> \
+    --conf spark.sql.catalog.iceberg_catalog=org.apache.iceberg.spark.SparkCatalog \
+    --conf spark.sql.catalog.iceberg_catalog.type=hadoop \
+    --conf spark.sql.catalog.iceberg_catalog.warehouse=<path-to-warehouse>/iceberg \
+    --conf spark.sql.catalog.iceberg_catalog.cache-enabled=false \ # disable iceberg catalog caching to quickly see the result
+    --conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions,org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
+```
+
+Run the following Spark SQL to create Paimon table and insert data.
+
+```sql
+CREATE TABLE paimon_catalog.`default`.cities (
+    country STRING,
+    name STRING
+) TBLPROPERTIES (
+    'metadata.iceberg.storage' = 'hadoop-catalog'
+);
+
+INSERT INTO paimon_catalog.`default`.cities VALUES ('usa', 'new york'), ('germany', 'berlin'), ('usa', 'chicago'), ('germany', 'hamburg');
+```
+{{< /tab >}}
+
+{{< /tabs >}}
+
+Now let's query this Paimon table with Iceberg connector.
+
+{{< tabs "query-paimon-append-only-table" >}}
+
+{{< tab "Flink SQL" >}}
+```sql
+CREATE TABLE cities (
+    country STRING,
+    name STRING
+) WITH (
+    'connector' = 'iceberg',
+    'catalog-type' = 'hadoop',
+    'catalog-name' = 'test',
+    'catalog-database' = 'default',
+    'warehouse' = '<path-to-warehouse>/iceberg'
+);
+
+SELECT * FROM cities WHERE country = 'germany';
+/*
++----+--------------------------------+--------------------------------+
+| op |                        country |                           name |
++----+--------------------------------+--------------------------------+
+| +I |                        germany |                         berlin |
+| +I |                        germany |                        hamburg |
++----+--------------------------------+--------------------------------+
+*/
+```
+{{< /tab >}}
+
+{{< tab "Spark SQL" >}}
+```sql
+SELECT * FROM iceberg_catalog.`default`.cities WHERE country = 'germany';
+/*
+germany berlin
+germany hamburg
+*/
+```
+{{< /tab >}}
+
+{{< /tabs >}}
+
+Let's insert more data and query again.
+
+{{< tabs "query-paimon-append-only-table-again" >}}
+
+{{< tab "Flink SQL" >}}
+```sql
+INSERT INTO paimon_catalog.`default`.cities VALUES ('usa', 'houston'), ('germany', 'munich');
+
+SELECT * FROM cities WHERE country = 'germany';
+/*
++----+--------------------------------+--------------------------------+
+| op |                        country |                           name |
++----+--------------------------------+--------------------------------+
+| +I |                        germany |                         munich |
+| +I |                        germany |                         berlin |
+| +I |                        germany |                        hamburg |
++----+--------------------------------+--------------------------------+
+*/
+```
+{{< /tab >}}
+
+{{< tab "Spark SQL" >}}
+```sql
+INSERT INTO paimon_catalog.`default`.cities VALUES ('usa', 'houston'), ('germany', 'munich');
+
+SELECT * FROM iceberg_catalog.`default`.cities WHERE country = 'germany';
+/*
+germany munich
+germany berlin
+germany hamburg
+*/
+```
+{{< /tab >}}
+
+{{< /tabs >}}
+
+## Example: Query Paimon Primary Key Tables with Iceberg Connector
+
+{{< tabs "paimon-primary-key-table" >}}
+
+{{< tab "Flink SQL" >}}
+```sql
+CREATE CATALOG paimon_catalog WITH (
+    'type' = 'paimon',
+    'warehouse' = '<path-to-warehouse>'
+);
+
+CREATE TABLE paimon_catalog.`default`.orders (
+    order_id BIGINT,
+    status STRING,
+    payment DOUBLE,
+    PRIMARY KEY (order_id) NOT ENFORCED
+) WITH (
+    'metadata.iceberg.storage' = 'hadoop-catalog',
+    'compaction.optimization-interval' = '1ms' -- ATTENTION: this option is only for testing, see "timeliness" section below for more information
+);
+
+INSERT INTO paimon_catalog.`default`.orders VALUES (1, 'SUBMITTED', CAST(NULL AS DOUBLE)), (2, 'COMPLETED', 200.0), (3, 'SUBMITTED', CAST(NULL AS DOUBLE));
+
+CREATE TABLE orders (
+    order_id BIGINT,
+    status STRING,
+    payment DOUBLE
+) WITH (
+    'connector' = 'iceberg',
+    'catalog-type' = 'hadoop',
+    'catalog-name' = 'test',
+    'catalog-database' = 'default',
+    'warehouse' = '<path-to-warehouse>/iceberg'
+);
+
+SELECT * FROM orders WHERE status = 'COMPLETED';
+/*
++----+----------------------+--------------------------------+--------------------------------+
+| op |             order_id |                         status |                        payment |
++----+----------------------+--------------------------------+--------------------------------+
+| +I |                    2 |                      COMPLETED |                          200.0 |
++----+----------------------+--------------------------------+--------------------------------+
+*/
+
+INSERT INTO paimon_catalog.`default`.orders VALUES (1, 'COMPLETED', 100.0);
+
+SELECT * FROM orders WHERE status = 'COMPLETED';
+/*
++----+----------------------+--------------------------------+--------------------------------+
+| op |             order_id |                         status |                        payment |
++----+----------------------+--------------------------------+--------------------------------+
+| +I |                    1 |                      COMPLETED |                          100.0 |
+| +I |                    2 |                      COMPLETED |                          200.0 |
++----+----------------------+--------------------------------+--------------------------------+
+*/
+```
+{{< /tab >}}
+
+{{< tab "Spark SQL" >}}
+Start `spark-sql` with the following command line.
+
+```bash
+spark-sql --jars <path-to-paimon-jar> \
+    --conf spark.sql.catalog.paimon_catalog=org.apache.paimon.spark.SparkCatalog \
+    --conf spark.sql.catalog.paimon_catalog.warehouse=/tmp/sparkware \
+    --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.6.1 \
+    --conf spark.sql.catalog.iceberg_catalog=org.apache.iceberg.spark.SparkCatalog \
+    --conf spark.sql.catalog.iceberg_catalog.type=hadoop \
+    --conf spark.sql.catalog.iceberg_catalog.warehouse=<path-to-warehouse>/iceberg \
+    --conf spark.sql.catalog.iceberg_catalog.cache-enabled=false \ # disable iceberg catalog caching to quickly see the result
+    --conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions,org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
+```
+
+Run the following Spark SQL to create Paimon table, insert/update data, and query with Iceberg catalog. 
+
+```sql
+CREATE TABLE paimon_catalog.`default`.orders (
+    order_id BIGINT,
+    status STRING,
+    payment DOUBLE
+) TBLPROPERTIES (
+    'primary-key' = 'order_id',
+    'metadata.iceberg.storage' = 'hadoop-catalog',
+    'compaction.optimization-interval' = '1ms' -- ATTENTION: this option is only for testing, see "timeliness" section below for more information
+);
+
+INSERT INTO paimon_catalog.`default`.orders VALUES (1, 'SUBMITTED', CAST(NULL AS DOUBLE)), (2, 'COMPLETED', 200.0), (3, 'SUBMITTED', CAST(NULL AS DOUBLE));
+
+SELECT * FROM iceberg_catalog.`default`.orders WHERE status = 'COMPLETED';
+/*
+2       COMPLETED       200.0
+*/
+
+INSERT INTO paimon_catalog.`default`.orders VALUES (1, 'COMPLETED', 100.0);
+
+SELECT * FROM iceberg_catalog.`default`.orders WHERE status = 'COMPLETED';
+/*
+2       COMPLETED       200.0
+1       COMPLETED       100.0
+*/
+```
+{{< /tab >}}
+
+{{< /tabs >}}
+
+### Timeliness
+
+Paimon primary key tables organize data files as [LSM trees]({{< ref "learn-paimon/understand-files/#understand-lsm-for-primary-table" >}}), so data files must be merged in memory before querying.
+However, Iceberg readers are not able to merge data files, so they can only query data files on the highest level of LSM trees.
+Data files on the highest level are produced by the full compaction process.
+So **to conclude, for primary key tables, Iceberg readers can only query data after full compaction**.
+
+By default, there is no guarantee on how frequently Paimon will perform full compaction.
+You can configure the following table option, so that Paimon is forced to perform full compaction after several commits.
+
+<table class="table table-bordered">
+    <thead>
+    <tr>
+      <th class="text-left" style="width: 20%">Option</th>
+      <th class="text-left" style="width: 5%">Default</th>
+      <th class="text-left" style="width: 10%">Type</th>
+      <th class="text-left" style="width: 60%">Description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td><h5>compaction.optimization-interval</h5></td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Duration</td>
+      <td>Full compaction will be constantly triggered per time interval. First compaction after the job starts will always be full compaction.</td>
+    </tr>
+    <tr>
+      <td><h5>full-compaction.delta-commits</h5></td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Integer</td>
+      <td>Full compaction will be constantly triggered after delta commits. Only implemented in Flink.</td>
+    </tr>
+    </tbody>
+</table>
+
+Note that full compaction is a resource-consuming process, so the value of this table option should not be too small.
+We recommend full compaction to be performed once or twice per hour.
+
+## Other Related Table Options
+
+<table class="table table-bordered">
+    <thead>
+    <tr>
+      <th class="text-left" style="width: 20%">Option</th>
+      <th class="text-left" style="width: 5%">Default</th>
+      <th class="text-left" style="width: 10%">Type</th>
+      <th class="text-left" style="width: 60%">Description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td><h5>metadata.iceberg.compaction.min.file-num</h5></td>
+      <td style="word-wrap: break-word;">10</td>
+      <td>Integer</td>
+      <td>Minimum number of Iceberg metadata files to trigger metadata compaction.</td>
+    </tr>
+    <tr>
+      <td><h5>metadata.iceberg.compaction.max.file-num</h5></td>
+      <td style="word-wrap: break-word;">50</td>
+      <td>Integer</td>
+      <td>If number of small Iceberg metadata files exceeds this limit, always trigger metadata compaction regardless of their total size.</td>
+    </tr>
+    </tbody>
+</table>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -472,12 +472,6 @@ Mainly to resolve data skew on primary keys. We recommend starting with 64 mb wh
             <td>Specify the merge engine for table with primary key.<br /><br />Possible values:<ul><li>"deduplicate": De-duplicate and keep the last row.</li><li>"partial-update": Partial update non-null fields.</li><li>"aggregation": Aggregate fields with same primary key.</li><li>"first-row": De-duplicate and keep the first row.</li></ul></td>
         </tr>
         <tr>
-            <td><h5>metadata.iceberg-compatible</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>When set to true, produce Iceberg metadata after a snapshot is committed, so that Iceberg readers can read Paimon's raw files.</td>
-        </tr>
-        <tr>
             <td><h5>metadata.stats-mode</h5></td>
             <td style="word-wrap: break-word;">"truncate(16)"</td>
             <td>String</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1342,14 +1342,6 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "When need to lookup, commit will wait for compaction by lookup.");
 
-    public static final ConfigOption<Boolean> METADATA_ICEBERG_COMPATIBLE =
-            key("metadata.iceberg-compatible")
-                    .booleanType()
-                    .defaultValue(false)
-                    .withDescription(
-                            "When set to true, produce Iceberg metadata after a snapshot is committed, "
-                                    + "so that Iceberg readers can read Paimon's raw files.");
-
     public static final ConfigOption<Integer> DELETE_FILE_THREAD_NUM =
             key("delete-file.thread-num")
                     .intType()
@@ -2083,7 +2075,7 @@ public class CoreOptions implements Serializable {
         Map<String, String> result = new HashMap<>();
         for (String className : options.get(callbacks).split(",")) {
             className = className.trim();
-            if (className.length() == 0) {
+            if (className.isEmpty()) {
                 continue;
             }
 
@@ -2166,10 +2158,6 @@ public class CoreOptions implements Serializable {
 
     public boolean asyncFileWrite() {
         return options.get(ASYNC_FILE_WRITE);
-    }
-
-    public boolean metadataIcebergCompatible() {
-        return options.get(METADATA_ICEBERG_COMPATIBLE);
     }
 
     /** Specifies the merge engine for table with primary key. */

--- a/paimon-core/pom.xml
+++ b/paimon-core/pom.xml
@@ -33,6 +33,7 @@ under the License.
 
     <properties>
         <frocksdbjni.version>6.20.3-ververica-2.0</frocksdbjni.version>
+        <iceberg.version>1.6.1</iceberg.version>
     </properties>
 
     <dependencies>
@@ -193,14 +194,14 @@ under the License.
         <dependency>
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-core</artifactId>
-            <version>1.5.2</version>
+            <version>${iceberg.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-data</artifactId>
-            <version>1.5.2</version>
+            <version>${iceberg.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/AbstractIcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/AbstractIcebergCommitCallback.java
@@ -102,10 +102,10 @@ public abstract class AbstractIcebergCommitCallback implements CommitCallback {
         IcebergOptions.StorageType storageType =
                 table.coreOptions().toConfiguration().get(IcebergOptions.METADATA_ICEBERG_STORAGE);
         switch (storageType) {
-            case PER_TABLE:
+            case TABLE_LOCATION:
                 this.pathFactory = new IcebergPathFactory(new Path(table.location(), "metadata"));
                 break;
-            case ICEBERG_WAREHOUSE:
+            case HADOOP_CATALOG:
                 String tableName = table.location().getName();
                 Path dbPath = table.location().getParent();
                 if (dbPath.getName().endsWith(".db")) {

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/AbstractIcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/AbstractIcebergCommitCallback.java
@@ -169,6 +169,13 @@ public abstract class AbstractIcebergCommitCallback implements CommitCallback {
 
     private void createMetadata(long snapshotId, FileChangesCollector fileChangesCollector) {
         try {
+            if (snapshotId == Snapshot.FIRST_SNAPSHOT_ID) {
+                // If Iceberg metadata is stored separately in another directory, dropping the table
+                // will not delete old Iceberg metadata. So we delete them here, when the table is
+                // created again and the first snapshot is committed.
+                table.fileIO().delete(pathFactory.metadataDirectory(), true);
+            }
+
             if (table.fileIO().exists(pathFactory.toMetadataPath(snapshotId))) {
                 return;
             }

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/AbstractIcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/AbstractIcebergCommitCallback.java
@@ -106,18 +106,17 @@ public abstract class AbstractIcebergCommitCallback implements CommitCallback {
                 this.pathFactory = new IcebergPathFactory(new Path(table.location(), "metadata"));
                 break;
             case HADOOP_CATALOG:
-                String tableName = table.location().getName();
                 Path dbPath = table.location().getParent();
-                if (dbPath.getName().endsWith(".db")) {
+                final String dbSuffix = ".db";
+                if (dbPath.getName().endsWith(dbSuffix)) {
+                    String dbName =
+                            dbPath.getName()
+                                    .substring(0, dbPath.getName().length() - dbSuffix.length());
+                    String tableName = table.location().getName();
                     Path separatePath =
                             new Path(
                                     dbPath.getParent(),
-                                    "iceberg/"
-                                            + dbPath.getName()
-                                                    .substring(0, dbPath.getName().length() - 3)
-                                            + "/"
-                                            + tableName
-                                            + "/metadata");
+                                    String.format("iceberg/%s/%s/metadata", dbName, tableName));
                     this.pathFactory = new IcebergPathFactory(separatePath);
                 } else {
                     throw new UnsupportedOperationException(

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
@@ -40,25 +40,38 @@ public class IcebergOptions {
     public static final ConfigOption<Integer> COMPACT_MIN_FILE_NUM =
             ConfigOptions.key("metadata.iceberg.compaction.min.file-num")
                     .intType()
-                    .defaultValue(10);
+                    .defaultValue(10)
+                    .withDescription(
+                            "Minimum number of Iceberg metadata files to trigger metadata compaction.");
 
     public static final ConfigOption<Integer> COMPACT_MAX_FILE_NUM =
             ConfigOptions.key("metadata.iceberg.compaction.max.file-num")
                     .intType()
-                    .defaultValue(50);
+                    .defaultValue(50)
+                    .withDescription(
+                            "If number of small Iceberg metadata files exceeds this limit, "
+                                    + "always trigger metadata compaction regardless of their total size.");
 
     /** Where to store Iceberg metadata. */
     public enum StorageType implements DescribedEnum {
-        DISABLED("Disable Iceberg compatibility support."),
-        TABLE_LOCATION("Store Iceberg metadata with each table."),
+        DISABLED("disabled", "Disable Iceberg compatibility support."),
+        TABLE_LOCATION("table-location", "Store Iceberg metadata in each table's directory."),
         HADOOP_CATALOG(
+                "hadoop-catalog",
                 "Store Iceberg metadata in a separate directory. "
                         + "This directory can be specified as the warehouse directory of an Iceberg Hadoop catalog.");
 
+        private final String value;
         private final String description;
 
-        StorageType(String description) {
+        StorageType(String value, String description) {
+            this.value = value;
             this.description = description;
+        }
+
+        @Override
+        public String toString() {
+            return value;
         }
 
         @Override

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
@@ -20,6 +20,9 @@ package org.apache.paimon.iceberg;
 
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
+import org.apache.paimon.options.description.DescribedEnum;
+import org.apache.paimon.options.description.InlineElement;
+import org.apache.paimon.options.description.TextElement;
 
 import static org.apache.paimon.options.ConfigOptions.key;
 
@@ -29,13 +32,10 @@ public class IcebergOptions {
     public static final ConfigOption<StorageType> METADATA_ICEBERG_STORAGE =
             key("metadata.iceberg.storage")
                     .enumType(StorageType.class)
-                    .noDefaultValue()
+                    .defaultValue(StorageType.DISABLED)
                     .withDescription(
                             "When set, produce Iceberg metadata after a snapshot is committed, "
-                                    + "so that Iceberg readers can read Paimon's raw files.\n"
-                                    + "PER_TABLE: Store Iceberg metadata with each table.\n"
-                                    + "ICEBERG_WAREHOUSE: Store Iceberg metadata in a separate directory. "
-                                    + "This directory can be specified as the Iceberg warehouse directory.");
+                                    + "so that Iceberg readers can read Paimon's raw data files.");
 
     public static final ConfigOption<Integer> COMPACT_MIN_FILE_NUM =
             ConfigOptions.key("metadata.iceberg.compaction.min.file-num")
@@ -48,11 +48,22 @@ public class IcebergOptions {
                     .defaultValue(50);
 
     /** Where to store Iceberg metadata. */
-    public enum StorageType {
-        // Store Iceberg metadata with each table.
-        PER_TABLE,
-        // Store Iceberg metadata in a separate directory.
-        // This directory can be specified as the Iceberg warehouse directory.
-        ICEBERG_WAREHOUSE
+    public enum StorageType implements DescribedEnum {
+        DISABLED("Disable Iceberg compatibility support."),
+        TABLE_LOCATION("Store Iceberg metadata with each table."),
+        HADOOP_CATALOG(
+                "Store Iceberg metadata in a separate directory. "
+                        + "This directory can be specified as the warehouse directory of an Iceberg Hadoop catalog.");
+
+        private final String description;
+
+        StorageType(String description) {
+            this.description = description;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return TextElement.text(description);
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg;
+
+import org.apache.paimon.options.ConfigOption;
+import org.apache.paimon.options.ConfigOptions;
+
+import static org.apache.paimon.options.ConfigOptions.key;
+
+/** Config options for Paimon Iceberg compatibility. */
+public class IcebergOptions {
+
+    public static final ConfigOption<StorageType> METADATA_ICEBERG_STORAGE =
+            key("metadata.iceberg.storage")
+                    .enumType(StorageType.class)
+                    .noDefaultValue()
+                    .withDescription(
+                            "When set, produce Iceberg metadata after a snapshot is committed, "
+                                    + "so that Iceberg readers can read Paimon's raw files.\n"
+                                    + "PER_TABLE: Store Iceberg metadata with each table.\n"
+                                    + "ICEBERG_WAREHOUSE: Store Iceberg metadata in a separate directory. "
+                                    + "This directory can be specified as the Iceberg warehouse directory.");
+
+    public static final ConfigOption<Integer> COMPACT_MIN_FILE_NUM =
+            ConfigOptions.key("metadata.iceberg.compaction.min.file-num")
+                    .intType()
+                    .defaultValue(10);
+
+    public static final ConfigOption<Integer> COMPACT_MAX_FILE_NUM =
+            ConfigOptions.key("metadata.iceberg.compaction.max.file-num")
+                    .intType()
+                    .defaultValue(50);
+
+    /** Where to store Iceberg metadata. */
+    public enum StorageType {
+        // Store Iceberg metadata with each table.
+        PER_TABLE,
+        // Store Iceberg metadata in a separate directory.
+        // This directory can be specified as the Iceberg warehouse directory.
+        ICEBERG_WAREHOUSE
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergPathFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergPathFactory.java
@@ -37,8 +37,8 @@ public class IcebergPathFactory {
     private int manifestFileCount;
     private int manifestListCount;
 
-    public IcebergPathFactory(Path root) {
-        this.metadataDirectory = new Path(root, "metadata");
+    public IcebergPathFactory(Path metadataDirectory) {
+        this.metadataDirectory = metadataDirectory;
         this.uuid = UUID.randomUUID().toString();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergDataFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergDataFileMeta.java
@@ -22,7 +22,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.iceberg.metadata.IcebergSchema;
 import org.apache.paimon.stats.SimpleStats;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
@@ -109,21 +109,22 @@ public class IcebergDataFileMeta {
             BinaryRow partition,
             long recordCount,
             long fileSizeInBytes,
-            TableSchema tableSchema,
+            IcebergSchema icebergSchema,
             SimpleStats stats) {
         Map<Integer, Long> nullValueCounts = new HashMap<>();
         Map<Integer, byte[]> lowerBounds = new HashMap<>();
         Map<Integer, byte[]> upperBounds = new HashMap<>();
 
         List<InternalRow.FieldGetter> fieldGetters = new ArrayList<>();
-        int numFields = tableSchema.fields().size();
+        int numFields = icebergSchema.fields().size();
         for (int i = 0; i < numFields; i++) {
-            fieldGetters.add(InternalRow.createFieldGetter(tableSchema.fields().get(i).type(), i));
+            fieldGetters.add(
+                    InternalRow.createFieldGetter(icebergSchema.fields().get(i).dataType(), i));
         }
 
         for (int i = 0; i < numFields; i++) {
-            int fieldId = tableSchema.fields().get(i).id();
-            DataType type = tableSchema.fields().get(i).type();
+            int fieldId = icebergSchema.fields().get(i).id();
+            DataType type = icebergSchema.fields().get(i).dataType();
             nullValueCounts.put(fieldId, stats.nullCounts().getLong(i));
             Object minValue = fieldGetters.get(i).getFieldOrNull(stats.minValues());
             Object maxValue = fieldGetters.get(i).getFieldOrNull(stats.maxValues());

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergDataField.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergDataField.java
@@ -58,9 +58,9 @@ public class IcebergDataField {
     @JsonProperty(FIELD_DOC)
     private final String doc;
 
-    public IcebergDataField(DataField dataField) {
+    public IcebergDataField(DataField dataField, int bias) {
         this(
-                dataField.id(),
+                dataField.id() + bias,
                 dataField.name(),
                 !dataField.type().isNullable(),
                 toTypeString(dataField.type()),

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergDataField.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergDataField.java
@@ -20,10 +20,12 @@ package org.apache.paimon.iceberg.metadata;
 
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.DecimalType;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -106,6 +108,11 @@ public class IcebergDataField {
         return doc;
     }
 
+    @JsonIgnore
+    public DataType dataType() {
+        return fromTypeString(type);
+    }
+
     private static String toTypeString(DataType dataType) {
         switch (dataType.getTypeRoot()) {
             case BOOLEAN:
@@ -132,6 +139,33 @@ public class IcebergDataField {
                         "decimal(%d, %d)", decimalType.getPrecision(), decimalType.getScale());
             default:
                 throw new UnsupportedOperationException("Unsupported data type: " + dataType);
+        }
+    }
+
+    private static DataType fromTypeString(String type) {
+        if ("boolean".equals(type)) {
+            return DataTypes.BOOLEAN();
+        } else if ("int".equals(type)) {
+            return DataTypes.INT();
+        } else if ("long".equals(type)) {
+            return DataTypes.BIGINT();
+        } else if ("float".equals(type)) {
+            return DataTypes.FLOAT();
+        } else if ("double".equals(type)) {
+            return DataTypes.DOUBLE();
+        } else if ("date".equals(type)) {
+            return DataTypes.DATE();
+        } else if ("string".equals(type)) {
+            return DataTypes.STRING();
+        } else if ("binary".equals(type)) {
+            return DataTypes.BYTES();
+        } else if (type.startsWith("decimal")) {
+            String[] precisionAndScale =
+                    type.substring("decimal(".length(), type.length() - 1).split(", ");
+            return DataTypes.DECIMAL(
+                    Integer.parseInt(precisionAndScale[0]), Integer.parseInt(precisionAndScale[1]));
+        } else {
+            throw new UnsupportedOperationException("Unsupported data type: " + type);
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergPartitionField.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergPartitionField.java
@@ -18,8 +18,6 @@
 
 package org.apache.paimon.iceberg.metadata;
 
-import org.apache.paimon.types.DataField;
-
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -55,7 +53,7 @@ public class IcebergPartitionField {
     @JsonProperty(FIELD_FIELD_ID)
     private final int fieldId;
 
-    public IcebergPartitionField(DataField dataField, int fieldId) {
+    public IcebergPartitionField(IcebergDataField dataField, int fieldId) {
         this(
                 dataField.name(),
                 // currently Paimon's partition value does not have any transformation

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergSchema.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergSchema.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.iceberg.metadata;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.schema.TableSchema;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
@@ -50,11 +51,20 @@ public class IcebergSchema {
     @JsonProperty(FIELD_FIELDS)
     private final List<IcebergDataField> fields;
 
-    public IcebergSchema(TableSchema tableSchema) {
-        this(
+    public static IcebergSchema create(TableSchema tableSchema) {
+        int bias;
+        if (new CoreOptions(tableSchema.options()).formatType().equals("parquet")) {
+            // data files start with trimmed primary keys + sequence number + value kind
+            // also ParquetSchemaUtil.addFallbackIds starts enumerating id from 1 instead of 0
+            bias = tableSchema.trimmedPrimaryKeys().size() + 3;
+        } else {
+            bias = 0;
+        }
+
+        return new IcebergSchema(
                 (int) tableSchema.id(),
                 tableSchema.fields().stream()
-                        .map(IcebergDataField::new)
+                        .map(f -> new IcebergDataField(f, bias))
                         .collect(Collectors.toList()));
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergSchema.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergSchema.java
@@ -54,9 +54,14 @@ public class IcebergSchema {
     public static IcebergSchema create(TableSchema tableSchema) {
         int bias;
         if (new CoreOptions(tableSchema.options()).formatType().equals("parquet")) {
-            // data files start with trimmed primary keys + sequence number + value kind
-            // also ParquetSchemaUtil.addFallbackIds starts enumerating id from 1 instead of 0
-            bias = tableSchema.trimmedPrimaryKeys().size() + 3;
+            if (tableSchema.primaryKeys().isEmpty()) {
+                // ParquetSchemaUtil.addFallbackIds starts enumerating id from 1 instead of 0
+                bias = 1;
+            } else {
+                // data files start with trimmed primary keys + sequence number + value kind
+                // also ParquetSchemaUtil.addFallbackIds starts enumerating id from 1 instead of 0
+                bias = tableSchema.trimmedPrimaryKeys().size() + 3;
+            }
         } else {
             bias = 0;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergSchema.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergSchema.java
@@ -54,7 +54,9 @@ public class IcebergSchema {
 
     public static IcebergSchema create(TableSchema tableSchema) {
         int bias;
-        if (new CoreOptions(tableSchema.options()).formatType().equals("parquet")) {
+        if (new CoreOptions(tableSchema.options())
+                .formatType()
+                .equals(CoreOptions.FILE_FORMAT_PARQUET)) {
             if (tableSchema.primaryKeys().isEmpty()) {
                 // ParquetSchemaUtil.addFallbackIds starts enumerating id from 1 instead of 0
                 bias = 1;

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergSchema.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergSchema.java
@@ -23,6 +23,7 @@ import org.apache.paimon.schema.TableSchema;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -100,6 +101,11 @@ public class IcebergSchema {
     @JsonGetter(FIELD_FIELDS)
     public List<IcebergDataField> fields() {
         return fields;
+    }
+
+    @JsonIgnore
+    public int highestFieldId() {
+        return fields.stream().mapToInt(IcebergDataField::id).max().orElse(0);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -166,7 +166,8 @@ class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
         List<CommitCallback> callbacks = super.createCommitCallbacks(commitUser);
         CoreOptions options = coreOptions();
 
-        if (options.toConfiguration().contains(IcebergOptions.METADATA_ICEBERG_STORAGE)) {
+        if (options.toConfiguration().get(IcebergOptions.METADATA_ICEBERG_STORAGE)
+                != IcebergOptions.StorageType.DISABLED) {
             callbacks.add(new AppendOnlyIcebergCommitCallback(this, commitUser));
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.iceberg.AppendOnlyIcebergCommitCallback;
+import org.apache.paimon.iceberg.IcebergOptions;
 import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.operation.AppendOnlyFileStoreScan;
 import org.apache.paimon.operation.AppendOnlyFileStoreWrite;
@@ -165,7 +166,7 @@ class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
         List<CommitCallback> callbacks = super.createCommitCallbacks(commitUser);
         CoreOptions options = coreOptions();
 
-        if (options.metadataIcebergCompatible()) {
+        if (options.toConfiguration().contains(IcebergOptions.METADATA_ICEBERG_STORAGE)) {
             callbacks.add(new AppendOnlyIcebergCommitCallback(this, commitUser));
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
@@ -186,7 +186,8 @@ class PrimaryKeyFileStoreTable extends AbstractFileStoreTable {
         List<CommitCallback> callbacks = super.createCommitCallbacks(commitUser);
         CoreOptions options = coreOptions();
 
-        if (options.toConfiguration().contains(IcebergOptions.METADATA_ICEBERG_STORAGE)) {
+        if (options.toConfiguration().get(IcebergOptions.METADATA_ICEBERG_STORAGE)
+                != IcebergOptions.StorageType.DISABLED) {
             callbacks.add(new PrimaryKeyIcebergCommitCallback(this, commitUser));
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
@@ -23,6 +23,7 @@ import org.apache.paimon.KeyValue;
 import org.apache.paimon.KeyValueFileStore;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.iceberg.IcebergOptions;
 import org.apache.paimon.iceberg.PrimaryKeyIcebergCommitCallback;
 import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.mergetree.compact.LookupMergeFunction;
@@ -185,7 +186,7 @@ class PrimaryKeyFileStoreTable extends AbstractFileStoreTable {
         List<CommitCallback> callbacks = super.createCommitCallbacks(commitUser);
         CoreOptions options = coreOptions();
 
-        if (options.metadataIcebergCompatible()) {
+        if (options.toConfiguration().contains(IcebergOptions.METADATA_ICEBERG_STORAGE)) {
             callbacks.add(new PrimaryKeyIcebergCommitCallback(this, commitUser));
         }
 

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
@@ -691,7 +691,8 @@ public class IcebergCompatibilityTest {
 
         Options options = new Options(customOptions);
         options.set(CoreOptions.BUCKET, numBuckets);
-        options.set(IcebergOptions.METADATA_ICEBERG_STORAGE, IcebergOptions.StorageType.PER_TABLE);
+        options.set(
+                IcebergOptions.METADATA_ICEBERG_STORAGE, IcebergOptions.StorageType.TABLE_LOCATION);
         options.set(CoreOptions.FILE_FORMAT, "avro");
         options.set(CoreOptions.TARGET_FILE_SIZE, MemorySize.ofKibiBytes(32));
         options.set(IcebergOptions.COMPACT_MIN_FILE_NUM, 4);

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
@@ -199,7 +199,8 @@ public class IcebergCompatibilityTest {
         commit.commit(2, commitMessages2);
         assertThat(table.latestSnapshotId()).hasValue(3L);
 
-        IcebergPathFactory pathFactory = new IcebergPathFactory(table.location());
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
         Path metadata3Path = pathFactory.toMetadataPath(3);
         assertThat(table.fileIO().exists(metadata3Path)).isTrue();
 
@@ -296,7 +297,8 @@ public class IcebergCompatibilityTest {
         // Number of snapshots will become 5 with the next commit, however only 3 Iceberg snapshots
         // are kept. So the first 2 Iceberg snapshots will be expired.
 
-        IcebergPathFactory pathFactory = new IcebergPathFactory(table.location());
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
         IcebergManifestList manifestList = IcebergManifestList.create(table, pathFactory);
         Set<String> usingManifests = new HashSet<>();
         for (IcebergManifestFileMeta fileMeta :
@@ -689,11 +691,11 @@ public class IcebergCompatibilityTest {
 
         Options options = new Options(customOptions);
         options.set(CoreOptions.BUCKET, numBuckets);
-        options.set(CoreOptions.METADATA_ICEBERG_COMPATIBLE, true);
+        options.set(IcebergOptions.METADATA_ICEBERG_STORAGE, IcebergOptions.StorageType.PER_TABLE);
         options.set(CoreOptions.FILE_FORMAT, "avro");
         options.set(CoreOptions.TARGET_FILE_SIZE, MemorySize.ofKibiBytes(32));
-        options.set(AbstractIcebergCommitCallback.COMPACT_MIN_FILE_NUM, 4);
-        options.set(AbstractIcebergCommitCallback.COMPACT_MIN_FILE_NUM, 8);
+        options.set(IcebergOptions.COMPACT_MIN_FILE_NUM, 4);
+        options.set(IcebergOptions.COMPACT_MIN_FILE_NUM, 8);
         options.set(CoreOptions.MANIFEST_TARGET_FILE_SIZE, MemorySize.ofKibiBytes(8));
         Schema schema =
                 new Schema(rowType.getFields(), partitionKeys, primaryKeys, options.toMap(), "");

--- a/paimon-flink/paimon-flink-1.16/pom.xml
+++ b/paimon-flink/paimon-flink-1.16/pom.xml
@@ -107,12 +107,6 @@ under the License.
             <artifactId>iceberg-flink-${iceberg.flink.version}</artifactId>
             <version>${iceberg.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.orc</groupId>
-                    <artifactId>orc-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/paimon-flink/paimon-flink-1.16/pom.xml
+++ b/paimon-flink/paimon-flink-1.16/pom.xml
@@ -35,6 +35,8 @@ under the License.
 
     <properties>
         <flink.version>1.16.3</flink.version>
+        <iceberg.flink.version>1.16</iceberg.flink.version>
+        <iceberg.version>1.5.2</iceberg.version>
     </properties>
 
     <dependencies>
@@ -100,6 +102,18 @@ under the License.
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-flink-${iceberg.flink.version}</artifactId>
+            <version>${iceberg.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.orc</groupId>
+                    <artifactId>orc-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/paimon-flink/paimon-flink-1.16/src/test/java/org/apache/paimon/flink/iceberg/Flink116IcebergITCase.java
+++ b/paimon-flink/paimon-flink-1.16/src/test/java/org/apache/paimon/flink/iceberg/Flink116IcebergITCase.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.iceberg;
+
+/** IT cases for Paimon Iceberg compatibility in Flink 1.16. */
+public class Flink116IcebergITCase extends FlinkIcebergITCaseBase {}

--- a/paimon-flink/paimon-flink-1.17/pom.xml
+++ b/paimon-flink/paimon-flink-1.17/pom.xml
@@ -35,6 +35,8 @@ under the License.
 
     <properties>
         <flink.version>1.17.2</flink.version>
+        <iceberg.flink.version>1.17</iceberg.flink.version>
+        <iceberg.version>1.6.1</iceberg.version>
     </properties>
 
     <dependencies>
@@ -105,6 +107,19 @@ under the License.
             <artifactId>flink-connector-files</artifactId>
             <version>${flink.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-flink-${iceberg.flink.version}</artifactId>
+            <version>${iceberg.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.orc</groupId>
+                    <artifactId>orc-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/paimon-flink/paimon-flink-1.17/pom.xml
+++ b/paimon-flink/paimon-flink-1.17/pom.xml
@@ -114,12 +114,6 @@ under the License.
             <artifactId>iceberg-flink-${iceberg.flink.version}</artifactId>
             <version>${iceberg.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.orc</groupId>
-                    <artifactId>orc-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/paimon-flink/paimon-flink-1.17/src/test/java/org/apache/paimon/flink/iceberg/Flink117IcebergITCase.java
+++ b/paimon-flink/paimon-flink-1.17/src/test/java/org/apache/paimon/flink/iceberg/Flink117IcebergITCase.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.iceberg;
+
+/** IT cases for Paimon Iceberg compatibility in Flink 1.17. */
+public class Flink117IcebergITCase extends FlinkIcebergITCaseBase {}

--- a/paimon-flink/paimon-flink-1.18/pom.xml
+++ b/paimon-flink/paimon-flink-1.18/pom.xml
@@ -107,12 +107,6 @@ under the License.
             <artifactId>iceberg-flink-${iceberg.flink.version}</artifactId>
             <version>${iceberg.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.orc</groupId>
-                    <artifactId>orc-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/paimon-flink/paimon-flink-1.18/pom.xml
+++ b/paimon-flink/paimon-flink-1.18/pom.xml
@@ -35,6 +35,8 @@ under the License.
 
     <properties>
         <flink.version>1.18.1</flink.version>
+        <iceberg.flink.version>1.18</iceberg.flink.version>
+        <iceberg.version>1.6.1</iceberg.version>
     </properties>
 
     <dependencies>
@@ -98,6 +100,19 @@ under the License.
             <artifactId>flink-connector-files</artifactId>
             <version>${flink.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-flink-${iceberg.flink.version}</artifactId>
+            <version>${iceberg.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.orc</groupId>
+                    <artifactId>orc-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/iceberg/Flink118IcebergITCase.java
+++ b/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/iceberg/Flink118IcebergITCase.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.iceberg;
+
+/** IT cases for Paimon Iceberg compatibility in Flink 1.18. */
+public class Flink118IcebergITCase extends FlinkIcebergITCaseBase {}

--- a/paimon-flink/paimon-flink-1.19/pom.xml
+++ b/paimon-flink/paimon-flink-1.19/pom.xml
@@ -114,12 +114,6 @@ under the License.
             <artifactId>iceberg-flink-${iceberg.flink.version}</artifactId>
             <version>${iceberg.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.orc</groupId>
-                    <artifactId>orc-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/paimon-flink/paimon-flink-1.19/pom.xml
+++ b/paimon-flink/paimon-flink-1.19/pom.xml
@@ -35,6 +35,8 @@ under the License.
 
     <properties>
         <flink.version>1.19.1</flink.version>
+        <iceberg.flink.version>1.19</iceberg.flink.version>
+        <iceberg.version>1.6.1</iceberg.version>
     </properties>
 
     <dependencies>
@@ -105,6 +107,19 @@ under the License.
             <artifactId>commons-compress</artifactId>
             <version>1.21</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-flink-${iceberg.flink.version}</artifactId>
+            <version>${iceberg.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.orc</groupId>
+                    <artifactId>orc-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/paimon-flink/paimon-flink-1.19/src/test/java/org/apache/paimon/flink/iceberg/Flink119IcebergITCase.java
+++ b/paimon-flink/paimon-flink-1.19/src/test/java/org/apache/paimon/flink/iceberg/Flink119IcebergITCase.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.iceberg;
+
+/** IT cases for Paimon Iceberg compatibility in Flink 1.19. */
+public class Flink119IcebergITCase extends FlinkIcebergITCaseBase {}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/iceberg/FlinkIcebergITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/iceberg/FlinkIcebergITCaseBase.java
@@ -190,9 +190,7 @@ public abstract class FlinkIcebergITCaseBase extends AbstractTestBase {
                         + "  v_float FLOAT,\n"
                         + "  v_double DOUBLE,\n"
                         + "  v_decimal DECIMAL(8, 3),\n"
-                        + "  v_char CHAR(20),\n"
                         + "  v_varchar STRING,\n"
-                        + "  v_binary BINARY(20),\n"
                         + "  v_varbinary VARBINARY(20),\n"
                         + "  v_date DATE\n"
                         + ") PARTITIONED BY (pt) WITH (\n"
@@ -203,9 +201,9 @@ public abstract class FlinkIcebergITCaseBase extends AbstractTestBase {
                         + ")");
         tEnv.executeSql(
                         "INSERT INTO paimon.`default`.T VALUES "
-                                + "(1, 1, 1, true, 10, CAST(100.0 AS FLOAT), 1000.0, 123.456, CAST('apple' AS CHAR(20)), 'cat', CAST('B_apple' AS BINARY(20)), CAST('B_cat' AS VARBINARY(20)), DATE '2024-10-10'), "
-                                + "(2, 2, 2, false, 20, CAST(200.0 AS FLOAT), 2000.0, 234.567, CAST('banana' AS CHAR(20)), 'dog', CAST('B_banana' AS BINARY(20)), CAST('B_dog' AS VARBINARY(20)), DATE '2024-10-20'), "
-                                + "(3, 3, CAST(NULL AS INT), CAST(NULL AS BOOLEAN), CAST(NULL AS BIGINT), CAST(NULL AS FLOAT), CAST(NULL AS DOUBLE), CAST(NULL AS DECIMAL(8, 3)), CAST(NULL AS CHAR(20)), CAST(NULL AS STRING), CAST(NULL AS BINARY(20)), CAST(NULL AS VARBINARY(20)), CAST(NULL AS DATE))")
+                                + "(1, 1, 1, true, 10, CAST(100.0 AS FLOAT), 1000.0, 123.456, 'cat', CAST('B_cat' AS VARBINARY(20)), DATE '2024-10-10'), "
+                                + "(2, 2, 2, false, 20, CAST(200.0 AS FLOAT), 2000.0, 234.567, 'dog', CAST('B_dog' AS VARBINARY(20)), DATE '2024-10-20'), "
+                                + "(3, 3, CAST(NULL AS INT), CAST(NULL AS BOOLEAN), CAST(NULL AS BIGINT), CAST(NULL AS FLOAT), CAST(NULL AS DOUBLE), CAST(NULL AS DECIMAL(8, 3)), CAST(NULL AS STRING), CAST(NULL AS VARBINARY(20)), CAST(NULL AS DATE))")
                 .await();
 
         tEnv.executeSql(
@@ -218,9 +216,7 @@ public abstract class FlinkIcebergITCaseBase extends AbstractTestBase {
                         + "  v_float FLOAT,\n"
                         + "  v_double DOUBLE,\n"
                         + "  v_decimal DECIMAL(8, 3),\n"
-                        + "  v_char CHAR(20),\n"
                         + "  v_varchar STRING,\n"
-                        + "  v_binary BINARY(20),\n"
                         + "  v_varbinary VARBINARY(20),\n"
                         + "  v_date DATE\n"
                         + ") PARTITIONED BY (pt) WITH (\n"
@@ -246,11 +242,6 @@ public abstract class FlinkIcebergITCaseBase extends AbstractTestBase {
                 .containsExactly(Row.of(1));
         assertThat(collect(tEnv.executeSql("SELECT id FROM T where v_decimal = 123.456")))
                 .containsExactly(Row.of(1));
-        assertThat(
-                        collect(
-                                tEnv.executeSql(
-                                        "SELECT id FROM T where v_char = CAST('apple' AS CHAR(20))")))
-                .containsExactly(Row.of(1));
         assertThat(collect(tEnv.executeSql("SELECT id FROM T where v_varchar = 'cat'")))
                 .containsExactly(Row.of(1));
         assertThat(collect(tEnv.executeSql("SELECT id FROM T where v_date = '2024-10-10'")))
@@ -267,11 +258,7 @@ public abstract class FlinkIcebergITCaseBase extends AbstractTestBase {
                 .containsExactly(Row.of(3));
         assertThat(collect(tEnv.executeSql("SELECT id FROM T where v_decimal IS NULL")))
                 .containsExactly(Row.of(3));
-        assertThat(collect(tEnv.executeSql("SELECT id FROM T where v_char IS NULL")))
-                .containsExactly(Row.of(3));
         assertThat(collect(tEnv.executeSql("SELECT id FROM T where v_varchar IS NULL")))
-                .containsExactly(Row.of(3));
-        assertThat(collect(tEnv.executeSql("SELECT id FROM T where v_binary IS NULL")))
                 .containsExactly(Row.of(3));
         assertThat(collect(tEnv.executeSql("SELECT id FROM T where v_varbinary IS NULL")))
                 .containsExactly(Row.of(3));

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/iceberg/FlinkIcebergITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/iceberg/FlinkIcebergITCaseBase.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.iceberg;
+
+import org.apache.paimon.flink.util.AbstractTestBase;
+
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** IT cases for Paimon Iceberg compatibility. */
+public abstract class FlinkIcebergITCaseBase extends AbstractTestBase {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"parquet", "avro"})
+    public void testIcebergWarehouse(String format) throws Exception {
+        String warehouse = getTempDirPath();
+        TableEnvironment tEnv = tableEnvironmentBuilder().batchMode().parallelism(2).build();
+        tEnv.executeSql(
+                "CREATE CATALOG paimon WITH (\n"
+                        + "  'type' = 'paimon',\n"
+                        + "  'warehouse' = '"
+                        + warehouse
+                        + "'\n"
+                        + ")");
+        tEnv.executeSql(
+                "CREATE TABLE paimon.`default`.T (\n"
+                        + "  pt INT,\n"
+                        + "  k INT,\n"
+                        + "  v1 INT,\n"
+                        + "  v2 STRING,\n"
+                        + "  PRIMARY KEY (pt, k) NOT ENFORCED\n"
+                        + ") PARTITIONED BY (pt) WITH (\n"
+                        + "  'metadata.iceberg.storage' = 'ICEBERG_WAREHOUSE',\n"
+                        // make sure all changes are visible in iceberg metadata
+                        + "  'full-compaction.delta-commits' = '1',\n"
+                        + "  'file.format' = '"
+                        + format
+                        + "'\n"
+                        + ")");
+        tEnv.executeSql(
+                        "INSERT INTO paimon.`default`.T VALUES "
+                                + "(1, 10, 100, 'apple'), "
+                                + "(1, 11, 110, 'banana'), "
+                                + "(2, 20, 200, 'cat'), "
+                                + "(2, 21, 210, 'dog')")
+                .await();
+
+        tEnv.executeSql(
+                "CREATE TABLE T (\n"
+                        + "  pt INT,\n"
+                        + "  k INT,\n"
+                        + "  v1 INT,\n"
+                        + "  v2 STRING\n"
+                        + ") PARTITIONED BY (pt) WITH (\n"
+                        + "  'connector' = 'iceberg',\n"
+                        + "  'catalog-type' = 'hadoop',\n"
+                        + "  'catalog-name' = 'test',\n"
+                        + "  'catalog-database' = 'default',\n"
+                        + "  'warehouse' = '"
+                        + warehouse
+                        + "/iceberg'\n"
+                        + ")");
+        assertThat(collect(tEnv.executeSql("SELECT v1, k, v2, pt FROM T ORDER BY pt, k")))
+                .containsExactly(
+                        Row.of(100, 10, "apple", 1),
+                        Row.of(110, 11, "banana", 1),
+                        Row.of(200, 20, "cat", 2),
+                        Row.of(210, 21, "dog", 2));
+
+        tEnv.executeSql(
+                        "INSERT INTO paimon.`default`.T VALUES "
+                                + "(1, 10, 101, 'red'), "
+                                + "(1, 12, 121, 'green'), "
+                                + "(2, 20, 201, 'blue'), "
+                                + "(2, 22, 221, 'yellow')")
+                .await();
+        assertThat(collect(tEnv.executeSql("SELECT v1, k, v2, pt FROM T ORDER BY pt, k")))
+                .containsExactly(
+                        Row.of(101, 10, "red", 1),
+                        Row.of(110, 11, "banana", 1),
+                        Row.of(121, 12, "green", 1),
+                        Row.of(201, 20, "blue", 2),
+                        Row.of(210, 21, "dog", 2),
+                        Row.of(221, 22, "yellow", 2));
+    }
+
+    private List<Row> collect(TableResult result) throws Exception {
+        List<Row> rows = new ArrayList<>();
+        try (CloseableIterator<Row> it = result.collect()) {
+            while (it.hasNext()) {
+                rows.add(it.next());
+            }
+        }
+        return rows;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/iceberg/FlinkIcebergITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/iceberg/FlinkIcebergITCaseBase.java
@@ -55,7 +55,7 @@ public abstract class FlinkIcebergITCaseBase extends AbstractTestBase {
                         + "  v2 STRING,\n"
                         + "  PRIMARY KEY (pt, k) NOT ENFORCED\n"
                         + ") PARTITIONED BY (pt) WITH (\n"
-                        + "  'metadata.iceberg.storage' = 'ICEBERG_WAREHOUSE',\n"
+                        + "  'metadata.iceberg.storage' = 'HADOOP_CATALOG',\n"
                         // make sure all changes are visible in iceberg metadata
                         + "  'full-compaction.delta-commits' = '1',\n"
                         + "  'file.format' = '"

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/iceberg/FlinkIcebergITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/iceberg/FlinkIcebergITCaseBase.java
@@ -55,7 +55,7 @@ public abstract class FlinkIcebergITCaseBase extends AbstractTestBase {
                         + "  v2 STRING,\n"
                         + "  PRIMARY KEY (pt, k) NOT ENFORCED\n"
                         + ") PARTITIONED BY (pt) WITH (\n"
-                        + "  'metadata.iceberg.storage' = 'HADOOP_CATALOG',\n"
+                        + "  'metadata.iceberg.storage' = 'hadoop-catalog',\n"
                         // make sure all changes are visible in iceberg metadata
                         + "  'full-compaction.delta-commits' = '1',\n"
                         + "  'file.format' = '"
@@ -126,7 +126,7 @@ public abstract class FlinkIcebergITCaseBase extends AbstractTestBase {
                         + "  country STRING,\n"
                         + "  name STRING\n"
                         + ") WITH (\n"
-                        + "  'metadata.iceberg.storage' = 'HADOOP_CATALOG',\n"
+                        + "  'metadata.iceberg.storage' = 'hadoop-catalog',\n"
                         + "  'file.format' = '"
                         + format
                         + "'\n"

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/iceberg/FlinkIcebergITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/iceberg/FlinkIcebergITCaseBase.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public abstract class FlinkIcebergITCaseBase extends AbstractTestBase {
 
     @ParameterizedTest
-    @ValueSource(strings = {"parquet", "avro"})
+    @ValueSource(strings = {"orc", "parquet", "avro"})
     public void testIcebergWarehouse(String format) throws Exception {
         String warehouse = getTempDirPath();
         TableEnvironment tEnv = tableEnvironmentBuilder().batchMode().parallelism(2).build();


### PR DESCRIPTION
### Purpose

Currently there is not IT cases for Paimon Iceberg compatibility in Flink. This PR adds IT cases and fixes some issues with parquet format.

### Tests

IT cases.

### API and Format

No format changes.

### Documentation

Document for the whole Iceberg compatibility feature is also added.
