### PR TITLE
[core] Support timestamp type in Iceberg compatibility

### DIFF
--- a/docs/content/migration/iceberg-compatibility.md
+++ b/docs/content/migration/iceberg-compatibility.md
@@ -345,6 +345,28 @@ You can configure the following table option, so that Paimon is forced to perfor
 Note that full compaction is a resource-consuming process, so the value of this table option should not be too small.
 We recommend full compaction to be performed once or twice per hour.
 
+## Supported Types
+
+Paimon Iceberg compatibility currently supports the following data types.
+
+| Paimon Data Type           | Iceberg Data Type |
+|----------------------------|-------------------|
+| `BOOLEAN`                  | `boolean`         |
+| `INT`                      | `int`             |
+| `BIGINT`                   | `long`            |
+| `FLOAT`                    | `float`           |
+| `DOUBLE`                   | `double`          |
+| `DECIMAL`                  | `decimal`         |
+| `CHAR`                     | `string`          |
+| `VARCHAR`                  | `string`          |
+| `BINARY`                   | `binary`          |
+| `VARBINARY`                | `binary`          |
+| `DATE`                     | `date` |
+| `TIMESTAMP`*     | `timestamp`       |
+| `TIMESTAMP_LTZ`* | `timestamptz`      |
+
+*: `TIMESTAMP` and `TIMESTAMP_LTZ` type only support precision from 4 to 6
+
 ## Other Related Table Options
 
 <table class="table table-bordered">

--- a/paimon-core/pom.xml
+++ b/paimon-core/pom.xml
@@ -33,7 +33,6 @@ under the License.
 
     <properties>
         <frocksdbjni.version>6.20.3-ververica-2.0</frocksdbjni.version>
-        <iceberg.version>1.6.1</iceberg.version>
     </properties>
 
     <dependencies>

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
@@ -26,6 +26,7 @@ import org.apache.paimon.data.BinaryRowWriter;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.disk.IOManagerImpl;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
@@ -59,6 +60,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -374,7 +376,8 @@ public class IcebergCompatibilityTest {
                             DataTypes.STRING(),
                             DataTypes.BINARY(20),
                             DataTypes.VARBINARY(20),
-                            DataTypes.DATE()
+                            DataTypes.DATE(),
+                            DataTypes.TIMESTAMP(6)
                         },
                         new String[] {
                             "v_int",
@@ -387,7 +390,8 @@ public class IcebergCompatibilityTest {
                             "v_varchar",
                             "v_binary",
                             "v_varbinary",
-                            "v_date"
+                            "v_date",
+                            "v_timestamp"
                         });
         FileStoreTable table =
                 createPaimonTable(rowType, Collections.emptyList(), Collections.emptyList(), -1);
@@ -408,7 +412,8 @@ public class IcebergCompatibilityTest {
                         BinaryString.fromString("cat"),
                         "B_apple".getBytes(),
                         "B_cat".getBytes(),
-                        100);
+                        100,
+                        Timestamp.fromLocalDateTime(LocalDateTime.of(2024, 10, 10, 11, 22, 33)));
         write.write(lowerBounds);
         GenericRow upperBounds =
                 GenericRow.of(
@@ -422,7 +427,8 @@ public class IcebergCompatibilityTest {
                         BinaryString.fromString("dog"),
                         "B_banana".getBytes(),
                         "B_dog".getBytes(),
-                        200);
+                        200,
+                        Timestamp.fromLocalDateTime(LocalDateTime.of(2024, 10, 20, 11, 22, 33)));
         write.write(upperBounds);
         commit.commit(1, write.prepareCommit(false, 1));
 
@@ -450,6 +456,9 @@ public class IcebergCompatibilityTest {
             } else if (type.getTypeRoot() == DataTypeRoot.DECIMAL) {
                 lower = new BigDecimal(lowerBounds.getField(i).toString());
                 upper = new BigDecimal(upperBounds.getField(i).toString());
+            } else if (type.getTypeRoot() == DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
+                lower = ((Timestamp) lowerBounds.getField(i)).toMicros();
+                upper = ((Timestamp) upperBounds.getField(i)).toMicros();
             } else {
                 lower = lowerBounds.getField(i);
                 upper = upperBounds.getField(i);
@@ -460,6 +469,9 @@ public class IcebergCompatibilityTest {
             if (type.getTypeRoot() == DataTypeRoot.DATE) {
                 expectedLower = LocalDate.ofEpochDay((int) lower).toString();
                 expectedUpper = LocalDate.ofEpochDay((int) upper).toString();
+            } else if (type.getTypeRoot() == DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
+                expectedLower = Timestamp.fromMicros((long) lower).toString();
+                expectedUpper = Timestamp.fromMicros((long) upper).toString();
             }
 
             assertThat(

--- a/paimon-flink/paimon-flink-1.17/pom.xml
+++ b/paimon-flink/paimon-flink-1.17/pom.xml
@@ -36,7 +36,6 @@ under the License.
     <properties>
         <flink.version>1.17.2</flink.version>
         <iceberg.flink.version>1.17</iceberg.flink.version>
-        <iceberg.version>1.6.1</iceberg.version>
     </properties>
 
     <dependencies>

--- a/paimon-flink/paimon-flink-1.18/pom.xml
+++ b/paimon-flink/paimon-flink-1.18/pom.xml
@@ -36,7 +36,6 @@ under the License.
     <properties>
         <flink.version>1.18.1</flink.version>
         <iceberg.flink.version>1.18</iceberg.flink.version>
-        <iceberg.version>1.6.1</iceberg.version>
     </properties>
 
     <dependencies>

--- a/paimon-flink/paimon-flink-1.19/pom.xml
+++ b/paimon-flink/paimon-flink-1.19/pom.xml
@@ -36,7 +36,6 @@ under the License.
     <properties>
         <flink.version>1.19.1</flink.version>
         <iceberg.flink.version>1.19</iceberg.flink.version>
-        <iceberg.version>1.6.1</iceberg.version>
     </properties>
 
     <dependencies>

--- a/paimon-flink/paimon-flink-common/pom.xml
+++ b/paimon-flink/paimon-flink-common/pom.xml
@@ -150,6 +150,19 @@ under the License.
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-core</artifactId>
+            <version>${iceberg.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-data</artifactId>
+            <version>${iceberg.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/iceberg/FlinkIcebergITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/iceberg/FlinkIcebergITCaseBase.java
@@ -285,7 +285,9 @@ public abstract class FlinkIcebergITCaseBase extends AbstractTestBase {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"orc", "parquet"})
+    // orc writer does not write timestamp_ltz correctly, however we won't fix it due to
+    // compatibility concern, so we don't test orc here
+    @ValueSource(strings = {"parquet"})
     public void testFilterTimestampLtz(String format) throws Exception {
         String warehouse = getTempDirPath();
         TableEnvironment tEnv = tableEnvironmentBuilder().batchMode().parallelism(2).build();

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@ under the License.
         <flink.forkCount>1C</flink.forkCount>
         <flink.reuseForks>true</flink.reuseForks>
         <testcontainers.version>1.19.1</testcontainers.version>
+        <iceberg.version>1.6.1</iceberg.version>
 
         <!-- Can be set to any value to reproduce a specific build. -->
         <test.randomization.seed/>


### PR DESCRIPTION
### Purpose

`TIMESTAMP` is a widely used data type. This PR supports `TIMESTAMP` and `TIMESTAMP_LTZ` type in Iceberg compatibility.

### Tests

Unit tests and IT cases.

### API and Format

No format changes.

### Documentation

Document is also added.
