### PR TITLE
[flink] Avoid deprecated SetupableStreamOperator

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcDynamicBucketSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcDynamicBucketSink.java
@@ -25,7 +25,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.KeyAndBucketExtractor;
 
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 
 /** {@link CdcDynamicBucketSinkBase} for {@link CdcRecord}. */
 public class CdcDynamicBucketSink extends CdcDynamicBucketSinkBase<CdcRecord> {
@@ -42,8 +42,8 @@ public class CdcDynamicBucketSink extends CdcDynamicBucketSinkBase<CdcRecord> {
     }
 
     @Override
-    protected OneInputStreamOperator<Tuple2<CdcRecord, Integer>, Committable> createWriteOperator(
-            StoreSinkWrite.Provider writeProvider, String commitUser) {
-        return new CdcDynamicBucketWriteOperator(table, writeProvider, commitUser);
+    protected OneInputStreamOperatorFactory<Tuple2<CdcRecord, Integer>, Committable>
+            createWriteOperatorFactory(StoreSinkWrite.Provider writeProvider, String commitUser) {
+        return new CdcDynamicBucketWriteOperator.Factory(table, writeProvider, commitUser);
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcDynamicBucketWriteOperator.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcDynamicBucketWriteOperator.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink.sink.cdc;
 
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.flink.sink.Committable;
 import org.apache.paimon.flink.sink.PrepareCommitOperator;
 import org.apache.paimon.flink.sink.StoreSinkWrite;
 import org.apache.paimon.flink.sink.TableWriteOperator;
@@ -26,6 +27,9 @@ import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 import java.io.IOException;
@@ -43,11 +47,12 @@ public class CdcDynamicBucketWriteOperator extends TableWriteOperator<Tuple2<Cdc
 
     private final long retrySleepMillis;
 
-    public CdcDynamicBucketWriteOperator(
+    private CdcDynamicBucketWriteOperator(
+            StreamOperatorParameters<Committable> parameters,
             FileStoreTable table,
             StoreSinkWrite.Provider storeSinkWriteProvider,
             String initialCommitUser) {
-        super(table, storeSinkWriteProvider, initialCommitUser);
+        super(parameters, table, storeSinkWriteProvider, initialCommitUser);
         this.retrySleepMillis =
                 table.coreOptions().toConfiguration().get(RETRY_SLEEP_TIME).toMillis();
     }
@@ -83,6 +88,32 @@ public class CdcDynamicBucketWriteOperator extends TableWriteOperator<Tuple2<Cdc
             write.write(optionalConverted.get(), record.f1);
         } catch (Exception e) {
             throw new IOException(e);
+        }
+    }
+
+    /** {@link StreamOperatorFactory} of {@link CdcDynamicBucketWriteOperator}. */
+    public static class Factory extends TableWriteOperator.Factory<Tuple2<CdcRecord, Integer>> {
+
+        public Factory(
+                FileStoreTable table,
+                StoreSinkWrite.Provider storeSinkWriteProvider,
+                String initialCommitUser) {
+            super(table, storeSinkWriteProvider, initialCommitUser);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T extends StreamOperator<Committable>> T createStreamOperator(
+                StreamOperatorParameters<Committable> parameters) {
+            return (T)
+                    new CdcDynamicBucketWriteOperator(
+                            parameters, table, storeSinkWriteProvider, initialCommitUser);
+        }
+
+        @Override
+        @SuppressWarnings("rawtypes")
+        public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+            return CdcDynamicBucketWriteOperator.class;
         }
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcFixedBucketSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcFixedBucketSink.java
@@ -24,7 +24,7 @@ import org.apache.paimon.flink.sink.FlinkWriteSink;
 import org.apache.paimon.flink.sink.StoreSinkWrite;
 import org.apache.paimon.table.FileStoreTable;
 
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 
 /**
  * A {@link FlinkSink} for fixed-bucket table which accepts {@link CdcRecord} and waits for a schema
@@ -39,8 +39,8 @@ public class CdcFixedBucketSink extends FlinkWriteSink<CdcRecord> {
     }
 
     @Override
-    protected OneInputStreamOperator<CdcRecord, Committable> createWriteOperator(
+    protected OneInputStreamOperatorFactory<CdcRecord, Committable> createWriteOperatorFactory(
             StoreSinkWrite.Provider writeProvider, String commitUser) {
-        return new CdcRecordStoreWriteOperator(table, writeProvider, commitUser);
+        return new CdcRecordStoreWriteOperator.Factory(table, writeProvider, commitUser);
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcUnawareBucketSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcUnawareBucketSink.java
@@ -24,7 +24,7 @@ import org.apache.paimon.flink.sink.StoreSinkWrite;
 import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 
 import javax.annotation.Nullable;
 
@@ -42,9 +42,9 @@ public class CdcUnawareBucketSink extends FlinkWriteSink<CdcRecord> {
     }
 
     @Override
-    protected OneInputStreamOperator<CdcRecord, Committable> createWriteOperator(
+    protected OneInputStreamOperatorFactory<CdcRecord, Committable> createWriteOperatorFactory(
             StoreSinkWrite.Provider writeProvider, String commitUser) {
-        return new CdcUnawareBucketWriteOperator(table, writeProvider, commitUser);
+        return new CdcUnawareBucketWriteOperator.Factory(table, writeProvider, commitUser);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
@@ -41,7 +41,7 @@ import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 
 import javax.annotation.Nullable;
 
@@ -137,9 +137,10 @@ public class FlinkCdcMultiTableSink implements Serializable {
         return committed.addSink(new DiscardingSink<>()).name("end").setParallelism(1);
     }
 
-    protected OneInputStreamOperator<CdcMultiplexRecord, MultiTableCommittable> createWriteOperator(
-            StoreSinkWrite.WithWriteBufferProvider writeProvider, String commitUser) {
-        return new CdcRecordStoreMultiWriteOperator(
+    protected OneInputStreamOperatorFactory<CdcMultiplexRecord, MultiTableCommittable>
+            createWriteOperator(
+                    StoreSinkWrite.WithWriteBufferProvider writeProvider, String commitUser) {
+        return new CdcRecordStoreMultiWriteOperator.Factory(
                 catalogLoader, writeProvider, commitUser, new Options());
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
@@ -21,7 +21,7 @@ package org.apache.paimon.flink.sink.cdc;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.flink.sink.CommittableStateManager;
 import org.apache.paimon.flink.sink.Committer;
-import org.apache.paimon.flink.sink.CommitterOperator;
+import org.apache.paimon.flink.sink.CommitterOperatorFactory;
 import org.apache.paimon.flink.sink.FlinkSink;
 import org.apache.paimon.flink.sink.FlinkStreamPartitioner;
 import org.apache.paimon.flink.sink.MultiTableCommittable;
@@ -63,19 +63,16 @@ public class FlinkCdcMultiTableSink implements Serializable {
     private final Catalog.Loader catalogLoader;
     private final double commitCpuCores;
     @Nullable private final MemorySize commitHeapMemory;
-    private final boolean commitChaining;
     private final String commitUser;
 
     public FlinkCdcMultiTableSink(
             Catalog.Loader catalogLoader,
             double commitCpuCores,
             @Nullable MemorySize commitHeapMemory,
-            boolean commitChaining,
             String commitUser) {
         this.catalogLoader = catalogLoader;
         this.commitCpuCores = commitCpuCores;
         this.commitHeapMemory = commitHeapMemory;
-        this.commitChaining = commitChaining;
         this.commitUser = commitUser;
     }
 
@@ -129,10 +126,9 @@ public class FlinkCdcMultiTableSink implements Serializable {
                         .transform(
                                 GLOBAL_COMMITTER_NAME,
                                 typeInfo,
-                                new CommitterOperator<>(
+                                new CommitterOperatorFactory<>(
                                         true,
                                         false,
-                                        commitChaining,
                                         commitUser,
                                         createCommitterFactory(),
                                         createCommittableStateManager()))

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
@@ -66,7 +66,6 @@ public class FlinkCdcSyncDatabaseSinkBuilder<T> {
     @Nullable private Integer parallelism;
     private double committerCpu;
     @Nullable private MemorySize committerMemory;
-    private boolean commitChaining;
 
     // Paimon catalog used to check and create tables. There will be two
     //     places where this catalog is used. 1) in processing function,
@@ -103,7 +102,6 @@ public class FlinkCdcSyncDatabaseSinkBuilder<T> {
         this.parallelism = options.get(FlinkConnectorOptions.SINK_PARALLELISM);
         this.committerCpu = options.get(FlinkConnectorOptions.SINK_COMMITTER_CPU);
         this.committerMemory = options.get(FlinkConnectorOptions.SINK_COMMITTER_MEMORY);
-        this.commitChaining = options.get(FlinkConnectorOptions.SINK_COMMITTER_OPERATOR_CHAINING);
         this.commitUser = createCommitUser(options);
         return this;
     }
@@ -169,7 +167,7 @@ public class FlinkCdcSyncDatabaseSinkBuilder<T> {
 
         FlinkCdcMultiTableSink sink =
                 new FlinkCdcMultiTableSink(
-                        catalogLoader, committerCpu, committerMemory, commitChaining, commitUser);
+                        catalogLoader, committerCpu, committerMemory, commitUser);
         sink.sinkFrom(partitioned);
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperatorTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperatorTest.java
@@ -689,8 +689,8 @@ public class CdcRecordStoreMultiWriteOperatorTest {
 
     private OneInputStreamOperatorTestHarness<CdcMultiplexRecord, MultiTableCommittable>
             createTestHarness(Catalog.Loader catalogLoader) throws Exception {
-        CdcRecordStoreMultiWriteOperator operator =
-                new CdcRecordStoreMultiWriteOperator(
+        CdcRecordStoreMultiWriteOperator.Factory operatorFactory =
+                new CdcRecordStoreMultiWriteOperator.Factory(
                         catalogLoader,
                         (t, commitUser, state, ioManager, memoryPoolFactory, metricGroup) ->
                                 new StoreSinkWriteImpl(
@@ -709,7 +709,7 @@ public class CdcRecordStoreMultiWriteOperatorTest {
         TypeSerializer<MultiTableCommittable> outputSerializer =
                 new MultiTableCommittableTypeInfo().createSerializer(new ExecutionConfig());
         OneInputStreamOperatorTestHarness<CdcMultiplexRecord, MultiTableCommittable> harness =
-                new OneInputStreamOperatorTestHarness<>(operator, inputSerializer);
+                new OneInputStreamOperatorTestHarness<>(operatorFactory, inputSerializer);
         harness.setup(outputSerializer);
         return harness;
     }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreWriteOperatorTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreWriteOperatorTest.java
@@ -253,8 +253,8 @@ public class CdcRecordStoreWriteOperatorTest {
 
     private OneInputStreamOperatorTestHarness<CdcRecord, Committable> createTestHarness(
             FileStoreTable table) throws Exception {
-        CdcRecordStoreWriteOperator operator =
-                new CdcRecordStoreWriteOperator(
+        CdcRecordStoreWriteOperator.Factory operatorFactory =
+                new CdcRecordStoreWriteOperator.Factory(
                         table,
                         (t, commitUser, state, ioManager, memoryPool, metricGroup) ->
                                 new StoreSinkWriteImpl(
@@ -272,7 +272,7 @@ public class CdcRecordStoreWriteOperatorTest {
         TypeSerializer<Committable> outputSerializer =
                 new CommittableTypeInfo().createSerializer(new ExecutionConfig());
         OneInputStreamOperatorTestHarness<CdcRecord, Committable> harness =
-                new OneInputStreamOperatorTestHarness<>(operator, inputSerializer);
+                new OneInputStreamOperatorTestHarness<>(operatorFactory, inputSerializer);
         harness.setup(outputSerializer);
         return harness;
     }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSinkTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSinkTest.java
@@ -60,7 +60,6 @@ public class FlinkCdcMultiTableSinkTest {
                         () -> FlinkCatalogFactory.createPaimonCatalog(new Options()),
                         FlinkConnectorOptions.SINK_COMMITTER_CPU.defaultValue(),
                         null,
-                        true,
                         UUID.randomUUID().toString());
         DataStreamSink<?> dataStreamSink = sink.sinkFrom(input);
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendBypassCompactWorkerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendBypassCompactWorkerOperator.java
@@ -21,6 +21,9 @@ package org.apache.paimon.flink.sink;
 import org.apache.paimon.append.UnawareAppendCompactionTask;
 import org.apache.paimon.table.FileStoreTable;
 
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.types.Either;
 
@@ -28,8 +31,11 @@ import org.apache.flink.types.Either;
 public class AppendBypassCompactWorkerOperator
         extends AppendCompactWorkerOperator<Either<Committable, UnawareAppendCompactionTask>> {
 
-    public AppendBypassCompactWorkerOperator(FileStoreTable table, String commitUser) {
-        super(table, commitUser);
+    private AppendBypassCompactWorkerOperator(
+            StreamOperatorParameters<Committable> parameters,
+            FileStoreTable table,
+            String commitUser) {
+        super(parameters, table, commitUser);
     }
 
     @Override
@@ -45,6 +51,29 @@ public class AppendBypassCompactWorkerOperator
             output.collect(new StreamRecord<>(element.getValue().left()));
         } else {
             unawareBucketCompactor.processElement(element.getValue().right());
+        }
+    }
+
+    /** {@link StreamOperatorFactory} of {@link AppendBypassCompactWorkerOperator}. */
+    public static class Factory
+            extends AppendCompactWorkerOperator.Factory<
+                    Either<Committable, UnawareAppendCompactionTask>> {
+
+        public Factory(FileStoreTable table, String initialCommitUser) {
+            super(table, initialCommitUser);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T extends StreamOperator<Committable>> T createStreamOperator(
+                StreamOperatorParameters<Committable> parameters) {
+            return (T) new AppendBypassCompactWorkerOperator(parameters, table, commitUser);
+        }
+
+        @Override
+        @SuppressWarnings("rawtypes")
+        public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+            return AppendBypassCompactWorkerOperator.class;
         }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendBypassCompactWorkerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendBypassCompactWorkerOperator.java
@@ -21,7 +21,6 @@ package org.apache.paimon.flink.sink;
 import org.apache.paimon.append.UnawareAppendCompactionTask;
 import org.apache.paimon.table.FileStoreTable;
 
-import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.types.Either;
 
@@ -31,7 +30,6 @@ public class AppendBypassCompactWorkerOperator
 
     public AppendBypassCompactWorkerOperator(FileStoreTable table, String commitUser) {
         super(table, commitUser);
-        this.chainingStrategy = ChainingStrategy.HEAD;
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendCompactWorkerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendCompactWorkerOperator.java
@@ -27,6 +27,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.utils.ExecutorThreadFactory;
 
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,6 +107,7 @@ public abstract class AppendCompactWorkerOperator<IN>
         }
     }
 
+    /** {@link StreamOperatorFactory} of {@link AppendCompactWorkerOperator}. */
     protected abstract static class Factory<IN>
             extends PrepareCommitOperator.Factory<IN, Committable> {
         protected final FileStoreTable table;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendCompactWorkerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendCompactWorkerOperator.java
@@ -27,6 +27,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.utils.ExecutorThreadFactory;
 
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,8 +54,11 @@ public abstract class AppendCompactWorkerOperator<IN>
 
     private transient ExecutorService lazyCompactExecutor;
 
-    public AppendCompactWorkerOperator(FileStoreTable table, String commitUser) {
-        super(Options.fromMap(table.options()));
+    public AppendCompactWorkerOperator(
+            StreamOperatorParameters<Committable> parameters,
+            FileStoreTable table,
+            String commitUser) {
+        super(parameters, Options.fromMap(table.options()));
         this.table = table;
         this.commitUser = commitUser;
     }
@@ -99,6 +103,18 @@ public abstract class AppendCompactWorkerOperator<IN>
                         "Executors shutdown timeout, there may be some files aren't deleted correctly");
             }
             this.unawareBucketCompactor.close();
+        }
+    }
+
+    protected abstract static class Factory<IN>
+            extends PrepareCommitOperator.Factory<IN, Committable> {
+        protected final FileStoreTable table;
+        protected final String commitUser;
+
+        protected Factory(FileStoreTable table, String commitUser) {
+            super(Options.fromMap(table.options()));
+            this.table = table;
+            this.commitUser = commitUser;
         }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AutoTagForSavepointCommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AutoTagForSavepointCommitterOperator.java
@@ -32,18 +32,13 @@ import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
-import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
-import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
-import org.apache.flink.streaming.api.operators.Output;
-import org.apache.flink.streaming.api.operators.SetupableStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 
 import java.time.Duration;
@@ -58,9 +53,7 @@ import java.util.TreeSet;
  * time, tags are automatically created for each flink savepoint.
  */
 public class AutoTagForSavepointCommitterOperator<CommitT, GlobalCommitT>
-        implements OneInputStreamOperator<CommitT, CommitT>,
-                SetupableStreamOperator,
-                BoundedOneInput {
+        implements OneInputStreamOperator<CommitT, CommitT>, BoundedOneInput {
     public static final String SAVEPOINT_TAG_PREFIX = "savepoint-";
 
     private static final long serialVersionUID = 1L;
@@ -255,20 +248,5 @@ public class AutoTagForSavepointCommitterOperator<CommitT, GlobalCommitT>
     @Override
     public void endInput() throws Exception {
         commitOperator.endInput();
-    }
-
-    @Override
-    public void setup(StreamTask containingTask, StreamConfig config, Output output) {
-        commitOperator.setup(containingTask, config, output);
-    }
-
-    @Override
-    public ChainingStrategy getChainingStrategy() {
-        return commitOperator.getChainingStrategy();
-    }
-
-    @Override
-    public void setChainingStrategy(ChainingStrategy strategy) {
-        commitOperator.setChainingStrategy(strategy);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AutoTagForSavepointCommitterOperatorFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AutoTagForSavepointCommitterOperatorFactory.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.operation.TagDeletion;
+import org.apache.paimon.table.sink.TagCallback;
+import org.apache.paimon.utils.SerializableSupplier;
+import org.apache.paimon.utils.SnapshotManager;
+import org.apache.paimon.utils.TagManager;
+
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.TreeSet;
+
+/**
+ * {@link org.apache.flink.streaming.api.operators.StreamOperatorFactory} for {@link
+ * AutoTagForSavepointCommitterOperator}.
+ */
+public class AutoTagForSavepointCommitterOperatorFactory<CommitT, GlobalCommitT>
+        extends AbstractStreamOperatorFactory<CommitT>
+        implements OneInputStreamOperatorFactory<CommitT, CommitT> {
+
+    private final CommitterOperatorFactory<CommitT, GlobalCommitT> commitOperatorFactory;
+
+    private final SerializableSupplier<SnapshotManager> snapshotManagerFactory;
+
+    private final SerializableSupplier<TagManager> tagManagerFactory;
+
+    private final SerializableSupplier<TagDeletion> tagDeletionFactory;
+
+    private final SerializableSupplier<List<TagCallback>> callbacksSupplier;
+
+    private final NavigableSet<Long> identifiersForTags;
+
+    private final Duration tagTimeRetained;
+
+    public AutoTagForSavepointCommitterOperatorFactory(
+            CommitterOperatorFactory<CommitT, GlobalCommitT> commitOperatorFactory,
+            SerializableSupplier<SnapshotManager> snapshotManagerFactory,
+            SerializableSupplier<TagManager> tagManagerFactory,
+            SerializableSupplier<TagDeletion> tagDeletionFactory,
+            SerializableSupplier<List<TagCallback>> callbacksSupplier,
+            Duration tagTimeRetained) {
+        this.commitOperatorFactory = commitOperatorFactory;
+        this.tagManagerFactory = tagManagerFactory;
+        this.snapshotManagerFactory = snapshotManagerFactory;
+        this.tagDeletionFactory = tagDeletionFactory;
+        this.callbacksSupplier = callbacksSupplier;
+        this.identifiersForTags = new TreeSet<>();
+        this.tagTimeRetained = tagTimeRetained;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends StreamOperator<CommitT>> T createStreamOperator(
+            StreamOperatorParameters<CommitT> parameters) {
+        return (T)
+                new AutoTagForSavepointCommitterOperator<>(
+                        commitOperatorFactory.createStreamOperator(parameters),
+                        snapshotManagerFactory,
+                        tagManagerFactory,
+                        tagDeletionFactory,
+                        callbacksSupplier,
+                        tagTimeRetained);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+        return AutoTagForSavepointCommitterOperator.class;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/BatchWriteGeneratorTagOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/BatchWriteGeneratorTagOperator.java
@@ -28,18 +28,13 @@ import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
-import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
-import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
-import org.apache.flink.streaming.api.operators.Output;
-import org.apache.flink.streaming.api.operators.SetupableStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 
 import java.time.Instant;
@@ -53,9 +48,7 @@ import java.util.List;
  * completed, the corresponding tag is generated.
  */
 public class BatchWriteGeneratorTagOperator<CommitT, GlobalCommitT>
-        implements OneInputStreamOperator<CommitT, CommitT>,
-                SetupableStreamOperator,
-                BoundedOneInput {
+        implements OneInputStreamOperator<CommitT, CommitT>, BoundedOneInput {
 
     private static final String BATCH_WRITE_TAG_PREFIX = "batch-write-";
 
@@ -249,20 +242,5 @@ public class BatchWriteGeneratorTagOperator<CommitT, GlobalCommitT>
     @Override
     public void endInput() throws Exception {
         commitOperator.endInput();
-    }
-
-    @Override
-    public void setup(StreamTask containingTask, StreamConfig config, Output output) {
-        commitOperator.setup(containingTask, config, output);
-    }
-
-    @Override
-    public ChainingStrategy getChainingStrategy() {
-        return commitOperator.getChainingStrategy();
-    }
-
-    @Override
-    public void setChainingStrategy(ChainingStrategy strategy) {
-        commitOperator.setChainingStrategy(strategy);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CombinedTableCompactorSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CombinedTableCompactorSink.java
@@ -160,15 +160,17 @@ public class CombinedTableCompactorSink implements Serializable {
                         .transform(
                                 GLOBAL_COMMITTER_NAME,
                                 new MultiTableCommittableTypeInfo(),
-                                new CommitterOperator<>(
+                                new CommitterOperatorFactory<>(
                                         streamingCheckpointEnabled,
                                         false,
-                                        options.get(SINK_COMMITTER_OPERATOR_CHAINING),
                                         commitUser,
                                         createCommitterFactory(isStreaming),
                                         createCommittableStateManager(),
                                         options.get(END_INPUT_WATERMARK)))
                         .setParallelism(written.getParallelism());
+        if (!options.get(SINK_COMMITTER_OPERATOR_CHAINING)) {
+            committed = committed.startNewChain();
+        }
         return committed.addSink(new DiscardingSink<>()).name("end").setParallelism(1);
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CombinedTableCompactorSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CombinedTableCompactorSink.java
@@ -33,7 +33,7 @@ import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 import org.apache.flink.table.data.RowData;
 
 import java.io.Serializable;
@@ -119,7 +119,7 @@ public class CombinedTableCompactorSink implements Serializable {
                         .transform(
                                 String.format("%s-%s", "Unaware-Bucket-Table", WRITER_NAME),
                                 new MultiTableCommittableTypeInfo(),
-                                new AppendOnlyMultiTableCompactionWorkerOperator(
+                                new AppendOnlyMultiTableCompactionWorkerOperator.Factory(
                                         catalogLoader, commitUser, options))
                         .setParallelism(unawareBucketTableSource.getParallelism());
 
@@ -175,13 +175,13 @@ public class CombinedTableCompactorSink implements Serializable {
     }
 
     // TODO:refactor FlinkSink to adopt this sink
-    protected OneInputStreamOperator<RowData, MultiTableCommittable>
+    protected OneInputStreamOperatorFactory<RowData, MultiTableCommittable>
             combinedMultiComacptionWriteOperator(
                     CheckpointConfig checkpointConfig,
                     boolean isStreaming,
                     boolean fullCompaction,
                     String commitUser) {
-        return new MultiTablesStoreCompactOperator(
+        return new MultiTablesStoreCompactOperator.Factory(
                 catalogLoader,
                 commitUser,
                 checkpointConfig,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
@@ -25,8 +25,8 @@ import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
-import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
@@ -91,26 +91,9 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
     private final Long endInputWatermark;
 
     public CommitterOperator(
+            StreamOperatorParameters<CommitT> parameters,
             boolean streamingCheckpointEnabled,
             boolean forceSingleParallelism,
-            boolean chaining,
-            String initialCommitUser,
-            Committer.Factory<CommitT, GlobalCommitT> committerFactory,
-            CommittableStateManager<GlobalCommitT> committableStateManager) {
-        this(
-                streamingCheckpointEnabled,
-                forceSingleParallelism,
-                chaining,
-                initialCommitUser,
-                committerFactory,
-                committableStateManager,
-                null);
-    }
-
-    public CommitterOperator(
-            boolean streamingCheckpointEnabled,
-            boolean forceSingleParallelism,
-            boolean chaining,
             String initialCommitUser,
             Committer.Factory<CommitT, GlobalCommitT> committerFactory,
             CommittableStateManager<GlobalCommitT> committableStateManager,
@@ -122,7 +105,10 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
         this.committerFactory = checkNotNull(committerFactory);
         this.committableStateManager = committableStateManager;
         this.endInputWatermark = endInputWatermark;
-        setChainingStrategy(chaining ? ChainingStrategy.ALWAYS : ChainingStrategy.HEAD);
+        this.setup(
+                parameters.getContainingTask(),
+                parameters.getStreamConfig(),
+                parameters.getOutput());
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperatorFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperatorFactory.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+import static org.apache.paimon.utils.Preconditions.checkNotNull;
+
+/**
+ * {@link org.apache.flink.streaming.api.operators.StreamOperatorFactory} for {@link
+ * CommitterOperator}.
+ */
+public class CommitterOperatorFactory<CommitT, GlobalCommitT>
+        extends AbstractStreamOperatorFactory<CommitT>
+        implements OneInputStreamOperatorFactory<CommitT, CommitT> {
+    protected final boolean streamingCheckpointEnabled;
+
+    /** Whether to check the parallelism while runtime. */
+    protected final boolean forceSingleParallelism;
+    /**
+     * This commitUser is valid only for new jobs. After the job starts, this commitUser will be
+     * recorded into the states of write and commit operators. When the job restarts, commitUser
+     * will be recovered from states and this value is ignored.
+     */
+    protected final String initialCommitUser;
+
+    /** Group the committable by the checkpoint id. */
+    protected final NavigableMap<Long, GlobalCommitT> committablesPerCheckpoint;
+
+    protected final Committer.Factory<CommitT, GlobalCommitT> committerFactory;
+
+    protected final CommittableStateManager<GlobalCommitT> committableStateManager;
+
+    /**
+     * Aggregate committables to global committables and commit the global committables to the
+     * external system.
+     */
+    protected Committer<CommitT, GlobalCommitT> committer;
+
+    protected final Long endInputWatermark;
+
+    public CommitterOperatorFactory(
+            boolean streamingCheckpointEnabled,
+            boolean forceSingleParallelism,
+            String initialCommitUser,
+            Committer.Factory<CommitT, GlobalCommitT> committerFactory,
+            CommittableStateManager<GlobalCommitT> committableStateManager) {
+        this(
+                streamingCheckpointEnabled,
+                forceSingleParallelism,
+                initialCommitUser,
+                committerFactory,
+                committableStateManager,
+                null);
+    }
+
+    public CommitterOperatorFactory(
+            boolean streamingCheckpointEnabled,
+            boolean forceSingleParallelism,
+            String initialCommitUser,
+            Committer.Factory<CommitT, GlobalCommitT> committerFactory,
+            CommittableStateManager<GlobalCommitT> committableStateManager,
+            Long endInputWatermark) {
+        this.streamingCheckpointEnabled = streamingCheckpointEnabled;
+        this.forceSingleParallelism = forceSingleParallelism;
+        this.initialCommitUser = initialCommitUser;
+        this.committablesPerCheckpoint = new TreeMap<>();
+        this.committerFactory = checkNotNull(committerFactory);
+        this.committableStateManager = committableStateManager;
+        this.endInputWatermark = endInputWatermark;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends StreamOperator<CommitT>> T createStreamOperator(
+            StreamOperatorParameters<CommitT> parameters) {
+        return (T)
+                new CommitterOperator<>(
+                        parameters,
+                        streamingCheckpointEnabled,
+                        forceSingleParallelism,
+                        initialCommitUser,
+                        committerFactory,
+                        committableStateManager,
+                        endInputWatermark);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+        return CommitterOperator.class;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSink.java
@@ -21,7 +21,7 @@ package org.apache.paimon.flink.sink;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.table.FileStoreTable;
 
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 import org.apache.flink.table.data.RowData;
 
 /** {@link FlinkSink} for dedicated compact jobs. */
@@ -37,9 +37,9 @@ public class CompactorSink extends FlinkSink<RowData> {
     }
 
     @Override
-    protected OneInputStreamOperator<RowData, Committable> createWriteOperator(
+    protected OneInputStreamOperatorFactory<RowData, Committable> createWriteOperatorFactory(
             StoreSinkWrite.Provider writeProvider, String commitUser) {
-        return new StoreCompactOperator(table, writeProvider, commitUser, fullCompaction);
+        return new StoreCompactOperator.Factory(table, writeProvider, commitUser, fullCompaction);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DynamicBucketRowWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DynamicBucketRowWriteOperator.java
@@ -22,6 +22,9 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 /**
@@ -32,11 +35,12 @@ public class DynamicBucketRowWriteOperator
 
     private static final long serialVersionUID = 1L;
 
-    public DynamicBucketRowWriteOperator(
+    private DynamicBucketRowWriteOperator(
+            StreamOperatorParameters<Committable> parameters,
             FileStoreTable table,
             StoreSinkWrite.Provider storeSinkWriteProvider,
             String initialCommitUser) {
-        super(table, storeSinkWriteProvider, initialCommitUser);
+        super(parameters, table, storeSinkWriteProvider, initialCommitUser);
     }
 
     @Override
@@ -48,5 +52,31 @@ public class DynamicBucketRowWriteOperator
     public void processElement(StreamRecord<Tuple2<InternalRow, Integer>> element)
             throws Exception {
         write.write(element.getValue().f0, element.getValue().f1);
+    }
+
+    /** {@link StreamOperatorFactory} of {@link DynamicBucketRowWriteOperator}. */
+    public static class Factory extends TableWriteOperator.Factory<Tuple2<InternalRow, Integer>> {
+
+        public Factory(
+                FileStoreTable table,
+                StoreSinkWrite.Provider storeSinkWriteProvider,
+                String initialCommitUser) {
+            super(table, storeSinkWriteProvider, initialCommitUser);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T extends StreamOperator<Committable>> T createStreamOperator(
+                StreamOperatorParameters<Committable> parameters) {
+            return (T)
+                    new DynamicBucketRowWriteOperator(
+                            parameters, table, storeSinkWriteProvider, initialCommitUser);
+        }
+
+        @Override
+        @SuppressWarnings("rawtypes")
+        public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+            return DynamicBucketRowWriteOperator.class;
+        }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FixedBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FixedBucketSink.java
@@ -21,7 +21,7 @@ package org.apache.paimon.flink.sink;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.table.FileStoreTable;
 
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 
 import javax.annotation.Nullable;
 
@@ -43,8 +43,9 @@ public class FixedBucketSink extends FlinkWriteSink<InternalRow> {
     }
 
     @Override
-    protected OneInputStreamOperator<InternalRow, Committable> createWriteOperator(
+    protected OneInputStreamOperatorFactory<InternalRow, Committable> createWriteOperatorFactory(
             StoreSinkWrite.Provider writeProvider, String commitUser) {
-        return new RowDataStoreWriteOperator(table, logSinkFunction, writeProvider, commitUser);
+        return new RowDataStoreWriteOperator.Factory(
+                table, logSinkFunction, writeProvider, commitUser);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -44,7 +44,6 @@ import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 
@@ -221,7 +220,7 @@ public abstract class FlinkSink<T> implements Serializable {
                                         + " : "
                                         + table.name(),
                                 new CommittableTypeInfo(),
-                                createWriteOperator(
+                                createWriteOperatorFactory(
                                         createWriteProvider(
                                                 env.getCheckpointConfig(),
                                                 isStreaming,
@@ -367,7 +366,7 @@ public abstract class FlinkSink<T> implements Serializable {
         }
     }
 
-    protected abstract OneInputStreamOperator<T, Committable> createWriteOperator(
+    protected abstract OneInputStreamOperatorFactory<T, Committable> createWriteOperatorFactory(
             StoreSinkWrite.Provider writeProvider, String commitUser);
 
     protected abstract Committer.Factory<Committable, ManifestCommittable> createCommitterFactory();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -45,6 +45,7 @@ import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 
 import javax.annotation.Nullable;
@@ -268,11 +269,10 @@ public abstract class FlinkSink<T> implements Serializable {
         }
 
         Options options = Options.fromMap(table.options());
-        OneInputStreamOperator<Committable, Committable> committerOperator =
-                new CommitterOperator<>(
+        OneInputStreamOperatorFactory<Committable, Committable> committerOperator =
+                new CommitterOperatorFactory<>(
                         streamingCheckpointEnabled,
                         true,
-                        options.get(SINK_COMMITTER_OPERATOR_CHAINING),
                         commitUser,
                         createCommitterFactory(),
                         createCommittableStateManager(),
@@ -280,8 +280,9 @@ public abstract class FlinkSink<T> implements Serializable {
 
         if (options.get(SINK_AUTO_TAG_FOR_SAVEPOINT)) {
             committerOperator =
-                    new AutoTagForSavepointCommitterOperator<>(
-                            (CommitterOperator<Committable, ManifestCommittable>) committerOperator,
+                    new AutoTagForSavepointCommitterOperatorFactory<>(
+                            (CommitterOperatorFactory<Committable, ManifestCommittable>)
+                                    committerOperator,
                             table::snapshotManager,
                             table::tagManager,
                             () -> table.store().newTagDeletion(),
@@ -291,8 +292,9 @@ public abstract class FlinkSink<T> implements Serializable {
         if (conf.get(ExecutionOptions.RUNTIME_MODE) == RuntimeExecutionMode.BATCH
                 && table.coreOptions().tagCreationMode() == TagCreationMode.BATCH) {
             committerOperator =
-                    new BatchWriteGeneratorTagOperator<>(
-                            (CommitterOperator<Committable, ManifestCommittable>) committerOperator,
+                    new BatchWriteGeneratorTagOperatorFactory<>(
+                            (CommitterOperatorFactory<Committable, ManifestCommittable>)
+                                    committerOperator,
                             table);
         }
         SingleOutputStreamOperator<?> committed =
@@ -309,6 +311,9 @@ public abstract class FlinkSink<T> implements Serializable {
                                     GLOBAL_COMMITTER_NAME,
                                     table.name(),
                                     options.get(SINK_OPERATOR_UID_SUFFIX)));
+        }
+        if (!options.get(SINK_COMMITTER_OPERATOR_CHAINING)) {
+            committed = committed.startNewChain();
         }
         configureGlobalCommitter(
                 committed, options.get(SINK_COMMITTER_CPU), options.get(SINK_COMMITTER_MEMORY));

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
@@ -222,7 +222,7 @@ public class FlinkSinkBuilder {
                             .transform(
                                     "local merge",
                                     input.getType(),
-                                    new LocalMergeOperator(table.schema()))
+                                    new LocalMergeOperator.Factory(table.schema()))
                             .setParallelism(input.getParallelism());
         }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/LocalMergeOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/LocalMergeOperator.java
@@ -81,12 +81,14 @@ public class LocalMergeOperator extends AbstractStreamOperator<InternalRow>
 
     private transient boolean endOfInput;
 
-    private LocalMergeOperator(TableSchema schema) {
+    private LocalMergeOperator(
+            StreamOperatorParameters<InternalRow> parameters, TableSchema schema) {
         Preconditions.checkArgument(
                 schema.primaryKeys().size() > 0,
                 "LocalMergeOperator currently only support tables with primary keys");
         this.schema = schema;
         this.ignoreDelete = CoreOptions.fromMap(schema.options()).ignoreDelete();
+        setup(parameters.getContainingTask(), parameters.getStreamConfig(), parameters.getOutput());
     }
 
     @Override
@@ -253,8 +255,8 @@ public class LocalMergeOperator extends AbstractStreamOperator<InternalRow>
         @Override
         @SuppressWarnings("unchecked")
         public <T extends StreamOperator<InternalRow>> T createStreamOperator(
-                StreamOperatorParameters<InternalRow> streamOperatorParameters) {
-            return (T) new LocalMergeOperator(schema);
+                StreamOperatorParameters<InternalRow> parameters) {
+            return (T) new LocalMergeOperator(parameters, schema);
         }
 
         @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/LocalMergeOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/LocalMergeOperator.java
@@ -45,7 +45,6 @@ import org.apache.paimon.utils.UserDefinedSeqComparator;
 
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
-import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -82,7 +81,6 @@ public class LocalMergeOperator extends AbstractStreamOperator<InternalRow>
                 "LocalMergeOperator currently only support tables with primary keys");
         this.schema = schema;
         this.ignoreDelete = CoreOptions.fromMap(schema.options()).ignoreDelete();
-        setChainingStrategy(ChainingStrategy.ALWAYS);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/PrepareCommitOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/PrepareCommitOperator.java
@@ -32,6 +32,7 @@ import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
@@ -107,6 +108,7 @@ public abstract class PrepareCommitOperator<IN, OUT> extends AbstractStreamOpera
     protected abstract List<OUT> prepareCommit(boolean waitCompaction, long checkpointId)
             throws IOException;
 
+    /** {@link StreamOperatorFactory} of {@link PrepareCommitOperator}. */
     protected abstract static class Factory<IN, OUT> extends AbstractStreamOperatorFactory<OUT>
             implements OneInputStreamOperatorFactory<IN, OUT> {
         protected final Options options;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/PrepareCommitOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/PrepareCommitOperator.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
-import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -54,7 +53,6 @@ public abstract class PrepareCommitOperator<IN, OUT> extends AbstractStreamOpera
 
     public PrepareCommitOperator(Options options) {
         this.options = options;
-        setChainingStrategy(ChainingStrategy.ALWAYS);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RewriteFileIndexSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RewriteFileIndexSink.java
@@ -45,13 +45,10 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.Pair;
 
-import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
-import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.runtime.tasks.StreamTask;
 
 import javax.annotation.Nullable;
 
@@ -113,26 +110,14 @@ public class RewriteFileIndexSink extends FlinkWriteSink<ManifestEntry> {
 
         private static final long serialVersionUID = 1L;
 
-        private final FileStoreTable table;
-
-        private transient FileIndexProcessor fileIndexProcessor;
-        private transient List<CommitMessage> messages;
+        private final transient FileIndexProcessor fileIndexProcessor;
+        private final transient List<CommitMessage> messages;
 
         private FileIndexModificationOperator(
                 StreamOperatorParameters<Committable> parameters,
                 Options options,
                 FileStoreTable table) {
             super(parameters, options);
-            this.table = table;
-        }
-
-        @Override
-        public void setup(
-                StreamTask<?, ?> containingTask,
-                StreamConfig config,
-                Output<StreamRecord<Committable>> output) {
-            super.setup(containingTask, config, output);
-
             this.fileIndexProcessor = new FileIndexProcessor(table);
             this.messages = new ArrayList<>();
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataStoreWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataStoreWriteOperator.java
@@ -32,16 +32,13 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
-import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
-import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
-import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.util.functions.StreamingFunctionUtils;
 
 import javax.annotation.Nullable;
@@ -72,14 +69,6 @@ public class RowDataStoreWriteOperator extends TableWriteOperator<InternalRow> {
             String initialCommitUser) {
         super(parameters, table, storeSinkWriteProvider, initialCommitUser);
         this.logSinkFunction = logSinkFunction;
-    }
-
-    @Override
-    public void setup(
-            StreamTask<?, ?> containingTask,
-            StreamConfig config,
-            Output<StreamRecord<Committable>> output) {
-        super.setup(containingTask, config, output);
         if (logSinkFunction != null) {
             FunctionUtils.setFunctionRuntimeContext(logSinkFunction, getRuntimeContext());
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataStoreWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataStoreWriteOperator.java
@@ -35,6 +35,9 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
@@ -61,12 +64,13 @@ public class RowDataStoreWriteOperator extends TableWriteOperator<InternalRow> {
     /** We listen to this ourselves because we don't have an {@link InternalTimerService}. */
     private long currentWatermark = Long.MIN_VALUE;
 
-    public RowDataStoreWriteOperator(
+    protected RowDataStoreWriteOperator(
+            StreamOperatorParameters<Committable> parameters,
             FileStoreTable table,
             @Nullable LogSinkFunction logSinkFunction,
             StoreSinkWrite.Provider storeSinkWriteProvider,
             String initialCommitUser) {
-        super(table, storeSinkWriteProvider, initialCommitUser);
+        super(parameters, table, storeSinkWriteProvider, initialCommitUser);
         this.logSinkFunction = logSinkFunction;
     }
 
@@ -247,6 +251,40 @@ public class RowDataStoreWriteOperator extends TableWriteOperator<InternalRow> {
         @Override
         public Long timestamp() {
             return timestamp;
+        }
+    }
+
+    /** {@link StreamOperatorFactory} of {@link RowDataStoreWriteOperator}. */
+    public static class Factory extends TableWriteOperator.Factory<InternalRow> {
+
+        @Nullable private final LogSinkFunction logSinkFunction;
+
+        public Factory(
+                FileStoreTable table,
+                @Nullable LogSinkFunction logSinkFunction,
+                StoreSinkWrite.Provider storeSinkWriteProvider,
+                String initialCommitUser) {
+            super(table, storeSinkWriteProvider, initialCommitUser);
+            this.logSinkFunction = logSinkFunction;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T extends StreamOperator<Committable>> T createStreamOperator(
+                StreamOperatorParameters<Committable> parameters) {
+            return (T)
+                    new RowDataStoreWriteOperator(
+                            parameters,
+                            table,
+                            logSinkFunction,
+                            storeSinkWriteProvider,
+                            initialCommitUser);
+        }
+
+        @Override
+        @SuppressWarnings("rawtypes")
+        public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+            return RowDataStoreWriteOperator.class;
         }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDynamicBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDynamicBucketSink.java
@@ -27,7 +27,7 @@ import org.apache.paimon.table.sink.RowPartitionKeyExtractor;
 import org.apache.paimon.utils.SerializableFunction;
 
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 
 import javax.annotation.Nullable;
 
@@ -60,8 +60,8 @@ public class RowDynamicBucketSink extends DynamicBucketSink<InternalRow> {
     }
 
     @Override
-    protected OneInputStreamOperator<Tuple2<InternalRow, Integer>, Committable> createWriteOperator(
-            StoreSinkWrite.Provider writeProvider, String commitUser) {
-        return new DynamicBucketRowWriteOperator(table, writeProvider, commitUser);
+    protected OneInputStreamOperatorFactory<Tuple2<InternalRow, Integer>, Committable>
+            createWriteOperatorFactory(StoreSinkWrite.Provider writeProvider, String commitUser) {
+        return new DynamicBucketRowWriteOperator.Factory(table, writeProvider, commitUser);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/TableWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/TableWriteOperator.java
@@ -28,6 +28,7 @@ import org.apache.paimon.table.sink.ChannelComputer;
 
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.runtime.streamrecord.RecordAttributes;
 
@@ -131,6 +132,7 @@ public abstract class TableWriteOperator<IN> extends PrepareCommitOperator<IN, C
         return write;
     }
 
+    /** {@link StreamOperatorFactory} of {@link TableWriteOperator}. */
     protected abstract static class Factory<IN>
             extends PrepareCommitOperator.Factory<IN, Committable> {
         protected final FileStoreTable table;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/TableWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/TableWriteOperator.java
@@ -28,6 +28,7 @@ import org.apache.paimon.table.sink.ChannelComputer;
 
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.runtime.streamrecord.RecordAttributes;
 
 import java.io.IOException;
@@ -45,10 +46,11 @@ public abstract class TableWriteOperator<IN> extends PrepareCommitOperator<IN, C
     protected transient StoreSinkWrite write;
 
     public TableWriteOperator(
+            StreamOperatorParameters<Committable> parameters,
             FileStoreTable table,
             StoreSinkWrite.Provider storeSinkWriteProvider,
             String initialCommitUser) {
-        super(Options.fromMap(table.options()));
+        super(parameters, Options.fromMap(table.options()));
         this.table = table;
         this.storeSinkWriteProvider = storeSinkWriteProvider;
         this.initialCommitUser = initialCommitUser;
@@ -127,5 +129,22 @@ public abstract class TableWriteOperator<IN> extends PrepareCommitOperator<IN, C
     @VisibleForTesting
     public StoreSinkWrite getWrite() {
         return write;
+    }
+
+    protected abstract static class Factory<IN>
+            extends PrepareCommitOperator.Factory<IN, Committable> {
+        protected final FileStoreTable table;
+        protected final StoreSinkWrite.Provider storeSinkWriteProvider;
+        protected final String initialCommitUser;
+
+        protected Factory(
+                FileStoreTable table,
+                StoreSinkWrite.Provider storeSinkWriteProvider,
+                String initialCommitUser) {
+            super(Options.fromMap(table.options()));
+            this.table = table;
+            this.storeSinkWriteProvider = storeSinkWriteProvider;
+            this.initialCommitUser = initialCommitUser;
+        }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketCompactionSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketCompactionSink.java
@@ -24,7 +24,7 @@ import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 
 /** Compaction Sink for unaware-bucket table. */
 public class UnawareBucketCompactionSink extends FlinkSink<UnawareAppendCompactionTask> {
@@ -42,9 +42,9 @@ public class UnawareBucketCompactionSink extends FlinkSink<UnawareAppendCompacti
     }
 
     @Override
-    protected OneInputStreamOperator<UnawareAppendCompactionTask, Committable> createWriteOperator(
-            StoreSinkWrite.Provider writeProvider, String commitUser) {
-        return new AppendOnlySingleTableCompactionWorkerOperator(table, commitUser);
+    protected OneInputStreamOperatorFactory<UnawareAppendCompactionTask, Committable>
+            createWriteOperatorFactory(StoreSinkWrite.Provider writeProvider, String commitUser) {
+        return new AppendOnlySingleTableCompactionWorkerOperator.Factory(table, commitUser);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketSink.java
@@ -79,7 +79,8 @@ public abstract class UnawareBucketSink<T> extends FlinkWriteSink<T> {
                             .transform(
                                     "Compact Worker: " + table.name(),
                                     new CommittableTypeInfo(),
-                                    new AppendBypassCompactWorkerOperator(table, initialCommitUser))
+                                    new AppendBypassCompactWorkerOperator.Factory(
+                                            table, initialCommitUser))
                             .startNewChain()
                             .setParallelism(written.getParallelism());
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/UnawareBucketSink.java
@@ -74,11 +74,13 @@ public abstract class UnawareBucketSink<T> extends FlinkWriteSink<T> {
                                             new CommittableTypeInfo(),
                                             new CompactionTaskTypeInfo()),
                                     new AppendBypassCoordinateOperatorFactory<>(table))
+                            .startNewChain()
                             .forceNonParallel()
                             .transform(
                                     "Compact Worker: " + table.name(),
                                     new CommittableTypeInfo(),
                                     new AppendBypassCompactWorkerOperator(table, initialCommitUser))
+                            .startNewChain()
                             .setParallelism(written.getParallelism());
         }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/IndexBootstrapOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/IndexBootstrapOperator.java
@@ -27,7 +27,6 @@ import org.apache.paimon.utils.SerializableFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
-import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
@@ -44,7 +43,6 @@ public class IndexBootstrapOperator<T> extends AbstractStreamOperator<Tuple2<Key
             IndexBootstrap bootstrap, SerializableFunction<InternalRow, T> converter) {
         this.bootstrap = bootstrap;
         this.converter = converter;
-        setChainingStrategy(ChainingStrategy.ALWAYS);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/IndexBootstrapOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/IndexBootstrapOperator.java
@@ -27,7 +27,13 @@ import org.apache.paimon.utils.SerializableFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 /** Operator for {@link IndexBootstrap}. */
@@ -39,7 +45,7 @@ public class IndexBootstrapOperator<T> extends AbstractStreamOperator<Tuple2<Key
     private final IndexBootstrap bootstrap;
     private final SerializableFunction<InternalRow, T> converter;
 
-    public IndexBootstrapOperator(
+    private IndexBootstrapOperator(
             IndexBootstrap bootstrap, SerializableFunction<InternalRow, T> converter) {
         this.bootstrap = bootstrap;
         this.converter = converter;
@@ -62,5 +68,31 @@ public class IndexBootstrapOperator<T> extends AbstractStreamOperator<Tuple2<Key
     private void collect(InternalRow row) {
         output.collect(
                 new StreamRecord<>(new Tuple2<>(KeyPartOrRow.KEY_PART, converter.apply(row))));
+    }
+
+    /** {@link StreamOperatorFactory} of {@link IndexBootstrapOperator}. */
+    public static class Factory<T> extends AbstractStreamOperatorFactory<Tuple2<KeyPartOrRow, T>>
+            implements OneInputStreamOperatorFactory<T, Tuple2<KeyPartOrRow, T>> {
+        private final IndexBootstrap bootstrap;
+        private final SerializableFunction<InternalRow, T> converter;
+
+        public Factory(IndexBootstrap bootstrap, SerializableFunction<InternalRow, T> converter) {
+            this.chainingStrategy = ChainingStrategy.ALWAYS;
+            this.bootstrap = bootstrap;
+            this.converter = converter;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <OP extends StreamOperator<Tuple2<KeyPartOrRow, T>>> OP createStreamOperator(
+                StreamOperatorParameters<Tuple2<KeyPartOrRow, T>> streamOperatorParameters) {
+            return (OP) new IndexBootstrapOperator<>(bootstrap, converter);
+        }
+
+        @Override
+        @SuppressWarnings("rawtypes")
+        public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+            return IndexBootstrapOperator.class;
+        }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/IndexBootstrapOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/IndexBootstrapOperator.java
@@ -46,9 +46,12 @@ public class IndexBootstrapOperator<T> extends AbstractStreamOperator<Tuple2<Key
     private final SerializableFunction<InternalRow, T> converter;
 
     private IndexBootstrapOperator(
-            IndexBootstrap bootstrap, SerializableFunction<InternalRow, T> converter) {
+            StreamOperatorParameters<Tuple2<KeyPartOrRow, T>> parameters,
+            IndexBootstrap bootstrap,
+            SerializableFunction<InternalRow, T> converter) {
         this.bootstrap = bootstrap;
         this.converter = converter;
+        setup(parameters.getContainingTask(), parameters.getStreamConfig(), parameters.getOutput());
     }
 
     @Override
@@ -85,8 +88,8 @@ public class IndexBootstrapOperator<T> extends AbstractStreamOperator<Tuple2<Key
         @Override
         @SuppressWarnings("unchecked")
         public <OP extends StreamOperator<Tuple2<KeyPartOrRow, T>>> OP createStreamOperator(
-                StreamOperatorParameters<Tuple2<KeyPartOrRow, T>> streamOperatorParameters) {
-            return (OP) new IndexBootstrapOperator<>(bootstrap, converter);
+                StreamOperatorParameters<Tuple2<KeyPartOrRow, T>> parameters) {
+            return (OP) new IndexBootstrapOperator<>(parameters, bootstrap, converter);
         }
 
         @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/AppendBypassCoordinateOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/AppendBypassCoordinateOperator.java
@@ -26,8 +26,8 @@ import org.apache.paimon.utils.ExecutorUtils;
 
 import org.apache.flink.api.common.operators.ProcessingTimeService.ProcessingTimeCallback;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
-import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.types.Either;
@@ -58,10 +58,12 @@ public class AppendBypassCoordinateOperator<CommitT>
     private transient LinkedBlockingQueue<UnawareAppendCompactionTask> compactTasks;
 
     public AppendBypassCoordinateOperator(
-            FileStoreTable table, ProcessingTimeService processingTimeService) {
+            StreamOperatorParameters<Either<CommitT, UnawareAppendCompactionTask>> parameters,
+            FileStoreTable table,
+            ProcessingTimeService processingTimeService) {
         this.table = table;
         this.processingTimeService = processingTimeService;
-        this.chainingStrategy = ChainingStrategy.HEAD;
+        setup(parameters.getContainingTask(), parameters.getStreamConfig(), parameters.getOutput());
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlyMultiTableCompactionWorkerOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlyMultiTableCompactionWorkerOperatorTest.java
@@ -25,7 +25,13 @@ import org.apache.paimon.table.TableTestBase;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
+import org.apache.flink.streaming.util.MockOutput;
+import org.apache.flink.streaming.util.MockStreamConfig;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -45,8 +51,17 @@ public class AppendOnlyMultiTableCompactionWorkerOperatorTest extends TableTestB
     public void testAsyncCompactionWorks() throws Exception {
 
         AppendOnlyMultiTableCompactionWorkerOperator workerOperator =
-                new AppendOnlyMultiTableCompactionWorkerOperator(
-                        () -> catalog, "user", new Options());
+                new AppendOnlyMultiTableCompactionWorkerOperator.Factory(
+                                () -> catalog, "user", new Options())
+                        .createStreamOperator(
+                                new StreamOperatorParameters<>(
+                                        new SourceOperatorStreamTask<Integer>(
+                                                new DummyEnvironment()),
+                                        new MockStreamConfig(new Configuration(), 1),
+                                        new MockOutput<>(new ArrayList<>()),
+                                        null,
+                                        null,
+                                        null));
 
         List<StreamRecord<MultiTableUnawareAppendCompactionTask>> records = new ArrayList<>();
         // create table and write

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlySingleTableCompactionWorkerOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlySingleTableCompactionWorkerOperatorTest.java
@@ -32,7 +32,13 @@ import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.types.DataTypes;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
+import org.apache.flink.streaming.util.MockOutput;
+import org.apache.flink.streaming.util.MockStreamConfig;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -49,7 +55,16 @@ public class AppendOnlySingleTableCompactionWorkerOperatorTest extends TableTest
     public void testAsyncCompactionWorks() throws Exception {
         createTableDefault();
         AppendOnlySingleTableCompactionWorkerOperator workerOperator =
-                new AppendOnlySingleTableCompactionWorkerOperator(getTableDefault(), "user");
+                new AppendOnlySingleTableCompactionWorkerOperator.Factory(getTableDefault(), "user")
+                        .createStreamOperator(
+                                new StreamOperatorParameters<>(
+                                        new SourceOperatorStreamTask<Integer>(
+                                                new DummyEnvironment()),
+                                        new MockStreamConfig(new Configuration(), 1),
+                                        new MockOutput<>(new ArrayList<>()),
+                                        null,
+                                        null,
+                                        null));
 
         // write 200 files
         List<CommitMessage> commitMessages = writeDataDefault(200, 20);
@@ -102,7 +117,16 @@ public class AppendOnlySingleTableCompactionWorkerOperatorTest extends TableTest
     public void testAsyncCompactionFileDeletedWhenShutdown() throws Exception {
         createTableDefault();
         AppendOnlySingleTableCompactionWorkerOperator workerOperator =
-                new AppendOnlySingleTableCompactionWorkerOperator(getTableDefault(), "user");
+                new AppendOnlySingleTableCompactionWorkerOperator.Factory(getTableDefault(), "user")
+                        .createStreamOperator(
+                                new StreamOperatorParameters<>(
+                                        new SourceOperatorStreamTask<Integer>(
+                                                new DummyEnvironment()),
+                                        new MockStreamConfig(new Configuration(), 1),
+                                        new MockOutput<>(new ArrayList<>()),
+                                        null,
+                                        null,
+                                        null));
 
         // write 200 files
         List<CommitMessage> commitMessages = writeDataDefault(200, 40);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AutoTagForSavepointCommitterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AutoTagForSavepointCommitterOperatorTest.java
@@ -32,7 +32,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.SavepointType;
 import org.apache.flink.runtime.state.StateInitializationContext;
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.junit.jupiter.api.Test;
 
@@ -198,13 +198,15 @@ public class AutoTagForSavepointCommitterOperatorTest extends CommitterOperatorT
     }
 
     @Override
-    protected OneInputStreamOperator<Committable, Committable> createCommitterOperator(
-            FileStoreTable table,
-            String commitUser,
-            CommittableStateManager<ManifestCommittable> committableStateManager) {
-        return new AutoTagForSavepointCommitterOperator<>(
-                (CommitterOperator<Committable, ManifestCommittable>)
-                        super.createCommitterOperator(table, commitUser, committableStateManager),
+    protected OneInputStreamOperatorFactory<Committable, Committable>
+            createCommitterOperatorFactory(
+                    FileStoreTable table,
+                    String commitUser,
+                    CommittableStateManager<ManifestCommittable> committableStateManager) {
+        return new AutoTagForSavepointCommitterOperatorFactory<>(
+                (CommitterOperatorFactory<Committable, ManifestCommittable>)
+                        super.createCommitterOperatorFactory(
+                                table, commitUser, committableStateManager),
                 table::snapshotManager,
                 table::tagManager,
                 () -> table.store().newTagDeletion(),
@@ -213,14 +215,15 @@ public class AutoTagForSavepointCommitterOperatorTest extends CommitterOperatorT
     }
 
     @Override
-    protected OneInputStreamOperator<Committable, Committable> createCommitterOperator(
-            FileStoreTable table,
-            String commitUser,
-            CommittableStateManager<ManifestCommittable> committableStateManager,
-            ThrowingConsumer<StateInitializationContext, Exception> initializeFunction) {
-        return new AutoTagForSavepointCommitterOperator<>(
-                (CommitterOperator<Committable, ManifestCommittable>)
-                        super.createCommitterOperator(
+    protected OneInputStreamOperatorFactory<Committable, Committable>
+            createCommitterOperatorFactory(
+                    FileStoreTable table,
+                    String commitUser,
+                    CommittableStateManager<ManifestCommittable> committableStateManager,
+                    ThrowingConsumer<StateInitializationContext, Exception> initializeFunction) {
+        return new AutoTagForSavepointCommitterOperatorFactory<>(
+                (CommitterOperatorFactory<Committable, ManifestCommittable>)
+                        super.createCommitterOperatorFactory(
                                 table, commitUser, committableStateManager, initializeFunction),
                 table::snapshotManager,
                 table::tagManager,

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/BatchWriteGeneratorTagOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/BatchWriteGeneratorTagOperatorTest.java
@@ -27,13 +27,21 @@ import org.apache.paimon.table.sink.TableCommitImpl;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
+import org.apache.flink.streaming.util.MockOutput;
+import org.apache.flink.streaming.util.MockStreamConfig;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Objects;
 
@@ -54,12 +62,23 @@ public class BatchWriteGeneratorTagOperatorTest extends CommitterOperatorTest {
         StreamTableWrite write =
                 table.newStreamWriteBuilder().withCommitUser(initialCommitUser).newWrite();
 
-        OneInputStreamOperator<Committable, Committable> committerOperator =
-                createCommitterOperator(
+        OneInputStreamOperatorFactory<Committable, Committable> committerOperatorFactory =
+                createCommitterOperatorFactory(
                         table,
                         initialCommitUser,
                         new RestoreAndFailCommittableStateManager<>(
                                 ManifestCommittableSerializer::new));
+
+        OneInputStreamOperator<Committable, Committable> committerOperator =
+                committerOperatorFactory.createStreamOperator(
+                        new StreamOperatorParameters<>(
+                                new SourceOperatorStreamTask<Integer>(new DummyEnvironment()),
+                                new MockStreamConfig(new Configuration(), 1),
+                                new MockOutput<>(new ArrayList<>()),
+                                null,
+                                null,
+                                null));
+
         committerOperator.open();
 
         TableCommitImpl tableCommit = table.newCommit(initialCommitUser);
@@ -106,13 +125,15 @@ public class BatchWriteGeneratorTagOperatorTest extends CommitterOperatorTest {
     }
 
     @Override
-    protected OneInputStreamOperator<Committable, Committable> createCommitterOperator(
-            FileStoreTable table,
-            String commitUser,
-            CommittableStateManager<ManifestCommittable> committableStateManager) {
-        return new BatchWriteGeneratorTagOperator<>(
-                (CommitterOperator<Committable, ManifestCommittable>)
-                        super.createCommitterOperator(table, commitUser, committableStateManager),
+    protected OneInputStreamOperatorFactory<Committable, Committable>
+            createCommitterOperatorFactory(
+                    FileStoreTable table,
+                    String commitUser,
+                    CommittableStateManager<ManifestCommittable> committableStateManager) {
+        return new BatchWriteGeneratorTagOperatorFactory<>(
+                (CommitterOperatorFactory<Committable, ManifestCommittable>)
+                        super.createCommitterOperatorFactory(
+                                table, commitUser, committableStateManager),
                 table);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CompactorSinkITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CompactorSinkITCase.java
@@ -254,8 +254,8 @@ public class CompactorSinkITCase extends AbstractTestBase {
         return harness;
     }
 
-    protected StoreCompactOperator createCompactOperator(FileStoreTable table) {
-        return new StoreCompactOperator(
+    protected StoreCompactOperator.Factory createCompactOperator(FileStoreTable table) {
+        return new StoreCompactOperator.Factory(
                 table,
                 (t, commitUser, state, ioManager, memoryPool, metricGroup) ->
                         new StoreSinkWriteImpl(
@@ -272,9 +272,9 @@ public class CompactorSinkITCase extends AbstractTestBase {
                 true);
     }
 
-    protected MultiTablesStoreCompactOperator createMultiTablesCompactOperator(
+    protected MultiTablesStoreCompactOperator.Factory createMultiTablesCompactOperator(
             Catalog.Loader catalogLoader) throws Exception {
-        return new MultiTablesStoreCompactOperator(
+        return new MultiTablesStoreCompactOperator.Factory(
                 catalogLoader,
                 commitUser,
                 new CheckpointConfig(),

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/LocalMergeOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/LocalMergeOperatorTest.java
@@ -151,7 +151,7 @@ class LocalMergeOperatorTest {
                         Collections.singletonList("f0"),
                         options,
                         null);
-        operator = new LocalMergeOperator(schema);
+        operator = new LocalMergeOperator.Factory(schema).createStreamOperator(null);
         operator.open();
         assertThat(operator.merger()).isInstanceOf(HashMapLocalMerger.class);
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/LocalMergeOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/LocalMergeOperatorTest.java
@@ -26,12 +26,18 @@ import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.RecordAttributes;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
+import org.apache.flink.streaming.util.MockOutput;
+import org.apache.flink.streaming.util.MockStreamConfig;
 import org.apache.flink.util.OutputTag;
 import org.junit.jupiter.api.Test;
 
@@ -151,7 +157,17 @@ class LocalMergeOperatorTest {
                         Collections.singletonList("f0"),
                         options,
                         null);
-        operator = new LocalMergeOperator.Factory(schema).createStreamOperator(null);
+        operator =
+                new LocalMergeOperator.Factory(schema)
+                        .createStreamOperator(
+                                new StreamOperatorParameters<>(
+                                        new SourceOperatorStreamTask<Integer>(
+                                                new DummyEnvironment()),
+                                        new MockStreamConfig(new Configuration(), 1),
+                                        new MockOutput<>(new ArrayList<>()),
+                                        null,
+                                        null,
+                                        null));
         operator.open();
         assertThat(operator.merger()).isInstanceOf(HashMapLocalMerger.class);
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreCompactOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreCompactOperatorTest.java
@@ -48,8 +48,8 @@ public class StoreCompactOperatorTest extends TableTestBase {
 
         CompactRememberStoreWrite compactRememberStoreWrite =
                 new CompactRememberStoreWrite(streamingMode);
-        StoreCompactOperator operator =
-                new StoreCompactOperator(
+        StoreCompactOperator.Factory operatorFactory =
+                new StoreCompactOperator.Factory(
                         getTableDefault(),
                         (table, commitUser, state, ioManager, memoryPool, metricGroup) ->
                                 compactRememberStoreWrite,
@@ -59,7 +59,7 @@ public class StoreCompactOperatorTest extends TableTestBase {
         TypeSerializer<Committable> serializer =
                 new CommittableTypeInfo().createSerializer(new ExecutionConfig());
         OneInputStreamOperatorTestHarness<RowData, Committable> harness =
-                new OneInputStreamOperatorTestHarness<>(operator);
+                new OneInputStreamOperatorTestHarness<>(operatorFactory);
         harness.setup(serializer);
         harness.initializeEmptyState();
         harness.open();
@@ -70,7 +70,7 @@ public class StoreCompactOperatorTest extends TableTestBase {
         harness.processElement(new StreamRecord<>(data(1)));
         harness.processElement(new StreamRecord<>(data(2)));
 
-        operator.prepareCommit(true, 1);
+        ((StoreCompactOperator) harness.getOneInputOperator()).prepareCommit(true, 1);
         Assertions.assertThat(compactRememberStoreWrite.compactTime).isEqualTo(3);
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreMultiCommitterTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreMultiCommitterTest.java
@@ -645,11 +645,10 @@ class StoreMultiCommitterTest {
 
     private OneInputStreamOperatorTestHarness<MultiTableCommittable, MultiTableCommittable>
             createRecoverableTestHarness() throws Exception {
-        CommitterOperator<MultiTableCommittable, WrappedManifestCommittable> operator =
-                new CommitterOperator<>(
+        CommitterOperatorFactory<MultiTableCommittable, WrappedManifestCommittable> operator =
+                new CommitterOperatorFactory<>(
                         true,
                         false,
-                        true,
                         initialCommitUser,
                         context -> new StoreMultiCommitter(catalogLoader, context),
                         new RestoreAndFailCommittableStateManager<>(
@@ -659,11 +658,10 @@ class StoreMultiCommitterTest {
 
     private OneInputStreamOperatorTestHarness<MultiTableCommittable, MultiTableCommittable>
             createLossyTestHarness() throws Exception {
-        CommitterOperator<MultiTableCommittable, WrappedManifestCommittable> operator =
-                new CommitterOperator<>(
+        CommitterOperatorFactory<MultiTableCommittable, WrappedManifestCommittable> operator =
+                new CommitterOperatorFactory<>(
                         true,
                         false,
-                        true,
                         initialCommitUser,
                         context -> new StoreMultiCommitter(catalogLoader, context),
                         new CommittableStateManager<WrappedManifestCommittable>() {
@@ -682,12 +680,13 @@ class StoreMultiCommitterTest {
 
     private OneInputStreamOperatorTestHarness<MultiTableCommittable, MultiTableCommittable>
             createTestHarness(
-                    CommitterOperator<MultiTableCommittable, WrappedManifestCommittable> operator)
+                    CommitterOperatorFactory<MultiTableCommittable, WrappedManifestCommittable>
+                            operatorFactory)
                     throws Exception {
         TypeSerializer<MultiTableCommittable> serializer =
                 new MultiTableCommittableTypeInfo().createSerializer(new ExecutionConfig());
         OneInputStreamOperatorTestHarness<MultiTableCommittable, MultiTableCommittable> harness =
-                new OneInputStreamOperatorTestHarness<>(operator, serializer);
+                new OneInputStreamOperatorTestHarness<>(operatorFactory, serializer);
         harness.setup(serializer);
         return harness;
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/WriterChainingStrategyTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/WriterChainingStrategyTest.java
@@ -39,6 +39,9 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Tests for {@link org.apache.flink.streaming.api.operators.ChainingStrategy} of writer operators.
+ */
 public class WriterChainingStrategyTest {
     private static final String TABLE_NAME = "paimon_table";
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/WriterChainingStrategyTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/WriterChainingStrategyTest.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.CompiledPlan;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.api.internal.CompiledPlanUtils;
+import org.apache.flink.util.TimeUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WriterChainingStrategyTest {
+    private static final String TABLE_NAME = "paimon_table";
+
+    @TempDir java.nio.file.Path tempDir;
+
+    private StreamTableEnvironment tEnv;
+
+    @BeforeEach
+    public void beforeEach() {
+        Configuration config = new Configuration();
+        config.setString(
+                "execution.checkpointing.interval",
+                TimeUtils.formatWithHighestUnit(Duration.ofMillis(500)));
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+        tEnv = StreamTableEnvironment.create(env);
+
+        String catalog = "PAIMON";
+        Map<String, String> options = new HashMap<>();
+        options.put("type", "paimon");
+        options.put("warehouse", tempDir.toString());
+        tEnv.executeSql(
+                String.format(
+                        "CREATE CATALOG %s WITH ( %s )",
+                        catalog,
+                        options.entrySet().stream()
+                                .map(e -> String.format("'%s'='%s'", e.getKey(), e.getValue()))
+                                .collect(Collectors.joining(","))));
+        tEnv.useCatalog(catalog);
+    }
+
+    @Test
+    public void testAppendTable() throws Exception {
+        tEnv.executeSql(
+                        String.format(
+                                "CREATE TABLE %s (id INT, data STRING, dt STRING) "
+                                        + "WITH ('bucket' = '1', 'bucket-key'='id', 'write-only' = 'true')",
+                                TABLE_NAME))
+                .await();
+
+        verifyChaining(false, true);
+    }
+
+    @Test
+    public void testAppendTableWithUnawareBucket() throws Exception {
+        tEnv.executeSql(
+                        String.format(
+                                "CREATE TABLE %s (id INT, data STRING, dt STRING) "
+                                        + "WITH ('bucket' = '-1', 'write-only' = 'true')",
+                                TABLE_NAME))
+                .await();
+
+        verifyChaining(true, true);
+    }
+
+    @Test
+    public void testPrimaryKeyTable() throws Exception {
+        tEnv.executeSql(
+                        String.format(
+                                "CREATE TABLE %s (id INT, data STRING, dt STRING, PRIMARY KEY (id) NOT ENFORCED) "
+                                        + "WITH ('bucket' = '1', 'bucket-key'='id', 'write-only' = 'true')",
+                                TABLE_NAME))
+                .await();
+
+        verifyChaining(false, true);
+    }
+
+    @Test
+    public void testPrimaryKeyTableWithDynamicBucket() throws Exception {
+        tEnv.executeSql(
+                        String.format(
+                                "CREATE TABLE %s (id INT, data STRING, dt STRING, PRIMARY KEY (id) NOT ENFORCED) "
+                                        + "WITH ('bucket' = '-1', 'write-only' = 'true')",
+                                TABLE_NAME))
+                .await();
+
+        verifyChaining(false, true);
+    }
+
+    @Test
+    public void testPrimaryKeyTableWithMultipleWriter() throws Exception {
+        tEnv.executeSql(
+                        String.format(
+                                "CREATE TABLE %s (id INT, data STRING, dt STRING, PRIMARY KEY (id) NOT ENFORCED) "
+                                        + "WITH ('bucket' = '1', 'bucket-key'='id', 'write-only' = 'true', 'sink.parallelism' = '2')",
+                                TABLE_NAME))
+                .await();
+
+        verifyChaining(false, false);
+    }
+
+    @Test
+    public void testPrimaryKeyTableWithCrossPartitionUpdate() throws Exception {
+        tEnv.executeSql(
+                        String.format(
+                                "CREATE TABLE %s (id INT, data STRING, dt STRING, PRIMARY KEY (id) NOT ENFORCED) "
+                                        + "PARTITIONED BY ( dt ) WITH ('bucket' = '-1', 'write-only' = 'true')",
+                                TABLE_NAME))
+                .await();
+
+        List<JobVertex> vertices = verifyChaining(false, true);
+        JobVertex vertex = findVertex(vertices, "INDEX_BOOTSTRAP");
+        assertThat(vertex.toString()).contains("Source");
+    }
+
+    @Test
+    public void testPrimaryKeyTableWithLocalMerge() throws Exception {
+        tEnv.executeSql(
+                        String.format(
+                                "CREATE TABLE %s (id INT, data STRING, dt STRING, PRIMARY KEY (id) NOT ENFORCED) "
+                                        + "WITH ('bucket' = '-1', 'write-only' = 'true', 'local-merge-buffer-size' = '1MB')",
+                                TABLE_NAME))
+                .await();
+
+        List<JobVertex> vertices = verifyChaining(false, true);
+        JobVertex vertex = findVertex(vertices, "local merge");
+        assertThat(vertex.toString()).contains("Source");
+    }
+
+    private List<JobVertex> verifyChaining(
+            boolean isWriterChainedWithUpstream, boolean isWriterChainedWithDownStream) {
+        CompiledPlan plan =
+                tEnv.compilePlanSql(
+                        String.format(
+                                "INSERT INTO %s VALUES (1, 'AAA', ''), (2, 'BBB', '')",
+                                TABLE_NAME));
+        List<Transformation<?>> transformations = CompiledPlanUtils.toTransformations(tEnv, plan);
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        transformations.forEach(env::addOperator);
+
+        List<JobVertex> vertices = new ArrayList<>();
+        env.getStreamGraph().getJobGraph().getVertices().forEach(vertices::add);
+        JobVertex vertex = findVertex(vertices, "Writer");
+
+        if (isWriterChainedWithUpstream) {
+            assertThat(vertex.toString()).contains("Source");
+        } else {
+            assertThat(vertex.toString()).doesNotContain("Source");
+        }
+
+        if (isWriterChainedWithDownStream) {
+            assertThat(vertex.toString()).contains("Committer");
+        } else {
+            assertThat(vertex.toString()).doesNotContain("Committer");
+        }
+
+        return vertices;
+    }
+
+    private JobVertex findVertex(List<JobVertex> vertices, String key) {
+        for (JobVertex vertex : vertices) {
+            if (vertex.toString().contains(key)) {
+                return vertex;
+            }
+        }
+        throw new IllegalStateException(
+                String.format(
+                        "Cannot find vertex with keyword %s among job vertices %s", key, vertices));
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #4442

<!-- What is the purpose of the change -->
This PR fixes deprecated usage on Flink's `SetupableStreamOperator`, and replaces the function with `StreamOperatorFactory`.

### Tests

<!-- List UT and IT cases to verify this change -->
Existing test cases are used to verify this change.

### API and Format

<!-- Does this change affect API or storage format -->
This change does not affect API or storage format.

### Documentation

<!-- Does this change introduce a new feature -->
This change does not affect introduce a new feature.
