### PR TITLE
[flink][hotfix] Wait for consumer reset before job close

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ContinuousFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/ContinuousFileStoreITCase.java
@@ -120,7 +120,14 @@ public class ContinuousFileStoreITCase extends CatalogITCaseBase {
         assertThat(iterator.collect(2))
                 .containsExactlyInAnyOrder(Row.of("1", "2", "3"), Row.of("4", "5", "6"));
 
-        Thread.sleep(1000);
+        List<Row> result;
+        do {
+            result = sql("SELECT * FROM %s$consumers", table);
+            if (!result.isEmpty()) {
+                break;
+            }
+            Thread.sleep(1000);
+        } while (true);
         iterator.close();
 
         iterator =


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #4442 

<!-- What is the purpose of the change -->
This PR fixes the bug that Consumers might not have been reset yet when the streaming job is closed in test cases. This is because the resetting logic happens in `MonitorFunction#notifyCheckpointComplete`, and Flink does not guarantee the invocation of this method when the job is canceled or stopped.

This bug happens rarely in the current test cases because Flink's legacy source function runs independently in a separated thread. When we use FLIP-27 source for MonitorFunction and checkpoint events may pile up in Flink's Mailbox, this bug will be triggered more frequently.

### Tests

<!-- List UT and IT cases to verify this change -->
Existing test cases are used to verify this change.

### API and Format

<!-- Does this change affect API or storage format -->
This change does not affect API or storage format.

### Documentation

<!-- Does this change introduce a new feature -->
This change does not affect introduce a new feature.

