### PR TITLE
[flink] Flink LookupTable support cache row filter

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/query/LocalTableQuery.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/query/LocalTableQuery.java
@@ -37,8 +37,10 @@ import org.apache.paimon.mergetree.Levels;
 import org.apache.paimon.mergetree.LookupFile;
 import org.apache.paimon.mergetree.LookupLevels;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.KeyComparatorSupplier;
 import org.apache.paimon.utils.Preconditions;
 
@@ -78,6 +80,8 @@ public class LocalTableQuery implements TableQuery {
 
     private final RowType rowType;
     private final RowType partitionType;
+
+    @Nullable private Filter<InternalRow> cacheRowFilter;
 
     public LocalTableQuery(FileStoreTable table) {
         this.options = table.coreOptions();
@@ -154,12 +158,20 @@ public class LocalTableQuery implements TableQuery {
                         keyComparatorSupplier.get(),
                         readerFactoryBuilder.keyType(),
                         new LookupLevels.KeyValueProcessor(readerFactoryBuilder.readValueType()),
-                        file ->
-                                factory.createRecordReader(
-                                        file.schemaId(),
-                                        file.fileName(),
-                                        file.fileSize(),
-                                        file.level()),
+                        file -> {
+                            RecordReader<KeyValue> reader =
+                                    factory.createRecordReader(
+                                            file.schemaId(),
+                                            file.fileName(),
+                                            file.fileSize(),
+                                            file.level());
+                            if (cacheRowFilter != null) {
+                                reader =
+                                        reader.filter(
+                                                keyValue -> cacheRowFilter.test(keyValue.value()));
+                            }
+                            return reader;
+                        },
                         file ->
                                 Preconditions.checkNotNull(ioManager, "IOManager is required.")
                                         .createChannel(
@@ -203,6 +215,11 @@ public class LocalTableQuery implements TableQuery {
 
     public LocalTableQuery withIOManager(IOManager ioManager) {
         this.ioManager = ioManager;
+        return this;
+    }
+
+    public LocalTableQuery withCacheRowFilter(Filter<InternalRow> cacheRowFilter) {
+        this.cacheRowFilter = cacheRowFilter;
         return this;
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/TableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/TableTestBase.java
@@ -57,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -105,6 +106,19 @@ public abstract class TableTestBase {
                 BatchTableCommit commit = writeBuilder.newCommit()) {
             for (Pair<InternalRow, Integer> row : rows) {
                 write.write(row.getKey(), row.getValue());
+            }
+            commit.commit(write.prepareCommit());
+        }
+    }
+
+    protected void writeWithBucketAssigner(
+            Table table, Function<InternalRow, Integer> bucketAssigner, InternalRow... rows)
+            throws Exception {
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = writeBuilder.newWrite();
+                BatchTableCommit commit = writeBuilder.newCommit()) {
+            for (InternalRow row : rows) {
+                write.write(row, bucketAssigner.apply(row));
             }
             commit.commit(write.prepareCommit());
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupTable.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.lookup;
 
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.utils.Filter;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -35,4 +36,6 @@ public interface LookupTable extends Closeable {
     List<InternalRow> get(InternalRow key) throws IOException;
 
     void refresh() throws Exception;
+
+    void specifyCacheRowFilter(Filter<InternalRow> filter);
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Flink LookupTable support cache row filter to filter out rows to be stored in cache.

### Tests

- UT added in `LookupTableTest` and `KeyValueFileReadWriteTest`.

### API and Format

No

### Documentation

No
