### PR TITLE
[core] Introduce drop-deleted-record-count compaction metric.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/reader/RecordReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/reader/RecordReader.java
@@ -48,6 +48,11 @@ public interface RecordReader<T> extends Closeable {
     @Nullable
     RecordIterator<T> readBatch() throws IOException;
 
+    /** Return the number of records that skipped by this reader. */
+    default long skippedRecordCount() {
+        return 0L;
+    }
+
     /** Closes the reader and should release all resources. */
     @Override
     void close() throws IOException;

--- a/paimon-core/src/main/java/org/apache/paimon/compact/CompactResult.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/CompactResult.java
@@ -35,6 +35,8 @@ public class CompactResult {
 
     @Nullable private CompactDeletionFile deletionFile;
 
+    private long dropDeletedRecordCount;
+
     public CompactResult() {
         this(Collections.emptyList(), Collections.emptyList());
     }
@@ -75,10 +77,19 @@ public class CompactResult {
         return deletionFile;
     }
 
+    public void setDropDeletedRecordCount(long dropDeletedRecordCount) {
+        this.dropDeletedRecordCount = dropDeletedRecordCount;
+    }
+
+    public long getDropDeletedRecordCount() {
+        return dropDeletedRecordCount;
+    }
+
     public void merge(CompactResult that) {
         before.addAll(that.before);
         after.addAll(that.after);
         changelog.addAll(that.changelog);
+        dropDeletedRecordCount += that.dropDeletedRecordCount;
 
         if (deletionFile != null || that.deletionFile != null) {
             throw new UnsupportedOperationException(

--- a/paimon-core/src/main/java/org/apache/paimon/compact/CompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/CompactTask.java
@@ -64,6 +64,8 @@ public abstract class CompactTask implements Callable<CompactResult> {
                                             .map(DataFileMeta::fileSize)
                                             .reduce(Long::sum)
                                             .orElse(0L));
+                            metricsReporter.reportDropDeletedRecordCount(
+                                    result.getDropDeletedRecordCount());
                         }
                     },
                     LOG);

--- a/paimon-core/src/main/java/org/apache/paimon/compact/CompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/CompactTask.java
@@ -64,8 +64,7 @@ public abstract class CompactTask implements Callable<CompactResult> {
                                             .map(DataFileMeta::fileSize)
                                             .reduce(Long::sum)
                                             .orElse(0L));
-                            metricsReporter.reportDropDeletedRecordCount(
-                                    result.getDropDeletedRecordCount());
+                            reportDropDeletedRecordCount(result.getDropDeletedRecordCount());
                         }
                     },
                     LOG);
@@ -77,6 +76,12 @@ public abstract class CompactTask implements Callable<CompactResult> {
         } finally {
             MetricUtils.safeCall(this::stopTimer, LOG);
             MetricUtils.safeCall(this::decreaseCompactionsQueuedCount, LOG);
+        }
+    }
+
+    private void reportDropDeletedRecordCount(long dropDeletedRecordCount) {
+        if (metricsReporter != null) {
+            metricsReporter.reportDropDeletedRecordCount(dropDeletedRecordCount);
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/DropDeleteReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/DropDeleteReader.java
@@ -32,7 +32,7 @@ import java.io.IOException;
  */
 public class DropDeleteReader implements RecordReader<KeyValue> {
 
-    private long dropDeletedRecordCount = 0L;
+    private long dropDeleteRecordCount = 0L;
     private final RecordReader<KeyValue> reader;
 
     public DropDeleteReader(RecordReader<KeyValue> reader) {
@@ -59,7 +59,7 @@ public class DropDeleteReader implements RecordReader<KeyValue> {
                     if (kv.isAdd()) {
                         return kv;
                     }
-                    ++dropDeletedRecordCount;
+                    ++dropDeleteRecordCount;
                 }
             }
 
@@ -72,7 +72,7 @@ public class DropDeleteReader implements RecordReader<KeyValue> {
 
     @Override
     public long skippedRecordCount() {
-        return dropDeletedRecordCount;
+        return dropDeleteRecordCount;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/DropDeleteReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/DropDeleteReader.java
@@ -32,6 +32,7 @@ import java.io.IOException;
  */
 public class DropDeleteReader implements RecordReader<KeyValue> {
 
+    private long dropDeletedRecordCount = 0L;
     private final RecordReader<KeyValue> reader;
 
     public DropDeleteReader(RecordReader<KeyValue> reader) {
@@ -58,6 +59,7 @@ public class DropDeleteReader implements RecordReader<KeyValue> {
                     if (kv.isAdd()) {
                         return kv;
                     }
+                    ++dropDeletedRecordCount;
                 }
             }
 
@@ -66,6 +68,11 @@ public class DropDeleteReader implements RecordReader<KeyValue> {
                 batch.releaseBatch();
             }
         };
+    }
+
+    @Override
+    public long skippedRecordCount() {
+        return dropDeletedRecordCount;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
@@ -104,7 +104,11 @@ public class MergeTreeCompactRewriter extends AbstractCompactRewriter {
 
         List<DataFileMeta> before = extractFilesFromSections(sections);
         notifyRewriteCompactBefore(before);
-        return new CompactResult(before, writer.result());
+        CompactResult compactResult = new CompactResult(before, writer.result());
+        if (dropDelete && reader != null) {
+            compactResult.setDropDeletedRecordCount(reader.skippedRecordCount());
+        }
+        return compactResult;
     }
 
     protected <T> RecordReader<T> readerForMergeTree(

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactTask.java
@@ -139,7 +139,7 @@ public class MergeTreeCompactTask extends CompactTask {
         }
         if (candidate.size() == 1) {
             List<SortedRun> section = candidate.get(0);
-            if (section.size() == 0) {
+            if (section.isEmpty()) {
                 return;
             } else if (section.size() == 1) {
                 for (DataFileMeta file : section.get(0).files()) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
Introduce a metric that records the number of  records(`DELETE(-D)`) that have been dropped by compaction.

### Tests

<!-- List UT and IT cases to verify this change -->
No

### API and Format

<!-- Does this change affect API or storage format -->
No

### Documentation

<!-- Does this change introduce a new feature -->
No
