### PR TITLE
[core] Fast return if rollback verion equals lastest version

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -512,13 +512,12 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
                 "Rollback snapshot '%s' doesn't exist.",
                 snapshotId);
 
-        Snapshot snapshot = snapshotManager.snapshot(snapshotId);
         // fast return
-        if (snapshot.equals(snapshotManager.latestSnapshot())) {
+        if (new Long(snapshotId).equals(snapshotManager.latestSnapshotId())) {
             return;
         }
 
-        rollbackHelper().cleanLargerThan(snapshot);
+        rollbackHelper().cleanLargerThan(snapshotManager.snapshot(snapshotId));
     }
 
     public Snapshot findSnapshot(long fromSnapshotId) throws SnapshotNotExistException {
@@ -633,7 +632,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
         Snapshot taggedSnapshot = tagManager.taggedSnapshot(tagName);
         SnapshotManager snapshotManager = snapshotManager();
         // fast return
-        if (taggedSnapshot.equals(snapshotManager.latestSnapshot())) {
+        if (new Long(taggedSnapshot.id()).equals(snapshotManager.latestSnapshotId())) {
             return;
         }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

If the rollback snapshot version is equal to the lastest snapshot version, we should fast return.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
