### PR TITLE
[spark] Replace create existing tag semantic with replace_tag

### DIFF
--- a/docs/content/flink/procedures.md
+++ b/docs/content/flink/procedures.md
@@ -222,6 +222,32 @@ All available procedures are listed below.
       </td>
    </tr>
    <tr>
+      <td>replace_tag</td>
+      <td>
+         -- Use named argument<br/>
+         -- replace tag with new time retained <br/>
+         CALL [catalog.]sys.replace_tag(`table` => 'identifier', tag => 'tagName', time_retained => 'timeRetained') <br/>
+         -- replace tag with new snapshot id and time retained <br/>
+         CALL [catalog.]sys.replace_tag(`table` => 'identifier', snapshot_id => 'snapshotId') <br/><br/>
+         -- Use indexed argument<br/>
+         -- replace tag with new snapshot id and time retained <br/>
+         CALL [catalog.]sys.replace_tag('identifier', 'tagName', 'snapshotId', 'timeRetained') <br/>
+      </td>
+      <td>
+         To replace an existing tag with new tag info. Arguments:
+            <li>table: the target table identifier. Cannot be empty.</li>
+            <li>tag: name of the existed tag. Cannot be empty.</li>
+            <li>snapshot(Long):  id of the snapshot which the tag is based on, it is optional.</li>
+            <li>time_retained: The maximum time retained for the existing tag, it is optional.</li>
+      </td>
+      <td>
+         -- for Flink 1.18<br/>
+         CALL sys.replace_tag('default.T', 'my_tag', 5, '1 d')<br/><br/>
+         -- for Flink 1.19 and later<br/>
+         CALL sys.replace_tag(`table` => 'default.T', tag => 'my_tag', snapshot_id => 5, time_retained => '1 d')<br/><br/>
+      </td>
+   </tr>
+   <tr>
       <td>expire_tags</td>
       <td>
          CALL [catalog.]sys.expire_tags('identifier', 'older_than')

--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -127,8 +127,8 @@ This section introduce all available spark procedures about paimon.
          Replace an existing tag with new tag info. Arguments:
             <li>table: the target table identifier. Cannot be empty.</li>
             <li>tag: name of the existed tag. Cannot be empty.</li>
-            <li>snapshot(Long):  id of the snapshot which the tag is based on.</li>
-            <li>time_retained: The maximum time retained for the existing tag.</li>
+            <li>snapshot(Long):  id of the snapshot which the tag is based on, it is optional.</li>
+            <li>time_retained: The maximum time retained for the existing tag, it is optional.</li>
       </td>
       <td>
          CALL sys.replace_tag(table => 'default.T', tag_name => 'tag1', snapshot => 10, time_retained => '1 d')

--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -122,6 +122,19 @@ This section introduce all available spark procedures about paimon.
       </td>
     </tr>
     <tr>
+      <td>replace_tag</td>
+      <td>
+         Replace an existing tag with new tag info. Arguments:
+            <li>table: the target table identifier. Cannot be empty.</li>
+            <li>tag: name of the existed tag. Cannot be empty.</li>
+            <li>snapshot(Long):  id of the snapshot which the tag is based on.</li>
+            <li>time_retained: The maximum time retained for the existing tag.</li>
+      </td>
+      <td>
+         CALL sys.replace_tag(table => 'default.T', tag_name => 'tag1', snapshot => 10, time_retained => '1 d')
+      </td>
+    </tr>
+    <tr>
       <td>delete_tag</td>
       <td>
          To delete a tag. Arguments:

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -577,16 +577,16 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
     }
 
     @Override
-    public void replaceTag(String tagName, @Nullable Duration timeRetained) {
-        Snapshot latestSnapshot = snapshotManager().latestSnapshot();
-        SnapshotNotExistException.checkNotNull(
-                latestSnapshot, "Cannot replace tag because latest snapshot doesn't exist.");
-        tagManager().replaceTag(latestSnapshot, tagName, timeRetained);
-    }
-
-    @Override
-    public void replaceTag(String tagName, long fromSnapshotId, @Nullable Duration timeRetained) {
-        tagManager().replaceTag(findSnapshot(fromSnapshotId), tagName, timeRetained);
+    public void replaceTag(
+            String tagName, @Nullable Long fromSnapshotId, @Nullable Duration timeRetained) {
+        if (fromSnapshotId == null) {
+            Snapshot latestSnapshot = snapshotManager().latestSnapshot();
+            SnapshotNotExistException.checkNotNull(
+                    latestSnapshot, "Cannot replace tag because latest snapshot doesn't exist.");
+            tagManager().replaceTag(latestSnapshot, tagName, timeRetained);
+        } else {
+            tagManager().replaceTag(findSnapshot(fromSnapshotId), tagName, timeRetained);
+        }
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -580,19 +580,13 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
     public void replaceTag(String tagName, @Nullable Duration timeRetained) {
         Snapshot latestSnapshot = snapshotManager().latestSnapshot();
         SnapshotNotExistException.checkNotNull(
-                latestSnapshot, "Cannot create tag because latest snapshot doesn't exist.");
-        tagManager()
-                .replaceTag(latestSnapshot, tagName, timeRetained, store().createTagCallbacks());
+                latestSnapshot, "Cannot replace tag because latest snapshot doesn't exist.");
+        tagManager().replaceTag(latestSnapshot, tagName, timeRetained);
     }
 
     @Override
     public void replaceTag(String tagName, long fromSnapshotId, @Nullable Duration timeRetained) {
-        tagManager()
-                .replaceTag(
-                        findSnapshot(fromSnapshotId),
-                        tagName,
-                        timeRetained,
-                        store().createTagCallbacks());
+        tagManager().replaceTag(findSnapshot(fromSnapshotId), tagName, timeRetained);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -577,6 +577,25 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
     }
 
     @Override
+    public void replaceTag(String tagName, @Nullable Duration timeRetained) {
+        Snapshot latestSnapshot = snapshotManager().latestSnapshot();
+        SnapshotNotExistException.checkNotNull(
+                latestSnapshot, "Cannot create tag because latest snapshot doesn't exist.");
+        tagManager()
+                .replaceTag(latestSnapshot, tagName, timeRetained, store().createTagCallbacks());
+    }
+
+    @Override
+    public void replaceTag(String tagName, long fromSnapshotId, @Nullable Duration timeRetained) {
+        tagManager()
+                .replaceTag(
+                        findSnapshot(fromSnapshotId),
+                        tagName,
+                        timeRetained,
+                        store().createTagCallbacks());
+    }
+
+    @Override
     public void deleteTag(String tagName) {
         tagManager()
                 .deleteTag(

--- a/paimon-core/src/main/java/org/apache/paimon/table/DelegatedFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/DelegatedFileStoreTable.java
@@ -188,12 +188,7 @@ public abstract class DelegatedFileStoreTable implements FileStoreTable {
     }
 
     @Override
-    public void replaceTag(String tagName, Duration timeRetained) {
-        wrapped.replaceTag(tagName, timeRetained);
-    }
-
-    @Override
-    public void replaceTag(String tagName, long fromSnapshotId, Duration timeRetained) {
+    public void replaceTag(String tagName, Long fromSnapshotId, Duration timeRetained) {
         wrapped.replaceTag(tagName, fromSnapshotId, timeRetained);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/DelegatedFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/DelegatedFileStoreTable.java
@@ -188,6 +188,16 @@ public abstract class DelegatedFileStoreTable implements FileStoreTable {
     }
 
     @Override
+    public void replaceTag(String tagName, Duration timeRetained) {
+        wrapped.replaceTag(tagName, timeRetained);
+    }
+
+    @Override
+    public void replaceTag(String tagName, long fromSnapshotId, Duration timeRetained) {
+        wrapped.replaceTag(tagName, fromSnapshotId, timeRetained);
+    }
+
+    @Override
     public void deleteTag(String tagName) {
         wrapped.deleteTag(tagName);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/FormatTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FormatTable.java
@@ -272,6 +272,16 @@ public interface FormatTable extends Table {
     }
 
     @Override
+    default void replaceTag(String tagName, Duration timeRetained) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    default void replaceTag(String tagName, long fromSnapshotId, Duration timeRetained) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     default void deleteTag(String tagName) {
         throw new UnsupportedOperationException();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/FormatTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FormatTable.java
@@ -272,12 +272,7 @@ public interface FormatTable extends Table {
     }
 
     @Override
-    default void replaceTag(String tagName, Duration timeRetained) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    default void replaceTag(String tagName, long fromSnapshotId, Duration timeRetained) {
+    default void replaceTag(String tagName, Long fromSnapshotId, Duration timeRetained) {
         throw new UnsupportedOperationException();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/ReadonlyTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ReadonlyTable.java
@@ -198,6 +198,22 @@ public interface ReadonlyTable extends InnerTable {
     }
 
     @Override
+    default void replaceTag(String tagName, Duration timeRetained) {
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Readonly Table %s does not support replaceTag.",
+                        this.getClass().getSimpleName()));
+    }
+
+    @Override
+    default void replaceTag(String tagName, long fromSnapshotId, Duration timeRetained) {
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Readonly Table %s does not support replaceTag.",
+                        this.getClass().getSimpleName()));
+    }
+
+    @Override
     default void deleteTag(String tagName) {
         throw new UnsupportedOperationException(
                 String.format(

--- a/paimon-core/src/main/java/org/apache/paimon/table/ReadonlyTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ReadonlyTable.java
@@ -198,15 +198,7 @@ public interface ReadonlyTable extends InnerTable {
     }
 
     @Override
-    default void replaceTag(String tagName, Duration timeRetained) {
-        throw new UnsupportedOperationException(
-                String.format(
-                        "Readonly Table %s does not support replaceTag.",
-                        this.getClass().getSimpleName()));
-    }
-
-    @Override
-    default void replaceTag(String tagName, long fromSnapshotId, Duration timeRetained) {
+    default void replaceTag(String tagName, Long fromSnapshotId, Duration timeRetained) {
         throw new UnsupportedOperationException(
                 String.format(
                         "Readonly Table %s does not support replaceTag.",

--- a/paimon-core/src/main/java/org/apache/paimon/table/Table.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/Table.java
@@ -120,9 +120,11 @@ public interface Table extends Serializable {
     @Experimental
     void renameTag(String tagName, String targetTagName);
 
+    /** Replace a tag with new time retained. */
     @Experimental
     void replaceTag(String tagName, Duration timeRetained);
 
+    /** Replace a tag with new snapshot id and new time retained. */
     @Experimental
     void replaceTag(String tagName, long fromSnapshotId, Duration timeRetained);
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/Table.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/Table.java
@@ -120,6 +120,12 @@ public interface Table extends Serializable {
     @Experimental
     void renameTag(String tagName, String targetTagName);
 
+    @Experimental
+    void replaceTag(String tagName, Duration timeRetained);
+
+    @Experimental
+    void replaceTag(String tagName, long fromSnapshotId, Duration timeRetained);
+
     /** Delete a tag by name. */
     @Experimental
     void deleteTag(String tagName);

--- a/paimon-core/src/main/java/org/apache/paimon/table/Table.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/Table.java
@@ -120,13 +120,9 @@ public interface Table extends Serializable {
     @Experimental
     void renameTag(String tagName, String targetTagName);
 
-    /** Replace a tag with new time retained. */
-    @Experimental
-    void replaceTag(String tagName, Duration timeRetained);
-
     /** Replace a tag with new snapshot id and new time retained. */
     @Experimental
-    void replaceTag(String tagName, long fromSnapshotId, Duration timeRetained);
+    void replaceTag(String tagName, Long fromSnapshotId, Duration timeRetained);
 
     /** Delete a tag by name. */
     @Experimental

--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -103,7 +103,7 @@ public class TagManager {
             List<TagCallback> callbacks) {
         checkArgument(
                 !StringUtils.isNullOrWhitespaceOnly(tagName), "Tag name '%s' is blank.", tagName);
-        checkArgument(!tagExists(tagName), "Tag %s already exists.", tagName);
+        checkArgument(!tagExists(tagName), "Tag name '%s' already exists.", tagName);
         createOrReplaceTag(snapshot, tagName, timeRetained, callbacks);
     }
 
@@ -115,7 +115,7 @@ public class TagManager {
             List<TagCallback> callbacks) {
         checkArgument(
                 !StringUtils.isNullOrWhitespaceOnly(tagName), "Tag name '%s' is blank.", tagName);
-        checkArgument(tagExists(tagName), "Tag %s does not exist.", tagName);
+        checkArgument(tagExists(tagName), "Tag name '%s' does not exist.", tagName);
         createOrReplaceTag(snapshot, tagName, timeRetained, callbacks);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -97,10 +97,7 @@ public class TagManager {
 
     /** Create a tag from given snapshot and save it in the storage. */
     public void createTag(
-            Snapshot snapshot,
-            String tagName,
-            @Nullable Duration timeRetained,
-            List<TagCallback> callbacks) {
+            Snapshot snapshot, String tagName, Duration timeRetained, List<TagCallback> callbacks) {
         checkArgument(
                 !StringUtils.isNullOrWhitespaceOnly(tagName), "Tag name '%s' is blank.", tagName);
         checkArgument(!tagExists(tagName), "Tag name '%s' already exists.", tagName);
@@ -108,22 +105,18 @@ public class TagManager {
     }
 
     /** Replace a tag from given snapshot and save it in the storage. */
-    public void replaceTag(
-            Snapshot snapshot,
-            String tagName,
-            @Nullable Duration timeRetained,
-            List<TagCallback> callbacks) {
+    public void replaceTag(Snapshot snapshot, String tagName, Duration timeRetained) {
         checkArgument(
                 !StringUtils.isNullOrWhitespaceOnly(tagName), "Tag name '%s' is blank.", tagName);
         checkArgument(tagExists(tagName), "Tag name '%s' does not exist.", tagName);
-        createOrReplaceTag(snapshot, tagName, timeRetained, callbacks);
+        createOrReplaceTag(snapshot, tagName, timeRetained, null);
     }
 
     public void createOrReplaceTag(
             Snapshot snapshot,
             String tagName,
             @Nullable Duration timeRetained,
-            List<TagCallback> callbacks) {
+            @Nullable List<TagCallback> callbacks) {
         // When timeRetained is not defined, please do not write the tagCreatorTime field,
         // as this will cause older versions (<= 0.7) of readers to be unable to read this
         // tag.
@@ -147,11 +140,13 @@ public class TagManager {
                     e);
         }
 
-        try {
-            callbacks.forEach(callback -> callback.notifyCreation(tagName));
-        } finally {
-            for (TagCallback tagCallback : callbacks) {
-                IOUtils.closeQuietly(tagCallback);
+        if (callbacks != null) {
+            try {
+                callbacks.forEach(callback -> callback.notifyCreation(tagName));
+            } finally {
+                for (TagCallback tagCallback : callbacks) {
+                    IOUtils.closeQuietly(tagCallback);
+                }
             }
         }
     }

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -1136,8 +1136,9 @@ public abstract class FileStoreTableTestBase {
             table.createTag("test-tag", 1);
             // verify that tag file exist
             assertThat(tagManager.tagExists("test-tag")).isTrue();
-            // Create again
-            table.createTag("test-tag", 1);
+            // Create again failed if tag existed
+            Assertions.assertThatThrownBy(() -> table.createTag("test-tag", 1))
+                    .hasMessageContaining("Tag name 'test-tag' already exists.");
             Assertions.assertThatThrownBy(() -> table.createTag("test-tag", 2))
                     .hasMessageContaining("Tag name 'test-tag' already exists.");
         }

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CreateOrReplaceTagBaseProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CreateOrReplaceTagBaseProcedure.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.procedure;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.utils.TimeUtils;
+
+import org.apache.flink.table.procedure.ProcedureContext;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+
+/** A base procedure to create or replace a tag. */
+public abstract class CreateOrReplaceTagBaseProcedure extends ProcedureBase {
+
+    public String[] call(ProcedureContext procedureContext, String tableId, String tagName)
+            throws Catalog.TableNotExistException {
+        return innerCall(tableId, tagName, null, null);
+    }
+
+    public String[] call(
+            ProcedureContext procedureContext, String tableId, String tagName, long snapshotId)
+            throws Catalog.TableNotExistException {
+        return innerCall(tableId, tagName, snapshotId, null);
+    }
+
+    public String[] call(
+            ProcedureContext procedureContext,
+            String tableId,
+            String tagName,
+            long snapshotId,
+            String timeRetained)
+            throws Catalog.TableNotExistException {
+        return innerCall(tableId, tagName, snapshotId, timeRetained);
+    }
+
+    public String[] call(
+            ProcedureContext procedureContext, String tableId, String tagName, String timeRetained)
+            throws Catalog.TableNotExistException {
+        return innerCall(tableId, tagName, null, timeRetained);
+    }
+
+    private String[] innerCall(
+            String tableId,
+            String tagName,
+            @Nullable Long snapshotId,
+            @Nullable String timeRetained)
+            throws Catalog.TableNotExistException {
+        Table table = catalog.getTable(Identifier.fromString(tableId));
+        createOrReplaceTag(table, tagName, snapshotId, toDuration(timeRetained));
+        return new String[] {"Success"};
+    }
+
+    abstract void createOrReplaceTag(
+            Table table, String tagName, Long snapshotId, Duration timeRetained);
+
+    @Nullable
+    private static Duration toDuration(@Nullable String s) {
+        if (s == null) {
+            return null;
+        }
+
+        return TimeUtils.parseDuration(s);
+    }
+}

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CreateTagProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CreateTagProcedure.java
@@ -18,14 +18,7 @@
 
 package org.apache.paimon.flink.procedure;
 
-import org.apache.paimon.catalog.Catalog;
-import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.table.Table;
-import org.apache.paimon.utils.TimeUtils;
-
-import org.apache.flink.table.procedure.ProcedureContext;
-
-import javax.annotation.Nullable;
 
 import java.time.Duration;
 
@@ -36,59 +29,17 @@ import java.time.Duration;
  *  CALL sys.create_tag('tableId', 'tagName', snapshotId, 'timeRetained')
  * </code></pre>
  */
-public class CreateTagProcedure extends ProcedureBase {
+public class CreateTagProcedure extends CreateOrReplaceTagBaseProcedure {
 
     public static final String IDENTIFIER = "create_tag";
 
-    public String[] call(
-            ProcedureContext procedureContext, String tableId, String tagName, long snapshotId)
-            throws Catalog.TableNotExistException {
-        return innerCall(tableId, tagName, snapshotId, null);
-    }
-
-    public String[] call(ProcedureContext procedureContext, String tableId, String tagName)
-            throws Catalog.TableNotExistException {
-        return innerCall(tableId, tagName, null, null);
-    }
-
-    public String[] call(
-            ProcedureContext procedureContext,
-            String tableId,
-            String tagName,
-            long snapshotId,
-            String timeRetained)
-            throws Catalog.TableNotExistException {
-        return innerCall(tableId, tagName, snapshotId, timeRetained);
-    }
-
-    public String[] call(
-            ProcedureContext procedureContext, String tableId, String tagName, String timeRetained)
-            throws Catalog.TableNotExistException {
-        return innerCall(tableId, tagName, null, timeRetained);
-    }
-
-    private String[] innerCall(
-            String tableId,
-            String tagName,
-            @Nullable Long snapshotId,
-            @Nullable String timeRetained)
-            throws Catalog.TableNotExistException {
-        Table table = catalog.getTable(Identifier.fromString(tableId));
+    @Override
+    void createOrReplaceTag(Table table, String tagName, Long snapshotId, Duration timeRetained) {
         if (snapshotId == null) {
-            table.createTag(tagName, toDuration(timeRetained));
+            table.createTag(tagName, timeRetained);
         } else {
-            table.createTag(tagName, snapshotId, toDuration(timeRetained));
+            table.createTag(tagName, snapshotId, timeRetained);
         }
-        return new String[] {"Success"};
-    }
-
-    @Nullable
-    private static Duration toDuration(@Nullable String s) {
-        if (s == null) {
-            return null;
-        }
-
-        return TimeUtils.parseDuration(s);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/ReplaceTagProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/ReplaceTagProcedure.java
@@ -29,11 +29,7 @@ public class ReplaceTagProcedure extends CreateOrReplaceTagBaseProcedure {
 
     @Override
     void createOrReplaceTag(Table table, String tagName, Long snapshotId, Duration timeRetained) {
-        if (snapshotId == null) {
-            table.replaceTag(tagName, timeRetained);
-        } else {
-            table.replaceTag(tagName, snapshotId, timeRetained);
-        }
+        table.replaceTag(tagName, snapshotId, timeRetained);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/ReplaceTagProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/ReplaceTagProcedure.java
@@ -16,41 +16,28 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.spark.procedure;
+package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.table.Table;
 
-import org.apache.spark.sql.connector.catalog.TableCatalog;
-
 import java.time.Duration;
 
-/** A procedure to create a tag. */
-public class CreateTagProcedure extends CreateOrReplaceTagBaseProcedure {
+/** A procedure to replace a tag. */
+public class ReplaceTagProcedure extends CreateOrReplaceTagBaseProcedure {
 
-    private CreateTagProcedure(TableCatalog tableCatalog) {
-        super(tableCatalog);
-    }
+    private static final String IDENTIFIER = "replace_tag";
 
     @Override
     void createOrReplaceTag(Table table, String tagName, Long snapshotId, Duration timeRetained) {
         if (snapshotId == null) {
-            table.createTag(tagName, timeRetained);
+            table.replaceTag(tagName, timeRetained);
         } else {
-            table.createTag(tagName, snapshotId, timeRetained);
+            table.replaceTag(tagName, snapshotId, timeRetained);
         }
     }
 
-    public static ProcedureBuilder builder() {
-        return new BaseProcedure.Builder<CreateTagProcedure>() {
-            @Override
-            public CreateTagProcedure doBuild() {
-                return new CreateTagProcedure(tableCatalog());
-            }
-        };
-    }
-
     @Override
-    public String description() {
-        return "CreateTagProcedure";
+    public String identifier() {
+        return IDENTIFIER;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateOrReplaceTagActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateOrReplaceTagActionFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action;
+
+import org.apache.paimon.utils.TimeUtils;
+
+import org.apache.flink.api.java.tuple.Tuple3;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+
+/** Factory to create {@link ReplaceTagAction} or {@link ReplaceTagAction}. */
+public abstract class CreateOrReplaceTagActionFactory implements ActionFactory {
+
+    private static final String TAG_NAME = "tag_name";
+    private static final String SNAPSHOT = "snapshot";
+    private static final String TIME_RETAINED = "time_retained";
+
+    @Override
+    public Optional<Action> create(MultipleParameterToolAdapter params) {
+        checkRequiredArgument(params, TAG_NAME);
+
+        Tuple3<String, String, String> tablePath = getTablePath(params);
+        Map<String, String> catalogConfig = optionalConfigMap(params, CATALOG_CONF);
+        String tagName = params.get(TAG_NAME);
+
+        Long snapshot = null;
+        if (params.has(SNAPSHOT)) {
+            snapshot = Long.parseLong(params.get(SNAPSHOT));
+        }
+
+        Duration timeRetained = null;
+        if (params.has(TIME_RETAINED)) {
+            timeRetained = TimeUtils.parseDuration(params.get(TIME_RETAINED));
+        }
+
+        return Optional.of(
+                createOrReplaceTagAction(
+                        tablePath, catalogConfig, tagName, snapshot, timeRetained));
+    }
+
+    abstract Action createOrReplaceTagAction(
+            Tuple3<String, String, String> tablePath,
+            Map<String, String> catalogConfig,
+            String tagName,
+            Long snapshot,
+            Duration timeRetained);
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ReplaceTagAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ReplaceTagAction.java
@@ -16,41 +16,40 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.spark.procedure;
+package org.apache.paimon.flink.action;
 
-import org.apache.paimon.table.Table;
-
-import org.apache.spark.sql.connector.catalog.TableCatalog;
+import javax.annotation.Nullable;
 
 import java.time.Duration;
+import java.util.Map;
 
-/** A procedure to replace a tag. */
-public class ReplaceTagTagProcedure extends CreateOrReplaceTagBaseProcedure {
+/** Replace tag action for Flink. */
+public class ReplaceTagAction extends TableActionBase {
 
-    protected ReplaceTagTagProcedure(TableCatalog tableCatalog) {
-        super(tableCatalog);
+    private final String tagName;
+    private final @Nullable Long snapshotId;
+    private final @Nullable Duration timeRetained;
+
+    public ReplaceTagAction(
+            String warehouse,
+            String databaseName,
+            String tableName,
+            Map<String, String> catalogConfig,
+            String tagName,
+            @Nullable Long snapshotId,
+            @Nullable Duration timeRetained) {
+        super(warehouse, databaseName, tableName, catalogConfig);
+        this.tagName = tagName;
+        this.timeRetained = timeRetained;
+        this.snapshotId = snapshotId;
     }
 
     @Override
-    void createOrReplaceTag(Table table, String tagName, Long snapshotId, Duration timeRetained) {
+    public void run() throws Exception {
         if (snapshotId == null) {
             table.replaceTag(tagName, timeRetained);
         } else {
             table.replaceTag(tagName, snapshotId, timeRetained);
         }
-    }
-
-    public static ProcedureBuilder builder() {
-        return new BaseProcedure.Builder<ReplaceTagTagProcedure>() {
-            @Override
-            public ReplaceTagTagProcedure doBuild() {
-                return new ReplaceTagTagProcedure(tableCatalog());
-            }
-        };
-    }
-
-    @Override
-    public String description() {
-        return "ReplaceTagProcedure";
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ReplaceTagAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ReplaceTagAction.java
@@ -46,10 +46,6 @@ public class ReplaceTagAction extends TableActionBase {
 
     @Override
     public void run() throws Exception {
-        if (snapshotId == null) {
-            table.replaceTag(tagName, timeRetained);
-        } else {
-            table.replaceTag(tagName, snapshotId, timeRetained);
-        }
+        table.replaceTag(tagName, snapshotId, timeRetained);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ReplaceTagActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ReplaceTagActionFactory.java
@@ -23,10 +23,10 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import java.time.Duration;
 import java.util.Map;
 
-/** Factory to create {@link CreateTagAction}. */
-public class CreateTagActionFactory extends CreateOrReplaceTagActionFactory {
+/** Factory to create {@link ReplaceTagAction}. */
+public class ReplaceTagActionFactory extends CreateOrReplaceTagActionFactory {
 
-    public static final String IDENTIFIER = "create_tag";
+    public static final String IDENTIFIER = "replace_tag";
 
     @Override
     public String identifier() {
@@ -40,7 +40,7 @@ public class CreateTagActionFactory extends CreateOrReplaceTagActionFactory {
             String tagName,
             Long snapshot,
             Duration timeRetained) {
-        return new CreateTagAction(
+        return new ReplaceTagAction(
                 tablePath.f0,
                 tablePath.f1,
                 tablePath.f2,
@@ -52,13 +52,13 @@ public class CreateTagActionFactory extends CreateOrReplaceTagActionFactory {
 
     @Override
     public void printHelp() {
-        System.out.println("Action \"create_tag\" creates a tag from given snapshot.");
+        System.out.println("Action \"replace_tag\" to replace an existing tag with new tag info.");
         System.out.println();
 
         System.out.println("Syntax:");
         System.out.println(
-                "  create_tag --warehouse <warehouse_path> --database <database_name> "
-                        + "--table <table_name> --tag_name <tag_name> [--snapshot <snapshot_id>]");
+                "  replace_tag --warehouse <warehouse_path> --database <database_name> "
+                        + "--table <table_name> --tag_name <tag_name> [--snapshot <snapshot_id>] [--time_retained <time_retained>]");
         System.out.println();
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateOrReplaceTagBaseProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateOrReplaceTagBaseProcedure.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.procedure;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.utils.TimeUtils;
+
+import org.apache.flink.table.annotation.ArgumentHint;
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.ProcedureHint;
+import org.apache.flink.table.procedure.ProcedureContext;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+
+/** A base procedure to create or replace a tag. */
+public abstract class CreateOrReplaceTagBaseProcedure extends ProcedureBase {
+
+    @ProcedureHint(
+            argument = {
+                @ArgumentHint(name = "table", type = @DataTypeHint("STRING")),
+                @ArgumentHint(name = "tag", type = @DataTypeHint("STRING")),
+                @ArgumentHint(
+                        name = "snapshot_id",
+                        type = @DataTypeHint("BIGINT"),
+                        isOptional = true),
+                @ArgumentHint(
+                        name = "time_retained",
+                        type = @DataTypeHint("STRING"),
+                        isOptional = true)
+            })
+    public String[] call(
+            ProcedureContext procedureContext,
+            String tableId,
+            String tagName,
+            @Nullable Long snapshotId,
+            @Nullable String timeRetained)
+            throws Catalog.TableNotExistException {
+        Table table = catalog.getTable(Identifier.fromString(tableId));
+        createOrReplaceTag(table, tagName, snapshotId, toDuration(timeRetained));
+        return new String[] {"Success"};
+    }
+
+    abstract void createOrReplaceTag(
+            Table table, String tagName, Long snapshotId, Duration timeRetained);
+
+    @Nullable
+    private static Duration toDuration(@Nullable String s) {
+        if (s == null) {
+            return null;
+        }
+
+        return TimeUtils.parseDuration(s);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateTagProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateTagProcedure.java
@@ -18,17 +18,7 @@
 
 package org.apache.paimon.flink.procedure;
 
-import org.apache.paimon.catalog.Catalog;
-import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.table.Table;
-import org.apache.paimon.utils.TimeUtils;
-
-import org.apache.flink.table.annotation.ArgumentHint;
-import org.apache.flink.table.annotation.DataTypeHint;
-import org.apache.flink.table.annotation.ProcedureHint;
-import org.apache.flink.table.procedure.ProcedureContext;
-
-import javax.annotation.Nullable;
 
 import java.time.Duration;
 
@@ -39,46 +29,17 @@ import java.time.Duration;
  *  CALL sys.create_tag('tableId', 'tagName', snapshotId, 'timeRetained')
  * </code></pre>
  */
-public class CreateTagProcedure extends ProcedureBase {
+public class CreateTagProcedure extends CreateOrReplaceTagBaseProcedure {
 
     public static final String IDENTIFIER = "create_tag";
 
-    @ProcedureHint(
-            argument = {
-                @ArgumentHint(name = "table", type = @DataTypeHint("STRING")),
-                @ArgumentHint(name = "tag", type = @DataTypeHint("STRING")),
-                @ArgumentHint(
-                        name = "snapshot_id",
-                        type = @DataTypeHint("BIGINT"),
-                        isOptional = true),
-                @ArgumentHint(
-                        name = "time_retained",
-                        type = @DataTypeHint("STRING"),
-                        isOptional = true)
-            })
-    public String[] call(
-            ProcedureContext procedureContext,
-            String tableId,
-            String tagName,
-            @Nullable Long snapshotId,
-            @Nullable String timeRetained)
-            throws Catalog.TableNotExistException {
-        Table table = catalog.getTable(Identifier.fromString(tableId));
+    @Override
+    void createOrReplaceTag(Table table, String tagName, Long snapshotId, Duration timeRetained) {
         if (snapshotId == null) {
-            table.createTag(tagName, toDuration(timeRetained));
+            table.createTag(tagName, timeRetained);
         } else {
-            table.createTag(tagName, snapshotId, toDuration(timeRetained));
+            table.createTag(tagName, snapshotId, timeRetained);
         }
-        return new String[] {"Success"};
-    }
-
-    @Nullable
-    private static Duration toDuration(@Nullable String s) {
-        if (s == null) {
-            return null;
-        }
-
-        return TimeUtils.parseDuration(s);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ReplaceTagProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ReplaceTagProcedure.java
@@ -29,11 +29,7 @@ public class ReplaceTagProcedure extends CreateOrReplaceTagBaseProcedure {
 
     @Override
     void createOrReplaceTag(Table table, String tagName, Long snapshotId, Duration timeRetained) {
-        if (snapshotId == null) {
-            table.replaceTag(tagName, timeRetained);
-        } else {
-            table.replaceTag(tagName, snapshotId, timeRetained);
-        }
+        table.replaceTag(tagName, snapshotId, timeRetained);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ReplaceTagProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ReplaceTagProcedure.java
@@ -16,41 +16,28 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.spark.procedure;
+package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.table.Table;
 
-import org.apache.spark.sql.connector.catalog.TableCatalog;
-
 import java.time.Duration;
 
-/** A procedure to create a tag. */
-public class CreateTagProcedure extends CreateOrReplaceTagBaseProcedure {
+/** A procedure to replace a tag. */
+public class ReplaceTagProcedure extends CreateOrReplaceTagBaseProcedure {
 
-    private CreateTagProcedure(TableCatalog tableCatalog) {
-        super(tableCatalog);
-    }
+    private static final String IDENTIFIER = "replace_tag";
 
     @Override
     void createOrReplaceTag(Table table, String tagName, Long snapshotId, Duration timeRetained) {
         if (snapshotId == null) {
-            table.createTag(tagName, timeRetained);
+            table.replaceTag(tagName, timeRetained);
         } else {
-            table.createTag(tagName, snapshotId, timeRetained);
+            table.replaceTag(tagName, snapshotId, timeRetained);
         }
     }
 
-    public static ProcedureBuilder builder() {
-        return new BaseProcedure.Builder<CreateTagProcedure>() {
-            @Override
-            public CreateTagProcedure doBuild() {
-                return new CreateTagProcedure(tableCatalog());
-            }
-        };
-    }
-
     @Override
-    public String description() {
-        return "CreateTagProcedure";
+    public String identifier() {
+        return IDENTIFIER;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/resources/META-INF/services/org.apache.paimon.factories.Factory
+++ b/paimon-flink/paimon-flink-common/src/main/resources/META-INF/services/org.apache.paimon.factories.Factory
@@ -26,6 +26,7 @@ org.apache.paimon.flink.action.CreateTagFromTimestampActionFactory
 org.apache.paimon.flink.action.CreateTagFromWatermarkActionFactory
 org.apache.paimon.flink.action.DeleteTagActionFactory
 org.apache.paimon.flink.action.ExpireTagsActionFactory
+org.apache.paimon.flink.action.ReplaceTagActionFactory
 org.apache.paimon.flink.action.ResetConsumerActionFactory
 org.apache.paimon.flink.action.MigrateTableActionFactory
 org.apache.paimon.flink.action.MigrateFileActionFactory
@@ -51,6 +52,7 @@ org.apache.paimon.flink.procedure.CreateTagFromTimestampProcedure
 org.apache.paimon.flink.procedure.CreateTagFromWatermarkProcedure
 org.apache.paimon.flink.procedure.DeleteTagProcedure
 org.apache.paimon.flink.procedure.ExpireTagsProcedure
+org.apache.paimon.flink.procedure.ReplaceTagProcedure
 org.apache.paimon.flink.procedure.CreateBranchProcedure
 org.apache.paimon.flink.procedure.DeleteBranchProcedure
 org.apache.paimon.flink.procedure.DropPartitionProcedure

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ReplaceTagActionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ReplaceTagActionTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action;
+
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.TagManager;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.paimon.flink.util.ReadWriteTableTestUtil.bEnv;
+import static org.apache.paimon.flink.util.ReadWriteTableTestUtil.init;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** IT cases for {@link ReplaceTagAction}. */
+public class ReplaceTagActionTest extends ActionITCaseBase {
+
+    @BeforeEach
+    public void setUp() {
+        init(warehouse);
+    }
+
+    @Test
+    public void testReplaceTag() throws Exception {
+        bEnv.executeSql(
+                "CREATE TABLE T (id INT, name STRING,"
+                        + " PRIMARY KEY (id) NOT ENFORCED)"
+                        + " WITH ('bucket'='1')");
+
+        FileStoreTable table = getFileStoreTable("T");
+        TagManager tagManager = table.tagManager();
+
+        bEnv.executeSql("INSERT INTO T VALUES (1, 'a')").await();
+        bEnv.executeSql("INSERT INTO T VALUES (2, 'b')").await();
+        assertThat(table.snapshotManager().snapshotCount()).isEqualTo(2);
+
+        Assertions.assertThatThrownBy(
+                        () ->
+                                bEnv.executeSql(
+                                        "CALL sys.replace_tag(`table` => 'default.T', tag => 'test_tag')"))
+                .hasMessageContaining("Tag name 'test_tag' does not exist.");
+
+        bEnv.executeSql("CALL sys.create_tag(`table` => 'default.T', tag => 'test_tag')");
+        assertThat(tagManager.tagExists("test_tag")).isEqualTo(true);
+        assertThat(tagManager.tag("test_tag").trimToSnapshot().id()).isEqualTo(2);
+        assertThat(tagManager.tag("test_tag").getTagTimeRetained()).isEqualTo(null);
+
+        // replace tag with new time_retained
+        createAction(
+                        ReplaceTagAction.class,
+                        "replace_tag",
+                        "--warehouse",
+                        warehouse,
+                        "--database",
+                        database,
+                        "--table",
+                        "T",
+                        "--tag_name",
+                        "test_tag",
+                        "--time_retained",
+                        "1 d")
+                .run();
+        assertThat(tagManager.tag("test_tag").getTagTimeRetained().toHours()).isEqualTo(24);
+
+        // replace tag with new snapshot and time_retained
+        createAction(
+                        ReplaceTagAction.class,
+                        "replace_tag",
+                        "--warehouse",
+                        warehouse,
+                        "--database",
+                        database,
+                        "--table",
+                        "T",
+                        "--tag_name",
+                        "test_tag",
+                        "--snapshot",
+                        "1",
+                        "--time_retained",
+                        "2 d")
+                .run();
+        assertThat(tagManager.tag("test_tag").trimToSnapshot().id()).isEqualTo(1);
+        assertThat(tagManager.tag("test_tag").getTagTimeRetained().toHours()).isEqualTo(48);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ProcedureTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ProcedureTest.java
@@ -98,7 +98,8 @@ public class ProcedureTest {
     }
 
     private Method getMethodFromName(Class<?> clazz, String methodName) {
-        Method[] methods = clazz.getDeclaredMethods();
+        // get all methods of current and parent class
+        Method[] methods = clazz.getMethods();
 
         for (Method method : methods) {
             if (method.getName().equals(methodName)) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ReplaceTagProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ReplaceTagProcedureITCase.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.procedure;
+
+import org.apache.paimon.flink.CatalogITCaseBase;
+
+import org.apache.flink.types.Row;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** IT Case for {@link ReplaceTagProcedure}. */
+public class ReplaceTagProcedureITCase extends CatalogITCaseBase {
+
+    @Test
+    public void testExpireTagsByTagCreateTimeAndTagTimeRetained() throws Exception {
+        sql(
+                "CREATE TABLE T (id INT, name STRING,"
+                        + " PRIMARY KEY (id) NOT ENFORCED)"
+                        + " WITH ('bucket'='1')");
+
+        sql("INSERT INTO T VALUES (1, 'a')");
+        sql("INSERT INTO T VALUES (2, 'b')");
+        assertThat(paimonTable("T").snapshotManager().snapshotCount()).isEqualTo(2);
+
+        Assertions.assertThatThrownBy(
+                        () ->
+                                sql(
+                                        "CALL sys.replace_tag(`table` => 'default.T', tag => 'test_tag')"))
+                .hasMessageContaining("Tag name 'test_tag' does not exist.");
+
+        sql("CALL sys.create_tag(`table` => 'default.T', tag => 'test_tag')");
+        assertThat(sql("select tag_name,snapshot_id,time_retained from `T$tags`"))
+                .containsExactly(Row.of("test_tag", 2L, null));
+
+        // replace tag with new time_retained
+        sql(
+                "CALL sys.replace_tag(`table` => 'default.T', tag => 'test_tag',"
+                        + " time_retained => '1 d')");
+        assertThat(sql("select tag_name,snapshot_id,time_retained from `T$tags`"))
+                .containsExactly(Row.of("test_tag", 2L, "PT24H"));
+
+        // replace tag with new snapshot and time_retained
+        sql(
+                "CALL sys.replace_tag(`table` => 'default.T', tag => 'test_tag',"
+                        + " snapshot => 1, time_retained => '2 d')");
+        assertThat(sql("select tag_name,snapshot_id,time_retained from `T$tags`"))
+                .containsExactly(Row.of("test_tag", 2L, "PT48H"));
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkProcedures.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkProcedures.java
@@ -37,6 +37,7 @@ import org.apache.paimon.spark.procedure.ProcedureBuilder;
 import org.apache.paimon.spark.procedure.RemoveOrphanFilesProcedure;
 import org.apache.paimon.spark.procedure.RenameTagProcedure;
 import org.apache.paimon.spark.procedure.RepairProcedure;
+import org.apache.paimon.spark.procedure.ReplaceTagTagProcedure;
 import org.apache.paimon.spark.procedure.ResetConsumerProcedure;
 import org.apache.paimon.spark.procedure.RollbackProcedure;
 
@@ -63,6 +64,7 @@ public class SparkProcedures {
                 ImmutableMap.builder();
         procedureBuilders.put("rollback", RollbackProcedure::builder);
         procedureBuilders.put("create_tag", CreateTagProcedure::builder);
+        procedureBuilders.put("replace_tag", ReplaceTagTagProcedure::builder);
         procedureBuilders.put("rename_tag", RenameTagProcedure::builder);
         procedureBuilders.put(
                 "create_tag_from_timestamp", CreateTagFromTimestampProcedure::builder);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkProcedures.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkProcedures.java
@@ -37,7 +37,7 @@ import org.apache.paimon.spark.procedure.ProcedureBuilder;
 import org.apache.paimon.spark.procedure.RemoveOrphanFilesProcedure;
 import org.apache.paimon.spark.procedure.RenameTagProcedure;
 import org.apache.paimon.spark.procedure.RepairProcedure;
-import org.apache.paimon.spark.procedure.ReplaceTagTagProcedure;
+import org.apache.paimon.spark.procedure.ReplaceTagProcedure;
 import org.apache.paimon.spark.procedure.ResetConsumerProcedure;
 import org.apache.paimon.spark.procedure.RollbackProcedure;
 
@@ -64,7 +64,7 @@ public class SparkProcedures {
                 ImmutableMap.builder();
         procedureBuilders.put("rollback", RollbackProcedure::builder);
         procedureBuilders.put("create_tag", CreateTagProcedure::builder);
-        procedureBuilders.put("replace_tag", ReplaceTagTagProcedure::builder);
+        procedureBuilders.put("replace_tag", ReplaceTagProcedure::builder);
         procedureBuilders.put("rename_tag", RenameTagProcedure::builder);
         procedureBuilders.put(
                 "create_tag_from_timestamp", CreateTagFromTimestampProcedure::builder);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateOrReplaceTagBaseProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateOrReplaceTagBaseProcedure.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.procedure;
+
+import org.apache.paimon.table.Table;
+import org.apache.paimon.utils.TimeUtils;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+import java.time.Duration;
+
+import static org.apache.spark.sql.types.DataTypes.LongType;
+import static org.apache.spark.sql.types.DataTypes.StringType;
+
+/** A base procedure to create or replace a tag. */
+public abstract class CreateOrReplaceTagBaseProcedure extends BaseProcedure {
+
+    private static final ProcedureParameter[] PARAMETERS =
+            new ProcedureParameter[] {
+                ProcedureParameter.required("table", StringType),
+                ProcedureParameter.required("tag", StringType),
+                ProcedureParameter.optional("snapshot", LongType),
+                ProcedureParameter.optional("time_retained", StringType)
+            };
+
+    private static final StructType OUTPUT_TYPE =
+            new StructType(
+                    new StructField[] {
+                        new StructField("result", DataTypes.BooleanType, true, Metadata.empty())
+                    });
+
+    protected CreateOrReplaceTagBaseProcedure(TableCatalog tableCatalog) {
+        super(tableCatalog);
+    }
+
+    @Override
+    public ProcedureParameter[] parameters() {
+        return PARAMETERS;
+    }
+
+    @Override
+    public StructType outputType() {
+        return OUTPUT_TYPE;
+    }
+
+    @Override
+    public InternalRow[] call(InternalRow args) {
+        Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
+        String tag = args.getString(1);
+        Long snapshot = args.isNullAt(2) ? null : args.getLong(2);
+        Duration timeRetained =
+                args.isNullAt(3) ? null : TimeUtils.parseDuration(args.getString(3));
+
+        return modifyPaimonTable(
+                tableIdent,
+                table -> {
+                    createOrReplaceTag(table, tag, snapshot, timeRetained);
+                    InternalRow outputRow = newInternalRow(true);
+                    return new InternalRow[] {outputRow};
+                });
+    }
+
+    abstract void createOrReplaceTag(
+            Table table, String tagName, Long snapshotId, Duration timeRetained);
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/ReplaceTagProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/ReplaceTagProcedure.java
@@ -24,33 +24,33 @@ import org.apache.spark.sql.connector.catalog.TableCatalog;
 
 import java.time.Duration;
 
-/** A procedure to create a tag. */
-public class CreateTagProcedure extends CreateOrReplaceTagBaseProcedure {
+/** A procedure to replace a tag. */
+public class ReplaceTagProcedure extends CreateOrReplaceTagBaseProcedure {
 
-    private CreateTagProcedure(TableCatalog tableCatalog) {
+    private ReplaceTagProcedure(TableCatalog tableCatalog) {
         super(tableCatalog);
     }
 
     @Override
     void createOrReplaceTag(Table table, String tagName, Long snapshotId, Duration timeRetained) {
         if (snapshotId == null) {
-            table.createTag(tagName, timeRetained);
+            table.replaceTag(tagName, timeRetained);
         } else {
-            table.createTag(tagName, snapshotId, timeRetained);
+            table.replaceTag(tagName, snapshotId, timeRetained);
         }
     }
 
     public static ProcedureBuilder builder() {
-        return new BaseProcedure.Builder<CreateTagProcedure>() {
+        return new BaseProcedure.Builder<ReplaceTagProcedure>() {
             @Override
-            public CreateTagProcedure doBuild() {
-                return new CreateTagProcedure(tableCatalog());
+            public ReplaceTagProcedure doBuild() {
+                return new ReplaceTagProcedure(tableCatalog());
             }
         };
     }
 
     @Override
     public String description() {
-        return "CreateTagProcedure";
+        return "ReplaceTagProcedure";
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/ReplaceTagProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/ReplaceTagProcedure.java
@@ -33,11 +33,7 @@ public class ReplaceTagProcedure extends CreateOrReplaceTagBaseProcedure {
 
     @Override
     void createOrReplaceTag(Table table, String tagName, Long snapshotId, Duration timeRetained) {
-        if (snapshotId == null) {
-            table.replaceTag(tagName, timeRetained);
-        } else {
-            table.replaceTag(tagName, snapshotId, timeRetained);
-        }
+        table.replaceTag(tagName, snapshotId, timeRetained);
     }
 
     public static ProcedureBuilder builder() {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/ReplaceTagTagProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/ReplaceTagTagProcedure.java
@@ -24,33 +24,33 @@ import org.apache.spark.sql.connector.catalog.TableCatalog;
 
 import java.time.Duration;
 
-/** A procedure to create a tag. */
-public class CreateTagProcedure extends CreateOrReplaceTagBaseProcedure {
+/** A procedure to replace a tag. */
+public class ReplaceTagTagProcedure extends CreateOrReplaceTagBaseProcedure {
 
-    protected CreateTagProcedure(TableCatalog tableCatalog) {
+    protected ReplaceTagTagProcedure(TableCatalog tableCatalog) {
         super(tableCatalog);
     }
 
     @Override
     void createOrReplaceTag(Table table, String tagName, Long snapshotId, Duration timeRetained) {
         if (snapshotId == null) {
-            table.createTag(tagName, timeRetained);
+            table.replaceTag(tagName, timeRetained);
         } else {
-            table.createTag(tagName, snapshotId, timeRetained);
+            table.replaceTag(tagName, snapshotId, timeRetained);
         }
     }
 
     public static ProcedureBuilder builder() {
-        return new BaseProcedure.Builder<CreateTagProcedure>() {
+        return new BaseProcedure.Builder<ReplaceTagTagProcedure>() {
             @Override
-            public CreateTagProcedure doBuild() {
-                return new CreateTagProcedure(tableCatalog());
+            public ReplaceTagTagProcedure doBuild() {
+                return new ReplaceTagTagProcedure(tableCatalog());
             }
         };
     }
 
     @Override
     public String description() {
-        return "CreateTagProcedure";
+        return "ReplaceTagProcedure";
     }
 }

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/CreateAndDeleteTagProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/CreateAndDeleteTagProcedureTest.scala
@@ -172,19 +172,15 @@ class CreateAndDeleteTagProcedureTest extends PaimonSparkTestBase with StreamTes
                   "table => 'test.T', tag => 'test_tag', snapshot => 1)"),
               Row(true) :: Nil)
             checkAnswer(
-              spark.sql(
-                "SELECT count(time_retained) FROM paimon.test.`T$tags` where tag_name = 'test_tag'"),
-              Row(0) :: Nil)
+              spark.sql("SELECT count(*) FROM paimon.test.`T$tags` where tag_name = 'test_tag'"),
+              Row(1) :: Nil)
 
-            checkAnswer(
+            // throw exception "Tag test_tag already exists"
+            assertThrows[IllegalArgumentException] {
               spark.sql(
                 "CALL paimon.sys.create_tag(" +
-                  "table => 'test.T', tag => 'test_tag', time_retained => '5 d', snapshot => 1)"),
-              Row(true) :: Nil)
-            checkAnswer(
-              spark.sql(
-                "SELECT count(time_retained) FROM paimon.test.`T$tags` where tag_name = 'test_tag'"),
-              Row(1) :: Nil)
+                  "table => 'test.T', tag => 'test_tag', time_retained => '5 d', snapshot => 1)")
+            }
           } finally {
             stream.stop()
           }

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/ReplaceTagProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/ReplaceTagProcedureTest.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.procedure
+
+import org.apache.paimon.spark.PaimonSparkTestBase
+
+import org.apache.spark.sql.Row
+
+class ReplaceTagProcedureTest extends PaimonSparkTestBase {
+  test("Paimon Procedure: replace tag to update tag meta") {
+    spark.sql(s"""
+                 |CREATE TABLE T (a INT, b STRING)
+                 |TBLPROPERTIES ('primary-key'='a', 'bucket'='3')
+                 |""".stripMargin)
+    spark.sql("insert into T values(1, 'a')")
+    spark.sql("insert into T values(2, 'b')")
+    assertResult(2)(loadTable("T").snapshotManager().snapshotCount())
+
+    // throw exception "Tag test_tag does not exist"
+    assertThrows[IllegalArgumentException] {
+      spark.sql("CALL paimon.sys.replace_tag(table => 'test.T', tag => 'test_tag')")
+    }
+
+    spark.sql("CALL paimon.sys.create_tag(table => 'test.T', tag => 'test_tag')")
+    checkAnswer(
+      spark.sql("select tag_name,snapshot_id,time_retained from `T$tags`"),
+      Row("test_tag", 2, null) :: Nil)
+
+    // replace tag with new time_retained
+    spark.sql(
+      "CALL paimon.sys.replace_tag(table => 'test.T', tag => 'test_tag', time_retained => '1 d')")
+    checkAnswer(
+      spark.sql("select tag_name,snapshot_id,time_retained from `T$tags`"),
+      Row("test_tag", 2, "PT24H") :: Nil)
+
+    // replace tag with new snapshot and time_retained
+    spark.sql(
+      "CALL paimon.sys.replace_tag(table => 'test.T', tag => 'test_tag', snapshot => 1, time_retained => '2 d')")
+    checkAnswer(
+      spark.sql("select tag_name,snapshot_id,time_retained from `T$tags`"),
+      Row("test_tag", 1, "PT48H") :: Nil)
+  }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
In default way, the create_tag procedure for an existing tag means to update it or fail,  it's semantic is not very accurate, replace it with repalce_tag procedure.

before semantic
```sql
CALL paimon.sys.create_tag(table => 'test.T', tag => 'test_tag', snapshot => 1)")

-- success. update it
CALL paimon.sys.create_tag(table => 'test.T', tag => 'test_tag', snapshot => 1, time_retained => '1 d')")

-- failed
CALL paimon.sys.create_tag(table => 'test.T', tag => 'test_tag', snapshot => 2)")
```

after semantic
```sql
CALL paimon.sys.create_tag(table => 'test.T', tag => 'test_tag', snapshot => 1)")

-- failed
CALL paimon.sys.create_tag(table => 'test.T', tag => 'test_tag', snapshot => 1, time_retained => '1 d')")

-- success. use replace to update
CALL paimon.sys.replace_tag(table => 'test.T', tag => 'test_tag', snapshot => 2, time_retained => '1 d')")
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
