### PR TITLE
[core] Fix that batch unaware bucket compact cannot stop when there is no snapshot

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinator.java
@@ -387,6 +387,9 @@ public class UnawareAppendTableCompactionCoordinator {
             if (nextSnapshot == null) {
                 nextSnapshot = snapshotManager.latestSnapshotId();
                 if (nextSnapshot == null) {
+                    if (!streamingMode) {
+                        throw new EndOfScanException();
+                    }
                     return;
                 }
                 snapshotReader.withMode(ScanMode.ALL);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
