### PR TITLE
[core] Improve the performance of show tables with hive metastore

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -1017,10 +1017,8 @@ public class HiveCatalog extends AbstractCatalog {
 
     private boolean isPaimonTable(Identifier identifier, Table table) {
         return isPaimonTable(table)
-                && tableSchemaInFileSystem(
-                                getTableLocation(identifier, table),
-                                identifier.getBranchNameOrDefault())
-                        .isPresent();
+                && tableExistsInFileSystem(
+                        getTableLocation(identifier, table), identifier.getBranchNameOrDefault());
     }
 
     private static boolean isPaimonTable(Table table) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

When store the catalog in s3 object store, as the number of tables increases, the performance of the `show tables` deteriorates.

`HiveCatalog#listTablesImpl` will check each table in filesystem, will send many `list` request to the s3 server.

reason as https://github.com/apache/paimon/pull/4592

### Tests

**List 102 tables** 

Before patch
```
abc098
abc099
Time taken: 25.643 seconds, Fetched 102 row(s)
```

After patch
```
abc098
abc099
Time taken: 1.711 seconds, Fetched 102 row(s)
```


### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
