### PR TITLE
[hive] Enable Format Table by default

### DIFF
--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -75,6 +75,12 @@ under the License.
             <td>Configure the size of the connection pool.</td>
         </tr>
         <tr>
+            <td><h5>format-table.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to support format tables, format table corresponds to a regular csv, parquet or orc table, allowing read and write operations. However, during these processes, it does not connect to the metastore; hence, newly added partitions will not be reflected in the metastore and need to be manually added as separate partition operations.</td>
+        </tr>
+        <tr>
             <td><h5>lineage-meta</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/hive_catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/hive_catalog_configuration.html
@@ -41,7 +41,7 @@ under the License.
         </tr>
         <tr>
             <td><h5>format-table.enabled</h5></td>
-            <td style="word-wrap: break-word;">false</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Whether to support format tables, format table corresponds to a regular Hive table, allowing read and write operations. However, during these processes, it does not connect to the metastore; hence, newly added partitions will not be reflected in the metastore and need to be manually added as separate partition operations.</td>
         </tr>

--- a/docs/layouts/shortcodes/generated/hive_catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/hive_catalog_configuration.html
@@ -40,12 +40,6 @@ under the License.
             <td>Specify client cache key, multiple elements separated by commas.<br /><ul><li>"ugi":  the Hadoop UserGroupInformation instance that represents the current user using the cache.</li></ul><ul><li>"user_name" similar to UGI but only includes the user's name determined by UserGroupInformation#getUserName.</li></ul><ul><li>"conf": name of an arbitrary configuration. The value of the configuration will be extracted from catalog properties and added to the cache key. A conf element should start with a "conf:" prefix which is followed by the configuration name. E.g. specifying "conf:a.b.c" will add "a.b.c" to the key, and so that configurations with different default catalog wouldn't share the same client pool. Multiple conf elements can be specified.</li></ul></td>
         </tr>
         <tr>
-            <td><h5>format-table.enabled</h5></td>
-            <td style="word-wrap: break-word;">true</td>
-            <td>Boolean</td>
-            <td>Whether to support format tables, format table corresponds to a regular Hive table, allowing read and write operations. However, during these processes, it does not connect to the metastore; hence, newly added partitions will not be reflected in the metastore and need to be manually added as separate partition operations.</td>
-        </tr>
-        <tr>
             <td><h5>hadoop-conf-dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -156,4 +156,13 @@ public class CatalogOptions {
                     .booleanType()
                     .defaultValue(false)
                     .withDescription("Sync all table properties to hive metastore");
+
+    public static final ConfigOption<Boolean> FORMAT_TABLE_ENABLED =
+            ConfigOptions.key("format-table.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to support format tables, format table corresponds to a regular csv, parquet or orc table, allowing read and write operations. "
+                                    + "However, during these processes, it does not connect to the metastore; hence, newly added partitions will not be reflected in"
+                                    + " the metastore and need to be manually added as separate partition operations.");
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/FormatTableOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FormatTableOptions.java
@@ -25,8 +25,9 @@ import org.apache.paimon.options.ConfigOptions;
 public class FormatTableOptions {
 
     public static final ConfigOption<String> FIELD_DELIMITER =
-            ConfigOptions.key("csv.field-delimiter")
+            ConfigOptions.key("field-delimiter")
                     .stringType()
                     .defaultValue(",")
-                    .withDescription("Optional field delimiter character (',' by default)");
+                    .withDescription(
+                            "Optional field delimiter character for CSV (',' by default).");
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -768,7 +768,9 @@ public class FlinkCatalog extends AbstractCatalog {
             throw new TableNotExistException(getName(), tablePath);
         }
 
-        Preconditions.checkArgument(table instanceof FileStoreTable, "Can't alter system table.");
+        checkArgument(
+                table instanceof FileStoreTable,
+                "Only support alter data table, but is: " + table.getClass());
         validateAlterTable(toCatalogTable(table), newTable);
         Map<String, Integer> oldTableNonPhysicalColumnIndex =
                 FlinkCatalogPropertiesUtil.nonPhysicalColumns(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkGenericCatalogFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkGenericCatalogFactory.java
@@ -20,7 +20,6 @@ package org.apache.paimon.flink;
 
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.CatalogContext;
-import org.apache.paimon.hive.HiveCatalogOptions;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 
@@ -90,7 +89,7 @@ public class FlinkGenericCatalogFactory implements CatalogFactory {
             ClassLoader cl, Map<String, String> optionMap, String name, Catalog flinkCatalog) {
         Options options = Options.fromMap(optionMap);
         options.set(CatalogOptions.METASTORE, "hive");
-        options.set(HiveCatalogOptions.FORMAT_TABLE_ENABLED, false);
+        options.set(CatalogOptions.FORMAT_TABLE_ENABLED, false);
         FlinkCatalog paimon =
                 new FlinkCatalog(
                         org.apache.paimon.catalog.CatalogFactory.createCatalog(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkGenericCatalogFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkGenericCatalogFactory.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink;
 
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.hive.HiveCatalogOptions;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 
@@ -89,6 +90,7 @@ public class FlinkGenericCatalogFactory implements CatalogFactory {
             ClassLoader cl, Map<String, String> optionMap, String name, Catalog flinkCatalog) {
         Options options = Options.fromMap(optionMap);
         options.set(CatalogOptions.METASTORE, "hive");
+        options.set(HiveCatalogOptions.FORMAT_TABLE_ENABLED, false);
         FlinkCatalog paimon =
                 new FlinkCatalog(
                         org.apache.paimon.catalog.CatalogFactory.createCatalog(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -189,7 +189,8 @@ public class CatalogTableITCase extends CatalogITCaseBase {
     public void testChangeTableInSystemDatabase() {
         sql("USE sys");
         assertThatCode(() -> sql("ALTER TABLE all_table_options SET ('bucket-num' = '5')"))
-                .hasRootCauseMessage("Can't alter system table.");
+                .rootCause()
+                .hasMessageContaining("Only support alter data table, but is: ");
     }
 
     @Test

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -44,6 +44,7 @@ import org.apache.paimon.table.CatalogEnvironment;
 import org.apache.paimon.table.CatalogTableType;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.FormatTable;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
@@ -97,13 +98,13 @@ import static org.apache.paimon.CoreOptions.TYPE;
 import static org.apache.paimon.TableType.FORMAT_TABLE;
 import static org.apache.paimon.hive.HiveCatalogLock.acquireTimeout;
 import static org.apache.paimon.hive.HiveCatalogLock.checkMaxSleep;
-import static org.apache.paimon.hive.HiveCatalogOptions.FORMAT_TABLE_ENABLED;
 import static org.apache.paimon.hive.HiveCatalogOptions.HADOOP_CONF_DIR;
 import static org.apache.paimon.hive.HiveCatalogOptions.HIVE_CONF_DIR;
 import static org.apache.paimon.hive.HiveCatalogOptions.IDENTIFIER;
 import static org.apache.paimon.hive.HiveCatalogOptions.LOCATION_IN_PROPERTIES;
 import static org.apache.paimon.hive.HiveTableUtils.convertToFormatTable;
 import static org.apache.paimon.options.CatalogOptions.ALLOW_UPPER_CASE;
+import static org.apache.paimon.options.CatalogOptions.FORMAT_TABLE_ENABLED;
 import static org.apache.paimon.options.CatalogOptions.SYNC_ALL_PROPERTIES;
 import static org.apache.paimon.options.CatalogOptions.TABLE_TYPE;
 import static org.apache.paimon.options.OptionsUtils.convertToPropertiesPrefixKey;
@@ -111,6 +112,7 @@ import static org.apache.paimon.table.FormatTableOptions.FIELD_DELIMITER;
 import static org.apache.paimon.utils.BranchManager.DEFAULT_MAIN_BRANCH;
 import static org.apache.paimon.utils.HadoopUtils.addHadoopConfIfFound;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.Preconditions.checkNotNull;
 import static org.apache.paimon.utils.StringUtils.isNullOrWhitespaceOnly;
 
 /** A catalog implementation for Hive. */
@@ -172,8 +174,8 @@ public class HiveCatalog extends AbstractCatalog {
         this.clients = new CachedClientPool(hiveConf, options, clientClassName);
     }
 
-    private boolean formatTableEnabled() {
-        return options.get(FORMAT_TABLE_ENABLED);
+    private boolean formatTableDisabled() {
+        return !options.get(FORMAT_TABLE_ENABLED);
     }
 
     @Override
@@ -607,7 +609,7 @@ public class HiveCatalog extends AbstractCatalog {
         } catch (TableNotExistException ignore) {
         }
 
-        if (!formatTableEnabled()) {
+        if (formatTableDisabled()) {
             throw new TableNotExistException(identifier);
         }
 
@@ -620,7 +622,7 @@ public class HiveCatalog extends AbstractCatalog {
 
     @Override
     public void createFormatTable(Identifier identifier, Schema schema) {
-        if (!formatTableEnabled()) {
+        if (formatTableDisabled()) {
             throw new UnsupportedOperationException(
                     "Format table is not enabled for " + identifier);
         }
@@ -731,6 +733,9 @@ public class HiveCatalog extends AbstractCatalog {
         String provider = PAIMON_TABLE_TYPE_VALUE;
         if (Options.fromMap(tableSchema.options()).get(TYPE) == FORMAT_TABLE) {
             provider = tableSchema.options().get(FILE_FORMAT.key());
+            checkNotNull(provider, FILE_FORMAT.key() + " should be configured.");
+            // valid supported format
+            FormatTable.Format.valueOf(provider.toUpperCase());
         }
         if (syncAllProperties() || !provider.equals(PAIMON_TABLE_TYPE_VALUE)) {
             tblProperties = new HashMap<>(tableSchema.options());
@@ -796,6 +801,11 @@ public class HiveCatalog extends AbstractCatalog {
     @Override
     protected void alterTableImpl(Identifier identifier, List<SchemaChange> changes)
             throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException {
+        Table table = getHmsTable(identifier);
+        if (!isPaimonTable(identifier, table)) {
+            throw new UnsupportedOperationException("Only data table support alter table.");
+        }
+
         final SchemaManager schemaManager = schemaManager(identifier, getTableLocation(identifier));
         // first commit changes to underlying files
         TableSchema schema = schemaManager.commitChanges(changes);
@@ -805,12 +815,6 @@ public class HiveCatalog extends AbstractCatalog {
             return;
         }
         try {
-            Table table =
-                    clients.run(
-                            client ->
-                                    client.getTable(
-                                            identifier.getDatabaseName(),
-                                            identifier.getTableName()));
             alterTableToHms(table, identifier, schema);
         } catch (Exception te) {
             schemaManager.deleteSchema(schema.id());

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogOptions.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogOptions.java
@@ -88,7 +88,7 @@ public final class HiveCatalogOptions {
     public static final ConfigOption<Boolean> FORMAT_TABLE_ENABLED =
             ConfigOptions.key("format-table.enabled")
                     .booleanType()
-                    .defaultValue(false)
+                    .defaultValue(true)
                     .withDescription(
                             "Whether to support format tables, format table corresponds to a regular Hive table, allowing read and write operations. "
                                     + "However, during these processes, it does not connect to the metastore; hence, newly added partitions will not be reflected in"

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogOptions.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogOptions.java
@@ -85,14 +85,5 @@ public final class HiveCatalogOptions {
                                                             + "E.g. specifying \"conf:a.b.c\" will add \"a.b.c\" to the key, and so that configurations with different default catalog wouldn't share the same client pool. Multiple conf elements can be specified."))
                                     .build());
 
-    public static final ConfigOption<Boolean> FORMAT_TABLE_ENABLED =
-            ConfigOptions.key("format-table.enabled")
-                    .booleanType()
-                    .defaultValue(true)
-                    .withDescription(
-                            "Whether to support format tables, format table corresponds to a regular Hive table, allowing read and write operations. "
-                                    + "However, during these processes, it does not connect to the metastore; hence, newly added partitions will not be reflected in"
-                                    + " the metastore and need to be manually added as separate partition operations.");
-
     private HiveCatalogOptions() {}
 }

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -273,4 +273,9 @@ public class HiveCatalogTest extends CatalogTestBase {
     protected boolean supportsView() {
         return true;
     }
+
+    @Override
+    protected boolean supportsFormatTable() {
+        return true;
+    }
 }

--- a/paimon-hive/paimon-hive-connector-2.3/src/test/java/org/apache/paimon/hive/Hive23CatalogITCase.java
+++ b/paimon-hive/paimon-hive-connector-2.3/src/test/java/org/apache/paimon/hive/Hive23CatalogITCase.java
@@ -113,7 +113,7 @@ public class Hive23CatalogITCase extends HiveCatalogITCaseBase {
     }
 
     @Test
-    public void testCreateExistTableInHive() throws Exception {
+    public void testCreateExistTableInHive() {
         tEnv.executeSql(
                 String.join(
                         "\n",
@@ -133,7 +133,6 @@ public class Hive23CatalogITCase extends HiveCatalogITCaseBase {
                                 tEnv.executeSql(
                                                 "CREATE TABLE hive_table(a INT, b INT, c INT, d INT)")
                                         .await())
-                .isInstanceOf(TableException.class)
                 .hasMessage(
                         "Could not execute CreateTable in path `my_hive_custom_client`.`test_db`.`hive_table`");
         assertThat(

--- a/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/Hive31CatalogITCase.java
+++ b/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/Hive31CatalogITCase.java
@@ -133,7 +133,6 @@ public class Hive31CatalogITCase extends HiveCatalogITCaseBase {
                                 tEnv.executeSql(
                                                 "CREATE TABLE hive_table(a INT, b INT, c INT, d INT)")
                                         .await())
-                .isInstanceOf(TableException.class)
                 .hasMessage(
                         "Could not execute CreateTable in path `my_hive_custom_client`.`test_db`.`hive_table`");
         assertThat(

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogFormatTableITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogFormatTableITCaseBase.java
@@ -147,7 +147,7 @@ public abstract class HiveCatalogFormatTableITCaseBase {
     @Test
     public void testFlinkCreateFormatTableWithDelimiter() throws Exception {
         tEnv.executeSql(
-                "CREATE TABLE flink_csv_table_delimiter (a INT, b STRING) with ('type'='format-table', 'file.format'='csv', 'csv.field-delimiter'=';')");
+                "CREATE TABLE flink_csv_table_delimiter (a INT, b STRING) with ('type'='format-table', 'file.format'='csv', 'field-delimiter'=';')");
         doTestFormatTable("flink_csv_table_delimiter");
     }
 

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogFormatTableITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogFormatTableITCaseBase.java
@@ -44,7 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.apache.paimon.hive.HiveCatalogOptions.FORMAT_TABLE_ENABLED;
+import static org.apache.paimon.options.CatalogOptions.FORMAT_TABLE_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** IT cases for using Paimon {@link HiveCatalog}. */

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -28,6 +28,7 @@ import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.spark.catalog.SparkBaseCatalog;
 import org.apache.paimon.spark.catalog.SupportFunction;
 import org.apache.paimon.table.FormatTable;
+import org.apache.paimon.table.FormatTableOptions;
 
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException;
@@ -511,8 +512,11 @@ public class SparkCatalog extends SparkBaseCatalog implements SupportFunction {
         StructType schema = SparkTypeUtils.fromPaimonRowType(formatTable.rowType());
         List<String> pathList = new ArrayList<>();
         pathList.add(formatTable.location());
-        CaseInsensitiveStringMap dsOptions = new CaseInsensitiveStringMap(formatTable.options());
+        Options options = Options.fromMap(formatTable.options());
+        CaseInsensitiveStringMap dsOptions = new CaseInsensitiveStringMap(options.toMap());
         if (formatTable.format() == FormatTable.Format.CSV) {
+            options.set("sep", options.get(FormatTableOptions.FIELD_DELIMITER));
+            dsOptions = new CaseInsensitiveStringMap(options.toMap());
             return new CSVTable(
                     ident.name(),
                     SparkSession.active(),

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkGenericCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkGenericCatalog.java
@@ -317,7 +317,7 @@ public class SparkGenericCatalog extends SparkBaseCatalog implements CatalogExte
                 options.put(METASTORE.key(), metastore);
             }
         }
-        options.put(HiveCatalogOptions.FORMAT_TABLE_ENABLED.key(), "false");
+        options.put(CatalogOptions.FORMAT_TABLE_ENABLED.key(), "false");
         String sessionCatalogDefaultDatabase = SQLConfUtils.defaultDatabase(sqlConf);
         if (options.containsKey(DEFAULT_DATABASE.key())) {
             String userDefineDefaultDatabase = options.get(DEFAULT_DATABASE.key());

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkGenericCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkGenericCatalog.java
@@ -317,6 +317,7 @@ public class SparkGenericCatalog extends SparkBaseCatalog implements CatalogExte
                 options.put(METASTORE.key(), metastore);
             }
         }
+        options.put(HiveCatalogOptions.FORMAT_TABLE_ENABLED.key(), "false");
         String sessionCatalogDefaultDatabase = SQLConfUtils.defaultDatabase(sqlConf);
         if (options.containsKey(DEFAULT_DATABASE.key())) {
             String userDefineDefaultDatabase = options.get(DEFAULT_DATABASE.key());


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

By default, we should enable PaimonCatalog to have default access to Hive tables

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
