### PR TITLE
[core] Make FormatReaderFactory return FileRecordReader to reduce cast

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bitmap/ApplyBitmapIndexRecordReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bitmap/ApplyBitmapIndexRecordReader.java
@@ -20,41 +20,35 @@ package org.apache.paimon.fileindex.bitmap;
 
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.reader.FileRecordIterator;
+import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.reader.RecordReader;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 
-import static org.apache.paimon.utils.Preconditions.checkArgument;
-
 /** A {@link RecordReader} which apply {@link BitmapIndexResult} to filter record. */
-public class ApplyBitmapIndexRecordReader implements RecordReader<InternalRow> {
+public class ApplyBitmapIndexRecordReader implements FileRecordReader<InternalRow> {
 
-    private final RecordReader<InternalRow> reader;
+    private final FileRecordReader<InternalRow> reader;
 
     private final BitmapIndexResult fileIndexResult;
 
     public ApplyBitmapIndexRecordReader(
-            RecordReader<InternalRow> reader, BitmapIndexResult fileIndexResult) {
+            FileRecordReader<InternalRow> reader, BitmapIndexResult fileIndexResult) {
         this.reader = reader;
         this.fileIndexResult = fileIndexResult;
     }
 
     @Nullable
     @Override
-    public RecordIterator<InternalRow> readBatch() throws IOException {
-        RecordIterator<InternalRow> batch = reader.readBatch();
+    public FileRecordIterator<InternalRow> readBatch() throws IOException {
+        FileRecordIterator<InternalRow> batch = reader.readBatch();
         if (batch == null) {
             return null;
         }
 
-        checkArgument(
-                batch instanceof FileRecordIterator,
-                "There is a bug, RecordIterator in ApplyBitmapIndexRecordReader must be FileRecordIterator");
-
-        return new ApplyBitmapIndexFileRecordIterator(
-                (FileRecordIterator<InternalRow>) batch, fileIndexResult);
+        return new ApplyBitmapIndexFileRecordIterator(batch, fileIndexResult);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/reader/EmptyFileRecordReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/reader/EmptyFileRecordReader.java
@@ -16,31 +16,21 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.format;
+package org.apache.paimon.reader;
 
-import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.fileindex.FileIndexResult;
-import org.apache.paimon.fs.FileIO;
-import org.apache.paimon.fs.Path;
-import org.apache.paimon.reader.FileRecordReader;
-import org.apache.paimon.reader.RecordReader;
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 
-/** A factory to create {@link RecordReader} for file. */
-public interface FormatReaderFactory {
+/** An empty {@link FileRecordReader}. */
+public class EmptyFileRecordReader<T> implements FileRecordReader<T> {
 
-    FileRecordReader<InternalRow> createReader(Context context) throws IOException;
-
-    /** Context for creating reader. */
-    interface Context {
-
-        FileIO fileIO();
-
-        Path filePath();
-
-        long fileSize();
-
-        FileIndexResult fileIndex();
+    @Nullable
+    @Override
+    public FileRecordIterator<T> readBatch() throws IOException {
+        return null;
     }
+
+    @Override
+    public void close() throws IOException {}
 }

--- a/paimon-common/src/main/java/org/apache/paimon/reader/FileRecordIterator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/reader/FileRecordIterator.java
@@ -27,10 +27,8 @@ import java.io.IOException;
 import java.util.function.Function;
 
 /**
- * Wrap {@link RecordReader.RecordIterator} to support returning the record's row position and file
+ * A {@link RecordReader.RecordIterator} to support returning the record's row position and file
  * Path.
- *
- * @param <T> The type of the record.
  */
 public interface FileRecordIterator<T> extends RecordReader.RecordIterator<T> {
 

--- a/paimon-common/src/main/java/org/apache/paimon/reader/FileRecordReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/reader/FileRecordReader.java
@@ -16,31 +16,16 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.format;
+package org.apache.paimon.reader;
 
-import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.fileindex.FileIndexResult;
-import org.apache.paimon.fs.FileIO;
-import org.apache.paimon.fs.Path;
-import org.apache.paimon.reader.FileRecordReader;
-import org.apache.paimon.reader.RecordReader;
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 
-/** A factory to create {@link RecordReader} for file. */
-public interface FormatReaderFactory {
+/** A {@link RecordReader} to support returning {@link FileRecordIterator}. */
+public interface FileRecordReader<T> extends RecordReader<T> {
 
-    FileRecordReader<InternalRow> createReader(Context context) throws IOException;
-
-    /** Context for creating reader. */
-    interface Context {
-
-        FileIO fileIO();
-
-        Path filePath();
-
-        long fileSize();
-
-        FileIndexResult fileIndex();
-    }
+    @Override
+    @Nullable
+    FileRecordIterator<T> readBatch() throws IOException;
 }

--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/ApplyDeletionVectorReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/ApplyDeletionVectorReader.java
@@ -20,23 +20,22 @@ package org.apache.paimon.deletionvectors;
 
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.reader.FileRecordIterator;
+import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.reader.RecordReader;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 
-import static org.apache.paimon.utils.Preconditions.checkArgument;
-
 /** A {@link RecordReader} which apply {@link DeletionVector} to filter record. */
-public class ApplyDeletionVectorReader implements RecordReader<InternalRow> {
+public class ApplyDeletionVectorReader implements FileRecordReader<InternalRow> {
 
-    private final RecordReader<InternalRow> reader;
+    private final FileRecordReader<InternalRow> reader;
 
     private final DeletionVector deletionVector;
 
     public ApplyDeletionVectorReader(
-            RecordReader<InternalRow> reader, DeletionVector deletionVector) {
+            FileRecordReader<InternalRow> reader, DeletionVector deletionVector) {
         this.reader = reader;
         this.deletionVector = deletionVector;
     }
@@ -51,19 +50,14 @@ public class ApplyDeletionVectorReader implements RecordReader<InternalRow> {
 
     @Nullable
     @Override
-    public RecordIterator<InternalRow> readBatch() throws IOException {
-        RecordIterator<InternalRow> batch = reader.readBatch();
+    public FileRecordIterator<InternalRow> readBatch() throws IOException {
+        FileRecordIterator<InternalRow> batch = reader.readBatch();
 
         if (batch == null) {
             return null;
         }
 
-        checkArgument(
-                batch instanceof FileRecordIterator,
-                "There is a bug, RecordIterator in ApplyDeletionVectorReader must be FileRecordIterator");
-
-        return new ApplyDeletionFileRecordIterator(
-                (FileRecordIterator<InternalRow>) batch, deletionVector);
+        return new ApplyDeletionFileRecordIterator(batch, deletionVector);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileRecordReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileRecordReader.java
@@ -21,6 +21,8 @@ package org.apache.paimon.io;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.KeyValueSerializer;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.reader.FileRecordIterator;
+import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.types.RowType;
 
@@ -29,14 +31,14 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 
 /** {@link RecordReader} for reading {@link KeyValue} data files. */
-public class KeyValueDataFileRecordReader implements RecordReader<KeyValue> {
+public class KeyValueDataFileRecordReader implements FileRecordReader<KeyValue> {
 
-    private final RecordReader<InternalRow> reader;
+    private final FileRecordReader<InternalRow> reader;
     private final KeyValueSerializer serializer;
     private final int level;
 
     public KeyValueDataFileRecordReader(
-            RecordReader<InternalRow> reader, RowType keyType, RowType valueType, int level) {
+            FileRecordReader<InternalRow> reader, RowType keyType, RowType valueType, int level) {
         this.reader = reader;
         this.serializer = new KeyValueSerializer(keyType, valueType);
         this.level = level;
@@ -44,8 +46,8 @@ public class KeyValueDataFileRecordReader implements RecordReader<KeyValue> {
 
     @Nullable
     @Override
-    public RecordIterator<KeyValue> readBatch() throws IOException {
-        RecordReader.RecordIterator<InternalRow> iterator = reader.readBatch();
+    public FileRecordIterator<KeyValue> readBatch() throws IOException {
+        FileRecordIterator<InternalRow> iterator = reader.readBatch();
         if (iterator == null) {
             return null;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
@@ -32,6 +32,7 @@ import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.partition.PartitionUtils;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.KeyValueFieldsExtractor;
 import org.apache.paimon.schema.SchemaManager;
@@ -109,7 +110,7 @@ public class KeyValueFileReaderFactory implements FileReaderFactory<KeyValue> {
         return createRecordReader(schemaId, fileName, level, true, null, fileSize);
     }
 
-    private RecordReader<KeyValue> createRecordReader(
+    private FileRecordReader<KeyValue> createRecordReader(
             long schemaId,
             String fileName,
             int level,
@@ -134,8 +135,8 @@ public class KeyValueFileReaderFactory implements FileReaderFactory<KeyValue> {
                         : formatSupplier.get();
         Path filePath = pathFactory.toPath(fileName);
 
-        RecordReader<InternalRow> fileRecordReader =
-                new FileRecordReader(
+        FileRecordReader<InternalRow> fileRecordReader =
+                new DataFileRecordReader(
                         bulkFormatMapping.getReaderFactory(),
                         orcPoolSize == null
                                 ? new FormatReaderContext(fileIO, filePath, fileSize)

--- a/paimon-core/src/main/java/org/apache/paimon/operation/RawFileSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/RawFileSplitRead.java
@@ -32,12 +32,13 @@ import org.apache.paimon.format.FormatReaderContext;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFilePathFactory;
+import org.apache.paimon.io.DataFileRecordReader;
 import org.apache.paimon.io.FileIndexEvaluator;
-import org.apache.paimon.io.FileRecordReader;
 import org.apache.paimon.mergetree.compact.ConcatRecordReader;
 import org.apache.paimon.partition.PartitionUtils;
 import org.apache.paimon.predicate.Predicate;
-import org.apache.paimon.reader.EmptyRecordReader;
+import org.apache.paimon.reader.EmptyFileRecordReader;
+import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.reader.ReaderSupplier;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.SchemaManager;
@@ -187,7 +188,7 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
         return ConcatRecordReader.create(suppliers);
     }
 
-    private RecordReader<InternalRow> createFileReader(
+    private FileRecordReader<InternalRow> createFileReader(
             BinaryRow partition,
             DataFileMeta file,
             DataFilePathFactory dataFilePathFactory,
@@ -204,7 +205,7 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
                             dataFilePathFactory,
                             file);
             if (!fileIndexResult.remain()) {
-                return new EmptyRecordReader<>();
+                return new EmptyFileRecordReader<>();
             }
         }
 
@@ -214,8 +215,8 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
                         dataFilePathFactory.toPath(file.fileName()),
                         file.fileSize(),
                         fileIndexResult);
-        RecordReader<InternalRow> fileRecordReader =
-                new FileRecordReader(
+        FileRecordReader<InternalRow> fileRecordReader =
+                new DataFileRecordReader(
                         bulkFormatMapping.getReaderFactory(),
                         formatReaderContext,
                         bulkFormatMapping.getIndexMapping(),

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/changelog/format/CompactedChangelogFormatReaderFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/changelog/format/CompactedChangelogFormatReaderFactory.java
@@ -27,7 +27,7 @@ import org.apache.paimon.fs.FileStatus;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.fs.SeekableInputStream;
-import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.reader.FileRecordReader;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -60,7 +60,7 @@ public class CompactedChangelogFormatReaderFactory implements FormatReaderFactor
     }
 
     @Override
-    public RecordReader<InternalRow> createReader(Context context) throws IOException {
+    public FileRecordReader<InternalRow> createReader(Context context) throws IOException {
         OffsetReadOnlyFileIO fileIO = new OffsetReadOnlyFileIO(context.fileIO());
         long length = decodePath(context.filePath()).length;
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/avro/AvroBulkFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/avro/AvroBulkFormat.java
@@ -22,7 +22,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FormatReaderFactory;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
-import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.IteratorResultIterator;
@@ -49,12 +49,12 @@ public class AvroBulkFormat implements FormatReaderFactory {
     }
 
     @Override
-    public RecordReader<InternalRow> createReader(FormatReaderFactory.Context context)
+    public FileRecordReader<InternalRow> createReader(FormatReaderFactory.Context context)
             throws IOException {
         return new AvroReader(context.fileIO(), context.filePath(), context.fileSize());
     }
 
-    private class AvroReader implements RecordReader<InternalRow> {
+    private class AvroReader implements FileRecordReader<InternalRow> {
 
         private final FileIO fileIO;
         private final DataFileReader<InternalRow> reader;
@@ -90,7 +90,7 @@ public class AvroBulkFormat implements FormatReaderFactory {
 
         @Nullable
         @Override
-        public RecordIterator<InternalRow> readBatch() throws IOException {
+        public IteratorResultIterator readBatch() throws IOException {
             Object ticket;
             try {
                 ticket = pool.pollEntry();

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcReaderFactory.java
@@ -30,6 +30,7 @@ import org.apache.paimon.format.fs.HadoopReadOnlyFileSystem;
 import org.apache.paimon.format.orc.filter.OrcFilters;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.reader.RecordReader.RecordIterator;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
@@ -184,7 +185,7 @@ public class OrcReaderFactory implements FormatReaderFactory {
             return orcVectorizedRowBatch;
         }
 
-        private RecordIterator<InternalRow> convertAndGetIterator(
+        private ColumnarRowIterator convertAndGetIterator(
                 VectorizedRowBatch orcBatch, long rowNumber) {
             // no copying from the ORC column vectors to the Paimon columns vectors necessary,
             // because they point to the same data arrays internally design
@@ -209,8 +210,7 @@ public class OrcReaderFactory implements FormatReaderFactory {
      * batch is addressed by the starting row number of the batch, plus the number of records to be
      * skipped before.
      */
-    private static final class OrcVectorizedReader
-            implements org.apache.paimon.reader.RecordReader<InternalRow> {
+    private static final class OrcVectorizedReader implements FileRecordReader<InternalRow> {
 
         private final RecordReader orcReader;
         private final Pool<OrcReaderBatch> pool;
@@ -222,7 +222,7 @@ public class OrcReaderFactory implements FormatReaderFactory {
 
         @Nullable
         @Override
-        public RecordIterator<InternalRow> readBatch() throws IOException {
+        public ColumnarRowIterator readBatch() throws IOException {
             final OrcReaderBatch batch = getCachedEntry();
             final VectorizedRowBatch orcVectorBatch = batch.orcVectorizedRowBatch();
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
@@ -31,8 +31,7 @@ import org.apache.paimon.format.parquet.reader.ParquetTimestampVector;
 import org.apache.paimon.format.parquet.type.ParquetField;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.options.Options;
-import org.apache.paimon.reader.RecordReader;
-import org.apache.paimon.reader.RecordReader.RecordIterator;
+import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
@@ -307,7 +306,7 @@ public class ParquetReaderFactory implements FormatReaderFactory {
         return new VectorizedColumnBatch(vectors);
     }
 
-    private class ParquetReader implements RecordReader<InternalRow> {
+    private class ParquetReader implements FileRecordReader<InternalRow> {
 
         private ParquetFileReader reader;
 
@@ -360,7 +359,7 @@ public class ParquetReaderFactory implements FormatReaderFactory {
 
         @Nullable
         @Override
-        public RecordIterator<InternalRow> readBatch() throws IOException {
+        public ColumnarRowIterator readBatch() throws IOException {
             final ParquetReaderBatch batch = getCachedEntry();
 
             if (!nextBatch(batch)) {
@@ -488,7 +487,7 @@ public class ParquetReaderFactory implements FormatReaderFactory {
             recycler.recycle(this);
         }
 
-        public RecordIterator<InternalRow> convertAndGetIterator(long rowNumber) {
+        public ColumnarRowIterator convertAndGetIterator(long rowNumber) {
             result.reset(rowNumber);
             return result;
         }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In `ApplyBitmapIndexRecordReader` and `ApplyBitmapIndexRecordReader`, they will check the type of iterator which should be `FileRecordIterator`, it is always `FileRecordIterator`, and we should garrantee it by interface.

So we let FormatReaderFactory return FileRecordReader, and all related readers should be `FileRecordReader`s.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
