### PR TITLE
[core] Cache statistics in AbstractFileStoreTable

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
@@ -265,6 +265,13 @@ public class CachingCatalog extends DelegateCatalog {
                             .maximumSize(snapshotMaxNumPerTable)
                             .executor(Runnable::run)
                             .build());
+            storeTable.setStatsCache(
+                    Caffeine.newBuilder()
+                            .softValues()
+                            .expireAfterAccess(expirationInterval)
+                            .maximumSize(5)
+                            .executor(Runnable::run)
+                            .build());
             if (manifestCache != null) {
                 storeTable.setManifestCache(manifestCache);
             }

--- a/paimon-core/src/main/java/org/apache/paimon/stats/StatsFileHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/StatsFileHandler.java
@@ -71,13 +71,14 @@ public class StatsFileHandler {
     }
 
     public Optional<Statistics> readStats(Snapshot snapshot) {
-        if (snapshot.statistics() == null) {
-            return Optional.empty();
-        } else {
-            Statistics stats = statsFile.read(snapshot.statistics());
-            stats.deserializeFieldsFromString(schemaManager.schema(stats.schemaId()));
-            return Optional.of(stats);
-        }
+        String file = snapshot.statistics();
+        return file == null ? Optional.empty() : Optional.of(readStats(file));
+    }
+
+    public Statistics readStats(String file) {
+        Statistics stats = statsFile.read(file);
+        stats.deserializeFieldsFromString(schemaManager.schema(stats.schemaId()));
+        return stats;
     }
 
     /** Delete stats of the specified snapshot. */

--- a/paimon-core/src/main/java/org/apache/paimon/table/DelegatedFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/DelegatedFileStoreTable.java
@@ -131,6 +131,11 @@ public abstract class DelegatedFileStoreTable implements FileStoreTable {
     }
 
     @Override
+    public void setStatsCache(Cache<String, Statistics> cache) {
+        wrapped.setStatsCache(cache);
+    }
+
+    @Override
     public TableSchema schema() {
         return wrapped.schema();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTable.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.ManifestCacheFilter;
 import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.stats.Statistics;
 import org.apache.paimon.table.query.LocalTableQuery;
 import org.apache.paimon.table.sink.RowKeyExtractor;
 import org.apache.paimon.table.sink.TableCommitImpl;
@@ -46,6 +47,8 @@ public interface FileStoreTable extends DataTable {
     void setManifestCache(SegmentsCache<Path> manifestCache);
 
     void setSnapshotCache(Cache<Path, Snapshot> cache);
+
+    void setStatsCache(Cache<String, Statistics> cache);
 
     @Override
     default RowType rowType() {

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
@@ -352,6 +352,10 @@ class CachingCatalogTest extends CatalogTestBase {
 
         Snapshot snapshot = table.snapshot(1);
         assertThat(snapshot).isSameAs(table.snapshot(1));
+
+        // copy
+        Snapshot copied = table.copy(Collections.singletonMap("a", "b")).snapshot(1);
+        assertThat(copied).isSameAs(snapshot);
     }
 
     @Test
@@ -386,7 +390,8 @@ class CachingCatalogTest extends CatalogTestBase {
 
         // repeat read
         for (int i = 0; i < 5; i++) {
-            table = catalog.getTable(tableIdent);
+            // test copy too
+            table = catalog.getTable(tableIdent).copy(Collections.singletonMap("a", "b"));
             ReadBuilder readBuilder = table.newReadBuilder();
             TableScan scan = readBuilder.newScan();
             TableRead read = readBuilder.newRead();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkAnalyzeTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkAnalyzeTableITCase.java
@@ -28,6 +28,7 @@ import org.apache.paimon.utils.DateTimeUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
@@ -63,7 +64,13 @@ public class FlinkAnalyzeTableITCase extends CatalogITCaseBase {
         Assertions.assertTrue(stats.mergedRecordSize().isPresent());
         Assertions.assertTrue(stats.colStats().isEmpty());
 
+        // by default, caching catalog should cache it
         Optional<Statistics> newStats = table.statistics();
+        assertThat(newStats.isPresent()).isTrue();
+        assertThat(newStats.get()).isSameAs(stats);
+
+        // copy the table
+        newStats = table.copy(Collections.singletonMap("a", "b")).statistics();
         assertThat(newStats.isPresent()).isTrue();
         assertThat(newStats.get()).isSameAs(stats);
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkAnalyzeTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkAnalyzeTableITCase.java
@@ -22,6 +22,7 @@ import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.stats.ColStats;
 import org.apache.paimon.stats.Statistics;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.utils.DateTimeUtils;
 
 import org.junit.jupiter.api.Assertions;
@@ -51,7 +52,8 @@ public class FlinkAnalyzeTableITCase extends CatalogITCaseBase {
         sql("INSERT INTO T VALUES ('2', 'aaa', 1, 2)");
         sql("ANALYZE TABLE T COMPUTE STATISTICS");
 
-        Optional<Statistics> statisticsOpt = paimonTable("T").statistics();
+        FileStoreTable table = paimonTable("T");
+        Optional<Statistics> statisticsOpt = table.statistics();
         assertThat(statisticsOpt.isPresent()).isTrue();
         Statistics stats = statisticsOpt.get();
 
@@ -60,6 +62,10 @@ public class FlinkAnalyzeTableITCase extends CatalogITCaseBase {
 
         Assertions.assertTrue(stats.mergedRecordSize().isPresent());
         Assertions.assertTrue(stats.colStats().isEmpty());
+
+        Optional<Statistics> newStats = table.statistics();
+        assertThat(newStats.isPresent()).isTrue();
+        assertThat(newStats.get()).isSameAs(stats);
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
1. Add Stats cache
2. Fix cache with Table.copy

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
