### PR TITLE
[flink] Lookup source should ignore scan options

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
@@ -244,8 +244,8 @@ public abstract class BaseDataTableSource extends FlinkTableSource
     @Override
     public LookupRuntimeProvider getLookupRuntimeProvider(LookupContext context) {
         if (!(table instanceof FileStoreTable)) {
-            throw new RuntimeException(
-                    "Lookup dim table should be FileStoreTable but is "
+            throw new UnsupportedOperationException(
+                    "Currently, lookup dim table only support FileStoreTable but is "
                             + table.getClass().getName());
         }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
@@ -51,8 +51,6 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.AggregateExpression;
 import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.types.DataType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -83,8 +81,6 @@ import static org.apache.paimon.flink.FlinkConnectorOptions.SCAN_WATERMARK_IDLE_
  */
 public abstract class BaseDataTableSource extends FlinkTableSource
         implements LookupTableSource, SupportsWatermarkPushDown, SupportsAggregatePushDown {
-
-    private static final Logger LOG = LoggerFactory.getLogger(BaseDataTableSource.class);
 
     private static final List<ConfigOption<?>> TIME_TRAVEL_OPTIONS =
             Arrays.asList(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
`lookup.dynamic-partition` will create `DynamicPartitionLoader`, it will use scan options to load data. But dim table should ignore scan options.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
