### PR TITLE
[core] Introduce timeout for commit retry avoid long time loop

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -135,6 +135,12 @@ under the License.
             <td>Maximum number of retries when commit failed.</td>
         </tr>
         <tr>
+            <td><h5>commit.max-timeout</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>Max timeout duration of retry when commit failed.</td>
+        </tr>
+        <tr>
             <td><h5>commit.user-prefix</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -138,7 +138,7 @@ under the License.
             <td><h5>commit.timeout</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
-            <td>Max timeout duration of retry when commit failed.</td>
+            <td>Timeout duration of retry when commit failed.</td>
         </tr>
         <tr>
             <td><h5>commit.user-prefix</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -135,7 +135,7 @@ under the License.
             <td>Maximum number of retries when commit failed.</td>
         </tr>
         <tr>
-            <td><h5>commit.max-timeout</h5></td>
+            <td><h5>commit.timeout</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
             <td>Max timeout duration of retry when commit failed.</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -528,7 +528,7 @@ public class CoreOptions implements Serializable {
                     .withDescription("Whether to force a compaction before commit.");
 
     public static final ConfigOption<Duration> COMMIT_MAX_TIMEOUT =
-            key("commit.max-timeout")
+            key("commit.timeout")
                     .durationType()
                     .noDefaultValue()
                     .withDescription("Max timeout duration of retry when commit failed.");

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -527,6 +527,12 @@ public class CoreOptions implements Serializable {
                     .defaultValue(false)
                     .withDescription("Whether to force a compaction before commit.");
 
+    public static final ConfigOption<Duration> COMMIT_MAX_TIMEOUT =
+            key("commit.max-timeout")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription("Max timeout duration of retry when commit failed.");
+
     public static final ConfigOption<Integer> COMMIT_MAX_RETRIES =
             key("commit.max-retries")
                     .intType()
@@ -1927,6 +1933,10 @@ public class CoreOptions implements Serializable {
 
     public boolean commitForceCompact() {
         return options.get(COMMIT_FORCE_COMPACT);
+    }
+
+    public Optional<Duration> commitMaxTimeout() {
+        return options.getOptional(COMMIT_MAX_TIMEOUT);
     }
 
     public int commitMaxRetries() {

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1935,8 +1935,8 @@ public class CoreOptions implements Serializable {
         return options.get(COMMIT_FORCE_COMPACT);
     }
 
-    public Optional<Duration> commitMaxTimeout() {
-        return options.getOptional(COMMIT_MAX_TIMEOUT);
+    public Duration commitMaxTimeout() {
+        return options.get(COMMIT_MAX_TIMEOUT);
     }
 
     public int commitMaxRetries() {

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1935,8 +1935,10 @@ public class CoreOptions implements Serializable {
         return options.get(COMMIT_FORCE_COMPACT);
     }
 
-    public Duration commitMaxTimeout() {
-        return options.get(COMMIT_MAX_TIMEOUT);
+    public long commitMaxTimeout() {
+        return options.get(COMMIT_MAX_TIMEOUT) == null
+                ? Long.MAX_VALUE
+                : options.get(COMMIT_MAX_TIMEOUT).toMillis();
     }
 
     public int commitMaxRetries() {

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -531,7 +531,7 @@ public class CoreOptions implements Serializable {
             key("commit.timeout")
                     .durationType()
                     .noDefaultValue()
-                    .withDescription("Max timeout duration of retry when commit failed.");
+                    .withDescription("Timeout duration of retry when commit failed.");
 
     public static final ConfigOption<Integer> COMMIT_MAX_RETRIES =
             key("commit.max-retries")

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1935,7 +1935,7 @@ public class CoreOptions implements Serializable {
         return options.get(COMMIT_FORCE_COMPACT);
     }
 
-    public long commitMaxTimeout() {
+    public long commitTimeout() {
         return options.get(COMMIT_MAX_TIMEOUT) == null
                 ? Long.MAX_VALUE
                 : options.get(COMMIT_MAX_TIMEOUT).toMillis();

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -527,7 +527,7 @@ public class CoreOptions implements Serializable {
                     .defaultValue(false)
                     .withDescription("Whether to force a compaction before commit.");
 
-    public static final ConfigOption<Duration> COMMIT_MAX_TIMEOUT =
+    public static final ConfigOption<Duration> COMMIT_TIMEOUT =
             key("commit.timeout")
                     .durationType()
                     .noDefaultValue()
@@ -1936,9 +1936,9 @@ public class CoreOptions implements Serializable {
     }
 
     public long commitTimeout() {
-        return options.get(COMMIT_MAX_TIMEOUT) == null
+        return options.get(COMMIT_TIMEOUT) == null
                 ? Long.MAX_VALUE
-                : options.get(COMMIT_MAX_TIMEOUT).toMillis();
+                : options.get(COMMIT_TIMEOUT).toMillis();
     }
 
     public int commitMaxRetries() {

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -238,7 +238,7 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 options.scanManifestParallelism(),
                 callbacks,
                 options.commitMaxRetries(),
-                options.commitMaxTimeout());
+                options.commitTimeout());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -237,7 +237,8 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 bucketMode(),
                 options.scanManifestParallelism(),
                 callbacks,
-                options.commitMaxRetries());
+                options.commitMaxRetries(),
+                options.commitMaxTimeout());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -750,7 +750,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             }
 
             retryResult = (RetryResult) result;
-            retryCount++;
+
 
             if ((commitMaxTimeout != null
                             && System.currentTimeMillis() - startMillis
@@ -762,6 +762,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                                 "Commit failed after %s millis with %s retries, there maybe exist commit conflicts between multiple jobs.",
                                 commitMaxTimeout.toMillis(), retryCount));
             }
+
+            retryCount++;
         }
         return retryCount + 1;
     }
@@ -1067,7 +1069,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 break;
             }
 
-            retryCount++;
+
 
             if ((commitMaxTimeout != null
                             && System.currentTimeMillis() - startMillis
@@ -1079,6 +1081,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                                 "Commit failed after %s millis with %s retries, there maybe exist commit conflicts between multiple jobs.",
                                 commitMaxTimeout.toMillis(), retryCount));
             }
+            
+            retryCount++;
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -134,7 +134,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
     private final List<CommitCallback> commitCallbacks;
     private final StatsFileHandler statsFileHandler;
     private final BucketMode bucketMode;
-    @Nullable private long commitTimeout;
+    private long commitTimeout;
     private final int commitMaxRetries;
 
     @Nullable private Lock lock;
@@ -168,7 +168,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             @Nullable Integer manifestReadParallelism,
             List<CommitCallback> commitCallbacks,
             int commitMaxRetries,
-            @Nullable long commitTimeout) {
+            long commitTimeout) {
         this.fileIO = fileIO;
         this.schemaManager = schemaManager;
         this.tableName = tableName;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -1085,7 +1085,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
             if (commitMaxTimeout.isPresent()
                     && System.currentTimeMillis() - startMillis
-                    > commitMaxTimeout.get().toMillis()) {
+                            > commitMaxTimeout.get().toMillis()) {
                 retryResult.cleanAll();
                 throw new RuntimeException(
                         String.format(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -751,7 +751,6 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
             retryResult = (RetryResult) result;
 
-
             if ((commitMaxTimeout != null
                             && System.currentTimeMillis() - startMillis
                                     > commitMaxTimeout.toMillis())
@@ -1069,8 +1068,6 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 break;
             }
 
-
-
             if ((commitMaxTimeout != null
                             && System.currentTimeMillis() - startMillis
                                     > commitMaxTimeout.toMillis())
@@ -1081,7 +1078,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                                 "Commit failed after %s millis with %s retries, there maybe exist commit conflicts between multiple jobs.",
                                 commitMaxTimeout.toMillis(), retryCount));
             }
-            
+
             retryCount++;
         }
     }

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -74,7 +74,7 @@ This file is based on the checkstyle file of Apache Beam.
 	-->
 
 	<module name="FileLength">
-		<property name="max" value="3000"/>
+		<property name="max" value="4000"/>
 	</module>
 
 	<!-- All Java AST specific tests live under TreeWalker module. -->


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
1. When execute drop partition or expire partition with large numbers partitions(eg: table with large number of files and stream job with 1 min ckp), would block batch job for overwrite in a long time loop,  so add a timeout option for commit retry, user can quick get job result in a specific timeout to handle their batch job(which can adjust ckp time interval or stop stream job to finish their batch job). 
2. FileLength change to 4000 for CoreOption lines was near 3000 which would block code compile.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
