### PR TITLE
[core] Delete useless methods in Catalog

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
@@ -62,7 +62,7 @@ public class CachingCatalog extends DelegateCatalog {
 
     private static final Logger LOG = LoggerFactory.getLogger(CachingCatalog.class);
 
-    protected final Cache<String, Map<String, String>> databaseCache;
+    protected final Cache<String, Database> databaseCache;
     protected final Cache<Identifier, Table> tableCache;
     @Nullable protected final SegmentsCache<Path> manifestCache;
 
@@ -159,16 +159,15 @@ public class CachingCatalog extends DelegateCatalog {
     }
 
     @Override
-    public Map<String, String> loadDatabaseProperties(String databaseName)
-            throws DatabaseNotExistException {
-        Map<String, String> properties = databaseCache.getIfPresent(databaseName);
-        if (properties != null) {
-            return properties;
+    public Database getDatabase(String databaseName) throws DatabaseNotExistException {
+        Database database = databaseCache.getIfPresent(databaseName);
+        if (database != null) {
+            return database;
         }
 
-        properties = super.loadDatabaseProperties(databaseName);
-        databaseCache.put(databaseName, properties);
-        return properties;
+        database = super.getDatabase(databaseName);
+        databaseCache.put(databaseName, database);
+        return database;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -22,7 +22,6 @@ import org.apache.paimon.annotation.Public;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.PartitionEntry;
-import org.apache.paimon.metastore.MetastoreClient;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.Table;
@@ -33,7 +32,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.options.OptionsUtils.convertToPropertiesPrefixKey;
@@ -73,43 +71,11 @@ public interface Catalog extends AutoCloseable {
     FileIO fileIO();
 
     /**
-     * Get lock factory from catalog. Lock is used to support multiple concurrent writes on the
-     * object store.
-     */
-    Optional<CatalogLockFactory> lockFactory();
-
-    /** Get lock context for lock factory to create a lock. */
-    default Optional<CatalogLockContext> lockContext() {
-        return Optional.empty();
-    }
-
-    /** Get metastore client factory for the table specified by {@code identifier}. */
-    default Optional<MetastoreClient.Factory> metastoreClientFactory(Identifier identifier)
-            throws TableNotExistException {
-        return Optional.empty();
-    }
-
-    /**
      * Get the names of all databases in this catalog.
      *
      * @return a list of the names of all databases
      */
     List<String> listDatabases();
-
-    /**
-     * Check if a database exists in this catalog.
-     *
-     * @param databaseName Name of the database
-     * @return true if the given database exists in the catalog false otherwise
-     */
-    default boolean databaseExists(String databaseName) {
-        try {
-            loadDatabaseProperties(databaseName);
-            return true;
-        } catch (DatabaseNotExistException e) {
-            return false;
-        }
-    }
 
     /**
      * Create a database, see {@link Catalog#createDatabase(String name, boolean ignoreIfExists, Map
@@ -141,7 +107,7 @@ public interface Catalog extends AutoCloseable {
      * @return The requested database's properties
      * @throws DatabaseNotExistException if the requested database does not exist
      */
-    Map<String, String> loadDatabaseProperties(String name) throws DatabaseNotExistException;
+    Database getDatabase(String name) throws DatabaseNotExistException;
 
     /**
      * Drop a database.
@@ -185,20 +151,6 @@ public interface Catalog extends AutoCloseable {
      * @throws DatabaseNotExistException if the database does not exist
      */
     List<String> listTables(String databaseName) throws DatabaseNotExistException;
-
-    /**
-     * Check if a table exists in this catalog.
-     *
-     * @param identifier Path of the table
-     * @return true if the given table exists in the catalog false otherwise
-     */
-    default boolean tableExists(Identifier identifier) {
-        try {
-            return getTable(identifier) != null;
-        } catch (TableNotExistException e) {
-            return false;
-        }
-    }
 
     /**
      * Drop a table.
@@ -273,6 +225,9 @@ public interface Catalog extends AutoCloseable {
     /**
      * Create the partition of the specify table.
      *
+     * <p>Only catalog with metastore can support this method, and only table with
+     * 'metastore.partitioned-table' can support this method.
+     *
      * @param identifier path of the table to drop partition
      * @param partitionSpec the partition to be created
      * @throws TableNotExistException if the table does not exist
@@ -313,20 +268,6 @@ public interface Catalog extends AutoCloseable {
     default void alterTable(Identifier identifier, SchemaChange change, boolean ignoreIfNotExists)
             throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException {
         alterTable(identifier, Collections.singletonList(change), ignoreIfNotExists);
-    }
-
-    /**
-     * Check if a view exists in this catalog.
-     *
-     * @param identifier Path of the view
-     * @return true if the given view exists in the catalog false otherwise
-     */
-    default boolean viewExists(Identifier identifier) {
-        try {
-            return getView(identifier) != null;
-        } catch (ViewNotExistException e) {
-            return false;
-        }
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -101,10 +101,10 @@ public interface Catalog extends AutoCloseable {
             throws DatabaseAlreadyExistException;
 
     /**
-     * Load database properties.
+     * Return a {@link Database} identified by the given name.
      *
      * @param name Database name
-     * @return The requested database's properties
+     * @return The requested {@link Database}
      * @throws DatabaseNotExistException if the requested database does not exist
      */
     Database getDatabase(String name) throws DatabaseNotExistException;

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Database.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Database.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.catalog;
+
+import org.apache.paimon.annotation.Public;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Interface of a database in a catalog.
+ *
+ * @since 1.0
+ */
+@Public
+public interface Database {
+
+    /** A name to identify this database. */
+    String name();
+
+    /** Options of this database. */
+    Map<String, String> options();
+
+    /** Optional comment of this database. */
+    Optional<String> comment();
+
+    static Database of(String name, Map<String, String> options, @Nullable String comment) {
+        return new DatabaseImpl(name, options, comment);
+    }
+
+    static Database of(String name) {
+        return new DatabaseImpl(name, new HashMap<>(), null);
+    }
+
+    /** Implementation of {@link Database}. */
+    class DatabaseImpl implements Database {
+
+        private final String name;
+        private final Map<String, String> options;
+        @Nullable private final String comment;
+
+        public DatabaseImpl(String name, Map<String, String> options, @Nullable String comment) {
+            this.name = name;
+            this.options = options;
+            this.comment = comment;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public Map<String, String> options() {
+            return options;
+        }
+
+        @Override
+        public Optional<String> comment() {
+            return Optional.ofNullable(comment);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -21,7 +21,6 @@ package org.apache.paimon.catalog;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.PartitionEntry;
-import org.apache.paimon.metastore.MetastoreClient;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.Table;
@@ -29,7 +28,6 @@ import org.apache.paimon.view.View;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /** A {@link Catalog} to delegate all operations to another {@link Catalog}. */
 public class DelegateCatalog implements Catalog {
@@ -65,22 +63,6 @@ public class DelegateCatalog implements Catalog {
     }
 
     @Override
-    public Optional<CatalogLockFactory> lockFactory() {
-        return wrapped.lockFactory();
-    }
-
-    @Override
-    public Optional<CatalogLockContext> lockContext() {
-        return wrapped.lockContext();
-    }
-
-    @Override
-    public Optional<MetastoreClient.Factory> metastoreClientFactory(Identifier identifier)
-            throws TableNotExistException {
-        return wrapped.metastoreClientFactory(identifier);
-    }
-
-    @Override
     public List<String> listDatabases() {
         return wrapped.listDatabases();
     }
@@ -92,9 +74,8 @@ public class DelegateCatalog implements Catalog {
     }
 
     @Override
-    public Map<String, String> loadDatabaseProperties(String name)
-            throws DatabaseNotExistException {
-        return wrapped.loadDatabaseProperties(name);
+    public Database getDatabase(String name) throws DatabaseNotExistException {
+        return wrapped.getDatabase(name);
     }
 
     @Override
@@ -136,16 +117,6 @@ public class DelegateCatalog implements Catalog {
     @Override
     public Table getTable(Identifier identifier) throws TableNotExistException {
         return wrapped.getTable(identifier);
-    }
-
-    @Override
-    public boolean tableExists(Identifier identifier) {
-        return wrapped.tableExists(identifier);
-    }
-
-    @Override
-    public boolean viewExists(Identifier identifier) {
-        return wrapped.viewExists(identifier);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
@@ -30,7 +30,6 @@ import org.apache.paimon.schema.TableSchema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -81,12 +80,11 @@ public class FileSystemCatalog extends AbstractCatalog {
     }
 
     @Override
-    public Map<String, String> loadDatabasePropertiesImpl(String name)
-            throws DatabaseNotExistException {
+    public Database getDatabaseImpl(String name) throws DatabaseNotExistException {
         if (!uncheck(() -> fileIO.exists(newDatabasePath(name)))) {
             throw new DatabaseNotExistException(name);
         }
-        return Collections.emptyMap();
+        return Database.of(name);
     }
 
     @Override
@@ -97,16 +95,6 @@ public class FileSystemCatalog extends AbstractCatalog {
     @Override
     protected List<String> listTablesImpl(String databaseName) {
         return uncheck(() -> listTablesInFileSystem(newDatabasePath(databaseName)));
-    }
-
-    @Override
-    public boolean tableExists(Identifier identifier) {
-        if (isTableInSystemDatabase(identifier)) {
-            return super.tableExists(identifier);
-        }
-
-        return tableExistsInFileSystem(
-                getTableLocation(identifier), identifier.getBranchNameOrDefault());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
@@ -22,6 +22,7 @@ import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.AbstractCatalog;
 import org.apache.paimon.catalog.CatalogLockContext;
 import org.apache.paimon.catalog.CatalogLockFactory;
+import org.apache.paimon.catalog.Database;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
@@ -159,18 +160,17 @@ public class JdbcCatalog extends AbstractCatalog {
     }
 
     @Override
-    protected Map<String, String> loadDatabasePropertiesImpl(String databaseName)
-            throws DatabaseNotExistException {
+    protected Database getDatabaseImpl(String databaseName) throws DatabaseNotExistException {
         if (!JdbcUtils.databaseExists(connections, catalogKey, databaseName)) {
             throw new DatabaseNotExistException(databaseName);
         }
-        Map<String, String> properties = Maps.newHashMap();
-        properties.putAll(fetchProperties(databaseName));
-        if (!properties.containsKey(DB_LOCATION_PROP)) {
-            properties.put(DB_LOCATION_PROP, newDatabasePath(databaseName).getName());
+        Map<String, String> options = Maps.newHashMap();
+        options.putAll(fetchProperties(databaseName));
+        if (!options.containsKey(DB_LOCATION_PROP)) {
+            options.put(DB_LOCATION_PROP, newDatabasePath(databaseName).getName());
         }
-        properties.remove(DATABASE_EXISTS_PROPERTY);
-        return ImmutableMap.copyOf(properties);
+        options.remove(DATABASE_EXISTS_PROPERTY);
+        return Database.of(databaseName, options, null);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedCatalog.java
@@ -102,12 +102,16 @@ public class PrivilegedCatalog extends DelegateCatalog {
             throws TableNotExistException, TableAlreadyExistException {
         privilegeManager.getPrivilegeChecker().assertCanAlterTable(fromTable);
         wrapped.renameTable(fromTable, toTable, ignoreIfNotExists);
-        Preconditions.checkState(
-                wrapped.tableExists(toTable),
-                "Table "
-                        + toTable
-                        + " does not exist. There might be concurrent renaming. "
-                        + "Aborting updates in privilege system.");
+
+        try {
+            getTable(toTable);
+        } catch (TableNotExistException e) {
+            throw new IllegalStateException(
+                    "Table "
+                            + toTable
+                            + " does not exist. There might be concurrent renaming. "
+                            + "Aborting updates in privilege system.");
+        }
         privilegeManager.objectRenamed(fromTable.getFullName(), toTable.getFullName());
     }
 
@@ -157,8 +161,11 @@ public class PrivilegedCatalog extends DelegateCatalog {
         Preconditions.checkArgument(
                 privilege.canGrantOnDatabase(),
                 "Privilege " + privilege + " can't be granted on a database");
-        Preconditions.checkArgument(
-                databaseExists(databaseName), "Database " + databaseName + " does not exist");
+        try {
+            getDatabase(databaseName);
+        } catch (DatabaseNotExistException e) {
+            throw new IllegalArgumentException("Database " + databaseName + " does not exist");
+        }
         privilegeManager.grant(user, databaseName, privilege);
     }
 
@@ -166,8 +173,12 @@ public class PrivilegedCatalog extends DelegateCatalog {
         Preconditions.checkArgument(
                 privilege.canGrantOnTable(),
                 "Privilege " + privilege + " can't be granted on a table");
-        Preconditions.checkArgument(
-                tableExists(identifier), "Table " + identifier + " does not exist");
+
+        try {
+            getTable(identifier);
+        } catch (TableNotExistException e) {
+            throw new IllegalArgumentException("Table " + identifier + " does not exist");
+        }
         privilegeManager.grant(user, identifier.getFullName(), privilege);
     }
 

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MigrateFileProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MigrateFileProcedure.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.procedure;
 
+import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.utils.TableMigrationUtils;
 import org.apache.paimon.migrate.Migrator;
@@ -88,7 +89,9 @@ public class MigrateFileProcedure extends ProcedureBase {
         Identifier sourceTableId = Identifier.fromString(sourceTablePath);
         Identifier targetTableId = Identifier.fromString(targetPaimonTablePath);
 
-        if (!(catalog.tableExists(targetTableId))) {
+        try {
+            catalog.getTable(targetTableId);
+        } catch (Catalog.TableNotExistException e) {
             throw new IllegalArgumentException(
                     "Target paimon table does not exist: " + targetPaimonTablePath);
         }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionBase.java
@@ -122,7 +122,7 @@ public abstract class SyncTableActionBase extends SynchronizationActionBase {
     protected void beforeBuildingSourceSink() throws Exception {
         Identifier identifier = new Identifier(database, table);
         // Check if table exists before trying to get or create it
-        if (catalog.tableExists(identifier)) {
+        try {
             fileStoreTable = (FileStoreTable) catalog.getTable(identifier);
             fileStoreTable = alterTableOptions(identifier, fileStoreTable);
             try {
@@ -146,7 +146,7 @@ public abstract class SyncTableActionBase extends SynchronizationActionBase {
                 // check partition keys and primary keys in case that user specified them
                 checkConstraints();
             }
-        } else {
+        } catch (Catalog.TableNotExistException e) {
             Schema retrievedSchema = retrieveSchema();
             computedColumns = buildComputedColumns(computedColumnArgs, retrievedSchema.fields());
             Schema paimonSchema = buildPaimonSchema(retrievedSchema);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/log/LogStoreRegister.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/log/LogStoreRegister.java
@@ -46,11 +46,14 @@ public interface LogStoreRegister {
             ClassLoader classLoader) {
         Options tableOptions = Options.fromMap(options);
         String logStore = tableOptions.get(LOG_SYSTEM);
-        if (!tableOptions.get(LOG_SYSTEM).equalsIgnoreCase(NONE)
-                && !catalog.tableExists(identifier)) {
-            LogStoreRegister logStoreRegister =
-                    getLogStoreRegister(identifier, classLoader, tableOptions, logStore);
-            options.putAll(logStoreRegister.registerTopic());
+        if (!tableOptions.get(LOG_SYSTEM).equalsIgnoreCase(NONE)) {
+            try {
+                catalog.getTable(identifier);
+            } catch (Catalog.TableNotExistException e) {
+                LogStoreRegister logStoreRegister =
+                        getLogStoreRegister(identifier, classLoader, tableOptions, logStore);
+                options.putAll(logStoreRegister.registerTopic());
+            }
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateFileProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MigrateFileProcedure.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.procedure;
 
+import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.utils.TableMigrationUtils;
 import org.apache.paimon.migrate.Migrator;
@@ -77,7 +78,9 @@ public class MigrateFileProcedure extends ProcedureBase {
         Identifier sourceTableId = Identifier.fromString(sourceTablePath);
         Identifier targetTableId = Identifier.fromString(targetPaimonTablePath);
 
-        if (!(catalog.tableExists(targetTableId))) {
+        try {
+            catalog.getTable(targetTableId);
+        } catch (Catalog.TableNotExistException e) {
             throw new IllegalArgumentException(
                     "Target paimon table does not exist: " + targetPaimonTablePath);
         }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateFileProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateFileProcedure.java
@@ -88,7 +88,9 @@ public class MigrateFileProcedure extends BaseProcedure {
 
         Catalog paimonCatalog = ((WithPaimonCatalog) tableCatalog()).paimonCatalog();
 
-        if (!(paimonCatalog.tableExists(targetTableId))) {
+        try {
+            paimonCatalog.getTable(targetTableId);
+        } catch (Catalog.TableNotExistException e) {
             throw new IllegalArgumentException(
                     "Target paimon table does not exist: " + targetTable);
         }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Delete follow methods in Catalog because of useless, We recommend using methods such as `getTable` directly to avoid errors in implementation.
```
    /**
     * Get lock factory from catalog. Lock is used to support multiple concurrent writes on the
     * object store.
     */
    Optional<CatalogLockFactory> lockFactory();

    /** Get lock context for lock factory to create a lock. */
    default Optional<CatalogLockContext> lockContext() {
        return Optional.empty();
    }

    /** Get metastore client factory for the table specified by {@code identifier}. */
    default Optional<MetastoreClient.Factory> metastoreClientFactory(Identifier identifier)
            throws TableNotExistException {
        return Optional.empty();
    }
```

Delete follow methods in Catalog because of repetitive:
```
    /**
     * Check if a database exists in this catalog.
     *
     * @param databaseName Name of the database
     * @return true if the given database exists in the catalog false otherwise
     */
    default boolean databaseExists(String databaseName) {
        try {
            loadDatabaseProperties(databaseName);
            return true;
        } catch (DatabaseNotExistException e) {
            return false;
        }
    }

    /**
     * Check if a table exists in this catalog.
     *
     * @param identifier Path of the table
     * @return true if the given table exists in the catalog false otherwise
     */
    default boolean tableExists(Identifier identifier) {
        try {
            return getTable(identifier) != null;
        } catch (TableNotExistException e) {
            return false;
        }
    }

    /**
     * Check if a view exists in this catalog.
     *
     * @param identifier Path of the view
     * @return true if the given view exists in the catalog false otherwise
     */
    default boolean viewExists(Identifier identifier) {
        try {
            return getView(identifier) != null;
        } catch (ViewNotExistException e) {
            return false;
        }
    }
```

Modify `loadDatabaseProperties` in Catalog because we can have a better naming for `getDatabase`:
```
    /**
     * Return a {@link Database} identified by the given name.
     *
     * @param name Database name
     * @return The requested {@link Database}
     * @throws DatabaseNotExistException if the requested database does not exist
     */
    Database getDatabase(String name) throws DatabaseNotExistException;
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

Existing tests.

### API and Format

<!-- Does this change affect API or storage format -->

Catalog API.

### Documentation

<!-- Does this change introduce a new feature -->
