### PR TITLE
[core] Introduce compactionsCompletedCount/compactionsFailedCount/compactionsQueuedCount metrics.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/BucketedAppendCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/BucketedAppendCompactManager.java
@@ -115,8 +115,15 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
                                 targetFileSize,
                                 rewriter,
                                 metricsReporter));
+        recordCompactionsQueuedRequest();
         compacting = new ArrayList<>(toCompact);
         toCompact.clear();
+    }
+
+    private void recordCompactionsQueuedRequest() {
+        if (metricsReporter != null) {
+            metricsReporter.increaseCompactionsQueuedCount();
+        }
     }
 
     private void triggerCompactionWithBestEffort() {
@@ -130,6 +137,7 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
                     executor.submit(
                             new AutoCompactTask(
                                     dvMaintainer, compacting, rewriter, metricsReporter));
+            recordCompactionsQueuedRequest();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManager.java
@@ -211,6 +211,9 @@ public class MergeTreeCompactManager extends CompactFutureManager {
                             .collect(Collectors.joining(", ")));
         }
         taskFuture = executor.submit(task);
+        if (metricsReporter != null) {
+            metricsReporter.increaseCompactionsQueuedCount();
+        }
     }
 
     /** Finish current task, and update result files to {@link Levels}. */

--- a/paimon-core/src/test/java/org/apache/paimon/operation/metrics/CompactionMetricsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/metrics/CompactionMetricsTest.java
@@ -19,7 +19,9 @@
 package org.apache.paimon.operation.metrics;
 
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.metrics.Counter;
 import org.apache.paimon.metrics.Gauge;
+import org.apache.paimon.metrics.Metric;
 import org.apache.paimon.metrics.MetricRegistryImpl;
 
 import org.junit.jupiter.api.Test;
@@ -36,6 +38,9 @@ public class CompactionMetricsTest {
         assertThat(getMetric(metrics, CompactionMetrics.AVG_LEVEL0_FILE_COUNT)).isEqualTo(-1.0);
         assertThat(getMetric(metrics, CompactionMetrics.COMPACTION_THREAD_BUSY)).isEqualTo(0.0);
         assertThat(getMetric(metrics, CompactionMetrics.AVG_COMPACTION_TIME)).isEqualTo(0.0);
+        assertThat(getMetric(metrics, CompactionMetrics.COMPACTIONS_COMPLETED_COUNT)).isEqualTo(0L);
+        assertThat(getMetric(metrics, CompactionMetrics.COMPACTIONS_FAILED_COUNT)).isEqualTo(0L);
+        assertThat(getMetric(metrics, CompactionMetrics.COMPACTIONS_QUEUED_COUNT)).isEqualTo(0L);
         CompactionMetrics.Reporter[] reporters = new CompactionMetrics.Reporter[3];
         for (int i = 0; i < reporters.length; i++) {
             reporters[i] = metrics.createReporter(BinaryRow.EMPTY_ROW, i);
@@ -44,6 +49,9 @@ public class CompactionMetricsTest {
         assertThat(getMetric(metrics, CompactionMetrics.MAX_LEVEL0_FILE_COUNT)).isEqualTo(0L);
         assertThat(getMetric(metrics, CompactionMetrics.AVG_LEVEL0_FILE_COUNT)).isEqualTo(0.0);
         assertThat(getMetric(metrics, CompactionMetrics.COMPACTION_THREAD_BUSY)).isEqualTo(0.0);
+        assertThat(getMetric(metrics, CompactionMetrics.COMPACTIONS_COMPLETED_COUNT)).isEqualTo(0L);
+        assertThat(getMetric(metrics, CompactionMetrics.COMPACTIONS_FAILED_COUNT)).isEqualTo(0L);
+        assertThat(getMetric(metrics, CompactionMetrics.COMPACTIONS_QUEUED_COUNT)).isEqualTo(0L);
 
         reporters[0].reportLevel0FileCount(5);
         reporters[1].reportLevel0FileCount(3);
@@ -60,9 +68,31 @@ public class CompactionMetricsTest {
         reporters[0].reportCompactionTime(270000);
         assertThat(getMetric(metrics, CompactionMetrics.AVG_COMPACTION_TIME))
                 .isEqualTo(273333.3333333333);
+
+        // enqueue compaction request
+        reporters[0].increaseCompactionsQueuedCount();
+        reporters[1].increaseCompactionsQueuedCount();
+        reporters[2].increaseCompactionsQueuedCount();
+        assertThat(getMetric(metrics, CompactionMetrics.COMPACTIONS_COMPLETED_COUNT)).isEqualTo(0L);
+        assertThat(getMetric(metrics, CompactionMetrics.COMPACTIONS_FAILED_COUNT)).isEqualTo(0L);
+        assertThat(getMetric(metrics, CompactionMetrics.COMPACTIONS_QUEUED_COUNT)).isEqualTo(3L);
+
+        // completed compactions and failed compactions
+        reporters[0].increaseCompactionsCompletedCount();
+        reporters[0].decreaseCompactionsQueuedCount();
+        reporters[1].increaseCompactionsFailedCount();
+        reporters[1].decreaseCompactionsQueuedCount();
+        assertThat(getMetric(metrics, CompactionMetrics.COMPACTIONS_COMPLETED_COUNT)).isEqualTo(1L);
+        assertThat(getMetric(metrics, CompactionMetrics.COMPACTIONS_FAILED_COUNT)).isEqualTo(1L);
+        assertThat(getMetric(metrics, CompactionMetrics.COMPACTIONS_QUEUED_COUNT)).isEqualTo(1L);
     }
 
     private Object getMetric(CompactionMetrics metrics, String metricName) {
-        return ((Gauge<?>) metrics.getMetricGroup().getMetrics().get(metricName)).getValue();
+        Metric metric = metrics.getMetricGroup().getMetrics().get(metricName);
+        if (metric instanceof Gauge) {
+            return ((Gauge<?>) metric).getValue();
+        } else {
+            return ((Counter) metric).getCount();
+        }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/UnawareBucketCompactor.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/UnawareBucketCompactor.java
@@ -100,14 +100,41 @@ public class UnawareBucketCompactor {
                                                         metricsReporter.reportCompactionTime(
                                                                 System.currentTimeMillis()
                                                                         - startMillis);
+                                                        metricsReporter
+                                                                .increaseCompactionsCompletedCount();
                                                     }
                                                 },
                                                 LOG);
                                         return commitMessage;
+                                    } catch (Exception e) {
+                                        MetricUtils.safeCall(
+                                                this::increaseCompactionsFailedCount, LOG);
+                                        throw e;
                                     } finally {
                                         MetricUtils.safeCall(this::stopTimer, LOG);
+                                        MetricUtils.safeCall(
+                                                this::decreaseCompactionsQueuedCount, LOG);
                                     }
                                 }));
+        recordCompactionsQueuedRequest();
+    }
+
+    private void recordCompactionsQueuedRequest() {
+        if (metricsReporter != null) {
+            metricsReporter.increaseCompactionsQueuedCount();
+        }
+    }
+
+    private void decreaseCompactionsQueuedCount() {
+        if (metricsReporter != null) {
+            metricsReporter.decreaseCompactionsQueuedCount();
+        }
+    }
+
+    private void increaseCompactionsFailedCount() {
+        if (metricsReporter != null) {
+            metricsReporter.increaseCompactionsFailedCount();
+        }
     }
 
     private void startTimer() {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/UnawareBucketCompactorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/UnawareBucketCompactorTest.java
@@ -34,8 +34,10 @@ import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.utils.ExecutorThreadFactory;
 
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.SimpleCounter;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -48,6 +50,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static org.apache.paimon.operation.metrics.CompactionMetrics.AVG_COMPACTION_TIME;
+import static org.apache.paimon.operation.metrics.CompactionMetrics.COMPACTIONS_COMPLETED_COUNT;
+import static org.apache.paimon.operation.metrics.CompactionMetrics.COMPACTIONS_FAILED_COUNT;
+import static org.apache.paimon.operation.metrics.CompactionMetrics.COMPACTIONS_QUEUED_COUNT;
 import static org.apache.paimon.operation.metrics.CompactionMetrics.COMPACTION_THREAD_BUSY;
 
 /** Test for {@link UnawareBucketCompactor}. */
@@ -65,7 +70,8 @@ public class UnawareBucketCompactorTest {
                 Executors.newSingleThreadScheduledExecutor(
                         new ExecutorThreadFactory(
                                 Thread.currentThread().getName() + "-append-only-compact-worker"));
-        Map<String, Gauge> map = new HashMap<>();
+        Map<String, Gauge> gaugeMap = new HashMap<>();
+        Map<String, Counter> counterMap = new HashMap<>();
         UnawareBucketCompactor unawareBucketCompactor =
                 new UnawareBucketCompactor(
                         (FileStoreTable) catalog.getTable(identifier()),
@@ -74,7 +80,7 @@ public class UnawareBucketCompactorTest {
                         new FileStoreSourceReaderTest.DummyMetricGroup() {
                             @Override
                             public <T, G extends Gauge<T>> G gauge(String name, G gauge) {
-                                map.put(name, gauge);
+                                gaugeMap.put(name, gauge);
                                 return null;
                             }
 
@@ -87,6 +93,13 @@ public class UnawareBucketCompactorTest {
                             public MetricGroup addGroup(String key, String value) {
                                 return this;
                             }
+
+                            @Override
+                            public Counter counter(String name) {
+                                SimpleCounter counter = new SimpleCounter();
+                                counterMap.put(name, counter);
+                                return counter;
+                            }
                         });
 
         for (int i = 0; i < 320; i++) {
@@ -94,11 +107,17 @@ public class UnawareBucketCompactorTest {
             Thread.sleep(250);
         }
 
-        double compactionThreadBusy = (double) map.get(COMPACTION_THREAD_BUSY).getValue();
-        double compactionAvrgTime = (double) map.get(AVG_COMPACTION_TIME).getValue();
+        double compactionThreadBusy = (double) gaugeMap.get(COMPACTION_THREAD_BUSY).getValue();
+        double compactionAvgTime = (double) gaugeMap.get(AVG_COMPACTION_TIME).getValue();
+        long compactionsCompletedCount = counterMap.get(COMPACTIONS_COMPLETED_COUNT).getCount();
+        long compactionsFailedCount = counterMap.get(COMPACTIONS_FAILED_COUNT).getCount();
+        long compactionsQueuedCount = counterMap.get(COMPACTIONS_QUEUED_COUNT).getCount();
 
         Assertions.assertThat(compactionThreadBusy).isGreaterThan(45).isLessThan(55);
-        Assertions.assertThat(compactionAvrgTime).isGreaterThan(120).isLessThan(140);
+        Assertions.assertThat(compactionAvgTime).isGreaterThan(120).isLessThan(140);
+        Assertions.assertThat(compactionsCompletedCount).isEqualTo(320L);
+        Assertions.assertThat(compactionsFailedCount).isEqualTo(0L);
+        Assertions.assertThat(compactionsQueuedCount).isEqualTo(0L);
     }
 
     protected Catalog getCatalog() {


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: https://github.com/apache/paimon/issues/4063 and add some metrics about compaction for paimon which refers to `HBase` component (includes `compactionsCompletedCount`/`compactionsFailedCount`/`compactionsQueuedCount`).

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
Existing tests

### API and Format

<!-- Does this change affect API or storage format -->
No

### Documentation

<!-- Does this change introduce a new feature -->
No
