### PR TITLE
[e2e] Try to fix e2e tests timeout by updating kafka image version

### DIFF
--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/E2eTestBase.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/E2eTestBase.java
@@ -111,7 +111,8 @@ public abstract class E2eTestBase {
             for (String s : kafkaServices) {
                 environment.withLogConsumer(s + "-1", new Slf4jLogConsumer(LOG));
             }
-            environment.waitingFor("kafka-1", buildWaitStrategy(".*Recorded new controller.*", 2));
+            environment.waitingFor(
+                    "kafka-1", buildWaitStrategy(".*Recorded new ZK controller.*", 2));
         }
         if (withHive) {
             List<String> hiveServices =

--- a/paimon-e2e-tests/src/test/resources-filtered/docker-compose.yaml
+++ b/paimon-e2e-tests/src/test/resources-filtered/docker-compose.yaml
@@ -77,7 +77,7 @@ services:
   # ----------------------------------------
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.0.1
+    image: confluentinc/cp-zookeeper:7.8.0
     networks:
       testnetwork:
         aliases:
@@ -89,7 +89,7 @@ services:
       - "2181"
 
   kafka:
-    image: confluentinc/cp-kafka:7.0.1
+    image: confluentinc/cp-kafka:7.8.0
     networks:
       testnetwork:
         aliases:


### PR DESCRIPTION
### Purpose

Currently e2e tests constantly suffers from initialization timeout, due to zookeeper not running. This PR tries to fix this issue by updating kafka image version.

Reference: https://github.com/confluentinc/cp-docker-images/issues/925

