### PR TITLE
[flink] Optimizing parallelism for fixed bucekt and non-partitioned t…

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
@@ -271,7 +271,8 @@ public class FlinkSinkBuilder {
                 && table.partitionKeys().isEmpty()) {
             // For non-partitioned table, if the bucketNums is less than job parallelism.
             LOG.warn(
-                    "For non-partitioned table, the writerOperator's parallelism will be set to bucketNums if the bucketNums is less than inputOperator's parallelism.");
+                    "For non-partitioned table, if bucketNums is less than the parallelism of inputOperator,"
+                            + " then the parallelism of writerOperator will be set to bucketNums.");
             parallelism = bucketNums;
         }
         DataStream<InternalRow> partitioned =


### PR DESCRIPTION
…able.

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

For non-partitioned table, the writerOperator's parallelism will be set to bucketNums if the bucketNums is less than inputOperator's parallelism.

Example :
Default parallelism : 4
Paimon tables bucket nums : 1
Result : There will be 3 tasks that are idle.

Before : 
<img width="1374" alt="image" src="https://github.com/user-attachments/assets/faf56ff8-6151-432b-861d-959b3b41889d">

After :

<img width="1186" alt="image" src="https://github.com/user-attachments/assets/7d2bf5f8-5b15-468a-a36a-5210b9e0847d">


### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
