### PR TITLE
[Core]Support async lookup

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1450,6 +1450,13 @@ public class CoreOptions implements Serializable {
                     .noDefaultValue()
                     .withDescription("The serialized refresh handler of materialized table.");
 
+    @ExcludeFromDocumentation("Internal use only")
+    public static final ConfigOption<Integer> LOOKUP_HASH_ASYNC_THREAD_NUMBER =
+            key("lookup.hash.async-thread-number")
+                    .intType()
+                    .defaultValue(16)
+                    .withDescription("The thread number for lookup async for hash store.");
+
     private final Options options;
 
     public CoreOptions(Map<String, String> options) {

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/RowCompactedSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/RowCompactedSerializer.java
@@ -101,14 +101,15 @@ public class RowCompactedSerializer implements Serializer<InternalRow> {
     }
 
     @Override
-    public void serialize(InternalRow record, DataOutputView target) throws IOException {
+    public synchronized void serialize(InternalRow record, DataOutputView target)
+            throws IOException {
         byte[] bytes = serializeToBytes(record);
         VarLengthIntUtils.encodeInt(target, bytes.length);
         target.write(bytes);
     }
 
     @Override
-    public InternalRow deserialize(DataInputView source) throws IOException {
+    public synchronized InternalRow deserialize(DataInputView source) throws IOException {
         int len = VarLengthIntUtils.decodeInt(source);
         byte[] bytes = new byte[len];
         source.readFully(bytes);
@@ -132,7 +133,7 @@ public class RowCompactedSerializer implements Serializer<InternalRow> {
         return Objects.hash(rowType);
     }
 
-    public byte[] serializeToBytes(InternalRow record) {
+    public synchronized byte[] serializeToBytes(InternalRow record) {
         if (rowWriter == null) {
             rowWriter = new RowWriter(calculateBitSetInBytes(getters.length));
         }
@@ -149,7 +150,7 @@ public class RowCompactedSerializer implements Serializer<InternalRow> {
         return rowWriter.copyBuffer();
     }
 
-    public InternalRow deserialize(byte[] bytes) {
+    public synchronized InternalRow deserialize(byte[] bytes) {
         if (rowReader == null) {
             rowReader = new RowReader(calculateBitSetInBytes(getters.length));
         }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ListDelimitedSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ListDelimitedSerializer.java
@@ -39,7 +39,8 @@ public final class ListDelimitedSerializer {
     private final DataInputDeserializer dataInputView = new DataInputDeserializer();
     private final DataOutputSerializer dataOutputView = new DataOutputSerializer(128);
 
-    public <T> List<T> deserializeList(byte[] valueBytes, Serializer<T> elementSerializer) {
+    public synchronized <T> List<T> deserializeList(
+            byte[] valueBytes, Serializer<T> elementSerializer) {
         if (valueBytes == null) {
             return null;
         }
@@ -54,7 +55,7 @@ public final class ListDelimitedSerializer {
         return result;
     }
 
-    public <T> byte[] serializeList(List<T> valueList, Serializer<T> elementSerializer)
+    public synchronized <T> byte[] serializeList(List<T> valueList, Serializer<T> elementSerializer)
             throws IOException {
 
         dataOutputView.clear();
@@ -74,7 +75,7 @@ public final class ListDelimitedSerializer {
         return dataOutputView.getCopyOfBuffer();
     }
 
-    public byte[] serializeList(List<byte[]> valueList) throws IOException {
+    public synchronized byte[] serializeList(List<byte[]> valueList) throws IOException {
 
         dataOutputView.clear();
         boolean first = true;

--- a/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBListState.java
+++ b/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBListState.java
@@ -72,13 +72,13 @@ public class RocksDBListState<K, V> extends RocksDBState<K, V, List<V>> {
                 });
     }
 
-    public byte[] serializeValue(V value) throws IOException {
+    public synchronized byte[] serializeValue(V value) throws IOException {
         valueOutputView.clear();
         valueSerializer.serialize(value, valueOutputView);
         return valueOutputView.getCopyOfBuffer();
     }
 
-    public byte[] serializeList(List<byte[]> valueList) throws IOException {
+    public synchronized byte[] serializeList(List<byte[]> valueList) throws IOException {
         return listSerializer.serializeList(valueList);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBSetState.java
+++ b/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBSetState.java
@@ -64,7 +64,10 @@ public class RocksDBSetState<K, V> extends RocksDBState<K, V, List<byte[]>> {
             }
             cache.put(keyBytes, valueBytes);
         }
+        return serializeValues(valueBytes);
+    }
 
+    private synchronized List<V> serializeValues(List<byte[]> valueBytes) throws IOException {
         List<V> values = new ArrayList<>(valueBytes.size());
         for (byte[] value : valueBytes) {
             valueInputView.setBuffer(value);
@@ -93,7 +96,7 @@ public class RocksDBSetState<K, V> extends RocksDBState<K, V, List<byte[]>> {
         }
     }
 
-    private byte[] invalidKeyAndGetKVBytes(K key, V value) throws IOException {
+    private synchronized byte[] invalidKeyAndGetKVBytes(K key, V value) throws IOException {
         checkArgument(value != null);
 
         keyOutView.clear();

--- a/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBState.java
+++ b/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBState.java
@@ -85,7 +85,7 @@ public abstract class RocksDBState<K, V, CacheV> {
                         .build();
     }
 
-    public byte[] serializeKey(K key) throws IOException {
+    public synchronized byte[] serializeKey(K key) throws IOException {
         keyOutView.clear();
         keySerializer.serialize(key, keyOutView);
         return keyOutView.getCopyOfBuffer();

--- a/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBValueState.java
+++ b/paimon-core/src/main/java/org/apache/paimon/lookup/RocksDBValueState.java
@@ -86,12 +86,12 @@ public class RocksDBValueState<K, V> extends RocksDBState<K, V, RocksDBState.Ref
         }
     }
 
-    public V deserializeValue(byte[] valueBytes) throws IOException {
+    public synchronized V deserializeValue(byte[] valueBytes) throws IOException {
         valueInputView.setBuffer(valueBytes);
         return valueSerializer.deserialize(valueInputView);
     }
 
-    public byte[] serializeValue(V value) throws IOException {
+    public synchronized byte[] serializeValue(V value) throws IOException {
         valueOutputView.clear();
         valueSerializer.serialize(value, valueOutputView);
         return valueOutputView.getCopyOfBuffer();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/AsyncLookupFunctionWrapper.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/AsyncLookupFunctionWrapper.java
@@ -54,9 +54,7 @@ public class AsyncLookupFunctionWrapper extends AsyncLookupFunction {
         Thread.currentThread()
                 .setContextClassLoader(AsyncLookupFunctionWrapper.class.getClassLoader());
         try {
-            synchronized (function) {
-                return function.lookup(keyRow);
-            }
+            return function.lookup(keyRow);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         } finally {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyLookupTable.java
@@ -37,7 +37,7 @@ import java.util.List;
 
 /** A {@link LookupTable} for primary key table. */
 public class PrimaryKeyLookupTable extends FullCacheLookupTable {
-
+    private final Object lock = new Object();
     protected final long lruCacheSize;
 
     protected final KeyProjectedRow primaryKeyRow;
@@ -86,8 +86,10 @@ public class PrimaryKeyLookupTable extends FullCacheLookupTable {
 
     @Override
     public List<InternalRow> innerGet(InternalRow key) throws IOException {
-        if (keyRearrange != null) {
-            key = keyRearrange.replaceRow(key);
+        synchronized (lock) {
+            if (keyRearrange != null) {
+                key = keyRearrange.replaceRow(key);
+            }
         }
         InternalRow value = tableState.get(key);
         return value == null ? Collections.emptyList() : Collections.singletonList(value);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/query/RemoteTableQuery.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/query/RemoteTableQuery.java
@@ -42,7 +42,7 @@ import static org.apache.paimon.service.ServiceManager.PRIMARY_KEY_LOOKUP;
 
 /** Implementation for {@link TableQuery} to lookup data from remote service. */
 public class RemoteTableQuery implements TableQuery {
-
+    private final Object lock = new Object();
     private final FileStoreTable table;
     private final KvQueryClient client;
     private final InternalRowSerializer keySerializer;
@@ -65,13 +65,12 @@ public class RemoteTableQuery implements TableQuery {
     @Override
     public InternalRow lookup(BinaryRow partition, int bucket, InternalRow key) throws IOException {
         BinaryRow row;
+        BinaryRow binaryRowKey;
         try {
-            row =
-                    client.getValues(
-                                    partition,
-                                    bucket,
-                                    new BinaryRow[] {keySerializer.toBinaryRow(key)})
-                            .get()[0];
+            synchronized (lock) {
+                binaryRowKey = keySerializer.toBinaryRow(key);
+            }
+            row = client.getValues(partition, bucket, new BinaryRow[] {binaryRowKey}).get()[0];
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException(e);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
@@ -244,7 +244,8 @@ public abstract class BaseDataTableSource extends FlinkTableSource
         boolean enableAsync = options.get(LOOKUP_ASYNC);
         int asyncThreadNumber = options.get(LOOKUP_ASYNC_THREAD_NUMBER);
         return LookupRuntimeProviderFactory.create(
-                new FileStoreLookupFunction(table, projection, joinKey, predicate),
+                new FileStoreLookupFunction(
+                        table, projection, joinKey, predicate, asyncThreadNumber),
                 enableAsync,
                 asyncThreadNumber);
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LookupJoinITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LookupJoinITCase.java
@@ -1029,10 +1029,10 @@ public class LookupJoinITCase extends CatalogITCaseBase {
     @EnumSource(LookupCacheMode.class)
     public void testAsyncLookupHashCacheSmallData(LookupCacheMode cacheMode) throws Exception {
         initTable(cacheMode);
-        batchSql("INSERT INTO BUCKET_DIM VALUES (1, 11, 111, 1111), (2, 22, 222, 2222)");
+        batchSql("INSERT INTO DIM_BUCKET VALUES (1, 11, 111, 1111), (2, 22, 222, 2222)");
 
         String query =
-                "SELECT T.i, D.j, D.k1, D.k2 FROM T LEFT JOIN BUCKET_DIM/*+OPTIONS('lookup.async'='true')*/ for system_time "
+                "SELECT T.i, D.j, D.k1, D.k2 FROM T LEFT JOIN DIM_BUCKET/*+OPTIONS('lookup.async'='true')*/ for system_time "
                         + "as of "
                         + "T.proctime AS D"
                         + " ON T.i = D.i";
@@ -1046,7 +1046,7 @@ public class LookupJoinITCase extends CatalogITCaseBase {
                         Row.of(2, 22, 222, 2222),
                         Row.of(3, null, null, null));
 
-        batchSql("INSERT INTO BUCKET_DIM VALUES (2, 44, 444, 4444), (3, 33, 333, 3333)");
+        batchSql("INSERT INTO DIM_BUCKET VALUES (2, 44, 444, 4444), (3, 33, 333, 3333)");
         Thread.sleep(2000); // wait refresh
         batchSql("INSERT INTO T VALUES (1), (2), (3), (4)");
         result = iterator.collect(4);
@@ -1066,7 +1066,7 @@ public class LookupJoinITCase extends CatalogITCaseBase {
         initTable(cacheMode);
         StringBuilder sb = new StringBuilder();
         // insert the dim table
-        String sql = "INSERT INTO BUCKET_DIM VALUES ";
+        String sql = "INSERT INTO DIM_BUCKET VALUES ";
         sb.append(sql);
         int dimTableCount = 1000;
         for (int i = 1; i <= dimTableCount; i++) {
@@ -1077,7 +1077,7 @@ public class LookupJoinITCase extends CatalogITCaseBase {
         batchSql(sb.toString());
 
         String query =
-                "SELECT T.i, D.j, D.k1, D.k2 FROM T LEFT JOIN BUCKET_DIM/*+OPTIONS('lookup.async'='true')*/ for system_time "
+                "SELECT T.i, D.j, D.k1, D.k2 FROM T LEFT JOIN DIM_BUCKET/*+OPTIONS('lookup.async'='true')*/ for system_time "
                         + "as of "
                         + "T.proctime AS D"
                         + " ON T.i = D.i";
@@ -1118,7 +1118,7 @@ public class LookupJoinITCase extends CatalogITCaseBase {
         batchSql(String.format("INSERT INTO T VALUES (%d)", dimTableCount + 1));
 
         // update the dim table
-        batchSql("INSERT INTO BUCKET_DIM VALUES (2, 22, 222, 2222), (4, 44, 444, 4444)");
+        batchSql("INSERT INTO DIM_BUCKET VALUES (2, 22, 222, 2222), (4, 44, 444, 4444)");
 
         // check result
         Thread.sleep(2000); // wait refresh


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Currently, lookup join does not really support asynchronous, and the purpose of this PR is to support asynchronous lookup join. 

### Tests

IT in `LookupJoinITCase.java`

### API and Format

no

### Documentation

no doc
