### PR TITLE
[spark] Improve write table plan explain string

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SaveMode.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SaveMode.scala
@@ -23,15 +23,15 @@ import org.apache.spark.sql.sources.{AlwaysTrue, Filter}
 
 sealed private[spark] trait SaveMode extends Serializable
 
-object InsertInto extends SaveMode
+case object InsertInto extends SaveMode
 
 case class Overwrite(filters: Option[Filter]) extends SaveMode
 
-object DynamicOverWrite extends SaveMode
+case object DynamicOverWrite extends SaveMode
 
-object ErrorIfExists extends SaveMode
+case object ErrorIfExists extends SaveMode
 
-object Ignore extends SaveMode
+case object Ignore extends SaveMode
 
 object SaveMode {
   def transform(saveMode: SparkSaveMode): SaveMode = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkTable.scala
@@ -107,4 +107,8 @@ case class SparkTable(table: Table)
         throw new RuntimeException("Only FileStoreTable can be written.")
     }
   }
+
+  override def toString: String = {
+    s"${table.getClass.getSimpleName}[${table.fullName()}]"
+  }
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkWrite.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkWrite.scala
@@ -35,4 +35,8 @@ class SparkWrite(val table: FileStoreTable, saveMode: SaveMode, options: Options
         WriteIntoPaimonTable(table, saveMode, data, options).run(data.sparkSession)
       }
   }
+
+  override def toString: String = {
+    s"table: ${table.fullName()}, saveMode: $saveMode, options: ${options.toMap}"
+  }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

For example: `explain insert into table ...`

before:
```
== Physical Plan ==
AppendDataExecV1 SparkTable(org.apache.paimon.table.PrimaryKeyFileStoreTable@55b12c21), Project [id#287L AS id#290L, (id % 3)#289L AS c1#291L, id#288 AS c2#292], org.apache.spark.sql.execution.datasources.v2.DataSourceV2Strategy$$Lambda$4534/0x000000080270fa08@5762dc14, org.apache.paimon.spark.SparkWrite@30ba29cf
```

after:
```
== Physical Plan ==
AppendDataExecV1 PrimaryKeyFileStoreTable[default.bucket_t1], Project [id#3L AS id#6L, (id % 3)#5L AS c1#7L, id#4 AS c2#8], org.apache.spark.sql.execution.datasources.v2.DataSourceV2Strategy$$Lambda$2239/0x0000000801fb0d88@13448d2d, table: default.bucket_t1, saveMode: InsertInto, options: {}
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
manually test

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
