### PR TITLE
[core] throw exception if table is recreated when it still being read

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/NextSnapshotFetcher.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/NextSnapshotFetcher.java
@@ -48,20 +48,16 @@ public class NextSnapshotFetcher {
         Long latestSnapshotId = snapshotManager.latestSnapshotId();
         // No snapshot now
         if (earliestSnapshotId == null || earliestSnapshotId <= nextSnapshotId) {
-            if (earliestSnapshotId == null && nextSnapshotId > 1) {
+            if ((earliestSnapshotId == null && nextSnapshotId > 1)
+                    || (latestSnapshotId != null && nextSnapshotId > latestSnapshotId + 1)) {
                 throw new OutOfRangeException(
                         String.format(
-                                "The earliest snapshot is null now, but the next expected snapshot id is %d. "
-                                        + "Most possible cause might be the table had been recreated.",
-                                nextSnapshotId));
+                                "The next expected snapshot is too big! Most possible cause might be the table had been recreated."
+                                        + "The next snapshot id is %d, while the latest snapshot id is %s",
+                                nextSnapshotId,
+                                latestSnapshotId == null ? "null" : latestSnapshotId));
             }
-            if (latestSnapshotId != null && nextSnapshotId > latestSnapshotId + 1) {
-                throw new OutOfRangeException(
-                        String.format(
-                                "The next expected snapshot with id %d is greater than latest snapshot with id %d plus one. "
-                                        + "Most possible cause might be the table had been recreated.",
-                                nextSnapshotId, latestSnapshotId));
-            }
+
             LOG.debug(
                     "Next snapshot id {} does not exist, wait for the snapshot generation.",
                     nextSnapshotId);

--- a/paimon-core/src/main/java/org/apache/paimon/utils/NextSnapshotFetcher.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/NextSnapshotFetcher.java
@@ -54,8 +54,7 @@ public class NextSnapshotFetcher {
                         String.format(
                                 "The next expected snapshot is too big! Most possible cause might be the table had been recreated."
                                         + "The next snapshot id is %d, while the latest snapshot id is %s",
-                                nextSnapshotId,
-                                latestSnapshotId == null ? "null" : latestSnapshotId));
+                                nextSnapshotId, latestSnapshotId));
             }
 
             LOG.debug(

--- a/paimon-core/src/main/java/org/apache/paimon/utils/NextSnapshotFetcher.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/NextSnapshotFetcher.java
@@ -45,8 +45,23 @@ public class NextSnapshotFetcher {
         }
 
         Long earliestSnapshotId = snapshotManager.earliestSnapshotId();
+        Long latestSnapshotId = snapshotManager.latestSnapshotId();
         // No snapshot now
         if (earliestSnapshotId == null || earliestSnapshotId <= nextSnapshotId) {
+            if (earliestSnapshotId == null && nextSnapshotId > 1) {
+                throw new OutOfRangeException(
+                        String.format(
+                                "The earliest snapshot is null now, but the next expected snapshot id is %d. "
+                                        + "Most possible cause might be the table had been recreated.",
+                                nextSnapshotId));
+            }
+            if (latestSnapshotId != null && nextSnapshotId > latestSnapshotId + 1) {
+                throw new OutOfRangeException(
+                        String.format(
+                                "The next expected snapshot with id %d is greater than latest snapshot with id %d plus one. "
+                                        + "Most possible cause might be the table had been recreated.",
+                                nextSnapshotId, latestSnapshotId));
+            }
             LOG.debug(
                     "Next snapshot id {} does not exist, wait for the snapshot generation.",
                     nextSnapshotId);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PrimaryKeyFileStoreTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PrimaryKeyFileStoreTableITCase.java
@@ -338,7 +338,7 @@ public class PrimaryKeyFileStoreTableITCase extends AbstractTestBase {
         }
     }
 
-    @Timeout(120)
+    @Timeout(60)
     @ParameterizedTest()
     @ValueSource(booleans = {false, true})
     public void testRecreateTableWithException(boolean isReloadData) throws Exception {
@@ -407,14 +407,7 @@ public class PrimaryKeyFileStoreTableITCase extends AbstractTestBase {
         if (isReloadData) {
             bEnv.executeSql("INSERT INTO t VALUES " + String.join(", ", values)).await();
         }
-        assertThatCode(
-                        () -> {
-                            while (true) {
-                                if (it.hasNext()) {
-                                    it.next();
-                                }
-                            }
-                        })
+        assertThatCode(it::next)
                 .rootCause()
                 .hasMessageContaining(
                         "The next expected snapshot is too big! Most possible cause might be the table had been recreated.");


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
A table which is read in streaming read, will not throw exception even if the table is recreated currently. For example, the expected snapshot id is 10001, but the latest snapshot of the recreated table might be null or much less than 10001.

This is because when try to get the next snapshot, if the next snapshot is not exists in filesystem and its id is greater than earliest snapshot id, it will be treat as the next snapshot is still in generating progress.

This feature adds a check in `NextSnapshotFetcher#getNextSnapshot`. If next expected snapshot id is greater than the latest snapshot id plus one, it will throw an exception.

### Tests

<!-- List UT and IT cases to verify this change -->
`PrimaryKeyFileStoreTableITCase#testRecreateTableWithException`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
