### PR TITLE
[hotfix] CloneAction throw more clear exception when no table in source catalog

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/CloneSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/CloneSourceBuilder.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.Preconditions.checkState;
 
 /**
  * Pick the tables to be cloned based on the user input parameters. The record type of the build
@@ -113,6 +114,8 @@ public class CloneSourceBuilder {
                     new Tuple2<>(
                             database + "." + tableName, targetDatabase + "." + targetTableName));
         }
+
+        checkState(!result.isEmpty(), "Didn't find any table in source catalog.");
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("The clone identifiers of source table and target table are: {}", result);


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
env.fromCollection will throw `Collection must not be null` which is confusing.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
