### PR TITLE
commit failed, add table name to the log

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -72,6 +72,7 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
     protected final FileIO fileIO;
     protected final SchemaManager schemaManager;
     protected final TableSchema schema;
+    protected final String tableName;
     protected final CoreOptions options;
     protected final RowType partitionType;
     private final CatalogEnvironment catalogEnvironment;
@@ -83,12 +84,14 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
             FileIO fileIO,
             SchemaManager schemaManager,
             TableSchema schema,
+            String tableName,
             CoreOptions options,
             RowType partitionType,
             CatalogEnvironment catalogEnvironment) {
         this.fileIO = fileIO;
         this.schemaManager = schemaManager;
         this.schema = schema;
+        this.tableName = tableName;
         this.options = options;
         this.partitionType = partitionType;
         this.catalogEnvironment = catalogEnvironment;
@@ -209,6 +212,7 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
         return new FileStoreCommitImpl(
                 fileIO,
                 schemaManager,
+                tableName,
                 commitUser,
                 partitionType,
                 options.partitionDefaultName(),

--- a/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
@@ -49,7 +49,6 @@ public class AppendOnlyFileStore extends AbstractFileStore<InternalRow> {
 
     private final RowType bucketKeyType;
     private final RowType rowType;
-    private final String tableName;
 
     public AppendOnlyFileStore(
             FileIO fileIO,
@@ -61,10 +60,9 @@ public class AppendOnlyFileStore extends AbstractFileStore<InternalRow> {
             RowType rowType,
             String tableName,
             CatalogEnvironment catalogEnvironment) {
-        super(fileIO, schemaManager, schema, options, partitionType, catalogEnvironment);
+        super(fileIO, schemaManager, schema, tableName, options, partitionType, catalogEnvironment);
         this.bucketKeyType = bucketKeyType;
         this.rowType = rowType;
-        this.tableName = tableName;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -70,7 +70,6 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
     private final Supplier<Comparator<InternalRow>> keyComparatorSupplier;
     private final Supplier<RecordEqualiser> logDedupEqualSupplier;
     private final MergeFunctionFactory<KeyValue> mfFactory;
-    private final String tableName;
 
     public KeyValueFileStore(
             FileIO fileIO,
@@ -86,7 +85,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
             MergeFunctionFactory<KeyValue> mfFactory,
             String tableName,
             CatalogEnvironment catalogEnvironment) {
-        super(fileIO, schemaManager, schema, options, partitionType, catalogEnvironment);
+        super(fileIO, schemaManager, schema, tableName, options, partitionType, catalogEnvironment);
         this.crossPartitionUpdate = crossPartitionUpdate;
         this.bucketKeyType = bucketKeyType;
         this.keyType = keyType;
@@ -99,7 +98,6 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                 options.changelogRowDeduplicate()
                         ? ValueEqualiserSupplier.fromIgnoreFields(valueType, logDedupIgnoreFields)
                         : () -> null;
-        this.tableName = tableName;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -112,6 +112,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
     private final FileIO fileIO;
     private final SchemaManager schemaManager;
+    private final String tableName;
     private final String commitUser;
     private final RowType partitionType;
     private final String partitionDefaultName;
@@ -142,6 +143,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
     public FileStoreCommitImpl(
             FileIO fileIO,
             SchemaManager schemaManager,
+            String tableName,
             String commitUser,
             RowType partitionType,
             String partitionDefaultName,
@@ -165,6 +167,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             int commitMaxRetries) {
         this.fileIO = fileIO;
         this.schemaManager = schemaManager;
+        this.tableName = tableName;
         this.commitUser = commitUser;
         this.partitionType = partitionType;
         this.partitionDefaultName = partitionDefaultName;
@@ -1331,8 +1334,9 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             for (SimpleFileEntry entry : mergedEntries) {
                 Preconditions.checkState(
                         entry.kind() != FileKind.DELETE,
-                        "Trying to delete file %s which is not previously added.",
-                        entry.fileName());
+                        "Trying to delete file %s for table %s which is not previously added.",
+                        entry.fileName(),
+                        tableName);
             }
         } catch (Throwable e) {
             if (partitionExpire != null && partitionExpire.isValueExpiration()) {


### PR DESCRIPTION
### Purpose

flink cdc pipeline writes multiple paimon. If write fails, only file name information, no table name.