### PR TITLE
[flink] Support minor compact strategy for dedicated compaction action.

### DIFF
--- a/docs/content/flink/procedures.md
+++ b/docs/content/flink/procedures.md
@@ -67,7 +67,8 @@ All available procedures are listed below.
             order_by => 'order_by', 
             options => 'options', 
             `where` => 'where', 
-            partition_idle_time => 'partition_idle_time') <br/><br/>
+            partition_idle_time => 'partition_idle_time',
+            compact_strategy => 'compact_strategy') <br/><br/>
          -- Use indexed argument<br/>
          CALL [catalog.]sys.compact('table') <br/><br/>
          CALL [catalog.]sys.compact('table', 'partitions') <br/><br/> 
@@ -76,6 +77,7 @@ All available procedures are listed below.
          CALL [catalog.]sys.compact('table', 'partitions', 'order_strategy', 'order_by', 'options') <br/><br/>
          CALL [catalog.]sys.compact('table', 'partitions', 'order_strategy', 'order_by', 'options', 'where') <br/><br/>
          CALL [catalog.]sys.compact('table', 'partitions', 'order_strategy', 'order_by', 'options', 'where', 'partition_idle_time') <br/><br/>
+         CALL [catalog.]sys.compact('table', 'partitions', 'order_strategy', 'order_by', 'options', 'where', 'partition_idle_time', 'compact_strategy') <br/><br/>
       </td>
       <td>
          To compact a table. Arguments:
@@ -86,6 +88,7 @@ All available procedures are listed below.
             <li>options(optional): additional dynamic options of the table.</li>
             <li>where(optional): partition predicate(Can't be used together with "partitions"). Note: as where is a keyword,a pair of backticks need to add around like `where`.</li>
             <li>partition_idle_time(optional): this is used to do a full compaction for partition which had not received any new data for 'partition_idle_time'. And only these partitions will be compacted. This argument can not be used with order compact.</li>
+            <li>compact_strategy(optional): this determines how to pick files to be merged, the default is determined by the runtime execution mode. 'full' strategy only supports batch mode. All files will be selected for merging. 'minor' strategy: Pick the set of files that need to be merged based on specified conditions.</li>
       </td>
       <td>
          -- use partition filter <br/>
@@ -104,7 +107,8 @@ All available procedures are listed below.
             including_tables => 'includingTables', 
             excluding_tables => 'excludingTables', 
             table_options => 'tableOptions', 
-            partition_idle_time => 'partitionIdleTime') <br/><br/>
+            partition_idle_time => 'partitionIdleTime',
+            compact_strategy => 'compact_strategy') <br/><br/>
          -- Use indexed argument<br/>
          CALL [catalog.]sys.compact_database() <br/><br/>
          CALL [catalog.]sys.compact_database('includingDatabases') <br/><br/> 
@@ -112,7 +116,8 @@ All available procedures are listed below.
          CALL [catalog.]sys.compact_database('includingDatabases', 'mode', 'includingTables') <br/><br/> 
          CALL [catalog.]sys.compact_database('includingDatabases', 'mode', 'includingTables', 'excludingTables') <br/><br/>
          CALL [catalog.]sys.compact_database('includingDatabases', 'mode', 'includingTables', 'excludingTables', 'tableOptions') <br/><br/>
-         CALL [catalog.]sys.compact_database('includingDatabases', 'mode', 'includingTables', 'excludingTables', 'tableOptions', 'partitionIdleTime')
+         CALL [catalog.]sys.compact_database('includingDatabases', 'mode', 'includingTables', 'excludingTables', 'tableOptions', 'partitionIdleTime')<br/><br/>
+         CALL [catalog.]sys.compact_database('includingDatabases', 'mode', 'includingTables', 'excludingTables', 'tableOptions', 'partitionIdleTime', 'compact_strategy')<br/><br/>
       </td>
       <td>
          To compact databases. Arguments:
@@ -124,6 +129,7 @@ All available procedures are listed below.
             <li>excludingTables: to specify tables that are not compacted. You can use regular expression.</li>
             <li>tableOptions: additional dynamic options of the table.</li>
             <li>partition_idle_time: this is used to do a full compaction for partition which had not received any new data for 'partition_idle_time'. And only these partitions will be compacted.</li>
+            <li>compact_strategy(optional): this determines how to pick files to be merged, the default is determined by the runtime execution mode. 'full' strategy only supports batch mode. All files will be selected for merging. 'minor' strategy: Pick the set of files that need to be merged based on specified conditions.</li>
       </td>
       <td>
          CALL sys.compact_database(
@@ -131,7 +137,8 @@ All available procedures are listed below.
             mode => 'combined', 
             including_tables => 'table_.*', 
             excluding_tables => 'ignore', 
-            table_options => 'sink.parallelism=4')
+            table_options => 'sink.parallelism=4',
+            compat_strategy => 'full')
       </td>
    </tr>
    <tr>

--- a/docs/content/maintenance/dedicated-compaction.md
+++ b/docs/content/maintenance/dedicated-compaction.md
@@ -107,6 +107,7 @@ Run the following command to submit a compaction job for the table.
     --database <database-name> \ 
     --table <table-name> \
     [--partition <partition-name>] \
+    [--compact_strategy <minor / full>] \
     [--table_conf <table_conf>] \
     [--catalog_conf <paimon-catalog-conf> [--catalog_conf <paimon-catalog-conf> ...]]
 ```
@@ -123,10 +124,14 @@ Example: compact table
     --partition dt=20221126,hh=08 \
     --partition dt=20221127,hh=09 \
     --table_conf sink.parallelism=10 \
+    --compact_strategy minor \
     --catalog_conf s3.endpoint=https://****.com \
     --catalog_conf s3.access-key=***** \
     --catalog_conf s3.secret-key=*****
 ```
+* `--compact_strategy` Determines how to pick files to be merged, the default is determined by the runtime execution mode, streaming-mode use `minor` strategy and batch-mode use `full` strategy.
+  * `full` : Only support in batch mode. All files will be picked up for merging.
+  * `minor` : Pick the set of files that need to be merged based on specified conditions.
 
 You can use `-D execution.runtime-mode=batch` or `-yD execution.runtime-mode=batch` (for the ON-YARN scenario) to control batch or streaming mode. If you submit a batch job, all
 current table files will be compacted. If you submit a streaming job, the job will continuously monitor new changes
@@ -190,6 +195,7 @@ CALL sys.compact_database(
     [--including_tables <paimon-table-name|name-regular-expr>] \
     [--excluding_tables <paimon-table-name|name-regular-expr>] \
     [--mode <compact-mode>] \
+    [--compact_strategy <minor / full>] \
     [--catalog_conf <paimon-catalog-conf> [--catalog_conf <paimon-catalog-conf> ...]] \
     [--table_conf <paimon-table_conf> [--table_conf <paimon-table_conf> ...]]
 ```
@@ -346,6 +352,7 @@ CALL sys.compact(`table` => 'default.T', 'partition_idle_time' => '1 d')
     --table <table-name> \
     --partition_idle_time <partition-idle-time> \ 
     [--partition <partition-name>] \
+    [--compact_strategy <minor / full>] \
     [--catalog_conf <paimon-catalog-conf> [--catalog_conf <paimon-catalog-conf> ...]] \
     [--table_conf <paimon-table-dynamic-conf> [--table_conf <paimon-table-dynamic-conf>] ...]
 ```
@@ -406,6 +413,7 @@ CALL sys.compact_database(
     [--including_tables <paimon-table-name|name-regular-expr>] \
     [--excluding_tables <paimon-table-name|name-regular-expr>] \
     [--mode <compact-mode>] \
+    [--compact_strategy <minor / full>] \
     [--catalog_conf <paimon-catalog-conf> [--catalog_conf <paimon-catalog-conf> ...]] \
     [--table_conf <paimon-table_conf> [--table_conf <paimon-table_conf> ...]]
 ```

--- a/docs/content/maintenance/dedicated-compaction.md
+++ b/docs/content/maintenance/dedicated-compaction.md
@@ -130,7 +130,7 @@ Example: compact table
     --catalog_conf s3.secret-key=*****
 ```
 * `--compact_strategy` Determines how to pick files to be merged, the default is determined by the runtime execution mode, streaming-mode use `minor` strategy and batch-mode use `full` strategy.
-  * `full` : Only support in batch mode. All files will be picked up for merging.
+  * `full` : Only supports batch mode. All files will be selected for merging.
   * `minor` : Pick the set of files that need to be merged based on specified conditions.
 
 You can use `-D execution.runtime-mode=batch` or `-yD execution.runtime-mode=batch` (for the ON-YARN scenario) to control batch or streaming mode. If you submit a batch job, all

--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -47,12 +47,14 @@ This section introduce all available spark procedures about paimon.
             <li>order_strategy: 'order' or 'zorder' or 'hilbert' or 'none'. Left empty for 'none'.</li>
             <li>order_columns: the columns need to be sort. Left empty if 'order_strategy' is 'none'.</li>
             <li>partition_idle_time: this is used to do a full compaction for partition which had not received any new data for 'partition_idle_time'. And only these partitions will be compacted. This argument can not be used with order compact.</li>
+            <li>compact_strategy: this determines how to pick files to be merged, the default is determined by the runtime execution mode. 'full' strategy only supports batch mode. All files will be selected for merging. 'minor' strategy: Pick the set of files that need to be merged based on specified conditions.</li>
       </td>
       <td>
          SET spark.sql.shuffle.partitions=10; --set the compact parallelism <br/><br/>
          CALL sys.compact(table => 'T', partitions => 'p=0;p=1',  order_strategy => 'zorder', order_by => 'a,b') <br/><br/>
          CALL sys.compact(table => 'T', where => 'p>0 and p<3', order_strategy => 'zorder', order_by => 'a,b') <br/><br/>
-         CALL sys.compact(table => 'T', partition_idle_time => '60s')
+         CALL sys.compact(table => 'T', partition_idle_time => '60s')<br/><br/>
+         CALL sys.compact(table => 'T', compact_strategy => 'minor')<br/><br/>
       </td>
     </tr>
     <tr>

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CompactDatabaseProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CompactDatabaseProcedure.java
@@ -26,6 +26,8 @@ import org.apache.flink.table.procedure.ProcedureContext;
 
 import java.util.Map;
 
+import static org.apache.paimon.flink.action.ActionFactory.FULL;
+import static org.apache.paimon.flink.action.CompactActionFactory.checkCompactStrategy;
 import static org.apache.paimon.utils.ParameterUtils.parseCommaSeparatedKeyValues;
 
 /**
@@ -51,6 +53,7 @@ import static org.apache.paimon.utils.ParameterUtils.parseCommaSeparatedKeyValue
  *
  *  -- set table options ('k=v,...')
  *  CALL sys.compact_database('includingDatabases', 'mode', 'includingTables', 'excludingTables', 'tableOptions')
+ *
  * </code></pre>
  */
 public class CompactDatabaseProcedure extends ProcedureBase {
@@ -106,7 +109,8 @@ public class CompactDatabaseProcedure extends ProcedureBase {
                 includingTables,
                 excludingTables,
                 tableOptions,
-                "");
+                "",
+                null);
     }
 
     public String[] call(
@@ -116,7 +120,8 @@ public class CompactDatabaseProcedure extends ProcedureBase {
             String includingTables,
             String excludingTables,
             String tableOptions,
-            String partitionIdleTime)
+            String partitionIdleTime,
+            String compactStrategy)
             throws Exception {
         String warehouse = catalog.warehouse();
         Map<String, String> catalogOptions = catalog.options();
@@ -131,6 +136,10 @@ public class CompactDatabaseProcedure extends ProcedureBase {
         }
         if (!StringUtils.isNullOrWhitespaceOnly(partitionIdleTime)) {
             action.withPartitionIdleTime(TimeUtils.parseDuration(partitionIdleTime));
+        }
+
+        if (checkCompactStrategy(compactStrategy)) {
+            action.withFullCompaction(compactStrategy.trim().equalsIgnoreCase(FULL));
         }
 
         return execute(procedureContext, action, "Compact database job");

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
@@ -52,6 +52,9 @@ import static org.apache.paimon.flink.action.CompactActionFactory.checkCompactSt
  *  -- compact specific partitions with sorting
  *  CALL sys.compact('tableId', 'partitions', 'ORDER/ZORDER', 'col1,col2', 'sink.parallelism=6')
  *
+ *  -- compact with specific compact strategy
+ *  CALL sys.compact('tableId', 'partitions', 'ORDER/ZORDER', 'col1,col2', 'sink.parallelism=6', 'minor')
+ *
  * </code></pre>
  */
 public class CompactProcedure extends ProcedureBase {
@@ -117,24 +120,24 @@ public class CompactProcedure extends ProcedureBase {
                 procedureContext,
                 tableId,
                 partitions,
-                null,
                 orderStrategy,
                 orderByColumns,
                 tableOptions,
                 whereSql,
-                "");
+                "",
+                null);
     }
 
     public String[] call(
             ProcedureContext procedureContext,
             String tableId,
             String partitions,
-            String compactStrategy,
             String orderStrategy,
             String orderByColumns,
             String tableOptions,
             String whereSql,
-            String partitionIdleTime)
+            String partitionIdleTime,
+            String compactStrategy)
             throws Exception {
 
         String warehouse = catalog.warehouse();

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
@@ -31,6 +31,9 @@ import org.apache.flink.table.procedure.ProcedureContext;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.apache.paimon.flink.action.ActionFactory.FULL;
+import static org.apache.paimon.flink.action.CompactActionFactory.checkCompactStrategy;
+
 /**
  * Stay compatible with 1.18 procedure which doesn't support named argument. Usage:
  *
@@ -114,6 +117,7 @@ public class CompactProcedure extends ProcedureBase {
                 procedureContext,
                 tableId,
                 partitions,
+                null,
                 orderStrategy,
                 orderByColumns,
                 tableOptions,
@@ -125,6 +129,7 @@ public class CompactProcedure extends ProcedureBase {
             ProcedureContext procedureContext,
             String tableId,
             String partitions,
+            String compactStrategy,
             String orderStrategy,
             String orderByColumns,
             String tableOptions,
@@ -151,6 +156,10 @@ public class CompactProcedure extends ProcedureBase {
                             tableConf);
             if (!(StringUtils.isNullOrWhitespaceOnly(partitionIdleTime))) {
                 action.withPartitionIdleTime(TimeUtils.parseDuration(partitionIdleTime));
+            }
+
+            if (checkCompactStrategy(compactStrategy)) {
+                action.withFullCompaction(compactStrategy.trim().equalsIgnoreCase(FULL));
             }
             jobName = "Compact Job";
         } else if (!orderStrategy.isEmpty() && !orderByColumns.isEmpty()) {

--- a/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/procedure/ProcedurePositionalArgumentsITCase.java
+++ b/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/procedure/ProcedurePositionalArgumentsITCase.java
@@ -68,9 +68,15 @@ public class ProcedurePositionalArgumentsITCase extends CatalogITCaseBase {
                                 sql(
                                         "CALL sys.compact('default.T', '', '', '', 'sink.parallelism=1','pt=1')"))
                 .doesNotThrowAnyException();
-        assertThatCode(() -> sql("CALL sys.compact('default.T', '', 'zorder', 'k', '','','5s')"))
+        assertThatCode(
+                        () ->
+                                sql(
+                                        "CALL sys.compact('default.T', '', '' ,'zorder', 'k', '','','5s')"))
                 .message()
                 .contains("sort compact do not support 'partition_idle_time'.");
+
+        assertThatCode(() -> sql("CALL sys.compact('default.T', '', 'full' ,'', '', '','','')"))
+                .doesNotThrowAnyException();
 
         assertThatCode(() -> sql("CALL sys.compact_database('default')"))
                 .doesNotThrowAnyException();

--- a/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/procedure/ProcedurePositionalArgumentsITCase.java
+++ b/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/procedure/ProcedurePositionalArgumentsITCase.java
@@ -71,11 +71,11 @@ public class ProcedurePositionalArgumentsITCase extends CatalogITCaseBase {
         assertThatCode(
                         () ->
                                 sql(
-                                        "CALL sys.compact('default.T', '', '' ,'zorder', 'k', '','','5s')"))
+                                        "CALL sys.compact('default.T', '' ,'zorder', 'k', '','','5s', '')"))
                 .message()
                 .contains("sort compact do not support 'partition_idle_time'.");
 
-        assertThatCode(() -> sql("CALL sys.compact('default.T', '', 'full' ,'', '', '','','')"))
+        assertThatCode(() -> sql("CALL sys.compact('default.T', '', '' ,'', '', '', '', 'full')"))
                 .doesNotThrowAnyException();
 
         assertThatCode(() -> sql("CALL sys.compact_database('default')"))

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ActionFactory.java
@@ -61,6 +61,7 @@ public interface ActionFactory extends Factory {
     // Supports `full` and `minor`.
     String COMPACT_STRATEGY = "compact_strategy";
     String MINOR = "minor";
+    String FULL = "full";
 
     Optional<Action> create(MultipleParameterToolAdapter params);
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ActionFactory.java
@@ -58,6 +58,9 @@ public interface ActionFactory extends Factory {
     String TIMESTAMPFORMATTER = "timestamp_formatter";
     String EXPIRE_STRATEGY = "expire_strategy";
     String TIMESTAMP_PATTERN = "timestamp_pattern";
+    // Supports `full` and `minor`.
+    String COMPACT_STRATEGY = "compact_strategy";
+    String MINOR = "minor";
 
     Optional<Action> create(MultipleParameterToolAdapter params);
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactAction.java
@@ -136,7 +136,7 @@ public class CompactAction extends TableActionBase {
         } else {
             Preconditions.checkArgument(
                     !(fullCompaction && isStreaming),
-                    "full compact strategy is only supported in batch mode. Please add -Dexecution.runtime-mode=BATCH.");
+                    "The full compact strategy is only supported in batch mode. Please add -Dexecution.runtime-mode=BATCH.");
         }
         if (isStreaming) {
             // for completely asynchronous compaction

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactActionFactory.java
@@ -76,6 +76,10 @@ public class CompactActionFactory implements ActionFactory {
                 action.withPartitionIdleTime(
                         TimeUtils.parseDuration(params.get(PARTITION_IDLE_TIME)));
             }
+            String compactStrategy = params.get(COMPACT_STRATEGY);
+            if (compactStrategy != null) {
+                action.withFullCompaction(!compactStrategy.trim().equalsIgnoreCase(MINOR));
+            }
         }
 
         if (params.has(PARTITION)) {
@@ -101,7 +105,8 @@ public class CompactActionFactory implements ActionFactory {
                         + "[--order_strategy <order_strategy>]"
                         + "[--table_conf <key>=<value>]"
                         + "[--order_by <order_columns>]"
-                        + "[--partition_idle_time <partition_idle_time>]");
+                        + "[--partition_idle_time <partition_idle_time>]"
+                        + "[--compact_strategy <compact_strategy>]");
         System.out.println(
                 "  compact --warehouse s3://path/to/warehouse --database <database_name> "
                         + "--table <table_name> [--catalog_conf <paimon_catalog_conf> [--catalog_conf <paimon_catalog_conf> ...]]");

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactActionFactory.java
@@ -77,8 +77,8 @@ public class CompactActionFactory implements ActionFactory {
                         TimeUtils.parseDuration(params.get(PARTITION_IDLE_TIME)));
             }
             String compactStrategy = params.get(COMPACT_STRATEGY);
-            if (compactStrategy != null) {
-                action.withFullCompaction(!compactStrategy.trim().equalsIgnoreCase(MINOR));
+            if (checkCompactStrategy(compactStrategy)) {
+                action.withFullCompaction(compactStrategy.trim().equalsIgnoreCase(FULL));
             }
         }
 
@@ -90,6 +90,19 @@ public class CompactActionFactory implements ActionFactory {
         }
 
         return Optional.of(action);
+    }
+
+    public static boolean checkCompactStrategy(String compactStrategy) {
+        if (compactStrategy != null) {
+            Preconditions.checkArgument(
+                    compactStrategy.equalsIgnoreCase(MINOR)
+                            || compactStrategy.equalsIgnoreCase(FULL),
+                    String.format(
+                            "The compact strategy only supports 'full' or 'minor', but '%s' is configured.",
+                            compactStrategy));
+            return true;
+        }
+        return false;
     }
 
     @Override
@@ -137,6 +150,10 @@ public class CompactActionFactory implements ActionFactory {
         System.out.println(
                 "  compact --warehouse hdfs:///path/to/warehouse --database test_db --table test_table "
                         + "--partition_idle_time 10s");
+        System.out.println(
+                "--compact_strategy determines how to pick files to be merged, the default is determined by the runtime execution mode. "
+                        + "`full` : Only supports batch mode. All files will be selected for merging."
+                        + "`minor`: Pick the set of files that need to be merged based on specified conditions.");
         System.out.println(
                 "  compact --warehouse s3:///path/to/warehouse "
                         + "--database test_db "

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactDatabaseAction.java
@@ -72,6 +72,10 @@ public class CompactDatabaseAction extends ActionBase {
 
     @Nullable private Duration partitionIdleTime = null;
 
+    private Boolean fullCompaction;
+
+    private boolean isStreaming;
+
     public CompactDatabaseAction(String warehouse, Map<String, String> catalogConfig) {
         super(warehouse, catalogConfig);
     }
@@ -110,6 +114,11 @@ public class CompactDatabaseAction extends ActionBase {
         return this;
     }
 
+    public CompactDatabaseAction withFullCompaction(boolean fullCompaction) {
+        this.fullCompaction = fullCompaction;
+        return this;
+    }
+
     private boolean shouldCompactionTable(String paimonFullTableName) {
         boolean shouldCompaction = includingPattern.matcher(paimonFullTableName).matches();
         if (excludingPattern != null) {
@@ -124,6 +133,12 @@ public class CompactDatabaseAction extends ActionBase {
 
     @Override
     public void build() {
+        ReadableConfig conf = env.getConfiguration();
+        isStreaming = conf.get(ExecutionOptions.RUNTIME_MODE) == RuntimeExecutionMode.STREAMING;
+
+        if (fullCompaction == null) {
+            fullCompaction = !isStreaming;
+        }
         if (databaseCompactMode == MultiTablesSinkMode.DIVIDED) {
             buildForDividedMode();
         } else {
@@ -170,24 +185,19 @@ public class CompactDatabaseAction extends ActionBase {
                 !tableMap.isEmpty(),
                 "no tables to be compacted. possible cause is that there are no tables detected after pattern matching");
 
-        ReadableConfig conf = env.getConfiguration();
-        boolean isStreaming =
-                conf.get(ExecutionOptions.RUNTIME_MODE) == RuntimeExecutionMode.STREAMING;
         for (Map.Entry<String, FileStoreTable> entry : tableMap.entrySet()) {
             FileStoreTable fileStoreTable = entry.getValue();
             switch (fileStoreTable.bucketMode()) {
                 case BUCKET_UNAWARE:
                     {
-                        buildForUnawareBucketCompaction(
-                                env, entry.getKey(), fileStoreTable, isStreaming);
+                        buildForUnawareBucketCompaction(env, entry.getKey(), fileStoreTable);
                         break;
                     }
                 case HASH_FIXED:
                 case HASH_DYNAMIC:
                 default:
                     {
-                        buildForTraditionalCompaction(
-                                env, entry.getKey(), fileStoreTable, isStreaming);
+                        buildForTraditionalCompaction(env, entry.getKey(), fileStoreTable);
                     }
             }
         }
@@ -195,9 +205,6 @@ public class CompactDatabaseAction extends ActionBase {
 
     private void buildForCombinedMode() {
 
-        ReadableConfig conf = env.getConfiguration();
-        boolean isStreaming =
-                conf.get(ExecutionOptions.RUNTIME_MODE) == RuntimeExecutionMode.STREAMING;
         CombinedTableCompactorSourceBuilder sourceBuilder =
                 new CombinedTableCompactorSourceBuilder(
                                 catalogLoader(),
@@ -234,15 +241,17 @@ public class CompactDatabaseAction extends ActionBase {
                                 .buildForUnawareBucketsTableSource(),
                         parallelism);
 
-        new CombinedTableCompactorSink(catalogLoader(), tableOptions)
+        new CombinedTableCompactorSink(catalogLoader(), tableOptions, fullCompaction)
                 .sinkFrom(awareBucketTableSource, unawareBucketTableSource);
     }
 
     private void buildForTraditionalCompaction(
-            StreamExecutionEnvironment env,
-            String fullName,
-            FileStoreTable table,
-            boolean isStreaming) {
+            StreamExecutionEnvironment env, String fullName, FileStoreTable table) {
+
+        Preconditions.checkArgument(
+                !(fullCompaction && isStreaming),
+                "full compact strategy is only supported in batch mode. Please add -Dexecution.runtime-mode=BATCH.");
+
         if (isStreaming) {
             // for completely asynchronous compaction
             HashMap<String, String> dynamicOptions =
@@ -259,8 +268,7 @@ public class CompactDatabaseAction extends ActionBase {
         CompactorSourceBuilder sourceBuilder =
                 new CompactorSourceBuilder(fullName, table)
                         .withPartitionIdleTime(partitionIdleTime);
-        CompactorSinkBuilder sinkBuilder =
-                new CompactorSinkBuilder(table).withFullCompaction(!isStreaming);
+        CompactorSinkBuilder sinkBuilder = new CompactorSinkBuilder(table, fullCompaction);
 
         DataStreamSource<RowData> source =
                 sourceBuilder.withEnv(env).withContinuousMode(isStreaming).build();
@@ -268,10 +276,7 @@ public class CompactDatabaseAction extends ActionBase {
     }
 
     private void buildForUnawareBucketCompaction(
-            StreamExecutionEnvironment env,
-            String fullName,
-            FileStoreTable table,
-            boolean isStreaming) {
+            StreamExecutionEnvironment env, String fullName, FileStoreTable table) {
         UnawareBucketCompactionTopoBuilder unawareBucketCompactionTopoBuilder =
                 new UnawareBucketCompactionTopoBuilder(env, fullName, table);
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactDatabaseAction.java
@@ -250,7 +250,7 @@ public class CompactDatabaseAction extends ActionBase {
 
         Preconditions.checkArgument(
                 !(fullCompaction && isStreaming),
-                "full compact strategy is only supported in batch mode. Please add -Dexecution.runtime-mode=BATCH.");
+                "The full compact strategy is only supported in batch mode. Please add -Dexecution.runtime-mode=BATCH.");
 
         if (isStreaming) {
             // for completely asynchronous compaction

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactDatabaseActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactDatabaseActionFactory.java
@@ -55,6 +55,11 @@ public class CompactDatabaseActionFactory implements ActionFactory {
             action.withPartitionIdleTime(TimeUtils.parseDuration(partitionIdleTime));
         }
 
+        String compactStrategy = params.get(COMPACT_STRATEGY);
+        if (compactStrategy != null && compactStrategy.trim().equalsIgnoreCase(MINOR)) {
+            action.withFullCompaction(false);
+        }
+
         return Optional.of(action);
     }
 
@@ -70,7 +75,8 @@ public class CompactDatabaseActionFactory implements ActionFactory {
                         + "[--including_tables <paimon_table_name|name_regular_expr>] "
                         + "[--excluding_tables <paimon_table_name|name_regular_expr>] "
                         + "[--mode <compact_mode>]"
-                        + "[--partition_idle_time <partition_idle_time>]");
+                        + "[--partition_idle_time <partition_idle_time>]"
+                        + "[--compact_strategy <compact_strategy>]");
         System.out.println(
                 "  compact_database --warehouse s3://path/to/warehouse --including_databases <database-name|name-regular-expr> "
                         + "[--catalog_conf <paimon_catalog_conf> [--catalog_conf <paimon_catalog_conf> ...]]");

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactDatabaseActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactDatabaseActionFactory.java
@@ -22,6 +22,8 @@ import org.apache.paimon.utils.TimeUtils;
 
 import java.util.Optional;
 
+import static org.apache.paimon.flink.action.CompactActionFactory.checkCompactStrategy;
+
 /** Factory to create {@link CompactDatabaseAction}. */
 public class CompactDatabaseActionFactory implements ActionFactory {
 
@@ -56,8 +58,8 @@ public class CompactDatabaseActionFactory implements ActionFactory {
         }
 
         String compactStrategy = params.get(COMPACT_STRATEGY);
-        if (compactStrategy != null && compactStrategy.trim().equalsIgnoreCase(MINOR)) {
-            action.withFullCompaction(false);
+        if (checkCompactStrategy(compactStrategy)) {
+            action.withFullCompaction(compactStrategy.trim().equalsIgnoreCase(FULL));
         }
 
         return Optional.of(action);
@@ -99,6 +101,11 @@ public class CompactDatabaseActionFactory implements ActionFactory {
         System.out.println(
                 "--partition_idle_time is used to do a full compaction for partition which had not receive any new data for 'partition_idle_time' time. And only these partitions will be compacted.");
         System.out.println("--partition_idle_time is only supported in batch mode. ");
+        System.out.println(
+                "--compact_strategy determines how to pick files to be merged, the default is determined by the runtime execution mode. "
+                        + "`full` : Only supports batch mode. All files will be selected for merging."
+                        + "`minor`: Pick the set of files that need to be merged based on specified conditions.");
+
         System.out.println();
 
         System.out.println("Examples:");

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CompactProcedure.java
@@ -51,10 +51,6 @@ public class CompactProcedure extends ProcedureBase {
                         type = @DataTypeHint("STRING"),
                         isOptional = true),
                 @ArgumentHint(
-                        name = "compact_strategy",
-                        type = @DataTypeHint("STRING"),
-                        isOptional = true),
-                @ArgumentHint(
                         name = "order_strategy",
                         type = @DataTypeHint("STRING"),
                         isOptional = true),
@@ -64,18 +60,22 @@ public class CompactProcedure extends ProcedureBase {
                 @ArgumentHint(
                         name = "partition_idle_time",
                         type = @DataTypeHint("STRING"),
+                        isOptional = true),
+                @ArgumentHint(
+                        name = "compact_strategy",
+                        type = @DataTypeHint("STRING"),
                         isOptional = true)
             })
     public String[] call(
             ProcedureContext procedureContext,
             String tableId,
             String partitions,
-            String compactStrategy,
             String orderStrategy,
             String orderByColumns,
             String tableOptions,
             String where,
-            String partitionIdleTime)
+            String partitionIdleTime,
+            String compactStrategy)
             throws Exception {
         String warehouse = catalog.warehouse();
         Map<String, String> catalogOptions = catalog.options();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSinkBuilder.java
@@ -37,19 +37,15 @@ public class CompactorSinkBuilder {
 
     private DataStream<RowData> input;
 
-    private boolean fullCompaction;
+    private final boolean fullCompaction;
 
-    public CompactorSinkBuilder(FileStoreTable table) {
+    public CompactorSinkBuilder(FileStoreTable table, boolean fullCompaction) {
         this.table = table;
+        this.fullCompaction = fullCompaction;
     }
 
     public CompactorSinkBuilder withInput(DataStream<RowData> input) {
         this.input = input;
-        return this;
-    }
-
-    public CompactorSinkBuilder withFullCompaction(boolean fullCompaction) {
-        this.fullCompaction = fullCompaction;
         return this;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
@@ -165,13 +165,13 @@ public class MultiTablesStoreCompactOperator
 
         if (write.streamingMode()) {
             write.notifyNewFiles(snapshotId, partition, bucket, files);
+            // The full compact is not supported in streaming mode.
             write.compact(partition, bucket, false);
         } else {
             Preconditions.checkArgument(
                     files.isEmpty(),
                     "Batch compact job does not concern what files are compacted. "
                             + "They only need to know what buckets are compacted.");
-            // `minor` compact strategy is supported in batch mode.
             write.compact(partition, bucket, fullCompaction);
         }
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
@@ -63,6 +63,7 @@ public class MultiTablesStoreCompactOperator
     private final CheckpointConfig checkpointConfig;
     private final boolean isStreaming;
     private final boolean ignorePreviousFiles;
+    private final boolean fullCompaction;
     private final String initialCommitUser;
 
     private transient StoreSinkWriteState state;
@@ -81,6 +82,7 @@ public class MultiTablesStoreCompactOperator
             CheckpointConfig checkpointConfig,
             boolean isStreaming,
             boolean ignorePreviousFiles,
+            boolean fullCompaction,
             Options options) {
         super(options);
         this.catalogLoader = catalogLoader;
@@ -88,6 +90,7 @@ public class MultiTablesStoreCompactOperator
         this.checkpointConfig = checkpointConfig;
         this.isStreaming = isStreaming;
         this.ignorePreviousFiles = ignorePreviousFiles;
+        this.fullCompaction = fullCompaction;
     }
 
     @Override
@@ -168,7 +171,8 @@ public class MultiTablesStoreCompactOperator
                     files.isEmpty(),
                     "Batch compact job does not concern what files are compacted. "
                             + "They only need to know what buckets are compacted.");
-            write.compact(partition, bucket, true);
+            // `minor` compact strategy is supported in batch mode.
+            write.compact(partition, bucket, fullCompaction);
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactActionITCase.java
@@ -23,13 +23,9 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.table.sink.StreamWriteBuilder;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.StreamTableScan;
 import org.apache.paimon.table.source.TableScan;
-import org.apache.paimon.types.DataType;
-import org.apache.paimon.types.DataTypes;
-import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.CommonTestUtils;
 import org.apache.paimon.utils.SnapshotManager;
 
@@ -55,12 +51,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** IT cases for {@link CompactAction}. */
 public class CompactActionITCase extends CompactActionITCaseBase {
-
-    private static final DataType[] FIELD_TYPES =
-            new DataType[] {DataTypes.INT(), DataTypes.INT(), DataTypes.INT(), DataTypes.STRING()};
-
-    private static final RowType ROW_TYPE =
-            RowType.of(FIELD_TYPES, new String[] {"k", "v", "hh", "dt"});
 
     @Test
     @Timeout(60)
@@ -400,31 +390,6 @@ public class CompactActionITCase extends CompactActionITCaseBase {
                                         "--order_by",
                                         "dt,hh"))
                 .hasMessage("sort compact do not support 'partition_idle_time'.");
-    }
-
-    private FileStoreTable prepareTable(
-            List<String> partitionKeys,
-            List<String> primaryKeys,
-            List<String> bucketKey,
-            Map<String, String> tableOptions)
-            throws Exception {
-        FileStoreTable table =
-                createFileStoreTable(ROW_TYPE, partitionKeys, primaryKeys, bucketKey, tableOptions);
-
-        StreamWriteBuilder streamWriteBuilder =
-                table.newStreamWriteBuilder().withCommitUser(commitUser);
-        write = streamWriteBuilder.newWrite();
-        commit = streamWriteBuilder.newCommit();
-
-        return table;
-    }
-
-    private void checkLatestSnapshot(
-            FileStoreTable table, long snapshotId, Snapshot.CommitKind commitKind) {
-        SnapshotManager snapshotManager = table.snapshotManager();
-        Snapshot snapshot = snapshotManager.snapshot(snapshotManager.latestSnapshotId());
-        assertThat(snapshot.id()).isEqualTo(snapshotId);
-        assertThat(snapshot.commitKind()).isEqualTo(commitKind);
     }
 
     private void runAction(boolean isStreaming) throws Exception {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MinorCompactActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MinorCompactActionITCase.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.source.DataSplit;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** IT cases for compact strategy {@link CompactAction}. */
+public class MinorCompactActionITCase extends CompactActionITCaseBase {
+
+    @Test
+    @Timeout(60)
+    public void testBatchMinorCompactStrategy() throws Exception {
+        FileStoreTable table =
+                prepareTable(
+                        Arrays.asList("dt", "hh"),
+                        Arrays.asList("dt", "hh", "k"),
+                        Collections.emptyList(),
+                        Collections.singletonMap(CoreOptions.WRITE_ONLY.key(), "true"));
+
+        writeData(
+                rowData(1, 100, 15, BinaryString.fromString("20221208")),
+                rowData(1, 100, 16, BinaryString.fromString("20221208")));
+
+        writeData(
+                rowData(2, 100, 15, BinaryString.fromString("20221208")),
+                rowData(2, 100, 16, BinaryString.fromString("20221208")));
+
+        checkLatestSnapshot(table, 2, Snapshot.CommitKind.APPEND);
+
+        CompactAction action =
+                createAction(
+                        CompactAction.class,
+                        "compact",
+                        "--warehouse",
+                        warehouse,
+                        "--database",
+                        database,
+                        "--table",
+                        tableName,
+                        "--compact_strategy",
+                        "minor",
+                        "--table_conf",
+                        CoreOptions.NUM_SORTED_RUNS_COMPACTION_TRIGGER.key() + "=3");
+        StreamExecutionEnvironment env = streamExecutionEnvironmentBuilder().batchMode().build();
+        action.withStreamExecutionEnvironment(env).build();
+        env.execute();
+
+        // Due to the limitation of parameter 'num-sorted-run.compaction-trigger', so compact is not
+        // performed.
+        checkLatestSnapshot(table, 2, Snapshot.CommitKind.APPEND);
+
+        // Make par-15 has 3 datafile and par-16 has 2 datafile, so par-16 will not be picked out to
+        // compact.
+        writeData(rowData(2, 100, 15, BinaryString.fromString("20221208")));
+
+        env = streamExecutionEnvironmentBuilder().batchMode().build();
+        action.withStreamExecutionEnvironment(env).build();
+        env.execute();
+
+        checkLatestSnapshot(table, 4, Snapshot.CommitKind.COMPACT);
+
+        List<DataSplit> splits = table.newSnapshotReader().read().dataSplits();
+        assertThat(splits.size()).isEqualTo(2);
+        for (DataSplit split : splits) {
+            // Par-16 is not compacted.
+            assertThat(split.dataFiles().size())
+                    .isEqualTo(split.partition().getInt(1) == 16 ? 2 : 1);
+        }
+    }
+
+    @Test
+    @Timeout(60)
+    public void testBatchFullCompactStrategy() throws Exception {
+        FileStoreTable table =
+                prepareTable(
+                        Arrays.asList("dt", "hh"),
+                        Arrays.asList("dt", "hh", "k"),
+                        Collections.emptyList(),
+                        Collections.singletonMap(CoreOptions.WRITE_ONLY.key(), "true"));
+
+        writeData(
+                rowData(1, 100, 15, BinaryString.fromString("20221208")),
+                rowData(1, 100, 16, BinaryString.fromString("20221208")));
+
+        writeData(
+                rowData(2, 100, 15, BinaryString.fromString("20221208")),
+                rowData(2, 100, 16, BinaryString.fromString("20221208")));
+
+        checkLatestSnapshot(table, 2, Snapshot.CommitKind.APPEND);
+
+        CompactAction action =
+                createAction(
+                        CompactAction.class,
+                        "compact",
+                        "--warehouse",
+                        warehouse,
+                        "--database",
+                        database,
+                        "--table",
+                        tableName,
+                        "--compact_strategy",
+                        "full",
+                        "--table_conf",
+                        CoreOptions.NUM_SORTED_RUNS_COMPACTION_TRIGGER.key() + "=3");
+        StreamExecutionEnvironment env = streamExecutionEnvironmentBuilder().batchMode().build();
+        action.withStreamExecutionEnvironment(env).build();
+        env.execute();
+
+        checkLatestSnapshot(table, 3, Snapshot.CommitKind.COMPACT);
+
+        List<DataSplit> splits = table.newSnapshotReader().read().dataSplits();
+        assertThat(splits.size()).isEqualTo(2);
+        for (DataSplit split : splits) {
+            assertThat(split.dataFiles().size()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    @Timeout(60)
+    public void testStreamingFullCompactStrategy() throws Exception {
+        prepareTable(
+                Arrays.asList("dt", "hh"),
+                Arrays.asList("dt", "hh", "k"),
+                Collections.emptyList(),
+                Collections.singletonMap(CoreOptions.WRITE_ONLY.key(), "true"));
+        CompactAction action =
+                createAction(
+                        CompactAction.class,
+                        "compact",
+                        "--warehouse",
+                        warehouse,
+                        "--database",
+                        database,
+                        "--table",
+                        tableName,
+                        "--compact_strategy",
+                        "full",
+                        "--table_conf",
+                        CoreOptions.NUM_SORTED_RUNS_COMPACTION_TRIGGER.key() + "=3");
+        StreamExecutionEnvironment env =
+                streamExecutionEnvironmentBuilder().streamingMode().build();
+        Assertions.assertThatThrownBy(() -> action.withStreamExecutionEnvironment(env).build())
+                .hasMessage(
+                        "full compact strategy is only supported in batch mode. Please add -Dexecution.runtime-mode=BATCH.");
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MinorCompactActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MinorCompactActionITCase.java
@@ -172,6 +172,34 @@ public class MinorCompactActionITCase extends CompactActionITCaseBase {
                 streamExecutionEnvironmentBuilder().streamingMode().build();
         Assertions.assertThatThrownBy(() -> action.withStreamExecutionEnvironment(env).build())
                 .hasMessage(
-                        "full compact strategy is only supported in batch mode. Please add -Dexecution.runtime-mode=BATCH.");
+                        "The full compact strategy is only supported in batch mode. Please add -Dexecution.runtime-mode=BATCH.");
+    }
+
+    @Test
+    @Timeout(60)
+    public void testCompactStrategyWithWrongUsage() throws Exception {
+        prepareTable(
+                Arrays.asList("dt", "hh"),
+                Arrays.asList("dt", "hh", "k"),
+                Collections.emptyList(),
+                Collections.singletonMap(CoreOptions.WRITE_ONLY.key(), "true"));
+        Assertions.assertThatThrownBy(
+                        () ->
+                                createAction(
+                                        CompactAction.class,
+                                        "compact",
+                                        "--warehouse",
+                                        warehouse,
+                                        "--database",
+                                        database,
+                                        "--table",
+                                        tableName,
+                                        "--compact_strategy",
+                                        "wrong_usage",
+                                        "--table_conf",
+                                        CoreOptions.NUM_SORTED_RUNS_COMPACTION_TRIGGER.key()
+                                                + "=3"))
+                .hasMessage(
+                        "The compact strategy only supports 'full' or 'minor', but 'wrong_usage' is configured.");
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CompactProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CompactProcedureITCase.java
@@ -268,8 +268,13 @@ public class CompactProcedureITCase extends CatalogITCaseBase {
                 "CALL sys.compact(`table` => 'default.T', compact_strategy => 'minor', "
                         + "options => 'num-sorted-run.compaction-trigger=3')");
 
+        // Due to the limitation of parameter 'num-sorted-run.compaction-trigger' = 3, so compact is
+        // not
+        // performed.
         checkLatestSnapshot(table, 2, Snapshot.CommitKind.APPEND);
 
+        // Make par-15 has 3 datafile and par-16 has 2 datafile, so par-16 will not be picked out to
+        // compact.
         sql("INSERT INTO T VALUES (1, 100, 15, '20221208')");
 
         sql(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CompactorSinkITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CompactorSinkITCase.java
@@ -132,7 +132,7 @@ public class CompactorSinkITCase extends AbstractTestBase {
                         .withContinuousMode(false)
                         .withPartitionPredicate(predicate)
                         .build();
-        new CompactorSinkBuilder(table).withFullCompaction(true).withInput(source).build();
+        new CompactorSinkBuilder(table, true).withInput(source).build();
         env.execute();
 
         snapshot = snapshotManager.snapshot(snapshotManager.latestSnapshotId());
@@ -181,8 +181,8 @@ public class CompactorSinkITCase extends AbstractTestBase {
                                                 FlinkConnectorOptions.SINK_PARALLELISM.key(),
                                                 String.valueOf(sinkParalellism));
                                     }
-                                }))
-                .withFullCompaction(false)
+                                }),
+                        false)
                 .withInput(source)
                 .build();
 
@@ -275,7 +275,13 @@ public class CompactorSinkITCase extends AbstractTestBase {
     protected MultiTablesStoreCompactOperator createMultiTablesCompactOperator(
             Catalog.Loader catalogLoader) throws Exception {
         return new MultiTablesStoreCompactOperator(
-                catalogLoader, commitUser, new CheckpointConfig(), false, false, new Options());
+                catalogLoader,
+                commitUser,
+                new CheckpointConfig(),
+                false,
+                false,
+                true,
+                new Options());
     }
 
     private static byte[] partition(String dt, int hh) {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -107,6 +107,7 @@ public class CompactProcedure extends BaseProcedure {
             new ProcedureParameter[] {
                 ProcedureParameter.required("table", StringType),
                 ProcedureParameter.optional("partitions", StringType),
+                ProcedureParameter.optional("compact_strategy", StringType),
                 ProcedureParameter.optional("order_strategy", StringType),
                 ProcedureParameter.optional("order_by", StringType),
                 ProcedureParameter.optional("where", StringType),
@@ -119,6 +120,9 @@ public class CompactProcedure extends BaseProcedure {
                     new StructField[] {
                         new StructField("result", DataTypes.BooleanType, true, Metadata.empty())
                     });
+
+    private final String MINOR = "minor";
+    private final String FULL = "full";
 
     protected CompactProcedure(TableCatalog tableCatalog) {
         super(tableCatalog);
@@ -138,15 +142,17 @@ public class CompactProcedure extends BaseProcedure {
     public InternalRow[] call(InternalRow args) {
         Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
         String partitions = blank(args, 1) ? null : args.getString(1);
-        String sortType = blank(args, 2) ? TableSorter.OrderType.NONE.name() : args.getString(2);
+        // make full compact strategy as default.
+        String compactStrategy = blank(args, 2) ? FULL : args.getString(2);
+        String sortType = blank(args, 3) ? TableSorter.OrderType.NONE.name() : args.getString(3);
         List<String> sortColumns =
-                blank(args, 3)
+                blank(args, 4)
                         ? Collections.emptyList()
-                        : Arrays.asList(args.getString(3).split(","));
-        String where = blank(args, 4) ? null : args.getString(4);
-        String options = args.isNullAt(5) ? null : args.getString(5);
+                        : Arrays.asList(args.getString(4).split(","));
+        String where = blank(args, 5) ? null : args.getString(5);
+        String options = args.isNullAt(6) ? null : args.getString(6);
         Duration partitionIdleTime =
-                blank(args, 6) ? null : TimeUtils.parseDuration(args.getString(6));
+                blank(args, 7) ? null : TimeUtils.parseDuration(args.getString(7));
         if (TableSorter.OrderType.NONE.name().equals(sortType) && !sortColumns.isEmpty()) {
             throw new IllegalArgumentException(
                     "order_strategy \"none\" cannot work with order_by columns.");
@@ -155,6 +161,14 @@ public class CompactProcedure extends BaseProcedure {
             throw new IllegalArgumentException(
                     "sort compact do not support 'partition_idle_time'.");
         }
+
+        if (!(compactStrategy.equalsIgnoreCase(FULL) || compactStrategy.equalsIgnoreCase(MINOR))) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "The compact strategy only supports 'full' or 'minor', but '%s' is configured.",
+                            compactStrategy));
+        }
+
         checkArgument(
                 partitions == null || where == null,
                 "partitions and where cannot be used together.");
@@ -192,6 +206,7 @@ public class CompactProcedure extends BaseProcedure {
                             newInternalRow(
                                     execute(
                                             (FileStoreTable) table,
+                                            compactStrategy,
                                             sortType,
                                             sortColumns,
                                             relation,
@@ -212,6 +227,7 @@ public class CompactProcedure extends BaseProcedure {
 
     private boolean execute(
             FileStoreTable table,
+            String compactStrategy,
             String sortType,
             List<String> sortColumns,
             DataSourceV2Relation relation,
@@ -219,6 +235,7 @@ public class CompactProcedure extends BaseProcedure {
             @Nullable Duration partitionIdleTime) {
         BucketMode bucketMode = table.bucketMode();
         TableSorter.OrderType orderType = TableSorter.OrderType.of(sortType);
+        boolean fullCompact = compactStrategy.equalsIgnoreCase(FULL);
         Predicate filter =
                 condition == null
                         ? null
@@ -233,7 +250,8 @@ public class CompactProcedure extends BaseProcedure {
             switch (bucketMode) {
                 case HASH_FIXED:
                 case HASH_DYNAMIC:
-                    compactAwareBucketTable(table, filter, partitionIdleTime, javaSparkContext);
+                    compactAwareBucketTable(
+                            table, fullCompact, filter, partitionIdleTime, javaSparkContext);
                     break;
                 case BUCKET_UNAWARE:
                     compactUnAwareBucketTable(table, filter, partitionIdleTime, javaSparkContext);
@@ -259,6 +277,7 @@ public class CompactProcedure extends BaseProcedure {
 
     private void compactAwareBucketTable(
             FileStoreTable table,
+            boolean fullCompact,
             @Nullable Predicate filter,
             @Nullable Duration partitionIdleTime,
             JavaSparkContext javaSparkContext) {
@@ -304,7 +323,7 @@ public class CompactProcedure extends BaseProcedure {
                                                             SerializationUtils.deserializeBinaryRow(
                                                                     pair.getLeft()),
                                                             pair.getRight(),
-                                                            true);
+                                                            fullCompact);
                                                 }
                                                 CommitMessageSerializer serializer =
                                                         new CommitMessageSerializer();

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -121,8 +121,8 @@ public class CompactProcedure extends BaseProcedure {
                         new StructField("result", DataTypes.BooleanType, true, Metadata.empty())
                     });
 
-    private final String MINOR = "minor";
-    private final String FULL = "full";
+    private static final String MINOR = "minor";
+    private static final String FULL = "full";
 
     protected CompactProcedure(TableCatalog tableCatalog) {
         super(tableCatalog);

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
@@ -64,7 +64,6 @@ class PaimonSparkTestBase
       "org.apache.spark.serializer.JavaSerializer"
     }
     super.sparkConf
-      .set("spark.driver.bindAddress", "127.0.0.1")
       .set("spark.sql.catalog.paimon", classOf[SparkCatalog].getName)
       .set("spark.sql.catalog.paimon.warehouse", tempDBDir.getCanonicalPath)
       .set("spark.sql.catalog.paimon.cache-enabled", "false")

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
@@ -64,6 +64,7 @@ class PaimonSparkTestBase
       "org.apache.spark.serializer.JavaSerializer"
     }
     super.sparkConf
+      .set("spark.driver.bindAddress", "127.0.0.1")
       .set("spark.sql.catalog.paimon", classOf[SparkCatalog].getName)
       .set("spark.sql.catalog.paimon.warehouse", tempDBDir.getCanonicalPath)
       .set("spark.sql.catalog.paimon.cache-enabled", "false")

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
@@ -42,53 +42,49 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
   // ----------------------- Minor Compact -----------------------
 
   test("Paimon Procedure: compact aware bucket pk table with minor compact strategy") {
-    Seq(1, -1).foreach(
-      bucket => {
-        withTable("T") {
-          spark.sql(
-            s"""
-               |CREATE TABLE T (id INT, value STRING, pt STRING)
-               |TBLPROPERTIES ('primary-key'='id, pt', 'bucket'='$bucket', 'write-only'='true')
-               |PARTITIONED BY (pt)
-               |""".stripMargin)
+    withTable("T") {
+      spark.sql(s"""
+                   |CREATE TABLE T (id INT, value STRING, pt STRING)
+                   |TBLPROPERTIES ('primary-key'='id, pt', 'bucket'='1', 'write-only'='true')
+                   |PARTITIONED BY (pt)
+                   |""".stripMargin)
 
-          val table = loadTable("T")
+      val table = loadTable("T")
 
-          spark.sql(s"INSERT INTO T VALUES (1, 'a', 'p1'), (2, 'b', 'p2')")
-          spark.sql(s"INSERT INTO T VALUES (3, 'c', 'p1'), (4, 'd', 'p2')")
+      spark.sql(s"INSERT INTO T VALUES (1, 'a', 'p1'), (2, 'b', 'p2')")
+      spark.sql(s"INSERT INTO T VALUES (3, 'c', 'p1'), (4, 'd', 'p2')")
 
-          Assertions.assertThat(lastSnapshotCommand(table).equals(CommitKind.APPEND)).isTrue
-          Assertions.assertThat(lastSnapshotId(table)).isEqualTo(2)
+      Assertions.assertThat(lastSnapshotCommand(table).equals(CommitKind.APPEND)).isTrue
+      Assertions.assertThat(lastSnapshotId(table)).isEqualTo(2)
 
-          spark.sql(
-            "CALL sys.compact(table => 'T', compact_strategy => 'full'," +
-              "options => 'num-sorted-run.compaction-trigger=3')")
+      spark.sql(
+        "CALL sys.compact(table => 'T', compact_strategy => 'minor'," +
+          "options => 'num-sorted-run.compaction-trigger=3')")
 
-          // Due to the limitation of parameter 'num-sorted-run.compaction-trigger' = 3, so compact is not
-          // performed.
-          Assertions.assertThat(lastSnapshotCommand(table).equals(CommitKind.APPEND)).isTrue
-          Assertions.assertThat(lastSnapshotId(table)).isEqualTo(2)
+      // Due to the limitation of parameter 'num-sorted-run.compaction-trigger' = 3, so compact is not
+      // performed.
+      Assertions.assertThat(lastSnapshotCommand(table).equals(CommitKind.APPEND)).isTrue
+      Assertions.assertThat(lastSnapshotId(table)).isEqualTo(2)
 
-          // Make par-p1 has 3 datafile and par-p2 has 2 datafile, so par-p2 will not be picked out to
-          // compact.
-          spark.sql(s"INSERT INTO T VALUES (1, 'a', 'p1')")
+      // Make par-p1 has 3 datafile and par-p2 has 2 datafile, so par-p2 will not be picked out to
+      // compact.
+      spark.sql(s"INSERT INTO T VALUES (1, 'a', 'p1')")
 
-          spark.sql(
-            "CALL sys.compact(table => 'T', compact_strategy => 'minor'," +
-              "options => 'num-sorted-run.compaction-trigger=3')")
+      spark.sql(
+        "CALL sys.compact(table => 'T', compact_strategy => 'minor'," +
+          "options => 'num-sorted-run.compaction-trigger=3')")
 
-          Assertions.assertThat(lastSnapshotCommand(table).equals(CommitKind.COMPACT)).isTrue
-          Assertions.assertThat(lastSnapshotId(table)).isEqualTo(4)
+      Assertions.assertThat(lastSnapshotId(table)).isEqualTo(4)
+      Assertions.assertThat(lastSnapshotCommand(table).equals(CommitKind.COMPACT)).isTrue
 
-          val splits = table.newSnapshotReader.read.dataSplits
-          splits.forEach(
-            split => {
-              Assertions
-                .assertThat(split.dataFiles.size)
-                .isEqualTo(if (split.partition().getInt(1) == 16) 2 else 1)
-            })
-        }
-      })
+      val splits = table.newSnapshotReader.read.dataSplits
+      splits.forEach(
+        split => {
+          Assertions
+            .assertThat(split.dataFiles.size)
+            .isEqualTo(if (split.partition().getString(0).toString == "p2") 2 else 1)
+        })
+    }
   }
 
   // ----------------------- Sort Compact -----------------------

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
@@ -39,6 +39,60 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
 
   import testImplicits._
 
+  // ----------------------- Minor Compact -----------------------
+
+  test("Paimon Procedure: compact aware bucket pk table with minor compact strategy") {
+    Seq(1, -1).foreach(
+      bucket => {
+        withTable("T") {
+          spark.sql(
+            s"""
+               |CREATE TABLE T (id INT, value STRING, pt STRING)
+               |TBLPROPERTIES ('primary-key'='id, pt', 'bucket'='$bucket', 'write-only'='true')
+               |PARTITIONED BY (pt)
+               |""".stripMargin)
+
+          val table = loadTable("T")
+
+          spark.sql(s"INSERT INTO T VALUES (1, 'a', 'p1'), (2, 'b', 'p2')")
+          spark.sql(s"INSERT INTO T VALUES (3, 'c', 'p1'), (4, 'd', 'p2')")
+
+          Assertions.assertThat(lastSnapshotCommand(table).equals(CommitKind.APPEND)).isTrue
+          Assertions.assertThat(lastSnapshotId(table)).isEqualTo(2)
+
+          spark.sql(
+            "CALL sys.compact(table => 'T', compact_strategy => 'full'," +
+              "options => 'num-sorted-run.compaction-trigger=3')")
+
+          // Due to the limitation of parameter 'num-sorted-run.compaction-trigger' = 3, so compact is not
+          // performed.
+          Assertions.assertThat(lastSnapshotCommand(table).equals(CommitKind.APPEND)).isTrue
+          Assertions.assertThat(lastSnapshotId(table)).isEqualTo(2)
+
+          // Make par-p1 has 3 datafile and par-p2 has 2 datafile, so par-p2 will not be picked out to
+          // compact.
+          spark.sql(s"INSERT INTO T VALUES (1, 'a', 'p1')")
+
+          spark.sql(
+            "CALL sys.compact(table => 'T', compact_strategy => 'minor'," +
+              "options => 'num-sorted-run.compaction-trigger=3')")
+
+          Assertions.assertThat(lastSnapshotCommand(table).equals(CommitKind.COMPACT)).isTrue
+          Assertions.assertThat(lastSnapshotId(table)).isEqualTo(4)
+
+          val splits = table.newSnapshotReader.read.dataSplits
+          splits.forEach(
+            split => {
+              Assertions
+                .assertThat(split.dataFiles.size)
+                .isEqualTo(if (split.partition().getInt(1) == 16) 2 else 1)
+            })
+        }
+      })
+  }
+
+  // ----------------------- Sort Compact -----------------------
+
   test("Paimon Procedure: sort compact") {
     failAfter(streamingTimeout) {
       withTempDir {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: (https://github.com/apache/paimon/issues/4566)

<!-- What is the purpose of the change -->

### Tests
```

- `--compact_strategy` Determines how to pick files to be merged, the default is determined by the runtime execution mode, streaming-mode use minor strategy and batch-mode use full strategy.

- `full `: Only supports batch mode. All files will be selected for merging.

- `minor `: Pick the set of files that need to be merged based on specified conditions.

```
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
