### PR TITLE
[core] RollingFileWriter#abort shouldn't abort currentWriter twice

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/io/RollingFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/RollingFileWriter.java
@@ -78,7 +78,12 @@ public class RollingFileWriter<T, R> implements FileWriter<T, List<R>> {
                 openCurrentWriter();
             }
 
-            currentWriter.write(row);
+            try {
+                currentWriter.write(row);
+            } catch (Throwable e) {
+                currentWriter = null;
+                throw e;
+            }
             recordCount += 1;
 
             if (rollingFile()) {
@@ -102,7 +107,12 @@ public class RollingFileWriter<T, R> implements FileWriter<T, List<R>> {
                 openCurrentWriter();
             }
 
-            currentWriter.writeBundle(bundle);
+            try {
+                currentWriter.writeBundle(bundle);
+            } catch (Throwable e) {
+                currentWriter = null;
+                throw e;
+            }
             recordCount += bundle.rowCount();
 
             if (rollingFile()) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
For example, `currentWriter#write` occurs exception `E1`, it will abort, then the `RollingFileWriter#abort` will abort `currentWriter` again. Some `OutputStream` cannot be closed twice, so it will throw an new exception `E2` which covers `E1`.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
