### PR TITLE
[core] Introduce View Support to HiveCatalog

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -25,6 +25,7 @@ import org.apache.paimon.metastore.MetastoreClient;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.Table;
+import org.apache.paimon.view.View;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -299,6 +300,69 @@ public interface Catalog extends AutoCloseable {
         alterTable(identifier, Collections.singletonList(change), ignoreIfNotExists);
     }
 
+    /**
+     * Check if a view exists in this catalog.
+     *
+     * @param identifier Path of the view
+     * @return true if the given view exists in the catalog false otherwise
+     */
+    default boolean viewExists(Identifier identifier) {
+        try {
+            return getView(identifier) != null;
+        } catch (ViewNotExistException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Return a {@link View} identified by the given {@link Identifier}.
+     *
+     * @param identifier Path of the view
+     * @return The requested view
+     * @throws ViewNotExistException if the target does not exist
+     */
+    default View getView(Identifier identifier) throws ViewNotExistException {
+        throw new ViewNotExistException(identifier);
+    }
+
+    /**
+     * Drop a view.
+     *
+     * @param identifier Path of the view to be dropped
+     * @param ignoreIfNotExists Flag to specify behavior when the view does not exist: if set to
+     *     false, throw an exception, if set to true, do nothing.
+     * @throws ViewNotExistException if the view does not exist
+     */
+    default void dropView(Identifier identifier, boolean ignoreIfNotExists)
+            throws ViewNotExistException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Create a new view.
+     *
+     * @param identifier path of the view to be created
+     * @param view the view definition
+     * @param ignoreIfExists flag to specify behavior when a view already exists at the given path:
+     *     if set to false, it throws a ViewAlreadyExistException, if set to true, do nothing.
+     * @throws ViewAlreadyExistException if view already exists and ignoreIfExists is false
+     * @throws DatabaseNotExistException if the database in identifier doesn't exist
+     */
+    default void createView(Identifier identifier, View view, boolean ignoreIfExists)
+            throws ViewAlreadyExistException, DatabaseNotExistException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Get names of all views under this database. An empty list is returned if none exists.
+     *
+     * @return a list of the names of all views in this database
+     * @throws DatabaseNotExistException if the database does not exist
+     */
+    default List<String> listViews(String databaseName) throws DatabaseNotExistException {
+        return Collections.emptyList();
+    }
+
     /** Return a boolean that indicates whether this catalog allow upper case. */
     boolean allowUpperCase();
 
@@ -529,6 +593,48 @@ public interface Catalog extends AutoCloseable {
 
         public String column() {
             return column;
+        }
+    }
+
+    /** Exception for trying to create a view that already exists. */
+    class ViewAlreadyExistException extends Exception {
+
+        private static final String MSG = "View %s already exists.";
+
+        private final Identifier identifier;
+
+        public ViewAlreadyExistException(Identifier identifier) {
+            this(identifier, null);
+        }
+
+        public ViewAlreadyExistException(Identifier identifier, Throwable cause) {
+            super(String.format(MSG, identifier.getFullName()), cause);
+            this.identifier = identifier;
+        }
+
+        public Identifier identifier() {
+            return identifier;
+        }
+    }
+
+    /** Exception for trying to operate on a view that doesn't exist. */
+    class ViewNotExistException extends Exception {
+
+        private static final String MSG = "View %s does not exist.";
+
+        private final Identifier identifier;
+
+        public ViewNotExistException(Identifier identifier) {
+            this(identifier, null);
+        }
+
+        public ViewNotExistException(Identifier identifier, Throwable cause) {
+            super(String.format(MSG, identifier.getFullName()), cause);
+            this.identifier = identifier;
+        }
+
+        public Identifier identifier() {
+            return identifier;
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -24,6 +24,7 @@ import org.apache.paimon.metastore.MetastoreClient;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.Table;
+import org.apache.paimon.view.View;
 
 import java.util.List;
 import java.util.Map;
@@ -133,6 +134,38 @@ public class DelegateCatalog implements Catalog {
     @Override
     public Table getTable(Identifier identifier) throws TableNotExistException {
         return wrapped.getTable(identifier);
+    }
+
+    @Override
+    public boolean tableExists(Identifier identifier) {
+        return wrapped.tableExists(identifier);
+    }
+
+    @Override
+    public boolean viewExists(Identifier identifier) {
+        return wrapped.viewExists(identifier);
+    }
+
+    @Override
+    public View getView(Identifier identifier) throws ViewNotExistException {
+        return wrapped.getView(identifier);
+    }
+
+    @Override
+    public void dropView(Identifier identifier, boolean ignoreIfNotExists)
+            throws ViewNotExistException {
+        wrapped.dropView(identifier, ignoreIfNotExists);
+    }
+
+    @Override
+    public void createView(Identifier identifier, View view, boolean ignoreIfExists)
+            throws ViewAlreadyExistException, DatabaseNotExistException {
+        wrapped.createView(identifier, view, ignoreIfExists);
+    }
+
+    @Override
+    public List<String> listViews(String databaseName) throws DatabaseNotExistException {
+        return wrapped.listViews(databaseName);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/view/View.java
+++ b/paimon-core/src/main/java/org/apache/paimon/view/View.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.view;
+
+import org.apache.paimon.types.RowType;
+
+import java.util.Map;
+import java.util.Optional;
+
+/** Interface for view definition. */
+public interface View {
+
+    /** A name to identify this view. */
+    String name();
+
+    /** Full name (including database) to identify this view. */
+    String fullName();
+
+    /** Returns the row type of this view. */
+    RowType rowType();
+
+    /** Returns the view representation. */
+    String query();
+
+    /** Optional comment of this view. */
+    Optional<String> comment();
+
+    /** Options of this view. */
+    Map<String, String> options();
+
+    /** Copy this view with adding dynamic options. */
+    View copy(Map<String, String> dynamicOptions);
+}

--- a/paimon-core/src/main/java/org/apache/paimon/view/ViewImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/view/ViewImpl.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.view;
+
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.types.RowType;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/** Implementation of {@link View}. */
+public class ViewImpl implements View {
+
+    private final Identifier identifier;
+    private final RowType rowType;
+    private final String query;
+    @Nullable private final String comment;
+    private final Map<String, String> options;
+
+    public ViewImpl(
+            Identifier identifier,
+            RowType rowType,
+            String query,
+            @Nullable String comment,
+            Map<String, String> options) {
+        this.identifier = identifier;
+        this.rowType = rowType;
+        this.query = query;
+        this.comment = comment;
+        this.options = options;
+    }
+
+    @Override
+    public String name() {
+        return identifier.getObjectName();
+    }
+
+    @Override
+    public String fullName() {
+        return identifier.getFullName();
+    }
+
+    @Override
+    public RowType rowType() {
+        return rowType;
+    }
+
+    @Override
+    public String query() {
+        return query;
+    }
+
+    @Override
+    public Optional<String> comment() {
+        return Optional.ofNullable(comment);
+    }
+
+    @Override
+    public Map<String, String> options() {
+        return options;
+    }
+
+    @Override
+    public View copy(Map<String, String> dynamicOptions) {
+        Map<String, String> newOptions = new HashMap<>(options);
+        newOptions.putAll(dynamicOptions);
+        return new ViewImpl(identifier, rowType, query, comment, newOptions);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ViewImpl view = (ViewImpl) o;
+        return Objects.equals(identifier, view.identifier)
+                && Objects.equals(rowType, view.rowType)
+                && Objects.equals(query, view.query)
+                && Objects.equals(comment, view.comment)
+                && Objects.equals(options, view.options);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identifier, rowType, query, comment, options);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -41,6 +41,8 @@ import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.InternalRowPartitionComputer;
 import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.StringUtils;
+import org.apache.paimon.view.View;
+import org.apache.paimon.view.ViewImpl;
 
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.AbstractCatalog;
@@ -53,10 +55,12 @@ import org.apache.flink.table.catalog.CatalogPartition;
 import org.apache.flink.table.catalog.CatalogPartitionImpl;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.IntervalFreshness;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.ResolvedCatalogBaseTable;
+import org.apache.flink.table.catalog.ResolvedCatalogView;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.TableChange;
 import org.apache.flink.table.catalog.TableChange.AddColumn;
@@ -284,6 +288,11 @@ public class FlinkCatalog extends AbstractCatalog {
         try {
             table = catalog.getTable(toIdentifier(tablePath));
         } catch (Catalog.TableNotExistException e) {
+            Optional<CatalogBaseTable> view = getView(tablePath, timestamp);
+            if (view.isPresent()) {
+                return view.get();
+            }
+
             throw new TableNotExistException(getName(), tablePath);
         }
 
@@ -309,17 +318,53 @@ public class FlinkCatalog extends AbstractCatalog {
         }
     }
 
+    private Optional<CatalogBaseTable> getView(ObjectPath tablePath, @Nullable Long timestamp) {
+        View view;
+        try {
+            view = catalog.getView(toIdentifier(tablePath));
+        } catch (Catalog.ViewNotExistException e) {
+            return Optional.empty();
+        }
+
+        if (timestamp != null) {
+            throw new UnsupportedOperationException(
+                    String.format("View %s does not support time travel.", tablePath));
+        }
+
+        org.apache.flink.table.api.Schema schema =
+                org.apache.flink.table.api.Schema.newBuilder()
+                        .fromRowDataType(fromLogicalToDataType(toLogicalType(view.rowType())))
+                        .build();
+        return Optional.of(
+                CatalogView.of(
+                        schema,
+                        view.comment().orElse(null),
+                        view.query(),
+                        view.query(),
+                        view.options()));
+    }
+
     @Override
     public boolean tableExists(ObjectPath tablePath) throws CatalogException {
-        return catalog.tableExists(toIdentifier(tablePath));
+        Identifier identifier = toIdentifier(tablePath);
+        return catalog.tableExists(identifier) || catalog.viewExists(identifier);
     }
 
     @Override
     public void dropTable(ObjectPath tablePath, boolean ignoreIfNotExists)
             throws TableNotExistException, CatalogException {
         Identifier identifier = toIdentifier(tablePath);
-        Table table = null;
+        if (catalog.viewExists(identifier)) {
+            try {
+                catalog.dropView(identifier, ignoreIfNotExists);
+                return;
+            } catch (Catalog.ViewNotExistException e) {
+                throw new RuntimeException("Unexpected exception.", e);
+            }
+        }
+
         try {
+            Table table = null;
             if (logStoreAutoRegister && catalog.tableExists(identifier)) {
                 table = catalog.getTable(identifier);
             }
@@ -335,16 +380,15 @@ public class FlinkCatalog extends AbstractCatalog {
     @Override
     public void createTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists)
             throws TableAlreadyExistException, DatabaseNotExistException, CatalogException {
-        if (!(table instanceof CatalogTable || table instanceof CatalogMaterializedTable)) {
-            throw new UnsupportedOperationException(
-                    "Only support CatalogTable and CatalogMaterializedTable, but is: "
-                            + table.getClass());
-        }
-
         if (Objects.equals(getDefaultDatabase(), tablePath.getDatabaseName())
                 && disableCreateTableInDefaultDatabase) {
             throw new UnsupportedOperationException(
                     "Creating table in default database is disabled, please specify a database name.");
+        }
+
+        if (table instanceof CatalogView) {
+            createView(tablePath, (ResolvedCatalogView) table, ignoreIfExists);
+            return;
         }
 
         Identifier identifier = toIdentifier(tablePath);
@@ -369,6 +413,34 @@ public class FlinkCatalog extends AbstractCatalog {
             if (logStoreAutoRegister && unRegisterLogSystem) {
                 unRegisterLogSystem(identifier, options, classLoader);
             }
+        }
+    }
+
+    private void createView(ObjectPath tablePath, ResolvedCatalogView table, boolean ignoreIfExists)
+            throws TableAlreadyExistException, DatabaseNotExistException {
+        Identifier identifier = toIdentifier(tablePath);
+        org.apache.paimon.types.RowType.Builder builder = org.apache.paimon.types.RowType.builder();
+        table.getResolvedSchema()
+                .getColumns()
+                .forEach(
+                        column ->
+                                builder.field(
+                                        column.getName(),
+                                        toDataType(column.getDataType().getLogicalType()),
+                                        column.getComment().orElse(null)));
+        View view =
+                new ViewImpl(
+                        identifier,
+                        builder.build(),
+                        table.getOriginalQuery(),
+                        table.getComment(),
+                        table.getOptions());
+        try {
+            catalog.createView(identifier, view, ignoreIfExists);
+        } catch (Catalog.ViewAlreadyExistException e) {
+            throw new TableAlreadyExistException(getName(), tablePath);
+        } catch (Catalog.DatabaseNotExistException e) {
+            throw new DatabaseNotExistException(getName(), tablePath.getDatabaseName());
         }
     }
 
@@ -1025,8 +1097,13 @@ public class FlinkCatalog extends AbstractCatalog {
     }
 
     @Override
-    public final List<String> listViews(String databaseName) throws CatalogException {
-        return Collections.emptyList();
+    public final List<String> listViews(String databaseName)
+            throws DatabaseNotExistException, CatalogException {
+        try {
+            return catalog.listViews(databaseName);
+        } catch (Catalog.DatabaseNotExistException e) {
+            throw new DatabaseNotExistException(getName(), databaseName);
+        }
     }
 
     @Override

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveTableUtils.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveTableUtils.java
@@ -44,7 +44,7 @@ import static org.apache.paimon.TableType.FORMAT_TABLE;
 import static org.apache.paimon.catalog.Catalog.COMMENT_PROP;
 import static org.apache.paimon.table.FormatTableOptions.FIELD_DELIMITER;
 
-class HiveFormatTableUtils {
+class HiveTableUtils {
 
     public static FormatTable convertToFormatTable(Table hiveTable) {
         if (TableType.valueOf(hiveTable.getTableType()) == TableType.VIRTUAL_VIEW) {
@@ -54,7 +54,7 @@ class HiveFormatTableUtils {
         Identifier identifier = new Identifier(hiveTable.getDbName(), hiveTable.getTableName());
         Map<String, String> options = new HashMap<>(hiveTable.getParameters());
         List<String> partitionKeys = getFieldNames(hiveTable.getPartitionKeys());
-        RowType rowType = createRowType(hiveTable.getSd().getCols(), hiveTable.getPartitionKeys());
+        RowType rowType = createRowType(hiveTable);
         String comment = options.remove(COMMENT_PROP);
         String location = hiveTable.getSd().getLocation();
         Format format;
@@ -104,10 +104,9 @@ class HiveFormatTableUtils {
     }
 
     /** Create a Paimon's Schema from Hive table's columns and partition keys. */
-    private static RowType createRowType(
-            List<FieldSchema> nonPartCols, List<FieldSchema> partitionKeys) {
-        List<FieldSchema> allCols = new ArrayList<>(nonPartCols);
-        allCols.addAll(partitionKeys);
+    public static RowType createRowType(Table table) {
+        List<FieldSchema> allCols = new ArrayList<>(table.getSd().getCols());
+        allCols.addAll(table.getPartitionKeys());
         Pair<String[], DataType[]> columnInformation = extractColumnInformation(allCols);
         return RowType.builder()
                 .fields(columnInformation.getRight(), columnInformation.getLeft())

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -268,4 +268,9 @@ public class HiveCatalogTest extends CatalogTestBase {
             fail("Test failed due to exception: " + e.getMessage());
         }
     }
+
+    @Override
+    protected boolean supportsView() {
+        return true;
+    }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This PR aims to support View in Catalog, our metastore behind us, such as Hive metastore, supports views, but our catalog has not done this conversion well. This PR aims to support the definition of views and bridge with HiveCatalog.

#### Definition of view

```
/** Interface for view definition. */
public interface View {

    /** A name to identify this view. */
    String name();

    /** Full name (including database) to identify this view. */
    String fullName();

    /** Returns the row type of this view. */
    RowType rowType();

    /** Returns the view representation. */
    String query();

    /** Optional comment of this view. */
    Optional<String> comment();

    /** Options of this view. */
    Map<String, String> options();

    /** Copy this view with adding dynamic options. */
    View copy(Map<String, String> dynamicOptions);
}
```

#### Catalog interfaces

```
/**
     * Return a {@link View} identified by the given {@link Identifier}.
     *
     * @param identifier Path of the view
     * @return The requested view
     * @throws ViewNotExistException if the target does not exist
     */
    default View getView(Identifier identifier) throws ViewNotExistException {
        throw new ViewNotExistException(identifier);
    }

    /**
     * Drop a view.
     *
     * @param identifier Path of the view to be dropped
     * @param ignoreIfNotExists Flag to specify behavior when the view does not exist: if set to
     *     false, throw an exception, if set to true, do nothing.
     * @throws ViewNotExistException if the view does not exist
     */
    default void dropView(Identifier identifier, boolean ignoreIfNotExists)
            throws ViewNotExistException {
        throw new UnsupportedOperationException();
    }

    /**
     * Create a new view.
     *
     * @param identifier path of the view to be created
     * @param view the view definition
     * @param ignoreIfExists flag to specify behavior when a view already exists at the given path:
     *     if set to false, it throws a ViewAlreadyExistException, if set to true, do nothing.
     * @throws ViewAlreadyExistException if view already exists and ignoreIfExists is false
     * @throws DatabaseNotExistException if the database in identifier doesn't exist
     */
    default void createView(Identifier identifier, View view, boolean ignoreIfExists)
            throws ViewAlreadyExistException, DatabaseNotExistException {
        throw new UnsupportedOperationException();
    }

    /**
     * Get names of all views under this database. An empty list is returned if none exists.
     *
     * @return a list of the names of all views in this database
     * @throws DatabaseNotExistException if the database does not exist
     */
    default List<String> listViews(String databaseName) throws DatabaseNotExistException {
        throw new UnsupportedOperationException();
    }
```

Implemented these methods in `HiveCatalog`.

#### Flink Integration

Integrate to Flink Catalog.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
