### PR TITLE
[hive]add dlf.lifecycle as a table param in hive catalog.

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -953,6 +953,11 @@ public class HiveCatalog extends AbstractCatalog {
         if (provider == null) {
             provider = PAIMON_TABLE_TYPE_VALUE;
         }
+        CoreOptions coreOptions = CoreOptions.fromMap(tableParameters);
+        java.time.Duration partitionExpireTime = coreOptions.partitionExpireTime();
+        if (partitionExpireTime != null && partitionExpireTime.toDays() > 0) {
+            tableParameters.put("dlf.lifecycle", String.valueOf(partitionExpireTime.toDays()));
+        }
         Table table =
                 new Table(
                         identifier.getTableName(),


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
add dlf.lifecycle to table params according to paimon.partitionExpireTime.
<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
