### PR TITLE
[doc] fix the ‘primary-key-table’ link

### DIFF
--- a/docs/content/flink/action-jars.md
+++ b/docs/content/flink/action-jars.md
@@ -50,7 +50,7 @@ Paimon supports "MERGE INTO" via submitting the 'merge_into' job through `flink 
 
 {{< hint info >}}
 Important table properties setting:
-1. Only [primary key table]({{< ref "primary-key-table" >}}) supports this feature.
+1. Only [primary key table]({{< ref "primary-key-table/overview" >}}) supports this feature.
 2. The action won't produce UPDATE_BEFORE, so it's not recommended to set 'changelog-producer' = 'input'.
    {{< /hint >}}
 

--- a/docs/content/flink/sql-write.md
+++ b/docs/content/flink/sql-write.md
@@ -175,7 +175,7 @@ PARTITION (k0 = 0, k1 = 0) SELECT v FROM my_table WHERE false;
 
 {{< hint info >}}
 Important table properties setting:
-1. Only [primary key table]({{< ref "primary-key-table" >}}) supports this feature.
+1. Only [primary key table]({{< ref "primary-key-table/overview" >}}) supports this feature.
 2. [MergeEngine]({{< ref "primary-key-table/merge-engine" >}}) needs to be [deduplicate]({{< ref "primary-key-table/merge-engine#deduplicate" >}})
    or [partial-update]({{< ref "primary-key-table/merge-engine#partial-update" >}}) to support this feature.
 3. Do not support updating primary keys.


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
When we click on ‘primary-key-table’, the jump page is not accurate and we need to jump to the exact address.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
_docs/content/flink/sql-write.md
docs/content/flink/action-jars.md_

Hi, @JingsongLi please take a look at it in your spare time,Thank you very much!