### PR TITLE
[flink] fix compact unaware bucket table in combine mode the writer parallelism is always 1

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedUnawareBatchSourceFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedUnawareBatchSourceFunction.java
@@ -36,8 +36,6 @@ import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.StreamSource;
-import org.apache.flink.streaming.api.transformations.PartitionTransformation;
-import org.apache.flink.streaming.runtime.partitioner.RebalancePartitioner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -135,11 +133,7 @@ public class CombinedUnawareBatchSourceFunction
                             new MultiUnawareTablesReadOperator(catalogLoader, partitionIdleTime));
         }
 
-        PartitionTransformation<MultiTableUnawareAppendCompactionTask> transformation =
-                new PartitionTransformation<>(
-                        source.getTransformation(), new RebalancePartitioner<>());
-
-        return new DataStream<>(env, transformation);
+        return source;
     }
 
     private static Long getPartitionInfo(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedUnawareStreamingSourceFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedUnawareStreamingSourceFunction.java
@@ -110,8 +110,7 @@ public class CombinedUnawareStreamingSourceFunction
                         isParallel,
                         name,
                         Boundedness.CONTINUOUS_UNBOUNDED)
-                .forceNonParallel()
-                .rebalance();
+                .forceNonParallel();
     }
 
     @Override


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
fix compact unaware bucket table in combine mode the writer parallelism is always 1

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
