### PR TITLE
[core] Introduce bitmap index record reader

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bitmap/ApplyBitmapIndexFileRecordIterator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bitmap/ApplyBitmapIndexFileRecordIterator.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex.bitmap;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.reader.FileRecordIterator;
+import org.apache.paimon.utils.RoaringBitmap32;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+/**
+ * A {@link FileRecordIterator} wraps a {@link FileRecordIterator} and {@link BitmapIndexResult}.
+ */
+public class ApplyBitmapIndexFileRecordIterator implements FileRecordIterator<InternalRow> {
+
+    private final FileRecordIterator<InternalRow> iterator;
+    private final RoaringBitmap32 bitmap;
+    private final int last;
+
+    public ApplyBitmapIndexFileRecordIterator(
+            FileRecordIterator<InternalRow> iterator, BitmapIndexResult fileIndexResult) {
+        this.iterator = iterator;
+        this.bitmap = fileIndexResult.get();
+        this.last = bitmap.last();
+    }
+
+    @Override
+    public long returnedPosition() {
+        return iterator.returnedPosition();
+    }
+
+    @Override
+    public Path filePath() {
+        return iterator.filePath();
+    }
+
+    @Nullable
+    @Override
+    public InternalRow next() throws IOException {
+        while (true) {
+            InternalRow next = iterator.next();
+            if (next == null) {
+                return null;
+            }
+            int position = (int) returnedPosition();
+            if (position > last) {
+                return null;
+            }
+            if (bitmap.contains(position)) {
+                return next;
+            }
+        }
+    }
+
+    @Override
+    public void releaseBatch() {
+        iterator.releaseBatch();
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bitmap/ApplyBitmapIndexRecordReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bitmap/ApplyBitmapIndexRecordReader.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.deletionvectors;
+package org.apache.paimon.fileindex.bitmap;
 
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.reader.FileRecordIterator;
@@ -28,42 +28,33 @@ import java.io.IOException;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
-/** A {@link RecordReader} which apply {@link DeletionVector} to filter record. */
-public class ApplyDeletionVectorReader implements RecordReader<InternalRow> {
+/** A {@link RecordReader} which apply {@link BitmapIndexResult} to filter record. */
+public class ApplyBitmapIndexRecordReader implements RecordReader<InternalRow> {
 
     private final RecordReader<InternalRow> reader;
 
-    private final DeletionVector deletionVector;
+    private final BitmapIndexResult fileIndexResult;
 
-    public ApplyDeletionVectorReader(
-            RecordReader<InternalRow> reader, DeletionVector deletionVector) {
+    public ApplyBitmapIndexRecordReader(
+            RecordReader<InternalRow> reader, BitmapIndexResult fileIndexResult) {
         this.reader = reader;
-        this.deletionVector = deletionVector;
-    }
-
-    public RecordReader<InternalRow> reader() {
-        return reader;
-    }
-
-    public DeletionVector deletionVector() {
-        return deletionVector;
+        this.fileIndexResult = fileIndexResult;
     }
 
     @Nullable
     @Override
     public RecordIterator<InternalRow> readBatch() throws IOException {
         RecordIterator<InternalRow> batch = reader.readBatch();
-
         if (batch == null) {
             return null;
         }
 
         checkArgument(
                 batch instanceof FileRecordIterator,
-                "There is a bug, RecordIterator in ApplyDeletionVectorReader must be FileRecordIterator");
+                "There is a bug, RecordIterator in ApplyBitmapIndexRecordReader must be FileRecordIterator");
 
-        return new ApplyDeletionFileRecordIterator(
-                (FileRecordIterator<InternalRow>) batch, deletionVector);
+        return new ApplyBitmapIndexFileRecordIterator(
+                (FileRecordIterator<InternalRow>) batch, fileIndexResult);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/utils/RoaringBitmap32.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/RoaringBitmap32.java
@@ -72,6 +72,10 @@ public class RoaringBitmap32 {
         return roaringBitmap.rangeCardinality(start, end);
     }
 
+    public int last() {
+        return roaringBitmap.last();
+    }
+
     public RoaringBitmap32 clone() {
         return new RoaringBitmap32(roaringBitmap.clone());
     }

--- a/paimon-core/src/main/java/org/apache/paimon/io/FileIndexEvaluator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/FileIndexEvaluator.java
@@ -40,6 +40,15 @@ public class FileIndexEvaluator {
             DataFileMeta file)
             throws IOException {
         if (dataFilter != null && !dataFilter.isEmpty()) {
+            byte[] embeddedIndex = file.embeddedIndex();
+            if (embeddedIndex != null) {
+                try (FileIndexPredicate predicate =
+                        new FileIndexPredicate(embeddedIndex, dataSchema.logicalRowType())) {
+                    return predicate.evaluate(
+                            PredicateBuilder.and(dataFilter.toArray(new Predicate[0])));
+                }
+            }
+
             List<String> indexFiles =
                     file.extraFiles().stream()
                             .filter(name -> name.endsWith(DataFilePathFactory.INDEX_PATH_SUFFIX))

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlyFileStoreTableTest.java
@@ -79,6 +79,7 @@ import java.util.stream.Collectors;
 import static org.apache.paimon.CoreOptions.BUCKET;
 import static org.apache.paimon.CoreOptions.BUCKET_KEY;
 import static org.apache.paimon.CoreOptions.FILE_INDEX_IN_MANIFEST_THRESHOLD;
+import static org.apache.paimon.CoreOptions.METADATA_STATS_MODE;
 import static org.apache.paimon.io.DataFileTestUtils.row;
 import static org.apache.paimon.table.sink.KeyAndBucketExtractor.bucket;
 import static org.apache.paimon.table.sink.KeyAndBucketExtractor.bucketKeyHashCode;
@@ -574,6 +575,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                 createUnawareBucketFileStoreTable(
                         rowType,
                         options -> {
+                            options.set(METADATA_STATS_MODE, "NONE");
                             options.set(
                                     FileIndexOptions.FILE_INDEX
                                             + "."
@@ -600,7 +602,11 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         write.write(GenericRow.of(1, BinaryString.fromString("B"), 3L));
         write.write(GenericRow.of(1, BinaryString.fromString("C"), 3L));
         result.addAll(write.prepareCommit(true, 0));
+        write.write(GenericRow.of(1, BinaryString.fromString("A"), 4L));
+        write.write(GenericRow.of(1, BinaryString.fromString("B"), 3L));
         write.write(GenericRow.of(1, BinaryString.fromString("C"), 4L));
+        write.write(GenericRow.of(1, BinaryString.fromString("D"), 2L));
+        write.write(GenericRow.of(1, BinaryString.fromString("D"), 4L));
         result.addAll(write.prepareCommit(true, 0));
         commit.commit(0, result);
         result.clear();
@@ -639,6 +645,7 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
                 createUnawareBucketFileStoreTable(
                         rowType,
                         options -> {
+                            options.set(METADATA_STATS_MODE, "NONE");
                             options.set(
                                     FileIndexOptions.FILE_INDEX
                                             + "."
@@ -665,7 +672,11 @@ public class AppendOnlyFileStoreTableTest extends FileStoreTableTestBase {
         write.write(GenericRow.of(1, BinaryString.fromString("B"), 3L));
         write.write(GenericRow.of(1, BinaryString.fromString("C"), 3L));
         result.addAll(write.prepareCommit(true, 0));
+        write.write(GenericRow.of(1, BinaryString.fromString("A"), 4L));
+        write.write(GenericRow.of(1, BinaryString.fromString("B"), 3L));
         write.write(GenericRow.of(1, BinaryString.fromString("C"), 4L));
+        write.write(GenericRow.of(1, BinaryString.fromString("D"), 2L));
+        write.write(GenericRow.of(1, BinaryString.fromString("D"), 4L));
         result.addAll(write.prepareCommit(true, 0));
         commit.commit(0, result);
         result.clear();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Introduction of bitmap index record reader to filter data in advance with bitmap index result.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
org.apache.paimon.table.AppendOnlyFileStoreTableTest#testBSIAndBitmapIndexInMemory
org.apache.paimon.table.AppendOnlyFileStoreTableTest#testBSIAndBitmapIndexInDisk
org.apache.paimon.table.PrimaryKeyFileStoreTableTest#testDeletionVectorsWithFileIndexInMeta
org.apache.paimon.table.PrimaryKeyFileStoreTableTest#testDeletionVectorsWithBitmapFileIndexInFile

### API and Format

<!-- Does this change affect API or storage format -->
No.

### Documentation

<!-- Does this change introduce a new feature -->
No.