### PR TITLE
[spark] Paimon parser only resolve own supported procedures

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkProcedures.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkProcedures.java
@@ -48,6 +48,7 @@ import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /** The {@link Procedure}s including all the stored procedures. */
@@ -60,6 +61,10 @@ public class SparkProcedures {
     public static ProcedureBuilder newBuilder(String name) {
         Supplier<ProcedureBuilder> builderSupplier = BUILDERS.get(name.toLowerCase(Locale.ROOT));
         return builderSupplier != null ? builderSupplier.get() : null;
+    }
+
+    public static Set<String> names() {
+        return BUILDERS.keySet();
     }
 
     private static Map<String, Supplier<ProcedureBuilder>> initProcedureBuilders() {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/ProcedureTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/ProcedureTestBase.scala
@@ -32,7 +32,7 @@ abstract class ProcedureTestBase extends PaimonSparkTestBase {
                  |""".stripMargin)
 
     assertThatThrownBy(() => spark.sql("CALL sys.unknown_procedure(table => 'test.T')"))
-      .isInstanceOf(classOf[NoSuchProcedureException])
+      .isInstanceOf(classOf[ParseException])
   }
 
   test(s"test parse exception") {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/ProcedureTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/ProcedureTestBase.scala
@@ -19,8 +19,8 @@
 package org.apache.paimon.spark.procedure
 
 import org.apache.paimon.spark.PaimonSparkTestBase
-import org.apache.paimon.spark.analysis.NoSuchProcedureException
 
+import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.parser.extensions.PaimonParseException
 import org.assertj.core.api.Assertions.assertThatThrownBy
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Spark allows users to configure multiple extensions and each extension is allowed to inject its own SQL parser, conflicts maybe occur if multiple extensions support the`call` command. We know that the `SYSTEM_DATABASE_NAME` of  all paimon procedures are `sys`, so only parsing supported procedures in paimon.

Also, support ``call catalog.`sys`.`rollback` procedure`` with backticks.

like iceberg https://github.com/apache/iceberg/pull/11480

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
