### PR TITLE
[Core][Flink][Spark] Add deletedFileTotalLenInBytes in result of OrphanFilesClean

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/CleanOrphanFilesResult.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/CleanOrphanFilesResult.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.operation;
+
+import org.apache.paimon.fs.Path;
+
+import java.util.List;
+
+/** The result of OrphanFilesClean. */
+public class CleanOrphanFilesResult {
+
+    private List<Path> deletedFilesPath;
+    private final long deletedFileCount;
+    private final long deletedFileTotalLenInBytes;
+
+    public CleanOrphanFilesResult(long deletedFileCount, long deletedFileTotalLenInBytes) {
+        this.deletedFileCount = deletedFileCount;
+        this.deletedFileTotalLenInBytes = deletedFileTotalLenInBytes;
+    }
+
+    public CleanOrphanFilesResult(
+            List<Path> deletedFilesPath, long deletedFileCount, long deletedFileTotalLenInBytes) {
+        this(deletedFileCount, deletedFileTotalLenInBytes);
+        this.deletedFilesPath = deletedFilesPath;
+    }
+
+    public long getDeletedFileCount() {
+        return deletedFileCount;
+    }
+
+    public long getDeletedFileTotalLenInBytes() {
+        return deletedFileTotalLenInBytes;
+    }
+
+    public List<Path> getDeletedFilesPath() {
+        return deletedFilesPath;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -119,21 +119,45 @@ public abstract class OrphanFilesClean implements Serializable {
         return branches;
     }
 
-    protected void cleanSnapshotDir(List<String> branches, Consumer<Path> deletedFileConsumer) {
+    protected void cleanSnapshotDir(
+            List<String> branches,
+            Consumer<Path> deletedFilesConsumer,
+            Consumer<Long> deletedFilesLenInBytesConsumer) {
         for (String branch : branches) {
             FileStoreTable branchTable = table.switchToBranch(branch);
             SnapshotManager snapshotManager = branchTable.snapshotManager();
 
             // specially handle the snapshot directory
-            List<Path> nonSnapshotFiles = snapshotManager.tryGetNonSnapshotFiles(this::oldEnough);
-            nonSnapshotFiles.forEach(fileCleaner);
-            nonSnapshotFiles.forEach(deletedFileConsumer);
+            List<Pair<Path, Long>> nonSnapshotFiles =
+                    snapshotManager.tryGetNonSnapshotFiles(this::oldEnough);
+            nonSnapshotFiles.forEach(
+                    nonSnapshotFile ->
+                            cleanFile(
+                                    nonSnapshotFile,
+                                    deletedFilesConsumer,
+                                    deletedFilesLenInBytesConsumer));
 
             // specially handle the changelog directory
-            List<Path> nonChangelogFiles = snapshotManager.tryGetNonChangelogFiles(this::oldEnough);
-            nonChangelogFiles.forEach(fileCleaner);
-            nonChangelogFiles.forEach(deletedFileConsumer);
+            List<Pair<Path, Long>> nonChangelogFiles =
+                    snapshotManager.tryGetNonChangelogFiles(this::oldEnough);
+            nonChangelogFiles.forEach(
+                    nonChangelogFile ->
+                            cleanFile(
+                                    nonChangelogFile,
+                                    deletedFilesConsumer,
+                                    deletedFilesLenInBytesConsumer));
         }
+    }
+
+    private void cleanFile(
+            Pair<Path, Long> deleteFileInfo,
+            Consumer<Path> deletedFilesConsumer,
+            Consumer<Long> deletedFilesLenInBytesConsumer) {
+        Path filePath = deleteFileInfo.getLeft();
+        Long fileSize = deleteFileInfo.getRight();
+        deletedFilesConsumer.accept(filePath);
+        deletedFilesLenInBytesConsumer.accept(fileSize);
+        fileCleaner.accept(filePath);
     }
 
     protected Set<Snapshot> safelyGetAllSnapshots(String branch) throws IOException {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -539,15 +539,15 @@ public class SnapshotManager implements Serializable {
      * Try to get non snapshot files. If any error occurred, just ignore it and return an empty
      * result.
      */
-    public List<Path> tryGetNonSnapshotFiles(Predicate<FileStatus> fileStatusFilter) {
+    public List<Pair<Path, Long>> tryGetNonSnapshotFiles(Predicate<FileStatus> fileStatusFilter) {
         return listPathWithFilter(snapshotDirectory(), fileStatusFilter, nonSnapshotFileFilter());
     }
 
-    public List<Path> tryGetNonChangelogFiles(Predicate<FileStatus> fileStatusFilter) {
+    public List<Pair<Path, Long>> tryGetNonChangelogFiles(Predicate<FileStatus> fileStatusFilter) {
         return listPathWithFilter(changelogDirectory(), fileStatusFilter, nonChangelogFileFilter());
     }
 
-    private List<Path> listPathWithFilter(
+    private List<Pair<Path, Long>> listPathWithFilter(
             Path directory, Predicate<FileStatus> fileStatusFilter, Predicate<Path> fileFilter) {
         try {
             FileStatus[] statuses = fileIO.listStatus(directory);
@@ -557,8 +557,8 @@ public class SnapshotManager implements Serializable {
 
             return Arrays.stream(statuses)
                     .filter(fileStatusFilter)
-                    .map(FileStatus::getPath)
-                    .filter(fileFilter)
+                    .filter(status -> fileFilter.test(status.getPath()))
+                    .map(status -> Pair.of(status.getPath(), status.getLen()))
                     .collect(Collectors.toList());
         } catch (IOException ignored) {
             return Collections.emptyList();

--- a/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
@@ -165,22 +165,20 @@ public class LocalOrphanFilesCleanTest {
 
         // randomly delete tags
         List<String> deleteTags = Collections.emptyList();
-        if (!allTags.isEmpty()) {
-            deleteTags = randomlyPick(allTags);
-            for (String tagName : deleteTags) {
-                table.deleteTag(tagName);
-            }
+        deleteTags = randomlyPick(allTags);
+        for (String tagName : deleteTags) {
+            table.deleteTag(tagName);
         }
 
         // first check, nothing will be deleted because the default olderThan interval is 1 day
         LocalOrphanFilesClean orphanFilesClean = new LocalOrphanFilesClean(table);
-        assertThat(orphanFilesClean.clean().size()).isEqualTo(0);
+        assertThat(orphanFilesClean.clean().getDeletedFilesPath().size()).isEqualTo(0);
 
         // second check
         orphanFilesClean =
                 new LocalOrphanFilesClean(
                         table, System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(2));
-        List<Path> deleted = orphanFilesClean.clean();
+        List<Path> deleted = orphanFilesClean.clean().getDeletedFilesPath();
         try {
             validate(deleted, snapshotData, new HashMap<>());
         } catch (Throwable t) {
@@ -363,13 +361,13 @@ public class LocalOrphanFilesCleanTest {
 
         // first check, nothing will be deleted because the default olderThan interval is 1 day
         LocalOrphanFilesClean orphanFilesClean = new LocalOrphanFilesClean(table);
-        assertThat(orphanFilesClean.clean().size()).isEqualTo(0);
+        assertThat(orphanFilesClean.clean().getDeletedFilesPath().size()).isEqualTo(0);
 
         // second check
         orphanFilesClean =
                 new LocalOrphanFilesClean(
                         table, System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(2));
-        List<Path> deleted = orphanFilesClean.clean();
+        List<Path> deleted = orphanFilesClean.clean().getDeletedFilesPath();
         validate(deleted, snapshotData, changelogData);
     }
 
@@ -399,7 +397,7 @@ public class LocalOrphanFilesCleanTest {
         LocalOrphanFilesClean orphanFilesClean =
                 new LocalOrphanFilesClean(
                         table, System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(2));
-        assertThat(orphanFilesClean.clean().size()).isGreaterThan(0);
+        assertThat(orphanFilesClean.clean().getDeletedFilesPath().size()).isGreaterThan(0);
     }
 
     private void writeData(

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.orphan.FlinkOrphanFilesClean;
+import org.apache.paimon.operation.CleanOrphanFilesResult;
 import org.apache.paimon.operation.LocalOrphanFilesClean;
 
 import org.apache.flink.table.procedure.ProcedureContext;
@@ -86,11 +87,12 @@ public class RemoveOrphanFilesProcedure extends ProcedureBase {
         if (mode == null) {
             mode = "DISTRIBUTED";
         }
-        long deletedFiles;
+
+        CleanOrphanFilesResult cleanOrphanFilesResult;
         try {
             switch (mode.toUpperCase(Locale.ROOT)) {
                 case "DISTRIBUTED":
-                    deletedFiles =
+                    cleanOrphanFilesResult =
                             FlinkOrphanFilesClean.executeDatabaseOrphanFiles(
                                     procedureContext.getExecutionEnvironment(),
                                     catalog,
@@ -101,7 +103,7 @@ public class RemoveOrphanFilesProcedure extends ProcedureBase {
                                     tableName);
                     break;
                 case "LOCAL":
-                    deletedFiles =
+                    cleanOrphanFilesResult =
                             LocalOrphanFilesClean.executeDatabaseOrphanFiles(
                                     catalog,
                                     databaseName,
@@ -116,7 +118,10 @@ public class RemoveOrphanFilesProcedure extends ProcedureBase {
                                     + mode
                                     + ". Only 'DISTRIBUTED' and 'LOCAL' are supported.");
             }
-            return new String[] {String.valueOf(deletedFiles)};
+            return new String[] {
+                String.valueOf(cleanOrphanFilesResult.getDeletedFileCount()),
+                String.valueOf(cleanOrphanFilesResult.getDeletedFileTotalLenInBytes())
+            };
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/RemoveOrphanFilesActionITCase.java
+++ b/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/RemoveOrphanFilesActionITCase.java
@@ -137,7 +137,7 @@ public class RemoveOrphanFilesActionITCase extends ActionITCaseBase {
                         database, tableName);
         ImmutableList<Row> actualDeleteFile = ImmutableList.copyOf(executeSQL(withOlderThan));
 
-        assertThat(actualDeleteFile).containsExactlyInAnyOrder(Row.of("2"));
+        assertThat(actualDeleteFile).containsExactlyInAnyOrder(Row.of("2"), Row.of("2"));
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/RemoveOrphanFilesActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/RemoveOrphanFilesActionITCaseBase.java
@@ -148,7 +148,7 @@ public abstract class RemoveOrphanFilesActionITCaseBase extends ActionITCaseBase
                         tableName);
         ImmutableList<Row> actualDeleteFile = ImmutableList.copyOf(executeSQL(withOlderThan));
 
-        assertThat(actualDeleteFile).containsExactlyInAnyOrder(Row.of("2"));
+        assertThat(actualDeleteFile).containsExactlyInAnyOrder(Row.of("2"), Row.of("2"));
     }
 
     @ParameterizedTest

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/orphan/SparkOrphanFilesClean.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/orphan/SparkOrphanFilesClean.scala
@@ -22,15 +22,14 @@ import org.apache.paimon.{utils, Snapshot}
 import org.apache.paimon.catalog.{Catalog, Identifier}
 import org.apache.paimon.fs.Path
 import org.apache.paimon.manifest.{ManifestEntry, ManifestFile}
-import org.apache.paimon.operation.OrphanFilesClean
+import org.apache.paimon.operation.{CleanOrphanFilesResult, OrphanFilesClean}
 import org.apache.paimon.operation.OrphanFilesClean.retryReadingFiles
 import org.apache.paimon.table.FileStoreTable
 import org.apache.paimon.utils.SerializableConsumer
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{Dataset, SparkSession}
+import org.apache.spark.sql.{functions, Dataset, SparkSession}
 import org.apache.spark.sql.catalyst.SQLConfHelper
-import org.apache.spark.sql.functions.sum
 
 import java.util
 import java.util.Collections
@@ -50,14 +49,18 @@ case class SparkOrphanFilesClean(
   with SQLConfHelper
   with Logging {
 
-  def doOrphanClean(): (Dataset[Long], Dataset[BranchAndManifestFile]) = {
+  def doOrphanClean(): (Dataset[(Long, Long)], Dataset[BranchAndManifestFile]) = {
     import spark.implicits._
 
     val branches = validBranches()
-    val deletedInLocal = new AtomicLong(0)
+    val deletedFilesCountInLocal = new AtomicLong(0)
+    val deletedFilesLenInBytesInLocal = new AtomicLong(0)
     // snapshot and changelog files are the root of everything, so they are handled specially
     // here, and subsequently, we will not count their orphan files.
-    cleanSnapshotDir(branches, (_: Path) => deletedInLocal.incrementAndGet)
+    cleanSnapshotDir(
+      branches,
+      (_: Path) => deletedFilesCountInLocal.incrementAndGet,
+      size => deletedFilesLenInBytesInLocal.addAndGet(size))
 
     val maxBranchParallelism = Math.min(branches.size(), parallelism)
     // find snapshots using branch and find manifests(manifest, index, statistics) using snapshot
@@ -121,10 +124,10 @@ case class SparkOrphanFilesClean(
       .flatMap {
         dir =>
           tryBestListingDirs(new Path(dir)).asScala.filter(oldEnough).map {
-            file => (file.getPath.getName, file.getPath.toUri.toString)
+            file => (file.getPath.getName, file.getPath.toUri.toString, file.getLen)
           }
       }
-      .toDF("name", "path")
+      .toDF("name", "path", "len")
       .repartition(parallelism)
 
     // use left anti to filter files which is not used
@@ -132,21 +135,30 @@ case class SparkOrphanFilesClean(
       .join(usedFiles, $"name" === $"used_name", "left_anti")
       .mapPartitions {
         it =>
-          var deleted = 0L
+          var deletedFilesCount = 0L
+          var deletedFilesLenInBytes = 0L
+
           while (it.hasNext) {
-            val pathToClean = it.next().getString(1)
-            specifiedFileCleaner.accept(new Path(pathToClean))
+            val fileInfo = it.next();
+            val pathToClean = fileInfo.getString(1)
+            val deletedPath = new Path(pathToClean)
+            deletedFilesLenInBytes += fileInfo.getLong(2)
+            specifiedFileCleaner.accept(deletedPath)
             logInfo(s"Cleaned file: $pathToClean")
-            deleted += 1
+            deletedFilesCount += 1
           }
-          logInfo(s"Total cleaned files: $deleted");
-          Iterator.single(deleted)
+          logInfo(
+            s"Total cleaned files: $deletedFilesCount, Total cleaned files len : $deletedFilesLenInBytes")
+          Iterator.single((deletedFilesCount, deletedFilesLenInBytes))
       }
-    val finalDeletedDataset = if (deletedInLocal.get() != 0) {
-      deleted.union(spark.createDataset(Seq(deletedInLocal.get())))
-    } else {
-      deleted
-    }
+    val finalDeletedDataset =
+      if (deletedFilesCountInLocal.get() != 0 || deletedFilesLenInBytesInLocal.get() != 0) {
+        deleted.union(
+          spark.createDataset(
+            Seq((deletedFilesCountInLocal.get(), deletedFilesLenInBytesInLocal.get()))))
+      } else {
+        deleted
+      }
 
     (finalDeletedDataset, usedManifestFiles)
   }
@@ -169,7 +181,7 @@ object SparkOrphanFilesClean extends SQLConfHelper {
       tableName: String,
       olderThanMillis: Long,
       fileCleaner: SerializableConsumer[Path],
-      parallelismOpt: Integer): Long = {
+      parallelismOpt: Integer): CleanOrphanFilesResult = {
     val spark = SparkSession.active
     val parallelism = if (parallelismOpt == null) {
       Math.max(spark.sparkContext.defaultParallelism, conf.numShufflePartitions)
@@ -192,7 +204,7 @@ object SparkOrphanFilesClean extends SQLConfHelper {
         table.asInstanceOf[FileStoreTable]
     }
     if (tables.isEmpty) {
-      return 0
+      return new CleanOrphanFilesResult(0, 0)
     }
     val (deleted, waitToRelease) = tables.map {
       table =>
@@ -207,15 +219,15 @@ object SparkOrphanFilesClean extends SQLConfHelper {
     try {
       val result = deleted
         .reduce((l, r) => l.union(r))
-        .toDF("deleted")
-        .agg(sum("deleted"))
+        .toDF("deletedFilesCount", "deletedFilesLenInBytes")
+        .agg(functions.sum("deletedFilesCount"), functions.sum("deletedFilesLenInBytes"))
         .head()
-      assert(result.schema.size == 1, result.schema)
+      assert(result.schema.size == 2, result.schema)
       if (result.isNullAt(0)) {
         // no files can be deleted
-        0
+        new CleanOrphanFilesResult(0, 0)
       } else {
-        result.getLong(0)
+        new CleanOrphanFilesResult(result.getLong(0), result.getLong(1))
       }
     } finally {
       waitToRelease.foreach(_.unpersist())

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedureTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedureTest.scala
@@ -52,7 +52,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
     fileIO.tryToWriteAtomic(orphanFile2, "b")
 
     // by default, no file deleted
-    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row(0) :: Nil)
+    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row(0, 0) :: Nil)
 
     val orphanFile2ModTime = fileIO.getFileStatus(orphanFile2).getModificationTime
     val older_than1 = DateTimeUtils.formatLocalDateTime(
@@ -63,7 +63,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
 
     checkAnswer(
       spark.sql(s"CALL sys.remove_orphan_files(table => 'T', older_than => '$older_than1')"),
-      Row(1) :: Nil)
+      Row(1, 1) :: Nil)
 
     val older_than2 = DateTimeUtils.formatLocalDateTime(
       DateTimeUtils.toLocalDateTime(System.currentTimeMillis()),
@@ -71,9 +71,9 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
 
     checkAnswer(
       spark.sql(s"CALL sys.remove_orphan_files(table => 'T', older_than => '$older_than2')"),
-      Row(1) :: Nil)
+      Row(1, 1) :: Nil)
 
-    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row(0) :: Nil)
+    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row(0, 0) :: Nil)
   }
 
   test("Paimon procedure: dry run remove orphan files") {
@@ -97,7 +97,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
     fileIO.writeFile(orphanFile2, "b", true)
 
     // by default, no file deleted
-    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row(0) :: Nil)
+    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row(0, 0) :: Nil)
 
     val older_than = DateTimeUtils.formatLocalDateTime(
       DateTimeUtils.toLocalDateTime(System.currentTimeMillis()),
@@ -106,10 +106,10 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
     checkAnswer(
       spark.sql(
         s"CALL sys.remove_orphan_files(table => 'T', older_than => '$older_than', dry_run => true)"),
-      Row(2) :: Nil
+      Row(2, 2) :: Nil
     )
 
-    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row(0) :: Nil)
+    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row(0, 0) :: Nil)
   }
 
   test("Paimon procedure: remove database orphan files") {
@@ -146,7 +146,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
     fileIO2.tryToWriteAtomic(orphanFile22, "b")
 
     // by default, no file deleted
-    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'test.*')"), Row(0) :: Nil)
+    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'test.*')"), Row(0, 0) :: Nil)
 
     val orphanFile12ModTime = fileIO1.getFileStatus(orphanFile12).getModificationTime
     val older_than1 = DateTimeUtils.formatLocalDateTime(
@@ -157,7 +157,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
 
     checkAnswer(
       spark.sql(s"CALL sys.remove_orphan_files(table => 'test.*', older_than => '$older_than1')"),
-      Row(2) :: Nil
+      Row(2, 2) :: Nil
     )
 
     val older_than2 = DateTimeUtils.formatLocalDateTime(
@@ -166,10 +166,10 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
 
     checkAnswer(
       spark.sql(s"CALL sys.remove_orphan_files(table => 'test.*', older_than => '$older_than2')"),
-      Row(2) :: Nil
+      Row(2, 2) :: Nil
     )
 
-    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'test.*')"), Row(0) :: Nil)
+    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'test.*')"), Row(0, 0) :: Nil)
   }
 
   test("Paimon procedure: remove orphan files with mode") {
@@ -193,7 +193,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
     fileIO.tryToWriteAtomic(orphanFile2, "b")
 
     // by default, no file deleted
-    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row(0) :: Nil)
+    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row(0, 0) :: Nil)
 
     val orphanFile2ModTime = fileIO.getFileStatus(orphanFile2).getModificationTime
     val older_than1 = DateTimeUtils.formatLocalDateTime(
@@ -205,7 +205,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
     checkAnswer(
       spark.sql(
         s"CALL sys.remove_orphan_files(table => 'T', older_than => '$older_than1', mode => 'diSTributed')"),
-      Row(1) :: Nil)
+      Row(1, 1) :: Nil)
 
     val older_than2 = DateTimeUtils.formatLocalDateTime(
       DateTimeUtils.toLocalDateTime(System.currentTimeMillis()),
@@ -214,9 +214,9 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
     checkAnswer(
       spark.sql(
         s"CALL sys.remove_orphan_files(table => 'T', older_than => '$older_than2', mode => 'local')"),
-      Row(1) :: Nil)
+      Row(1, 1) :: Nil)
 
-    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row(0) :: Nil)
+    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row(0, 0) :: Nil)
   }
 
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

In my company, after we run a RemoveOrphanFilesAction, we not only want to know the number of orphan files that have been cleared, but also want to know how much capacity has been cleared.

This pr add deletedFileTotalLenInBytes in result of OrphanFilesClean.



<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
