### PR TITLE
[Bug] Fix NoSuchElementException when enable partition mark done

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionMarkDoneTrigger.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionMarkDoneTrigger.java
@@ -183,7 +183,10 @@ public class PartitionMarkDoneTrigger {
         public List<String> restore() throws Exception {
             List<String> pendingPartitions = new ArrayList<>();
             if (isRestored) {
-                pendingPartitions.addAll(pendingPartitionsState.get().iterator().next());
+                Iterator<List<String>> state = pendingPartitionsState.get().iterator();
+                if (state.hasNext()) {
+                    pendingPartitions.addAll(state.next());
+                }
             }
             return pendingPartitions;
         }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTestBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTestBase.java
@@ -88,10 +88,15 @@ public abstract class CommitterOperatorTestBase {
     }
 
     protected FileStoreTable createFileStoreTable() throws Exception {
-        return createFileStoreTable(options -> {});
+        return createFileStoreTable(options -> {}, Collections.emptyList());
     }
 
     protected FileStoreTable createFileStoreTable(Consumer<Options> setOptions) throws Exception {
+        return createFileStoreTable(setOptions, Collections.emptyList());
+    }
+
+    protected FileStoreTable createFileStoreTable(
+            Consumer<Options> setOptions, List<String> partitionKeys) throws Exception {
         Options conf = new Options();
         conf.set(CoreOptions.PATH, tablePath.toString());
         conf.setString("bucket", "1");
@@ -101,7 +106,7 @@ public abstract class CommitterOperatorTestBase {
         schemaManager.createTable(
                 new Schema(
                         ROW_TYPE.getFields(),
-                        Collections.emptyList(),
+                        partitionKeys,
                         Collections.emptyList(),
                         conf.toMap(),
                         ""));


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

![image](https://github.com/user-attachments/assets/4afb6000-95dd-403a-96ca-ea743569d7ef)

when enable the partition mark done, the streaming job will fail with `NoSuchElementException`.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
