### PR TITLE
[arrow] Allocate buffer for MapVector in init

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/writer/ArrowFieldWriterFactoryVisitor.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/writer/ArrowFieldWriterFactoryVisitor.java
@@ -158,6 +158,7 @@ public class ArrowFieldWriterFactoryVisitor implements DataTypeVisitor<ArrowFiel
         ArrowFieldWriterFactory valueWriterFactory = mapType.getValueType().accept(this);
         return fieldVector -> {
             MapVector mapVector = (MapVector) fieldVector;
+            mapVector.reAlloc();
             List<FieldVector> keyValueVectors = mapVector.getDataVector().getChildrenFromFields();
             return new ArrowFieldWriters.MapWriter(
                     fieldVector,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Init MapVector before write. If not, export VectorSchemaRoot to c-struct when meet a empty Map will cause an error while deserializing in c++: arrow/cpp/src/arrow/result.cc:28: ValueOrDie called on an error: Invalid: ArrowArrayStruct contains null data pointer for a buffer with non-zero computed size


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
