### PR TITLE
[core] Support delete stats in result of scan plan.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta.java
@@ -409,6 +409,27 @@ public class DataFileMeta {
                 valueStatsCols);
     }
 
+    public DataFileMeta copyWithoutStats() {
+        return new DataFileMeta(
+                fileName,
+                fileSize,
+                rowCount,
+                minKey,
+                maxKey,
+                keyStats,
+                EMPTY_STATS,
+                minSequenceNumber,
+                maxSequenceNumber,
+                schemaId,
+                level,
+                extraFiles,
+                creationTime,
+                deleteRowCount,
+                embeddedIndex,
+                fileSource,
+                Collections.emptyList());
+    }
+
     public List<Path> collectFiles(DataFilePathFactory pathFactory) {
         List<Path> paths = new ArrayList<>();
         paths.add(pathFactory.toPath(fileName));

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntry.java
@@ -121,6 +121,10 @@ public class ManifestEntry implements FileEntry {
                 file.embeddedIndex());
     }
 
+    public ManifestEntry copyWithoutStats() {
+        return new ManifestEntry(kind, partition, bucket, totalBuckets, file.copyWithoutStats());
+    }
+
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof ManifestEntry)) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -90,6 +90,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
 
     private ManifestCacheFilter manifestCacheFilter = null;
     private ScanMetrics scanMetrics = null;
+    private boolean dropStats;
 
     public AbstractFileStoreScan(
             ManifestsReader manifestsReader,
@@ -105,6 +106,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
         this.manifestFileFactory = manifestFileFactory;
         this.tableSchemas = new ConcurrentHashMap<>();
         this.parallelism = parallelism;
+        this.dropStats = false;
     }
 
     @Override
@@ -215,6 +217,12 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
         return this;
     }
 
+    @Override
+    public FileStoreScan dropStats() {
+        this.dropStats = true;
+        return this;
+    }
+
     @Nullable
     @Override
     public Integer parallelism() {
@@ -291,6 +299,11 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
 
             @Override
             public List<ManifestEntry> files() {
+                if (dropStats) {
+                    return files.stream()
+                            .map(ManifestEntry::copyWithoutStats)
+                            .collect(Collectors.toList());
+                }
                 return files;
             }
         };

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
@@ -81,6 +81,8 @@ public interface FileStoreScan {
 
     FileStoreScan withMetrics(ScanMetrics metrics);
 
+    FileStoreScan dropStats();
+
     @Nullable
     Integer parallelism();
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
@@ -102,6 +102,12 @@ public abstract class AbstractDataTableScan implements DataTableScan {
         return this;
     }
 
+    @Override
+    public AbstractDataTableScan dropStats() {
+        snapshotReader.dropStats();
+        return this;
+    }
+
     public CoreOptions options() {
         return options;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableScan.java
@@ -55,4 +55,9 @@ public interface InnerTableScan extends TableScan {
         // do nothing, should implement this if need
         return this;
     }
+
+    default InnerTableScan dropStats() {
+        // do nothing, should implement this if need
+        return this;
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
@@ -150,6 +150,9 @@ public interface ReadBuilder extends Serializable {
      */
     ReadBuilder withShard(int indexOfThisSubtask, int numberOfParallelSubtasks);
 
+    /** Delete stats in scan plan result. */
+    ReadBuilder dropStats();
+
     /** Create a {@link TableScan} to perform batch planning. */
     TableScan newScan();
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -51,6 +51,8 @@ public class ReadBuilderImpl implements ReadBuilder {
 
     private @Nullable RowType readType;
 
+    private boolean dropStats = false;
+
     public ReadBuilderImpl(InnerTable table) {
         this.table = table;
     }
@@ -125,6 +127,12 @@ public class ReadBuilderImpl implements ReadBuilder {
     }
 
     @Override
+    public ReadBuilder dropStats() {
+        this.dropStats = true;
+        return this;
+    }
+
+    @Override
     public TableScan newScan() {
         InnerTableScan tableScan = configureScan(table.newScan());
         if (limit != null) {
@@ -155,6 +163,9 @@ public class ReadBuilderImpl implements ReadBuilder {
         }
         if (bucketFilter != null) {
             scan.withBucketFilter(bucketFilter);
+        }
+        if (dropStats) {
+            scan.dropStats();
         }
         return scan;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
@@ -85,6 +85,8 @@ public interface SnapshotReader {
 
     SnapshotReader withDataFileNameFilter(Filter<String> fileNameFilter);
 
+    SnapshotReader dropStats();
+
     SnapshotReader withShard(int indexOfThisSubtask, int numberOfParallelSubtasks);
 
     SnapshotReader withMetricRegistry(MetricRegistry registry);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
@@ -265,6 +265,12 @@ public class SnapshotReaderImpl implements SnapshotReader {
     }
 
     @Override
+    public SnapshotReader dropStats() {
+        scan.dropStats();
+        return this;
+    }
+
+    @Override
     public SnapshotReader withShard(int indexOfThisSubtask, int numberOfParallelSubtasks) {
         if (splitGenerator.alwaysRawConvertible()) {
             withDataFileNameFilter(

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
@@ -343,6 +343,12 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
         }
 
         @Override
+        public SnapshotReader dropStats() {
+            wrapped.dropStats();
+            return this;
+        }
+
+        @Override
         public SnapshotReader withShard(int indexOfThisSubtask, int numberOfParallelSubtasks) {
             wrapped.withShard(indexOfThisSubtask, numberOfParallelSubtasks);
             return this;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileStoreSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileStoreSource.java
@@ -77,7 +77,7 @@ public class ContinuousFileStoreSource extends FlinkSource {
             nextSnapshotId = checkpoint.currentSnapshotId();
             splits = checkpoint.splits();
         }
-        StreamTableScan scan = readBuilder.newStreamScan();
+        StreamTableScan scan = readBuilder.dropStats().newStreamScan();
         if (metricGroup(context) != null) {
             ((StreamDataTableScan) scan)
                     .withMetricsRegistry(new FlinkMetricRegistry(context.metricGroup()));

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkTableSource.java
@@ -175,6 +175,7 @@ public abstract class FlinkTableSource
                 List<PartitionEntry> partitionEntries =
                         table.newReadBuilder()
                                 .withFilter(predicate)
+                                .dropStats()
                                 .newScan()
                                 .listPartitionEntries();
                 long totalSize = 0;
@@ -188,7 +189,12 @@ public abstract class FlinkTableSource
                         new SplitStatistics((int) (totalSize / splitTargetSize + 1), rowCount);
             } else {
                 List<Split> splits =
-                        table.newReadBuilder().withFilter(predicate).newScan().plan().splits();
+                        table.newReadBuilder()
+                                .withFilter(predicate)
+                                .dropStats()
+                                .newScan()
+                                .plan()
+                                .splits();
                 splitStatistics =
                         new SplitStatistics(
                                 splits.size(), splits.stream().mapToLong(Split::rowCount).sum());

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSource.java
@@ -87,7 +87,7 @@ public class StaticFileStoreSource extends FlinkSource {
 
     private List<FileStoreSourceSplit> getSplits(SplitEnumeratorContext context) {
         FileStoreSourceSplitGenerator splitGenerator = new FileStoreSourceSplitGenerator();
-        TableScan scan = readBuilder.newScan();
+        TableScan scan = readBuilder.dropStats().newScan();
         // register scan metrics
         if (context.metricGroup() != null) {
             ((InnerTableScan) scan)

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/MonitorFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/MonitorFunction.java
@@ -106,7 +106,7 @@ public class MonitorFunction extends RichSourceFunction<Split>
 
     @Override
     public void initializeState(FunctionInitializationContext context) throws Exception {
-        this.scan = readBuilder.newStreamScan();
+        this.scan = readBuilder.dropStats().newStreamScan();
 
         this.checkpointState =
                 context.getOperatorStateStore()


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

In my company's production environment, when use Flink session cluster for OLAP scan Paimon, we found the JobManager's memory is always heavy.
So, we will optimize this by two ways:
(1) Delete stats in DataSplit.
(2) When dataSkipping, cut unused stats in ManifestEntry.

This pr is for (1)

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
