### PR TITLE
[core] Add batch add partitions in MetastoreClient

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/metastore/AddPartitionCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/AddPartitionCommitCallback.java
@@ -90,7 +90,9 @@ public class AddPartitionCommitCallback implements CommitCallback {
         try {
             List<BinaryRow> filteredPartitions = new ArrayList<>();
             for (BinaryRow partition : partitions) {
-                if (!cache.get(partition, () -> false)) filteredPartitions.add(partition);
+                if (!cache.get(partition, () -> false)) {
+                    filteredPartitions.add(partition);
+                }
             }
             client.addPartitions(filteredPartitions);
             filteredPartitions.forEach(partition -> cache.put(partition, true));

--- a/paimon-core/src/main/java/org/apache/paimon/metastore/AddPartitionCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/AddPartitionCommitCallback.java
@@ -88,14 +88,16 @@ public class AddPartitionCommitCallback implements CommitCallback {
 
     private void addPartitions(Set<BinaryRow> partitions) {
         try {
-            List<BinaryRow> filteredPartitions = new ArrayList<>();
+            List<BinaryRow> newPartitions = new ArrayList<>();
             for (BinaryRow partition : partitions) {
                 if (!cache.get(partition, () -> false)) {
-                    filteredPartitions.add(partition);
+                    newPartitions.add(partition);
                 }
             }
-            client.addPartitions(filteredPartitions);
-            filteredPartitions.forEach(partition -> cache.put(partition, true));
+            if (!newPartitions.isEmpty()) {
+                client.addPartitions(newPartitions);
+                newPartitions.forEach(partition -> cache.put(partition, true));
+            }
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/metastore/AddPartitionCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/AddPartitionCommitCallback.java
@@ -30,7 +30,10 @@ import org.apache.paimon.shade.guava30.com.google.common.cache.Cache;
 import org.apache.paimon.shade.guava30.com.google.common.cache.CacheBuilder;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /** A {@link CommitCallback} to add newly created partitions to metastore. */
 public class AddPartitionCommitCallback implements CommitCallback {
@@ -52,19 +55,21 @@ public class AddPartitionCommitCallback implements CommitCallback {
 
     @Override
     public void call(List<ManifestEntry> committedEntries, Snapshot snapshot) {
-        committedEntries.stream()
-                .filter(e -> FileKind.ADD.equals(e.kind()))
-                .map(ManifestEntry::partition)
-                .distinct()
-                .forEach(this::addPartition);
+        Set<BinaryRow> partitions =
+                committedEntries.stream()
+                        .filter(e -> FileKind.ADD.equals(e.kind()))
+                        .map(ManifestEntry::partition)
+                        .collect(Collectors.toSet());
+        addPartitions(partitions);
     }
 
     @Override
     public void retry(ManifestCommittable committable) {
-        committable.fileCommittables().stream()
-                .map(CommitMessage::partition)
-                .distinct()
-                .forEach(this::addPartition);
+        Set<BinaryRow> partitions =
+                committable.fileCommittables().stream()
+                        .map(CommitMessage::partition)
+                        .collect(Collectors.toSet());
+        addPartitions(partitions);
     }
 
     private void addPartition(BinaryRow partition) {
@@ -76,6 +81,19 @@ public class AddPartitionCommitCallback implements CommitCallback {
 
             client.addPartition(partition);
             cache.put(partition, true);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void addPartitions(Set<BinaryRow> partitions) {
+        try {
+            List<BinaryRow> filteredPartitions = new ArrayList<>();
+            for (BinaryRow partition : partitions) {
+                if (!cache.get(partition, () -> false)) filteredPartitions.add(partition);
+            }
+            client.addPartitions(filteredPartitions);
+            filteredPartitions.forEach(partition -> cache.put(partition, true));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/metastore/MetastoreClient.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/MetastoreClient.java
@@ -22,6 +22,7 @@ import org.apache.paimon.data.BinaryRow;
 
 import java.io.Serializable;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -32,7 +33,20 @@ public interface MetastoreClient extends AutoCloseable {
 
     void addPartition(BinaryRow partition) throws Exception;
 
+    default void addPartitions(List<BinaryRow> partitions) throws Exception {
+        for (BinaryRow partition : partitions) {
+            addPartition(partition);
+        }
+    }
+
     void addPartition(LinkedHashMap<String, String> partitionSpec) throws Exception;
+
+    default void addPartitionsSpec(List<LinkedHashMap<String, String>> partitionSpecsList)
+            throws Exception {
+        for (LinkedHashMap<String, String> partitionSpecs : partitionSpecsList) {
+            addPartition(partitionSpecs);
+        }
+    }
 
     void deletePartition(LinkedHashMap<String, String> partitionSpec) throws Exception;
 

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
@@ -352,7 +352,7 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
           .column("ts", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE())
           .column("ts_ntz", DataTypes.TIMESTAMP())
           .build
-        catalog.createTable(identifier, schema, false)
+        paimonCatalog.createTable(identifier, schema, false)
         sql(
           s"INSERT INTO paimon_tbl VALUES (timestamp'2024-01-01 00:00:00', timestamp_ntz'2024-01-01 00:00:00')")
 
@@ -370,7 +370,7 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
         // Due to previous design, read timestamp ltz type with spark 3.3 and below will cause problems,
         // skip testing it
         if (gteqSpark3_4) {
-          val table = catalog.getTable(identifier)
+          val table = paimonCatalog.getTable(identifier)
           val builder = table.newReadBuilder.withProjection(Array[Int](0, 1))
           val splits = builder.newScan().plan().splits()
           builder.newRead
@@ -405,7 +405,7 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
           // Due to previous design, read timestamp ltz type with spark 3.3 and below will cause problems,
           // skip testing it
           if (gteqSpark3_4) {
-            val table = catalog.getTable(identifier)
+            val table = paimonCatalog.getTable(identifier)
             val builder = table.newReadBuilder.withProjection(Array[Int](0, 1))
             val splits = builder.newScan().plan().splits()
             builder.newRead
@@ -423,7 +423,7 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
         }
       }
     } finally {
-      catalog.dropTable(identifier, true)
+      paimonCatalog.dropTable(identifier, true)
     }
   }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

hiveClient support `client.add_partitions` to add partitions at once, we can use it in AddPartitionCommitCallback

this speeds up the load table a lot when have many partitions to sync.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
