### PR TITLE
[core] Support RollbackAction and Procedure with timestamp

### DIFF
--- a/docs/content/flink/procedures.md
+++ b/docs/content/flink/procedures.md
@@ -325,12 +325,15 @@ All available procedures are listed below.
          CALL sys.rollback_to(`table` => 'identifier', snapshot_id => snapshotId)<br/><br/>
          -- rollback to a tag<br/>
          CALL sys.rollback_to(`table` => 'identifier', tag => 'tagName')
+         -- rollback to a timestamp<br/>
+         CALL sys.rollback_to(`table` => 'identifier', timestamp => 'timestamp')
       </td>
       <td>
          To rollback to a specific version of target table. Argument:
             <li>identifier: the target table identifier. Cannot be empty.</li>
             <li>snapshotId (Long): id of the snapshot that will roll back to.</li>
             <li>tagName: name of the tag that will roll back to.</li>
+            <li>timestamp: earlier or equal to the timestamp that will roll back to.</li>
       </td>
       <td>
          -- for Flink 1.18<br/>

--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -136,10 +136,12 @@ This section introduce all available spark procedures about paimon.
          To rollback to a specific version of target table. Argument:
             <li>table: the target table identifier. Cannot be empty.</li>
             <li>version: id of the snapshot or name of tag that will roll back to.</li>
+            <li>is_timestamp: whether version is a timestamp.</li>
       </td>
       <td>
           CALL sys.rollback(table => 'default.T', version => 'my_tag')<br/><br/>
           CALL sys.rollback(table => 'default.T', version => 10)
+          CALL sys.rollback(table => 'default.T', version => 1729410996001, is_timestamp = true)
       </td>
     </tr>
     <tr>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RollbackToActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RollbackToActionFactory.java
@@ -30,6 +30,8 @@ public class RollbackToActionFactory implements ActionFactory {
 
     private static final String VERSION = "version";
 
+    private static final String IS_TIMESTAMP = "is_timestamp";
+
     @Override
     public String identifier() {
         return IDENTIFIER;
@@ -41,12 +43,18 @@ public class RollbackToActionFactory implements ActionFactory {
 
         checkRequiredArgument(params, VERSION);
         String version = params.get(VERSION);
+        Boolean isTimestamp = Boolean.parseBoolean(params.get(IS_TIMESTAMP));
 
         Map<String, String> catalogConfig = optionalConfigMap(params, CATALOG_CONF);
 
         RollbackToAction action =
                 new RollbackToAction(
-                        tablePath.f0, tablePath.f1, tablePath.f2, version, catalogConfig);
+                        tablePath.f0,
+                        tablePath.f1,
+                        tablePath.f2,
+                        version,
+                        isTimestamp,
+                        catalogConfig);
 
         return Optional.of(action);
     }
@@ -60,9 +68,9 @@ public class RollbackToActionFactory implements ActionFactory {
         System.out.println("Syntax:");
         System.out.println(
                 "  rollback_to --warehouse <warehouse_path> --database <database_name> "
-                        + "--table <table_name> --version <version_string>");
+                        + "--table <table_name> --version <version_string> --is_timestamp <is_timestamp>");
         System.out.println(
-                "  <version_string> can be a long value representing a snapshot ID or a tag name.");
+                "  <version_string> can be a long value representing a snapshot ID or a tag name or a timestamp.");
         System.out.println();
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RollbackToProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RollbackToProcedure.java
@@ -18,10 +18,12 @@
 
 package org.apache.paimon.flink.procedure;
 
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
+import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.StringUtils;
 
 import org.apache.flink.table.annotation.ArgumentHint;
@@ -68,8 +70,10 @@ public class RollbackToProcedure extends ProcedureBase {
             table.rollbackTo(snapshotId);
         } else {
             FileStoreTable fileStoreTable = (FileStoreTable) table;
-            fileStoreTable.rollbackTo(
-                    fileStoreTable.snapshotManager().earlierOrEqualTimeMills(timestamp).id());
+            Snapshot snapshot = fileStoreTable.snapshotManager().earlierOrEqualTimeMills(timestamp);
+            Preconditions.checkNotNull(
+                    snapshot, String.format("count not find snapshot earlier than %s", timestamp));
+            fileStoreTable.rollbackTo(snapshot.id());
         }
         return new String[] {"Success"};
     }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RollbackProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RollbackProcedure.java
@@ -39,7 +39,7 @@ public class RollbackProcedure extends BaseProcedure {
                 ProcedureParameter.required("table", StringType),
                 // snapshot id or tag name or timestamp
                 ProcedureParameter.required("version", StringType),
-                ProcedureParameter.optional("isTimestamp", BooleanType)
+                ProcedureParameter.optional("is_timestamp", BooleanType)
             };
 
     private static final StructType OUTPUT_TYPE =

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/RollbackProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/RollbackProcedureTest.scala
@@ -28,7 +28,7 @@ class RollbackProcedureTest extends PaimonSparkTestBase with StreamTest {
 
   import testImplicits._
 
-  test("Paimon Procedure: rollback to snapshot and tag") {
+  test("Paimon Procedure: rollback to snapshot and tag and timestamp") {
     failAfter(streamingTimeout) {
       withTempDir {
         checkpointDir =>
@@ -68,6 +68,7 @@ class RollbackProcedureTest extends PaimonSparkTestBase with StreamTest {
             inputData.addData((2, "b"))
             stream.processAllAvailable()
             checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
+
             val ts = System.currentTimeMillis
 
             // snapshot-3
@@ -89,10 +90,10 @@ class RollbackProcedureTest extends PaimonSparkTestBase with StreamTest {
               Row(true) :: Nil)
             checkAnswer(query(), Row(1, "a") :: Row(2, "b2") :: Nil)
 
-            // rollback to timestamp
+            // rollback with timestamp
             checkAnswer(
               spark.sql(
-                s"CALL paimon.sys.rollback(table => 'test.T', version => '$ts', isTimestamp => true)"),
+                s"CALL paimon.sys.rollback(table => 'test.T', version => '$ts', is_timestamp => true)"),
               Row(true) :: Nil)
             checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Currently Rollback cannot rollback according timestamp which can make user more easy to rollback，this pr is aim to support it.
due to difference in spark and flink args do two ways to support it.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
