### PR TITLE
[core] Introduce refreshPartitions interface to CachingCatalog

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
@@ -268,7 +268,6 @@ public class CachingCatalog extends DelegateCatalog {
 
     public void refreshPartitions(Identifier identifier) throws TableNotExistException {
         if (partitionCache != null) {
-            partitionCache.invalidate(identifier);
             List<PartitionEntry> result = wrapped.listPartitions(identifier);
             partitionCache.put(identifier, result);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
@@ -267,6 +267,14 @@ public class CachingCatalog extends DelegateCatalog {
     }
 
     @Override
+    public void refreshPartitions(Identifier identifier) throws TableNotExistException {
+        if (partitionCache != null) {
+            partitionCache.invalidate(identifier);
+            this.listPartitions(identifier);
+        }
+    }
+
+    @Override
     public void dropPartition(Identifier identifier, Map<String, String> partitions)
             throws TableNotExistException, PartitionNotExistException {
         wrapped.dropPartition(identifier, partitions);
@@ -289,6 +297,9 @@ public class CachingCatalog extends DelegateCatalog {
     public void invalidateTable(Identifier identifier) {
         tableCache.invalidate(identifier);
         tryInvalidateSysTables(identifier);
+        if (partitionCache != null) {
+            partitionCache.invalidate(identifier);
+        }
     }
 
     private void tryInvalidateSysTables(Identifier identifier) {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
@@ -266,11 +266,11 @@ public class CachingCatalog extends DelegateCatalog {
         return result;
     }
 
-    @Override
     public void refreshPartitions(Identifier identifier) throws TableNotExistException {
         if (partitionCache != null) {
             partitionCache.invalidate(identifier);
-            this.listPartitions(identifier);
+            List<PartitionEntry> result = wrapped.listPartitions(identifier);
+            partitionCache.put(identifier, result);
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -300,14 +300,6 @@ public interface Catalog extends AutoCloseable {
     List<PartitionEntry> listPartitions(Identifier identifier) throws TableNotExistException;
 
     /**
-     * Refresh cached partitions of the table.
-     *
-     * @param identifier path of the table to refresh partitions
-     * @throws TableNotExistException if the table does not exist
-     */
-    default void refreshPartitions(Identifier identifier) throws TableNotExistException {}
-
-    /**
      * Modify an existing table from a {@link SchemaChange}.
      *
      * <p>NOTE: System tables can not be altered.

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -300,6 +300,14 @@ public interface Catalog extends AutoCloseable {
     List<PartitionEntry> listPartitions(Identifier identifier) throws TableNotExistException;
 
     /**
+     * Refresh cached partitions of the table.
+     *
+     * @param identifier path of the table to refresh partitions
+     * @throws TableNotExistException if the table does not exist
+     */
+    default void refreshPartitions(Identifier identifier) throws TableNotExistException {}
+
+    /**
      * Modify an existing table from a {@link SchemaChange}.
      *
      * <p>NOTE: System tables can not be altered.

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
@@ -243,6 +243,9 @@ class CachingCatalogTest extends CatalogTestBase {
         catalog.createTable(tableIdent, schema, false);
         List<PartitionEntry> partitionEntryList = catalog.listPartitions(tableIdent);
         assertThat(catalog.partitionCache().asMap()).containsKey(tableIdent);
+        catalog.invalidateTable(tableIdent);
+        catalog.refreshPartitions(tableIdent);
+        assertThat(catalog.partitionCache().asMap()).containsKey(tableIdent);
         List<PartitionEntry> partitionEntryListFromCache =
                 catalog.partitionCache().getIfPresent(tableIdent);
         assertThat(partitionEntryListFromCache).isNotNull();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Among OLAP scenario, we need an interface to refresh cached partition info to assure that if it is necessary to renew a materialized view's partition.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
added.

### API and Format

<!-- Does this change affect API or storage format -->
Catalog.refreshPartitions

### Documentation

<!-- Does this change introduce a new feature -->
no