### PR TITLE
[core] Improve object table for fileIO, Privileged and parent_path

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedCatalog.java
@@ -127,7 +127,7 @@ public class PrivilegedCatalog extends DelegateCatalog {
     public Table getTable(Identifier identifier) throws TableNotExistException {
         Table table = wrapped.getTable(identifier);
         if (table instanceof FileStoreTable) {
-            return new PrivilegedFileStoreTable(
+            return PrivilegedFileStoreTable.wrap(
                     (FileStoreTable) table, privilegeManager.getPrivilegeChecker(), identifier);
         } else {
             return table;

--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedObjectTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedObjectTable.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.privilege;
+
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.object.ObjectTable;
+
+import java.util.Map;
+
+/** A {@link PrivilegedFileStoreTable} for {@link ObjectTable}. */
+public class PrivilegedObjectTable extends PrivilegedFileStoreTable implements ObjectTable {
+
+    private final ObjectTable objectTable;
+
+    protected PrivilegedObjectTable(
+            ObjectTable wrapped, PrivilegeChecker privilegeChecker, Identifier identifier) {
+        super(wrapped, privilegeChecker, identifier);
+        this.objectTable = wrapped;
+    }
+
+    @Override
+    public String objectLocation() {
+        return objectTable.objectLocation();
+    }
+
+    @Override
+    public FileStoreTable underlyingTable() {
+        return objectTable.underlyingTable();
+    }
+
+    @Override
+    public FileIO objectFileIO() {
+        return objectTable.objectFileIO();
+    }
+
+    @Override
+    public long refresh() {
+        privilegeChecker.assertCanInsert(identifier);
+        return objectTable.refresh();
+    }
+
+    // ======================= copy ============================
+
+    @Override
+    public PrivilegedObjectTable copy(Map<String, String> dynamicOptions) {
+        return new PrivilegedObjectTable(
+                objectTable.copy(dynamicOptions), privilegeChecker, identifier);
+    }
+
+    @Override
+    public PrivilegedObjectTable copy(TableSchema newTableSchema) {
+        return new PrivilegedObjectTable(
+                objectTable.copy(newTableSchema), privilegeChecker, identifier);
+    }
+
+    @Override
+    public PrivilegedObjectTable copyWithoutTimeTravel(Map<String, String> dynamicOptions) {
+        return new PrivilegedObjectTable(
+                objectTable.copyWithoutTimeTravel(dynamicOptions), privilegeChecker, identifier);
+    }
+
+    @Override
+    public PrivilegedObjectTable copyWithLatestSchema() {
+        return new PrivilegedObjectTable(
+                objectTable.copyWithLatestSchema(), privilegeChecker, identifier);
+    }
+
+    @Override
+    public PrivilegedObjectTable switchToBranch(String branchName) {
+        return new PrivilegedObjectTable(
+                objectTable.switchToBranch(branchName), privilegeChecker, identifier);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTableFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTableFactory.java
@@ -19,14 +19,12 @@
 package org.apache.paimon.table;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.TableType;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
-import org.apache.paimon.table.object.ObjectTable;
 import org.apache.paimon.utils.StringUtils;
 
 import java.io.IOException;
@@ -35,7 +33,6 @@ import java.util.Optional;
 
 import static org.apache.paimon.CoreOptions.PATH;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
-import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
 /** Factory to create {@link FileStoreTable}. */
 public class FileStoreTableFactory {
@@ -127,17 +124,6 @@ public class FileStoreTableFactory {
                                 fileIO, tablePath, tableSchema, catalogEnvironment)
                         : new PrimaryKeyFileStoreTable(
                                 fileIO, tablePath, tableSchema, catalogEnvironment);
-        table = table.copy(dynamicOptions.toMap());
-        CoreOptions options = table.coreOptions();
-        if (options.type() == TableType.OBJECT_TABLE) {
-            String objectLocation = options.objectLocation();
-            checkNotNull(objectLocation, "Object location should not be null for object table.");
-            table =
-                    ObjectTable.builder()
-                            .underlyingTable(table)
-                            .objectLocation(objectLocation)
-                            .build();
-        }
-        return table;
+        return table.copy(dynamicOptions.toMap());
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Improve object table:
1. FileIO can be customized in AbstractCatalog.
2. Privileged should handle ObjectTable.
3. Add parent_path in Object table schema.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
