### PR TITLE
[core] Optimization of Parquet Predicate Pushdown Capability

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
@@ -860,7 +860,7 @@ public class PrimaryKeyFileStoreTableTest extends FileStoreTableTestBase {
                             Arrays.asList(
                                     String.format(
                                             "%d|%d|%d|binary|varbinary|mapKey:mapVal|multiset",
-                                            i, i, i * 100l)));
+                                            i, i, i * 100L)));
         }
 
         for (int i = 1500; i < 1510; i++) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
@@ -76,7 +76,15 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;

--- a/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeyFileStoreTableTest.java
@@ -76,14 +76,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
@@ -830,8 +823,8 @@ public class PrimaryKeyFileStoreTableTest extends FileStoreTableTestBase {
                                 .newWrite()
                                 .withIOManager(new IOManagerImpl(tempDir.toString()));
 
-        for (int i = 0; i < 2000; i++) {
-            write.write(rowData(i, i, i * 100L));
+        for (int i = 0; i < 200000; i++) {
+            write.write(rowData(1, i, i * 100L));
         }
 
         List<CommitMessage> messages = write.prepareCommit();
@@ -842,8 +835,8 @@ public class PrimaryKeyFileStoreTableTest extends FileStoreTableTestBase {
                         writeBuilder
                                 .newWrite()
                                 .withIOManager(new IOManagerImpl(tempDir.toString()));
-        for (int i = 1000; i < 2000; i++) {
-            write.write(rowDataWithKind(RowKind.DELETE, i, i, i * 100L));
+        for (int i = 180000; i < 200000; i++) {
+            write.write(rowDataWithKind(RowKind.DELETE, 1, i, i * 100L));
         }
 
         messages = write.prepareCommit();
@@ -852,19 +845,22 @@ public class PrimaryKeyFileStoreTableTest extends FileStoreTableTestBase {
 
         PredicateBuilder builder = new PredicateBuilder(ROW_TYPE);
         List<Split> splits = toSplits(table.newSnapshotReader().read().dataSplits());
+        Random random = new Random();
 
-        for (int i = 500; i < 510; i++) {
-            TableRead read = table.newRead().withFilter(builder.equal(0, i)).executeFilter();
+        for (int i = 0; i < 10; i++) {
+            int value = random.nextInt(180000);
+            TableRead read = table.newRead().withFilter(builder.equal(1, value)).executeFilter();
             assertThat(getResult(read, splits, BATCH_ROW_TO_STRING))
                     .isEqualTo(
                             Arrays.asList(
                                     String.format(
                                             "%d|%d|%d|binary|varbinary|mapKey:mapVal|multiset",
-                                            i, i, i * 100L)));
+                                            1, value, value * 100L)));
         }
 
-        for (int i = 1500; i < 1510; i++) {
-            TableRead read = table.newRead().withFilter(builder.equal(0, i)).executeFilter();
+        for (int i = 0; i < 10; i++) {
+            int value = 180000 + random.nextInt(20000);
+            TableRead read = table.newRead().withFilter(builder.equal(1, value)).executeFilter();
             assertThat(getResult(read, splits, BATCH_ROW_TO_STRING)).isEmpty();
         }
     }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
@@ -28,6 +28,7 @@ import org.apache.paimon.data.columnar.writable.WritableColumnVector;
 import org.apache.paimon.format.FormatReaderFactory;
 import org.apache.paimon.format.parquet.reader.ColumnReader;
 import org.apache.paimon.format.parquet.reader.ParquetDecimalVector;
+import org.apache.paimon.format.parquet.reader.ParquetReadState;
 import org.apache.paimon.format.parquet.reader.ParquetTimestampVector;
 import org.apache.paimon.format.parquet.type.ParquetField;
 import org.apache.paimon.fs.Path;
@@ -336,6 +337,10 @@ public class ParquetReaderFactory implements FormatReaderFactory {
 
         private long nextRowPosition;
 
+        private ParquetReadState currentRowGroupReadState;
+
+        private long currentRowGroupFirstRowIndex;
+
         /**
          * For each request column, the reader to read this column. This is NULL if this column is
          * missing from the file, in which case we populate the attribute with NULL.
@@ -359,6 +364,7 @@ public class ParquetReaderFactory implements FormatReaderFactory {
             this.totalCountLoadedSoFar = 0;
             this.currentRowPosition = 0;
             this.nextRowPosition = 0;
+            this.currentRowGroupFirstRowIndex = 0;
             this.fields = fields;
         }
 
@@ -390,7 +396,8 @@ public class ParquetReaderFactory implements FormatReaderFactory {
                 currentRowPosition = nextRowPosition;
             }
 
-            int num = (int) Math.min(batchSize, totalCountLoadedSoFar - rowsReturned);
+            int num = getBachSize();
+
             for (int i = 0; i < columnReaders.length; ++i) {
                 if (columnReaders[i] == null) {
                     batch.writableVectors[i].fillWithNulls();
@@ -400,7 +407,7 @@ public class ParquetReaderFactory implements FormatReaderFactory {
                 }
             }
             rowsReturned += num;
-            nextRowPosition = currentRowPosition + num;
+            nextRowPosition = getNextRowPosition(num);
             batch.columnarBatch.setNumRows(num);
             return true;
         }
@@ -414,6 +421,9 @@ public class ParquetReaderFactory implements FormatReaderFactory {
                                 + " out of "
                                 + totalRowCount);
             }
+
+            this.currentRowGroupReadState =
+                    new ParquetReadState(rowGroup.getRowIndexes().orElse(null));
 
             List<Type> types = requestedSchema.getFields();
             columnReaders = new ColumnReader[types.size()];
@@ -429,15 +439,59 @@ public class ParquetReaderFactory implements FormatReaderFactory {
                                     0);
                 }
             }
+
             totalCountLoadedSoFar += rowGroup.getRowCount();
-            if (rowGroup.getRowIndexOffset().isPresent()) {
-                currentRowPosition = rowGroup.getRowIndexOffset().get();
+
+            if (rowGroup.getRowIndexOffset().isPresent()) { // filter
+                currentRowGroupFirstRowIndex = rowGroup.getRowIndexOffset().get();
+                long pageIndex = 0;
+                if (!this.currentRowGroupReadState.isMaxRange()) {
+                    pageIndex = this.currentRowGroupReadState.currentRangeStart();
+                }
+                currentRowPosition = currentRowGroupFirstRowIndex + pageIndex;
             } else {
                 if (reader.rowGroupsFiltered()) {
                     throw new RuntimeException(
                             "There is a bug, rowIndexOffset must be present when row groups are filtered.");
                 }
+                currentRowGroupFirstRowIndex = nextRowPosition;
                 currentRowPosition = nextRowPosition;
+            }
+        }
+
+        private int getBachSize() throws IOException {
+
+            long rangeBatchSize = Long.MAX_VALUE;
+            if (this.currentRowGroupReadState.isFinished()) {
+                throw new IOException(
+                        "expecting more rows but reached last page block. Read "
+                                + rowsReturned
+                                + " out of "
+                                + totalRowCount);
+            } else if (!this.currentRowGroupReadState.isMaxRange()) {
+                long pageIndex = this.currentRowPosition - this.currentRowGroupFirstRowIndex;
+                rangeBatchSize = this.currentRowGroupReadState.currentRangeEnd() - pageIndex + 1;
+            }
+
+            return (int)
+                    Math.min(
+                            batchSize,
+                            Math.min(rangeBatchSize, totalCountLoadedSoFar - rowsReturned));
+        }
+
+        private long getNextRowPosition(int num) {
+            if (this.currentRowGroupReadState.isMaxRange()) {
+                return this.currentRowPosition + num;
+            } else {
+                long pageIndex = this.currentRowPosition - this.currentRowGroupFirstRowIndex;
+                long nextIndex = pageIndex + num;
+
+                if (this.currentRowGroupReadState.currentRangeEnd() < nextIndex) {
+                    this.currentRowGroupReadState.nextRange();
+                    nextIndex = this.currentRowGroupReadState.currentRangeStart();
+                }
+
+                return nextIndex;
             }
         }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
@@ -130,7 +130,7 @@ public class ParquetReaderFactory implements FormatReaderFactory {
                 buildFieldsList(projectedType.getFields(), projectedType.getFieldNames(), columnIO);
 
         return new ParquetReader(
-                reader, requestedSchema, reader.getRecordCount(), poolOfBatches, fields);
+                reader, requestedSchema, reader.getFilteredRecordCount(), poolOfBatches, fields);
     }
 
     private void setReadOptions(ParquetReadOptions.Builder builder) {
@@ -406,7 +406,7 @@ public class ParquetReaderFactory implements FormatReaderFactory {
         }
 
         private void readNextRowGroup() throws IOException {
-            PageReadStore rowGroup = reader.readNextRowGroup();
+            PageReadStore rowGroup = reader.readNextFilteredRowGroup();
             if (rowGroup == null) {
                 throw new IOException(
                         "expecting more rows but reached last block. Read "

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/AbstractColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/AbstractColumnReader.java
@@ -28,11 +28,7 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Dictionary;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.impl.ColumnReaderImpl;
-import org.apache.parquet.column.page.DataPage;
-import org.apache.parquet.column.page.DataPageV1;
-import org.apache.parquet.column.page.DataPageV2;
-import org.apache.parquet.column.page.DictionaryPage;
-import org.apache.parquet.column.page.PageReader;
+import org.apache.parquet.column.page.*;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.PrimitiveType;
@@ -65,20 +61,14 @@ public abstract class AbstractColumnReader<VECTOR extends WritableColumnVector>
 
     protected final ColumnDescriptor descriptor;
 
-    /** Total number of values read. */
-    private long valuesRead;
-
-    /**
-     * value that indicates the end of the current page. That is, if valuesRead ==
-     * endOfPageValueCount, we are at the end of the page.
-     */
-    private long endOfPageValueCount;
-
     /** If true, the current page is dictionary encoded. */
     private boolean isCurrentPageDictionaryEncoded;
 
     /** Total values in the current page. */
-    private int pageValueCount;
+//    private int pageValueCount;
+
+    /** Helper struct to track intermediate states while reading Parquet pages in the column chunk.*/
+    private final ParquetReadState readState;
 
     /*
      * Input streams:
@@ -101,11 +91,13 @@ public abstract class AbstractColumnReader<VECTOR extends WritableColumnVector>
     /** Dictionary decoder to wrap dictionary ids input stream. */
     private RunLengthDecoder dictionaryIdsDecoder;
 
-    public AbstractColumnReader(ColumnDescriptor descriptor, PageReader pageReader)
+    public AbstractColumnReader(ColumnDescriptor descriptor, PageReadStore pageReadStore)
             throws IOException {
         this.descriptor = descriptor;
-        this.pageReader = pageReader;
+        this.pageReader = pageReadStore.getPageReader(descriptor);
         this.maxDefLevel = descriptor.getMaxDefinitionLevel();
+
+        this.readState = new ParquetReadState(pageReadStore.getRowIndexes().orElse(null));
 
         DictionaryPage dictionaryPage = pageReader.readDictionaryPage();
         if (dictionaryPage != null) {
@@ -147,56 +139,126 @@ public abstract class AbstractColumnReader<VECTOR extends WritableColumnVector>
         if (dictionary != null) {
             dictionaryIds = vector.reserveDictionaryIds(readNumber);
         }
-        while (readNumber > 0) {
+
+        readState.resetForNewBatch(readNumber);
+
+        while (readState.rowsToReadInBatch > 0) {
             // Compute the number of values we want to read in this page.
-            int leftInPage = (int) (endOfPageValueCount - valuesRead);
-            if (leftInPage == 0) {
-                DataPage page = pageReader.readPage();
-                if (page instanceof DataPageV1) {
-                    readPageV1((DataPageV1) page);
-                } else if (page instanceof DataPageV2) {
-                    readPageV2((DataPageV2) page);
-                } else {
-                    throw new RuntimeException("Unsupported page type: " + page.getClass());
+            if (readState.valuesToReadInPage == 0) {
+                int pageValueCount = readPage();
+                if (pageValueCount < 0) {
+                    // we've read all the pages; this could happen when we're reading a repeated list and we
+                    // don't know where the list will end until we've seen all the pages.
+                    break;
                 }
-                leftInPage = (int) (endOfPageValueCount - valuesRead);
-            }
-            int num = Math.min(readNumber, leftInPage);
-            if (isCurrentPageDictionaryEncoded) {
-                // Read and decode dictionary ids.
-                runLenDecoder.readDictionaryIds(
-                        num, dictionaryIds, vector, rowId, maxDefLevel, this.dictionaryIdsDecoder);
-
-                if (vector.hasDictionary() || (rowId == 0 && supportLazyDecode())) {
-                    // Column vector supports lazy decoding of dictionary values so just set the
-                    // dictionary.
-                    // We can't do this if rowId != 0 AND the column doesn't have a dictionary (i.e.
-                    // some
-                    // non-dictionary encoded values have already been added).
-                    vector.setDictionary(new ParquetDictionary(dictionary));
-                } else {
-                    readBatchFromDictionaryIds(rowId, num, vector, dictionaryIds);
-                }
-            } else {
-                if (vector.hasDictionary() && rowId != 0) {
-                    // This batch already has dictionary encoded values but this new page is not.
-                    // The batch
-                    // does not support a mix of dictionary and not so we will decode the
-                    // dictionary.
-                    readBatchFromDictionaryIds(0, rowId, vector, vector.getDictionaryIds());
-                }
-                vector.setDictionary(null);
-                readBatch(rowId, num, vector);
             }
 
-            valuesRead += num;
-            rowId += num;
-            readNumber -= num;
+            if (readState.isFinished()){
+                break;
+            }
+
+            long pageRowId = readState.rowId;
+            int leftInBatch = readState.rowsToReadInBatch;
+            int leftInPage = readState.valuesToReadInPage;
+
+            int readBatch = Math.min(leftInBatch, leftInPage);
+
+            long rangeStart = readState.currentRangeStart();
+            long rangeEnd = readState.currentRangeEnd();
+
+            if (pageRowId < rangeStart){
+                int toSkip = (int)(rangeStart - pageRowId);
+                if (toSkip >= leftInPage) {  // drop page
+                    pageRowId += leftInPage;
+                    leftInPage = 0;
+                }else {
+                    if (isCurrentPageDictionaryEncoded) {
+                        runLenDecoder.skipDictionaryIds(toSkip, maxDefLevel, this.dictionaryIdsDecoder);
+                        pageRowId += toSkip;
+                        leftInPage -= toSkip;
+                    }else{
+                        skipBatch(toSkip);
+                        pageRowId += toSkip;
+                        leftInPage -= toSkip;
+                    }
+                }
+            }else if (pageRowId > rangeEnd){
+                readState.nextRange();
+            }else{
+                long start = pageRowId;
+                long end = Math.min(rangeEnd, pageRowId + readBatch -1);
+                int num  = (int) (end - start +1);
+
+                if (isCurrentPageDictionaryEncoded) {
+                    // Read and decode dictionary ids.
+                    runLenDecoder.readDictionaryIds(
+                            num, dictionaryIds, vector, rowId, maxDefLevel, this.dictionaryIdsDecoder);
+
+                    if (vector.hasDictionary() || (rowId == 0 && supportLazyDecode())) {
+                        // Column vector supports lazy decoding of dictionary values so just set the
+                        // dictionary.
+                        // We can't do this if rowId != 0 AND the column doesn't have a dictionary (i.e.
+                        // some
+                        // non-dictionary encoded values have already been added).
+                        vector.setDictionary(new ParquetDictionary(dictionary));
+                    } else {
+                        readBatchFromDictionaryIds(rowId, num, vector, dictionaryIds);
+                    }
+                } else {
+                    if (vector.hasDictionary() && rowId != 0) {
+                        // This batch already has dictionary encoded values but this new page is not.
+                        // The batch
+                        // does not support a mix of dictionary and not so we will decode the
+                        // dictionary.
+                        readBatchFromDictionaryIds(0, rowId, vector, vector.getDictionaryIds());
+                    }
+                    vector.setDictionary(null);
+                    readBatch(rowId, num, vector);
+                }
+                leftInBatch -= num;
+                pageRowId += num;
+                leftInPage -= num;
+                rowId += num;
+
+            }
+            readState.rowsToReadInBatch = leftInBatch;
+            readState.valuesToReadInPage = leftInPage;
+            readState.rowId = pageRowId;
         }
     }
 
-    private void readPageV1(DataPageV1 page) throws IOException {
-        this.pageValueCount = page.getValueCount();
+    private int readPage() {
+        DataPage page = pageReader.readPage();
+        if (page == null) {
+            return -1;
+        }
+        long pageFirstRowIndex = page.getFirstRowIndex().orElse(0L);
+
+        int pageValueCount =  page.accept(new DataPage.Visitor<Integer>() {
+            @Override
+            public Integer visit(DataPageV1 dataPageV1) {
+                try {
+                    return readPageV1(dataPageV1);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public Integer visit(DataPageV2 dataPageV2) {
+                try {
+                    return readPageV2(dataPageV2);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        readState.resetForNewPage(pageValueCount, pageFirstRowIndex);
+        return pageValueCount;
+    }
+
+    private int readPageV1(DataPageV1 page) throws IOException {
+        int pageValueCount = page.getValueCount();
         ValuesReader rlReader = page.getRlEncoding().getValuesReader(descriptor, REPETITION_LEVEL);
 
         // Initialize the decoders.
@@ -211,30 +273,31 @@ public abstract class AbstractColumnReader<VECTOR extends WritableColumnVector>
             ByteBufferInputStream in = bytes.toInputStream();
             rlReader.initFromPage(pageValueCount, in);
             this.runLenDecoder.initFromStream(pageValueCount, in);
-            prepareNewPage(page.getValueEncoding(), in);
+            prepareNewPage(page.getValueEncoding(), in, pageValueCount);
+            return pageValueCount;
         } catch (IOException e) {
             throw new IOException("could not read page " + page + " in col " + descriptor, e);
         }
     }
 
-    private void readPageV2(DataPageV2 page) throws IOException {
-        this.pageValueCount = page.getValueCount();
+    private int readPageV2(DataPageV2 page) throws IOException {
+        int pageValueCount = page.getValueCount();
 
         int bitWidth = BytesUtils.getWidthFromMaxInt(descriptor.getMaxDefinitionLevel());
         // do not read the length from the stream. v2 pages handle dividing the page bytes.
         this.runLenDecoder = new RunLengthDecoder(bitWidth, false);
         this.runLenDecoder.initFromStream(
-                this.pageValueCount, page.getDefinitionLevels().toInputStream());
+                pageValueCount, page.getDefinitionLevels().toInputStream());
         try {
-            prepareNewPage(page.getDataEncoding(), page.getData().toInputStream());
+            prepareNewPage(page.getDataEncoding(), page.getData().toInputStream(), pageValueCount);
+            return pageValueCount;
         } catch (IOException e) {
             throw new IOException("could not read page " + page + " in col " + descriptor, e);
         }
     }
 
-    private void prepareNewPage(Encoding dataEncoding, ByteBufferInputStream in)
+    private void prepareNewPage(Encoding dataEncoding, ByteBufferInputStream in, int pageValueCount)
             throws IOException {
-        this.endOfPageValueCount = valuesRead + pageValueCount;
         if (dataEncoding.usesDictionary()) {
             if (dictionary == null) {
                 throw new IOException(
@@ -269,6 +332,15 @@ public abstract class AbstractColumnReader<VECTOR extends WritableColumnVector>
         afterReadPage();
     }
 
+
+    final void skipDataBuffer(int length){
+        try {
+            dataInputStream.skipFully(length);
+        } catch (IOException e) {
+            throw new ParquetDecodingException("Failed to skip " + length + " bytes", e);
+        }
+    }
+
     final ByteBuffer readDataBuffer(int length) {
         try {
             return dataInputStream.slice(length).order(ByteOrder.LITTLE_ENDIAN);
@@ -290,6 +362,8 @@ public abstract class AbstractColumnReader<VECTOR extends WritableColumnVector>
 
     /** Read batch from {@link #runLenDecoder} and {@link #dataInputStream}. */
     protected abstract void readBatch(int rowId, int num, VECTOR column);
+
+    protected abstract void skipBatch(int num);
 
     /**
      * Decode dictionary ids to data. From {@link #runLenDecoder} and {@link #dictionaryIdsDecoder}.

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/BooleanColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/BooleanColumnReader.java
@@ -23,7 +23,6 @@ import org.apache.paimon.data.columnar.writable.WritableIntVector;
 
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReadStore;
-import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.PrimitiveType;
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ByteColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ByteColumnReader.java
@@ -23,7 +23,6 @@ import org.apache.paimon.data.columnar.writable.WritableIntVector;
 
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReadStore;
-import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.schema.PrimitiveType;
 
 import java.io.IOException;
@@ -32,7 +31,8 @@ import java.nio.ByteBuffer;
 /** Byte {@link ColumnReader}. Using INT32 to store byte, so just cast int to byte. */
 public class ByteColumnReader extends AbstractColumnReader<WritableByteVector> {
 
-    public ByteColumnReader(ColumnDescriptor descriptor, PageReadStore pageReadStore) throws IOException {
+    public ByteColumnReader(ColumnDescriptor descriptor, PageReadStore pageReadStore)
+            throws IOException {
         super(descriptor, pageReadStore);
         checkTypeName(PrimitiveType.PrimitiveTypeName.INT32);
     }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/BytesColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/BytesColumnReader.java
@@ -22,6 +22,7 @@ import org.apache.paimon.data.columnar.writable.WritableBytesVector;
 import org.apache.paimon.data.columnar.writable.WritableIntVector;
 
 import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -31,9 +32,9 @@ import java.nio.ByteBuffer;
 /** Bytes {@link ColumnReader}. A int length and bytes data. */
 public class BytesColumnReader extends AbstractColumnReader<WritableBytesVector> {
 
-    public BytesColumnReader(ColumnDescriptor descriptor, PageReader pageReader)
+    public BytesColumnReader(ColumnDescriptor descriptor, PageReadStore pageReadStore)
             throws IOException {
-        super(descriptor, pageReader);
+        super(descriptor, pageReadStore);
         checkTypeName(PrimitiveType.PrimitiveTypeName.BINARY);
     }
 
@@ -67,6 +68,40 @@ public class BytesColumnReader extends AbstractColumnReader<WritableBytesVector>
             rowId += n;
             left -= n;
             runLenDecoder.currentCount -= n;
+        }
+    }
+
+    @Override
+    protected void skipBatch(int num) {
+        int left = num;
+        while (left > 0) {
+            if (runLenDecoder.currentCount == 0) {
+                runLenDecoder.readNextGroup();
+            }
+            int n = Math.min(left, runLenDecoder.currentCount);
+            switch (runLenDecoder.mode) {
+                case RLE:
+                    if (runLenDecoder.currentValue == maxDefLevel) {
+                        skipBinary(n);
+                    }
+                    break;
+                case PACKED:
+                    for (int i = 0; i < n; ++i) {
+                        if (runLenDecoder.currentBuffer[runLenDecoder.currentBufferIdx++] == maxDefLevel) {
+                            skipBinary(1);
+                        }
+                    }
+                    break;
+            }
+            left -= n;
+            runLenDecoder.currentCount -= n;
+        }
+    }
+
+    private void skipBinary(int num){
+        for (int i = 0; i < num; i++) {
+            int len = readDataBuffer(4).getInt();
+            skipDataBuffer(len);
         }
     }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/BytesColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/BytesColumnReader.java
@@ -23,7 +23,6 @@ import org.apache.paimon.data.columnar.writable.WritableIntVector;
 
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReadStore;
-import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.schema.PrimitiveType;
 
 import java.io.IOException;
@@ -87,7 +86,8 @@ public class BytesColumnReader extends AbstractColumnReader<WritableBytesVector>
                     break;
                 case PACKED:
                     for (int i = 0; i < n; ++i) {
-                        if (runLenDecoder.currentBuffer[runLenDecoder.currentBufferIdx++] == maxDefLevel) {
+                        if (runLenDecoder.currentBuffer[runLenDecoder.currentBufferIdx++]
+                                == maxDefLevel) {
                             skipBinary(1);
                         }
                     }
@@ -98,7 +98,7 @@ public class BytesColumnReader extends AbstractColumnReader<WritableBytesVector>
         }
     }
 
-    private void skipBinary(int num){
+    private void skipBinary(int num) {
         for (int i = 0; i < num; i++) {
             int len = readDataBuffer(4).getInt();
             skipDataBuffer(len);

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/DoubleColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/DoubleColumnReader.java
@@ -23,7 +23,6 @@ import org.apache.paimon.data.columnar.writable.WritableIntVector;
 
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReadStore;
-import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.schema.PrimitiveType;
 
 import java.io.IOException;
@@ -99,7 +98,7 @@ public class DoubleColumnReader extends AbstractColumnReader<WritableDoubleVecto
         }
     }
 
-    private void skipDouble(int num){
+    private void skipDouble(int num) {
         skipDataBuffer(8 * num);
     }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/FixedLenBytesColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/FixedLenBytesColumnReader.java
@@ -26,7 +26,6 @@ import org.apache.paimon.format.parquet.ParquetSchemaConverter;
 
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReadStore;
-import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -40,7 +39,8 @@ public class FixedLenBytesColumnReader<VECTOR extends WritableColumnVector>
     private final int precision;
 
     public FixedLenBytesColumnReader(
-            ColumnDescriptor descriptor, PageReadStore pageReadStore, int precision) throws IOException {
+            ColumnDescriptor descriptor, PageReadStore pageReadStore, int precision)
+            throws IOException {
         super(descriptor, pageReadStore);
         checkTypeName(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
         this.precision = precision;
@@ -100,16 +100,14 @@ public class FixedLenBytesColumnReader<VECTOR extends WritableColumnVector>
             for (int i = 0; i < num; i++) {
                 if (runLenDecoder.readInteger() == maxDefLevel) {
                     skipDataBinary(bytesLen);
-
                 }
             }
         }
     }
 
-    private void skipDataBinary(int len){
+    private void skipDataBinary(int len) {
         skipDataBuffer(len);
     }
-
 
     @Override
     protected void readBatchFromDictionaryIds(

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/FloatColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/FloatColumnReader.java
@@ -23,7 +23,6 @@ import org.apache.paimon.data.columnar.writable.WritableIntVector;
 
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReadStore;
-import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.schema.PrimitiveType;
 
 import java.io.IOException;
@@ -71,7 +70,6 @@ public class FloatColumnReader extends AbstractColumnReader<WritableFloatVector>
         }
     }
 
-
     @Override
     protected void skipBatch(int num) {
         int left = num;
@@ -100,10 +98,9 @@ public class FloatColumnReader extends AbstractColumnReader<WritableFloatVector>
         }
     }
 
-    private void skipFloat(int num){
+    private void skipFloat(int num) {
         skipDataBuffer(4 * num);
     }
-
 
     @Override
     protected void readBatchFromDictionaryIds(

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/IntColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/IntColumnReader.java
@@ -22,7 +22,6 @@ import org.apache.paimon.data.columnar.writable.WritableIntVector;
 
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReadStore;
-import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.schema.PrimitiveType;
 
 import java.io.IOException;
@@ -31,7 +30,8 @@ import java.nio.ByteBuffer;
 /** Int {@link ColumnReader}. */
 public class IntColumnReader extends AbstractColumnReader<WritableIntVector> {
 
-    public IntColumnReader(ColumnDescriptor descriptor, PageReadStore pageReadStore) throws IOException {
+    public IntColumnReader(ColumnDescriptor descriptor, PageReadStore pageReadStore)
+            throws IOException {
         super(descriptor, pageReadStore);
         checkTypeName(PrimitiveType.PrimitiveTypeName.INT32);
     }
@@ -100,7 +100,6 @@ public class IntColumnReader extends AbstractColumnReader<WritableIntVector> {
     private void skipInteger(int num) {
         skipDataBuffer(4 * num);
     }
-
 
     @Override
     protected void readBatchFromDictionaryIds(

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/IntColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/IntColumnReader.java
@@ -21,6 +21,7 @@ package org.apache.paimon.format.parquet.reader;
 import org.apache.paimon.data.columnar.writable.WritableIntVector;
 
 import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -30,8 +31,8 @@ import java.nio.ByteBuffer;
 /** Int {@link ColumnReader}. */
 public class IntColumnReader extends AbstractColumnReader<WritableIntVector> {
 
-    public IntColumnReader(ColumnDescriptor descriptor, PageReader pageReader) throws IOException {
-        super(descriptor, pageReader);
+    public IntColumnReader(ColumnDescriptor descriptor, PageReadStore pageReadStore) throws IOException {
+        super(descriptor, pageReadStore);
         checkTypeName(PrimitiveType.PrimitiveTypeName.INT32);
     }
 
@@ -67,6 +68,39 @@ public class IntColumnReader extends AbstractColumnReader<WritableIntVector> {
             runLenDecoder.currentCount -= n;
         }
     }
+
+    @Override
+    protected void skipBatch(int num) {
+        int left = num;
+        while (left > 0) {
+            if (runLenDecoder.currentCount == 0) {
+                runLenDecoder.readNextGroup();
+            }
+            int n = Math.min(left, runLenDecoder.currentCount);
+            switch (runLenDecoder.mode) {
+                case RLE:
+                    if (runLenDecoder.currentValue == maxDefLevel) {
+                        skipInteger(n);
+                    }
+                    break;
+                case PACKED:
+                    for (int i = 0; i < n; ++i) {
+                        if (runLenDecoder.currentBuffer[runLenDecoder.currentBufferIdx++]
+                                == maxDefLevel) {
+                            skipInteger(1);
+                        }
+                    }
+                    break;
+            }
+            left -= n;
+            runLenDecoder.currentCount -= n;
+        }
+    }
+
+    private void skipInteger(int num) {
+        skipDataBuffer(4 * num);
+    }
+
 
     @Override
     protected void readBatchFromDictionaryIds(

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/LongColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/LongColumnReader.java
@@ -23,7 +23,6 @@ import org.apache.paimon.data.columnar.writable.WritableLongVector;
 
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReadStore;
-import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.schema.PrimitiveType;
 
 import java.io.IOException;
@@ -32,7 +31,8 @@ import java.nio.ByteBuffer;
 /** Long {@link ColumnReader}. */
 public class LongColumnReader extends AbstractColumnReader<WritableLongVector> {
 
-    public LongColumnReader(ColumnDescriptor descriptor, PageReadStore pageReadStore) throws IOException {
+    public LongColumnReader(ColumnDescriptor descriptor, PageReadStore pageReadStore)
+            throws IOException {
         super(descriptor, pageReadStore);
         checkTypeName(PrimitiveType.PrimitiveTypeName.INT64);
     }
@@ -98,7 +98,7 @@ public class LongColumnReader extends AbstractColumnReader<WritableLongVector> {
         }
     }
 
-    private void skipValue(int num){
+    private void skipValue(int num) {
         skipDataBuffer(num * 8);
     }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/LongColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/LongColumnReader.java
@@ -22,6 +22,7 @@ import org.apache.paimon.data.columnar.writable.WritableIntVector;
 import org.apache.paimon.data.columnar.writable.WritableLongVector;
 
 import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -31,8 +32,8 @@ import java.nio.ByteBuffer;
 /** Long {@link ColumnReader}. */
 public class LongColumnReader extends AbstractColumnReader<WritableLongVector> {
 
-    public LongColumnReader(ColumnDescriptor descriptor, PageReader pageReader) throws IOException {
-        super(descriptor, pageReader);
+    public LongColumnReader(ColumnDescriptor descriptor, PageReadStore pageReadStore) throws IOException {
+        super(descriptor, pageReadStore);
         checkTypeName(PrimitiveType.PrimitiveTypeName.INT64);
     }
 
@@ -67,6 +68,38 @@ public class LongColumnReader extends AbstractColumnReader<WritableLongVector> {
             left -= n;
             runLenDecoder.currentCount -= n;
         }
+    }
+
+    @Override
+    protected void skipBatch(int num) {
+        int left = num;
+        while (left > 0) {
+            if (runLenDecoder.currentCount == 0) {
+                runLenDecoder.readNextGroup();
+            }
+            int n = Math.min(left, runLenDecoder.currentCount);
+            switch (runLenDecoder.mode) {
+                case RLE:
+                    if (runLenDecoder.currentValue == maxDefLevel) {
+                        skipValue(n);
+                    }
+                    break;
+                case PACKED:
+                    for (int i = 0; i < n; ++i) {
+                        if (runLenDecoder.currentBuffer[runLenDecoder.currentBufferIdx++]
+                                == maxDefLevel) {
+                            skipValue(1);
+                        }
+                    }
+                    break;
+            }
+            left -= n;
+            runLenDecoder.currentCount -= n;
+        }
+    }
+
+    private void skipValue(int num){
+        skipDataBuffer(num * 8);
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/NestedColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/NestedColumnReader.java
@@ -279,7 +279,7 @@ public class NestedColumnReader implements ColumnReader<WritableColumnVector> {
             reader =
                     new NestedPrimitiveColumnReader(
                             descriptor,
-                            pages.getPageReader(descriptor),
+                            pages,
                             isUtcTimestamp,
                             descriptor.getPrimitiveType(),
                             field.getType(),

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/NestedPrimitiveColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/NestedPrimitiveColumnReader.java
@@ -44,6 +44,7 @@ import org.apache.parquet.column.page.DataPage;
 import org.apache.parquet.column.page.DataPageV1;
 import org.apache.parquet.column.page.DataPageV2;
 import org.apache.parquet.column.page.DictionaryPage;
+import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
@@ -82,15 +83,6 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
 
     private final boolean isUtcTimestamp;
 
-    /** Total number of values read. */
-    private long valuesRead;
-
-    /**
-     * value that indicates the end of the current page. That is, if valuesRead ==
-     * endOfPageValueCount, we are at the end of the page.
-     */
-    private long endOfPageValueCount;
-
     /** If true, the current page is dictionary encoded. */
     private boolean isCurrentPageDictionaryEncoded;
 
@@ -104,7 +96,12 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
     private ParquetDataColumnReader dataColumn;
 
     /** Total values in the current page. */
-    private int pageValueCount;
+    //    private int pageValueCount;
+
+    /**
+     * Helper struct to track intermediate states while reading Parquet pages in the column chunk.
+     */
+    protected final ParquetReadState readState;
 
     // flag to indicate if there is no data in parquet data page
     private boolean eof = false;
@@ -115,7 +112,7 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
 
     public NestedPrimitiveColumnReader(
             ColumnDescriptor descriptor,
-            PageReader pageReader,
+            PageReadStore pageReadStore,
             boolean isUtcTimestamp,
             Type parquetType,
             DataType dataType,
@@ -124,7 +121,7 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
             throws IOException {
         this.descriptor = descriptor;
         this.type = parquetType;
-        this.pageReader = pageReader;
+        this.pageReader = pageReadStore.getPageReader(descriptor);
         this.maxDefLevel = descriptor.getMaxDefinitionLevel();
         this.isUtcTimestamp = isUtcTimestamp;
         this.dataType = dataType;
@@ -132,6 +129,9 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
         this.readMapKey = readMapKey;
 
         DictionaryPage dictionaryPage = pageReader.readDictionaryPage();
+
+        this.readState = new ParquetReadState(pageReadStore.getRowIndexes().orElse(null));
+
         if (dictionaryPage != null) {
             try {
                 this.dictionary =
@@ -166,23 +166,55 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
             isFirstRow = false;
         }
 
-        // index to set value.
-        int index = 0;
-        int valueIndex = 0;
         List<Object> valueList = new ArrayList<>();
 
+        int valueIndex = collectDataFromParquetPage(readNumber, valueList);
+
+        return fillColumnVector(valueIndex, valueList);
+    }
+
+    private int collectDataFromParquetPage(int total, List<Object> valueList) throws IOException {
+        int valueIndex = 0;
         // repeated type need two loops to read data.
-        while (!eof && index < readNumber) {
+
+        readState.resetForNewBatch(total);
+
+        while (!eof && readState.rowsToReadInBatch > 0) {
+
+            if (readState.isFinished()) { // finished to read
+                eof = true;
+                break;
+            }
+
+            long pageRowId = readState.rowId;
+            long rangeStart = readState.currentRangeStart();
+            long rangeEnd = readState.currentRangeEnd();
+
+            if (pageRowId > rangeEnd) {
+                readState.nextRange();
+                continue;
+            }
+
+            boolean needFilterSkip = pageRowId < rangeStart;
+
             do {
-                if (!lastValue.shouldSkip) {
+
+                if (!lastValue.shouldSkip && !needFilterSkip) {
                     valueList.add(lastValue.value);
                     valueIndex++;
                 }
             } while (readValue() && (repetitionLevel != 0));
-            index++;
+
+            if (pageRowId == readState.rowId) {
+                readState.rowId = readState.rowId + 1;
+            }
+
+            if (!needFilterSkip) {
+                readState.rowsToReadInBatch = readState.rowsToReadInBatch - 1;
+            }
         }
 
-        return fillColumnVector(valueIndex, valueList);
+        return valueIndex;
     }
 
     public LevelDelegation getLevelDelegation() {
@@ -255,20 +287,24 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
         // get the values of repetition and definitionLevel
         repetitionLevel = repetitionLevelColumn.nextInt();
         definitionLevel = definitionLevelColumn.nextInt();
-        valuesRead++;
+        readState.valuesToReadInPage = readState.valuesToReadInPage - 1;
         repetitionLevelList.add(repetitionLevel);
         definitionLevelList.add(definitionLevel);
     }
 
     private int readPageIfNeed() throws IOException {
         // Compute the number of values we want to read in this page.
-        int leftInPage = (int) (endOfPageValueCount - valuesRead);
-        if (leftInPage == 0) {
-            // no data left in current page, load data from new page
-            readPage();
-            leftInPage = (int) (endOfPageValueCount - valuesRead);
+        if (readState.valuesToReadInPage == 0) {
+            int pageValueCount = readPage();
+            // 返回当前 page 的数据量
+            if (pageValueCount < 0) {
+                // we've read all the pages; this could happen when we're reading a repeated list
+                // and we
+                // don't know where the list will end until we've seen all the pages.
+                return -1;
+            }
         }
-        return leftInPage;
+        return readState.valuesToReadInPage;
     }
 
     private Object readPrimitiveTypedRow(DataType category) {
@@ -528,33 +564,36 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
         return phbv;
     }
 
-    protected void readPage() {
+    protected int readPage() {
         DataPage page = pageReader.readPage();
 
         if (page == null) {
-            return;
+            return -1;
         }
 
-        page.accept(
-                new DataPage.Visitor<Void>() {
-                    @Override
-                    public Void visit(DataPageV1 dataPageV1) {
-                        readPageV1(dataPageV1);
-                        return null;
-                    }
+        long pageFirstRowIndex = page.getFirstRowIndex().orElse(0L);
 
-                    @Override
-                    public Void visit(DataPageV2 dataPageV2) {
-                        readPageV2(dataPageV2);
-                        return null;
-                    }
-                });
+        int pageValueCount =
+                page.accept(
+                        new DataPage.Visitor<Integer>() {
+                            @Override
+                            public Integer visit(DataPageV1 dataPageV1) {
+                                return readPageV1(dataPageV1);
+                            }
+
+                            @Override
+                            public Integer visit(DataPageV2 dataPageV2) {
+                                return readPageV2(dataPageV2);
+                            }
+                        });
+        readState.resetForNewPage(pageValueCount, pageFirstRowIndex);
+        return pageValueCount;
     }
 
     private void initDataReader(Encoding dataEncoding, ByteBufferInputStream in, int valueCount)
             throws IOException {
-        this.pageValueCount = valueCount;
-        this.endOfPageValueCount = valuesRead + pageValueCount;
+        //        this.pageValueCount = valueCount;
+        //        this.endOfPageValueCount = valuesRead + pageValueCount;
         if (dataEncoding.usesDictionary()) {
             this.dataColumn = null;
             if (dictionary == null) {
@@ -577,13 +616,14 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
         }
 
         try {
-            dataColumn.initFromPage(pageValueCount, in);
+            dataColumn.initFromPage(valueCount, in);
         } catch (IOException e) {
             throw new IOException(String.format("Could not read page in col %s.", descriptor), e);
         }
     }
 
-    private void readPageV1(DataPageV1 page) {
+    private int readPageV1(DataPageV1 page) {
+        int pageValueCount = page.getValueCount();
         ValuesReader rlReader = page.getRlEncoding().getValuesReader(descriptor, REPETITION_LEVEL);
         ValuesReader dlReader = page.getDlEncoding().getValuesReader(descriptor, DEFINITION_LEVEL);
         this.repetitionLevelColumn = new ValuesReaderIntIterator(rlReader);
@@ -597,15 +637,16 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
             LOG.debug("Reading definition levels at {}.", in.position());
             dlReader.initFromPage(pageValueCount, in);
             LOG.debug("Reading data at {}.", in.position());
-            initDataReader(page.getValueEncoding(), in, page.getValueCount());
+            initDataReader(page.getValueEncoding(), in, pageValueCount);
+            return pageValueCount;
         } catch (IOException e) {
             throw new ParquetDecodingException(
                     String.format("Could not read page %s in col %s.", page, descriptor), e);
         }
     }
 
-    private void readPageV2(DataPageV2 page) {
-        this.pageValueCount = page.getValueCount();
+    private int readPageV2(DataPageV2 page) {
+        int pageValueCount = page.getValueCount();
         this.repetitionLevelColumn =
                 newRLEIterator(descriptor.getMaxRepetitionLevel(), page.getRepetitionLevels());
         this.definitionLevelColumn =
@@ -615,8 +656,8 @@ public class NestedPrimitiveColumnReader implements ColumnReader<WritableColumnV
                     "Page data size {} bytes and {} records.",
                     page.getData().size(),
                     pageValueCount);
-            initDataReader(
-                    page.getDataEncoding(), page.getData().toInputStream(), page.getValueCount());
+            initDataReader(page.getDataEncoding(), page.getData().toInputStream(), pageValueCount);
+            return pageValueCount;
         } catch (IOException e) {
             throw new ParquetDecodingException(
                     String.format("Could not read page %s in col %s.", page, descriptor), e);

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetReadState.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetReadState.java
@@ -1,140 +1,140 @@
-package org.apache.paimon.format.parquet.reader;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+package org.apache.paimon.format.parquet.reader;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.PrimitiveIterator;
 
-/*Parquet reader state*/
+/** Parquet reader state for column index. */
 public class ParquetReadState {
-  /**
-   *  A special row range used when there is no row indexes (hence all rows must be included)
-   * */
-  private static final RowRange MAX_ROW_RANGE = new RowRange(Long.MIN_VALUE, Long.MAX_VALUE);
+    /** A special row range used when there is no row indexes (hence all rows must be included). */
+    private static final RowRange MAX_ROW_RANGE = new RowRange(Long.MIN_VALUE, Long.MAX_VALUE);
 
-  /**
-   * A special row range used when the row indexes are present AND all the row ranges have been
-   * processed. This serves as a sentinel at the end indicating that all rows come after the last
-   * row range should be skipped.
-   */
-  private static final RowRange END_ROW_RANGE = new RowRange(Long.MAX_VALUE, Long.MIN_VALUE);
+    /**
+     * A special row range used when the row indexes are present AND all the row ranges have been
+     * processed. This serves as a sentinel at the end indicating that all rows come after the last
+     * row range should be skipped.
+     */
+    private static final RowRange END_ROW_RANGE = new RowRange(Long.MAX_VALUE, Long.MIN_VALUE);
 
-  private final Iterator<RowRange> rowRanges;
+    private final Iterator<RowRange> rowRanges;
 
-  private RowRange currentRange;
+    private RowRange currentRange;
 
-  /**
-   * row index for the next read
-   */
-  long rowId;
-  int valuesToReadInPage;
-  int rowsToReadInBatch;
+    /** row index for the next read. */
+    long rowId;
 
-  ParquetReadState(PrimitiveIterator.OfLong rowIndexes) {
-    this.rowRanges = constructRanges(rowIndexes);
-    nextRange();
-  }
+    int valuesToReadInPage;
+    int rowsToReadInBatch;
 
-  /**
-   * Construct a list of row ranges from the given `rowIndexes`.
-   * For example, suppose the `rowIndexes` are `[0, 1, 2, 4, 5, 7, 8, 9]`,
-   * it will be converted into 3 row ranges: `[0-2], [4-5], [7-9]`.
-   */
-  private Iterator<RowRange> constructRanges(PrimitiveIterator.OfLong rowIndexes) {
-    if (rowIndexes == null) {
-      return null;
+    ParquetReadState(PrimitiveIterator.OfLong rowIndexes) {
+        this.rowRanges = constructRanges(rowIndexes);
+        nextRange();
     }
 
-    List<RowRange> rowRanges = new ArrayList<>();
-    long currentStart = Long.MIN_VALUE;
-    long previous = Long.MIN_VALUE;
+    /**
+     * Construct a list of row ranges from the given `rowIndexes`. For example, suppose the
+     * `rowIndexes` are `[0, 1, 2, 4, 5, 7, 8, 9]`, it will be converted into 3 row ranges: `[0-2],
+     * [4-5], [7-9]`.
+     */
+    private Iterator<RowRange> constructRanges(PrimitiveIterator.OfLong rowIndexes) {
+        if (rowIndexes == null) {
+            return null;
+        }
 
-    while (rowIndexes.hasNext()) {
-      long idx = rowIndexes.nextLong();
-      if (currentStart == Long.MIN_VALUE) {
-        currentStart = idx;
-      } else if (previous + 1 != idx) {
-        RowRange range = new RowRange(currentStart, previous);
-        rowRanges.add(range);
-        currentStart = idx;
-      }
-      previous = idx;
+        List<RowRange> rowRanges = new ArrayList<>();
+        long currentStart = Long.MIN_VALUE;
+        long previous = Long.MIN_VALUE;
+
+        while (rowIndexes.hasNext()) {
+            long idx = rowIndexes.nextLong();
+            if (currentStart == Long.MIN_VALUE) {
+                currentStart = idx;
+            } else if (previous + 1 != idx) {
+                RowRange range = new RowRange(currentStart, previous);
+                rowRanges.add(range);
+                currentStart = idx;
+            }
+            previous = idx;
+        }
+
+        if (previous != Long.MIN_VALUE) {
+            rowRanges.add(new RowRange(currentStart, previous));
+        }
+
+        return rowRanges.iterator();
     }
 
-    if (previous != Long.MIN_VALUE) {
-      rowRanges.add(new RowRange(currentStart, previous));
+    /** Must be called at the beginning of reading a new batch. */
+    void resetForNewBatch(int batchSize) {
+        this.rowsToReadInBatch = batchSize;
     }
 
-    return rowRanges.iterator();
-  }
-
-  /**
-   * Must be called at the beginning of reading a new batch.
-   */
-  void resetForNewBatch(int batchSize) {
-    this.rowsToReadInBatch = batchSize;
-  }
-
-  /**
-   * Must be called at the beginning of reading a new page.
-   */
-  void resetForNewPage(int totalValuesInPage, long pageFirstRowIndex) {
-    this.valuesToReadInPage = totalValuesInPage;
-    this.rowId = pageFirstRowIndex;
-  }
-
-  /**
-   * Returns the start index of the current row range.
-   */
-  long currentRangeStart() {
-    return currentRange.start;
-  }
-
-  /**
-   * Returns the end index of the current row range.
-   */
-  long currentRangeEnd() {
-    return currentRange.end;
-  }
-
-  boolean isFinished(){
-    return this.currentRange.equals(this.END_ROW_RANGE);
-  }
-
-  /**
-   * Advance to the next range.
-   */
-  void nextRange() {
-    if (rowRanges == null) {
-      currentRange = MAX_ROW_RANGE;
-    } else if (!rowRanges.hasNext()) {
-      currentRange = END_ROW_RANGE;
-    } else {
-      currentRange = rowRanges.next();
-    }
-  }
-
-  /**
-   * Helper struct to represent a range of row indexes `[start, end]`.
-   */
-  private static class RowRange {
-    final long start;
-    final long end;
-
-    RowRange(long start, long end) {
-      this.start = start;
-      this.end = end;
+    /** Must be called at the beginning of reading a new page. */
+    void resetForNewPage(int totalValuesInPage, long pageFirstRowIndex) {
+        this.valuesToReadInPage = totalValuesInPage;
+        this.rowId = pageFirstRowIndex;
     }
 
-    @Override
-    public boolean equals(Object obj) {
-      if (!(obj instanceof RowRange)){
-        return false;
-      }
-      return ((RowRange) obj).start == this.start &&
-              ((RowRange) obj).end == this.end;
-
+    /** Returns the start index of the current row range. */
+    long currentRangeStart() {
+        return currentRange.start;
     }
-  }
+
+    /** Returns the end index of the current row range. */
+    long currentRangeEnd() {
+        return currentRange.end;
+    }
+
+    boolean isFinished() {
+        return this.currentRange.equals(this.END_ROW_RANGE);
+    }
+
+    /** Advance to the next range. */
+    void nextRange() {
+        if (rowRanges == null) {
+            currentRange = MAX_ROW_RANGE;
+        } else if (!rowRanges.hasNext()) {
+            currentRange = END_ROW_RANGE;
+        } else {
+            currentRange = rowRanges.next();
+        }
+    }
+
+    /** Helper struct to represent a range of row indexes `[start, end]`. */
+    private static class RowRange {
+        final long start;
+        final long end;
+
+        RowRange(long start, long end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof RowRange)) {
+                return false;
+            }
+            return ((RowRange) obj).start == this.start && ((RowRange) obj).end == this.end;
+        }
+    }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetReadState.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetReadState.java
@@ -45,7 +45,7 @@ public class ParquetReadState {
     int valuesToReadInPage;
     int rowsToReadInBatch;
 
-    ParquetReadState(PrimitiveIterator.OfLong rowIndexes) {
+    public ParquetReadState(PrimitiveIterator.OfLong rowIndexes) {
         this.rowRanges = constructRanges(rowIndexes);
         nextRange();
     }
@@ -95,21 +95,29 @@ public class ParquetReadState {
     }
 
     /** Returns the start index of the current row range. */
-    long currentRangeStart() {
+    public long currentRangeStart() {
         return currentRange.start;
     }
 
     /** Returns the end index of the current row range. */
-    long currentRangeEnd() {
+    public long currentRangeEnd() {
         return currentRange.end;
     }
 
-    boolean isFinished() {
+    public boolean isFinished() {
         return this.currentRange.equals(this.END_ROW_RANGE);
     }
 
+    public boolean isMaxRange() {
+        return this.currentRange.equals(this.MAX_ROW_RANGE);
+    }
+
+    public RowRange getCurrentRange() {
+        return currentRange;
+    }
+
     /** Advance to the next range. */
-    void nextRange() {
+    public void nextRange() {
         if (rowRanges == null) {
             currentRange = MAX_ROW_RANGE;
         } else if (!rowRanges.hasNext()) {
@@ -120,7 +128,7 @@ public class ParquetReadState {
     }
 
     /** Helper struct to represent a range of row indexes `[start, end]`. */
-    private static class RowRange {
+    public static class RowRange {
         final long start;
         final long end;
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetReadState.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetReadState.java
@@ -1,0 +1,120 @@
+package org.apache.paimon.format.parquet.reader;
+
+/*Parquet reader state*/
+public class ParquetReadState {
+  /**
+   *  A special row range used when there is no row indexes (hence all rows must be included)
+   * */
+  private static final RowRange MAX_ROW_RANGE = new RowRange(Long.MIN_VALUE, Long.MAX_VALUE);
+
+  /**
+   * A special row range used when the row indexes are present AND all the row ranges have been
+   * processed. This serves as a sentinel at the end indicating that all rows come after the last
+   * row range should be skipped.
+   */
+  private static final RowRange END_ROW_RANGE = new RowRange(Long.MAX_VALUE, Long.MIN_VALUE);
+
+  private final Iterator<RowRange> rowRanges;
+
+  private RowRange currentRange;
+
+  /**
+   * row index for the next read
+   */
+  long rowId;
+  int valuesToReadInPage;
+  int rowsToReadInBatch;
+
+  ParquetReadState(PrimitiveIterator.OfLong rowIndexes) {
+    this.rowRanges = constructRanges(rowIndexes);
+    nextRange();
+  }
+
+  /**
+   * Construct a list of row ranges from the given `rowIndexes`.
+   * For example, suppose the `rowIndexes` are `[0, 1, 2, 4, 5, 7, 8, 9]`,
+   * it will be converted into 3 row ranges: `[0-2], [4-5], [7-9]`.
+   */
+  private Iterator<RowRange> constructRanges(PrimitiveIterator.OfLong rowIndexes) {
+    if (rowIndexes == null) {
+      return null;
+    }
+
+    List<RowRange> rowRanges = new ArrayList<>();
+    long currentStart = Long.MIN_VALUE;
+    long previous = Long.MIN_VALUE;
+
+    while (rowIndexes.hasNext()) {
+      long idx = rowIndexes.nextLong();
+      if (currentStart == Long.MIN_VALUE) {
+        currentStart = idx;
+      } else if (previous + 1 != idx) {
+        RowRange range = new RowRange(currentStart, previous);
+        rowRanges.add(range);
+        currentStart = idx;
+      }
+      previous = idx;
+    }
+
+    if (previous != Long.MIN_VALUE) {
+      rowRanges.add(new RowRange(currentStart, previous));
+    }
+
+    return rowRanges.iterator();
+  }
+
+  /**
+   * Must be called at the beginning of reading a new batch.
+   */
+  void resetForNewBatch(int batchSize) {
+    this.rowsToReadInBatch = batchSize;
+  }
+
+  /**
+   * Must be called at the beginning of reading a new page.
+   */
+  void resetForNewPage(int totalValuesInPage, long pageFirstRowIndex) {
+    this.valuesToReadInPage = totalValuesInPage;
+    this.rowId = pageFirstRowIndex;
+  }
+
+  /**
+   * Returns the start index of the current row range.
+   */
+  long currentRangeStart() {
+    return currentRange.start;
+  }
+
+  /**
+   * Returns the end index of the current row range.
+   */
+  long currentRangeEnd() {
+    return currentRange.end;
+  }
+
+  /**
+   * Advance to the next range.
+   */
+  void nextRange() {
+    if (rowRanges == null) {
+      currentRange = MAX_ROW_RANGE;
+    } else if (!rowRanges.hasNext()) {
+      currentRange = END_ROW_RANGE;
+    } else {
+      currentRange = rowRanges.next();
+    }
+  }
+
+  /**
+   * Helper struct to represent a range of row indexes `[start, end]`.
+   */
+  private static class RowRange {
+    final long start;
+    final long end;
+
+    RowRange(long start, long end) {
+      this.start = start;
+      this.end = end;
+    }
+  }
+}

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetReadState.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetReadState.java
@@ -1,5 +1,11 @@
 package org.apache.paimon.format.parquet.reader;
 
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.PrimitiveIterator;
+
 /*Parquet reader state*/
 public class ParquetReadState {
   /**
@@ -92,6 +98,10 @@ public class ParquetReadState {
     return currentRange.end;
   }
 
+  boolean isFinished(){
+    return this.currentRange.equals(this.END_ROW_RANGE);
+  }
+
   /**
    * Advance to the next range.
    */
@@ -115,6 +125,16 @@ public class ParquetReadState {
     RowRange(long start, long end) {
       this.start = start;
       this.end = end;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (!(obj instanceof RowRange)){
+        return false;
+      }
+      return ((RowRange) obj).start == this.start &&
+              ((RowRange) obj).end == this.end;
+
     }
   }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetSplitReaderUtil.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetSplitReaderUtil.java
@@ -87,58 +87,45 @@ public class ParquetSplitReaderUtil {
                 getAllColumnDescriptorByType(depth, type, columnDescriptors);
         switch (fieldType.getTypeRoot()) {
             case BOOLEAN:
-                return new BooleanColumnReader(
-                        descriptors.get(0), pages.getPageReader(descriptors.get(0)));
+                return new BooleanColumnReader(descriptors.get(0), pages);
             case TINYINT:
-                return new ByteColumnReader(
-                        descriptors.get(0), pages.getPageReader(descriptors.get(0)));
+                return new ByteColumnReader(descriptors.get(0), pages);
             case DOUBLE:
-                return new DoubleColumnReader(
-                        descriptors.get(0), pages.getPageReader(descriptors.get(0)));
+                return new DoubleColumnReader(descriptors.get(0), pages);
             case FLOAT:
-                return new FloatColumnReader(
-                        descriptors.get(0), pages.getPageReader(descriptors.get(0)));
+                return new FloatColumnReader(descriptors.get(0), pages);
             case INTEGER:
             case DATE:
             case TIME_WITHOUT_TIME_ZONE:
-                return new IntColumnReader(
-                        descriptors.get(0), pages.getPageReader(descriptors.get(0)));
+                return new IntColumnReader(descriptors.get(0), pages);
             case BIGINT:
-                return new LongColumnReader(
-                        descriptors.get(0), pages.getPageReader(descriptors.get(0)));
+                return new LongColumnReader(descriptors.get(0), pages);
             case SMALLINT:
-                return new ShortColumnReader(
-                        descriptors.get(0), pages.getPageReader(descriptors.get(0)));
+                return new ShortColumnReader(descriptors.get(0), pages);
             case CHAR:
             case VARCHAR:
             case BINARY:
             case VARBINARY:
-                return new BytesColumnReader(
-                        descriptors.get(0), pages.getPageReader(descriptors.get(0)));
+                return new BytesColumnReader(descriptors.get(0), pages);
             case TIMESTAMP_WITHOUT_TIME_ZONE:
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
                 if (descriptors.get(0).getPrimitiveType().getPrimitiveTypeName()
                         == PrimitiveType.PrimitiveTypeName.INT64) {
-                    return new LongColumnReader(
-                            descriptors.get(0), pages.getPageReader(descriptors.get(0)));
+                    return new LongColumnReader(descriptors.get(0), pages);
                 }
-                return new TimestampColumnReader(
-                        true, descriptors.get(0), pages.getPageReader(descriptors.get(0)));
+                return new TimestampColumnReader(true, descriptors.get(0), pages);
             case DECIMAL:
                 switch (descriptors.get(0).getPrimitiveType().getPrimitiveTypeName()) {
                     case INT32:
-                        return new IntColumnReader(
-                                descriptors.get(0), pages.getPageReader(descriptors.get(0)));
+                        return new IntColumnReader(descriptors.get(0), pages);
                     case INT64:
-                        return new LongColumnReader(
-                                descriptors.get(0), pages.getPageReader(descriptors.get(0)));
+                        return new LongColumnReader(descriptors.get(0), pages);
                     case BINARY:
-                        return new BytesColumnReader(
-                                descriptors.get(0), pages.getPageReader(descriptors.get(0)));
+                        return new BytesColumnReader(descriptors.get(0), pages);
                     case FIXED_LEN_BYTE_ARRAY:
                         return new FixedLenBytesColumnReader(
                                 descriptors.get(0),
-                                pages.getPageReader(descriptors.get(0)),
+                                pages,
                                 ((DecimalType) fieldType).getPrecision());
                 }
             case ARRAY:

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/RunLengthDecoder.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/RunLengthDecoder.java
@@ -194,10 +194,7 @@ final class RunLengthDecoder {
         }
     }
 
-    void skipDictionaryIds(
-            int total,
-            int level,
-            RunLengthDecoder data) {
+    void skipDictionaryIds(int total, int level, RunLengthDecoder data) {
         int left = total;
         while (left > 0) {
             if (this.currentCount == 0) {

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/RunLengthDecoder.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/RunLengthDecoder.java
@@ -194,6 +194,54 @@ final class RunLengthDecoder {
         }
     }
 
+    void skipDictionaryIds(
+            int total,
+            int level,
+            RunLengthDecoder data) {
+        int left = total;
+        while (left > 0) {
+            if (this.currentCount == 0) {
+                this.readNextGroup();
+            }
+            int n = Math.min(left, this.currentCount);
+            switch (mode) {
+                case RLE:
+                    if (currentValue == level) {
+                        data.skipDictionaryIdData(n);
+                    }
+                    break;
+                case PACKED:
+                    for (int i = 0; i < n; ++i) {
+                        if (currentBuffer[currentBufferIdx++] == level) {
+                            data.readInteger();
+                        }
+                    }
+                    break;
+            }
+            left -= n;
+            currentCount -= n;
+        }
+    }
+
+    private void skipDictionaryIdData(int total) {
+        int left = total;
+        while (left > 0) {
+            if (this.currentCount == 0) {
+                this.readNextGroup();
+            }
+            int n = Math.min(left, this.currentCount);
+            switch (mode) {
+                case RLE:
+                    break;
+                case PACKED:
+                    currentBufferIdx += n;
+                    break;
+            }
+            left -= n;
+            currentCount -= n;
+        }
+    }
+
     /** Reads the next varint encoded int. */
     private int readUnsignedVarInt() throws IOException {
         int value = 0;

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ShortColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ShortColumnReader.java
@@ -22,6 +22,7 @@ import org.apache.paimon.data.columnar.writable.WritableIntVector;
 import org.apache.paimon.data.columnar.writable.WritableShortVector;
 
 import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -30,9 +31,9 @@ import java.io.IOException;
 /** Short {@link ColumnReader}. Using INT32 to store short, so just cast int to short. */
 public class ShortColumnReader extends AbstractColumnReader<WritableShortVector> {
 
-    public ShortColumnReader(ColumnDescriptor descriptor, PageReader pageReader)
+    public ShortColumnReader(ColumnDescriptor descriptor, PageReadStore pageReadStore)
             throws IOException {
-        super(descriptor, pageReader);
+        super(descriptor, pageReadStore);
         checkTypeName(PrimitiveType.PrimitiveTypeName.INT32);
     }
 
@@ -69,6 +70,38 @@ public class ShortColumnReader extends AbstractColumnReader<WritableShortVector>
             left -= n;
             runLenDecoder.currentCount -= n;
         }
+    }
+
+    @Override
+    protected void skipBatch(int num) {
+        int left = num;
+        while (left > 0) {
+            if (runLenDecoder.currentCount == 0) {
+                runLenDecoder.readNextGroup();
+            }
+            int n = Math.min(left, runLenDecoder.currentCount);
+            switch (runLenDecoder.mode) {
+                case RLE:
+                    if (runLenDecoder.currentValue == maxDefLevel) {
+                        skipShot(n);
+                    }
+                    break;
+                case PACKED:
+                    for (int i = 0; i < n; ++i) {
+                        if (runLenDecoder.currentBuffer[runLenDecoder.currentBufferIdx++]
+                                == maxDefLevel) {
+                            skipShot(1);
+                        }
+                    }
+                    break;
+            }
+            left -= n;
+            runLenDecoder.currentCount -= n;
+        }
+    }
+
+    private void skipShot(int num){
+        skipDataBuffer(4 * num);
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ShortColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ShortColumnReader.java
@@ -23,7 +23,6 @@ import org.apache.paimon.data.columnar.writable.WritableShortVector;
 
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReadStore;
-import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.schema.PrimitiveType;
 
 import java.io.IOException;
@@ -100,7 +99,7 @@ public class ShortColumnReader extends AbstractColumnReader<WritableShortVector>
         }
     }
 
-    private void skipShot(int num){
+    private void skipShot(int num) {
         skipDataBuffer(4 * num);
     }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/TimestampColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/TimestampColumnReader.java
@@ -24,7 +24,6 @@ import org.apache.paimon.data.columnar.writable.WritableTimestampVector;
 
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReadStore;
-import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.PrimitiveType;
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/TimestampColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/TimestampColumnReader.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.columnar.writable.WritableIntVector;
 import org.apache.paimon.data.columnar.writable.WritableTimestampVector;
 
 import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.PrimitiveType;
@@ -49,9 +50,9 @@ public class TimestampColumnReader extends AbstractColumnReader<WritableTimestam
     private final boolean utcTimestamp;
 
     public TimestampColumnReader(
-            boolean utcTimestamp, ColumnDescriptor descriptor, PageReader pageReader)
+            boolean utcTimestamp, ColumnDescriptor descriptor, PageReadStore pageReadStore)
             throws IOException {
-        super(descriptor, pageReader);
+        super(descriptor, pageReadStore);
         this.utcTimestamp = utcTimestamp;
         checkTypeName(PrimitiveType.PrimitiveTypeName.INT96);
     }
@@ -71,6 +72,15 @@ public class TimestampColumnReader extends AbstractColumnReader<WritableTimestam
                         int96ToTimestamp(utcTimestamp, buffer.getLong(), buffer.getInt()));
             } else {
                 column.setNullAt(rowId + i);
+            }
+        }
+    }
+
+    @Override
+    protected void skipBatch(int num) {
+        for (int i = 0; i < num; i++) {
+            if (runLenDecoder.readInteger() == maxDefLevel) {
+                skipDataBuffer(12);
             }
         }
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #4586 

优化了基于 Parquet 文件过滤读取时的谓词下推能力，将原先的Parquet 谓词下推由RowGroup级别增强到了 Column page 级别，查询性能提升明显。

Optimized the predicate pushdown capability for filtering and reading Parquet files, enhancing the original predicate pushdown from the RowGroup level to the Column Page level, resulting in a significant improvement in query performance.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
