### PR TITLE
[core] Show fileSource in the FilesTable

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/system/FilesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/FilesTable.java
@@ -27,6 +27,7 @@ import org.apache.paimon.data.LazyGenericRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFilePathFactory;
+import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.predicate.Equal;
 import org.apache.paimon.predicate.LeafPredicate;
 import org.apache.paimon.predicate.LeafPredicateExtractor;
@@ -111,7 +112,8 @@ public class FilesTable implements ReadonlyTable {
                                     12, "max_value_stats", SerializationUtils.newStringType(false)),
                             new DataField(13, "min_sequence_number", new BigIntType(true)),
                             new DataField(14, "max_sequence_number", new BigIntType(true)),
-                            new DataField(15, "creation_time", DataTypes.TIMESTAMP_MILLIS())));
+                            new DataField(15, "creation_time", DataTypes.TIMESTAMP_MILLIS()),
+                            new DataField(16, "file_source", DataTypes.STRING())));
 
     private final FileStoreTable storeTable;
 
@@ -413,7 +415,13 @@ public class FilesTable implements ReadonlyTable {
                         () -> BinaryString.fromString(statsGetter.upperValueBounds().toString()),
                         dataFileMeta::minSequenceNumber,
                         dataFileMeta::maxSequenceNumber,
-                        dataFileMeta::creationTime
+                        dataFileMeta::creationTime,
+                        () ->
+                                BinaryString.fromString(
+                                        dataFileMeta
+                                                .fileSource()
+                                                .map(FileSource::toString)
+                                                .orElse(null))
                     };
 
             return new LazyGenericRow(fields);

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/FilesTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/FilesTableTest.java
@@ -211,7 +211,8 @@ public class FilesTableTest extends TableTestBase {
                                             maxCol1, maxKey, partition1, partition2)),
                             file.minSequenceNumber(),
                             file.maxSequenceNumber(),
-                            file.creationTime()));
+                            file.creationTime(),
+                            BinaryString.fromString(file.fileSource().get().toString())));
         }
         return expectedRow;
     }

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/FilesTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/FilesTableTest.java
@@ -212,7 +212,8 @@ public class FilesTableTest extends TableTestBase {
                             file.minSequenceNumber(),
                             file.maxSequenceNumber(),
                             file.creationTime(),
-                            BinaryString.fromString(file.fileSource().get().toString())));
+                            BinaryString.fromString(
+                                    file.fileSource().map(Object::toString).orElse(null))));
         }
         return expectedRow;
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

This could let user know where is the file come from: Append or Compact.
<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
