### PR TITLE
[catalog] Support set HiveCatalog options in SparkGenericCatalog.

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogOptions.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogOptions.java
@@ -22,6 +22,9 @@ import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
 import org.apache.paimon.options.description.Description;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.paimon.options.description.TextElement.text;
@@ -93,6 +96,21 @@ public final class HiveCatalogOptions {
                             "Whether to support format tables, format table corresponds to a regular Hive table, allowing read and write operations. "
                                     + "However, during these processes, it does not connect to the metastore; hence, newly added partitions will not be reflected in"
                                     + " the metastore and need to be manually added as separate partition operations.");
+
+    public static List<ConfigOption<?>> getOptions() {
+        final Field[] fields = HiveCatalogOptions.class.getFields();
+        final List<ConfigOption<?>> list = new ArrayList<>(fields.length);
+        for (Field field : fields) {
+            if (ConfigOption.class.isAssignableFrom(field.getType())) {
+                try {
+                    list.add((ConfigOption<?>) field.get(HiveCatalogOptions.class));
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        return list;
+    }
 
     private HiveCatalogOptions() {}
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkGenericCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkGenericCatalog.java
@@ -21,6 +21,7 @@ package org.apache.paimon.spark;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.hive.HiveCatalogOptions;
 import org.apache.paimon.options.CatalogOptions;
+import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.spark.catalog.SparkBaseCatalog;
 import org.apache.paimon.spark.util.SQLConfUtils;
 import org.apache.paimon.utils.Preconditions;
@@ -286,6 +287,7 @@ public class SparkGenericCatalog extends SparkBaseCatalog implements CatalogExte
         Map<String, String> newOptions = new HashMap<>(options.asCaseSensitiveMap());
         fillAliyunConfigurations(newOptions, hadoopConf);
         fillCommonConfigurations(newOptions, sqlConf);
+        fillHiveCatalogOptions(newOptions, sqlConf);
 
         // if spark is case-insensitive, set allow upper case to catalog
         if (!sqlConf.caseSensitiveAnalysis()) {
@@ -329,6 +331,14 @@ public class SparkGenericCatalog extends SparkBaseCatalog implements CatalogExte
             }
         } else {
             options.put(DEFAULT_DATABASE.key(), sessionCatalogDefaultDatabase);
+        }
+    }
+
+    private void fillHiveCatalogOptions(Map<String, String> options, SQLConf sqlConf) {
+        for (ConfigOption<?> option : HiveCatalogOptions.getOptions()) {
+            if (sqlConf.contains(option.key())) {
+                options.put(option.key(), sqlConf.getConfString(option.key()));
+            }
         }
     }
 

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkGenericCatalogWithHiveTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkGenericCatalogWithHiveTest.java
@@ -171,5 +171,7 @@ public class SparkGenericCatalogWithHiveTest {
                 .rootCause()
                 .isInstanceOf(FileNotFoundException.class)
                 .hasMessageContaining("nonExistentPath");
+
+        spark.close();
     }
 }

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkGenericCatalogWithHiveTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkGenericCatalogWithHiveTest.java
@@ -27,7 +27,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.FileNotFoundException;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Base tests for spark read. */
@@ -100,7 +103,7 @@ public class SparkGenericCatalogWithHiveTest {
 
     @Test
     public void testBuildWithHive(@TempDir java.nio.file.Path tempDir) {
-        // firstly, we use hive metastore to creata table, and check the result.
+        // firstly, we use hive metastore to create table, and check the result.
         Path warehousePath = new Path("file:" + tempDir.toString());
         SparkSession spark =
                 SparkSession.builder()
@@ -147,5 +150,26 @@ public class SparkGenericCatalogWithHiveTest {
                                 .map(s -> s.get(1))
                                 .map(Object::toString))
                 .containsExactlyInAnyOrder("t1");
+    }
+
+    @Test
+    public void testHiveCatalogOptions(@TempDir java.nio.file.Path tempDir) {
+        Path warehousePath = new Path("file:" + tempDir.toString());
+        SparkSession spark =
+                SparkSession.builder()
+                        .config("hive-conf-dir", "nonExistentPath")
+                        .config("spark.sql.warehouse.dir", warehousePath.toString())
+                        // with hive metastore
+                        .config("spark.sql.catalogImplementation", "hive")
+                        .config(
+                                "spark.sql.catalog.spark_catalog",
+                                SparkGenericCatalog.class.getName())
+                        .master("local[2]")
+                        .getOrCreate();
+
+        assertThatThrownBy(() -> spark.sql("CREATE DATABASE my_db"))
+                .rootCause()
+                .isInstanceOf(FileNotFoundException.class)
+                .hasMessageContaining("nonExistentPath");
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

support  : 
spark-sql --conf hive-conf-dir=/xx/xx/xx to specify conf file `hive-site.xml` path.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
