### PR TITLE
[flink] Fix FlinkGenericCatalog can not get procedure

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkGenericCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkGenericCatalog.java
@@ -498,7 +498,11 @@ public class FlinkGenericCatalog extends AbstractCatalog {
      */
     public Procedure getProcedure(ObjectPath procedurePath)
             throws ProcedureNotExistException, CatalogException {
-        return ProcedureUtil.getProcedure(paimon.catalog(), procedurePath)
-                .orElse(flink.getProcedure(procedurePath));
+        Optional<Procedure> procedure = ProcedureUtil.getProcedure(paimon.catalog(), procedurePath);
+        if (procedure.isPresent()) {
+            return procedure.get();
+        } else {
+            return flink.getProcedure(procedurePath);
+        }
     }
 }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/FlinkGenericCatalogITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/FlinkGenericCatalogITCase.java
@@ -201,4 +201,20 @@ public class FlinkGenericCatalogITCase extends AbstractTestBaseJUnit4 {
         assertThat(result)
                 .contains(Row.of("compact"), Row.of("merge_into"), Row.of("migrate_table"));
     }
+
+    @Test
+    public void testCreateTag() {
+        sql(
+                "CREATE TABLE paimon_t ( "
+                        + "f0 INT, "
+                        + "f1 INT "
+                        + ") WITH ('connector'='paimon', 'file.format' = 'avro' )");
+        sql("INSERT INTO paimon_t VALUES (1, 1), (2, 2)");
+        assertThat(sql("SELECT * FROM paimon_t"))
+                .containsExactlyInAnyOrder(Row.of(1, 1), Row.of(2, 2));
+        sql("CALL sys.create_tag('test_db.paimon_t', 'tag_1')");
+
+        List<Row> result = sql("SELECT tag_name FROM paimon_t$tags");
+        assertThat(result).contains(Row.of("tag_1"));
+    }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Fix the exception as below when use `FlinkGenericCatalog`

![image](https://github.com/user-attachments/assets/1a590641-1077-4d5b-b54f-31ea51973b7f)


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
