### PR TITLE
[format] Fix ParquetFilters cannot handle tinyint and smallint correctly

### DIFF
--- a/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
+++ b/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
@@ -172,6 +172,11 @@ public class ParquetFilters {
         }
 
         if (value instanceof Number) {
+            if (value instanceof Byte) {
+                return ((Byte) value).intValue();
+            } else if (value instanceof Short) {
+                return ((Short) value).intValue();
+            }
             return (Comparable<?>) value;
         } else if (value instanceof String) {
             return Binary.fromString((String) value);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
