### PR TITLE
[hive] Fix wrong construct for dlf metastore

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/RetryingMetaStoreClientFactory.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/RetryingMetaStoreClientFactory.java
@@ -182,7 +182,7 @@ public class RetryingMetaStoreClientFactory {
             Class<?> baseClass = Class.forName(clientClassName, false, JavaUtils.getClassLoader());
 
             // Configuration.class or HiveConf.class
-            Class<?> firstParamType = getProxyMethod.getParameterTypes()[0];
+            Class<?> firstParamType = hiveConf.getClass();
 
             Class<?>[] fullParams =
                     new Class[] {firstParamType, HiveMetaHookLoader.class, Boolean.TYPE};

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/RetryingMetaStoreClientFactory.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/RetryingMetaStoreClientFactory.java
@@ -32,6 +32,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
@@ -182,25 +183,30 @@ public class RetryingMetaStoreClientFactory {
             Class<?> baseClass = Class.forName(clientClassName, false, JavaUtils.getClassLoader());
 
             // Configuration.class or HiveConf.class
-            Class<?> firstParamType = hiveConf.getClass();
+            List<Class<?>> possibleFirstParamTypes =
+                    Arrays.asList(getProxyMethod.getParameterTypes()[0], hiveConf.getClass());
 
-            Class<?>[] fullParams =
-                    new Class[] {firstParamType, HiveMetaHookLoader.class, Boolean.TYPE};
-            Object[] fullParamValues =
-                    new Object[] {hiveConf, (HiveMetaHookLoader) (tbl -> null), Boolean.TRUE};
+            for (Class<?> possibleFirstParamType : possibleFirstParamTypes) {
+                Class<?>[] fullParams =
+                        new Class[] {
+                            possibleFirstParamType, HiveMetaHookLoader.class, Boolean.TYPE
+                        };
+                Object[] fullParamValues =
+                        new Object[] {hiveConf, (HiveMetaHookLoader) (tbl -> null), Boolean.TRUE};
 
-            for (int i = fullParams.length; i >= 1; i--) {
-                try {
-                    baseClass.getConstructor(Arrays.copyOfRange(fullParams, 0, i));
-                    return (IMetaStoreClient)
-                            getProxyMethod.invoke(
-                                    null,
-                                    hiveConf,
-                                    Arrays.copyOfRange(fullParams, 0, i),
-                                    Arrays.copyOfRange(fullParamValues, 0, i),
-                                    new ConcurrentHashMap<>(),
-                                    clientClassName);
-                } catch (NoSuchMethodException ignored) {
+                for (int i = fullParams.length; i >= 1; i--) {
+                    try {
+                        baseClass.getConstructor(Arrays.copyOfRange(fullParams, 0, i));
+                        return (IMetaStoreClient)
+                                getProxyMethod.invoke(
+                                        null,
+                                        hiveConf,
+                                        Arrays.copyOfRange(fullParams, 0, i),
+                                        Arrays.copyOfRange(fullParamValues, 0, i),
+                                        new ConcurrentHashMap<>(),
+                                        clientClassName);
+                    } catch (NoSuchMethodException ignored) {
+                    }
                 }
             }
 

--- a/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/CustomConstructorMetastoreClient.java
+++ b/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/CustomConstructorMetastoreClient.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.hive.metastore.api.MetaException;
 public class CustomConstructorMetastoreClient {
 
     /**
-     * A {@link HiveMetaStoreClient} to test custom Hive metastore client with (HiveConf,
+     * A {@link HiveMetaStoreClient} to test custom Hive metastore client with (Configuration,
      * HiveMetaHookLoader) constructor.
      */
     public static class TwoParameterConstructorMetastoreClient extends HiveMetaStoreClient
@@ -42,7 +42,7 @@ public class CustomConstructorMetastoreClient {
     }
 
     /**
-     * A {@link HiveMetaStoreClient} to test custom Hive metastore client with (HiveConf)
+     * A {@link HiveMetaStoreClient} to test custom Hive metastore client with (Configuration)
      * constructor.
      */
     public static class OneParameterConstructorMetastoreClient extends HiveMetaStoreClient
@@ -53,6 +53,10 @@ public class CustomConstructorMetastoreClient {
         }
     }
 
+    /**
+     * A {@link HiveMetaStoreClient} to test custom Hive metastore client with (HiveConf)
+     * constructor.
+     */
     public static class OtherParameterConstructorMetastoreClient extends HiveMetaStoreClient
             implements IMetaStoreClient {
 

--- a/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/CustomConstructorMetastoreClient.java
+++ b/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/CustomConstructorMetastoreClient.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.hive;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
@@ -48,6 +49,14 @@ public class CustomConstructorMetastoreClient {
             implements IMetaStoreClient {
 
         public OneParameterConstructorMetastoreClient(Configuration conf) throws MetaException {
+            super(conf);
+        }
+    }
+
+    public static class OtherParameterConstructorMetastoreClient extends HiveMetaStoreClient
+            implements IMetaStoreClient {
+
+        public OtherParameterConstructorMetastoreClient(HiveConf conf) throws MetaException {
             super(conf);
         }
     }

--- a/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/Hive31CatalogITCase.java
+++ b/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/Hive31CatalogITCase.java
@@ -89,7 +89,8 @@ public class Hive31CatalogITCase extends HiveCatalogITCaseBase {
         EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
         Class<?>[] customConstructorMetastoreClientClass = {
             CustomConstructorMetastoreClient.TwoParameterConstructorMetastoreClient.class,
-            CustomConstructorMetastoreClient.OneParameterConstructorMetastoreClient.class
+            CustomConstructorMetastoreClient.OneParameterConstructorMetastoreClient.class,
+            CustomConstructorMetastoreClient.OtherParameterConstructorMetastoreClient.class
         };
 
         for (Class<?> clazz : customConstructorMetastoreClientClass) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
An enhancement introduced by #4283 lead to the following problem for dlf catalog:
```
Failed to create the desired metastore client (class name: com.aliyun.datalake.metastore.hive3.ProxyMetaStoreClient)
```

Because dlf hive3 ProxyMetaStoreClient still uses hive2 construct method.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
