### PR TITLE
[core] Remove FileStoreScan.withManifestList and fix unstable test

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -63,7 +63,6 @@ import static org.apache.paimon.utils.ManifestReadThreadPool.getExecutorService;
 import static org.apache.paimon.utils.ManifestReadThreadPool.randomlyExecuteSequentialReturn;
 import static org.apache.paimon.utils.ManifestReadThreadPool.sequentialBatchedExecute;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
-import static org.apache.paimon.utils.Preconditions.checkState;
 import static org.apache.paimon.utils.ThreadPoolUtils.randomlyOnlyExecute;
 
 /** Default implementation of {@link FileStoreScan}. */
@@ -81,7 +80,6 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
     private Snapshot specifiedSnapshot = null;
     private Filter<Integer> bucketFilter = null;
     private BiFilter<Integer, Integer> totalAwareBucketFilter = null;
-    private List<ManifestFileMeta> specifiedManifests = null;
     protected ScanMode scanMode = ScanMode.ALL;
     private Filter<Integer> levelFilter = null;
     private Filter<ManifestEntry> manifestEntryFilter = null;
@@ -161,22 +159,13 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
 
     @Override
     public FileStoreScan withSnapshot(long snapshotId) {
-        checkState(specifiedManifests == null, "Cannot set both snapshot and manifests.");
         this.specifiedSnapshot = snapshotManager.snapshot(snapshotId);
         return this;
     }
 
     @Override
     public FileStoreScan withSnapshot(Snapshot snapshot) {
-        checkState(specifiedManifests == null, "Cannot set both snapshot and manifests.");
         this.specifiedSnapshot = snapshot;
-        return this;
-    }
-
-    @Override
-    public FileStoreScan withManifestList(List<ManifestFileMeta> manifests) {
-        checkState(specifiedSnapshot == null, "Cannot set both snapshot and manifests.");
-        this.specifiedManifests = manifests;
         return this;
     }
 
@@ -401,10 +390,6 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
     }
 
     private ManifestsReader.Result readManifests() {
-        if (specifiedManifests != null) {
-            return new ManifestsReader.Result(null, specifiedManifests, specifiedManifests);
-        }
-
         return manifestsReader.read(specifiedSnapshot, scanMode);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
@@ -67,8 +67,6 @@ public interface FileStoreScan {
 
     FileStoreScan withSnapshot(Snapshot snapshot);
 
-    FileStoreScan withManifestList(List<ManifestFileMeta> manifests);
-
     FileStoreScan withKind(ScanMode scanMode);
 
     FileStoreScan withLevelFilter(Filter<Integer> levelFilter);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/SnapshotDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/SnapshotDeletion.java
@@ -23,7 +23,6 @@ import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.index.IndexFileHandler;
-import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFile;
@@ -35,7 +34,6 @@ import org.apache.paimon.utils.Pair;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -73,17 +71,10 @@ public class SnapshotDeletion extends FileDeletionBase<Snapshot> {
             // eg: the old version table file, we just skip clean this here, let it done by
             // ExpireChangelogImpl
             Predicate<ManifestEntry> enriched =
-                    manifestEntry -> {
-                        if (skipper.test(manifestEntry)) {
-                            return true;
-                        }
-
-                        Optional<FileSource> fileSource = manifestEntry.file().fileSource();
-                        if (!fileSource.isPresent() || fileSource.get() == FileSource.APPEND) {
-                            return manifestEntry.kind() == FileKind.ADD;
-                        }
-                        return false;
-                    };
+                    manifestEntry ->
+                            skipper.test(manifestEntry)
+                                    || (manifestEntry.file().fileSource().orElse(FileSource.APPEND)
+                                            == FileSource.APPEND);
             cleanUnusedDataFiles(snapshot.deltaManifestList(), enriched);
         } else {
             cleanUnusedDataFiles(snapshot.deltaManifestList(), skipper);

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -526,9 +526,6 @@ public class TestFileStore extends KeyValueFileStore {
                         .map(Path::toString)
                         .sorted()
                         .collect(Collectors.joining(",\n"));
-        if (!actualString.equals(expectedString)) {
-            System.out.println("");
-        }
         assertThat(actualString).isEqualTo(expectedString);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -499,11 +499,11 @@ public class ExpireSnapshotsTest {
         ThreadLocalRandom random = ThreadLocalRandom.current();
 
         CoreOptions.ChangelogProducer changelogProducer;
-        //        if (random.nextBoolean()) {
-        //            changelogProducer = CoreOptions.ChangelogProducer.INPUT;
-        //        } else {
-        changelogProducer = CoreOptions.ChangelogProducer.NONE;
-        //        }
+        if (random.nextBoolean()) {
+            changelogProducer = CoreOptions.ChangelogProducer.INPUT;
+        } else {
+            changelogProducer = CoreOptions.ChangelogProducer.NONE;
+        }
 
         return new TestFileStore.Builder(
                         "avro",

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -44,6 +44,7 @@ import org.apache.paimon.utils.TagManager;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -451,7 +452,7 @@ public class ExpireSnapshotsTest {
         store.assertCleaned();
     }
 
-    @Test
+    @RepeatedTest(5)
     public void testChangelogOutLivedSnapshot() throws Exception {
         List<KeyValue> allData = new ArrayList<>();
         List<Integer> snapshotPositions = new ArrayList<>();
@@ -498,11 +499,11 @@ public class ExpireSnapshotsTest {
         ThreadLocalRandom random = ThreadLocalRandom.current();
 
         CoreOptions.ChangelogProducer changelogProducer;
-        if (random.nextBoolean()) {
-            changelogProducer = CoreOptions.ChangelogProducer.INPUT;
-        } else {
-            changelogProducer = CoreOptions.ChangelogProducer.NONE;
-        }
+        //        if (random.nextBoolean()) {
+        //            changelogProducer = CoreOptions.ChangelogProducer.INPUT;
+        //        } else {
+        changelogProducer = CoreOptions.ChangelogProducer.NONE;
+        //        }
 
         return new TestFileStore.Builder(
                         "avro",

--- a/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreScanTest.java
@@ -26,8 +26,6 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.manifest.ManifestEntry;
-import org.apache.paimon.manifest.ManifestFileMeta;
-import org.apache.paimon.manifest.ManifestList;
 import org.apache.paimon.mergetree.compact.DeduplicateMergeFunction;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.schema.Schema;
@@ -250,29 +248,6 @@ public class KeyValueFileStoreScanTest {
                                 .flatMap(Collection::stream)
                                 .collect(Collectors.toList()));
         runTestExactMatch(scan, wantedSnapshot, expected);
-    }
-
-    @Test
-    public void testWithManifestList() throws Exception {
-        ThreadLocalRandom random = ThreadLocalRandom.current();
-        int numCommits = random.nextInt(10) + 1;
-        for (int i = 0; i < numCommits; i++) {
-            List<KeyValue> data = generateData(random.nextInt(100) + 1);
-            writeData(data);
-        }
-
-        ManifestList manifestList = store.manifestListFactory().create();
-        long wantedSnapshotId = random.nextLong(snapshotManager.latestSnapshotId()) + 1;
-        Snapshot wantedSnapshot = snapshotManager.snapshot(wantedSnapshotId);
-        List<ManifestFileMeta> wantedManifests = manifestList.readDataManifests(wantedSnapshot);
-
-        FileStoreScan scan = store.newScan();
-        scan.withManifestList(wantedManifests);
-
-        List<KeyValue> expectedKvs = store.readKvsFromSnapshot(wantedSnapshotId);
-        gen.sort(expectedKvs);
-        Map<BinaryRow, BinaryRow> expected = store.toKvMap(expectedKvs);
-        runTestExactMatch(scan, null, expected);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -1473,10 +1473,10 @@ public abstract class FileStoreTableTestBase {
                 TestFileStore.getFilesInUse(
                         latestSnapshotId,
                         snapshotManager,
-                        store.newScan(),
                         table.fileIO(),
                         store.pathFactory(),
-                        store.manifestListFactory().create());
+                        store.manifestListFactory().create(),
+                        store.manifestFileFactory().create());
 
         List<Path> unusedFileList =
                 Files.walk(Paths.get(tempDir.toString()))


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
- FileStoreScan.withManifestList is only used by test code, we should remove it.
- Fix unstable test ExpireSnapshotsTest.testChangelogOutLivedSnapshot

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
