### PR TITLE
[iceberg] Introduce metadata.iceberg.manifest-legacy-version

### DIFF
--- a/docs/content/migration/iceberg-compatibility.md
+++ b/docs/content/migration/iceberg-compatibility.md
@@ -377,8 +377,19 @@ you also need to set some (or all) of the following table options when creating 
       <td>String</td>
       <td>Compression for Iceberg manifest files.</td>
     </tr>
+    <tr>
+      <td><h5>metadata.iceberg.manifest-legacy-version</h5></td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Should use the legacy manifest version to generate Iceberg's 1.4 manifest files.</td>
+    </tr>
     </tbody>
 </table>
+
+## AWS Athena
+
+AWS Athena may use old manifest reader to read Iceberg manifest by names, we should let Paimon producing legacy Iceberg
+manifest list file, you can enable: `'metadata.iceberg.manifest-legacy-version'`.
 
 ## Trino Iceberg
 

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
@@ -77,6 +77,13 @@ public class IcebergOptions {
                             "gzip") // some Iceberg reader cannot support zstd, for example DuckDB
                     .withDescription("Compression for Iceberg manifest files.");
 
+    public static final ConfigOption<Boolean> MANIFEST_LEGACY_VERSION =
+            key("metadata.iceberg.manifest-legacy-version")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Should use the legacy manifest version to generate Iceberg's 1.4 manifest files.");
+
     /** Where to store Iceberg metadata. */
     public enum StorageType implements DescribedEnum {
         DISABLED("disabled", "Disable Iceberg compatibility support."),

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestFileMeta.java
@@ -165,7 +165,11 @@ public class IcebergManifestFileMeta {
         return partitions;
     }
 
-    public static RowType schema() {
+    public static RowType schema(boolean legacyVersion) {
+        return legacyVersion ? schemaForIceberg1_4() : schemaForIcebergNew();
+    }
+
+    private static RowType schemaForIcebergNew() {
         List<DataField> fields = new ArrayList<>();
         fields.add(new DataField(500, "manifest_path", DataTypes.STRING().notNull()));
         fields.add(new DataField(501, "manifest_length", DataTypes.BIGINT().notNull()));
@@ -177,6 +181,29 @@ public class IcebergManifestFileMeta {
         fields.add(new DataField(504, "added_files_count", DataTypes.INT().notNull()));
         fields.add(new DataField(505, "existing_files_count", DataTypes.INT().notNull()));
         fields.add(new DataField(506, "deleted_files_count", DataTypes.INT().notNull()));
+        fields.add(new DataField(512, "added_rows_count", DataTypes.BIGINT().notNull()));
+        fields.add(new DataField(513, "existing_rows_count", DataTypes.BIGINT().notNull()));
+        fields.add(new DataField(514, "deleted_rows_count", DataTypes.BIGINT().notNull()));
+        fields.add(
+                new DataField(
+                        508, "partitions", DataTypes.ARRAY(IcebergPartitionSummary.schema())));
+        return new RowType(false, fields);
+    }
+
+    private static RowType schemaForIceberg1_4() {
+        // see https://github.com/apache/iceberg/pull/5338
+        // some reader still want old schema, for example, AWS athena
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(500, "manifest_path", DataTypes.STRING().notNull()));
+        fields.add(new DataField(501, "manifest_length", DataTypes.BIGINT().notNull()));
+        fields.add(new DataField(502, "partition_spec_id", DataTypes.INT().notNull()));
+        fields.add(new DataField(517, "content", DataTypes.INT().notNull()));
+        fields.add(new DataField(515, "sequence_number", DataTypes.BIGINT().notNull()));
+        fields.add(new DataField(516, "min_sequence_number", DataTypes.BIGINT().notNull()));
+        fields.add(new DataField(503, "added_snapshot_id", DataTypes.BIGINT()));
+        fields.add(new DataField(504, "added_data_files_count", DataTypes.INT().notNull()));
+        fields.add(new DataField(505, "existing_data_files_count", DataTypes.INT().notNull()));
+        fields.add(new DataField(506, "deleted_data_files_count", DataTypes.INT().notNull()));
         fields.add(new DataField(512, "added_rows_count", DataTypes.BIGINT().notNull()));
         fields.add(new DataField(513, "existing_rows_count", DataTypes.BIGINT().notNull()));
         fields.add(new DataField(514, "deleted_rows_count", DataTypes.BIGINT().notNull()));

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestFileMetaSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestFileMetaSerializer.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.iceberg.manifest.IcebergManifestFileMeta.Content;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.ObjectSerializer;
 
 import java.util.ArrayList;
@@ -36,8 +37,8 @@ public class IcebergManifestFileMetaSerializer extends ObjectSerializer<IcebergM
 
     private final IcebergPartitionSummarySerializer partitionSummarySerializer;
 
-    public IcebergManifestFileMetaSerializer() {
-        super(IcebergManifestFileMeta.schema());
+    public IcebergManifestFileMetaSerializer(RowType schema) {
+        super(schema);
         this.partitionSummarySerializer = new IcebergPartitionSummarySerializer();
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
AWS Athena may use old manifest reader to read Iceberg manifest by names, we should let Paimon producing legacy Iceberg manifest list file, so we introduce: `'metadata.iceberg.manifest-legacy-version'`.

Depends on https://github.com/apache/paimon/pull/4620

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
