### PR TITLE
[hotfix] Add `.java-version` to to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ target
 .DS_Store
 *.ipr
 *.iws
+.java-version
 dependency-reduced-pom.xml


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

[Jenv](https://github.com/jenv/jenv) is a popular tool for managing multiple Java versions.

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
