### PR TITLE
[parquet] Fix nested array/map has no id in parquet files

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/table/SpecialFields.java
+++ b/paimon-common/src/main/java/org/apache/paimon/table/SpecialFields.java
@@ -48,9 +48,18 @@ import java.util.stream.Stream;
  * directly by id. These ids are not stored in {@link org.apache.paimon.types.DataField}.
  *
  * <ul>
- *   <li>Array element field: ID = 536870911 + <code>(array-field-id)</code>.
- *   <li>Map key field: ID = 536870911 + <code>(array-field-id)</code>.
- *   <li>Map value field: ID = 536870911 - <code>(array-field-id)</code>.
+ *   <li>Array element field: ID = 536870911 + 1024 * <code>(array-field-id)</code> + depth.
+ *   <li>Map key field: ID = 536870911 - 1024 * <code>(array-field-id)</code> - depth.
+ *   <li>Map value field: ID = 536870911 + 1024 * <code>(array-field-id)</code> + depth.
+ * </ul>
+ *
+ * <p>Examples:
+ *
+ * <ul>
+ *   <li>ARRAY(MAP(INT, ARRAY(INT))) type, outer array has field id 10, then map (element of outer
+ *       array) has field id 536870911 + 1024 * 10 + 1, map key (int) has field id 536870911 - 1024
+ *       * 10 - 2, map value (inner array) has field id 536870911 + 1024 * 10 + 2, inner array
+ *       element (int) has field id 536870911 + 1024 * 10 + 3
  * </ul>
  */
 public class SpecialFields {
@@ -95,16 +104,23 @@ public class SpecialFields {
     // ----------------------------------------------------------------------------------------
 
     public static final int STRUCTURED_TYPE_FIELD_ID_BASE = Integer.MAX_VALUE / 4;
+    public static final int STRUCTURED_TYPE_FIELD_DEPTH_LIMIT = 1 << 10;
 
-    public static int getArrayElementFieldId(int arrayFieldId) {
-        return STRUCTURED_TYPE_FIELD_ID_BASE + arrayFieldId;
+    public static int getArrayElementFieldId(int arrayFieldId, int depth) {
+        return STRUCTURED_TYPE_FIELD_ID_BASE
+                + arrayFieldId * STRUCTURED_TYPE_FIELD_DEPTH_LIMIT
+                + depth;
     }
 
-    public static int getMapKeyFieldId(int mapFieldId) {
-        return STRUCTURED_TYPE_FIELD_ID_BASE + mapFieldId;
+    public static int getMapKeyFieldId(int mapFieldId, int depth) {
+        return STRUCTURED_TYPE_FIELD_ID_BASE
+                - mapFieldId * STRUCTURED_TYPE_FIELD_DEPTH_LIMIT
+                - depth;
     }
 
-    public static int getMapValueFieldId(int mapFieldId) {
-        return STRUCTURED_TYPE_FIELD_ID_BASE - mapFieldId;
+    public static int getMapValueFieldId(int mapFieldId, int depth) {
+        return STRUCTURED_TYPE_FIELD_ID_BASE
+                + mapFieldId * STRUCTURED_TYPE_FIELD_DEPTH_LIMIT
+                + depth;
     }
 }


### PR DESCRIPTION
### Purpose

In #4362 we write field ids into parquet files. However that PR fails to add id for nested array/map type (for example `ARRAY(MAP(INT, ARRAY(INT)))` type. This PR fixes the bug.

### Tests

Unit tests.

### API and Format

Field id of array element, map keys and values are changed.

### Documentation

No document is needed.
