### PR TITLE
[cdc] Add flink execution mode check for cdc table sync action.

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SynchronizationActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SynchronizationActionBase.java
@@ -143,8 +143,8 @@ public abstract class SynchronizationActionBase extends ActionBase {
     protected void validateRuntimeExecutionMode() {
         checkArgument(
                 env.getConfiguration().get(ExecutionOptions.RUNTIME_MODE)
-                        != RuntimeExecutionMode.BATCH,
-                "Don't support batch mode for flink-cdc sync table action.");
+                        == RuntimeExecutionMode.STREAMING,
+                "It's only support STREAMING mode for flink-cdc sync table action.");
     }
 
     private DataStreamSource<CdcSourceRecord> buildDataStreamSource(Object source) {

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SynchronizationActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SynchronizationActionBase.java
@@ -32,10 +32,12 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.FileStoreTable;
 
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
@@ -53,6 +55,7 @@ import static org.apache.paimon.flink.FlinkConnectorOptions.SCAN_WATERMARK_ALIGN
 import static org.apache.paimon.flink.FlinkConnectorOptions.SCAN_WATERMARK_ALIGNMENT_MAX_DRIFT;
 import static org.apache.paimon.flink.FlinkConnectorOptions.SCAN_WATERMARK_ALIGNMENT_UPDATE_INTERVAL;
 import static org.apache.paimon.flink.FlinkConnectorOptions.SCAN_WATERMARK_IDLE_TIMEOUT;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Base {@link Action} for table/database synchronizing job. */
 public abstract class SynchronizationActionBase extends ActionBase {
@@ -135,6 +138,13 @@ public abstract class SynchronizationActionBase extends ActionBase {
     protected CdcTimestampExtractor createCdcTimestampExtractor() {
         throw new IllegalArgumentException(
                 "Unsupported timestamp extractor for current cdc source.");
+    }
+
+    protected void validateRuntimeExecutionMode() {
+        checkArgument(
+                env.getConfiguration().get(ExecutionOptions.RUNTIME_MODE)
+                        != RuntimeExecutionMode.BATCH,
+                "Don't support batch mode for flink-cdc sync table action.");
     }
 
     private DataStreamSource<CdcSourceRecord> buildDataStreamSource(Object source) {

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
@@ -188,6 +188,7 @@ public class MySqlSyncDatabaseAction extends SyncDatabaseActionBase {
 
     @Override
     protected MySqlSource<CdcSourceRecord> buildSource() {
+        validateRuntimeExecutionMode();
         return MySqlActionUtils.buildMySqlSource(
                 cdcSourceConfig,
                 tableList(

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableAction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableAction.java
@@ -102,6 +102,7 @@ public class MySqlSyncTableAction extends SyncTableActionBase {
 
     @Override
     protected MySqlSource<CdcSourceRecord> buildSource() {
+        validateRuntimeExecutionMode();
         String tableList =
                 String.format(
                         "(%s)\\.(%s)",

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/CdcActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/CdcActionITCaseBase.java
@@ -38,6 +38,7 @@ import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.junit.jupiter.api.AfterEach;
@@ -214,6 +215,15 @@ public class CdcActionITCaseBase extends ActionITCaseBase {
     }
 
     public JobClient runActionWithDefaultEnv(ActionBase action) throws Exception {
+        env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+        action.withStreamExecutionEnvironment(env).build();
+        JobClient client = env.executeAsync();
+        waitJobRunning(client);
+        return client;
+    }
+
+    public JobClient runActionWithBatchEnv(ActionBase action) throws Exception {
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
         action.withStreamExecutionEnvironment(env).build();
         JobClient client = env.executeAsync();
         waitJobRunning(client);

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncTableActionITCase.java
@@ -1514,7 +1514,7 @@ public class MySqlSyncTableActionITCase extends MySqlActionITCaseBase {
                 .satisfies(
                         anyCauseMatches(
                                 IllegalArgumentException.class,
-                                "Don't support batch mode for flink-cdc sync table action"));
+                                "It's only support STREAMING mode for flink-cdc sync table action"));
 
         runActionWithDefaultEnv(action);
 

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/mysql/sync_table_setup.sql
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/mysql/sync_table_setup.sql
@@ -445,3 +445,14 @@ CREATE TABLE t (
     k INT PRIMARY KEY,
     v1 VARCHAR(10)
 );
+
+-- ################################################################################
+--  testRuntimeExecutionModeCheckForCdcSync
+-- ################################################################################
+
+CREATE DATABASE check_cdc_sync_runtime_execution_mode;
+USE check_cdc_sync_runtime_execution_mode;
+CREATE TABLE t (
+                   k INT PRIMARY KEY,
+                   v1 VARCHAR(10)
+);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

Flink-cdc do not support batch mode, including flink cdc `snapshot` scan mode . Although it is a bounded source.

https://issues.apache.org/jira/browse/FLINK-36280

https://github.com/apache/flink-cdc/pull/2901

if use set RuntimeExecutionMode = Batch. job will be never finish and never fail.

<img width="1517" alt="image" src="https://github.com/user-attachments/assets/d138cf34-f3b5-4448-9381-6d6eb632e6d6">

so , we need to check the flink execution mode.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
