### PR TITLE
[core] Allow cache and refresh partitions for CachingCatalog

### DIFF
--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -45,6 +45,12 @@ under the License.
             <td>Controls the duration for which databases and tables in the catalog are cached.</td>
         </tr>
         <tr>
+            <td><h5>cache.partition.max-num</h5></td>
+            <td style="word-wrap: break-word;">0</td>
+            <td>Long</td>
+            <td>Controls the max number for which partitions in the catalog are cached.</td>
+        </tr>
+        <tr>
             <td><h5>cache.manifest.max-memory</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>MemorySize</td>

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -98,6 +98,13 @@ public class CatalogOptions {
                     .withDescription(
                             "Controls the duration for which databases and tables in the catalog are cached.");
 
+    public static final ConfigOption<Long> CACHE_PARTITION_MAX_NUM =
+            key("cache.partition.max-num")
+                    .longType()
+                    .defaultValue(0L)
+                    .withDescription(
+                            "Controls the duration for which databases and tables in the catalog are cached.");
+
     public static final ConfigOption<MemorySize> CACHE_MANIFEST_SMALL_FILE_MEMORY =
             key("cache.manifest.small-file-memory")
                     .memoryType()

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -103,7 +103,7 @@ public class CatalogOptions {
                     .longType()
                     .defaultValue(0L)
                     .withDescription(
-                            "Controls the duration for which databases and tables in the catalog are cached.");
+                            "Controls the max number for which partitions in the catalog are cached.");
 
     public static final ConfigOption<MemorySize> CACHE_MANIFEST_SMALL_FILE_MEMORY =
             key("cache.manifest.small-file-memory")

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
@@ -126,6 +126,7 @@ public class CachingCatalog extends DelegateCatalog {
                                 .softValues()
                                 .executor(Runnable::run)
                                 .expireAfterAccess(expirationInterval)
+                                .weigher(this::weigh)
                                 .maximumWeight(cachedPartitionMaxNum)
                                 .ticker(ticker)
                                 .build();
@@ -277,6 +278,10 @@ public class CachingCatalog extends DelegateCatalog {
         return partitionCache != null
                 && table instanceof FileStoreTable
                 && !table.partitionKeys().isEmpty();
+    }
+
+    private int weigh(Identifier identifier, List<PartitionEntry> partitions) {
+        return partitions.size();
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
@@ -242,10 +242,11 @@ class CachingCatalogTest extends CatalogTestBase {
                         "");
         catalog.createTable(tableIdent, schema, false);
         List<PartitionEntry> partitionEntryList = catalog.getPartitions(tableIdent);
-        assertThat(catalog.partitionCache().asMap().containsKey(tableIdent));
+        assertThat(catalog.partitionCache().asMap()).containsKey(tableIdent);
         List<PartitionEntry> partitionEntryListFromCache =
                 catalog.partitionCache().getIfPresent(tableIdent);
-        assertThat(partitionEntryListFromCache.containsAll(partitionEntryList));
+        assertThat(partitionEntryListFromCache).isNotNull();
+        assertThat(partitionEntryListFromCache).containsAll(partitionEntryList);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
@@ -341,7 +341,8 @@ class CachingCatalogTest extends CatalogTestBase {
                         this.catalog,
                         Duration.ofSeconds(10),
                         MemorySize.ofMebiBytes(1),
-                        manifestCacheThreshold);
+                        manifestCacheThreshold,
+                        0L);
         Identifier tableIdent = new Identifier("db", "tbl");
         catalog.dropTable(tableIdent, true);
         catalog.createTable(tableIdent, DEFAULT_TABLE_SCHEMA, false);

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
@@ -20,8 +20,10 @@ package org.apache.paimon.catalog;
 
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.BatchTableCommit;
@@ -32,6 +34,8 @@ import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.utils.FakeTicker;
 
 import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
@@ -44,6 +48,7 @@ import java.io.FileNotFoundException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -51,6 +56,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.apache.paimon.data.BinaryString.fromString;
 import static org.apache.paimon.options.CatalogOptions.CACHE_MANIFEST_MAX_MEMORY;
 import static org.apache.paimon.options.CatalogOptions.CACHE_MANIFEST_SMALL_FILE_MEMORY;
@@ -113,15 +120,15 @@ class CachingCatalogTest extends CatalogTestBase {
         Table table = catalog.getTable(tableIdent);
 
         // Ensure table is cached with full ttl remaining upon creation
-        assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+        assertThat(catalog.tableCache().asMap()).containsKey(tableIdent);
         assertThat(catalog.remainingAgeFor(tableIdent)).isPresent().get().isEqualTo(EXPIRATION_TTL);
 
         ticker.advance(HALF_OF_EXPIRATION);
-        assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+        assertThat(catalog.tableCache().asMap()).containsKey(tableIdent);
         assertThat(catalog.ageOf(tableIdent)).isPresent().get().isEqualTo(HALF_OF_EXPIRATION);
 
         ticker.advance(HALF_OF_EXPIRATION.plus(Duration.ofSeconds(10)));
-        assertThat(catalog.cache().asMap()).doesNotContainKey(tableIdent);
+        assertThat(catalog.tableCache().asMap()).doesNotContainKey(tableIdent);
         assertThat(catalog.getTable(tableIdent))
                 .as("CachingCatalog should return a new instance after expiration")
                 .isNotSameAs(table);
@@ -135,11 +142,11 @@ class CachingCatalogTest extends CatalogTestBase {
         Identifier tableIdent = new Identifier("db", "tbl");
         catalog.createTable(tableIdent, DEFAULT_TABLE_SCHEMA, false);
         catalog.getTable(tableIdent);
-        assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+        assertThat(catalog.tableCache().asMap()).containsKey(tableIdent);
         assertThat(catalog.ageOf(tableIdent)).isPresent().get().isEqualTo(Duration.ZERO);
 
         ticker.advance(HALF_OF_EXPIRATION);
-        assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+        assertThat(catalog.tableCache().asMap()).containsKey(tableIdent);
         assertThat(catalog.ageOf(tableIdent)).isPresent().get().isEqualTo(HALF_OF_EXPIRATION);
         assertThat(catalog.remainingAgeFor(tableIdent))
                 .isPresent()
@@ -148,7 +155,7 @@ class CachingCatalogTest extends CatalogTestBase {
 
         Duration oneMinute = Duration.ofMinutes(1L);
         ticker.advance(oneMinute);
-        assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+        assertThat(catalog.tableCache().asMap()).containsKey(tableIdent);
         assertThat(catalog.ageOf(tableIdent))
                 .isPresent()
                 .get()
@@ -175,17 +182,17 @@ class CachingCatalogTest extends CatalogTestBase {
         Identifier tableIdent = new Identifier("db", "tbl");
         catalog.createTable(tableIdent, DEFAULT_TABLE_SCHEMA, false);
         Table table = catalog.getTable(tableIdent);
-        assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+        assertThat(catalog.tableCache().asMap()).containsKey(tableIdent);
         assertThat(catalog.ageOf(tableIdent)).get().isEqualTo(Duration.ZERO);
 
         ticker.advance(HALF_OF_EXPIRATION);
-        assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+        assertThat(catalog.tableCache().asMap()).containsKey(tableIdent);
         assertThat(catalog.ageOf(tableIdent)).get().isEqualTo(HALF_OF_EXPIRATION);
 
         for (Identifier sysTable : sysTables(tableIdent)) {
             catalog.getTable(sysTable);
         }
-        assertThat(catalog.cache().asMap()).containsKeys(sysTables(tableIdent));
+        assertThat(catalog.tableCache().asMap()).containsKeys(sysTables(tableIdent));
         assertThat(Arrays.stream(sysTables(tableIdent)).map(catalog::ageOf))
                 .isNotEmpty()
                 .allMatch(age -> age.isPresent() && age.get().equals(Duration.ZERO));
@@ -209,15 +216,36 @@ class CachingCatalogTest extends CatalogTestBase {
 
         // Move time forward so the data table drops.
         ticker.advance(HALF_OF_EXPIRATION);
-        assertThat(catalog.cache().asMap()).doesNotContainKey(tableIdent);
+        assertThat(catalog.tableCache().asMap()).doesNotContainKey(tableIdent);
 
         Arrays.stream(sysTables(tableIdent))
                 .forEach(
                         sysTable ->
-                                assertThat(catalog.cache().asMap())
+                                assertThat(catalog.tableCache().asMap())
                                         .as(
                                                 "When a data table expires, its sys tables should expire regardless of age")
                                         .doesNotContainKeys(sysTable));
+    }
+
+    @Test
+    public void testPartitionCache() throws Exception {
+        TestableCachingCatalog catalog =
+                new TestableCachingCatalog(this.catalog, EXPIRATION_TTL, ticker);
+
+        Identifier tableIdent = new Identifier("db", "tbl");
+        Schema schema =
+                new Schema(
+                        RowType.of(VarCharType.STRING_TYPE, VarCharType.STRING_TYPE).getFields(),
+                        singletonList("f0"),
+                        emptyList(),
+                        Collections.emptyMap(),
+                        "");
+        catalog.createTable(tableIdent, schema, false);
+        List<PartitionEntry> partitionEntryList = catalog.getPartitions(tableIdent);
+        assertThat(catalog.partitionCache().asMap().containsKey(tableIdent));
+        List<PartitionEntry> partitionEntryListFromCache =
+                catalog.partitionCache().getIfPresent(tableIdent);
+        assertThat(partitionEntryListFromCache.containsAll(partitionEntryList));
     }
 
     @Test
@@ -233,7 +261,7 @@ class CachingCatalogTest extends CatalogTestBase {
             createdTables.add(tableIdent);
         }
 
-        Cache<Identifier, Table> cache = catalog.cache();
+        Cache<Identifier, Table> cache = catalog.tableCache();
         AtomicInteger cacheGetCount = new AtomicInteger(0);
         AtomicInteger cacheCleanupCount = new AtomicInteger(0);
         ExecutorService executor = Executors.newFixedThreadPool(numThreads);
@@ -288,10 +316,10 @@ class CachingCatalogTest extends CatalogTestBase {
         Identifier tableIdent = new Identifier("db", "tbl");
         catalog.createTable(tableIdent, DEFAULT_TABLE_SCHEMA, false);
         catalog.getTable(tableIdent);
-        assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+        assertThat(catalog.tableCache().asMap()).containsKey(tableIdent);
         catalog.dropTable(tableIdent, false);
-        assertThat(catalog.cache().asMap()).doesNotContainKey(tableIdent);
-        assertThat(wrappedCatalog.cache().asMap()).doesNotContainKey(tableIdent);
+        assertThat(catalog.tableCache().asMap()).doesNotContainKey(tableIdent);
+        assertThat(wrappedCatalog.tableCache().asMap()).doesNotContainKey(tableIdent);
     }
 
     public static Identifier[] sysTables(Identifier tableIdent) {

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/TestableCachingCatalog.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/TestableCachingCatalog.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.catalog;
 
+import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.table.Table;
 
@@ -25,6 +26,7 @@ import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cach
 import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Ticker;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -40,12 +42,16 @@ public class TestableCachingCatalog extends CachingCatalog {
         this.cacheExpirationInterval = expirationInterval;
     }
 
-    public Cache<Identifier, Table> cache() {
+    public Cache<Identifier, Table> tableCache() {
         // cleanUp must be called as tests apply assertions directly on the underlying map, but
-        // metadata
-        // table map entries are cleaned up asynchronously.
+        // metadata table map entries are cleaned up asynchronously.
         tableCache.cleanUp();
         return tableCache;
+    }
+
+    public Cache<Identifier, List<PartitionEntry>> partitionCache() {
+        partitionCache.cleanUp();
+        return partitionCache;
     }
 
     public Optional<Duration> ageOf(Identifier identifier) {

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/TestableCachingCatalog.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/TestableCachingCatalog.java
@@ -38,7 +38,7 @@ public class TestableCachingCatalog extends CachingCatalog {
     private final Duration cacheExpirationInterval;
 
     public TestableCachingCatalog(Catalog catalog, Duration expirationInterval, Ticker ticker) {
-        super(catalog, expirationInterval, MemorySize.ZERO, Long.MAX_VALUE, ticker);
+        super(catalog, expirationInterval, MemorySize.ZERO, Long.MAX_VALUE, Long.MAX_VALUE, ticker);
         this.cacheExpirationInterval = expirationInterval;
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #4205

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
testPartitionCache

### API and Format

<!-- Does this change affect API or storage format -->
CachingCatalog.getPartitions
CachingCatalog.refreshPartitions

### Documentation

<!-- Does this change introduce a new feature -->
Allow cache and refresh partitions for CachingCatalog.
