### PR TITLE
[flink] Fix query service error while query table with deletion vectors option

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/Levels.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/Levels.java
@@ -187,6 +187,11 @@ public class Levels {
             List<DataFileMeta> files = new ArrayList<>(runOfLevel(level).files());
             files.removeAll(before);
             files.addAll(after);
+            for (DataFileMeta file : after) {
+                if (!files.contains(file)) {
+                    files.add(file);
+                }
+            }
             levels.set(level - 1, SortedRun.fromUnsorted(files, keyComparator));
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/SortedRun.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/SortedRun.java
@@ -86,6 +86,13 @@ public class SortedRun {
 
     @VisibleForTesting
     public void validate(Comparator<InternalRow> comparator) {
+
+        Preconditions.checkNotNull(comparator, "Comparator cannot be null");
+
+        if (files == null || files.size() <= 1) {
+            return;
+        }
+
         for (int i = 1; i < files.size(); i++) {
             Preconditions.checkState(
                     comparator.compare(files.get(i).minKey(), files.get(i - 1).maxKey()) > 0,

--- a/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/procedure/ProcedurePositionalArgumentsITCase.java
+++ b/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/procedure/ProcedurePositionalArgumentsITCase.java
@@ -424,6 +424,20 @@ public class ProcedurePositionalArgumentsITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testQueryServiceWithDeletionVectors() {
+        sql(
+                "CREATE TABLE DIM (k INT, v STRING, PRIMARY KEY(k) NOT ENFORCED) WITH ('bucket' = '1', 'deletion-vectors.enabled' = 'true')");
+        sql("INSERT INTO DIM VALUES (1, 'a'), (2, 'b')");
+        assertThatCode(
+                        () -> {
+                            CloseableIterator<Row> service =
+                                    streamSqlIter("CALL sys.query_service('default.DIM', 1)");
+                            service.close();
+                        })
+                .doesNotThrowAnyException();
+    }
+
+    @Test
     public void testRemoveOrphanFiles() {
         sql(
                 "CREATE TABLE T ("


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Test query service with deletion vectors options, its okay for table with option `'deletion-vectors.enabled' = 'true'`
<!-- Linking this pull request to the issue -->
Linked issue: close #4265

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
Add test `testQueryServiceWithDeletionVectors`

### API and Format

<!-- Does this change affect API or storage format -->
No
### Documentation

<!-- Does this change introduce a new feature -->
No
