### PR TITLE
[Bug] Skip overwriting the partition when no data append for dynamic …

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -440,12 +440,16 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             // partition filter is built from static or dynamic partition according to properties
             PartitionPredicate partitionFilter = null;
             if (dynamicPartitionOverwrite) {
-                if (appendTableFiles.isEmpty()) {
+                List<ManifestEntry> appendTableAddedFiles =
+                        appendTableFiles.stream()
+                                .filter(f -> f.kind() == FileKind.ADD)
+                                .collect(Collectors.toList());
+                if (appendTableAddedFiles.isEmpty()) {
                     // in dynamic mode, if there is no changes to commit, no data will be deleted
                     skipOverwrite = true;
                 } else {
                     Set<BinaryRow> partitions =
-                            appendTableFiles.stream()
+                            appendTableAddedFiles.stream()
                                     .map(ManifestEntry::partition)
                                     .collect(Collectors.toSet());
                     partitionFilter = PartitionPredicate.fromMultiple(partitionType, partitions);


### PR DESCRIPTION
…partition overwrite mode.

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

If `dynamic-partition-overwrite` is enabled, the partition should not be overwrite when the input data is empty. Currently, we check the `appendTableFiles`, but it contains the `DELETE` files. We should exclude the `DELETE` files for check.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
