### PR TITLE
[doc]  Remove unused config in record-level expire

### DIFF
--- a/docs/content/primary-key-table/compaction.md
+++ b/docs/content/primary-key-table/compaction.md
@@ -76,7 +76,6 @@ In compaction, you can configure record-Level expire time to expire records, you
 
 1. `'record-level.expire-time'`: time retain for records.
 2. `'record-level.time-field'`: time field for record level expire.
-3. `'record-level.time-field-type'`: time field type for record level expire, it can be seconds-int,seconds-long or millis-long.
 
 Expiration happens in compaction, and there is no strong guarantee to expire records in time.
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

In https://github.com/apache/paimon/pull/4458 removed the config `record-level.time-field-type`, update doc.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
