### PR TITLE
[flink] change env.fromData to fromElements for compatibility with flink 1.18 and lower versions

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
@@ -279,7 +279,7 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                 });
 
         if (deletedInLocal.get() != 0) {
-            deleted = deleted.union(env.fromData(deletedInLocal.get()));
+            deleted = deleted.union(env.fromElements(deletedInLocal.get()));
         }
         return deleted;
     }


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
In `FlinkOrphanFilesClean#doOrphanClean`, `env.fromData` is used for collecting information. While `env.fromData` was introduced in Flink 1.19, so it'll throw `NoSuchMethodError` when used in Flink 1.18- version. This pr changed `env.fromData` to `env.fromElements` to be compatible with lower flink versions.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
