### PR TITLE
[core] Improve TruncateSimpleColStatsCollector performance

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/statistics/TruncateSimpleColStatsCollector.java
+++ b/paimon-common/src/main/java/org/apache/paimon/statistics/TruncateSimpleColStatsCollector.java
@@ -53,6 +53,11 @@ public class TruncateSimpleColStatsCollector extends AbstractSimpleColStatsColle
             return;
         }
 
+        // fast fail since the result is not correct
+        if (failed) {
+            return;
+        }
+
         // TODO use comparator for not comparable types and extract this logic to a util class
         if (!(field instanceof Comparable)) {
             return;
@@ -66,7 +71,12 @@ public class TruncateSimpleColStatsCollector extends AbstractSimpleColStatsColle
             Object max = truncateMax(field);
             // may fail
             if (max != null) {
-                maxValue = fieldSerializer.copy(truncateMax(field));
+                if (max != field) {
+                    // copied in `truncateMax`
+                    maxValue = max;
+                } else {
+                    maxValue = fieldSerializer.copy(max);
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This pr improves TruncateSimpleColStatsCollector performance:
1. avoid doing tuncate if previous row failed to truncate max
2. avoid unnecessary copy if we succeeded to tuncate max
3. avoid truncate max twice

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
the test has been convered by `SimpleColStatsCollectorTest`

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
