### PR TITLE
[core] Drop stats in manifest file reading

### DIFF
--- a/docs/content/maintenance/metrics.md
+++ b/docs/content/maintenance/metrics.md
@@ -68,16 +68,6 @@ Below is lists of Paimon built-in metrics. They are summarized into types of sca
             <td>Number of scanned manifest files in the last scan.</td>
         </tr>
         <tr>
-            <td>lastSkippedByPartitionAndStats</td>
-            <td>Gauge</td>
-            <td>Skipped table files by partition filter and value / key stats information in the last scan.</td>
-        </tr>
-        <tr>
-            <td>lastSkippedByWholeBucketFilesFilter</td>
-            <td>Gauge</td>
-            <td>Skipped table files by bucket level value filter (only primary key table) in the last scan.</td>
-        </tr>
-        <tr>
             <td>lastScanSkippedTableFiles</td>
             <td>Gauge</td>
             <td>Total skipped table files in the last scan.</td>

--- a/paimon-common/src/main/java/org/apache/paimon/utils/Filter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/Filter.java
@@ -37,6 +37,13 @@ public interface Filter<T> {
      */
     boolean test(T t);
 
+    default Filter<T> and(Filter<? super T> other) {
+        if (other == null) {
+            return this;
+        }
+        return t -> test(t) && other.test(t);
+    }
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     static <T> Filter<T> alwaysTrue() {
         return (Filter) ALWAYS_TRUE;

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ThreadPoolUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ThreadPoolUtils.java
@@ -110,7 +110,9 @@ public class ThreadPoolUtils {
                                 if (stack.isEmpty()) {
                                     return;
                                 }
-                                activeList = randomlyExecute(executor, processor, stack.poll());
+                                activeList =
+                                        randomlyExecuteSequentialReturn(
+                                                executor, processor, stack.poll());
                             }
                         }
                     }
@@ -132,7 +134,7 @@ public class ThreadPoolUtils {
         awaitAllFutures(futures);
     }
 
-    public static <U, T> Iterator<T> randomlyExecute(
+    public static <U, T> Iterator<T> randomlyExecuteSequentialReturn(
             ExecutorService executor, Function<U, List<T>> processor, Collection<U> input) {
         List<Future<List<T>>> futures = new ArrayList<>(input.size());
         ClassLoader cl = Thread.currentThread().getContextClassLoader();

--- a/paimon-core/src/main/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinator.java
@@ -27,6 +27,7 @@ import org.apache.paimon.deletionvectors.append.UnawareAppendDeletionFileMaintai
 import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.FileStoreTable;
@@ -441,7 +442,12 @@ public class UnawareAppendTableCompactionCoordinator {
                 }
 
                 if (currentIterator.hasNext()) {
-                    return currentIterator.next();
+                    ManifestEntry entry = currentIterator.next();
+                    if (entry.kind() == FileKind.DELETE) {
+                        continue;
+                    } else {
+                        return entry;
+                    }
                 }
                 currentIterator = null;
             }

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/FilteredManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/FilteredManifestEntry.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.manifest;
+
+/** Wrap a {@link ManifestEntry} to contain {@link #selected}. */
+public class FilteredManifestEntry extends ManifestEntry {
+
+    private final boolean selected;
+
+    public FilteredManifestEntry(ManifestEntry entry, boolean selected) {
+        super(entry.kind(), entry.partition(), entry.bucket(), entry.totalBuckets(), entry.file());
+        this.selected = selected;
+    }
+
+    public boolean selected() {
+        return selected;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestFile.java
@@ -211,18 +211,5 @@ public class ManifestFile extends ObjectsFile<ManifestEntry> {
                     suggestedFileSize,
                     cache);
         }
-
-        public ObjectsFile<SimpleFileEntry> createSimpleFileEntryReader() {
-            RowType entryType = VersionedObjectSerializer.versionType(ManifestEntry.SCHEMA);
-            return new ObjectsFile<>(
-                    fileIO,
-                    new SimpleFileEntrySerializer(),
-                    entryType,
-                    fileFormat.createReaderFactory(entryType),
-                    fileFormat.createWriterFactory(entryType),
-                    compression,
-                    pathFactory.manifestFileFactory(),
-                    cache);
-        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -76,7 +76,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
 
     private final ConcurrentMap<Long, TableSchema> tableSchemas;
     private final SchemaManager schemaManager;
-    protected final TableSchema schema;
+    private final TableSchema schema;
 
     private Snapshot specifiedSnapshot = null;
     private Filter<Integer> bucketFilter = null;
@@ -351,14 +351,6 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
         return readManifestEntries(readManifests().filteredManifests, true);
     }
 
-    protected boolean wholeBucketFilterEnabled() {
-        return false;
-    }
-
-    protected List<ManifestEntry> filterWholeBucketByStats(List<ManifestEntry> entries) {
-        return entries;
-    }
-
     private Iterator<ManifestEntry> readManifestEntries(
             List<ManifestFileMeta> manifests, boolean useSequential) {
         return scanMode == ScanMode.ALL
@@ -429,6 +421,14 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
 
     /** Note: Keep this thread-safe. */
     protected abstract boolean filterByStats(ManifestEntry entry);
+
+    protected boolean wholeBucketFilterEnabled() {
+        return false;
+    }
+
+    protected List<ManifestEntry> filterWholeBucketByStats(List<ManifestEntry> entries) {
+        return entries;
+    }
 
     /** Note: Keep this thread-safe. */
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
@@ -34,7 +34,6 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /** {@link FileStoreScan} for {@link AppendOnlyFileStore}. */
@@ -98,12 +97,6 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
                         stats.maxValues(),
                         stats.nullCounts())
                 && (!fileIndexReadEnabled || testFileIndex(entry.file().embeddedIndex(), entry));
-    }
-
-    @Override
-    protected List<ManifestEntry> filterWholeBucketByStats(List<ManifestEntry> entries) {
-        // We don't need to filter per-bucket entries here
-        return entries;
     }
 
     private boolean testFileIndex(@Nullable byte[] embeddedIndexBytes, ManifestEntry entry) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
@@ -73,6 +73,8 @@ public interface FileStoreScan {
 
     FileStoreScan withLevelFilter(Filter<Integer> levelFilter);
 
+    FileStoreScan enableValueFilter();
+
     FileStoreScan withManifestEntryFilter(Filter<ManifestEntry> filter);
 
     FileStoreScan withManifestCacheFilter(ManifestCacheFilter manifestFilter);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreScan.java
@@ -23,6 +23,7 @@ import org.apache.paimon.CoreOptions.MergeEngine;
 import org.apache.paimon.KeyValueFileStore;
 import org.apache.paimon.fileindex.FileIndexPredicate;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.FilteredManifestEntry;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFile;
 import org.apache.paimon.predicate.Predicate;
@@ -45,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.paimon.CoreOptions.MergeEngine.AGGREGATE;
-import static org.apache.paimon.CoreOptions.MergeEngine.FIRST_ROW;
 import static org.apache.paimon.CoreOptions.MergeEngine.PARTIAL_UPDATE;
 
 /** {@link FileStoreScan} for {@link KeyValueFileStore}. */
@@ -63,6 +63,8 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
 
     private final boolean fileIndexReadEnabled;
     private final Map<Long, Predicate> schemaId2DataFilter = new HashMap<>();
+
+    private boolean valueFilterForceEnabled = false;
 
     public KeyValueFileStoreScan(
             ManifestsReader manifestsReader,
@@ -110,11 +112,17 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
         return this;
     }
 
+    @Override
+    public FileStoreScan enableValueFilter() {
+        this.valueFilterForceEnabled = true;
+        return this;
+    }
+
     /** Note: Keep this thread-safe. */
     @Override
     protected boolean filterByStats(ManifestEntry entry) {
         DataFileMeta file = entry.file();
-        if (isValueFilterEnabled(entry) && !filterByValueFilter(entry)) {
+        if (isValueFilterEnabled() && !filterByValueFilter(entry)) {
             return false;
         }
 
@@ -128,6 +136,14 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
         }
 
         return true;
+    }
+
+    @Override
+    protected ManifestEntry dropStats(ManifestEntry entry) {
+        if (!isValueFilterEnabled() && wholeBucketFilterEnabled()) {
+            return new FilteredManifestEntry(entry.copyWithoutStats(), filterByValueFilter(entry));
+        }
+        return entry.copyWithoutStats();
     }
 
     private boolean filterByFileIndex(@Nullable byte[] embeddedIndexBytes, ManifestEntry entry) {
@@ -150,14 +166,14 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
         }
     }
 
-    private boolean isValueFilterEnabled(ManifestEntry entry) {
+    private boolean isValueFilterEnabled() {
         if (valueFilter == null) {
             return false;
         }
 
         switch (scanMode) {
             case ALL:
-                return (deletionVectorsEnabled || mergeEngine == FIRST_ROW) && entry.level() > 0;
+                return valueFilterForceEnabled;
             case DELTA:
                 return false;
             case CHANGELOG:
@@ -168,13 +184,13 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
         }
     }
 
-    /** Note: Keep this thread-safe. */
+    @Override
+    protected boolean wholeBucketFilterEnabled() {
+        return valueFilter != null && scanMode == ScanMode.ALL;
+    }
+
     @Override
     protected List<ManifestEntry> filterWholeBucketByStats(List<ManifestEntry> entries) {
-        if (valueFilter == null || scanMode != ScanMode.ALL) {
-            return entries;
-        }
-
         return noOverlapping(entries)
                 ? filterWholeBucketPerFile(entries)
                 : filterWholeBucketAllFiles(entries);
@@ -207,6 +223,10 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
     }
 
     private boolean filterByValueFilter(ManifestEntry entry) {
+        if (entry instanceof FilteredManifestEntry) {
+            return ((FilteredManifestEntry) entry).selected();
+        }
+
         DataFileMeta file = entry.file();
         SimpleStatsEvolution.Result result =
                 fieldValueStatsConverters

--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -53,7 +53,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.ThreadPoolUtils.createCachedThreadPool;
-import static org.apache.paimon.utils.ThreadPoolUtils.randomlyExecute;
+import static org.apache.paimon.utils.ThreadPoolUtils.randomlyExecuteSequentialReturn;
 import static org.apache.paimon.utils.ThreadPoolUtils.randomlyOnlyExecute;
 
 /**
@@ -180,7 +180,7 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
                                 .filter(this::oldEnough)
                                 .map(FileStatus::getPath)
                                 .collect(Collectors.toList());
-        Iterator<Path> allPaths = randomlyExecute(executor, processor, fileDirs);
+        Iterator<Path> allPaths = randomlyExecuteSequentialReturn(executor, processor, fileDirs);
         Map<String, Path> result = new HashMap<>();
         while (allPaths.hasNext()) {
             Path next = allPaths.next();

--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanMetrics.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanMetrics.java
@@ -49,12 +49,6 @@ public class ScanMetrics {
     public static final String SCAN_DURATION = "scanDuration";
     public static final String LAST_SCANNED_MANIFESTS = "lastScannedManifests";
 
-    public static final String LAST_SKIPPED_BY_PARTITION_AND_STATS =
-            "lastSkippedByPartitionAndStats";
-
-    public static final String LAST_SKIPPED_BY_WHOLE_BUCKET_FILES_FILTER =
-            "lastSkippedByWholeBucketFilesFilter";
-
     public static final String LAST_SCAN_SKIPPED_TABLE_FILES = "lastScanSkippedTableFiles";
 
     public static final String LAST_SCAN_RESULTED_TABLE_FILES = "lastScanResultedTableFiles";
@@ -66,12 +60,6 @@ public class ScanMetrics {
         metricGroup.gauge(
                 LAST_SCANNED_MANIFESTS,
                 () -> latestScan == null ? 0L : latestScan.getScannedManifests());
-        metricGroup.gauge(
-                LAST_SKIPPED_BY_PARTITION_AND_STATS,
-                () -> latestScan == null ? 0L : latestScan.getSkippedByPartitionAndStats());
-        metricGroup.gauge(
-                LAST_SKIPPED_BY_WHOLE_BUCKET_FILES_FILTER,
-                () -> latestScan == null ? 0L : latestScan.getSkippedByWholeBucketFiles());
         metricGroup.gauge(
                 LAST_SCAN_SKIPPED_TABLE_FILES,
                 () -> latestScan == null ? 0L : latestScan.getSkippedTableFiles());

--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanStats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanStats.java
@@ -25,23 +25,15 @@ public class ScanStats {
     // the unit is milliseconds
     private final long duration;
     private final long scannedManifests;
-    private final long skippedByPartitionAndStats;
 
-    private final long skippedByWholeBucketFiles;
     private final long skippedTableFiles;
     private final long resultedTableFiles;
 
     public ScanStats(
-            long duration,
-            long scannedManifests,
-            long skippedByPartitionAndStats,
-            long skippedByWholeBucketFiles,
-            long resultedTableFiles) {
+            long duration, long scannedManifests, long skippedTableFiles, long resultedTableFiles) {
         this.duration = duration;
         this.scannedManifests = scannedManifests;
-        this.skippedByPartitionAndStats = skippedByPartitionAndStats;
-        this.skippedByWholeBucketFiles = skippedByWholeBucketFiles;
-        this.skippedTableFiles = skippedByPartitionAndStats + skippedByWholeBucketFiles;
+        this.skippedTableFiles = skippedTableFiles;
         this.resultedTableFiles = resultedTableFiles;
     }
 
@@ -58,16 +50,6 @@ public class ScanStats {
     @VisibleForTesting
     protected long getResultedTableFiles() {
         return resultedTableFiles;
-    }
-
-    @VisibleForTesting
-    protected long getSkippedByPartitionAndStats() {
-        return skippedByPartitionAndStats;
-    }
-
-    @VisibleForTesting
-    protected long getSkippedByWholeBucketFiles() {
-        return skippedByWholeBucketFiles;
     }
 
     @VisibleForTesting

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
@@ -68,7 +68,7 @@ import static org.apache.paimon.CoreOptions.ExpireExecutionMode;
 import static org.apache.paimon.table.sink.BatchWriteBuilder.COMMIT_IDENTIFIER;
 import static org.apache.paimon.utils.ManifestReadThreadPool.getExecutorService;
 import static org.apache.paimon.utils.Preconditions.checkState;
-import static org.apache.paimon.utils.ThreadPoolUtils.randomlyExecute;
+import static org.apache.paimon.utils.ThreadPoolUtils.randomlyExecuteSequentialReturn;
 
 /** An abstraction layer above {@link FileStoreCommit} to provide snapshot commit and expiration. */
 public class TableCommitImpl implements InnerTableCommit {
@@ -292,7 +292,7 @@ public class TableCommitImpl implements InnerTableCommit {
 
         List<Path> nonExistFiles =
                 Lists.newArrayList(
-                        randomlyExecute(
+                        randomlyExecuteSequentialReturn(
                                 getExecutorService(null),
                                 f -> nonExists.test(f) ? singletonList(f) : emptyList(),
                                 files));

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
@@ -51,7 +51,7 @@ public class DataTableBatchScan extends AbstractDataTableScan {
         this.hasNext = true;
         this.defaultValueAssigner = defaultValueAssigner;
         if (pkTable && (options.deletionVectorsEnabled() || options.mergeEngine() == FIRST_ROW)) {
-            snapshotReader.withLevelFilter(level -> level > 0);
+            snapshotReader.withLevelFilter(level -> level > 0).enableValueFilter();
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/StreamDataTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/StreamDataTableScan.java
@@ -29,4 +29,10 @@ public interface StreamDataTableScan extends DataTableScan, StreamTableScan {
 
     /** Restore from checkpoint next snapshot id with scan kind. */
     void restore(@Nullable Long nextSnapshotId, boolean scanAllSnapshot);
+
+    @Override
+    default StreamDataTableScan dropStats() {
+        // do nothing, should implement this if need
+        return this;
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/StreamDataTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/StreamDataTableScan.java
@@ -29,10 +29,4 @@ public interface StreamDataTableScan extends DataTableScan, StreamTableScan {
 
     /** Restore from checkpoint next snapshot id with scan kind. */
     void restore(@Nullable Long nextSnapshotId, boolean scanAllSnapshot);
-
-    @Override
-    default StreamDataTableScan dropStats() {
-        // do nothing, should implement this if need
-        return this;
-    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/IncrementalStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/IncrementalStartingScanner.java
@@ -31,7 +31,6 @@ import org.apache.paimon.table.source.PlanImpl;
 import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.SplitGenerator;
-import org.apache.paimon.utils.ManifestReadThreadPool;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.SnapshotManager;
 
@@ -50,6 +49,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
+import static org.apache.paimon.utils.ManifestReadThreadPool.randomlyExecuteSequentialReturn;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** {@link StartingScanner} for incremental changes by snapshot. */
@@ -84,7 +84,7 @@ public class IncrementalStartingScanner extends AbstractStartingScanner {
                         .collect(Collectors.toList());
 
         Iterator<ManifestFileMeta> manifests =
-                ManifestReadThreadPool.randomlyExecute(
+                randomlyExecuteSequentialReturn(
                         id -> {
                             Snapshot snapshot = snapshotManager.snapshot(id);
                             switch (scanMode) {
@@ -111,7 +111,7 @@ public class IncrementalStartingScanner extends AbstractStartingScanner {
                         reader.parallelism());
 
         Iterator<ManifestEntry> entries =
-                ManifestReadThreadPool.randomlyExecute(
+                randomlyExecuteSequentialReturn(
                         reader::readManifest, Lists.newArrayList(manifests), reader.parallelism());
 
         while (entries.hasNext()) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
@@ -77,6 +77,8 @@ public interface SnapshotReader {
 
     SnapshotReader withLevelFilter(Filter<Integer> levelFilter);
 
+    SnapshotReader enableValueFilter();
+
     SnapshotReader withManifestEntryFilter(Filter<ManifestEntry> filter);
 
     SnapshotReader withBucket(int bucket);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
@@ -235,6 +235,12 @@ public class SnapshotReaderImpl implements SnapshotReader {
     }
 
     @Override
+    public SnapshotReader enableValueFilter() {
+        scan.enableValueFilter();
+        return this;
+    }
+
+    @Override
     public SnapshotReader withManifestEntryFilter(Filter<ManifestEntry> filter) {
         scan.withManifestEntryFilter(filter);
         return this;

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
@@ -320,6 +320,12 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
         }
 
         @Override
+        public SnapshotReader enableValueFilter() {
+            wrapped.enableValueFilter();
+            return this;
+        }
+
+        @Override
         public SnapshotReader withManifestEntryFilter(Filter<ManifestEntry> filter) {
             wrapped.withManifestEntryFilter(filter);
             return this;

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ReadOptimizedTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ReadOptimizedTable.java
@@ -120,7 +120,8 @@ public class ReadOptimizedTable implements DataTable, ReadonlyTable {
     public SnapshotReader newSnapshotReader() {
         if (wrapped.schema().primaryKeys().size() > 0) {
             return wrapped.newSnapshotReader()
-                    .withLevelFilter(level -> level == coreOptions().numLevels() - 1);
+                    .withLevelFilter(level -> level == coreOptions().numLevels() - 1)
+                    .enableValueFilter();
         } else {
             return wrapped.newSnapshotReader();
         }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ManifestReadThreadPool.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ManifestReadThreadPool.java
@@ -54,9 +54,9 @@ public class ManifestReadThreadPool {
     }
 
     /** This method aims to parallel process tasks with randomly but return values sequentially. */
-    public static <T, U> Iterator<T> randomlyExecute(
+    public static <T, U> Iterator<T> randomlyExecuteSequentialReturn(
             Function<U, List<T>> processor, List<U> input, @Nullable Integer threadNum) {
         ThreadPoolExecutor executor = getExecutorService(threadNum);
-        return ThreadPoolUtils.randomlyExecute(executor, processor, input);
+        return ThreadPoolUtils.randomlyExecuteSequentialReturn(executor, processor, input);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
@@ -94,7 +94,8 @@ public class ObjectsFile<T> implements SimpleFileReader<T> {
     }
 
     public List<T> read(String fileName, @Nullable Long fileSize) {
-        return read(fileName, fileSize, Filter.alwaysTrue(), Filter.alwaysTrue());
+        return read(
+                fileName, fileSize, Filter.alwaysTrue(), Filter.alwaysTrue(), Filter.alwaysTrue());
     }
 
     public List<T> readWithIOException(String fileName) throws IOException {
@@ -103,7 +104,8 @@ public class ObjectsFile<T> implements SimpleFileReader<T> {
 
     public List<T> readWithIOException(String fileName, @Nullable Long fileSize)
             throws IOException {
-        return readWithIOException(fileName, fileSize, Filter.alwaysTrue(), Filter.alwaysTrue());
+        return readWithIOException(
+                fileName, fileSize, Filter.alwaysTrue(), Filter.alwaysTrue(), Filter.alwaysTrue());
     }
 
     public boolean exists(String fileName) {
@@ -118,9 +120,10 @@ public class ObjectsFile<T> implements SimpleFileReader<T> {
             String fileName,
             @Nullable Long fileSize,
             Filter<InternalRow> loadFilter,
-            Filter<InternalRow> readFilter) {
+            Filter<InternalRow> readFilter,
+            Filter<T> readTFilter) {
         try {
-            return readWithIOException(fileName, fileSize, loadFilter, readFilter);
+            return readWithIOException(fileName, fileSize, loadFilter, readFilter, readTFilter);
         } catch (IOException e) {
             throw new RuntimeException("Failed to read " + fileName, e);
         }
@@ -130,14 +133,16 @@ public class ObjectsFile<T> implements SimpleFileReader<T> {
             String fileName,
             @Nullable Long fileSize,
             Filter<InternalRow> loadFilter,
-            Filter<InternalRow> readFilter)
+            Filter<InternalRow> readFilter,
+            Filter<T> readTFilter)
             throws IOException {
         Path path = pathFactory.toPath(fileName);
         if (cache != null) {
-            return cache.read(path, fileSize, loadFilter, readFilter);
+            return cache.read(path, fileSize, loadFilter, readFilter, readTFilter);
         }
 
-        return readFromIterator(createIterator(path, fileSize), serializer, readFilter);
+        return readFromIterator(
+                createIterator(path, fileSize), serializer, readFilter, readTFilter);
     }
 
     public String writeWithoutRolling(Collection<T> records) {
@@ -184,13 +189,17 @@ public class ObjectsFile<T> implements SimpleFileReader<T> {
     public static <V> List<V> readFromIterator(
             CloseableIterator<InternalRow> inputIterator,
             ObjectSerializer<V> serializer,
-            Filter<InternalRow> readFilter) {
+            Filter<InternalRow> readFilter,
+            Filter<V> readVFilter) {
         try (CloseableIterator<InternalRow> iterator = inputIterator) {
             List<V> result = new ArrayList<>();
             while (iterator.hasNext()) {
                 InternalRow row = iterator.next();
                 if (readFilter.test(row)) {
-                    result.add(serializer.fromRow(row));
+                    V v = serializer.fromRow(row);
+                    if (readVFilter.test(v)) {
+                        result.add(v);
+                    }
                 }
             }
             return result;

--- a/paimon-core/src/test/java/org/apache/paimon/operation/metrics/ScanMetricsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/metrics/ScanMetricsTest.java
@@ -48,9 +48,7 @@ public class ScanMetricsTest {
                         ScanMetrics.SCAN_DURATION,
                         ScanMetrics.LAST_SCANNED_MANIFESTS,
                         ScanMetrics.LAST_SCAN_SKIPPED_TABLE_FILES,
-                        ScanMetrics.LAST_SCAN_RESULTED_TABLE_FILES,
-                        ScanMetrics.LAST_SKIPPED_BY_PARTITION_AND_STATS,
-                        ScanMetrics.LAST_SKIPPED_BY_WHOLE_BUCKET_FILES_FILTER);
+                        ScanMetrics.LAST_SCAN_RESULTED_TABLE_FILES);
     }
 
     /** Tests that the metrics are updated properly. */
@@ -66,14 +64,6 @@ public class ScanMetricsTest {
                 (Histogram) registeredGenericMetrics.get(ScanMetrics.SCAN_DURATION);
         Gauge<Long> lastScannedManifests =
                 (Gauge<Long>) registeredGenericMetrics.get(ScanMetrics.LAST_SCANNED_MANIFESTS);
-        Gauge<Long> lastSkippedByPartitionAndStats =
-                (Gauge<Long>)
-                        registeredGenericMetrics.get(
-                                ScanMetrics.LAST_SKIPPED_BY_PARTITION_AND_STATS);
-        Gauge<Long> lastSkippedByWholeBucketFilesFilter =
-                (Gauge<Long>)
-                        registeredGenericMetrics.get(
-                                ScanMetrics.LAST_SKIPPED_BY_WHOLE_BUCKET_FILES_FILTER);
         Gauge<Long> lastScanSkippedTableFiles =
                 (Gauge<Long>)
                         registeredGenericMetrics.get(ScanMetrics.LAST_SCAN_SKIPPED_TABLE_FILES);
@@ -85,8 +75,6 @@ public class ScanMetricsTest {
         assertThat(scanDuration.getCount()).isEqualTo(0);
         assertThat(scanDuration.getStatistics().size()).isEqualTo(0);
         assertThat(lastScannedManifests.getValue()).isEqualTo(0);
-        assertThat(lastSkippedByPartitionAndStats.getValue()).isEqualTo(0);
-        assertThat(lastSkippedByWholeBucketFilesFilter.getValue()).isEqualTo(0);
         assertThat(lastScanSkippedTableFiles.getValue()).isEqualTo(0);
         assertThat(lastScanResultedTableFiles.getValue()).isEqualTo(0);
 
@@ -104,9 +92,7 @@ public class ScanMetricsTest {
         assertThat(scanDuration.getStatistics().getMax()).isEqualTo(200);
         assertThat(scanDuration.getStatistics().getStdDev()).isEqualTo(0);
         assertThat(lastScannedManifests.getValue()).isEqualTo(20);
-        assertThat(lastSkippedByPartitionAndStats.getValue()).isEqualTo(25);
-        assertThat(lastSkippedByWholeBucketFilesFilter.getValue()).isEqualTo(32);
-        assertThat(lastScanSkippedTableFiles.getValue()).isEqualTo(57);
+        assertThat(lastScanSkippedTableFiles.getValue()).isEqualTo(25);
         assertThat(lastScanResultedTableFiles.getValue()).isEqualTo(10);
 
         // report again
@@ -123,19 +109,17 @@ public class ScanMetricsTest {
         assertThat(scanDuration.getStatistics().getMax()).isEqualTo(500);
         assertThat(scanDuration.getStatistics().getStdDev()).isCloseTo(212.132, offset(0.001));
         assertThat(lastScannedManifests.getValue()).isEqualTo(22);
-        assertThat(lastSkippedByPartitionAndStats.getValue()).isEqualTo(30);
-        assertThat(lastSkippedByWholeBucketFilesFilter.getValue()).isEqualTo(33);
-        assertThat(lastScanSkippedTableFiles.getValue()).isEqualTo(63);
+        assertThat(lastScanSkippedTableFiles.getValue()).isEqualTo(30);
         assertThat(lastScanResultedTableFiles.getValue()).isEqualTo(8);
     }
 
     private void reportOnce(ScanMetrics scanMetrics) {
-        ScanStats scanStats = new ScanStats(200, 20, 25, 32, 10);
+        ScanStats scanStats = new ScanStats(200, 20, 25, 10);
         scanMetrics.reportScan(scanStats);
     }
 
     private void reportAgain(ScanMetrics scanMetrics) {
-        ScanStats scanStats = new ScanStats(500, 22, 30, 33, 8);
+        ScanStats scanStats = new ScanStats(500, 22, 30, 8);
         scanMetrics.reportScan(scanStats);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
@@ -121,17 +121,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /** Tests for {@link PrimaryKeyFileStoreTable}. */
 public class PrimaryKeyFileStoreTableTest extends FileStoreTableTestBase {
 
-    protected static final RowType COMPATIBILITY_ROW_TYPE =
-            RowType.of(
-                    new DataType[] {
-                        DataTypes.INT(),
-                        DataTypes.INT(),
-                        DataTypes.BIGINT(),
-                        DataTypes.BINARY(1),
-                        DataTypes.VARBINARY(1)
-                    },
-                    new String[] {"pt", "a", "b", "c", "d"});
-
     protected static final Function<InternalRow, String> COMPATIBILITY_BATCH_ROW_TO_STRING =
             rowData ->
                     rowData.getInt(0)
@@ -143,12 +132,6 @@ public class PrimaryKeyFileStoreTableTest extends FileStoreTableTestBase {
                             + new String(rowData.getBinary(3))
                             + "|"
                             + new String(rowData.getBinary(4));
-
-    protected static final Function<InternalRow, String> COMPATIBILITY_CHANGELOG_ROW_TO_STRING =
-            rowData ->
-                    rowData.getRowKind().shortString()
-                            + " "
-                            + COMPATIBILITY_BATCH_ROW_TO_STRING.apply(rowData);
 
     @Test
     public void testMultipleWriters() throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/utils/ObjectsCacheTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/ObjectsCacheTest.java
@@ -58,17 +58,23 @@ public class ObjectsCacheTest {
 
         // test empty
         map.put("k1", Collections.emptyList());
-        List<String> values = cache.read("k1", null, Filter.alwaysTrue(), Filter.alwaysTrue());
+        List<String> values =
+                cache.read(
+                        "k1", null, Filter.alwaysTrue(), Filter.alwaysTrue(), Filter.alwaysTrue());
         assertThat(values).isEmpty();
 
         // test values
         List<String> expect = Arrays.asList("v1", "v2", "v3");
         map.put("k2", expect);
-        values = cache.read("k2", null, Filter.alwaysTrue(), Filter.alwaysTrue());
+        values =
+                cache.read(
+                        "k2", null, Filter.alwaysTrue(), Filter.alwaysTrue(), Filter.alwaysTrue());
         assertThat(values).containsExactlyElementsOf(expect);
 
         // test cache
-        values = cache.read("k2", null, Filter.alwaysTrue(), Filter.alwaysTrue());
+        values =
+                cache.read(
+                        "k2", null, Filter.alwaysTrue(), Filter.alwaysTrue(), Filter.alwaysTrue());
         assertThat(values).containsExactlyElementsOf(expect);
 
         // test filter
@@ -77,7 +83,8 @@ public class ObjectsCacheTest {
                         "k2",
                         null,
                         Filter.alwaysTrue(),
-                        r -> r.getString(0).toString().endsWith("2"));
+                        r -> r.getString(0).toString().endsWith("2"),
+                        Filter.alwaysTrue());
         assertThat(values).containsExactly("v2");
 
         // test load filter
@@ -88,6 +95,7 @@ public class ObjectsCacheTest {
                         "k3",
                         null,
                         r -> r.getString(0).toString().endsWith("2"),
+                        Filter.alwaysTrue(),
                         Filter.alwaysTrue());
         assertThat(values).containsExactly("v2");
 
@@ -99,6 +107,7 @@ public class ObjectsCacheTest {
                         "k4",
                         null,
                         r -> r.getString(0).toString().endsWith("5"),
+                        Filter.alwaysTrue(),
                         Filter.alwaysTrue());
         assertThat(values).isEmpty();
 
@@ -116,6 +125,7 @@ public class ObjectsCacheTest {
                                                 cache.read(
                                                         k,
                                                         null,
+                                                        Filter.alwaysTrue(),
                                                         Filter.alwaysTrue(),
                                                         Filter.alwaysTrue()))
                                         .containsExactly(k);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileStoreSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileStoreSource.java
@@ -77,7 +77,7 @@ public class ContinuousFileStoreSource extends FlinkSource {
             nextSnapshotId = checkpoint.currentSnapshotId();
             splits = checkpoint.splits();
         }
-        StreamTableScan scan = readBuilder.dropStats().newStreamScan();
+        StreamTableScan scan = readBuilder.newStreamScan();
         if (metricGroup(context) != null) {
             ((StreamDataTableScan) scan)
                     .withMetricsRegistry(new FlinkMetricRegistry(context.metricGroup()));

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
@@ -178,7 +178,7 @@ public class FlinkSourceBuilder {
         if (limit != null) {
             readBuilder.withLimit(limit.intValue());
         }
-        return readBuilder;
+        return readBuilder.dropStats();
     }
 
     private DataStream<RowData> buildStaticFileSource() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSource.java
@@ -87,7 +87,7 @@ public class StaticFileStoreSource extends FlinkSource {
 
     private List<FileStoreSourceSplit> getSplits(SplitEnumeratorContext context) {
         FileStoreSourceSplitGenerator splitGenerator = new FileStoreSourceSplitGenerator();
-        TableScan scan = readBuilder.dropStats().newScan();
+        TableScan scan = readBuilder.newScan();
         // register scan metrics
         if (context.metricGroup() != null) {
             ((InnerTableScan) scan)

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/MonitorFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/MonitorFunction.java
@@ -106,7 +106,7 @@ public class MonitorFunction extends RichSourceFunction<Split>
 
     @Override
     public void initializeState(FunctionInitializationContext context) throws Exception {
-        this.scan = readBuilder.dropStats().newStreamScan();
+        this.scan = readBuilder.newStreamScan();
 
         this.checkpointState =
                 context.getOperatorStateStore()

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/utils/HiveSplitGenerator.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/utils/HiveSplitGenerator.java
@@ -96,7 +96,8 @@ public class HiveSplitGenerator {
                     scan.withFilter(PredicateBuilder.and(predicatePerPartition));
                 }
             }
-            scan.plan()
+            scan.dropStats()
+                    .plan()
                     .splits()
                     .forEach(
                             split ->

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/ColumnPruningAndPushDown.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/ColumnPruningAndPushDown.scala
@@ -62,7 +62,7 @@ trait ColumnPruningAndPushDown extends Scan with Logging {
       _readBuilder.withFilter(pushedPredicate)
     }
     pushDownLimit.foreach(_readBuilder.withLimit)
-    _readBuilder
+    _readBuilder.dropStats()
   }
 
   final def metadataColumns: Seq[PaimonMetadataColumn] = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -71,6 +71,7 @@ abstract class PaimonBaseScan(
       .newScan()
       .asInstanceOf[InnerTableScan]
       .withMetricsRegistry(paimonMetricsRegistry)
+      .dropStats()
       .plan()
       .splits()
       .asScala

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -71,7 +71,6 @@ abstract class PaimonBaseScan(
       .newScan()
       .asInstanceOf[InnerTableScan]
       .withMetricsRegistry(paimonMetricsRegistry)
-      .dropStats()
       .plan()
       .splits()
       .asScala

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeTableColumnCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeTableColumnCommand.scala
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.spark.commands
 
+import org.apache.paimon.manifest.PartitionEntry
 import org.apache.paimon.schema.TableSchema
 import org.apache.paimon.spark.SparkTable
 import org.apache.paimon.spark.leafnode.PaimonLeafRunnableCommand
@@ -64,11 +65,9 @@ case class PaimonAnalyzeTableColumnCommand(
     // compute stats
     val totalSize = table
       .newScan()
-      .plan()
-      .splits()
+      .listPartitionEntries()
       .asScala
-      .flatMap { case split: DataSplit => split.dataFiles().asScala }
-      .map(_.fileSize())
+      .map(_.fileSizeInBytes())
       .sum
     val (mergedRecordCount, colStats) =
       PaimonStatsUtils.computeColumnStats(sparkSession, relation, attributes)

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/sources/StreamHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/sources/StreamHelper.scala
@@ -44,7 +44,7 @@ private[spark] trait StreamHelper {
 
   var lastTriggerMillis: Long
 
-  private lazy val streamScan: StreamDataTableScan = table.newStreamScan()
+  private lazy val streamScan: StreamDataTableScan = table.newStreamScan().dropStats()
 
   private lazy val partitionSchema: StructType =
     SparkTypeUtils.fromPaimonRowType(TypeUtils.project(table.rowType(), table.partitionKeys()))

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/sources/StreamHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/sources/StreamHelper.scala
@@ -44,7 +44,8 @@ private[spark] trait StreamHelper {
 
   var lastTriggerMillis: Long
 
-  private lazy val streamScan: StreamDataTableScan = table.newStreamScan().dropStats()
+  private lazy val streamScan: StreamDataTableScan =
+    table.newStreamScan().dropStats().asInstanceOf[StreamDataTableScan]
 
   private lazy val partitionSchema: StructType =
     SparkTypeUtils.fromPaimonRowType(TypeUtils.project(table.rowType(), table.partitionKeys()))


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
We planned to remove the statistical information when reading the file, but this optimization was hindered by the need for statistical information later for whole bucket filter.

In this PR, we refactor this logical to drop stats and compute filter selected result, in this way, we can keep whole bucket filter.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
