### PR TITLE
[flink] support flink sourceIdleTime metric in ReadOperator

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/metrics/FileStoreSourceReaderMetrics.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/metrics/FileStoreSourceReaderMetrics.java
@@ -27,22 +27,18 @@ public class FileStoreSourceReaderMetrics {
 
     private long latestFileCreationTime = UNDEFINED;
     private long lastSplitUpdateTime = UNDEFINED;
-    private long idleStartTime = ACTIVE;
 
     public static final long UNDEFINED = -1L;
-    private static final long ACTIVE = Long.MAX_VALUE;
 
     public FileStoreSourceReaderMetrics(MetricGroup sourceReaderMetricGroup) {
         sourceReaderMetricGroup.gauge(
                 MetricNames.CURRENT_FETCH_EVENT_TIME_LAG, this::getFetchTimeLag);
-        sourceReaderMetricGroup.gauge(MetricNames.SOURCE_IDLE_TIME, this::getIdleTime);
     }
 
     /** Called when consumed snapshot changes. */
     public void recordSnapshotUpdate(long fileCreationTime) {
         this.latestFileCreationTime = fileCreationTime;
         lastSplitUpdateTime = System.currentTimeMillis();
-        idleStartTime = ACTIVE;
     }
 
     @VisibleForTesting
@@ -60,20 +56,5 @@ public class FileStoreSourceReaderMetrics {
     @VisibleForTesting
     long getLastSplitUpdateTime() {
         return lastSplitUpdateTime;
-    }
-
-    public void idlingStarted() {
-        if (!isIdling()) {
-            idleStartTime = System.currentTimeMillis();
-        }
-    }
-
-    boolean isIdling() {
-        return idleStartTime != ACTIVE;
-    }
-
-    @VisibleForTesting
-    long getIdleTime() {
-        return isIdling() ? System.currentTimeMillis() - idleStartTime : 0;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/metrics/FileStoreSourceReaderMetrics.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/metrics/FileStoreSourceReaderMetrics.java
@@ -27,18 +27,22 @@ public class FileStoreSourceReaderMetrics {
 
     private long latestFileCreationTime = UNDEFINED;
     private long lastSplitUpdateTime = UNDEFINED;
+    private long idleStartTime = ACTIVE;
 
     public static final long UNDEFINED = -1L;
+    private static final long ACTIVE = Long.MAX_VALUE;
 
     public FileStoreSourceReaderMetrics(MetricGroup sourceReaderMetricGroup) {
         sourceReaderMetricGroup.gauge(
                 MetricNames.CURRENT_FETCH_EVENT_TIME_LAG, this::getFetchTimeLag);
+        sourceReaderMetricGroup.gauge(MetricNames.SOURCE_IDLE_TIME, this::getIdleTime);
     }
 
     /** Called when consumed snapshot changes. */
     public void recordSnapshotUpdate(long fileCreationTime) {
         this.latestFileCreationTime = fileCreationTime;
         lastSplitUpdateTime = System.currentTimeMillis();
+        idleStartTime = ACTIVE;
     }
 
     @VisibleForTesting
@@ -56,5 +60,20 @@ public class FileStoreSourceReaderMetrics {
     @VisibleForTesting
     long getLastSplitUpdateTime() {
         return lastSplitUpdateTime;
+    }
+
+    public void idlingStarted() {
+        if (!isIdling()) {
+            idleStartTime = System.currentTimeMillis();
+        }
+    }
+
+    boolean isIdling() {
+        return idleStartTime != ACTIVE;
+    }
+
+    @VisibleForTesting
+    long getIdleTime() {
+        return isIdling() ? System.currentTimeMillis() - idleStartTime : 0;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/metrics/FileStoreSourceReaderMetrics.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/metrics/FileStoreSourceReaderMetrics.java
@@ -29,6 +29,7 @@ public class FileStoreSourceReaderMetrics {
     private long lastSplitUpdateTime = UNDEFINED;
 
     public static final long UNDEFINED = -1L;
+    public static final long ACTIVE = Long.MAX_VALUE;
 
     public FileStoreSourceReaderMetrics(MetricGroup sourceReaderMetricGroup) {
         sourceReaderMetricGroup.gauge(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/ReadOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/ReadOperator.java
@@ -83,6 +83,7 @@ public class ReadOperator extends AbstractStreamOperator<RowData>
         this.read = readBuilder.newRead().withIOManager(ioManager);
         this.reuseRow = new FlinkRowData(null);
         this.reuseRecord = new StreamRecord<>(reuseRow);
+        this.sourceReaderMetrics.idlingStarted();
     }
 
     @Override
@@ -113,6 +114,7 @@ public class ReadOperator extends AbstractStreamOperator<RowData>
                 output.collect(reuseRecord);
             }
         }
+        sourceReaderMetrics.idlingStarted();
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/ReadOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/ReadOperator.java
@@ -58,7 +58,7 @@ public class ReadOperator extends AbstractStreamOperator<RowData>
     // is not a FLIP-27
     // source and Flink can't automatically calculate this metric
     private transient long emitEventTimeLag = FileStoreSourceReaderMetrics.UNDEFINED;
-    private transient long idleStartTime = FileStoreSourceReaderMetrics.UNDEFINED;
+    private transient long idleStartTime = FileStoreSourceReaderMetrics.ACTIVE;
     private transient Counter numRecordsIn;
 
     public ReadOperator(ReadBuilder readBuilder) {
@@ -99,7 +99,7 @@ public class ReadOperator extends AbstractStreamOperator<RowData>
                         .orElse(FileStoreSourceReaderMetrics.UNDEFINED);
         sourceReaderMetrics.recordSnapshotUpdate(eventTime);
         // update idleStartTime when reading a new split
-        idleStartTime = FileStoreSourceReaderMetrics.UNDEFINED;
+        idleStartTime = FileStoreSourceReaderMetrics.ACTIVE;
 
         boolean firstRecord = true;
         try (CloseableIterator<InternalRow> iterator =
@@ -138,7 +138,7 @@ public class ReadOperator extends AbstractStreamOperator<RowData>
     }
 
     private boolean isIdling() {
-        return idleStartTime != FileStoreSourceReaderMetrics.UNDEFINED;
+        return idleStartTime != FileStoreSourceReaderMetrics.ACTIVE;
     }
 
     private long getIdleTime() {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/metrics/FileStoreSourceReaderMetricsTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/metrics/FileStoreSourceReaderMetricsTest.java
@@ -66,7 +66,7 @@ class FileStoreSourceReaderMetricsTest {
         Thread.sleep(10L);
         assertThat(sourceReaderMetrics.getIdleTime()).isGreaterThan(9L);
 
-        //non-idle
+        // non-idle
         sourceReaderMetrics.recordSnapshotUpdate(123);
         Thread.sleep(10L);
         assertThat(sourceReaderMetrics.getIdleTime()).isEqualTo(0L);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/metrics/FileStoreSourceReaderMetricsTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/metrics/FileStoreSourceReaderMetricsTest.java
@@ -52,28 +52,4 @@ class FileStoreSourceReaderMetricsTest {
         assertThat(sourceReaderMetrics.getFetchTimeLag())
                 .isNotEqualTo(FileStoreSourceReaderMetrics.UNDEFINED);
     }
-
-    @Test
-    public void testSourceIdleTimeUpdated() throws InterruptedException {
-        MetricListener metricListener = new MetricListener();
-        final FileStoreSourceReaderMetrics sourceReaderMetrics =
-                new FileStoreSourceReaderMetrics(metricListener.getMetricGroup());
-
-        assertThat(sourceReaderMetrics.getIdleTime()).isEqualTo(0L);
-
-        // idle start
-        sourceReaderMetrics.idlingStarted();
-        Thread.sleep(10L);
-        assertThat(sourceReaderMetrics.getIdleTime()).isGreaterThan(9L);
-
-        // non-idle
-        sourceReaderMetrics.recordSnapshotUpdate(123);
-        Thread.sleep(10L);
-        assertThat(sourceReaderMetrics.getIdleTime()).isEqualTo(0L);
-
-        // idle start
-        sourceReaderMetrics.idlingStarted();
-        Thread.sleep(10L);
-        assertThat(sourceReaderMetrics.getIdleTime()).isGreaterThan(9L);
-    }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/metrics/FileStoreSourceReaderMetricsTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/metrics/FileStoreSourceReaderMetricsTest.java
@@ -52,4 +52,28 @@ class FileStoreSourceReaderMetricsTest {
         assertThat(sourceReaderMetrics.getFetchTimeLag())
                 .isNotEqualTo(FileStoreSourceReaderMetrics.UNDEFINED);
     }
+
+    @Test
+    public void testSourceIdleTimeUpdated() throws InterruptedException {
+        MetricListener metricListener = new MetricListener();
+        final FileStoreSourceReaderMetrics sourceReaderMetrics =
+                new FileStoreSourceReaderMetrics(metricListener.getMetricGroup());
+
+        assertThat(sourceReaderMetrics.getIdleTime()).isEqualTo(0L);
+
+        // idle start
+        sourceReaderMetrics.idlingStarted();
+        Thread.sleep(10L);
+        assertThat(sourceReaderMetrics.getIdleTime()).isGreaterThan(9L);
+
+        //non-idle
+        sourceReaderMetrics.recordSnapshotUpdate(123);
+        Thread.sleep(10L);
+        assertThat(sourceReaderMetrics.getIdleTime()).isEqualTo(0L);
+
+        // idle start
+        sourceReaderMetrics.idlingStarted();
+        Thread.sleep(10L);
+        assertThat(sourceReaderMetrics.getIdleTime()).isGreaterThan(9L);
+    }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
@@ -205,9 +205,12 @@ public class OperatorSourceTest {
                 .isEqualTo(-1L);
 
         Thread.sleep(300L);
-        assertThat((Long)TestingMetricUtils.getGauge(
-                        readerOperatorMetricGroup, "sourceIdleTime")
-                .getValue()).isGreaterThan(299L);
+        assertThat(
+                        (Long)
+                                TestingMetricUtils.getGauge(
+                                                readerOperatorMetricGroup, "sourceIdleTime")
+                                        .getValue())
+                .isGreaterThan(299L);
 
         harness.processElement(new StreamRecord<>(splits.get(0)));
         assertThat(
@@ -234,10 +237,13 @@ public class OperatorSourceTest {
                                         .getValue())
                 .isEqualTo(emitEventTimeLag);
 
-        assertThat((Long)TestingMetricUtils.getGauge(
-                        readerOperatorMetricGroup, "sourceIdleTime")
-                .getValue()).isGreaterThan(99L).isLessThan(300L);
-
+        assertThat(
+                        (Long)
+                                TestingMetricUtils.getGauge(
+                                                readerOperatorMetricGroup, "sourceIdleTime")
+                                        .getValue())
+                .isGreaterThan(99L)
+                .isLessThan(300L);
     }
 
     private <T> T testReadSplit(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
@@ -204,6 +204,11 @@ public class OperatorSourceTest {
                                 .getValue())
                 .isEqualTo(-1L);
 
+        Thread.sleep(300L);
+        assertThat((Long)TestingMetricUtils.getGauge(
+                        readerOperatorMetricGroup, "sourceIdleTime")
+                .getValue()).isGreaterThan(299L);
+
         harness.processElement(new StreamRecord<>(splits.get(0)));
         assertThat(
                         (Long)
@@ -228,6 +233,11 @@ public class OperatorSourceTest {
                                                 "currentEmitEventTimeLag")
                                         .getValue())
                 .isEqualTo(emitEventTimeLag);
+
+        assertThat((Long)TestingMetricUtils.getGauge(
+                        readerOperatorMetricGroup, "sourceIdleTime")
+                .getValue()).isGreaterThan(99L).isLessThan(300L);
+
     }
 
     private <T> T testReadSplit(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Support Flink sourceIdleTime metric in ReadOperator

Linked issue: close #4249 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
