### PR TITLE
Fix InsertOnly behavior for CDC and deduplication scenarios

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeWriter.java
@@ -289,6 +289,9 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
 
     @Override
     public void withInsertOnly(boolean insertOnly) {
+        if (this.isInsertOnly == insertOnly) {
+            return;
+        }
         if (insertOnly && writeBuffer != null && writeBuffer.size() > 0) {
             throw new IllegalStateException(
                     "Insert-only can only be set before any record is received.");

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
@@ -65,6 +65,8 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
 
     @Nullable private final MetricGroup metricGroup;
 
+    @Nullable private Boolean lastInsertOnly;
+
     public StoreSinkWriteImpl(
             FileStoreTable table,
             String commitUser,
@@ -154,15 +156,21 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
         }
 
         if (memoryPoolFactory != null) {
-            return tableWrite.withMemoryPoolFactory(memoryPoolFactory);
+            tableWrite.withMemoryPoolFactory(memoryPoolFactory);
         } else {
-            return tableWrite.withMemoryPool(
+            tableWrite.withMemoryPool(
                     memoryPool != null
                             ? memoryPool
                             : new HeapMemorySegmentPool(
                                     table.coreOptions().writeBufferSize(),
                                     table.coreOptions().pageSize()));
         }
+
+        if (lastInsertOnly != null) {
+            tableWrite.withInsertOnly(lastInsertOnly);
+        }
+
+        return tableWrite;
     }
 
     public void withCompactExecutor(ExecutorService compactExecutor) {
@@ -171,6 +179,7 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
 
     @Override
     public void withInsertOnly(boolean insertOnly) {
+        this.lastInsertOnly = insertOnly;
         write.withInsertOnly(insertOnly);
     }
 


### PR DESCRIPTION
### Purpose

This PR fixes InsertOnly related behavior in CDC and deduplication scenarios.

Related PR: #3791 

### API and Format

This change does not affect API or storage format.

### Documentation

This change does not introduce changes that require a document.
