### PR TITLE
[hive] Make HiveCatalog.listTables Lighter weight

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -391,10 +391,14 @@ public class HiveCatalog extends AbstractCatalog {
         try {
             List<String> allTables = clients.run(client -> client.getAllTables(databaseName));
             List<String> result = new ArrayList<>(allTables.size());
-            for (String table : allTables) {
+            for (String t : allTables) {
                 try {
-                    getTable(new Identifier(databaseName, table));
-                    result.add(table);
+                    Identifier identifier = new Identifier(databaseName, t);
+                    Table table = getHmsTable(identifier);
+                    if (isPaimonTable(identifier, table)
+                            || (!formatTableDisabled() && isFormatTable(table))) {
+                        result.add(t);
+                    }
                 } catch (TableNotExistException ignored) {
                 }
             }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Try to avoid create Paimon table in HiveCatalog.listTables, this can accelerate list tables and avoid potential problems (just show tables here, we don't need to access tables).

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
