### PR TITLE
[core] Add file compression type in file names

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -333,6 +333,12 @@ under the License.
             <td>Define different file format for different level, you can add the conf like this: 'file.format.per.level' = '0:avro,3:parquet', if the file format for level is not provided, the default format which set by `file.format` will be used.</td>
         </tr>
         <tr>
+            <td><h5>file.suffix.include.compression</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to add file compression type in the file name of data file and changelog file.</td>
+        </tr>
+        <tr>
             <td><h5>force-lookup</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -190,6 +190,13 @@ public class CoreOptions implements Serializable {
                     .defaultValue("changelog-")
                     .withDescription("Specify the file name prefix of changelog files.");
 
+    public static final ConfigOption<Boolean> FILE_SUFFIX_INCLUDE_COMPRESSION =
+            key("file.suffix.include.compression")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to add file compression type in the file name of data file and changelog file.");
+
     public static final ConfigOption<MemorySize> FILE_BLOCK_SIZE =
             key("file.block-size")
                     .memoryType()
@@ -1596,6 +1603,10 @@ public class CoreOptions implements Serializable {
 
     public String changelogFilePrefix() {
         return options.get(CHANGELOG_FILE_PREFIX);
+    }
+
+    public boolean fileSuffixIncludeCompression() {
+        return options.get(FILE_SUFFIX_INCLUDE_COMPRESSION);
     }
 
     public String fieldsDefaultFunc() {

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -107,6 +107,7 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 options.dataFilePrefix(),
                 options.changelogFilePrefix(),
                 options.legacyPartitionName(),
+                options.fileSuffixIncludeCompression(),
                 options.fileCompression());
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -106,7 +106,8 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 options.fileFormat().getFormatIdentifier(),
                 options.dataFilePrefix(),
                 options.changelogFilePrefix(),
-                options.legacyPartitionName());
+                options.legacyPartitionName(),
+                options.fileCompression());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -208,6 +208,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                                         options.dataFilePrefix(),
                                         options.changelogFilePrefix(),
                                         options.legacyPartitionName(),
+                                        options.fileSuffixIncludeCompression(),
                                         options.fileCompression())));
         return pathFactoryMap;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -207,7 +207,8 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                                         format,
                                         options.dataFilePrefix(),
                                         options.changelogFilePrefix(),
-                                        options.legacyPartitionName())));
+                                        options.legacyPartitionName(),
+                                        options.fileCompression())));
         return pathFactoryMap;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFilePathFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFilePathFactory.java
@@ -39,18 +39,21 @@ public class DataFilePathFactory {
     private final String formatIdentifier;
     private final String dataFilePrefix;
     private final String changelogFilePrefix;
+    private final String fileCompression;
 
     public DataFilePathFactory(
             Path parent,
             String formatIdentifier,
             String dataFilePrefix,
-            String changelogFilePrefix) {
+            String changelogFilePrefix,
+            String fileCompression) {
         this.parent = parent;
         this.uuid = UUID.randomUUID().toString();
         this.pathCount = new AtomicInteger(0);
         this.formatIdentifier = formatIdentifier;
         this.dataFilePrefix = dataFilePrefix;
         this.changelogFilePrefix = changelogFilePrefix;
+        this.fileCompression = fileCompression;
     }
 
     public Path newPath() {
@@ -62,7 +65,8 @@ public class DataFilePathFactory {
     }
 
     private Path newPath(String prefix) {
-        String name = prefix + uuid + "-" + pathCount.getAndIncrement() + "." + formatIdentifier;
+        String extension = "." + fileCompression + "." + formatIdentifier;
+        String name = prefix + uuid + "-" + pathCount.getAndIncrement() + extension;
         return new Path(parent, name);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFilePathFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFilePathFactory.java
@@ -39,6 +39,7 @@ public class DataFilePathFactory {
     private final String formatIdentifier;
     private final String dataFilePrefix;
     private final String changelogFilePrefix;
+    private final boolean fileSuffixIncludeCompression;
     private final String fileCompression;
 
     public DataFilePathFactory(
@@ -46,6 +47,7 @@ public class DataFilePathFactory {
             String formatIdentifier,
             String dataFilePrefix,
             String changelogFilePrefix,
+            boolean fileSuffixIncludeCompression,
             String fileCompression) {
         this.parent = parent;
         this.uuid = UUID.randomUUID().toString();
@@ -53,6 +55,7 @@ public class DataFilePathFactory {
         this.formatIdentifier = formatIdentifier;
         this.dataFilePrefix = dataFilePrefix;
         this.changelogFilePrefix = changelogFilePrefix;
+        this.fileSuffixIncludeCompression = fileSuffixIncludeCompression;
         this.fileCompression = fileCompression;
     }
 
@@ -65,7 +68,12 @@ public class DataFilePathFactory {
     }
 
     private Path newPath(String prefix) {
-        String extension = "." + fileCompression + "." + formatIdentifier;
+        String extension;
+        if (fileSuffixIncludeCompression) {
+            extension = "." + fileCompression + "." + formatIdentifier;
+        } else {
+            extension = "." + formatIdentifier;
+        }
         String name = prefix + uuid + "-" + pathCount.getAndIncrement() + extension;
         return new Path(parent, name);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
@@ -43,6 +43,7 @@ public class FileStorePathFactory {
     private final String formatIdentifier;
     private final String dataFilePrefix;
     private final String changelogFilePrefix;
+    private final String fileCompression;
 
     private final AtomicInteger manifestFileCount;
     private final AtomicInteger manifestListCount;
@@ -57,7 +58,8 @@ public class FileStorePathFactory {
             String formatIdentifier,
             String dataFilePrefix,
             String changelogFilePrefix,
-            boolean legacyPartitionName) {
+            boolean legacyPartitionName,
+            String fileCompression) {
         this.root = root;
         this.uuid = UUID.randomUUID().toString();
 
@@ -66,6 +68,7 @@ public class FileStorePathFactory {
         this.formatIdentifier = formatIdentifier;
         this.dataFilePrefix = dataFilePrefix;
         this.changelogFilePrefix = changelogFilePrefix;
+        this.fileCompression = fileCompression;
 
         this.manifestFileCount = new AtomicInteger(0);
         this.manifestListCount = new AtomicInteger(0);
@@ -113,7 +116,8 @@ public class FileStorePathFactory {
                 bucketPath(partition, bucket),
                 formatIdentifier,
                 dataFilePrefix,
-                changelogFilePrefix);
+                changelogFilePrefix,
+                fileCompression);
     }
 
     public Path bucketPath(BinaryRow partition, int bucket) {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
@@ -43,6 +43,7 @@ public class FileStorePathFactory {
     private final String formatIdentifier;
     private final String dataFilePrefix;
     private final String changelogFilePrefix;
+    private final boolean fileSuffixIncludeCompression;
     private final String fileCompression;
 
     private final AtomicInteger manifestFileCount;
@@ -59,6 +60,7 @@ public class FileStorePathFactory {
             String dataFilePrefix,
             String changelogFilePrefix,
             boolean legacyPartitionName,
+            boolean fileSuffixIncludeCompression,
             String fileCompression) {
         this.root = root;
         this.uuid = UUID.randomUUID().toString();
@@ -68,6 +70,7 @@ public class FileStorePathFactory {
         this.formatIdentifier = formatIdentifier;
         this.dataFilePrefix = dataFilePrefix;
         this.changelogFilePrefix = changelogFilePrefix;
+        this.fileSuffixIncludeCompression = fileSuffixIncludeCompression;
         this.fileCompression = fileCompression;
 
         this.manifestFileCount = new AtomicInteger(0);
@@ -117,6 +120,7 @@ public class FileStorePathFactory {
                 formatIdentifier,
                 dataFilePrefix,
                 changelogFilePrefix,
+                fileSuffixIncludeCompression,
                 fileCompression);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -523,6 +523,7 @@ public class AppendOnlyWriterTest {
                 CoreOptions.FILE_FORMAT.defaultValue().toString(),
                 CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                 CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
+                CoreOptions.FILE_SUFFIX_INCLUDE_COMPRESSION.defaultValue(),
                 CoreOptions.FILE_COMPRESSION.defaultValue());
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -522,7 +522,8 @@ public class AppendOnlyWriterTest {
                 new Path(tempDir + "/dt=" + PART + "/bucket-0"),
                 CoreOptions.FILE_FORMAT.defaultValue().toString(),
                 CoreOptions.DATA_FILE_PREFIX.defaultValue(),
-                CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue());
+                CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
+                CoreOptions.FILE_COMPRESSION.defaultValue());
     }
 
     private AppendOnlyWriter createEmptyWriter(long targetFileSize) {

--- a/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
@@ -70,7 +70,8 @@ public class FileFormatSuffixTest extends KeyValueFileReadWriteTest {
                         new Path(tempDir + "/dt=1/bucket-1"),
                         format,
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
-                        CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue());
+                        CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
+                        CoreOptions.FILE_COMPRESSION.defaultValue());
         FileFormat fileFormat = FileFormat.fromIdentifier(format, new Options());
         LinkedList<DataFileMeta> toCompact = new LinkedList<>();
         CoreOptions options = new CoreOptions(new HashMap<>());

--- a/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
@@ -71,6 +71,7 @@ public class FileFormatSuffixTest extends KeyValueFileReadWriteTest {
                         format,
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                         CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
+                        CoreOptions.FILE_SUFFIX_INCLUDE_COMPRESSION.defaultValue(),
                         CoreOptions.FILE_COMPRESSION.defaultValue());
         FileFormat fileFormat = FileFormat.fromIdentifier(format, new Options());
         LinkedList<DataFileMeta> toCompact = new LinkedList<>();

--- a/paimon-core/src/test/java/org/apache/paimon/io/DataFilePathFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/DataFilePathFactoryTest.java
@@ -39,6 +39,7 @@ public class DataFilePathFactoryTest {
                         CoreOptions.FILE_FORMAT.defaultValue().toString(),
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                         CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
+                        CoreOptions.FILE_SUFFIX_INCLUDE_COMPRESSION.defaultValue(),
                         CoreOptions.FILE_COMPRESSION.defaultValue());
         String uuid = pathFactory.uuid();
 
@@ -51,8 +52,6 @@ public class DataFilePathFactoryTest {
                                             + uuid
                                             + "-"
                                             + i
-                                            + "."
-                                            + CoreOptions.FILE_COMPRESSION.defaultValue()
                                             + "."
                                             + CoreOptions.FILE_FORMAT.defaultValue()));
         }
@@ -68,6 +67,7 @@ public class DataFilePathFactoryTest {
                         CoreOptions.FILE_FORMAT.defaultValue().toString(),
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                         CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
+                        CoreOptions.FILE_SUFFIX_INCLUDE_COMPRESSION.defaultValue(),
                         CoreOptions.FILE_COMPRESSION.defaultValue());
         String uuid = pathFactory.uuid();
 
@@ -80,8 +80,6 @@ public class DataFilePathFactoryTest {
                                             + uuid
                                             + "-"
                                             + i
-                                            + "."
-                                            + CoreOptions.FILE_COMPRESSION.defaultValue()
                                             + "."
                                             + CoreOptions.FILE_FORMAT.defaultValue()));
         }

--- a/paimon-core/src/test/java/org/apache/paimon/io/DataFilePathFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/DataFilePathFactoryTest.java
@@ -38,7 +38,8 @@ public class DataFilePathFactoryTest {
                         new Path(tempDir + "/bucket-123"),
                         CoreOptions.FILE_FORMAT.defaultValue().toString(),
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
-                        CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue());
+                        CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
+                        CoreOptions.FILE_COMPRESSION.defaultValue());
         String uuid = pathFactory.uuid();
 
         for (int i = 0; i < 20; i++) {
@@ -64,7 +65,8 @@ public class DataFilePathFactoryTest {
                         new Path(tempDir + "/dt=20211224/bucket-123"),
                         CoreOptions.FILE_FORMAT.defaultValue().toString(),
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
-                        CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue());
+                        CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
+                        CoreOptions.FILE_COMPRESSION.defaultValue());
         String uuid = pathFactory.uuid();
 
         for (int i = 0; i < 20; i++) {

--- a/paimon-core/src/test/java/org/apache/paimon/io/DataFilePathFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/DataFilePathFactoryTest.java
@@ -52,6 +52,8 @@ public class DataFilePathFactoryTest {
                                             + "-"
                                             + i
                                             + "."
+                                            + CoreOptions.FILE_COMPRESSION.defaultValue()
+                                            + "."
                                             + CoreOptions.FILE_FORMAT.defaultValue()));
         }
         assertThat(pathFactory.toPath("my-data-file-name"))
@@ -78,6 +80,8 @@ public class DataFilePathFactoryTest {
                                             + uuid
                                             + "-"
                                             + i
+                                            + "."
+                                            + CoreOptions.FILE_COMPRESSION.defaultValue()
                                             + "."
                                             + CoreOptions.FILE_FORMAT.defaultValue()));
         }

--- a/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
@@ -229,7 +229,8 @@ public class KeyValueFileReadWriteTest {
                         format,
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                         CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
-                        CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue());
+                        CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue(),
+                        CoreOptions.FILE_COMPRESSION.defaultValue());
         int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
         FileIO fileIO = FileIOFinder.find(path);
         Options options = new Options();
@@ -246,7 +247,8 @@ public class KeyValueFileReadWriteTest {
                         CoreOptions.FILE_FORMAT.defaultValue().toString(),
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                         CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
-                        CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue()));
+                        CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue(),
+                        CoreOptions.FILE_COMPRESSION.defaultValue()));
 
         return KeyValueFileWriterFactory.builder(
                         fileIO,

--- a/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
@@ -230,6 +230,7 @@ public class KeyValueFileReadWriteTest {
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                         CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
                         CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue(),
+                        CoreOptions.FILE_SUFFIX_INCLUDE_COMPRESSION.defaultValue(),
                         CoreOptions.FILE_COMPRESSION.defaultValue());
         int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
         FileIO fileIO = FileIOFinder.find(path);
@@ -248,6 +249,7 @@ public class KeyValueFileReadWriteTest {
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                         CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
                         CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue(),
+                        CoreOptions.FILE_SUFFIX_INCLUDE_COMPRESSION.defaultValue(),
                         CoreOptions.FILE_COMPRESSION.defaultValue()));
 
         return KeyValueFileWriterFactory.builder(

--- a/paimon-core/src/test/java/org/apache/paimon/io/RollingFileWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/RollingFileWriterTest.java
@@ -82,6 +82,8 @@ public class RollingFileWriterTest {
                                                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                                                         CoreOptions.CHANGELOG_FILE_PREFIX
                                                                 .defaultValue(),
+                                                        CoreOptions.FILE_SUFFIX_INCLUDE_COMPRESSION
+                                                                .defaultValue(),
                                                         CoreOptions.FILE_COMPRESSION.defaultValue())
                                                 .newPath(),
                                         SCHEMA,

--- a/paimon-core/src/test/java/org/apache/paimon/io/RollingFileWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/RollingFileWriterTest.java
@@ -81,7 +81,8 @@ public class RollingFileWriterTest {
                                                                 .toString(),
                                                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                                                         CoreOptions.CHANGELOG_FILE_PREFIX
-                                                                .defaultValue())
+                                                                .defaultValue(),
+                                                        CoreOptions.FILE_COMPRESSION.defaultValue())
                                                 .newPath(),
                                         SCHEMA,
                                         fileFormat

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTestBase.java
@@ -147,7 +147,8 @@ public abstract class ManifestFileMetaTestBase {
                                 CoreOptions.FILE_FORMAT.defaultValue(),
                                 CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                                 CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
-                                CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue()),
+                                CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue(),
+                                CoreOptions.FILE_COMPRESSION.defaultValue()),
                         Long.MAX_VALUE,
                         null)
                 .create();

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTestBase.java
@@ -148,6 +148,7 @@ public abstract class ManifestFileMetaTestBase {
                                 CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                                 CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
                                 CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue(),
+                                CoreOptions.FILE_SUFFIX_INCLUDE_COMPRESSION.defaultValue(),
                                 CoreOptions.FILE_COMPRESSION.defaultValue()),
                         Long.MAX_VALUE,
                         null)

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileTest.java
@@ -104,6 +104,7 @@ public class ManifestFileTest {
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                         CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
                         CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue(),
+                        CoreOptions.FILE_SUFFIX_INCLUDE_COMPRESSION.defaultValue(),
                         CoreOptions.FILE_COMPRESSION.defaultValue());
         int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
         FileIO fileIO = FileIOFinder.find(path);

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileTest.java
@@ -103,7 +103,8 @@ public class ManifestFileTest {
                         CoreOptions.FILE_FORMAT.defaultValue().toString(),
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                         CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
-                        CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue());
+                        CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue(),
+                        CoreOptions.FILE_COMPRESSION.defaultValue());
         int suggestedFileSize = ThreadLocalRandom.current().nextInt(8192) + 1024;
         FileIO fileIO = FileIOFinder.find(path);
         return new ManifestFile.Factory(

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestListTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestListTest.java
@@ -107,7 +107,8 @@ public class ManifestListTest {
                         CoreOptions.FILE_FORMAT.defaultValue().toString(),
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                         CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
-                        CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue());
+                        CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue(),
+                        CoreOptions.FILE_COMPRESSION.defaultValue());
         return new ManifestList.Factory(FileIOFinder.find(path), avro, "zstd", pathFactory, null)
                 .create();
     }

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestListTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestListTest.java
@@ -108,6 +108,7 @@ public class ManifestListTest {
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                         CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
                         CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue(),
+                        CoreOptions.FILE_SUFFIX_INCLUDE_COMPRESSION.defaultValue(),
                         CoreOptions.FILE_COMPRESSION.defaultValue());
         return new ManifestList.Factory(FileIOFinder.find(path), avro, "zstd", pathFactory, null)
                 .create();

--- a/paimon-core/src/test/java/org/apache/paimon/utils/FileStorePathFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/FileStorePathFactoryTest.java
@@ -89,6 +89,7 @@ public class FileStorePathFactoryTest {
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                         CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
                         CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue(),
+                        CoreOptions.FILE_SUFFIX_INCLUDE_COMPRESSION.defaultValue(),
                         CoreOptions.FILE_COMPRESSION.defaultValue());
 
         assertPartition("20211224", 16, pathFactory, "/dt=20211224/hr=16");
@@ -128,6 +129,7 @@ public class FileStorePathFactoryTest {
                 CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                 CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
                 CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue(),
+                CoreOptions.FILE_SUFFIX_INCLUDE_COMPRESSION.defaultValue(),
                 CoreOptions.FILE_COMPRESSION.defaultValue());
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/utils/FileStorePathFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/FileStorePathFactoryTest.java
@@ -88,7 +88,8 @@ public class FileStorePathFactoryTest {
                         CoreOptions.FILE_FORMAT.defaultValue().toString(),
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                         CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
-                        CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue());
+                        CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue(),
+                        CoreOptions.FILE_COMPRESSION.defaultValue());
 
         assertPartition("20211224", 16, pathFactory, "/dt=20211224/hr=16");
         assertPartition("20211224", null, pathFactory, "/dt=20211224/hr=default");
@@ -126,6 +127,7 @@ public class FileStorePathFactoryTest {
                 CoreOptions.FILE_FORMAT.defaultValue().toString(),
                 CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                 CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
-                CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue());
+                CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue(),
+                CoreOptions.FILE_COMPRESSION.defaultValue());
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
@@ -108,7 +108,8 @@ public class TestChangelogDataReadWrite {
                         CoreOptions.FILE_FORMAT.defaultValue().toString(),
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                         CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
-                        CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue());
+                        CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue(),
+                        CoreOptions.FILE_COMPRESSION.defaultValue());
         this.snapshotManager = new SnapshotManager(LocalFileIO.create(), new Path(root));
         this.commitUser = UUID.randomUUID().toString();
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
@@ -109,6 +109,7 @@ public class TestChangelogDataReadWrite {
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                         CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
                         CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue(),
+                        CoreOptions.FILE_SUFFIX_INCLUDE_COMPRESSION.defaultValue(),
                         CoreOptions.FILE_COMPRESSION.defaultValue());
         this.snapshotManager = new SnapshotManager(LocalFileIO.create(), new Path(root));
         this.commitUser = UUID.randomUUID().toString();

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFileIndexITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFileIndexITCase.java
@@ -131,7 +131,8 @@ public class SparkFileIndexITCase extends SparkWriteITCase {
                         CoreOptions.FILE_FORMAT.defaultValue().toString(),
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                         CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
-                        CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue());
+                        CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue(),
+                        CoreOptions.FILE_COMPRESSION.defaultValue());
 
         Table table = fileSystemCatalog.getTable(Identifier.create("db", "T"));
         ReadBuilder readBuilder = table.newReadBuilder();

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFileIndexITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkFileIndexITCase.java
@@ -132,6 +132,7 @@ public class SparkFileIndexITCase extends SparkWriteITCase {
                         CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                         CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
                         CoreOptions.PARTITION_GENERATE_LEGCY_NAME.defaultValue(),
+                        CoreOptions.FILE_SUFFIX_INCLUDE_COMPRESSION.defaultValue(),
                         CoreOptions.FILE_COMPRESSION.defaultValue());
 
         Table table = fileSystemCatalog.getTable(Identifier.create("db", "T"));

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkWriteITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkWriteITCase.java
@@ -344,12 +344,12 @@ public class SparkWriteITCase {
     public void testDataFileSuffixName() {
         spark.sql(
                 "CREATE TABLE T (a INT, b INT, c STRING)"
-                        + " TBLPROPERTIES (" +
-                        "'bucket' = '1', " +
-                        "'primary-key'='a', " +
-                        "'write-only' = 'true', " +
-                        "'file.format' = 'parquet', " +
-                        "'file.compression' = 'zstd')");
+                        + " TBLPROPERTIES ("
+                        + "'bucket' = '1', "
+                        + "'primary-key'='a', "
+                        + "'write-only' = 'true', "
+                        + "'file.format' = 'parquet', "
+                        + "'file.compression' = 'zstd')");
 
         spark.sql("INSERT INTO T VALUES (1, 1, 'aa')");
         spark.sql("INSERT INTO T VALUES (2, 2, 'bb')");
@@ -385,13 +385,13 @@ public class SparkWriteITCase {
     @Test
     public void testChangelogFileSuffixName() throws Exception {
         spark.sql(
-                "CREATE TABLE T (a INT, b INT, c STRING) " +
-                        "TBLPROPERTIES (" +
-                        "'primary-key'='a', " +
-                        "'bucket' = '1', " +
-                        "'changelog-producer' = 'lookup', " +
-                        "'file.format' = 'parquet', " +
-                        "'file.compression' = 'zstd')");
+                "CREATE TABLE T (a INT, b INT, c STRING) "
+                        + "TBLPROPERTIES ("
+                        + "'primary-key'='a', "
+                        + "'bucket' = '1', "
+                        + "'changelog-producer' = 'lookup', "
+                        + "'file.format' = 'parquet', "
+                        + "'file.compression' = 'zstd')");
 
         FileStoreTable table = getTable("T");
         Path tabLocation = table.location();

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkWriteITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkWriteITCase.java
@@ -344,7 +344,12 @@ public class SparkWriteITCase {
     public void testDataFileSuffixName() {
         spark.sql(
                 "CREATE TABLE T (a INT, b INT, c STRING)"
-                        + " TBLPROPERTIES ('bucket' = '1', 'primary-key'='a', 'write-only' = 'true', 'file.format' = 'parquet', 'file.compression' = 'zstd')");
+                        + " TBLPROPERTIES (" +
+                        "'bucket' = '1', " +
+                        "'primary-key'='a', " +
+                        "'write-only' = 'true', " +
+                        "'file.format' = 'parquet', " +
+                        "'file.compression' = 'zstd')");
 
         spark.sql("INSERT INTO T VALUES (1, 1, 'aa')");
         spark.sql("INSERT INTO T VALUES (2, 2, 'bb')");
@@ -380,7 +385,13 @@ public class SparkWriteITCase {
     @Test
     public void testChangelogFileSuffixName() throws Exception {
         spark.sql(
-                "CREATE TABLE T (a INT, b INT, c STRING) TBLPROPERTIES ('primary-key'='a', 'bucket' = '1', 'changelog-producer' = 'lookup', 'file.format' = 'parquet', 'file.compression' = 'zstd')");
+                "CREATE TABLE T (a INT, b INT, c STRING) " +
+                        "TBLPROPERTIES (" +
+                        "'primary-key'='a', " +
+                        "'bucket' = '1', " +
+                        "'changelog-producer' = 'lookup', " +
+                        "'file.format' = 'parquet', " +
+                        "'file.compression' = 'zstd')");
 
         FileStoreTable table = getTable("T");
         Path tabLocation = table.location();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Default, the file name written by paimon only has the file format, it can also include the file compression like spark.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
