### PR TITLE
[iceberg] Use gzip by default to iceberg avro writer

### DIFF
--- a/docs/content/migration/iceberg-compatibility.md
+++ b/docs/content/migration/iceberg-compatibility.md
@@ -371,6 +371,12 @@ you also need to set some (or all) of the following table options when creating 
       <td>String</td>
       <td>hadoop-conf-dir for Iceberg Hive catalog.</td>
     </tr>
+    <tr>
+      <td><h5>metadata.iceberg.manifest-compression</h5></td>
+      <td style="word-wrap: break-word;">gzip</td>
+      <td>String</td>
+      <td>Compression for Iceberg manifest files.</td>
+    </tr>
     </tbody>
 </table>
 

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
@@ -70,6 +70,13 @@ public class IcebergOptions {
                     .noDefaultValue()
                     .withDescription("hadoop-conf-dir for Iceberg Hive catalog.");
 
+    public static final ConfigOption<String> MANIFEST_COMPRESSION =
+            key("metadata.iceberg.manifest-compression")
+                    .stringType()
+                    .defaultValue(
+                            "gzip") // some Iceberg reader cannot support zstd, for example DuckDB
+                    .withDescription("Compression for Iceberg manifest files.");
+
     /** Where to store Iceberg metadata. */
     public enum StorageType implements DescribedEnum {
         DISABLED("disabled", "Disable Iceberg compatibility support."),

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
@@ -30,6 +30,7 @@ import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.disk.IOManagerImpl;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.iceberg.manifest.IcebergManifestFile;
 import org.apache.paimon.iceberg.manifest.IcebergManifestFileMeta;
 import org.apache.paimon.iceberg.manifest.IcebergManifestList;
 import org.apache.paimon.iceberg.metadata.IcebergMetadata;
@@ -302,6 +303,11 @@ public class IcebergCompatibilityTest {
         IcebergPathFactory pathFactory =
                 new IcebergPathFactory(new Path(table.location(), "metadata"));
         IcebergManifestList manifestList = IcebergManifestList.create(table, pathFactory);
+        assertThat(manifestList.compression()).isEqualTo("gzip");
+
+        IcebergManifestFile manifestFile = IcebergManifestFile.create(table, pathFactory);
+        assertThat(manifestFile.compression()).isEqualTo("gzip");
+
         Set<String> usingManifests = new HashSet<>();
         for (IcebergManifestFileMeta fileMeta :
                 manifestList.read(new Path(metadata.currentSnapshot().manifestList()).getName())) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Some Iceberg reader cannot support zstd for manifest files, for example DuckDB.

It is better to use gzip by default.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
