### PR TITLE
[core] small fix of FilesTable system table

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/system/FilesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/FilesTable.java
@@ -385,7 +385,9 @@ public class FilesTable implements ReadonlyTable {
                                                         partitionConverter.convert(
                                                                 dataSplit.partition()))),
                         dataSplit::bucket,
-                        () -> BinaryString.fromString(dataFileMeta.fileName()),
+                        () ->
+                                BinaryString.fromString(
+                                        dataSplit.bucketPath() + "/" + dataFileMeta.fileName()),
                         () ->
                                 BinaryString.fromString(
                                         DataFilePathFactory.formatIdentifier(

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/FilesTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/FilesTableTest.java
@@ -191,7 +191,16 @@ public class FilesTableTest extends TableTestBase {
                             BinaryString.fromString(
                                     Arrays.toString(new String[] {partition1, partition2})),
                             fileEntry.bucket(),
-                            BinaryString.fromString(file.fileName()),
+                            BinaryString.fromString(
+                                    table.location()
+                                            + "/pt1="
+                                            + partition1
+                                            + "/pt2="
+                                            + partition2
+                                            + "/bucket-"
+                                            + fileEntry.bucket()
+                                            + "/"
+                                            + file.fileName()),
                             BinaryString.fromString(file.fileFormat()),
                             file.schemaId(),
                             file.level(),


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Now search FilesTable System table, the file_path column only shows file_name, not file_path.
This PR fix it.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
