### PR TITLE
[core] Use min/max to fast skip the bsi index comparison

### DIFF
--- a/docs/content/concepts/spec/fileindex.md
+++ b/docs/content/concepts/spec/fileindex.md
@@ -154,11 +154,35 @@ BSI file index format (V1)
 +-------------------------------------------------+
 ｜ has positive value (1 byte)                    ｜
 +-------------------------------------------------+
-｜ positive bsi serialized (if has positive value)｜       
+｜ positive BSI serialized (if has positive value)｜       
 +-------------------------------------------------+
 ｜ has negative value (1 byte)                    ｜
 +-------------------------------------------------+
-｜ negative bsi serialized (if has negative value)｜       
+｜ negative BSI serialized (if has negative value)｜       
++-------------------------------------------------+
+</pre>
+
+BSI serialized format (V1):
+<pre>
+BSI serialized format (V1)
++-------------------------------------------------+
+｜ version (1 byte)                               ｜
++-------------------------------------------------+
+｜ min value (8 bytes long)                       ｜
++-------------------------------------------------+
+｜ max value (8 bytes long)                       ｜
++-------------------------------------------------+
+｜ serialized existence bitmap                    ｜       
++-------------------------------------------------+
+｜ bit slice bitmap count (4 bytes int)           ｜
++-------------------------------------------------+
+｜ serialized bit 0 bitmap                        ｜
++-------------------------------------------------+
+｜ serialized bit 1 bitmap                        ｜
++-------------------------------------------------+
+｜ serialized bit 2 bitmap                        ｜
++-------------------------------------------------+
+｜ ...                                            ｜
 +-------------------------------------------------+
 </pre>
 

--- a/paimon-common/src/test/java/org/apache/paimon/utils/BitSliceIndexRoaringBitmapTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/BitSliceIndexRoaringBitmapTest.java
@@ -26,34 +26,69 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.stream.IntStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Random;
 
+import static org.apache.paimon.utils.BitSliceIndexRoaringBitmap.Operation.EQ;
+import static org.apache.paimon.utils.BitSliceIndexRoaringBitmap.Operation.GT;
+import static org.apache.paimon.utils.BitSliceIndexRoaringBitmap.Operation.GTE;
+import static org.apache.paimon.utils.BitSliceIndexRoaringBitmap.Operation.LT;
+import static org.apache.paimon.utils.BitSliceIndexRoaringBitmap.Operation.LTE;
+import static org.apache.paimon.utils.BitSliceIndexRoaringBitmap.Operation.NEQ;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link BitSliceIndexRoaringBitmap}. */
 public class BitSliceIndexRoaringBitmapTest {
 
-    private long base;
+    public static final int NUM_OF_ROWS = 100000;
+    public static final int VALUE_BOUND = 1000;
+    public static final int VALUE_LT_MIN = 0;
+    public static final int VALUE_GT_MAX = VALUE_BOUND + 100;
+
+    private Random random;
+    private List<Pair> pairs;
     private BitSliceIndexRoaringBitmap bsi;
 
     @BeforeEach
     public void setup() throws IOException {
-        this.base = System.currentTimeMillis();
+        this.random = new Random();
+        List<Pair> pairs = new ArrayList<>();
+        long min = 0;
+        long max = 0;
+        for (int i = 0; i < NUM_OF_ROWS; i++) {
+            if (i % 5 == 0) {
+                pairs.add(new Pair(i, null));
+                continue;
+            }
+            long next = generateNextValue();
+            min = Math.min(min == 0 ? next : min, next);
+            max = Math.max(max == 0 ? next : max, next);
+            pairs.add(new Pair(i, next));
+        }
         BitSliceIndexRoaringBitmap.Appender appender =
-                new BitSliceIndexRoaringBitmap.Appender(base, toPredicate(100));
-        IntStream.range(0, 31).forEach(x -> appender.append(x, toPredicate(x)));
-        IntStream.range(51, 100).forEach(x -> appender.append(x, toPredicate(x)));
-        appender.append(100, toPredicate(30));
+                new BitSliceIndexRoaringBitmap.Appender(min, max);
+        for (Pair pair : pairs) {
+            if (pair.value == null) {
+                continue;
+            }
+            appender.append(pair.index, pair.value);
+        }
         this.bsi = appender.build();
+        this.pairs = Collections.unmodifiableList(pairs);
     }
 
     @Test
     public void testSerde() throws IOException {
         BitSliceIndexRoaringBitmap.Appender appender =
-                new BitSliceIndexRoaringBitmap.Appender(0, toPredicate(100));
-        IntStream.range(0, 31).forEach(x -> appender.append(x, toPredicate(x)));
-        IntStream.range(51, 100).forEach(x -> appender.append(x, toPredicate(x)));
-        appender.append(100, toPredicate(30));
+                new BitSliceIndexRoaringBitmap.Appender(0, 10);
+        appender.append(0, 0);
+        appender.append(1, 1);
+        appender.append(2, 2);
+        appender.append(10, 6);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         appender.serialize(new DataOutputStream(out));
@@ -65,60 +100,171 @@ public class BitSliceIndexRoaringBitmapTest {
 
     @Test
     public void testEQ() {
-        assertThat(bsi.eq(toPredicate(1))).isEqualTo(RoaringBitmap32.bitmapOf(1));
-        assertThat(bsi.eq(toPredicate(32))).isEqualTo(RoaringBitmap32.bitmapOf());
-        assertThat(bsi.eq(toPredicate(30))).isEqualTo(RoaringBitmap32.bitmapOf(30, 100));
+        // test predicate in the value bound
+        for (int i = 0; i < 10; i++) {
+            long predicate = generateNextValue();
+            assertThat(bsi.eq(predicate))
+                    .isEqualTo(
+                            pairs.stream()
+                                    .filter(x -> Objects.equals(x.value, predicate))
+                                    .map(x -> x.index)
+                                    .collect(
+                                            RoaringBitmap32::new,
+                                            RoaringBitmap32::add,
+                                            (x, y) -> x.or(y)));
+        }
+
+        // test predicate out of the value bound
+        assertThat(bsi.eq(VALUE_LT_MIN)).isEqualTo(new RoaringBitmap32());
+        assertThat(bsi.eq(VALUE_GT_MAX)).isEqualTo(new RoaringBitmap32());
     }
 
     @Test
     public void testLT() {
-        assertThat(bsi.lt(toPredicate(30)))
-                .isEqualTo(RoaringBitmap32.bitmapOf(IntStream.range(0, 30).toArray()));
-        assertThat(bsi.lt(toPredicate(45)))
-                .isEqualTo(
-                        RoaringBitmap32.bitmapOf(
-                                IntStream.concat(IntStream.range(0, 31), IntStream.range(100, 101))
-                                        .toArray()));
+        // test predicate in the value bound
+        for (int i = 0; i < 10; i++) {
+            long predicate = generateNextValue();
+            assertThat(bsi.lt(predicate))
+                    .isEqualTo(
+                            pairs.stream()
+                                    .filter(x -> x.value != null)
+                                    .filter(x -> x.value < predicate)
+                                    .map(x -> x.index)
+                                    .collect(
+                                            RoaringBitmap32::new,
+                                            RoaringBitmap32::add,
+                                            (x, y) -> x.or(y)));
+        }
+
+        // test predicate out of the value bound
+        assertThat(bsi.lt(VALUE_LT_MIN)).isEqualTo(new RoaringBitmap32());
+        assertThat(bsi.lt(VALUE_GT_MAX)).isEqualTo(bsi.isNotNull());
     }
 
     @Test
     public void testLTE() {
-        RoaringBitmap32 expected =
-                RoaringBitmap32.bitmapOf(
-                        IntStream.concat(IntStream.range(0, 31), IntStream.range(100, 101))
-                                .toArray());
-        assertThat(bsi.lte(toPredicate(30))).isEqualTo(expected);
-        assertThat(bsi.lte(toPredicate(45))).isEqualTo(expected);
+        // test predicate in the value bound
+        for (int i = 0; i < 10; i++) {
+            long predicate = generateNextValue();
+            assertThat(bsi.lte(predicate))
+                    .isEqualTo(
+                            pairs.stream()
+                                    .filter(x -> x.value != null)
+                                    .filter(x -> x.value <= predicate)
+                                    .map(x -> x.index)
+                                    .collect(
+                                            RoaringBitmap32::new,
+                                            RoaringBitmap32::add,
+                                            (x, y) -> x.or(y)));
+        }
+
+        // test predicate out of the value bound
+        assertThat(bsi.lte(VALUE_LT_MIN)).isEqualTo(new RoaringBitmap32());
+        assertThat(bsi.lte(VALUE_GT_MAX)).isEqualTo(bsi.isNotNull());
     }
 
     @Test
     public void testGT() {
-        RoaringBitmap32 expected = RoaringBitmap32.bitmapOf(IntStream.range(51, 100).toArray());
-        assertThat(bsi.gt(toPredicate(30))).isEqualTo(expected);
-        assertThat(bsi.gt(toPredicate(45))).isEqualTo(expected);
+        // test predicate in the value bound
+        for (int i = 0; i < 10; i++) {
+            long predicate = generateNextValue();
+            assertThat(bsi.gt(predicate))
+                    .isEqualTo(
+                            pairs.stream()
+                                    .filter(x -> x.value != null)
+                                    .filter(x -> x.value > predicate)
+                                    .map(x -> x.index)
+                                    .collect(
+                                            RoaringBitmap32::new,
+                                            RoaringBitmap32::add,
+                                            (x, y) -> x.or(y)));
+        }
+
+        // test predicate out of the value bound
+        assertThat(bsi.gt(VALUE_LT_MIN)).isEqualTo(bsi.isNotNull());
+        assertThat(bsi.gt(VALUE_GT_MAX)).isEqualTo(new RoaringBitmap32());
     }
 
     @Test
     public void testGTE() {
-        assertThat(bsi.gte(toPredicate(30)))
-                .isEqualTo(
-                        RoaringBitmap32.bitmapOf(
-                                IntStream.concat(IntStream.range(30, 31), IntStream.range(51, 101))
-                                        .toArray()));
-        assertThat(bsi.gte(toPredicate(45)))
-                .isEqualTo(RoaringBitmap32.bitmapOf(IntStream.range(51, 100).toArray()));
+        // test predicate in the value bound
+        for (int i = 0; i < 10; i++) {
+            long predicate = generateNextValue();
+            assertThat(bsi.gte(predicate))
+                    .isEqualTo(
+                            pairs.stream()
+                                    .filter(x -> x.value != null)
+                                    .filter(x -> x.value >= predicate)
+                                    .map(x -> x.index)
+                                    .collect(
+                                            RoaringBitmap32::new,
+                                            RoaringBitmap32::add,
+                                            (x, y) -> x.or(y)));
+        }
+
+        // test predicate out of the value bound
+        assertThat(bsi.gte(VALUE_LT_MIN)).isEqualTo(bsi.isNotNull());
+        assertThat(bsi.gte(VALUE_GT_MAX)).isEqualTo(new RoaringBitmap32());
     }
 
     @Test
     public void testIsNotNull() {
         assertThat(bsi.isNotNull())
                 .isEqualTo(
-                        RoaringBitmap32.bitmapOf(
-                                IntStream.concat(IntStream.range(0, 31), IntStream.range(51, 101))
-                                        .toArray()));
+                        pairs.stream()
+                                .filter(x -> x.value != null)
+                                .map(x -> x.index)
+                                .collect(
+                                        RoaringBitmap32::new,
+                                        RoaringBitmap32::add,
+                                        (x, y) -> x.or(y)));
     }
 
-    private long toPredicate(long predicate) {
-        return base + predicate;
+    @Test
+    public void testCompareUsingMinMax() {
+        // a predicate in the value bound
+        final int predicate = generateNextValue();
+        final Optional<RoaringBitmap32> empty = Optional.of(new RoaringBitmap32());
+        final Optional<RoaringBitmap32> notNul = Optional.of(bsi.isNotNull());
+        final Optional<RoaringBitmap32> inBound = Optional.empty();
+
+        // test eq & neq
+        assertThat(bsi.compareUsingMinMax(EQ, predicate, null)).isEqualTo(inBound);
+        assertThat(bsi.compareUsingMinMax(EQ, VALUE_LT_MIN, null)).isEqualTo(empty);
+        assertThat(bsi.compareUsingMinMax(EQ, VALUE_GT_MAX, null)).isEqualTo(empty);
+        assertThat(bsi.compareUsingMinMax(NEQ, predicate, null)).isEqualTo(inBound);
+        assertThat(bsi.compareUsingMinMax(NEQ, VALUE_LT_MIN, null)).isEqualTo(notNul);
+        assertThat(bsi.compareUsingMinMax(NEQ, VALUE_GT_MAX, null)).isEqualTo(notNul);
+
+        // test lt & lte
+        assertThat(bsi.compareUsingMinMax(LT, predicate, null)).isEqualTo(inBound);
+        assertThat(bsi.compareUsingMinMax(LTE, predicate, null)).isEqualTo(inBound);
+        assertThat(bsi.compareUsingMinMax(LT, VALUE_LT_MIN, null)).isEqualTo(empty);
+        assertThat(bsi.compareUsingMinMax(LTE, VALUE_LT_MIN, null)).isEqualTo(empty);
+        assertThat(bsi.compareUsingMinMax(LT, VALUE_GT_MAX, null)).isEqualTo(notNul);
+        assertThat(bsi.compareUsingMinMax(LTE, VALUE_GT_MAX, null)).isEqualTo(notNul);
+
+        // test gt & gte
+        assertThat(bsi.compareUsingMinMax(GT, predicate, null)).isEqualTo(inBound);
+        assertThat(bsi.compareUsingMinMax(GTE, predicate, null)).isEqualTo(inBound);
+        assertThat(bsi.compareUsingMinMax(GT, VALUE_LT_MIN, null)).isEqualTo(notNul);
+        assertThat(bsi.compareUsingMinMax(GTE, VALUE_LT_MIN, null)).isEqualTo(notNul);
+        assertThat(bsi.compareUsingMinMax(GT, VALUE_GT_MAX, null)).isEqualTo(empty);
+        assertThat(bsi.compareUsingMinMax(GT, VALUE_GT_MAX, null)).isEqualTo(empty);
+    }
+
+    private int generateNextValue() {
+        // return a value in the range [1, VALUE_BOUND)
+        return random.nextInt(VALUE_BOUND) + 1;
+    }
+
+    private static class Pair {
+        int index;
+        Long value;
+
+        public Pair(int index, Long value) {
+            this.index = index;
+            this.value = value;
+        }
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Firstly, When users turn off to collect the column stats, bsi compare would return a wrong result. Because the predicate can not out of the bsi min/max range in oneil compare.

Secondly, using min/max compare can fast return. e.g. in the GT case, if the predicate is less than the min value, we just need to return the existence bitmap.

At last, because of the v1.0 in paimon is not yet released, I didn't do the compatibility work about the bsi index.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
org.apache.paimon.utils.BitSliceIndexRoaringBitmapTest

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
