### PR TITLE
[hive] Make HiveMetastoreClient.addPartition thread safe

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/metastore/AddPartitionCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/AddPartitionCommitCallback.java
@@ -72,20 +72,6 @@ public class AddPartitionCommitCallback implements CommitCallback {
         addPartitions(partitions);
     }
 
-    private void addPartition(BinaryRow partition) {
-        try {
-            boolean added = cache.get(partition, () -> false);
-            if (added) {
-                return;
-            }
-
-            client.addPartition(partition);
-            cache.put(partition, true);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     private void addPartitions(Set<BinaryRow> partitions) {
         try {
             List<BinaryRow> newPartitions = new ArrayList<>();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
We can catch `AlreadyExistsException` to support automatic partition addition. Otherwise, adding partitions for multiple jobs together may cause exceptions.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
