### PR TITLE
[spark] Fix push down limit data correctness issue with deletion vector

### DIFF
--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/PaimonPushDownTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/PaimonPushDownTest.scala
@@ -86,6 +86,22 @@ class PaimonPushDownTest extends PaimonSparkTestBase {
     checkAnswer(spark.sql(q), Row(1, "a", "p1") :: Row(2, "b", "p1") :: Row(3, "c", "p2") :: Nil)
   }
 
+  test("Paimon pushDown: limit for append-only tables with deletion vector") {
+    withTable("dv_test") {
+      spark.sql(
+        """
+          |CREATE TABLE dv_test (c1 INT, c2 STRING)
+          |TBLPROPERTIES ('deletion-vectors.enabled' = 'true', 'source.split.target-size' = '1')
+          |""".stripMargin)
+
+      spark.sql("insert into table dv_test values(1, 'a'),(2, 'b'),(3, 'c')")
+      assert(spark.sql("select * from dv_test limit 2").count() == 2)
+
+      spark.sql("delete from dv_test where c1 = 1")
+      assert(spark.sql("select * from dv_test limit 2").count() == 2)
+    }
+  }
+
   test("Paimon pushDown: limit for append-only tables") {
     spark.sql(s"""
                  |CREATE TABLE T (a INT, b STRING, c STRING)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
If we enable the deletion vector, the raw files row count may not equal to the actual row count. We can not push down limit if there are some deletion files. 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
add test

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
