### PR TITLE
[Bug] Close PartitionMarkDone to prevent potential resource leakage

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
@@ -146,6 +146,9 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
     @Override
     public void close() throws Exception {
         commit.close();
+        if (partitionMarkDone != null) {
+            partitionMarkDone.close();
+        }
     }
 
     private void calcNumBytesAndRecordsOut(List<ManifestCommittable> committables) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

During closing, we should also close partition mark done to release the resource such as metastore client in MarkDoneAction.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
