### PR TITLE
[spark] Support spark to create external table sql statements.

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -135,7 +135,7 @@ public class HiveCatalog extends AbstractCatalog {
             "org.apache.paimon.hive.PaimonStorageHandler";
     private static final String HIVE_PREFIX = "hive.";
     public static final String HIVE_SITE_FILE = "hive-site.xml";
-    public static final String HIVE_EXTERNAL_TABLE_PROP = "EXTERNAL";
+    private static final String HIVE_EXTERNAL_TABLE_PROP = "EXTERNAL";
 
     private final HiveConf hiveConf;
     private final String clientClassName;
@@ -666,9 +666,12 @@ public class HiveCatalog extends AbstractCatalog {
                         hiveConf.get(TABLE_TYPE.key(), CatalogTableType.MANAGED.toString()),
                         CatalogTableType.class);
 
+        String externalPropValue =
+                tableOptions.getOrDefault(
+                        HIVE_EXTERNAL_TABLE_PROP.toLowerCase(),
+                        tableOptions.get(HIVE_EXTERNAL_TABLE_PROP.toUpperCase()));
         return CatalogTableType.EXTERNAL.equals(tableType)
-                || "TRUE"
-                        .equalsIgnoreCase(tableOptions.get(HIVE_EXTERNAL_TABLE_PROP.toLowerCase()));
+                || "TRUE".equalsIgnoreCase(externalPropValue);
     }
 
     @Override

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkCatalogWithHiveTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkCatalogWithHiveTest.java
@@ -19,7 +19,9 @@
 package org.apache.paimon.spark;
 
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.hive.TestHiveMetastore;
+import org.apache.paimon.table.FileStoreTableFactory;
 
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -31,8 +33,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.FileNotFoundException;
 import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 
 /** Base tests for spark read. */
 public class SparkCatalogWithHiveTest {
@@ -133,6 +134,48 @@ public class SparkCatalogWithHiveTest {
                 .rootCause()
                 .isInstanceOf(FileNotFoundException.class)
                 .hasMessageContaining("nonExistentPath");
+
+        spark.close();
+    }
+
+    @Test
+    public void testCreateExternalTable(@TempDir java.nio.file.Path tempDir) {
+        Path warehousePath = new Path("file:" + tempDir.toString());
+        SparkSession spark =
+                SparkSession.builder()
+                        .config("spark.sql.warehouse.dir", warehousePath.toString())
+                        // with hive metastore
+                        .config("spark.sql.catalogImplementation", "hive")
+                        .config("hive.metastore.uris", "thrift://localhost:" + PORT)
+                        .config("spark.sql.catalog.spark_catalog", SparkCatalog.class.getName())
+                        .config("spark.sql.catalog.spark_catalog.metastore", "hive")
+                        .config(
+                                "spark.sql.catalog.spark_catalog.hive.metastore.uris",
+                                "thrift://localhost:" + PORT)
+                        .config(
+                                "spark.sql.catalog.spark_catalog.warehouse",
+                                warehousePath.toString())
+                        .master("local[2]")
+                        .getOrCreate();
+
+        spark.sql("CREATE DATABASE IF NOT EXISTS test_db");
+        spark.sql("USE spark_catalog.test_db");
+
+        // create hive external table
+        spark.sql("CREATE EXTERNAL TABLE t1 (a INT, bb INT, c STRING)");
+
+        // drop hive external table
+        spark.sql("DROP TABLE t1");
+
+        // file system table exists
+        assertThatCode(
+                        () ->
+                                FileStoreTableFactory.create(
+                                        LocalFileIO.create(),
+                                        new Path(
+                                                warehousePath,
+                                                String.format("%s.db/%s", "test_db", "t1"))))
+                .doesNotThrowAnyException();
 
         spark.close();
     }

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkCatalogWithHiveTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkCatalogWithHiveTest.java
@@ -33,7 +33,9 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.FileNotFoundException;
 import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Base tests for spark read. */
 public class SparkCatalogWithHiveTest {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

Support spark to create external table sql statements.

```sql
CREATE EXTERNAL TABLE t1 (a INT, bb INT, c STRING)
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
