### PR TITLE
[core][spark] Support push down limit for primary key table

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
@@ -112,6 +112,7 @@ public class DataTableBatchScan extends AbstractDataTableScan {
                             return 1;
                         }
                     });
+
             // fast return if there is no rawConvertible split
             if (!splits.get(0).rawConvertible()) {
                 return result;

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
@@ -34,9 +34,8 @@ class PaimonScanBuilder(table: Table)
   private var localScan: Option[Scan] = None
 
   override def pushLimit(limit: Int): Boolean = {
-    if (table.primaryKeys().isEmpty) {
-      pushDownLimit = Some(limit)
-    }
+    // It is safe, since we will do nothing if it is the primary table and the split is not `rawConvertible`
+    pushDownLimit = Some(limit)
     // just make a best effort to push down limit
     false
   }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
For the primary key table, we still have a chance to push down limit if the split is raw convertible. This pr relaxes the push down limit condition to support primary key table.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
add test

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
