### PR TITLE
[flink] Lookup join supports time periods black list

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -87,6 +87,12 @@ under the License.
             <td>If the pending snapshot count exceeds the threshold, lookup operator will refresh the table in sync.</td>
         </tr>
         <tr>
+            <td><h5>lookup.refresh.time-periods-blacklist</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The blacklist contains several time periods. During these time periods, the lookup table's cache refreshing is forbidden. Blacklist format is start1-&gt;end1,start2-&gt;end2,... , and the time format is yyyy-MM-dd HH:mm. Only used when lookup table is FULL cache mode.</td>
+        </tr>
+        <tr>
             <td><h5>partition.idle-time-to-done</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -311,6 +311,15 @@ public class FlinkConnectorOptions {
                     .withDescription(
                             "If the pending snapshot count exceeds the threshold, lookup operator will refresh the table in sync.");
 
+    public static final ConfigOption<String> LOOKUP_REFRESH_TIME_PERIODS_BLACKLIST =
+            ConfigOptions.key("lookup.refresh.time-periods-blacklist")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The blacklist contains several time periods. During these time periods, the lookup table's "
+                                    + "cache refreshing is forbidden. Blacklist format is start1->end1,start2->end2,... , "
+                                    + "and the time format is yyyy-MM-dd HH:mm. Only used when lookup table is FULL cache mode.");
+
     public static final ConfigOption<Boolean> SINK_AUTO_TAG_FOR_SAVEPOINT =
             ConfigOptions.key("sink.savepoint.auto-tag")
                     .booleanType()

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -356,11 +356,12 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
                 lookupTable.specificPartitionFilter(createSpecificPartFilter(partition));
                 lookupTable.close();
                 lookupTable.open();
-                // no need to refresh the lookupTable because it is reopened
+                // no need to refresh the lookup table because it is reopened
                 return;
             }
         }
 
+        // 3. refresh lookup table
         if (shouldRefreshLookupTable()) {
             lookupTable.refresh();
             nextRefreshTime = System.currentTimeMillis() + refreshInterval.toMillis();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -32,9 +32,12 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.OutOfRangeException;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.DateTimeUtils;
 import org.apache.paimon.utils.FileIOUtils;
 import org.apache.paimon.utils.Filter;
+import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.RowDataToObjectArrayConverter;
+import org.apache.paimon.utils.StringUtils;
 
 import org.apache.paimon.shade.guava30.com.google.common.primitives.Ints;
 
@@ -53,6 +56,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.time.Duration;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -62,6 +66,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
@@ -69,6 +74,7 @@ import java.util.stream.IntStream;
 
 import static org.apache.paimon.CoreOptions.CONTINUOUS_DISCOVERY_INTERVAL;
 import static org.apache.paimon.flink.FlinkConnectorOptions.LOOKUP_CACHE_MODE;
+import static org.apache.paimon.flink.FlinkConnectorOptions.LOOKUP_REFRESH_TIME_PERIODS_BLACKLIST;
 import static org.apache.paimon.flink.query.RemoteTableQuery.isRemoteServiceAvailable;
 import static org.apache.paimon.lookup.RocksDBOptions.LOOKUP_CACHE_ROWS;
 import static org.apache.paimon.lookup.RocksDBOptions.LOOKUP_CONTINUOUS_DISCOVERY_INTERVAL;
@@ -87,6 +93,7 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
     private final List<String> projectFields;
     private final List<String> joinKeys;
     @Nullable private final Predicate predicate;
+    private final List<Pair<Long, Long>> timePeriodsBlacklist;
 
     private transient Duration refreshInterval;
     private transient File path;
@@ -131,6 +138,44 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         }
 
         this.predicate = predicate;
+
+        this.timePeriodsBlacklist =
+                parseTimePeriodsBlacklist(
+                        table.options().get(LOOKUP_REFRESH_TIME_PERIODS_BLACKLIST.key()));
+    }
+
+    private List<Pair<Long, Long>> parseTimePeriodsBlacklist(String blacklist) {
+        if (StringUtils.isNullOrWhitespaceOnly(blacklist)) {
+            return Collections.emptyList();
+        }
+        String[] timePeriods = blacklist.split(",");
+        List<Pair<Long, Long>> result = new ArrayList<>();
+        for (String period : timePeriods) {
+            String[] times = period.split("->");
+            if (times.length != 2) {
+                throw new IllegalArgumentException(
+                        String.format("Incorrect time periods format: [%s].", blacklist));
+            }
+
+            long left = parseToMillis(times[0]);
+            long right = parseToMillis(times[1]);
+            if (left > right) {
+                throw new IllegalArgumentException(
+                        String.format("Incorrect time period: [%s->%s].", times[0], times[1]));
+            }
+            result.add(Pair.of(left, right));
+        }
+        return result;
+    }
+
+    private long parseToMillis(String dateTime) {
+        try {
+            return DateTimeUtils.parseTimestampData(dateTime + ":00", 3, TimeZone.getDefault())
+                    .getMillisecond();
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException(
+                    String.format("Date time format error: [%s].", dateTime), e);
+        }
     }
 
     public void open(FunctionContext context) throws Exception {
@@ -293,10 +338,24 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         }
     }
 
-    private void checkRefresh() throws Exception {
-        if (nextLoadTime > System.currentTimeMillis()) {
+    @VisibleForTesting
+    void checkRefresh() throws Exception {
+        long currentTimeMillis = System.currentTimeMillis();
+        if (nextLoadTime > currentTimeMillis) {
             return;
         }
+
+        Pair<Long, Long> period = getFirstTimePeriods(timePeriodsBlacklist, currentTimeMillis);
+        if (period != null) {
+            LOG.info(
+                    "Current time {} is in black list {}-{}, so try to refresh cache next time.",
+                    currentTimeMillis,
+                    period.getLeft(),
+                    period.getRight());
+            this.nextLoadTime = period.getRight() + 1;
+            return;
+        }
+
         if (nextLoadTime > 0) {
             LOG.info(
                     "Lookup table {} has refreshed after {} second(s), refreshing",
@@ -309,9 +368,24 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         nextLoadTime = System.currentTimeMillis() + refreshInterval.toMillis();
     }
 
+    @Nullable
+    private Pair<Long, Long> getFirstTimePeriods(List<Pair<Long, Long>> timePeriods, long time) {
+        for (Pair<Long, Long> period : timePeriods) {
+            if (period.getLeft() <= time && time <= period.getRight()) {
+                return period;
+            }
+        }
+        return null;
+    }
+
     @VisibleForTesting
     LookupTable lookupTable() {
         return lookupTable;
+    }
+
+    @VisibleForTesting
+    long nextLoadTime() {
+        return nextLoadTime;
     }
 
     private void refresh() throws Exception {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/FileStoreLookupFunctionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/FileStoreLookupFunctionTest.java
@@ -280,9 +280,9 @@ public class FileStoreLookupFunctionTest {
 
         FileStoreLookupFunction lookupFunction = createLookupFunction(table, true);
 
-        lookupFunction.checkRefresh();
+        lookupFunction.tryRefresh();
 
-        assertThat(lookupFunction.nextLoadTime()).isEqualTo(end.toEpochMilli() + 1);
+        assertThat(lookupFunction.nextBlacklistCheckTime()).isEqualTo(end.toEpochMilli() + 1);
     }
 
     private void commit(List<CommitMessage> messages) throws Exception {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/FileStoreLookupFunctionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/FileStoreLookupFunctionTest.java
@@ -34,6 +34,7 @@ import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.service.ServiceManager;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.StreamTableWrite;
 import org.apache.paimon.table.sink.TableCommitImpl;
@@ -52,6 +53,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -59,8 +63,11 @@ import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 
+import static org.apache.paimon.flink.FlinkConnectorOptions.LOOKUP_REFRESH_TIME_PERIODS_BLACKLIST;
 import static org.apache.paimon.service.ServiceManager.PRIMARY_KEY_LOOKUP;
+import static org.apache.paimon.testutils.assertj.PaimonAssertions.anyCauseMatches;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 /** Tests for {@link FileStoreLookupFunction}. */
 public class FileStoreLookupFunctionTest {
@@ -91,6 +98,18 @@ public class FileStoreLookupFunctionTest {
             boolean dynamicPartition,
             boolean refreshAsync)
             throws Exception {
+        table = createFileStoreTable(isPartition, dynamicPartition, refreshAsync);
+        lookupFunction = createLookupFunction(table, joinEqualPk);
+        lookupFunction.open(tempDir.toString());
+    }
+
+    private FileStoreLookupFunction createLookupFunction(Table table, boolean joinEqualPk) {
+        return new FileStoreLookupFunction(
+                table, new int[] {0, 1}, joinEqualPk ? new int[] {0, 1} : new int[] {1}, null);
+    }
+
+    private FileStoreTable createFileStoreTable(
+            boolean isPartition, boolean dynamicPartition, boolean refreshAsync) throws Exception {
         SchemaManager schemaManager = new SchemaManager(fileIO, tablePath);
         Options conf = new Options();
         conf.set(FlinkConnectorOptions.LOOKUP_REFRESH_ASYNC, refreshAsync);
@@ -106,7 +125,6 @@ public class FileStoreLookupFunctionTest {
                 RowType.of(
                         new DataType[] {DataTypes.INT(), DataTypes.INT(), DataTypes.BIGINT()},
                         new String[] {"pt", "k", "v"});
-
         Schema schema =
                 new Schema(
                         rowType.getFields(),
@@ -115,17 +133,8 @@ public class FileStoreLookupFunctionTest {
                         conf.toMap(),
                         "");
         TableSchema tableSchema = schemaManager.createTable(schema);
-        table =
-                FileStoreTableFactory.create(
-                        fileIO, new org.apache.paimon.fs.Path(tempDir.toString()), tableSchema);
-
-        lookupFunction =
-                new FileStoreLookupFunction(
-                        table,
-                        new int[] {0, 1},
-                        joinEqualPk ? new int[] {0, 1} : new int[] {1},
-                        null);
-        lookupFunction.open(tempDir.toString());
+        return FileStoreTableFactory.create(
+                fileIO, new org.apache.paimon.fs.Path(tempDir.toString()), tableSchema);
     }
 
     @AfterEach
@@ -212,6 +221,68 @@ public class FileStoreLookupFunctionTest {
                                         s -> s.toString().contains(tempDir.toString()))
                                 .size())
                 .isEqualTo(0);
+    }
+
+    @Test
+    public void testParseWrongTimePeriodsBlacklist() throws Exception {
+        Table table = createFileStoreTable(false, false, false);
+
+        Table table1 =
+                table.copy(
+                        Collections.singletonMap(
+                                LOOKUP_REFRESH_TIME_PERIODS_BLACKLIST.key(),
+                                "2024-10-31 12:00,2024-10-31 16:00"));
+        assertThatThrownBy(() -> createLookupFunction(table1, true))
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class,
+                                "Incorrect time periods format: [2024-10-31 12:00,2024-10-31 16:00]."));
+
+        Table table2 =
+                table.copy(
+                        Collections.singletonMap(
+                                LOOKUP_REFRESH_TIME_PERIODS_BLACKLIST.key(),
+                                "20241031 12:00->20241031 16:00"));
+        assertThatThrownBy(() -> createLookupFunction(table2, true))
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class,
+                                "Date time format error: [20241031 12:00]"));
+
+        Table table3 =
+                table.copy(
+                        Collections.singletonMap(
+                                LOOKUP_REFRESH_TIME_PERIODS_BLACKLIST.key(),
+                                "2024-10-31 12:00->2024-10-31 16:00,2024-10-31 20:00->2024-10-31 18:00"));
+        assertThatThrownBy(() -> createLookupFunction(table3, true))
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class,
+                                "Incorrect time period: [2024-10-31 20:00->2024-10-31 18:00]"));
+    }
+
+    @Test
+    public void testCheckRefreshInBlacklist() throws Exception {
+        Instant now = Instant.now();
+        Instant start = Instant.ofEpochSecond(now.getEpochSecond() / 60 * 60);
+        Instant end = start.plusSeconds(30 * 60);
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        String left = start.atZone(ZoneId.systemDefault()).format(formatter);
+        String right = end.atZone(ZoneId.systemDefault()).format(formatter);
+
+        Table table =
+                createFileStoreTable(false, false, false)
+                        .copy(
+                                Collections.singletonMap(
+                                        LOOKUP_REFRESH_TIME_PERIODS_BLACKLIST.key(),
+                                        left + "->" + right));
+
+        FileStoreLookupFunction lookupFunction = createLookupFunction(table, true);
+
+        lookupFunction.checkRefresh();
+
+        assertThat(lookupFunction.nextLoadTime()).isEqualTo(end.toEpochMilli() + 1);
     }
 
     private void commit(List<CommitMessage> messages) throws Exception {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

In the specified periods, lookup table cache refreshing is forbidden. This is aimed at avoiding server busy time.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
