### PR TITLE
[core] Add avg/max/total compaction io size metric

### DIFF
--- a/docs/content/maintenance/metrics.md
+++ b/docs/content/maintenance/metrics.md
@@ -181,6 +181,16 @@ Below is lists of Paimon built-in metrics. They are summarized into types of sca
             <td>Gauge</td>
             <td>Number of buckets written in the last commit.</td>
         </tr>
+        <tr>
+            <td>lastCompactionInputFileSize</td>
+            <td>Gauge</td>
+            <td>Total size of the input files for the last compaction.</td>
+        </tr>
+        <tr>
+            <td>lastCompactionOutputFileSize</td>
+            <td>Gauge</td>
+            <td>Total size of the output files for the last compaction.</td>
+        </tr>
     </tbody>
 </table>
 
@@ -232,17 +242,17 @@ Below is lists of Paimon built-in metrics. They are summarized into types of sca
         <tr>
             <td>maxLevel0FileCount</td>
             <td>Gauge</td>
-            <td>The maximum number of level 0 files currently handled by this writer. This value will become larger if asynchronous compaction cannot be done in time.</td>
+            <td>The maximum number of level 0 files currently handled by this task. This value will become larger if asynchronous compaction cannot be done in time.</td>
         </tr>
         <tr>
             <td>avgLevel0FileCount</td>
             <td>Gauge</td>
-            <td>The average number of level 0 files currently handled by this writer. This value will become larger if asynchronous compaction cannot be done in time.</td>
+            <td>The average number of level 0 files currently handled by this task. This value will become larger if asynchronous compaction cannot be done in time.</td>
         </tr>
         <tr>
             <td>compactionThreadBusy</td>
             <td>Gauge</td>
-            <td>The maximum business of compaction threads in this parallelism. Currently, there is only one compaction thread in each parallelism, so value of business ranges from 0 (idle) to 100 (compaction running all the time).</td>
+            <td>The maximum business of compaction threads in this task. Currently, there is only one compaction thread in each parallelism, so value of business ranges from 0 (idle) to 100 (compaction running all the time).</td>
         </tr>
         <tr>
             <td>avgCompactionTime</td>
@@ -258,6 +268,26 @@ Below is lists of Paimon built-in metrics. They are summarized into types of sca
             <td>compactionQueuedCount</td>
             <td>Counter</td>
             <td>The total number of compactions that are queued/running.</td>
+        </tr>
+        <tr>
+            <td>maxCompactionInputSize</td>
+            <td>Gauge</td>
+            <td>The maximum input file size for this task's compaction.</td>
+        </tr>
+        <tr>
+            <td>avgCompactionInputSize/td>
+            <td>Gauge</td>
+            <td>The average input file size for this task's compaction.</td>
+        </tr>
+        <tr>
+            <td>maxCompactionOutputSize</td>
+            <td>Gauge</td>
+            <td>The maximum output file size for this task's compaction.</td>
+        </tr>
+        <tr>
+            <td>avgCompactionOutputSize</td>
+            <td>Gauge</td>
+            <td>The average output file size for this task's compaction.</td>
         </tr>
     </tbody>
 </table>

--- a/paimon-core/src/main/java/org/apache/paimon/compact/CompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/CompactTask.java
@@ -54,6 +54,16 @@ public abstract class CompactTask implements Callable<CompactResult> {
                             metricsReporter.reportCompactionTime(
                                     System.currentTimeMillis() - startMillis);
                             metricsReporter.increaseCompactionsCompletedCount();
+                            metricsReporter.reportCompactionInputSize(
+                                    result.before().stream()
+                                            .map(DataFileMeta::fileSize)
+                                            .reduce(Long::sum)
+                                            .orElse(0L));
+                            metricsReporter.reportCompactionOutputSize(
+                                    result.after().stream()
+                                            .map(DataFileMeta::fileSize)
+                                            .reduce(Long::sum)
+                                            .orElse(0L));
                         }
                     },
                     LOG);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/CommitMetrics.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/CommitMetrics.java
@@ -76,6 +76,9 @@ public class CommitMetrics {
     @VisibleForTesting static final String LAST_PARTITIONS_WRITTEN = "lastPartitionsWritten";
     @VisibleForTesting static final String LAST_BUCKETS_WRITTEN = "lastBucketsWritten";
 
+    static final String LAST_COMPACTION_INPUT_FILE_SIZE = "lastCompactionInputFileSize";
+    static final String LAST_COMPACTION_OUTPUT_FILE_SIZE = "lastCompactionOutputFileSize";
+
     private void registerGenericCommitMetrics() {
         metricGroup.gauge(
                 LAST_COMMIT_DURATION, () -> latestCommit == null ? 0L : latestCommit.getDuration());
@@ -121,6 +124,12 @@ public class CommitMetrics {
         metricGroup.gauge(
                 LAST_CHANGELOG_RECORDS_COMMIT_COMPACTED,
                 () -> latestCommit == null ? 0L : latestCommit.getChangelogRecordsCompacted());
+        metricGroup.gauge(
+                LAST_COMPACTION_INPUT_FILE_SIZE,
+                () -> latestCommit == null ? 0L : latestCommit.getCompactionInputFileSize());
+        metricGroup.gauge(
+                LAST_COMPACTION_OUTPUT_FILE_SIZE,
+                () -> latestCommit == null ? 0L : latestCommit.getCompactionOutputFileSize());
     }
 
     public void reportCommit(CommitStats commitStats) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

Some bucket level IO size metrics are removed in https://github.com/apache/paimon/pull/2930/files 

This PR add the avg/max/total compaction input & output io size metrics back.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
