### PR TITLE
[core] Increase the default value of cache.expiration-interval to 10m

### DIFF
--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -40,7 +40,7 @@ under the License.
         </tr>
         <tr>
             <td><h5>cache.expiration-interval</h5></td>
-            <td style="word-wrap: break-word;">1 min</td>
+            <td style="word-wrap: break-word;">10 min</td>
             <td>Duration</td>
             <td>Controls the duration for which databases and tables in the catalog are cached.</td>
         </tr>

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -94,7 +94,7 @@ public class CatalogOptions {
     public static final ConfigOption<Duration> CACHE_EXPIRATION_INTERVAL_MS =
             key("cache.expiration-interval")
                     .durationType()
-                    .defaultValue(Duration.ofSeconds(60))
+                    .defaultValue(Duration.ofMinutes(10))
                     .withDescription(
                             "Controls the duration for which databases and tables in the catalog are cached.");
 


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The default value of database/table/partition cache for a catalog is 1 minute, leading to a low hit rate. We would like to increase it to 10 minutes.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
no.

### API and Format

<!-- Does this change affect API or storage format -->
no.

### Documentation

<!-- Does this change introduce a new feature -->
added.