### PR TITLE
[core][spark] Support adding and dropping nested columns in Spark

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -536,7 +536,7 @@ public abstract class AbstractCatalog implements Catalog {
         for (SchemaChange change : changes) {
             if (change instanceof SchemaChange.AddColumn) {
                 SchemaChange.AddColumn addColumn = (SchemaChange.AddColumn) change;
-                fieldNames.add(addColumn.fieldName());
+                fieldNames.addAll(addColumn.fieldNames());
             } else if (change instanceof SchemaChange.RenameColumn) {
                 SchemaChange.RenameColumn rename = (SchemaChange.RenameColumn) change;
                 fieldNames.add(rename.newName());

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaChange.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaChange.java
@@ -25,6 +25,8 @@ import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -52,11 +54,16 @@ public interface SchemaChange extends Serializable {
     }
 
     static SchemaChange addColumn(String fieldName, DataType dataType, String comment) {
-        return new AddColumn(fieldName, dataType, comment, null);
+        return new AddColumn(Collections.singletonList(fieldName), dataType, comment, null);
     }
 
     static SchemaChange addColumn(String fieldName, DataType dataType, String comment, Move move) {
-        return new AddColumn(fieldName, dataType, comment, move);
+        return new AddColumn(Collections.singletonList(fieldName), dataType, comment, move);
+    }
+
+    static SchemaChange addColumn(
+            List<String> fieldNames, DataType dataType, String comment, Move move) {
+        return new AddColumn(fieldNames, dataType, comment, move);
     }
 
     static SchemaChange renameColumn(String fieldName, String newName) {
@@ -64,7 +71,11 @@ public interface SchemaChange extends Serializable {
     }
 
     static SchemaChange dropColumn(String fieldName) {
-        return new DropColumn(fieldName);
+        return new DropColumn(Collections.singletonList(fieldName));
+    }
+
+    static SchemaChange dropColumn(List<String> fieldNames) {
+        return new DropColumn(fieldNames);
     }
 
     static SchemaChange updateColumnType(String fieldName, DataType newDataType) {
@@ -207,20 +218,21 @@ public interface SchemaChange extends Serializable {
 
         private static final long serialVersionUID = 1L;
 
-        private final String fieldName;
+        private final List<String> fieldNames;
         private final DataType dataType;
         private final String description;
         private final Move move;
 
-        private AddColumn(String fieldName, DataType dataType, String description, Move move) {
-            this.fieldName = fieldName;
+        private AddColumn(
+                List<String> fieldNames, DataType dataType, String description, Move move) {
+            this.fieldNames = fieldNames;
             this.dataType = dataType;
             this.description = description;
             this.move = move;
         }
 
-        public String fieldName() {
-            return fieldName;
+        public List<String> fieldNames() {
+            return fieldNames;
         }
 
         public DataType dataType() {
@@ -246,7 +258,7 @@ public interface SchemaChange extends Serializable {
                 return false;
             }
             AddColumn addColumn = (AddColumn) o;
-            return Objects.equals(fieldName, addColumn.fieldName)
+            return Objects.equals(fieldNames, addColumn.fieldNames)
                     && dataType.equals(addColumn.dataType)
                     && Objects.equals(description, addColumn.description)
                     && move.equals(addColumn.move);
@@ -255,7 +267,7 @@ public interface SchemaChange extends Serializable {
         @Override
         public int hashCode() {
             int result = Objects.hash(dataType, description);
-            result = 31 * result + Objects.hashCode(fieldName);
+            result = 31 * result + Objects.hashCode(fieldNames);
             result = 31 * result + Objects.hashCode(move);
             return result;
         }
@@ -308,14 +320,14 @@ public interface SchemaChange extends Serializable {
 
         private static final long serialVersionUID = 1L;
 
-        private final String fieldName;
+        private final List<String> fieldNames;
 
-        private DropColumn(String fieldName) {
-            this.fieldName = fieldName;
+        private DropColumn(List<String> fieldNames) {
+            this.fieldNames = fieldNames;
         }
 
-        public String fieldName() {
-            return fieldName;
+        public List<String> fieldNames() {
+            return fieldNames;
         }
 
         @Override
@@ -327,12 +339,12 @@ public interface SchemaChange extends Serializable {
                 return false;
             }
             DropColumn that = (DropColumn) o;
-            return Objects.equals(fieldName, that.fieldName);
+            return Objects.equals(fieldNames, that.fieldNames);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(fieldName);
+            return Objects.hashCode(fieldNames);
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -241,8 +241,7 @@ public class SchemaManager implements Serializable {
 
     /** Update {@link SchemaChange}s. */
     public TableSchema commitChanges(List<SchemaChange> changes)
-            throws Catalog.TableNotExistException,
-                    Catalog.ColumnAlreadyExistException,
+            throws Catalog.TableNotExistException, Catalog.ColumnAlreadyExistException,
                     Catalog.ColumnNotExistException {
         SnapshotManager snapshotManager = new SnapshotManager(fileIO, tableRoot, branch);
         boolean hasSnapshots = (snapshotManager.latestSnapshotId() != null);

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -40,7 +40,6 @@ import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeCasts;
-import org.apache.paimon.types.DataTypeVisitor;
 import org.apache.paimon.types.ReassignFieldId;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.BranchManager;
@@ -282,44 +281,52 @@ public class SchemaManager implements Serializable {
                 } else if (change instanceof AddColumn) {
                     AddColumn addColumn = (AddColumn) change;
                     SchemaChange.Move move = addColumn.move();
-                    if (newFields.stream().anyMatch(f -> f.name().equals(addColumn.fieldName()))) {
-                        throw new Catalog.ColumnAlreadyExistException(
-                                identifierFromPath(tableRoot.toString(), true, branch),
-                                addColumn.fieldName());
-                    }
                     Preconditions.checkArgument(
                             addColumn.dataType().isNullable(),
                             "Column %s cannot specify NOT NULL in the %s table.",
-                            addColumn.fieldName(),
+                            addColumn.fieldNames(),
                             identifierFromPath(tableRoot.toString(), true, branch).getFullName());
                     int id = highestFieldId.incrementAndGet();
                     DataType dataType =
                             ReassignFieldId.reassign(addColumn.dataType(), highestFieldId);
 
-                    DataField dataField =
-                            new DataField(
-                                    id, addColumn.fieldName(), dataType, addColumn.description());
+                    new NestedColumnModifier<Catalog.ColumnAlreadyExistException>(
+                            addColumn.fieldNames().toArray(new String[0])) {
+                        @Override
+                        protected void updateLastColumn(List<DataField> newFields, String fieldName)
+                                throws Catalog.ColumnAlreadyExistException {
+                            for (DataField field : newFields) {
+                                if (field.name().equals(fieldName)) {
+                                    throw new Catalog.ColumnAlreadyExistException(
+                                            identifierFromPath(tableRoot.toString(), true, branch),
+                                            addColumn.fieldNames().toString());
+                                }
+                            }
 
-                    // key: name ; value : index
-                    Map<String, Integer> map = new HashMap<>();
-                    for (int i = 0; i < newFields.size(); i++) {
-                        map.put(newFields.get(i).name(), i);
-                    }
+                            DataField dataField =
+                                    new DataField(id, fieldName, dataType, addColumn.description());
 
-                    if (null != move) {
-                        if (move.type().equals(SchemaChange.Move.MoveType.FIRST)) {
-                            newFields.add(0, dataField);
-                        } else if (move.type().equals(SchemaChange.Move.MoveType.AFTER)) {
-                            int fieldIndex = map.get(move.referenceFieldName());
-                            newFields.add(fieldIndex + 1, dataField);
+                            // key: name ; value : index
+                            Map<String, Integer> map = new HashMap<>();
+                            for (int i = 0; i < newFields.size(); i++) {
+                                map.put(newFields.get(i).name(), i);
+                            }
+
+                            if (null != move) {
+                                if (move.type().equals(SchemaChange.Move.MoveType.FIRST)) {
+                                    newFields.add(0, dataField);
+                                } else if (move.type().equals(SchemaChange.Move.MoveType.AFTER)) {
+                                    int fieldIndex = map.get(move.referenceFieldName());
+                                    newFields.add(fieldIndex + 1, dataField);
+                                }
+                            } else {
+                                newFields.add(dataField);
+                            }
                         }
-                    } else {
-                        newFields.add(dataField);
-                    }
-
+                    }.updateIntermediateColumn(newFields, 0);
                 } else if (change instanceof RenameColumn) {
                     RenameColumn rename = (RenameColumn) change;
-                    columnChangeValidation(oldTableSchema, change);
+                    renameColumnValidation(oldTableSchema, rename);
                     if (newFields.stream().anyMatch(f -> f.name().equals(rename.newName()))) {
                         throw new Catalog.ColumnAlreadyExistException(
                                 identifierFromPath(tableRoot.toString(), true, branch),
@@ -329,7 +336,6 @@ public class SchemaManager implements Serializable {
                     updateNestedColumn(
                             newFields,
                             new String[] {rename.fieldName()},
-                            0,
                             (field) ->
                                     new DataField(
                                             field.id(),
@@ -338,16 +344,23 @@ public class SchemaManager implements Serializable {
                                             field.description()));
                 } else if (change instanceof DropColumn) {
                     DropColumn drop = (DropColumn) change;
-                    columnChangeValidation(oldTableSchema, change);
-                    if (!newFields.removeIf(
-                            f -> f.name().equals(((DropColumn) change).fieldName()))) {
-                        throw new Catalog.ColumnNotExistException(
-                                identifierFromPath(tableRoot.toString(), true, branch),
-                                drop.fieldName());
-                    }
-                    if (newFields.isEmpty()) {
-                        throw new IllegalArgumentException("Cannot drop all fields in table");
-                    }
+                    dropColumnValidation(oldTableSchema, drop);
+                    new NestedColumnModifier<Catalog.ColumnNotExistException>(
+                            drop.fieldNames().toArray(new String[0])) {
+                        @Override
+                        protected void updateLastColumn(List<DataField> newFields, String fieldName)
+                                throws Catalog.ColumnNotExistException {
+                            if (!newFields.removeIf(f -> f.name().equals(fieldName))) {
+                                throw new Catalog.ColumnNotExistException(
+                                        identifierFromPath(tableRoot.toString(), true, branch),
+                                        drop.fieldNames().toString());
+                            }
+                            if (newFields.isEmpty()) {
+                                throw new IllegalArgumentException(
+                                        "Cannot drop all fields in table");
+                            }
+                        }
+                    }.updateIntermediateColumn(newFields, 0);
                 } else if (change instanceof UpdateColumnType) {
                     UpdateColumnType update = (UpdateColumnType) change;
                     if (oldTableSchema.partitionKeys().contains(update.fieldName())) {
@@ -356,9 +369,9 @@ public class SchemaManager implements Serializable {
                                         "Cannot update partition column [%s] type in the table[%s].",
                                         update.fieldName(), tableRoot.getName()));
                     }
-                    updateColumn(
+                    updateNestedColumn(
                             newFields,
-                            update.fieldName(),
+                            new String[] {update.fieldName()},
                             (field) -> {
                                 DataType targetType = update.newDataType();
                                 if (update.keepNullability()) {
@@ -392,7 +405,6 @@ public class SchemaManager implements Serializable {
                     updateNestedColumn(
                             newFields,
                             update.fieldNames(),
-                            0,
                             (field) ->
                                     new DataField(
                                             field.id(),
@@ -404,7 +416,6 @@ public class SchemaManager implements Serializable {
                     updateNestedColumn(
                             newFields,
                             update.fieldNames(),
-                            0,
                             (field) ->
                                     new DataField(
                                             field.id(),
@@ -569,74 +580,96 @@ public class SchemaManager implements Serializable {
                 .collect(Collectors.toList());
     }
 
-    private static void columnChangeValidation(TableSchema schema, SchemaChange change) {
-        /// TODO support partition and primary keys schema evolution
-        if (change instanceof DropColumn) {
-            String columnToDrop = ((DropColumn) change).fieldName();
-            if (schema.partitionKeys().contains(columnToDrop)
-                    || schema.primaryKeys().contains(columnToDrop)) {
-                throw new UnsupportedOperationException(
-                        String.format(
-                                "Cannot drop partition key or primary key: [%s]", columnToDrop));
-            }
-        } else if (change instanceof RenameColumn) {
-            String columnToRename = ((RenameColumn) change).fieldName();
-            if (schema.partitionKeys().contains(columnToRename)) {
-                throw new UnsupportedOperationException(
-                        String.format("Cannot rename partition column: [%s]", columnToRename));
-            }
-        } else {
-            throw new IllegalArgumentException(
-                    String.format(
-                            "Validation for %s is not supported",
-                            change.getClass().getSimpleName()));
+    private static void dropColumnValidation(TableSchema schema, DropColumn change) {
+        // primary keys and partition keys can't be nested columns
+        if (change.fieldNames().size() > 1) {
+            return;
+        }
+        String columnToDrop = change.fieldNames().get(0);
+        if (schema.partitionKeys().contains(columnToDrop)
+                || schema.primaryKeys().contains(columnToDrop)) {
+            throw new UnsupportedOperationException(
+                    String.format("Cannot drop partition key or primary key: [%s]", columnToDrop));
         }
     }
 
-    /** This method is hacky, newFields may be immutable. We should use {@link DataTypeVisitor}. */
+    private static void renameColumnValidation(TableSchema schema, RenameColumn change) {
+        String columnToRename = change.fieldName();
+        if (schema.partitionKeys().contains(columnToRename)) {
+            throw new UnsupportedOperationException(
+                    String.format("Cannot rename partition column: [%s]", columnToRename));
+        }
+    }
+
+    private abstract class NestedColumnModifier<E extends Exception> {
+
+        private final String[] updateFieldNames;
+
+        private NestedColumnModifier(String[] updateFieldNames) {
+            this.updateFieldNames = updateFieldNames;
+        }
+
+        public void updateIntermediateColumn(List<DataField> newFields, int depth)
+                throws Catalog.ColumnNotExistException, E {
+            if (depth == updateFieldNames.length - 1) {
+                updateLastColumn(newFields, updateFieldNames[depth]);
+                return;
+            }
+
+            for (int i = 0; i < newFields.size(); i++) {
+                DataField field = newFields.get(i);
+                if (!field.name().equals(updateFieldNames[depth])) {
+                    continue;
+                }
+
+                List<DataField> nestedFields =
+                        new ArrayList<>(
+                                ((org.apache.paimon.types.RowType) field.type()).getFields());
+                updateIntermediateColumn(nestedFields, depth + 1);
+                newFields.set(
+                        i,
+                        new DataField(
+                                field.id(),
+                                field.name(),
+                                new org.apache.paimon.types.RowType(
+                                        field.type().isNullable(), nestedFields),
+                                field.description()));
+                return;
+            }
+
+            throw new Catalog.ColumnNotExistException(
+                    identifierFromPath(tableRoot.toString(), true, branch),
+                    Arrays.asList(updateFieldNames).subList(0, depth + 1).toString());
+        }
+
+        protected abstract void updateLastColumn(List<DataField> newFields, String fieldName)
+                throws E;
+    }
+
     private void updateNestedColumn(
             List<DataField> newFields,
             String[] updateFieldNames,
-            int index,
             Function<DataField, DataField> updateFunc)
             throws Catalog.ColumnNotExistException {
-        boolean found = false;
-        for (int i = 0; i < newFields.size(); i++) {
-            DataField field = newFields.get(i);
-            if (field.name().equals(updateFieldNames[index])) {
-                found = true;
-                if (index == updateFieldNames.length - 1) {
-                    newFields.set(i, updateFunc.apply(field));
-                    break;
-                } else {
-                    List<DataField> nestedFields =
-                            new ArrayList<>(
-                                    ((org.apache.paimon.types.RowType) field.type()).getFields());
-                    updateNestedColumn(nestedFields, updateFieldNames, index + 1, updateFunc);
-                    newFields.set(
-                            i,
-                            new DataField(
-                                    field.id(),
-                                    field.name(),
-                                    new org.apache.paimon.types.RowType(
-                                            field.type().isNullable(), nestedFields),
-                                    field.description()));
-                }
-            }
-        }
-        if (!found) {
-            throw new Catalog.ColumnNotExistException(
-                    identifierFromPath(tableRoot.toString(), true, branch),
-                    Arrays.toString(updateFieldNames));
-        }
-    }
+        new NestedColumnModifier<Catalog.ColumnNotExistException>(updateFieldNames) {
+            @Override
+            protected void updateLastColumn(List<DataField> newFields, String fieldName)
+                    throws Catalog.ColumnNotExistException {
+                for (int i = 0; i < newFields.size(); i++) {
+                    DataField field = newFields.get(i);
+                    if (!field.name().equals(fieldName)) {
+                        continue;
+                    }
 
-    private void updateColumn(
-            List<DataField> newFields,
-            String updateFieldName,
-            Function<DataField, DataField> updateFunc)
-            throws Catalog.ColumnNotExistException {
-        updateNestedColumn(newFields, new String[] {updateFieldName}, 0, updateFunc);
+                    newFields.set(i, updateFunc.apply(field));
+                    return;
+                }
+
+                throw new Catalog.ColumnNotExistException(
+                        identifierFromPath(tableRoot.toString(), true, branch),
+                        Arrays.toString(updateFieldNames));
+            }
+        }.updateIntermediateColumn(newFields, 0);
     }
 
     @VisibleForTesting

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -299,7 +299,7 @@ public class SchemaManager implements Serializable {
                                 if (field.name().equals(fieldName)) {
                                     throw new Catalog.ColumnAlreadyExistException(
                                             identifierFromPath(tableRoot.toString(), true, branch),
-                                            addColumn.fieldNames().toString());
+                                            String.join(".", addColumn.fieldNames()));
                                 }
                             }
 
@@ -353,7 +353,7 @@ public class SchemaManager implements Serializable {
                             if (!newFields.removeIf(f -> f.name().equals(fieldName))) {
                                 throw new Catalog.ColumnNotExistException(
                                         identifierFromPath(tableRoot.toString(), true, branch),
-                                        drop.fieldNames().toString());
+                                        String.join(".", drop.fieldNames()));
                             }
                             if (newFields.isEmpty()) {
                                 throw new IllegalArgumentException(
@@ -639,7 +639,7 @@ public class SchemaManager implements Serializable {
 
             throw new Catalog.ColumnNotExistException(
                     identifierFromPath(tableRoot.toString(), true, branch),
-                    Arrays.asList(updateFieldNames).subList(0, depth + 1).toString());
+                    String.join(".", Arrays.asList(updateFieldNames).subList(0, depth + 1)));
         }
 
         protected abstract void updateLastColumn(List<DataField> newFields, String fieldName)
@@ -667,7 +667,7 @@ public class SchemaManager implements Serializable {
 
                 throw new Catalog.ColumnNotExistException(
                         identifierFromPath(tableRoot.toString(), true, branch),
-                        Arrays.toString(updateFieldNames));
+                        String.join(".", updateFieldNames));
             }
         }.updateIntermediateColumn(newFields, 0);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -241,7 +241,8 @@ public class SchemaManager implements Serializable {
 
     /** Update {@link SchemaChange}s. */
     public TableSchema commitChanges(List<SchemaChange> changes)
-            throws Catalog.TableNotExistException, Catalog.ColumnAlreadyExistException,
+            throws Catalog.TableNotExistException,
+                    Catalog.ColumnAlreadyExistException,
                     Catalog.ColumnNotExistException {
         SnapshotManager snapshotManager = new SnapshotManager(fileIO, tableRoot, branch);
         boolean hasSnapshots = (snapshotManager.latestSnapshotId() != null);
@@ -284,7 +285,7 @@ public class SchemaManager implements Serializable {
                     Preconditions.checkArgument(
                             addColumn.dataType().isNullable(),
                             "Column %s cannot specify NOT NULL in the %s table.",
-                            addColumn.fieldNames(),
+                            String.join(".", addColumn.fieldNames()),
                             identifierFromPath(tableRoot.toString(), true, branch).getFullName());
                     int id = highestFieldId.incrementAndGet();
                     DataType dataType =

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -541,7 +541,7 @@ public abstract class CatalogTestBase {
                 .satisfies(
                         anyCauseMatches(
                                 Catalog.ColumnNotExistException.class,
-                                "Column [non_existing_col] does not exist in the test_db.test_table table."));
+                                "Column non_existing_col does not exist in the test_db.test_table table."));
     }
 
     @Test
@@ -647,7 +647,7 @@ public abstract class CatalogTestBase {
                 .satisfies(
                         anyCauseMatches(
                                 Catalog.ColumnNotExistException.class,
-                                "Column [non_existing_col] does not exist in the test_db.test_table table."));
+                                "Column non_existing_col does not exist in the test_db.test_table table."));
         // Alter table update a column type throws Exception when column is partition columns
         assertThatThrownBy(
                         () ->
@@ -718,7 +718,7 @@ public abstract class CatalogTestBase {
                 .satisfies(
                         anyCauseMatches(
                                 Catalog.ColumnNotExistException.class,
-                                "Column [non_existing_col] does not exist in the test_db.test_table table."));
+                                "Column non_existing_col does not exist in the test_db.test_table table."));
     }
 
     @Test
@@ -774,7 +774,7 @@ public abstract class CatalogTestBase {
                 .satisfies(
                         anyCauseMatches(
                                 Catalog.ColumnNotExistException.class,
-                                "Column [non_existing_col] does not exist in the test_db.test_table table."));
+                                "Column non_existing_col does not exist in the test_db.test_table table."));
 
         // Alter table update a column nullability throws Exception when column is pk columns
         assertThatThrownBy(

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -65,6 +65,7 @@ import java.util.stream.IntStream;
 
 import static org.apache.paimon.utils.FailingFileIO.retryArtificialException;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link SchemaManager}. */
@@ -526,5 +527,83 @@ public class SchemaManagerTest {
                                         SchemaChange.setOption("merge-engine", "deduplicate")))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Change 'merge-engine' is not supported yet.");
+    }
+
+    @Test
+    public void testAddAndDropNestedColumns() throws Exception {
+        RowType innerType =
+                RowType.of(
+                        new DataField(4, "f1", DataTypes.INT()),
+                        new DataField(5, "f2", DataTypes.BIGINT()));
+        RowType middleType =
+                RowType.of(
+                        new DataField(2, "f1", DataTypes.STRING()),
+                        new DataField(3, "f2", innerType));
+        RowType outerType =
+                RowType.of(
+                        new DataField(0, "k", DataTypes.INT()), new DataField(1, "v", middleType));
+
+        Schema schema =
+                new Schema(
+                        outerType.getFields(),
+                        Collections.singletonList("k"),
+                        Collections.emptyList(),
+                        new HashMap<>(),
+                        "");
+        SchemaManager manager = new SchemaManager(LocalFileIO.create(), path);
+        manager.createTable(schema);
+
+        SchemaChange addColumn =
+                SchemaChange.addColumn(
+                        Arrays.asList("v", "f2", "f3"),
+                        DataTypes.STRING(),
+                        "",
+                        SchemaChange.Move.after("f3", "f1"));
+        manager.commitChanges(addColumn);
+
+        innerType =
+                RowType.of(
+                        new DataField(4, "f1", DataTypes.INT()),
+                        new DataField(6, "f3", DataTypes.STRING(), ""),
+                        new DataField(5, "f2", DataTypes.BIGINT()));
+        middleType =
+                RowType.of(
+                        new DataField(2, "f1", DataTypes.STRING()),
+                        new DataField(3, "f2", innerType));
+        outerType =
+                RowType.of(
+                        new DataField(0, "k", DataTypes.INT()), new DataField(1, "v", middleType));
+        assertThat(manager.latest().get().logicalRowType()).isEqualTo(outerType);
+
+        assertThatCode(() -> manager.commitChanges(addColumn))
+                .hasMessageContaining("Column [v, f2, f3] already exists");
+        SchemaChange middleColumnNotExistAddColumn =
+                SchemaChange.addColumn(
+                        Arrays.asList("v", "invalid", "f4"), DataTypes.STRING(), "", null);
+        assertThatCode(() -> manager.commitChanges(middleColumnNotExistAddColumn))
+                .hasMessageContaining("Column [v, invalid] does not exist");
+
+        SchemaChange dropColumn = SchemaChange.dropColumn(Arrays.asList("v", "f2", "f1"));
+        manager.commitChanges(dropColumn);
+
+        innerType =
+                RowType.of(
+                        new DataField(6, "f3", DataTypes.STRING(), ""),
+                        new DataField(5, "f2", DataTypes.BIGINT()));
+        middleType =
+                RowType.of(
+                        new DataField(2, "f1", DataTypes.STRING()),
+                        new DataField(3, "f2", innerType));
+        outerType =
+                RowType.of(
+                        new DataField(0, "k", DataTypes.INT()), new DataField(1, "v", middleType));
+        assertThat(manager.latest().get().logicalRowType()).isEqualTo(outerType);
+
+        assertThatCode(() -> manager.commitChanges(dropColumn))
+                .hasMessageContaining("Column [v, f2, f1] does not exist");
+        SchemaChange middleColumnNotExistDropColumn =
+                SchemaChange.dropColumn(Arrays.asList("v", "invalid", "f2"));
+        assertThatCode(() -> manager.commitChanges(middleColumnNotExistDropColumn))
+                .hasMessageContaining("Column [v, invalid] does not exist");
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -576,12 +576,12 @@ public class SchemaManagerTest {
         assertThat(manager.latest().get().logicalRowType()).isEqualTo(outerType);
 
         assertThatCode(() -> manager.commitChanges(addColumn))
-                .hasMessageContaining("Column [v, f2, f3] already exists");
+                .hasMessageContaining("Column v.f2.f3 already exists");
         SchemaChange middleColumnNotExistAddColumn =
                 SchemaChange.addColumn(
                         Arrays.asList("v", "invalid", "f4"), DataTypes.STRING(), "", null);
         assertThatCode(() -> manager.commitChanges(middleColumnNotExistAddColumn))
-                .hasMessageContaining("Column [v, invalid] does not exist");
+                .hasMessageContaining("Column v.invalid does not exist");
 
         SchemaChange dropColumn = SchemaChange.dropColumn(Arrays.asList("v", "f2", "f1"));
         manager.commitChanges(dropColumn);
@@ -600,10 +600,10 @@ public class SchemaManagerTest {
         assertThat(manager.latest().get().logicalRowType()).isEqualTo(outerType);
 
         assertThatCode(() -> manager.commitChanges(dropColumn))
-                .hasMessageContaining("Column [v, f2, f1] does not exist");
+                .hasMessageContaining("Column v.f2.f1 does not exist");
         SchemaChange middleColumnNotExistDropColumn =
                 SchemaChange.dropColumn(Arrays.asList("v", "invalid", "f2"));
         assertThatCode(() -> manager.commitChanges(middleColumnNotExistDropColumn))
-                .hasMessageContaining("Column [v, invalid] does not exist");
+                .hasMessageContaining("Column v.invalid does not exist");
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -371,10 +371,9 @@ public class SparkCatalog extends SparkBaseCatalog implements SupportFunction {
             }
         } else if (change instanceof TableChange.AddColumn) {
             TableChange.AddColumn add = (TableChange.AddColumn) change;
-            validateAlterNestedField(add.fieldNames());
             SchemaChange.Move move = getMove(add.position(), add.fieldNames());
             return SchemaChange.addColumn(
-                    add.fieldNames()[0],
+                    Arrays.asList(add.fieldNames()),
                     toPaimonType(add.dataType()).copy(add.isNullable()),
                     add.comment(),
                     move);
@@ -384,8 +383,7 @@ public class SparkCatalog extends SparkBaseCatalog implements SupportFunction {
             return SchemaChange.renameColumn(rename.fieldNames()[0], rename.newName());
         } else if (change instanceof TableChange.DeleteColumn) {
             TableChange.DeleteColumn delete = (TableChange.DeleteColumn) change;
-            validateAlterNestedField(delete.fieldNames());
-            return SchemaChange.dropColumn(delete.fieldNames()[0]);
+            return SchemaChange.dropColumn(Arrays.asList(delete.fieldNames()));
         } else if (change instanceof TableChange.UpdateColumnType) {
             TableChange.UpdateColumnType update = (TableChange.UpdateColumnType) change;
             validateAlterNestedField(update.fieldNames());

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadITCase.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkReadITCase.java
@@ -456,6 +456,11 @@ public class SparkReadITCase extends SparkReadTestBase {
                 "INSERT INTO paimon.default."
                         + tableName
                         + " VALUES (2, STRUCT(20, STRUCT('banana', 200)))");
+        assertThat(
+                        spark.sql("SELECT v.f2.f1, k FROM paimon.default." + tableName)
+                                .collectAsList().stream()
+                                .map(Row::toString))
+                .containsExactlyInAnyOrder("[apple,1]", "[banana,2]");
         spark.sql(
                 "INSERT INTO paimon.default."
                         + tableName


### PR DESCRIPTION
### Purpose

Spark SQL supports adding and dropping nested columns, but Paimon currently does not support it. This PR adds support for adding and dropping nested columns.

### Tests

Unit tests and IT cases.

### API and Format

No format changes.

### Documentation

This feature does not need a document.
