### PR TITLE
[core]  add check for make directory for db location when creating database

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
@@ -70,7 +70,14 @@ public class FileSystemCatalog extends AbstractCatalog {
                     "Currently filesystem catalog can't store database properties, discard properties: {}",
                     properties);
         }
-        uncheck(() -> fileIO.mkdirs(newDatabasePath(name)));
+
+        Path databasePath = newDatabasePath(name);
+        if (!uncheck(() -> fileIO.mkdirs(databasePath))) {
+            throw new RuntimeException(
+                    String.format(
+                            "Create database location failed, " + "database: %s, location: %s",
+                            name, databasePath));
+        }
     }
 
     @Override


### PR DESCRIPTION

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #4396 

<!-- What is the purpose of the change -->
According the API of mkdirs in `FileIO`, it may return false to represent mkdir failed,  we should handle the false condition when creating database.

```java
    boolean mkdirs(Path path) throws IOException;
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
