### PR TITLE
[Flink]Optimize flink listPartitions speed

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -39,6 +39,7 @@ import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.FormatTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
+import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.utils.Preconditions;
 
@@ -200,7 +201,17 @@ public abstract class AbstractCatalog implements Catalog {
     @Override
     public List<PartitionEntry> listPartitions(Identifier identifier)
             throws TableNotExistException {
-        return getTable(identifier).newReadBuilder().newScan().listPartitionEntries();
+        return listPartitions(identifier, null);
+    }
+
+    public List<PartitionEntry> listPartitions(
+            Identifier identifier, Map<String, String> partitionSpec)
+            throws TableNotExistException {
+        ReadBuilder readBuilder = getTable(identifier).newReadBuilder();
+        if (partitionSpec != null) {
+            readBuilder.withPartitionFilter(partitionSpec);
+        }
+        return readBuilder.newScan().listPartitionEntries();
     }
 
     protected abstract void createDatabaseImpl(String name, Map<String, String> properties);

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -255,6 +255,16 @@ public interface Catalog extends AutoCloseable {
     List<PartitionEntry> listPartitions(Identifier identifier) throws TableNotExistException;
 
     /**
+     * Get PartitionEntry of filtered partitions of the table.
+     *
+     * @param identifier path of the table to list partitions
+     * @param partitions – the partition to be filtered
+     * @throws TableNotExistException if the table does not exist
+     */
+    List<PartitionEntry> listPartitions(Identifier identifier, Map<String, String> partitions)
+            throws TableNotExistException;
+
+    /**
      * Modify an existing table from a {@link SchemaChange}.
      *
      * <p>NOTE: System tables can not be altered.

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -171,6 +171,12 @@ public class DelegateCatalog implements Catalog {
     }
 
     @Override
+    public List<PartitionEntry> listPartitions(
+            Identifier identifier, Map<String, String> partitions) throws TableNotExistException {
+        return wrapped.listPartitions(identifier, partitions);
+    }
+
+    @Override
     public void repairCatalog() {
         wrapped.repairCatalog();
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Flink listPartitions from catalog.listPartitions, caching catalog can increase acquisition speed of partition.
<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
