### PR TITLE
[core] Delete tag not failed if tag not exists

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -188,7 +188,10 @@ public class TagManager {
             List<TagCallback> callbacks) {
         checkArgument(
                 !StringUtils.isNullOrWhitespaceOnly(tagName), "Tag name '%s' is blank.", tagName);
-        checkArgument(tagExists(tagName), "Tag '%s' doesn't exist.", tagName);
+        if (!tagExists(tagName)) {
+            LOG.warn("Tag '{}' doesn't exist.", tagName);
+            return;
+        }
 
         Snapshot taggedSnapshot = taggedSnapshot(tagName);
         List<Snapshot> taggedSnapshots;

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -1425,10 +1425,7 @@ public abstract class FileStoreTableTestBase {
         table.createTag("tag1", 1);
         table.deleteTag("tag1");
 
-        assertThatThrownBy(() -> table.deleteTag("tag1"))
-                .satisfies(
-                        anyCauseMatches(
-                                IllegalArgumentException.class, "Tag 'tag1' doesn't exist."));
+        assertThat(table.tagManager().tags().containsValue("tag1")).isFalse();
     }
 
     @Test

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/CreateAndDeleteTagProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/CreateAndDeleteTagProcedureTest.scala
@@ -191,4 +191,12 @@ class CreateAndDeleteTagProcedureTest extends PaimonSparkTestBase with StreamTes
       }
     }
   }
+
+  test("Paimon Procedure: delete tag not failed if tag not exists") {
+    spark.sql("CREATE TABLE T (id STRING, name STRING) USING PAIMON")
+
+    checkAnswer(
+      spark.sql("CALL paimon.sys.delete_tag(table => 'test.T', tag => 'test_tag')"),
+      Row(true) :: Nil)
+  }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

when re-create a tag with the same name, we should delete it first and dont want to the job failed if tag not exists, like this:
```
CALL sys.delete_tag(table => 'default.T', tag => 'my_tag');
CALL sys.create_tag(table => 'default.T', tag => 'my_tag');
```
This is like `drop table [if exists] tb` usage.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
