### PR TITLE
[core] Introduce CacheStats and expose ScanStats

### DIFF
--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -30,7 +30,7 @@ under the License.
             <td><h5>cache-enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
-            <td>Controls whether the catalog will cache databases, tables and manifests.</td>
+            <td>Controls whether the catalog will cache databases, tables, manifests and partitions.</td>
         </tr>
         <tr>
             <td><h5>cache.expiration-interval</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -87,7 +87,7 @@ public class CatalogOptions {
                     .booleanType()
                     .defaultValue(true)
                     .withDescription(
-                            "Controls whether the catalog will cache databases, tables and manifests.");
+                            "Controls whether the catalog will cache databases, tables, manifests and partitions.");
 
     public static final ConfigOption<Duration> CACHE_EXPIRATION_INTERVAL_MS =
             key("cache.expiration-interval")

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -31,7 +31,6 @@ import org.apache.paimon.manifest.ManifestFile;
 import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.manifest.SimpleFileEntry;
-import org.apache.paimon.operation.metrics.CacheMetrics;
 import org.apache.paimon.operation.metrics.ScanMetrics;
 import org.apache.paimon.operation.metrics.ScanStats;
 import org.apache.paimon.partition.PartitionPredicate;
@@ -426,11 +425,11 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
             ManifestFileMeta manifest,
             @Nullable Filter<InternalRow> additionalFilter,
             @Nullable Filter<ManifestEntry> additionalTFilter) {
-        CacheMetrics cacheMetrics = scanMetrics != null ? new CacheMetrics() : null;
         List<ManifestEntry> entries =
                 manifestFileFactory
                         .create()
-                        .withCacheMetrics(cacheMetrics)
+                        .withCacheMetrics(
+                                scanMetrics != null ? scanMetrics.getCacheMetrics() : null)
                         .read(
                                 manifest.fileName(),
                                 manifest.fileSize(),
@@ -447,9 +446,6 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
                 copied.add(dropStats(entry));
             }
             entries = copied;
-        }
-        if (scanMetrics != null) {
-            scanMetrics.reportCache(cacheMetrics);
         }
         return entries;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/CacheMetrics.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/CacheMetrics.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.operation.metrics;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/** Metrics for manifest file cache of a caching catalog. */
+public class CacheMetrics {
+
+    private final AtomicLong hitObject;
+    private final AtomicLong missedObject;
+
+    public CacheMetrics() {
+        this.hitObject = new AtomicLong(0);
+        this.missedObject = new AtomicLong(0);
+    }
+
+    public AtomicLong getHitObject() {
+        return hitObject;
+    }
+
+    public void increaseHitObject() {
+        this.hitObject.incrementAndGet();
+    }
+
+    public AtomicLong getMissedObject() {
+        return missedObject;
+    }
+
+    public void increaseMissedObject() {
+        this.missedObject.incrementAndGet();
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanMetrics.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanMetrics.java
@@ -30,9 +30,14 @@ public class ScanMetrics {
     public static final String GROUP_NAME = "scan";
 
     private final MetricGroup metricGroup;
+    private Histogram durationHistogram;
+
+    private ScanStats latestScan;
+    private CacheMetrics cacheMetrics;
 
     public ScanMetrics(MetricRegistry registry, String tableName) {
         this.metricGroup = registry.tableMetricGroup(GROUP_NAME, tableName);
+        this.cacheMetrics = new CacheMetrics();
         registerGenericScanMetrics();
     }
 
@@ -41,17 +46,13 @@ public class ScanMetrics {
         return metricGroup;
     }
 
-    private Histogram durationHistogram;
-
-    private ScanStats latestScan;
-
     public static final String LAST_SCAN_DURATION = "lastScanDuration";
     public static final String SCAN_DURATION = "scanDuration";
     public static final String LAST_SCANNED_MANIFESTS = "lastScannedManifests";
-
     public static final String LAST_SCAN_SKIPPED_TABLE_FILES = "lastScanSkippedTableFiles";
-
     public static final String LAST_SCAN_RESULTED_TABLE_FILES = "lastScanResultedTableFiles";
+    public static final String MANIFEST_HIT_CACHE = "manifestHitCache";
+    public static final String MANIFEST_MISSED_CACHE = "manifestMissedCache";
 
     private void registerGenericScanMetrics() {
         metricGroup.gauge(
@@ -66,10 +67,25 @@ public class ScanMetrics {
         metricGroup.gauge(
                 LAST_SCAN_RESULTED_TABLE_FILES,
                 () -> latestScan == null ? 0L : latestScan.getResultedTableFiles());
+        metricGroup.gauge(
+                MANIFEST_HIT_CACHE,
+                () -> cacheMetrics == null ? 0L : cacheMetrics.getHitObject().get());
+        metricGroup.gauge(
+                MANIFEST_MISSED_CACHE,
+                () -> cacheMetrics == null ? 0L : cacheMetrics.getMissedObject().get());
     }
 
     public void reportScan(ScanStats scanStats) {
         latestScan = scanStats;
         durationHistogram.update(scanStats.getDuration());
+    }
+
+    public void reportCache(CacheMetrics cacheMetrics) {
+        this.cacheMetrics = cacheMetrics;
+    }
+
+    @VisibleForTesting
+    public CacheMetrics getCacheMetrics() {
+        return cacheMetrics;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanMetrics.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanMetrics.java
@@ -80,11 +80,6 @@ public class ScanMetrics {
         durationHistogram.update(scanStats.getDuration());
     }
 
-    public void reportCache(CacheMetrics cacheMetrics) {
-        this.cacheMetrics = cacheMetrics;
-    }
-
-    @VisibleForTesting
     public CacheMetrics getCacheMetrics() {
         return cacheMetrics;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ObjectsFile.java
@@ -25,6 +25,7 @@ import org.apache.paimon.format.FormatWriterFactory;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.operation.metrics.CacheMetrics;
 import org.apache.paimon.types.RowType;
 
 import javax.annotation.Nullable;
@@ -206,5 +207,12 @@ public class ObjectsFile<T> implements SimpleFileReader<T> {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public ObjectsFile<T> withCacheMetrics(CacheMetrics cacheMetrics) {
+        if (cache != null) {
+            cache.withCacheMetrics(cacheMetrics);
+        }
+        return this;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SegmentsCache.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SegmentsCache.java
@@ -90,4 +90,14 @@ public class SegmentsCache<T> {
 
         return new SegmentsCache<>(pageSize, maxMemorySize, maxElementSize);
     }
+
+    public long getSegmentCacheSize() {
+        return cache.estimatedSize();
+    }
+
+    public long getSegmentCacheBytes() {
+        return cache.asMap().entrySet().stream()
+                .mapToLong(entry -> weigh(entry.getKey(), entry.getValue()))
+                .sum();
+    }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/metrics/MetricGroupTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/metrics/MetricGroupTest.java
@@ -24,12 +24,12 @@ import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Tests for the {@link MetricRegistryImpl}. */
-public class MetricRegistryImplTest {
+/** Tests for the {@link MetricGroup}. */
+public class MetricGroupTest {
 
     @Test
     public void testGroupRegisterMetrics() {
-        MetricRegistryImpl registry = new MetricRegistryImpl();
+        TestMetricRegistry registry = new TestMetricRegistry();
         MetricGroup group = registry.tableMetricGroup("commit", "myTable");
 
         // these will fail is the registration is propagated
@@ -50,7 +50,7 @@ public class MetricRegistryImplTest {
     @Test
     public void testTolerateMetricNameCollisions() {
         final String name = "abctestname";
-        MetricRegistryImpl registry = new MetricRegistryImpl();
+        TestMetricRegistry registry = new TestMetricRegistry();
         MetricGroup group = registry.tableMetricGroup("commit", "myTable");
 
         Counter counter = group.counter(name);

--- a/paimon-core/src/test/java/org/apache/paimon/metrics/TestMetricRegistry.java
+++ b/paimon-core/src/test/java/org/apache/paimon/metrics/TestMetricRegistry.java
@@ -20,8 +20,8 @@ package org.apache.paimon.metrics;
 
 import java.util.Map;
 
-/** Default implementation of {@link MetricRegistry}. */
-public class MetricRegistryImpl extends MetricRegistry {
+/** Implementation of {@link MetricRegistry} for tests. */
+public class TestMetricRegistry extends MetricRegistry {
 
     @Override
     protected MetricGroup createMetricGroup(String groupName, Map<String, String> variables) {

--- a/paimon-core/src/test/java/org/apache/paimon/operation/metrics/CommitMetricsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/metrics/CommitMetricsTest.java
@@ -23,7 +23,7 @@ import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.metrics.Gauge;
 import org.apache.paimon.metrics.Histogram;
 import org.apache.paimon.metrics.Metric;
-import org.apache.paimon.metrics.MetricRegistryImpl;
+import org.apache.paimon.metrics.TestMetricRegistry;
 
 import org.junit.jupiter.api.Test;
 
@@ -234,6 +234,6 @@ public class CommitMetricsTest {
     }
 
     private CommitMetrics getCommitMetrics() {
-        return new CommitMetrics(new MetricRegistryImpl(), TABLE_NAME);
+        return new CommitMetrics(new TestMetricRegistry(), TABLE_NAME);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/metrics/CompactionMetricsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/metrics/CompactionMetricsTest.java
@@ -22,7 +22,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.metrics.Counter;
 import org.apache.paimon.metrics.Gauge;
 import org.apache.paimon.metrics.Metric;
-import org.apache.paimon.metrics.MetricRegistryImpl;
+import org.apache.paimon.metrics.TestMetricRegistry;
 
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +33,7 @@ public class CompactionMetricsTest {
 
     @Test
     public void testReportMetrics() {
-        CompactionMetrics metrics = new CompactionMetrics(new MetricRegistryImpl(), "myTable");
+        CompactionMetrics metrics = new CompactionMetrics(new TestMetricRegistry(), "myTable");
         assertThat(getMetric(metrics, CompactionMetrics.MAX_LEVEL0_FILE_COUNT)).isEqualTo(-1L);
         assertThat(getMetric(metrics, CompactionMetrics.AVG_LEVEL0_FILE_COUNT)).isEqualTo(-1.0);
         assertThat(getMetric(metrics, CompactionMetrics.COMPACTION_THREAD_BUSY)).isEqualTo(0.0);

--- a/paimon-core/src/test/java/org/apache/paimon/operation/metrics/ScanMetricsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/metrics/ScanMetricsTest.java
@@ -22,7 +22,7 @@ import org.apache.paimon.metrics.Gauge;
 import org.apache.paimon.metrics.Histogram;
 import org.apache.paimon.metrics.Metric;
 import org.apache.paimon.metrics.MetricGroup;
-import org.apache.paimon.metrics.MetricRegistryImpl;
+import org.apache.paimon.metrics.TestMetricRegistry;
 
 import org.junit.jupiter.api.Test;
 
@@ -48,7 +48,9 @@ public class ScanMetricsTest {
                         ScanMetrics.SCAN_DURATION,
                         ScanMetrics.LAST_SCANNED_MANIFESTS,
                         ScanMetrics.LAST_SCAN_SKIPPED_TABLE_FILES,
-                        ScanMetrics.LAST_SCAN_RESULTED_TABLE_FILES);
+                        ScanMetrics.LAST_SCAN_RESULTED_TABLE_FILES,
+                        ScanMetrics.MANIFEST_HIT_CACHE,
+                        ScanMetrics.MANIFEST_MISSED_CACHE);
     }
 
     /** Tests that the metrics are updated properly. */
@@ -124,6 +126,6 @@ public class ScanMetricsTest {
     }
 
     private ScanMetrics getScanMetrics() {
-        return new ScanMetrics(new MetricRegistryImpl(), TABLE_NAME);
+        return new ScanMetrics(new TestMetricRegistry(), TABLE_NAME);
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

Add CacheSizes for CachingCatalog and CacheMetrics for ObjectCache so that engine can get cache stats at query level.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
added

### API and Format

<!-- Does this change affect API or storage format -->
CachingCatalog.estimatedCacheSizes
ScanMetrics.getLatestScan
ScanMetrics.getCacheMetrics

### Documentation

<!-- Does this change introduce a new feature -->
added
