### PR TITLE
[spark]: clean up zstd-jni lib files

### DIFF
--- a/paimon-spark/paimon-spark-3.2/pom.xml
+++ b/paimon-spark/paimon-spark-3.2/pom.xml
@@ -114,6 +114,8 @@ under the License.
                                     <artifact>*</artifact>
                                     <excludes>
                                         <exclude>com/github/luben/zstd/**</exclude>
+                                        <exclude>**/*libzstd-jni-*.so</exclude>
+                                        <exclude>**/*libzstd-jni-*.dll</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/paimon-spark/paimon-spark-3.3/pom.xml
+++ b/paimon-spark/paimon-spark-3.3/pom.xml
@@ -114,6 +114,8 @@ under the License.
                                     <artifact>*</artifact>
                                     <excludes>
                                         <exclude>com/github/luben/zstd/**</exclude>
+                                        <exclude>**/*libzstd-jni-*.so</exclude>
+                                        <exclude>**/*libzstd-jni-*.dll</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/paimon-spark/paimon-spark-3.4/pom.xml
+++ b/paimon-spark/paimon-spark-3.4/pom.xml
@@ -114,6 +114,8 @@ under the License.
                                     <artifact>*</artifact>
                                     <excludes>
                                         <exclude>com/github/luben/zstd/**</exclude>
+                                        <exclude>**/*libzstd-jni-*.so</exclude>
+                                        <exclude>**/*libzstd-jni-*.dll</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/paimon-spark/paimon-spark-3.5/pom.xml
+++ b/paimon-spark/paimon-spark-3.5/pom.xml
@@ -114,6 +114,8 @@ under the License.
                                     <artifact>*</artifact>
                                     <excludes>
                                         <exclude>com/github/luben/zstd/**</exclude>
+                                        <exclude>**/*libzstd-jni-*.so</exclude>
+                                        <exclude>**/*libzstd-jni-*.dll</exclude>
                                     </excludes>
                                 </filter>
                             </filters>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
we already excluded zstd-jni jar from spark runtime jar(#4085), however, the zstd-jni jar contains not only Java files but also references to some native libraries. These files should also be excluded.

![image](https://github.com/user-attachments/assets/0f295aa5-1de0-40ed-8f9e-c3cf8b0375e6)


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
