### PR TITLE
[Hive] Fix Hive DDL and paimon schema mismatched bug

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
@@ -233,9 +233,10 @@ public class HiveSchema {
             }
         }
 
-        if (schemaFieldNames.size() != hiveFieldNames.size()) {
+        // It is OK that hive is a subset of paimon
+        if (schemaFieldNames.size() < hiveFieldNames.size()) {
             throw new IllegalArgumentException(
-                    "Hive DDL and paimon schema mismatched! "
+                    "Hive DDL is a superset of paimon schema! "
                             + "It is recommended not to write any column definition "
                             + "as Paimon external table can read schema from the specified location.\n"
                             + "There are "

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveTableSchemaTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveTableSchemaTest.java
@@ -44,9 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/**
- * Tests for {@link HiveSchema}.
- */
+/** Tests for {@link HiveSchema}. */
 public class HiveTableSchemaTest {
 
     private static final RowType ROW_TYPE =
@@ -56,8 +54,7 @@ public class HiveTableSchemaTest {
                             new DataField(1, "b", DataTypes.STRING(), "second comment"),
                             new DataField(2, "c", DataTypes.DECIMAL(5, 3), "last comment")));
 
-    @TempDir
-    java.nio.file.Path tempDir;
+    @TempDir java.nio.file.Path tempDir;
 
     @Test
     public void testExtractSchemaWithEmptyDDLAndNoPaimonTable() {
@@ -156,13 +153,12 @@ public class HiveTableSchemaTest {
                 .hasMessageContaining(expected);
     }
 
-
     @Test
     public void testSubsetColumnNameAndType() throws Exception {
         createSchema();
         Properties properties = new Properties();
-        List<String> columns = Arrays.asList("a","b");
-        properties.setProperty("columns", String.join(",",columns));
+        List<String> columns = Arrays.asList("a", "b");
+        properties.setProperty("columns", String.join(",", columns));
         properties.setProperty(
                 "columns.types",
                 String.join(
@@ -204,7 +200,6 @@ public class HiveTableSchemaTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining(expected);
     }
-
 
     @Test
     public void testTooFewColumns() throws Exception {
@@ -414,8 +409,7 @@ public class HiveTableSchemaTest {
         String dataFieldStr = JsonSerdeUtil.toJson(dataFields);
 
         List<DataField> dataFieldsDeserialized =
-                JsonSerdeUtil.fromJson(dataFieldStr, new TypeReference<List<DataField>>() {
-                });
+                JsonSerdeUtil.fromJson(dataFieldStr, new TypeReference<List<DataField>>() {});
         HiveSchema newHiveSchema = new HiveSchema(new RowType(dataFieldsDeserialized));
         assertThat(newHiveSchema).usingRecursiveComparison().isEqualTo(hiveSchema);
     }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveTableSchemaTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveTableSchemaTest.java
@@ -210,16 +210,7 @@ public class HiveTableSchemaTest {
         properties.setProperty("columns.types", TypeInfoFactory.intTypeInfo.getTypeName());
         properties.setProperty("location", tempDir.toString());
         properties.setProperty("columns.comments", "");
-
-        String expected =
-                "Hive DDL and paimon schema mismatched! "
-                        + "It is recommended not to write any column definition "
-                        + "as Paimon external table can read schema from the specified location.\n"
-                        + "There are 1 fields in Hive DDL: a\n"
-                        + "There are 3 fields in Paimon schema: a, b, c";
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> HiveSchema.extract(null, properties))
-                .withMessageContaining(expected);
+        assertThat(HiveSchema.extract(null, properties)).isInstanceOf(HiveSchema.class);
     }
 
     @Test
@@ -242,7 +233,7 @@ public class HiveTableSchemaTest {
         properties.setProperty("location", tempDir.toString());
 
         String expected =
-                "Hive DDL and paimon schema mismatched! "
+                "Hive DDL is a superset of paimon schema! "
                         + "It is recommended not to write any column definition "
                         + "as Paimon external table can read schema from the specified location.\n"
                         + "There are 5 fields in Hive DDL: a, b, c, d, e\n"


### PR DESCRIPTION
### Purpose
Linked issue: [issue-4556](https://github.com/apache/paimon/issues/4556)

HiveCatalog add column is divided into two stages: first modify the paimon schema, then modify HMS. There will be a time difference between the two stages. If there is a task read (based on hivecatalog) during this time, the paimon schema and hive schema check will fail in the getDataFieldsJsonStr link.

Solution: Actually, you only need to ensure that the Hive DDL is a subset of the paimon schema.

### Tests
org.apache.paimon.hive.HiveTableSchemaTest#testSupersetColumnNameAndType
org.apache.paimon.hive.HiveTableSchemaTest#testSubsetColumnNameAndType

### API and Format
org.apache.paimon.hive.HiveSchema#checkPartitionMatched

### Documentation
only need to ensure that the Hive DDL is a subset of the paimon schema.

