### PR TITLE
[core] try to get table store for checking table options when creating table

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -279,6 +279,18 @@ public abstract class AbstractCatalog implements Catalog {
         } else {
             createTableImpl(identifier, schema);
         }
+        Table table = null;
+        try {
+            table = getTable(identifier);
+            FileStoreTable fileStoreTable = (FileStoreTable) table;
+            fileStoreTable.store();
+        } catch (Exception e) {
+            throw new RuntimeException("create table failed", e);
+        } finally {
+            if (table == null) {
+                fileIO.deleteQuietly(getTableLocation(identifier));
+            }
+        }
     }
 
     protected abstract void createTableImpl(Identifier identifier, Schema schema);

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -279,18 +279,6 @@ public abstract class AbstractCatalog implements Catalog {
         } else {
             createTableImpl(identifier, schema);
         }
-        Table table = null;
-        try {
-            table = getTable(identifier);
-            FileStoreTable fileStoreTable = (FileStoreTable) table;
-            fileStoreTable.store();
-        } catch (Exception e) {
-            throw new RuntimeException("create table failed", e);
-        } finally {
-            if (table == null) {
-                fileIO.deleteQuietly(getTableLocation(identifier));
-            }
-        }
     }
 
     protected abstract void createTableImpl(Identifier identifier, Schema schema);
@@ -399,12 +387,15 @@ public abstract class AbstractCatalog implements Catalog {
                 fileIO,
                 getTableLocation(identifier),
                 getDataTableSchema(identifier),
-                new CatalogEnvironment(
-                        identifier,
-                        Lock.factory(
-                                lockFactory().orElse(null), lockContext().orElse(null), identifier),
-                        metastoreClientFactory(identifier).orElse(null),
-                        lineageMetaFactory));
+                catalogEnvironment(identifier));
+    }
+
+    protected CatalogEnvironment catalogEnvironment(Identifier identifier) throws TableNotExistException {
+        return new CatalogEnvironment(
+                identifier,
+                Lock.factory(lockFactory().orElse(null), lockContext().orElse(null), identifier),
+                metastoreClientFactory(identifier).orElse(null),
+                lineageMetaFactory);
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -390,7 +390,8 @@ public abstract class AbstractCatalog implements Catalog {
                 catalogEnvironment(identifier));
     }
 
-    protected CatalogEnvironment catalogEnvironment(Identifier identifier) throws TableNotExistException {
+    protected CatalogEnvironment catalogEnvironment(Identifier identifier)
+            throws TableNotExistException {
         return new CatalogEnvironment(
                 identifier,
                 Lock.factory(lockFactory().orElse(null), lockContext().orElse(null), identifier),

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
@@ -127,7 +127,7 @@ public class FileSystemCatalog extends AbstractCatalog {
         uncheck(() -> schemaManager(identifier).createTable(schema));
     }
 
-    private SchemaManager schemaManager(Identifier identifier) {
+    private SchemaManager schemaManager(Identifier identifier) throws TableNotExistException {
         Path path = getTableLocation(identifier);
         CatalogLock catalogLock =
                 lockFactory().map(fac -> fac.createLock(assertGetLockContext())).orElse(null);

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
@@ -132,7 +132,8 @@ public class FileSystemCatalog extends AbstractCatalog {
         CatalogLock catalogLock =
                 lockFactory().map(fac -> fac.createLock(assertGetLockContext())).orElse(null);
         return new SchemaManager(fileIO, path, identifier.getBranchNameOrDefault())
-                .withLock(catalogLock == null ? null : Lock.fromCatalog(catalogLock, identifier));
+                .withLock(catalogLock == null ? null : Lock.fromCatalog(catalogLock, identifier))
+                .withCatalogEnvironment(catalogEnvironment(identifier));
     }
 
     private CatalogLockContext assertGetLockContext() {

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
@@ -352,7 +352,9 @@ public class JdbcCatalog extends AbstractCatalog {
     }
 
     private SchemaManager getSchemaManager(Identifier identifier) {
-        return new SchemaManager(fileIO, getTableLocation(identifier)).withLock(lock(identifier));
+        return new SchemaManager(fileIO, getTableLocation(identifier))
+                .withLock(lock(identifier))
+                .withCatalogEnvironment(catalogEnvironment(identifier));
     }
 
     private Map<String, String> fetchProperties(String databaseName) {

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
@@ -351,7 +351,7 @@ public class JdbcCatalog extends AbstractCatalog {
         connections.close();
     }
 
-    private SchemaManager getSchemaManager(Identifier identifier) {
+    private SchemaManager getSchemaManager(Identifier identifier) throws TableNotExistException {
         return new SchemaManager(fileIO, getTableLocation(identifier))
                 .withLock(lock(identifier))
                 .withCatalogEnvironment(catalogEnvironment(identifier));

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -77,7 +77,6 @@ import java.util.stream.LongStream;
 
 import static org.apache.paimon.CoreOptions.BUCKET_KEY;
 import static org.apache.paimon.catalog.AbstractCatalog.DB_SUFFIX;
-import static org.apache.paimon.catalog.Catalog.DB_SUFFIX;
 import static org.apache.paimon.catalog.Identifier.UNKNOWN_DATABASE;
 import static org.apache.paimon.utils.BranchManager.DEFAULT_MAIN_BRANCH;
 import static org.apache.paimon.utils.FileUtils.listVersionedFiles;
@@ -230,16 +229,15 @@ public class SchemaManager implements Serializable {
                             options,
                             schema.comment());
 
-            try {
-                FileStoreTableFactory.create(fileIO, tableRoot, newSchema, catalogEnvironment)
-                        .store();
-            } catch (Exception e) {
-                fileIO.deleteQuietly(tableRoot);
-                throw new RuntimeException("create table failed", e);
-            }
-
             boolean success = commit(newSchema);
             if (success) {
+                try {
+                    FileStoreTableFactory.create(fileIO, tableRoot, newSchema, catalogEnvironment)
+                            .store();
+                } catch (Exception e) {
+                    fileIO.deleteQuietly(tableRoot);
+                    throw new RuntimeException("create table failed", e);
+                }
                 return newSchema;
             }
         }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -306,6 +306,19 @@ public abstract class CatalogTestBase {
                                                 ""),
                                         true))
                 .doesNotThrowAnyException();
+        // Create table throws IleaArgumentException when some table options are not set correctly
+        schema.options()
+                .put(
+                        CoreOptions.MERGE_ENGINE.key(),
+                        CoreOptions.MergeEngine.DEDUPLICATE.toString());
+        schema.options().put(CoreOptions.IGNORE_DELETE.key(), "max");
+        assertThatCode(
+                        () ->
+                                catalog.createTable(
+                                        Identifier.create("test_db", "wrong_table"), schema, false))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage(
+                        "Unrecognized option for boolean: max. Expected either true or false(case insensitive)");
     }
 
     @Test


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
If some table options are set incorrectly, such as `ignore-delete = max`, it may cause an exception when dropping the table. This is because it tries to getTable before dropping.

The implementation of getting table in different catalog is different too. For example:
 `CachingCatalog` will `putTableCache` and this may call `PrimaryKeyFileStoreTable#store()` method, which will create `MergeFunction` through some table options. When trying to read these options, exception occurs, causing getTable failed and leads to dropping table failed.

So, When creating table, we will try to get table store for checking if the relevant table options are set correctly. If not, the table created will be deleted and throw an exception.

### Tests

<!-- List UT and IT cases to verify this change -->
CatalogTestBase#testCreateTable
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
