### PR TITLE
[core] Support nested types in Iceberg compatible metadata

### DIFF
--- a/docs/content/migration/iceberg-compatibility.md
+++ b/docs/content/migration/iceberg-compatibility.md
@@ -479,21 +479,24 @@ SELECT * FROM animals WHERE class = 'mammal';
 
 Paimon Iceberg compatibility currently supports the following data types.
 
-| Paimon Data Type  | Iceberg Data Type |
-|-------------------|-------------------|
-| `BOOLEAN`         | `boolean`         |
-| `INT`             | `int`             |
-| `BIGINT`          | `long`            |
-| `FLOAT`           | `float`           |
-| `DOUBLE`          | `double`          |
-| `DECIMAL`         | `decimal`         |
-| `CHAR`            | `string`          |
-| `VARCHAR`         | `string`          |
-| `BINARY`          | `binary`          |
-| `VARBINARY`       | `binary`          |
-| `DATE`            | `date`            |
-| `TIMESTAMP`*      | `timestamp`       |
-| `TIMESTAMP_LTZ`*  | `timestamptz`     |
+| Paimon Data Type | Iceberg Data Type |
+|------------------|-------------------|
+| `BOOLEAN`        | `boolean`         |
+| `INT`            | `int`             |
+| `BIGINT`         | `long`            |
+| `FLOAT`          | `float`           |
+| `DOUBLE`         | `double`          |
+| `DECIMAL`        | `decimal`         |
+| `CHAR`           | `string`          |
+| `VARCHAR`        | `string`          |
+| `BINARY`         | `binary`          |
+| `VARBINARY`      | `binary`          |
+| `DATE`           | `date`            |
+| `TIMESTAMP`*     | `timestamp`       |
+| `TIMESTAMP_LTZ`* | `timestamptz`     |
+| `ARRAY`          | `list`            |
+| `MAP`            | `map`             |
+| `ROW`            | `struct`          |
 
 *: `TIMESTAMP` and `TIMESTAMP_LTZ` type only support precision from 4 to 6
 

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/AbstractIcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/AbstractIcebergCommitCallback.java
@@ -295,7 +295,8 @@ public abstract class AbstractIcebergCommitCallback implements CommitCallback {
                             rawFile.rowCount(),
                             rawFile.fileSize(),
                             schemaCache.get(paimonFileMeta.schemaId()),
-                            paimonFileMeta.valueStats());
+                            paimonFileMeta.valueStats(),
+                            paimonFileMeta.valueStatsCols());
             result.add(
                     new IcebergManifestEntry(
                             IcebergManifestEntry.Status.ADDED,
@@ -509,7 +510,8 @@ public abstract class AbstractIcebergCommitCallback implements CommitCallback {
                                                     paimonFileMeta.rowCount(),
                                                     paimonFileMeta.fileSize(),
                                                     schemaCache.get(paimonFileMeta.schemaId()),
-                                                    paimonFileMeta.valueStats());
+                                                    paimonFileMeta.valueStats(),
+                                                    paimonFileMeta.valueStatsCols());
                                     return new IcebergManifestEntry(
                                             IcebergManifestEntry.Status.ADDED,
                                             currentSnapshotId,

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergDataField.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergDataField.java
@@ -18,10 +18,14 @@
 
 package org.apache.paimon.iceberg.metadata;
 
+import org.apache.paimon.table.SpecialFields;
+import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.LocalZonedTimestampType;
+import org.apache.paimon.types.MapType;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.utils.Preconditions;
 
@@ -32,6 +36,7 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgn
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * {@link DataField} in Iceberg.
@@ -57,7 +62,7 @@ public class IcebergDataField {
     private final boolean required;
 
     @JsonProperty(FIELD_TYPE)
-    private final String type;
+    private final Object type;
 
     @JsonIgnore private final DataType dataType;
 
@@ -69,7 +74,7 @@ public class IcebergDataField {
                 dataField.id(),
                 dataField.name(),
                 !dataField.type().isNullable(),
-                toTypeString(dataField.type()),
+                toTypeObject(dataField.type(), dataField.id(), 0),
                 dataField.type(),
                 dataField.description());
     }
@@ -79,13 +84,13 @@ public class IcebergDataField {
             @JsonProperty(FIELD_ID) int id,
             @JsonProperty(FIELD_NAME) String name,
             @JsonProperty(FIELD_REQUIRED) boolean required,
-            @JsonProperty(FIELD_TYPE) String type,
+            @JsonProperty(FIELD_TYPE) Object type,
             @JsonProperty(FIELD_DOC) String doc) {
         this(id, name, required, type, null, doc);
     }
 
     public IcebergDataField(
-            int id, String name, boolean required, String type, DataType dataType, String doc) {
+            int id, String name, boolean required, Object type, DataType dataType, String doc) {
         this.id = id;
         this.name = name;
         this.required = required;
@@ -110,7 +115,7 @@ public class IcebergDataField {
     }
 
     @JsonGetter(FIELD_TYPE)
-    public String type() {
+    public Object type() {
         return type;
     }
 
@@ -124,7 +129,7 @@ public class IcebergDataField {
         return Preconditions.checkNotNull(dataType);
     }
 
-    private static String toTypeString(DataType dataType) {
+    private static Object toTypeObject(DataType dataType, int fieldId, int depth) {
         switch (dataType.getTypeRoot()) {
             case BOOLEAN:
                 return "boolean";
@@ -160,6 +165,26 @@ public class IcebergDataField {
                         timestampLtzPrecision > 3 && timestampLtzPrecision <= 6,
                         "Paimon Iceberg compatibility only support timestamp type with precision from 4 to 6.");
                 return "timestamptz";
+            case ARRAY:
+                ArrayType arrayType = (ArrayType) dataType;
+                return new IcebergListType(
+                        SpecialFields.getArrayElementFieldId(fieldId, depth + 1),
+                        !dataType.isNullable(),
+                        toTypeObject(arrayType.getElementType(), fieldId, depth + 1));
+            case MAP:
+                MapType mapType = (MapType) dataType;
+                return new IcebergMapType(
+                        SpecialFields.getMapKeyFieldId(fieldId, depth + 1),
+                        toTypeObject(mapType.getKeyType(), fieldId, depth + 1),
+                        SpecialFields.getMapValueFieldId(fieldId, depth + 1),
+                        !mapType.getValueType().isNullable(),
+                        toTypeObject(mapType.getValueType(), fieldId, depth + 1));
+            case ROW:
+                RowType rowType = (RowType) dataType;
+                return new IcebergStructType(
+                        rowType.getFields().stream()
+                                .map(IcebergDataField::new)
+                                .collect(Collectors.toList()));
             default:
                 throw new UnsupportedOperationException("Unsupported data type: " + dataType);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergListType.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergListType.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg.metadata;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * {@link org.apache.paimon.types.ArrayType} in Iceberg.
+ *
+ * <p>See <a href="https://iceberg.apache.org/spec/#schemas">Iceberg spec</a>.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class IcebergListType {
+
+    private static final String FIELD_TYPE = "type";
+    private static final String FIELD_ELEMENT_ID = "element-id";
+    private static final String FIELD_ELEMENT_REQUIRED = "element-required";
+    private static final String FIELD_ELEMENT = "element";
+
+    @JsonProperty(FIELD_TYPE)
+    private final String type;
+
+    @JsonProperty(FIELD_ELEMENT_ID)
+    private final int elementId;
+
+    @JsonProperty(FIELD_ELEMENT_REQUIRED)
+    private final boolean elementRequired;
+
+    @JsonProperty(FIELD_ELEMENT)
+    private final Object element;
+
+    public IcebergListType(int elementId, boolean elementRequired, Object element) {
+        this("list", elementId, elementRequired, element);
+    }
+
+    @JsonCreator
+    public IcebergListType(
+            @JsonProperty(FIELD_TYPE) String type,
+            @JsonProperty(FIELD_ELEMENT_ID) int elementId,
+            @JsonProperty(FIELD_ELEMENT_REQUIRED) boolean elementRequired,
+            @JsonProperty(FIELD_ELEMENT) Object element) {
+        this.type = type;
+        this.elementId = elementId;
+        this.elementRequired = elementRequired;
+        this.element = element;
+    }
+
+    @JsonGetter(FIELD_TYPE)
+    public String type() {
+        return type;
+    }
+
+    @JsonGetter(FIELD_ELEMENT_ID)
+    public int elementId() {
+        return elementId;
+    }
+
+    @JsonGetter(FIELD_ELEMENT_REQUIRED)
+    public boolean elementRequired() {
+        return elementRequired;
+    }
+
+    @JsonGetter(FIELD_ELEMENT)
+    public Object element() {
+        return element;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, elementId, elementRequired, element);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof IcebergListType)) {
+            return false;
+        }
+
+        IcebergListType that = (IcebergListType) o;
+        return Objects.equals(type, that.type)
+                && elementId == that.elementId
+                && elementRequired == that.elementRequired
+                && Objects.equals(element, that.element);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergMapType.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergMapType.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg.metadata;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * {@link org.apache.paimon.types.MapType} in Iceberg.
+ *
+ * <p>See <a href="https://iceberg.apache.org/spec/#schemas">Iceberg spec</a>.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class IcebergMapType {
+
+    private static final String FIELD_TYPE = "type";
+    private static final String FIELD_KEY_ID = "key-id";
+    private static final String FIELD_KEY = "key";
+    private static final String FIELD_VALUE_ID = "value-id";
+    private static final String FIELD_VALUE_REQUIRED = "value-required";
+    private static final String FIELD_VALUE = "value";
+
+    @JsonProperty(FIELD_TYPE)
+    private final String type;
+
+    @JsonProperty(FIELD_KEY_ID)
+    private final int keyId;
+
+    @JsonProperty(FIELD_KEY)
+    private final Object key;
+
+    @JsonProperty(FIELD_VALUE_ID)
+    private final int valueId;
+
+    @JsonProperty(FIELD_VALUE_REQUIRED)
+    private final boolean valueRequired;
+
+    @JsonProperty(FIELD_VALUE)
+    private final Object value;
+
+    public IcebergMapType(int keyId, Object key, int valueId, boolean valueRequired, Object value) {
+        this("map", keyId, key, valueId, valueRequired, value);
+    }
+
+    @JsonCreator
+    public IcebergMapType(
+            @JsonProperty(FIELD_TYPE) String type,
+            @JsonProperty(FIELD_KEY_ID) int keyId,
+            @JsonProperty(FIELD_KEY) Object key,
+            @JsonProperty(FIELD_VALUE_ID) int valueId,
+            @JsonProperty(FIELD_VALUE_REQUIRED) boolean valueRequired,
+            @JsonProperty(FIELD_VALUE) Object value) {
+        this.type = type;
+        this.keyId = keyId;
+        this.key = key;
+        this.valueId = valueId;
+        this.valueRequired = valueRequired;
+        this.value = value;
+    }
+
+    @JsonGetter(FIELD_TYPE)
+    public String type() {
+        return type;
+    }
+
+    @JsonGetter(FIELD_KEY_ID)
+    public int keyId() {
+        return keyId;
+    }
+
+    @JsonGetter(FIELD_KEY)
+    public Object key() {
+        return key;
+    }
+
+    @JsonGetter(FIELD_VALUE_ID)
+    public int valueId() {
+        return valueId;
+    }
+
+    @JsonGetter(FIELD_VALUE_REQUIRED)
+    public boolean valueRequired() {
+        return valueRequired;
+    }
+
+    @JsonGetter(FIELD_VALUE)
+    public Object value() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, keyId, key, valueId, valueRequired, value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof IcebergMapType)) {
+            return false;
+        }
+        IcebergMapType that = (IcebergMapType) o;
+        return Objects.equals(type, that.type)
+                && keyId == that.keyId
+                && Objects.equals(key, that.key)
+                && valueId == that.valueId
+                && valueRequired == that.valueRequired
+                && Objects.equals(value, that.value);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergStructType.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergStructType.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg.metadata;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link org.apache.paimon.types.RowType} in Iceberg.
+ *
+ * <p>See <a href="https://iceberg.apache.org/spec/#schemas">Iceberg spec</a>.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class IcebergStructType {
+
+    private static final String FIELD_TYPE = "type";
+    private static final String FIELD_FIELDS = "fields";
+
+    @JsonProperty(FIELD_TYPE)
+    private final String type;
+
+    @JsonProperty(FIELD_FIELDS)
+    private final List<IcebergDataField> fields;
+
+    public IcebergStructType(List<IcebergDataField> fields) {
+        this("struct", fields);
+    }
+
+    @JsonCreator
+    public IcebergStructType(
+            @JsonProperty(FIELD_TYPE) String type,
+            @JsonProperty(FIELD_FIELDS) List<IcebergDataField> fields) {
+        this.type = type;
+        this.fields = fields;
+    }
+
+    @JsonGetter(FIELD_TYPE)
+    public String type() {
+        return type;
+    }
+
+    @JsonGetter(FIELD_FIELDS)
+    public List<IcebergDataField> fields() {
+        return fields;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, fields);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof IcebergStructType)) {
+            return false;
+        }
+
+        IcebergStructType that = (IcebergStructType) o;
+        return Objects.equals(type, that.type) && Objects.equals(fields, that.fields);
+    }
+}

--- a/paimon-flink/paimon-flink-1.16/src/test/java/org/apache/paimon/flink/iceberg/Flink116IcebergITCase.java
+++ b/paimon-flink/paimon-flink-1.16/src/test/java/org/apache/paimon/flink/iceberg/Flink116IcebergITCase.java
@@ -19,4 +19,11 @@
 package org.apache.paimon.flink.iceberg;
 
 /** IT cases for Paimon Iceberg compatibility in Flink 1.16. */
-public class Flink116IcebergITCase extends FlinkIcebergITCaseBase {}
+public class Flink116IcebergITCase extends FlinkIcebergITCaseBase {
+
+    @Override
+    public void testNestedTypes(String format) {
+        // Flink 1.16 (or maybe Calcite?) will mistakenly cast the result to VARCHAR(5),
+        // so we skip this test in Flink 1.16.
+    }
+}


### PR DESCRIPTION
### Purpose

Currently, Iceberg compatible metadata has supported all primitive types in Iceberg. This PR adds support for nested types.

### Tests

Unit tests and IT cases.

### API and Format

No format changes.

### Documentation

Document is also added.
