### PR TITLE
[core] Unify the order of procedure loading properties

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/ProcedureUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ProcedureUtils.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.options.ExpireConfig;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TimeZone;
+
+/** Utils for procedure. */
+public class ProcedureUtils {
+
+    public static Map<String, String> fillInPartitionOptions(
+            String expireStrategy,
+            String timestampFormatter,
+            String timestampPattern,
+            String expirationTime,
+            Integer maxExpires,
+            String options) {
+
+        HashMap<String, String> dynamicOptions = new HashMap<>();
+        putAllOptions(dynamicOptions, options);
+        putIfNotEmpty(
+                dynamicOptions, CoreOptions.PARTITION_EXPIRATION_STRATEGY.key(), expireStrategy);
+        putIfNotEmpty(
+                dynamicOptions,
+                CoreOptions.PARTITION_TIMESTAMP_FORMATTER.key(),
+                timestampFormatter);
+        putIfNotEmpty(
+                dynamicOptions, CoreOptions.PARTITION_TIMESTAMP_PATTERN.key(), timestampPattern);
+        putIfNotEmpty(dynamicOptions, CoreOptions.PARTITION_EXPIRATION_TIME.key(), expirationTime);
+        // Set check interval to 0 for dedicated partition expiration.
+        putIfNotEmpty(dynamicOptions, CoreOptions.PARTITION_EXPIRATION_CHECK_INTERVAL.key(), "0");
+        putIfNotEmpty(
+                dynamicOptions,
+                CoreOptions.PARTITION_EXPIRATION_MAX_NUM.key(),
+                maxExpires == null ? null : String.valueOf(maxExpires));
+        return dynamicOptions;
+    }
+
+    public static void putAllOptions(HashMap<String, String> dynamicOptions, String options) {
+        if (!StringUtils.isNullOrWhitespaceOnly(options)) {
+            dynamicOptions.putAll(ParameterUtils.parseCommaSeparatedKeyValues(options));
+        }
+    }
+
+    public static void putIfNotEmpty(
+            HashMap<String, String> dynamicOptions, String key, String value) {
+        if (!StringUtils.isNullOrWhitespaceOnly(value)) {
+            dynamicOptions.put(key, value);
+        }
+    }
+
+    public static ExpireConfig.Builder fillInSnapshotOptions(
+            CoreOptions tableOptions,
+            Integer retainMax,
+            Integer retainMin,
+            String olderThanStr,
+            Integer maxDeletes) {
+
+        ExpireConfig.Builder builder = ExpireConfig.builder();
+        builder.snapshotRetainMax(
+                        Optional.ofNullable(retainMax).orElse(tableOptions.snapshotNumRetainMax()))
+                .snapshotRetainMin(
+                        Optional.ofNullable(retainMin).orElse(tableOptions.snapshotNumRetainMin()))
+                .snapshotMaxDeletes(
+                        Optional.ofNullable(maxDeletes).orElse(tableOptions.snapshotExpireLimit()))
+                .snapshotTimeRetain(tableOptions.snapshotTimeRetain());
+        if (!StringUtils.isNullOrWhitespaceOnly(olderThanStr)) {
+            long olderThanMills =
+                    DateTimeUtils.parseTimestampData(olderThanStr, 3, TimeZone.getDefault())
+                            .getMillisecond();
+            builder.snapshotTimeRetain(
+                    Duration.ofMillis(System.currentTimeMillis() - olderThanMills));
+        }
+        return builder;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
@@ -95,11 +95,6 @@ public class PartitionExpire {
                 maxExpireNum);
     }
 
-    public PartitionExpire withMaxExpireNum(int maxExpireNum) {
-        this.maxExpireNum = maxExpireNum;
-        return this;
-    }
-
     public List<Map<String, String>> expire(long commitIdentifier) {
         return expire(LocalDateTime.now(), commitIdentifier);
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireSnapshotsAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireSnapshotsAction.java
@@ -33,6 +33,7 @@ public class ExpireSnapshotsAction extends ActionBase {
     private final Integer retainMin;
     private final String olderThan;
     private final Integer maxDeletes;
+    private final String options;
 
     public ExpireSnapshotsAction(
             String database,
@@ -41,7 +42,8 @@ public class ExpireSnapshotsAction extends ActionBase {
             Integer retainMax,
             Integer retainMin,
             String olderThan,
-            Integer maxDeletes) {
+            Integer maxDeletes,
+            String options) {
         super(catalogConfig);
         this.database = database;
         this.table = table;
@@ -49,6 +51,7 @@ public class ExpireSnapshotsAction extends ActionBase {
         this.retainMin = retainMin;
         this.olderThan = olderThan;
         this.maxDeletes = maxDeletes;
+        this.options = options;
     }
 
     public void run() throws Exception {
@@ -60,6 +63,7 @@ public class ExpireSnapshotsAction extends ActionBase {
                 retainMax,
                 retainMin,
                 olderThan,
-                maxDeletes);
+                maxDeletes,
+                options);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireSnapshotsActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireSnapshotsActionFactory.java
@@ -31,6 +31,7 @@ public class ExpireSnapshotsActionFactory implements ActionFactory {
     private static final String RETAIN_MIN = "retain_min";
     private static final String OLDER_THAN = "older_than";
     private static final String MAX_DELETES = "max_deletes";
+    private static final String OPTIONS = "options";
 
     @Override
     public String identifier() {
@@ -46,6 +47,7 @@ public class ExpireSnapshotsActionFactory implements ActionFactory {
         String olderThan = params.has(OLDER_THAN) ? params.get(OLDER_THAN) : null;
         Integer maxDeletes =
                 params.has(MAX_DELETES) ? Integer.parseInt(params.get(MAX_DELETES)) : null;
+        String options = params.has(OPTIONS) ? params.get(OPTIONS) : null;
 
         ExpireSnapshotsAction action =
                 new ExpireSnapshotsAction(
@@ -55,7 +57,8 @@ public class ExpireSnapshotsActionFactory implements ActionFactory {
                         retainMax,
                         retainMin,
                         olderThan,
-                        maxDeletes);
+                        maxDeletes,
+                        options);
 
         return Optional.of(action);
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/UnawareBucketNewFilesCompactionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/UnawareBucketNewFilesCompactionITCase.java
@@ -118,7 +118,8 @@ public class UnawareBucketNewFilesCompactionITCase extends AbstractTestBase {
         assertThat(actual.keySet()).hasSameElementsAs(values);
         assertThat(actual.values()).allMatch(i -> i == 3);
 
-        tEnv.executeSql("CALL sys.expire_snapshots(`table` => 'default.T', retain_max => 1)")
+        tEnv.executeSql(
+                        "CALL sys.expire_snapshots(`table` => 'default.T', retain_max => 1, retain_min => 1)")
                 .await();
         assertThat(fileIO.listStatus(new Path(warehouse, "default.db/T/pt=0/bucket-0"))).hasSize(1);
         assertThat(fileIO.listStatus(new Path(warehouse, "default.db/T/pt=1/bucket-0"))).hasSize(1);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpirePartitionsProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpirePartitionsProcedureITCase.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** IT Case for {@link ExpirePartitionsProcedure}. */
 public class ExpirePartitionsProcedureITCase extends CatalogITCaseBase {
@@ -446,6 +447,91 @@ public class ExpirePartitionsProcedureITCase extends CatalogITCaseBase {
                                         + "`table` => 'default.T'"
                                         + ", expiration_time => '1 d'"
                                         + ", timestamp_formatter => 'yyyy-MM-dd')"))
+                .containsExactlyInAnyOrder("dt=2024-06-01", "dt=2024-06-02");
+
+        assertThat(read(table, consumerReadResult))
+                .containsExactlyInAnyOrder("c:2024-06-03", "Never-expire:9999-09-09");
+    }
+
+    @Test
+    public void testExpirePartitionsLoadTablePropsFirst() throws Exception {
+        sql(
+                "CREATE TABLE T ("
+                        + " k STRING,"
+                        + " dt STRING,"
+                        + " PRIMARY KEY (k, dt) NOT ENFORCED"
+                        + ") PARTITIONED BY (dt) WITH ("
+                        + " 'bucket' = '1', "
+                        + " 'write-only' = 'true', "
+                        + " 'partition.timestamp-formatter' = 'yyyy-MM-dd', "
+                        + " 'partition.expiration-max-num'='2'"
+                        + ")");
+        FileStoreTable table = paimonTable("T");
+
+        sql("INSERT INTO T VALUES ('a', '2024-06-01')");
+        sql("INSERT INTO T VALUES ('b', '2024-06-02')");
+        sql("INSERT INTO T VALUES ('c', '2024-06-03')");
+        // This partition never expires.
+        sql("INSERT INTO T VALUES ('Never-expire', '9999-09-09')");
+        Function<InternalRow, String> consumerReadResult =
+                (InternalRow row) -> row.getString(0) + ":" + row.getString(1);
+
+        assertThat(read(table, consumerReadResult))
+                .containsExactlyInAnyOrder(
+                        "a:2024-06-01", "b:2024-06-02", "c:2024-06-03", "Never-expire:9999-09-09");
+
+        // no 'partition.expiration-time' value in table property or procedure parameter.
+        assertThatThrownBy(() -> sql("CALL sys.expire_partitions(`table` => 'default.T')"))
+                .rootCause()
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining(
+                        "Both the partition expiration time and partition field can not be null.");
+
+        // 'partition.timestamp-formatter' value using table property.
+        // 'partition.expiration-time' value using procedure parameter.
+        assertThat(
+                        callExpirePartitions(
+                                "CALL sys.expire_partitions("
+                                        + "`table` => 'default.T'"
+                                        + ", expiration_time => '1 d')"))
+                .containsExactlyInAnyOrder("dt=2024-06-01", "dt=2024-06-02");
+
+        assertThat(read(table, consumerReadResult))
+                .containsExactlyInAnyOrder("c:2024-06-03", "Never-expire:9999-09-09");
+    }
+
+    @Test
+    public void testExpirePartitionsUseOptionsParam() throws Exception {
+        sql(
+                "CREATE TABLE T ("
+                        + " k STRING,"
+                        + " dt STRING,"
+                        + " PRIMARY KEY (k, dt) NOT ENFORCED"
+                        + ") PARTITIONED BY (dt) WITH ("
+                        + " 'bucket' = '1'"
+                        + ")");
+        FileStoreTable table = paimonTable("T");
+
+        sql("INSERT INTO T VALUES ('a', '2024-06-01')");
+        sql("INSERT INTO T VALUES ('b', '2024-06-02')");
+        sql("INSERT INTO T VALUES ('c', '2024-06-03')");
+        // This partition never expires.
+        sql("INSERT INTO T VALUES ('Never-expire', '9999-09-09')");
+        Function<InternalRow, String> consumerReadResult =
+                (InternalRow row) -> row.getString(0) + ":" + row.getString(1);
+
+        assertThat(read(table, consumerReadResult))
+                .containsExactlyInAnyOrder(
+                        "a:2024-06-01", "b:2024-06-02", "c:2024-06-03", "Never-expire:9999-09-09");
+
+        // set conf in options.
+        assertThat(
+                        callExpirePartitions(
+                                "CALL sys.expire_partitions("
+                                        + "`table` => 'default.T'"
+                                        + ", options => 'partition.expiration-time = 1d,"
+                                        + " partition.expiration-max-num = 2, "
+                                        + " partition.timestamp-formatter = yyyy-MM-dd')"))
                 .containsExactlyInAnyOrder("dt=2024-06-01", "dt=2024-06-02");
 
         assertThat(read(table, consumerReadResult))

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpireSnapshotsProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpireSnapshotsProcedureITCase.java
@@ -40,7 +40,8 @@ public class ExpireSnapshotsProcedureITCase extends CatalogITCaseBase {
     public void testExpireSnapshotsProcedure() throws Exception {
         sql(
                 "CREATE TABLE word_count ( word STRING PRIMARY KEY NOT ENFORCED, cnt INT)"
-                        + " WITH ( 'num-sorted-run.compaction-trigger' = '9999' )");
+                        + " WITH ( 'num-sorted-run.compaction-trigger' = '9999',"
+                        + "'write-only' = 'true', 'snapshot.num-retained.min' = '1')");
         FileStoreTable table = paimonTable("word_count");
         SnapshotManager snapshotManager = table.snapshotManager();
 
@@ -81,7 +82,9 @@ public class ExpireSnapshotsProcedureITCase extends CatalogITCaseBase {
     public void testExpireSnapshotsAction() throws Exception {
         sql(
                 "CREATE TABLE word_count ( word STRING PRIMARY KEY NOT ENFORCED, cnt INT)"
-                        + " WITH ( 'num-sorted-run.compaction-trigger' = '9999' )");
+                        + " WITH ( 'num-sorted-run.compaction-trigger' = '9999',"
+                        + "'write-only' = 'true', 'snapshot.num-retained.min' = '1')");
+
         FileStoreTable table = paimonTable("word_count");
         StreamExecutionEnvironment env =
                 streamExecutionEnvironmentBuilder().streamingMode().build();
@@ -160,6 +163,35 @@ public class ExpireSnapshotsProcedureITCase extends CatalogITCaseBase {
                 .withStreamExecutionEnvironment(env)
                 .run();
         checkSnapshots(snapshotManager, 6, 6);
+    }
+
+    @Test
+    public void testLoadTablePropsFirstAndOptions() throws Exception {
+        sql(
+                "CREATE TABLE word_count ( word STRING PRIMARY KEY NOT ENFORCED, cnt INT)"
+                        + " WITH ( 'num-sorted-run.compaction-trigger' = '9999',"
+                        + "'write-only' = 'true', 'snapshot.num-retained.min' = '1', 'snapshot.num-retained.max' = '5')");
+        FileStoreTable table = paimonTable("word_count");
+        SnapshotManager snapshotManager = table.snapshotManager();
+
+        // initially prepare 6 snapshots, expected snapshots (1, 2, 3, 4, 5, 6)
+        for (int i = 0; i < 6; ++i) {
+            sql("INSERT INTO word_count VALUES ('" + String.valueOf(i) + "', " + i + ")");
+        }
+        checkSnapshots(snapshotManager, 1, 6);
+
+        // snapshot.num-retained.max is 5, expected snapshots (2, 3, 4, 5, 6)
+        sql("CALL sys.expire_snapshots(`table` => 'default.word_count')");
+        checkSnapshots(snapshotManager, 2, 6);
+
+        // older_than => timestamp of snapshot 6, snapshot.expire.limit => 1, expected snapshots (3,
+        // 4, 5, 6)
+        Timestamp ts6 = new Timestamp(snapshotManager.latestSnapshot().timeMillis());
+        sql(
+                "CALL sys.expire_snapshots(`table` => 'default.word_count', older_than => '"
+                        + ts6.toString()
+                        + "', options => 'snapshot.expire.limit=1')");
+        checkSnapshots(snapshotManager, 3, 6);
     }
 
     protected void checkSnapshots(SnapshotManager sm, int earliest, int latest) throws IOException {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -48,6 +48,7 @@ import org.apache.paimon.table.source.EndOfScanException;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.ParameterUtils;
+import org.apache.paimon.utils.ProcedureUtils;
 import org.apache.paimon.utils.SerializationUtils;
 import org.apache.paimon.utils.StringUtils;
 import org.apache.paimon.utils.TimeUtils;
@@ -197,11 +198,10 @@ public class CompactProcedure extends BaseProcedure {
                                 table.partitionKeys());
                     }
 
-                    Map<String, String> dynamicOptions = new HashMap<>();
-                    dynamicOptions.put(CoreOptions.WRITE_ONLY.key(), "false");
-                    if (!StringUtils.isNullOrWhitespaceOnly(options)) {
-                        dynamicOptions.putAll(ParameterUtils.parseCommaSeparatedKeyValues(options));
-                    }
+                    HashMap<String, String> dynamicOptions = new HashMap<>();
+                    ProcedureUtils.putIfNotEmpty(
+                            dynamicOptions, CoreOptions.WRITE_ONLY.key(), "false");
+                    ProcedureUtils.putAllOptions(dynamicOptions, options);
                     table = table.copy(dynamicOptions);
                     InternalRow internalRow =
                             newInternalRow(

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/ExpirePartitionsProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/ExpirePartitionsProcedure.java
@@ -18,11 +18,11 @@
 
 package org.apache.paimon.spark.procedure;
 
-import org.apache.paimon.CoreOptions;
 import org.apache.paimon.FileStore;
 import org.apache.paimon.operation.PartitionExpire;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.utils.TimeUtils;
+import org.apache.paimon.utils.Preconditions;
+import org.apache.paimon.utils.ProcedureUtils;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
@@ -32,12 +32,9 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.types.UTF8String;
 
-import java.time.Duration;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.paimon.partition.PartitionExpireStrategy.createPartitionExpireStrategy;
 import static org.apache.spark.sql.types.DataTypes.IntegerType;
 import static org.apache.spark.sql.types.DataTypes.StringType;
 
@@ -47,11 +44,12 @@ public class ExpirePartitionsProcedure extends BaseProcedure {
     private static final ProcedureParameter[] PARAMETERS =
             new ProcedureParameter[] {
                 ProcedureParameter.required("table", StringType),
-                ProcedureParameter.required("expiration_time", StringType),
+                ProcedureParameter.optional("expiration_time", StringType),
                 ProcedureParameter.optional("timestamp_formatter", StringType),
                 ProcedureParameter.optional("timestamp_pattern", StringType),
                 ProcedureParameter.optional("expire_strategy", StringType),
-                ProcedureParameter.optional("max_expires", IntegerType)
+                ProcedureParameter.optional("max_expires", IntegerType),
+                ProcedureParameter.optional("options", StringType)
             };
 
     private static final StructType OUTPUT_TYPE =
@@ -77,32 +75,33 @@ public class ExpirePartitionsProcedure extends BaseProcedure {
     @Override
     public InternalRow[] call(InternalRow args) {
         Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
-        String expirationTime = args.getString(1);
+        String expirationTime = args.isNullAt(1) ? null : args.getString(1);
         String timestampFormatter = args.isNullAt(2) ? null : args.getString(2);
         String timestampPattern = args.isNullAt(3) ? null : args.getString(3);
         String expireStrategy = args.isNullAt(4) ? null : args.getString(4);
         Integer maxExpires = args.isNullAt(5) ? null : args.getInt(5);
+        String options = args.isNullAt(6) ? null : args.getString(6);
+
         return modifyPaimonTable(
                 tableIdent,
                 table -> {
+                    Map<String, String> dynamicOptions =
+                            ProcedureUtils.fillInPartitionOptions(
+                                    expireStrategy,
+                                    timestampFormatter,
+                                    timestampPattern,
+                                    expirationTime,
+                                    maxExpires,
+                                    options);
+                    table = table.copy(dynamicOptions);
                     FileStoreTable fileStoreTable = (FileStoreTable) table;
                     FileStore fileStore = fileStoreTable.store();
-                    Map<String, String> map = new HashMap<>();
-                    map.put(CoreOptions.PARTITION_EXPIRATION_STRATEGY.key(), expireStrategy);
-                    map.put(CoreOptions.PARTITION_TIMESTAMP_FORMATTER.key(), timestampFormatter);
-                    map.put(CoreOptions.PARTITION_TIMESTAMP_PATTERN.key(), timestampPattern);
 
                     PartitionExpire partitionExpire =
-                            fileStore.newPartitionExpire(
-                                    "",
-                                    fileStoreTable,
-                                    TimeUtils.parseDuration(expirationTime),
-                                    Duration.ofMillis(0L),
-                                    createPartitionExpireStrategy(
-                                            CoreOptions.fromMap(map), fileStore.partitionType()));
-                    if (maxExpires != null) {
-                        partitionExpire.withMaxExpireNum(maxExpires);
-                    }
+                            fileStore.newPartitionExpire("", fileStoreTable);
+                    Preconditions.checkNotNull(
+                            partitionExpire,
+                            "Both the partition expiration time and partition field can not be null.");
                     List<Map<String, String>> expired = partitionExpire.expire(Long.MAX_VALUE);
                     return expired == null || expired.isEmpty()
                             ? new InternalRow[] {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CreateTagFromTimestampProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CreateTagFromTimestampProcedureTest.scala
@@ -148,7 +148,8 @@ class CreateTagFromTimestampProcedureTest extends PaimonSparkTestBase with Strea
 
             // make snapshot 1 expire.
             checkAnswer(
-              spark.sql("CALL paimon.sys.expire_snapshots(table => 'test.T', retain_max => 1)"),
+              spark.sql(
+                "CALL paimon.sys.expire_snapshots(table => 'test.T', retain_max => 1, retain_min => 1)"),
               Row(1) :: Nil)
 
             // create tag from timestamp that earlier than the expired snapshot 1.

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/ExpirePartitionsProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/ExpirePartitionsProcedureTest.scala
@@ -23,6 +23,7 @@ import org.apache.paimon.spark.PaimonSparkTestBase
 import org.apache.spark.sql.{Dataset, Row}
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.streaming.StreamTest
+import org.assertj.core.api.Assertions.assertThatThrownBy
 
 /** IT Case for [[ExpirePartitionsProcedure]]. */
 class ExpirePartitionsProcedureTest extends PaimonSparkTestBase with StreamTest {
@@ -605,6 +606,145 @@ class ExpirePartitionsProcedureTest extends PaimonSparkTestBase with StreamTest 
               spark.sql(
                 "CALL paimon.sys.expire_partitions(table => 'test.T', expiration_time => '1 d'" +
                   ", timestamp_formatter => 'yyyy-MM-dd')"),
+              Row("pt=2024-06-01") :: Row("pt=2024-06-02") :: Nil
+            )
+
+            checkAnswer(query(), Row("c", "2024-06-03") :: Row("Never-expire", "9999-09-09") :: Nil)
+
+          } finally {
+            stream.stop()
+          }
+      }
+    }
+  }
+
+  test("Paimon Procedure: expire partitions load table property first") {
+    failAfter(streamingTimeout) {
+      withTempDir {
+        checkpointDir =>
+          spark.sql(s"""
+                       |CREATE TABLE T (k STRING, pt STRING)
+                       |TBLPROPERTIES (
+                       |  'primary-key' = 'k,pt',
+                       |  'bucket' = '1',
+                       |  'write-only' = 'true',
+                       |  'partition.timestamp-formatter' = 'yyyy-MM-dd',
+                       |  'partition.expiration-max-num'='2')
+                       |PARTITIONED BY (pt)
+                       |""".stripMargin)
+          val location = loadTable("T").location().toString
+
+          val inputData = MemoryStream[(String, String)]
+          val stream = inputData
+            .toDS()
+            .toDF("k", "pt")
+            .writeStream
+            .option("checkpointLocation", checkpointDir.getCanonicalPath)
+            .foreachBatch {
+              (batch: Dataset[Row], _: Long) =>
+                batch.write.format("paimon").mode("append").save(location)
+            }
+            .start()
+
+          val query = () => spark.sql("SELECT * FROM T")
+
+          try {
+            // snapshot-1
+            inputData.addData(("a", "2024-06-01"))
+            stream.processAllAvailable()
+
+            // snapshot-2
+            inputData.addData(("b", "2024-06-02"))
+            stream.processAllAvailable()
+
+            // snapshot-3
+            inputData.addData(("c", "2024-06-03"))
+            stream.processAllAvailable()
+
+            // This partition never expires.
+            inputData.addData(("Never-expire", "9999-09-09"))
+            stream.processAllAvailable()
+
+            checkAnswer(
+              query(),
+              Row("a", "2024-06-01") :: Row("b", "2024-06-02") :: Row("c", "2024-06-03") :: Row(
+                "Never-expire",
+                "9999-09-09") :: Nil)
+
+            // 'partition.timestamp-formatter' value using table property.
+            // 'partition.expiration-time' value using procedure parameter.
+            checkAnswer(
+              spark.sql(
+                "CALL paimon.sys.expire_partitions(table => 'test.T', expiration_time => '1 d')"),
+              Row("pt=2024-06-01") :: Row("pt=2024-06-02") :: Nil
+            )
+
+            checkAnswer(query(), Row("c", "2024-06-03") :: Row("Never-expire", "9999-09-09") :: Nil)
+
+          } finally {
+            stream.stop()
+          }
+      }
+    }
+  }
+
+  test("Paimon Procedure: expire partitions add options parameter") {
+    failAfter(streamingTimeout) {
+      withTempDir {
+        checkpointDir =>
+          spark.sql(s"""
+                       |CREATE TABLE T (k STRING, pt STRING)
+                       |TBLPROPERTIES (
+                       |  'primary-key' = 'k,pt',
+                       |  'bucket' = '1')
+                       |PARTITIONED BY (pt)
+                       |""".stripMargin)
+          val location = loadTable("T").location().toString
+
+          val inputData = MemoryStream[(String, String)]
+          val stream = inputData
+            .toDS()
+            .toDF("k", "pt")
+            .writeStream
+            .option("checkpointLocation", checkpointDir.getCanonicalPath)
+            .foreachBatch {
+              (batch: Dataset[Row], _: Long) =>
+                batch.write.format("paimon").mode("append").save(location)
+            }
+            .start()
+
+          val query = () => spark.sql("SELECT * FROM T")
+
+          try {
+            // snapshot-1
+            inputData.addData(("a", "2024-06-01"))
+            stream.processAllAvailable()
+
+            // snapshot-2
+            inputData.addData(("b", "2024-06-02"))
+            stream.processAllAvailable()
+
+            // snapshot-3
+            inputData.addData(("c", "2024-06-03"))
+            stream.processAllAvailable()
+
+            // This partition never expires.
+            inputData.addData(("Never-expire", "9999-09-09"))
+            stream.processAllAvailable()
+
+            checkAnswer(
+              query(),
+              Row("a", "2024-06-01") :: Row("b", "2024-06-02") :: Row("c", "2024-06-03") :: Row(
+                "Never-expire",
+                "9999-09-09") :: Nil)
+
+            // set conf in options.
+            checkAnswer(
+              spark.sql(
+                "CALL paimon.sys.expire_partitions(table => 'test.T', " +
+                  "options => 'partition.expiration-time = 1d," +
+                  " partition.expiration-max-num = 2," +
+                  " partition.timestamp-formatter = yyyy-MM-dd')"),
               Row("pt=2024-06-01") :: Row("pt=2024-06-02") :: Nil
             )
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedureTest.scala
@@ -278,7 +278,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
     fileIO.writeFile(orphanFile2, "b", true)
 
     checkAnswer(
-      spark.sql("CALL paimon.sys.expire_snapshots(table => 'T', retain_max => 1)"),
+      spark.sql("CALL paimon.sys.expire_snapshots(table => 'T', retain_max => 1, retain_min => 1)"),
       Row(2) :: Nil)
 
     val older_than1 = new java.sql.Timestamp(

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
@@ -379,7 +379,7 @@ abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
     Assertions.assertEquals(2, statsFileCount(tableLocation, fileIO))
 
     // test expire statistic
-    spark.sql("CALL sys.expire_snapshots(table => 'test.T', retain_max => 1)")
+    spark.sql("CALL sys.expire_snapshots(table => 'test.T', retain_max => 1, retain_min => 1)")
     Assertions.assertEquals(1, statsFileCount(tableLocation, fileIO))
 
     val orphanStats = new Path(tableLocation, "statistics/stats-orphan-0")


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
If the table property have related properties, we do not need to configure them separately in procedure, unify them for expire_partitions and expire_snapshots.

1. Properties loading priority: procedure param > options param > table properties.
2. Add 'options' parameter for some procedures, we can control some behaviors, such as manifest merge.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
