### PR TITLE
[core] Manage the bloomfilter buffer in cache manager

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/hash/HashLookupStoreReader.java
@@ -169,6 +169,9 @@ public class HashLookupStoreReader
 
     @Override
     public void close() throws IOException {
+        if (bloomFilter != null) {
+            bloomFilter.close();
+        }
         inputView.close();
         inputView = null;
     }

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/sort/SortLookupStoreFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/sort/SortLookupStoreFactory.java
@@ -52,7 +52,7 @@ public class SortLookupStoreFactory implements LookupStoreFactory {
 
     @Override
     public SortLookupStoreReader createReader(File file, Context context) throws IOException {
-        return new SortLookupStoreReader(comparator, file, (SortContext) context, cacheManager);
+        return new SortLookupStoreReader(comparator, file, blockSize, (SortContext) context, cacheManager);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/sort/SortLookupStoreFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/sort/SortLookupStoreFactory.java
@@ -52,7 +52,8 @@ public class SortLookupStoreFactory implements LookupStoreFactory {
 
     @Override
     public SortLookupStoreReader createReader(File file, Context context) throws IOException {
-        return new SortLookupStoreReader(comparator, file, blockSize, (SortContext) context, cacheManager);
+        return new SortLookupStoreReader(
+                comparator, file, blockSize, (SortContext) context, cacheManager);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/sort/SortLookupStoreReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/sort/SortLookupStoreReader.java
@@ -20,12 +20,13 @@ package org.apache.paimon.lookup.sort;
 
 import org.apache.paimon.compression.BlockCompressionFactory;
 import org.apache.paimon.compression.BlockDecompressor;
+import org.apache.paimon.io.PageFileInput;
 import org.apache.paimon.io.cache.CacheManager;
 import org.apache.paimon.lookup.LookupStoreReader;
 import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.memory.MemorySlice;
 import org.apache.paimon.memory.MemorySliceInput;
-import org.apache.paimon.utils.BloomFilter;
+import org.apache.paimon.utils.FileBasedBloomFilter;
 import org.apache.paimon.utils.MurmurHashUtils;
 
 import javax.annotation.Nullable;
@@ -55,11 +56,12 @@ public class SortLookupStoreReader implements LookupStoreReader {
     private final long fileSize;
 
     private final BlockIterator indexBlockIterator;
-    @Nullable private final BloomFilter bloomFilter;
+    @Nullable private FileBasedBloomFilter bloomFilter;
 
     public SortLookupStoreReader(
             Comparator<MemorySlice> comparator,
             File file,
+            int blockSize,
             SortContext context,
             CacheManager cacheManager)
             throws IOException {
@@ -71,18 +73,17 @@ public class SortLookupStoreReader implements LookupStoreReader {
 
         Footer footer = readFooter();
         this.indexBlockIterator = readBlock(footer.getIndexBlockHandle()).iterator();
-        this.bloomFilter = readBloomFilter(footer.getBloomFilterHandle());
-    }
-
-    private BloomFilter readBloomFilter(@Nullable BloomFilterHandle bloomFilterHandle)
-            throws IOException {
-        BloomFilter bloomFilter = null;
-        if (bloomFilterHandle != null) {
-            MemorySegment segment = read(bloomFilterHandle.offset(), bloomFilterHandle.size());
-            bloomFilter = new BloomFilter(bloomFilterHandle.expectedEntries(), segment.size());
-            bloomFilter.setMemorySegment(segment, 0);
+        BloomFilterHandle handle = footer.getBloomFilterHandle();
+        if (handle != null) {
+            PageFileInput fileInput = PageFileInput.create(file, blockSize, null, fileSize, null);
+            this.bloomFilter =
+                    new FileBasedBloomFilter(
+                            fileInput,
+                            cacheManager,
+                            handle.expectedEntries(),
+                            handle.offset(),
+                            handle.size());
         }
-        return bloomFilter;
     }
 
     private Footer readFooter() throws IOException {

--- a/paimon-common/src/test/java/org/apache/paimon/utils/FileBasedBloomFilterTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/FileBasedBloomFilterTest.java
@@ -59,7 +59,8 @@ public class FileBasedBloomFilterTest {
 
         Arrays.stream(inputs)
                 .forEach(i -> Assertions.assertThat(filter.testHash(Integer.hashCode(i))).isTrue());
-        cacheManager.cache().invalidateAll();
+        filter.close();
+        Assertions.assertThat(cacheManager.cache().asMap()).isEmpty();
         Assertions.assertThat(filter.bloomFilter().getMemorySegment()).isNull();
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

The BloomFilter in `SortLookupStoreReader` is not managed by the CacheManager, which will lead to the excessive buffer usage. This PR do these two things:

- Manage the BloomFilter's buffer with the CacheManager
- Release the BloomFilter's buffer when the Reader is closed.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
