### PR TITLE
[hotfix] Fix flaky test of orc tests in ArrowBatchConverterTest

### DIFF
--- a/paimon-arrow/src/test/java/org/apache/paimon/arrow/converter/ArrowBatchConverterTest.java
+++ b/paimon-arrow/src/test/java/org/apache/paimon/arrow/converter/ArrowBatchConverterTest.java
@@ -910,8 +910,9 @@ public class ArrowBatchConverterTest {
 
     private Object[] randomRowValues(boolean[] nullable) {
         Object[] values = new Object[18];
-        values[0] = BinaryString.fromString(StringUtils.getRandomString(RND, 10, 10));
-        values[1] = BinaryString.fromString(StringUtils.getRandomString(RND, 1, 20));
+        // The orc char reader will trim the string. See TreeReaderFactory.CharTreeReader
+        values[0] = BinaryString.fromString(StringUtils.getRandomString(RND, 9, 9) + "A");
+        values[1] = BinaryString.fromString(StringUtils.getRandomString(RND, 1, 19) + "A");
         values[2] = RND.nextBoolean();
         values[3] = randomBytes(10, 10);
         values[4] = randomBytes(1, 20);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The orc char reader will trim the string which make the tests assumption wrong.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
