### PR TITLE
[Flink] Support speculative execution when batch read paimon table.

### DIFF
--- a/paimon-flink/paimon-flink-1.15/src/main/java/org/apache/flink/api/connector/source/SupportsHandleExecutionAttemptSourceEvent.java
+++ b/paimon-flink/paimon-flink-1.15/src/main/java/org/apache/flink/api/connector/source/SupportsHandleExecutionAttemptSourceEvent.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * An decorative interface of {@link SplitEnumerator} which allows to handle {@link SourceEvent}
+ * sent from a specific execution attempt.
+ *
+ * <p>The split enumerator must implement this interface if it needs to deal with custom source
+ * events and is used in cases that a subtask can have multiple concurrent execution attempts, e.g.
+ * if speculative execution is enabled. Otherwise an error will be thrown when the split enumerator
+ * receives a custom source event.
+ */
+@PublicEvolving
+public interface SupportsHandleExecutionAttemptSourceEvent {
+
+    /**
+     * Handles a custom source event from the source reader. It is similar to {@link
+     * SplitEnumerator#handleSourceEvent(int, SourceEvent)} but is aware of the subtask execution
+     * attempt who sent this event.
+     *
+     * @param subtaskId the subtask id of the source reader who sent the source event.
+     * @param attemptNumber the attempt number of the source reader who sent the source event.
+     * @param sourceEvent the source event from the source reader.
+     */
+    void handleSourceEvent(int subtaskId, int attemptNumber, SourceEvent sourceEvent);
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSplitEnumerator.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.apache.flink.api.connector.source.SupportsHandleExecutionAttemptSourceEvent;
 import org.apache.flink.table.connector.source.DynamicFilteringEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +42,8 @@ import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
 /** A {@link SplitEnumerator} implementation for {@link StaticFileStoreSource} input. */
 public class StaticFileStoreSplitEnumerator
-        implements SplitEnumerator<FileStoreSourceSplit, PendingSplitsCheckpoint> {
+        implements SplitEnumerator<FileStoreSourceSplit, PendingSplitsCheckpoint>,
+                SupportsHandleExecutionAttemptSourceEvent {
 
     private static final Logger LOG = LoggerFactory.getLogger(StaticFileStoreSplitEnumerator.class);
 
@@ -118,6 +120,17 @@ public class StaticFileStoreSplitEnumerator
         return snapshot;
     }
 
+    @Override
+    public void handleSourceEvent(int subtaskId, int attemptNumber, SourceEvent sourceEvent) {
+        // Only recognize events that don't care attemptNumber.
+        handleSourceEvent(subtaskId, sourceEvent);
+    }
+
+    /**
+     * When to support a new kind of event, pay attention that whether the new event can be sent
+     * multiple times from different attempts of one subtask. If so, it should be handled via method
+     * {@link #handleSourceEvent(int, int, SourceEvent)}
+     */
     @Override
     public void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {
         if (sourceEvent instanceof ReaderConsumeProgressEvent) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

![image](https://github.com/user-attachments/assets/40508661-d094-4cd2-90af-2e01de934e1b)

In my company's production job, when batch read a paimon table, I receive the exception.
After read flink and paimon code, I know it means paimon use custom SourceEvent ReaderConsumeProgressEvent.
I have come up with two solutions:
1、Implement the interface SupportsHandleExecutionAttemptSourceEvent according to the exception suggestion;
2、Delete ReaderConsumeProgressEvent in StaticFileStoreSplitEnumerator.

Due to the possibility of new other SourceEvent being added in the future, so I chose the solutions-1.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
