### PR TITLE
[core] Support parallel reading of local orphan clean

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -55,7 +55,6 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.ThreadPoolUtils.createCachedThreadPool;
 import static org.apache.paimon.utils.ThreadPoolUtils.randomlyExecute;
 import static org.apache.paimon.utils.ThreadPoolUtils.randomlyOnlyExecute;
-import static org.apache.paimon.utils.ThreadPoolUtils.sequentialBatchedExecute;
 
 /**
  * Local {@link OrphanFilesClean}, it will use thread pool to execute deletion.
@@ -71,8 +70,6 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
 
     private Set<String> candidateDeletes;
 
-    private final int parallelism;
-
     public LocalOrphanFilesClean(FileStoreTable table) {
         this(table, System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1));
     }
@@ -85,8 +82,9 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
             FileStoreTable table, long olderThanMillis, SerializableConsumer<Path> fileCleaner) {
         super(table, olderThanMillis, fileCleaner);
         this.deleteFiles = new ArrayList<>();
-        this.parallelism = table.coreOptions().deleteFileThreadNum();
-        this.executor = createCachedThreadPool(parallelism, "ORPHAN_FILES_CLEAN");
+        this.executor =
+                createCachedThreadPool(
+                        table.coreOptions().deleteFileThreadNum(), "ORPHAN_FILES_CLEAN");
     }
 
     public List<Path> clean() throws IOException, ExecutionException, InterruptedException {
@@ -141,39 +139,29 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
         try {
             Set<String> manifests = ConcurrentHashMap.newKeySet();
             collectWithoutDataFile(branch, usedFiles::add, manifests::add);
-            Iterable<String> dataFiles =
-                    sequentialBatchedExecute(
-                            executor,
-                            manifestName -> {
-                                try {
-                                    List<String> dataFilesInBatch = new ArrayList<>();
-                                    retryReadingFiles(
-                                                    () ->
-                                                            manifestFile.readWithIOException(
-                                                                    manifestName),
-                                                    Collections.<ManifestEntry>emptyList())
-                                            .stream()
-                                            .map(ManifestEntry::file)
-                                            .forEach(
-                                                    f -> {
-                                                        if (candidateDeletes.contains(
-                                                                f.fileName())) {
-                                                            dataFilesInBatch.add(f.fileName());
-                                                        }
-                                                        f.extraFiles().stream()
-                                                                .filter(candidateDeletes::contains)
-                                                                .forEach(dataFilesInBatch::add);
-                                                    });
-                                    return dataFilesInBatch;
-                                } catch (IOException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            },
-                            new ArrayList<>(manifests),
-                            parallelism);
-            for (String fileName : dataFiles) {
-                usedFiles.add(fileName);
-            }
+            randomlyOnlyExecute(
+                    executor,
+                    manifestName -> {
+                        try {
+                            retryReadingFiles(
+                                            () -> manifestFile.readWithIOException(manifestName),
+                                            Collections.<ManifestEntry>emptyList())
+                                    .stream()
+                                    .map(ManifestEntry::file)
+                                    .forEach(
+                                            f -> {
+                                                if (candidateDeletes.contains(f.fileName())) {
+                                                    usedFiles.add(f.fileName());
+                                                }
+                                                f.extraFiles().stream()
+                                                        .filter(candidateDeletes::contains)
+                                                        .forEach(usedFiles::add);
+                                            });
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    },
+                    manifests);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -116,7 +116,7 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
         return deleteFiles;
     }
 
-    protected void collectWithoutDataFile(
+    private void collectWithoutDataFile(
             String branch, Consumer<String> usedFileConsumer, Consumer<String> manifestConsumer)
             throws IOException {
         randomlyOnlyExecute(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -147,14 +147,6 @@ public abstract class OrphanFilesClean implements Serializable {
     }
 
     protected void collectWithoutDataFile(
-            String branch, Consumer<String> usedFileConsumer, Consumer<String> manifestConsumer)
-            throws IOException {
-        for (Snapshot snapshot : safelyGetAllSnapshots(branch)) {
-            collectWithoutDataFile(branch, snapshot, usedFileConsumer, manifestConsumer);
-        }
-    }
-
-    protected void collectWithoutDataFile(
             String branch,
             Snapshot snapshot,
             Consumer<String> usedFileConsumer,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->

Increase parallel reading of snapshot, manifest, and data file meta to improve execution efficiency

### Tests

<!-- List UT and IT cases to verify this change -->

Test in table with 7TB size with local mode:
Before this patch: local orphan clean will cost **20 min**
After this patcgh, use the same sql in **parallelism 16**, the procedure only cost **5 min**

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
