### PR TITLE
[paimon-flink-cdc] Add the latest_schema state at schema evolution operator ，Reduce the latest schema access frequency

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/types/FieldIdentifier.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/FieldIdentifier.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.types;
+
+import java.util.Objects;
+
+/** Used to indicate the uniqueness of a field. */
+public class FieldIdentifier {
+    private String name;
+    private DataType type;
+    private String description;
+
+    public FieldIdentifier(DataField dataField) {
+        this.name = dataField.name();
+        this.type = dataField.type();
+        this.description = dataField.description();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FieldIdentifier field = (FieldIdentifier) o;
+        return Objects.equals(name, field.name)
+                && Objects.equals(type, field.type)
+                && Objects.equals(description, field.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, type, description);
+    }
+}

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunction.java
@@ -54,7 +54,7 @@ public class UpdatedDataFieldsProcessFunction
     private final Identifier identifier;
 
     private ListState<DataField> latestSchemaListState;
-    private List<DataField> latestSchemaList;
+    private final List<DataField> latestSchemaList;
 
     public UpdatedDataFieldsProcessFunction(
             SchemaManager schemaManager, Identifier identifier, Catalog.Loader catalogLoader) {
@@ -79,7 +79,7 @@ public class UpdatedDataFieldsProcessFunction
                 extractSchemaChanges(schemaManager, actualUpdatedDataFields)) {
             applySchemaChange(schemaManager, schemaChange, identifier);
         }
-        actualUpdatedDataFields.forEach(field -> latestSchemaList.add(field));
+        latestSchemaList.addAll(actualUpdatedDataFields);
     }
 
     @Override
@@ -96,10 +96,10 @@ public class UpdatedDataFieldsProcessFunction
                                 new ListStateDescriptor<>(
                                         "latest-schema-list-state", DataField.class));
         if (context.isRestored()) {
-            latestSchemaListState.get().forEach(dataField -> latestSchemaList.add(dataField));
+            latestSchemaListState.get().forEach(latestSchemaList::add);
         } else {
             RowType oldRowType = schemaManager.latest().get().logicalRowType();
-            oldRowType.getFields().forEach(dataField -> latestSchemaList.add(dataField));
+            latestSchemaList.addAll(oldRowType.getFields());
         }
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/SchemaEvolutionTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/SchemaEvolutionTest.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action.cdc;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.flink.FlinkCatalogFactory;
+import org.apache.paimon.flink.sink.cdc.UpdatedDataFieldsProcessFunction;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.types.*;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.junit.Before;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class SchemaEvolutionTest {
+
+    private static List<List<DataField>> prepareData() {
+        List<DataField> upField1 =
+                Arrays.asList(
+                        new DataField(0, "col_0", new VarCharType(), "test description."),
+                        new DataField(1, "col_1", new VarCharType(), "test description."),
+                        new DataField(2, "col_2", new IntType(), "test description."),
+                        new DataField(3, "col_3", new VarCharType(), "Someone's desc."),
+                        new DataField(4, "col_4", new VarCharType(), "Someone's desc."),
+                        new DataField(5, "col_5", new VarCharType(), "Someone's desc."),
+                        new DataField(6, "col_6", new DecimalType(), "Someone's desc."),
+                        new DataField(7, "col_7", new VarCharType(), "Someone's desc."),
+                        new DataField(8, "col_8", new VarCharType(), "Someone's desc."),
+                        new DataField(9, "col_9", new VarCharType(), "Someone's desc."),
+                        new DataField(10, "col_10", new VarCharType(), "Someone's desc."),
+                        new DataField(11, "col_11", new VarCharType(), "Someone's desc."),
+                        new DataField(12, "col_12", new DoubleType(), "Someone's desc."),
+                        new DataField(13, "col_13", new VarCharType(), "Someone's desc."),
+                        new DataField(14, "col_14", new VarCharType(), "Someone's desc."),
+                        new DataField(15, "col_15", new VarCharType(), "Someone's desc."),
+                        new DataField(16, "col_16", new VarCharType(), "Someone's desc."),
+                        new DataField(17, "col_17", new VarCharType(), "Someone's desc."),
+                        new DataField(18, "col_18", new VarCharType(), "Someone's desc."),
+                        new DataField(19, "col_19", new VarCharType(), "Someone's desc."),
+                        new DataField(20, "col_20", new VarCharType(), "Someone's desc."));
+        List<DataField> upField2 =
+                Arrays.asList(
+                        new DataField(0, "col_0", new VarCharType(), "test description."),
+                        new DataField(1, "col_1", new IntType(), "test description."),
+                        new DataField(2, "col_2", new IntType(), "test description."),
+                        new DataField(3, "col_3", new VarCharType(), "Someone's desc."),
+                        new DataField(4, "col_4", new VarCharType(), "Someone's desc."),
+                        new DataField(5, "col_5", new VarCharType(), "Someone's desc."),
+                        new DataField(6, "col_6", new DecimalType(), "Someone's desc."),
+                        new DataField(7, "col_7", new VarCharType(), "Someone's desc."),
+                        new DataField(8, "col_8", new VarCharType(), "Someone's desc."),
+                        new DataField(9, "col_9", new VarCharType(), "Someone's desc."),
+                        new DataField(10, "col_10", new VarCharType(), "Someone's desc."),
+                        new DataField(11, "col_11", new VarCharType(), "Someone's desc."),
+                        new DataField(12, "col_12", new DoubleType(), "Someone's desc."),
+                        new DataField(13, "col_13", new VarCharType(), "Someone's desc."),
+                        new DataField(14, "col_14", new VarCharType(), "Someone's desc."),
+                        new DataField(15, "col_15_1", new VarCharType(), "Someone's desc."),
+                        new DataField(16, "col_16", new VarCharType(), "Someone's desc."),
+                        new DataField(17, "col_17", new VarCharType(), "Someone's desc."),
+                        new DataField(18, "col_18", new VarCharType(), "Someone's desc."),
+                        new DataField(19, "col_19", new VarCharType(), "Someone's desc."),
+                        new DataField(20, "col_20", new VarCharType(), "Someone's desc."));
+        List<DataField> upField3 =
+                Arrays.asList(
+                        new DataField(0, "col_0", new VarCharType(), "test description."),
+                        new DataField(1, "col_1", new VarCharType(), "test description."),
+                        new DataField(2, "col_2", new IntType(), "test description."),
+                        new DataField(3, "col_3", new VarCharType(), "Someone's desc."),
+                        new DataField(4, "col_4", new VarCharType(), "Someone's desc."),
+                        new DataField(5, "col_5", new VarCharType(), "Someone's desc."),
+                        new DataField(6, "col_6", new DecimalType(), "Someone's desc."),
+                        new DataField(7, "col_7", new VarCharType(), "Someone's desc."),
+                        new DataField(8, "col_8", new VarCharType(), "Someone's desc."),
+                        new DataField(9, "col_9", new VarCharType(), "Someone's desc."),
+                        new DataField(10, "col_10", new VarCharType(), "Someone's desc."),
+                        new DataField(11, "col_11", new IntType(), "Someone's desc."),
+                        new DataField(12, "col_12_2", new DoubleType(), "Someone's desc."),
+                        new DataField(13, "col_13", new VarCharType(), "Someone's desc."),
+                        new DataField(14, "col_14", new VarCharType(), "Someone's desc."),
+                        new DataField(15, "col_15", new VarCharType(), "Someone's desc."),
+                        new DataField(16, "col_16", new VarCharType(), "Someone's desc."),
+                        new DataField(17, "col_17", new VarCharType(), "Someone's desc."),
+                        new DataField(18, "col_18", new VarCharType(), "Someone's desc."),
+                        new DataField(19, "col_19_1", new VarCharType(), "Someone's desc."),
+                        new DataField(20, "col_20", new VarCharType(), "Someone's desc."));
+        List<DataField> upField4 =
+                Arrays.asList(
+                        new DataField(0, "col_0", new VarCharType(), "test description."),
+                        new DataField(1, "col_1", new VarCharType(), "test description."),
+                        new DataField(2, "col_2", new IntType(), "test description."),
+                        new DataField(3, "col_3", new VarCharType(), "Someone's desc."),
+                        new DataField(4, "col_4", new VarCharType(), "Someone's desc."),
+                        new DataField(5, "col_5", new VarCharType(), "Someone's desc."),
+                        new DataField(6, "col_6", new DecimalType(), "Someone's desc."),
+                        new DataField(7, "col_7", new VarCharType(), "Someone's desc."),
+                        new DataField(8, "col_8", new VarCharType(), "Someone's desc."),
+                        new DataField(9, "col_9", new VarCharType(), "Someone's desc."),
+                        new DataField(10, "col_10", new VarCharType(), "Someone's desc."),
+                        new DataField(11, "col_11", new VarCharType(), "Someone's desc."),
+                        new DataField(12, "col_12", new DoubleType(), "up desc."),
+                        new DataField(13, "col_13", new VarCharType(), "Someone's desc."),
+                        new DataField(14, "col_14", new VarCharType(), "Someone's desc."),
+                        new DataField(15, "col_15", new VarCharType(), "Someone's desc."),
+                        new DataField(16, "col_16_1", new VarCharType(), "up desc."),
+                        new DataField(17, "col_17", new VarCharType(), "Someone's desc."),
+                        new DataField(18, "col_18", new VarCharType(), "Someone's desc."),
+                        new DataField(19, "col_19", new VarCharType(), "Someone's desc."),
+                        new DataField(20, "col_20", new VarCharType(), "Someone's desc."));
+        List<DataField> upField5 =
+                Arrays.asList(
+                        new DataField(0, "col_0", new VarCharType(), "test description."),
+                        new DataField(1, "col_1", new VarCharType(), "test description."),
+                        new DataField(2, "col_2", new IntType(), "test description."),
+                        new DataField(3, "col_3", new VarCharType(), "Someone's desc."),
+                        new DataField(4, "col_4", new VarCharType(), "Someone's desc."),
+                        new DataField(5, "col_5", new VarCharType(), "Someone's desc."),
+                        new DataField(6, "col_6", new DecimalType(), "Someone's desc."),
+                        new DataField(7, "col_7", new VarCharType(), "Someone's desc."),
+                        new DataField(8, "col_8", new VarCharType(), "Someone's desc."),
+                        new DataField(9, "col_9", new VarCharType(), "Someone's desc."),
+                        new DataField(10, "col_10", new VarCharType(), "Someone's desc."),
+                        new DataField(11, "col_11", new VarCharType(), "Someone's desc."),
+                        new DataField(12, "col_12", new DoubleType(), "Someone's desc."),
+                        new DataField(13, "col_13", new VarCharType(), "Someone's desc."),
+                        new DataField(14, "col_14", new VarCharType(), "Someone's desc."),
+                        new DataField(15, "col_15", new VarCharType(), "Someone's desc."),
+                        new DataField(16, "col_16", new VarCharType(), "Someone's desc."),
+                        new DataField(17, "col_17", new VarCharType(), "Someone's desc."),
+                        new DataField(18, "col_18", new VarCharType(), "Someone's desc."),
+                        new DataField(19, "col_19", new VarCharType(), "Someone's desc."),
+                        new DataField(20, "col_20", new VarCharType(), "Someone's desc."));
+        return Arrays.asList(upField1, upField3, upField3, upField4, upField5);
+    }
+
+    private final String warehouse = "/tmp/paimon/";
+    private final String database = "test_db";
+    private final String tableName = "test_tb";
+
+    @Before
+    public void createTable() throws Exception {
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.primaryKey("f0", "f1");
+        schemaBuilder.partitionKeys("f1");
+        schemaBuilder.column("f0", DataTypes.STRING());
+        schemaBuilder.column("f1", DataTypes.INT());
+        Schema schema = schemaBuilder.build();
+        Identifier identifier = Identifier.create(database, tableName);
+        try {
+            CatalogContext context = CatalogContext.create(new Path(warehouse));
+            Catalog catalog = CatalogFactory.createCatalog(context);
+            catalog.createDatabase(database, true);
+            catalog.createTable(identifier, schema, true);
+        } catch (Catalog.TableAlreadyExistException e) {
+            // do something
+        } catch (Catalog.DatabaseNotExistException e) {
+            // do something
+        }
+    }
+
+    @Test
+    public void testSchemaEvolution() throws Exception {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        DataStream<List<DataField>> upDataFieldStream = env.fromCollection(prepareData());
+        Options options = new Options();
+        options.set("warehouse", warehouse);
+        final Catalog.Loader catalogLoader = () -> FlinkCatalogFactory.createPaimonCatalog(options);
+        Identifier identifier = Identifier.create(database, tableName);
+        Table table = catalogLoader.load().getTable(identifier);
+        FileStoreTable dataTable = (FileStoreTable) table;
+        upDataFieldStream
+                .process(
+                        new UpdatedDataFieldsProcessFunction(
+                                new SchemaManager(dataTable.fileIO(), dataTable.location()),
+                                identifier,
+                                catalogLoader))
+                .name("Schema Evolution");
+        env.execute();
+    }
+}

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/SchemaEvolutionTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/SchemaEvolutionTest.java
@@ -30,7 +30,12 @@ import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
-import org.apache.paimon.types.*;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.DecimalType;
+import org.apache.paimon.types.DoubleType;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.VarCharType;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -40,6 +45,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 
+/** Used to test schema evolution related logic. */
 public class SchemaEvolutionTest {
 
     private static List<List<DataField>> prepareData() {
@@ -158,7 +164,7 @@ public class SchemaEvolutionTest {
                         new DataField(18, "col_18", new VarCharType(), "Someone's desc."),
                         new DataField(19, "col_19", new VarCharType(), "Someone's desc."),
                         new DataField(20, "col_20", new VarCharType(), "Someone's desc."));
-        return Arrays.asList(upField1, upField3, upField3, upField4, upField5);
+        return Arrays.asList(upField1, upField2, upField3, upField4, upField5);
     }
 
     private final String warehouse = "/tmp/paimon/";

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/SchemaEvolutionTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/SchemaEvolutionTest.java
@@ -21,13 +21,11 @@ package org.apache.paimon.flink.action.cdc;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
-import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.flink.FlinkCatalogFactory;
 import org.apache.paimon.flink.sink.cdc.UpdatedDataFieldsProcessFunction;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
-import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
@@ -36,14 +34,13 @@ import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.TableTestBase;
-import org.apache.paimon.table.system.FilesTable;
+import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.DoubleType;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.VarCharType;
-import org.apache.paimon.utils.SnapshotManager;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -60,7 +57,7 @@ public class SchemaEvolutionTest extends TableTestBase {
         List<DataField> upField1 =
                 Arrays.asList(
                         new DataField(0, "col_0", new VarCharType(), "test description."),
-                        new DataField(1, "col_1", new VarCharType(), "test description."),
+                        new DataField(1, "col_1", new IntType(), "test description."),
                         new DataField(2, "col_2", new IntType(), "test description."),
                         new DataField(3, "col_3", new VarCharType(), "Someone's desc."),
                         new DataField(4, "col_4", new VarCharType(), "Someone's desc."),
@@ -83,7 +80,7 @@ public class SchemaEvolutionTest extends TableTestBase {
         List<DataField> upField2 =
                 Arrays.asList(
                         new DataField(0, "col_0", new VarCharType(), "test description."),
-                        new DataField(1, "col_1", new IntType(), "test description."),
+                        new DataField(1, "col_1", new BigIntType(), "test description."),
                         new DataField(2, "col_2", new IntType(), "test description."),
                         new DataField(3, "col_3", new VarCharType(), "Someone's desc."),
                         new DataField(4, "col_4", new VarCharType(), "Someone's desc."),
@@ -97,7 +94,7 @@ public class SchemaEvolutionTest extends TableTestBase {
                         new DataField(12, "col_12", new DoubleType(), "Someone's desc."),
                         new DataField(13, "col_13", new VarCharType(), "Someone's desc."),
                         new DataField(14, "col_14", new VarCharType(), "Someone's desc."),
-                        new DataField(15, "col_15_1", new VarCharType(), "Someone's desc."),
+                        new DataField(15, "col_15", new VarCharType(), "Someone's desc."),
                         new DataField(16, "col_16", new VarCharType(), "Someone's desc."),
                         new DataField(17, "col_17", new VarCharType(), "Someone's desc."),
                         new DataField(18, "col_18", new VarCharType(), "Someone's desc."),
@@ -106,31 +103,8 @@ public class SchemaEvolutionTest extends TableTestBase {
         List<DataField> upField3 =
                 Arrays.asList(
                         new DataField(0, "col_0", new VarCharType(), "test description."),
-                        new DataField(1, "col_1", new VarCharType(), "test description."),
-                        new DataField(2, "col_2", new IntType(), "test description."),
-                        new DataField(3, "col_3", new VarCharType(), "Someone's desc."),
-                        new DataField(4, "col_4", new VarCharType(), "Someone's desc."),
-                        new DataField(5, "col_5", new VarCharType(), "Someone's desc."),
-                        new DataField(6, "col_6", new DecimalType(), "Someone's desc."),
-                        new DataField(7, "col_7", new VarCharType(), "Someone's desc."),
-                        new DataField(8, "col_8", new VarCharType(), "Someone's desc."),
-                        new DataField(9, "col_9", new VarCharType(), "Someone's desc."),
-                        new DataField(10, "col_10", new VarCharType(), "Someone's desc."),
-                        new DataField(11, "col_11", new IntType(), "Someone's desc."),
-                        new DataField(12, "col_12_2", new DoubleType(), "Someone's desc."),
-                        new DataField(13, "col_13", new VarCharType(), "Someone's desc."),
-                        new DataField(14, "col_14", new VarCharType(), "Someone's desc."),
-                        new DataField(15, "col_15", new VarCharType(), "Someone's desc."),
-                        new DataField(16, "col_16", new VarCharType(), "Someone's desc."),
-                        new DataField(17, "col_17", new VarCharType(), "Someone's desc."),
-                        new DataField(18, "col_18", new VarCharType(), "Someone's desc."),
-                        new DataField(19, "col_19_1", new VarCharType(), "Someone's desc."),
-                        new DataField(20, "col_20", new VarCharType(), "Someone's desc."));
-        List<DataField> upField4 =
-                Arrays.asList(
-                        new DataField(0, "col_0", new VarCharType(), "test description."),
-                        new DataField(1, "col_1", new VarCharType(), "test description."),
-                        new DataField(2, "col_2", new IntType(), "test description."),
+                        new DataField(1, "col_1", new BigIntType(), "test description."),
+                        new DataField(2, "col_2", new IntType(), "test description 2."),
                         new DataField(3, "col_3", new VarCharType(), "Someone's desc."),
                         new DataField(4, "col_4", new VarCharType(), "Someone's desc."),
                         new DataField(5, "col_5", new VarCharType(), "Someone's desc."),
@@ -140,11 +114,34 @@ public class SchemaEvolutionTest extends TableTestBase {
                         new DataField(9, "col_9", new VarCharType(), "Someone's desc."),
                         new DataField(10, "col_10", new VarCharType(), "Someone's desc."),
                         new DataField(11, "col_11", new VarCharType(), "Someone's desc."),
-                        new DataField(12, "col_12", new DoubleType(), "up desc."),
+                        new DataField(12, "col_12", new DoubleType(), "Someone's desc."),
                         new DataField(13, "col_13", new VarCharType(), "Someone's desc."),
                         new DataField(14, "col_14", new VarCharType(), "Someone's desc."),
                         new DataField(15, "col_15", new VarCharType(), "Someone's desc."),
-                        new DataField(16, "col_16_1", new VarCharType(), "up desc."),
+                        new DataField(16, "col_16", new VarCharType(), "Someone's desc."),
+                        new DataField(17, "col_17", new VarCharType(), "Someone's desc."),
+                        new DataField(18, "col_18", new VarCharType(), "Someone's desc."),
+                        new DataField(19, "col_19", new VarCharType(), "Someone's desc."),
+                        new DataField(20, "col_20", new VarCharType(), "Someone's desc."));
+        List<DataField> upField4 =
+                Arrays.asList(
+                        new DataField(0, "col_0", new VarCharType(), "test description."),
+                        new DataField(1, "col_1", new BigIntType(), "test description."),
+                        new DataField(2, "col_2", new IntType(), "test description."),
+                        new DataField(3, "col_3_1", new VarCharType(), "Someone's desc."),
+                        new DataField(4, "col_4", new VarCharType(), "Someone's desc."),
+                        new DataField(5, "col_5", new VarCharType(), "Someone's desc."),
+                        new DataField(6, "col_6", new DecimalType(), "Someone's desc."),
+                        new DataField(7, "col_7", new VarCharType(), "Someone's desc."),
+                        new DataField(8, "col_8", new VarCharType(), "Someone's desc."),
+                        new DataField(9, "col_9", new VarCharType(), "Someone's desc."),
+                        new DataField(10, "col_10", new VarCharType(), "Someone's desc."),
+                        new DataField(11, "col_11", new VarCharType(), "Someone's desc."),
+                        new DataField(12, "col_12", new DoubleType(), "Someone's desc."),
+                        new DataField(13, "col_13", new VarCharType(), "Someone's desc."),
+                        new DataField(14, "col_14", new VarCharType(), "Someone's desc."),
+                        new DataField(15, "col_15", new VarCharType(), "Someone's desc."),
+                        new DataField(16, "col_16", new VarCharType(), "Someone's desc."),
                         new DataField(17, "col_17", new VarCharType(), "Someone's desc."),
                         new DataField(18, "col_18", new VarCharType(), "Someone's desc."),
                         new DataField(19, "col_19", new VarCharType(), "Someone's desc."),
@@ -152,8 +149,8 @@ public class SchemaEvolutionTest extends TableTestBase {
         List<DataField> upField5 =
                 Arrays.asList(
                         new DataField(0, "col_0", new VarCharType(), "test description."),
-                        new DataField(1, "col_1", new VarCharType(), "test description."),
-                        new DataField(2, "col_2", new IntType(), "test description."),
+                        new DataField(1, "col_1", new BigIntType(), "test description."),
+                        new DataField(2, "col_2_1", new BigIntType(), "test description 2."),
                         new DataField(3, "col_3", new VarCharType(), "Someone's desc."),
                         new DataField(4, "col_4", new VarCharType(), "Someone's desc."),
                         new DataField(5, "col_5", new VarCharType(), "Someone's desc."),
@@ -176,9 +173,6 @@ public class SchemaEvolutionTest extends TableTestBase {
     }
 
     private FileStoreTable table;
-    private FileStoreScan scan;
-    private FilesTable filesTable;
-    private SnapshotManager snapshotManager;
     private String tableName = "MyTable";
 
     @BeforeEach
@@ -200,18 +194,6 @@ public class SchemaEvolutionTest extends TableTestBase {
         TableSchema tableSchema =
                 SchemaUtils.forceCommit(new SchemaManager(fileIO, tablePath), schema);
         table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath, tableSchema);
-        scan = table.store().newScan();
-
-        Identifier filesTableId =
-                identifier(tableName + Catalog.SYSTEM_TABLE_SPLITTER + FilesTable.FILES);
-        filesTable = (FilesTable) catalog.getTable(filesTableId);
-        snapshotManager = new SnapshotManager(fileIO, tablePath);
-
-        // snapshot 1: append
-        write(table, GenericRow.of(1, 1, 10, 1), GenericRow.of(1, 2, 20, 5));
-
-        // snapshot 2: append
-        write(table, GenericRow.of(2, 1, 10, 3), GenericRow.of(2, 2, 20, 4));
     }
 
     @Test
@@ -222,13 +204,16 @@ public class SchemaEvolutionTest extends TableTestBase {
         options.set("warehouse", tempPath.toString());
         final Catalog.Loader catalogLoader = () -> FlinkCatalogFactory.createPaimonCatalog(options);
         Identifier identifier = Identifier.create(database, tableName);
-        upDataFieldStream
-                .process(
-                        new UpdatedDataFieldsProcessFunction(
-                                new SchemaManager(table.fileIO(), table.location()),
-                                identifier,
-                                catalogLoader))
-                .name("Schema Evolution");
+        DataStream<Void> schemaChangeProcessFunction =
+                upDataFieldStream
+                        .process(
+                                new UpdatedDataFieldsProcessFunction(
+                                        new SchemaManager(table.fileIO(), table.location()),
+                                        identifier,
+                                        catalogLoader))
+                        .name("Schema Evolution");
+        schemaChangeProcessFunction.getTransformation().setParallelism(1);
+        schemaChangeProcessFunction.getTransformation().setMaxParallelism(1);
         env.execute();
     }
 }


### PR DESCRIPTION
### Purpose

Linked issue: [Issue-4521](https://github.com/apache/paimon/issues/4521)

In scenarios where the number of Paimon table fields is large and the Write concurrency is high, reduce the Latest-Schema access frequency to improve the throughput of job cold start

### Tests
Case-1: Observe whether the checkpoint time of schema evolution changes
![image](https://github.com/user-attachments/assets/fe57c57d-f3ed-48d7-a056-abf726ab0e68)
![image](https://github.com/user-attachments/assets/4bb84ecc-f141-46e6-9663-0a0e46b8365d)
![image](https://github.com/user-attachments/assets/0e081c69-ab2d-4b30-9e71-9e1799690137)
Conclusion: After optimization, Schema Evolution is basically completed in seconds, or even milliseconds.

Case-2: Observe the log to see if there are still a large number of read schema behaviors
![image](https://github.com/user-attachments/assets/a8a41eaf-daec-452e-a753-45823276836f)
Conclusion: From hundreds of thousands to 115 times

### API and Format
org.apache.paimon.flink.sink.cdc.UpdatedDataFieldsProcessFunction#processElement

### Documentation
Before the Schema Evolution operator calls org.apache.paimon.flink.sink.cdc.UpdatedDataFieldsProcessFunctionBase#extractSchemaChanges, add a judgment to confirm whether the field update really needs to be triggered.
1. Add a List variable to determine whether it is an updated column: List<DataField> latestSchemaList
2. Add a state ListState. When the task is restored from the state, it is directly restored from here: ListState<DataField> latestSchemaListState
