### PR TITLE
[flink] support multiple writers writing to the same partition when using kafka as logSystem in unaware bucket mode.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestCommittable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestCommittable.java
@@ -62,13 +62,14 @@ public class ManifestCommittable {
         commitMessages.add(commitMessage);
     }
 
-    public void addLogOffset(int bucket, long offset) {
-        if (logOffsets.containsKey(bucket)) {
+    public void addLogOffset(int bucket, long offset, boolean allowDuplicate) {
+        if (!allowDuplicate && logOffsets.containsKey(bucket)) {
             throw new RuntimeException(
                     String.format(
                             "bucket-%d appears multiple times, which is not possible.", bucket));
         }
-        logOffsets.put(bucket, offset);
+        long newOffset = Math.max(logOffsets.getOrDefault(bucket, offset), offset);
+        logOffsets.put(bucket, newOffset);
     }
 
     public long identifier() {

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -222,7 +222,8 @@ public class TestFileStore extends KeyValueFileStore {
                 null,
                 Collections.emptyList(),
                 (commit, committable) -> {
-                    logOffsets.forEach(committable::addLogOffset);
+                    logOffsets.forEach(
+                            (bucket, offset) -> committable.addLogOffset(bucket, offset, false));
                     commit.commit(committable, Collections.emptyMap());
                 });
     }

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestCommittableSerializerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestCommittableSerializerTest.java
@@ -83,7 +83,7 @@ public class ManifestCommittableSerializerTest {
 
         if (!committable.logOffsets().containsKey(bucket)) {
             int offset = ID.incrementAndGet();
-            committable.addLogOffset(bucket, offset);
+            committable.addLogOffset(bucket, offset, false);
             assertThat(committable.logOffsets().get(bucket)).isEqualTo(offset);
         }
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/WrappedManifestCommittableSerializerTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/WrappedManifestCommittableSerializerTest.java
@@ -98,7 +98,7 @@ class WrappedManifestCommittableSerializerTest {
 
         if (!committable.logOffsets().containsKey(bucket)) {
             int offset = ID.incrementAndGet();
-            committable.addLogOffset(bucket, offset);
+            committable.addLogOffset(bucket, offset, false);
             assertThat(committable.logOffsets().get(bucket)).isEqualTo(offset);
         }
     }


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #4515 

<!-- What is the purpose of the change -->
[flink] support multiple writers writing to the same partition when using kafka as logSystem in unaware bucket mode.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
