### PR TITLE
[core] Support file index filter push down

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexFilterFallbackPredicateVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexFilterFallbackPredicateVisitor.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex;
+
+import org.apache.paimon.predicate.CompoundPredicate;
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.LeafPredicate;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateVisitor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/** Visit the predicate and extract the file index fallback predicate. */
+public class FileIndexFilterFallbackPredicateVisitor
+        implements PredicateVisitor<Optional<Predicate>> {
+
+    private final Set<FieldRef> fields;
+
+    public FileIndexFilterFallbackPredicateVisitor(Set<FieldRef> fields) {
+        this.fields = fields;
+    }
+
+    @Override
+    public Optional<Predicate> visit(LeafPredicate predicate) {
+        if (fields.contains(predicate.fieldRef())) {
+            return Optional.empty();
+        }
+        return Optional.of(predicate);
+    }
+
+    @Override
+    public Optional<Predicate> visit(CompoundPredicate predicate) {
+        List<Predicate> converted = new ArrayList<>();
+        for (Predicate child : predicate.children()) {
+            child.visit(this).ifPresent(converted::add);
+        }
+        if (converted.isEmpty()) {
+            return Optional.empty();
+        }
+        if (converted.size() == 1) {
+            return Optional.of(converted.get(0));
+        }
+        return Optional.of(new CompoundPredicate(predicate.function(), converted));
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexFilterPushDownAnalyzer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexFilterPushDownAnalyzer.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex;
+
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.FunctionVisitor;
+
+import java.util.List;
+
+/** Visit the predicate and check if file index can be filter push down. */
+public abstract class FileIndexFilterPushDownAnalyzer implements FunctionVisitor<Boolean> {
+
+    @Override
+    public Boolean visitIsNotNull(FieldRef fieldRef) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitIsNull(FieldRef fieldRef) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitStartsWith(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitEndsWith(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitContains(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitLessThan(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitGreaterOrEqual(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitNotEqual(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitLessOrEqual(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitEqual(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitGreaterThan(FieldRef fieldRef, Object literal) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitIn(FieldRef fieldRef, List<Object> literals) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitNotIn(FieldRef fieldRef, List<Object> literals) {
+        return false;
+    }
+
+    @Override
+    public Boolean visitAnd(List<Boolean> children) {
+        throw new UnsupportedOperationException("Should not invoke this");
+    }
+
+    @Override
+    public Boolean visitOr(List<Boolean> children) {
+        throw new UnsupportedOperationException("Should not invoke this");
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexFilterPushDownVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexFilterPushDownVisitor.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex;
+
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.predicate.CompoundPredicate;
+import org.apache.paimon.predicate.LeafPredicate;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateVisitor;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/** Visit the predicate and check if index can push down the predicate. */
+public class FileIndexFilterPushDownVisitor implements PredicateVisitor<Boolean> {
+
+    private final Map<String, List<FileIndexFilterPushDownAnalyzer>> analyzers;
+
+    public FileIndexFilterPushDownVisitor() {
+        this(Collections.emptyMap());
+    }
+
+    public FileIndexFilterPushDownVisitor(
+            Map<String, List<FileIndexFilterPushDownAnalyzer>> analyzers) {
+        this.analyzers = analyzers;
+    }
+
+    @Override
+    public Boolean visit(LeafPredicate predicate) {
+        List<FileIndexFilterPushDownAnalyzer> analyzers =
+                this.analyzers.getOrDefault(predicate.fieldName(), Collections.emptyList());
+        for (FileIndexFilterPushDownAnalyzer analyzer : analyzers) {
+            if (analyzer.visit(predicate)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Boolean visit(CompoundPredicate predicate) {
+        for (Predicate child : predicate.children()) {
+            Boolean matched = child.visit(this);
+            if (!matched) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @VisibleForTesting
+    public Map<String, List<FileIndexFilterPushDownAnalyzer>> getAnalyzers() {
+        return analyzers;
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexResult.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexResult.java
@@ -18,6 +18,11 @@
 
 package org.apache.paimon.fileindex;
 
+import org.apache.paimon.predicate.FieldRef;
+
+import java.util.Collections;
+import java.util.Set;
+
 /** File index result to decide whether filter a file. */
 public interface FileIndexResult {
 
@@ -58,6 +63,10 @@ public interface FileIndexResult {
             };
 
     boolean remain();
+
+    default Set<FieldRef> applyIndexes() {
+        return Collections.emptySet();
+    }
 
     default FileIndexResult and(FileIndexResult fileIndexResult) {
         if (fileIndexResult.remain()) {

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexer.java
@@ -34,6 +34,8 @@ public interface FileIndexer {
 
     FileIndexReader createReader(SeekableInputStream inputStream, int start, int length);
 
+    FileIndexFilterPushDownAnalyzer createFilterPushDownAnalyzer();
+
     static FileIndexer create(String type, DataType dataType, Options options) {
         FileIndexerFactory fileIndexerFactory = FileIndexerFactoryUtils.load(type);
         return fileIndexerFactory.create(dataType, options);

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bloomfilter/BloomFilterFileIndex.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bloomfilter/BloomFilterFileIndex.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.fileindex.bloomfilter;
 
+import org.apache.paimon.fileindex.FileIndexFilterPushDownAnalyzer;
 import org.apache.paimon.fileindex.FileIndexReader;
 import org.apache.paimon.fileindex.FileIndexResult;
 import org.apache.paimon.fileindex.FileIndexWriter;
@@ -80,6 +81,11 @@ public class BloomFilterFileIndex implements FileIndexer {
         }
     }
 
+    @Override
+    public FileIndexFilterPushDownAnalyzer createFilterPushDownAnalyzer() {
+        return new FilterPushDownAnalyzer();
+    }
+
     private static class Writer extends FileIndexWriter {
 
         private final BloomFilter64 filter;
@@ -133,4 +139,6 @@ public class BloomFilterFileIndex implements FileIndexer {
             return key == null || filter.testHash(hashFunction.hash(key)) ? REMAIN : SKIP;
         }
     }
+
+    private static class FilterPushDownAnalyzer extends FileIndexFilterPushDownAnalyzer {}
 }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
@@ -390,6 +390,20 @@ public class PredicateBuilder {
                 .collect(Collectors.toList());
     }
 
+    public static List<Predicate> trimPredicate(
+            @Nullable List<Predicate> predicates, @Nullable Predicate exclude) {
+        if (predicates == null || predicates.isEmpty() || exclude == null) {
+            return predicates;
+        }
+        List<Predicate> result = new ArrayList<>();
+        for (Predicate predicate : predicates) {
+            if (!predicate.equals(exclude)) {
+                result.add(predicate);
+            }
+        }
+        return result;
+    }
+
     @Nullable
     public static Predicate partition(
             Map<String, String> map, RowType rowType, String defaultPartValue) {

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/FileIndexFilterFallbackPredicateVisitorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/FileIndexFilterFallbackPredicateVisitorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex;
+
+import org.apache.paimon.predicate.CompoundPredicate;
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.LeafPredicate;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link FileIndexFilterFallbackPredicateVisitor}. */
+public class FileIndexFilterFallbackPredicateVisitorTest {
+
+    @Test
+    public void testVisitLeafPredicate() {
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "a", DataTypes.STRING()),
+                                new DataField(1, "b", DataTypes.STRING())));
+        Set<FieldRef> indexFields = Collections.singleton(new FieldRef(0, "a", DataTypes.STRING()));
+        FileIndexFilterFallbackPredicateVisitor visitor =
+                new FileIndexFilterFallbackPredicateVisitor(indexFields);
+
+        Predicate p1 = new PredicateBuilder(rowType).equal(0, "a");
+        Optional<Predicate> r1 = visitor.visit((LeafPredicate) p1);
+        assertThat(r1.isPresent()).isFalse();
+
+        Predicate p2 = new PredicateBuilder(rowType).equal(1, "b");
+        Optional<Predicate> r2 = visitor.visit((LeafPredicate) p2);
+        assertThat(r2).isPresent();
+        assertThat(r2.get()).isEqualTo(p2);
+    }
+
+    @Test
+    public void testVisitCompoundPredicate() {
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "a", DataTypes.INT()),
+                                new DataField(1, "b", DataTypes.STRING()),
+                                new DataField(2, "c", DataTypes.INT())));
+
+        Predicate predicate =
+                PredicateBuilder.and(
+                        new PredicateBuilder(rowType).greaterThan(0, 1),
+                        new PredicateBuilder(rowType).equal(1, "b"),
+                        new PredicateBuilder(rowType).lessThan(2, 2));
+
+        Set<FieldRef> indexFields =
+                new HashSet<>(
+                        Arrays.asList(
+                                new FieldRef(0, "a", DataTypes.INT()),
+                                new FieldRef(2, "c", DataTypes.INT())));
+        FileIndexFilterFallbackPredicateVisitor v1 =
+                new FileIndexFilterFallbackPredicateVisitor(indexFields);
+        Optional<Predicate> r1 = v1.visit((CompoundPredicate) predicate);
+        assertThat(r1).isPresent();
+        assertThat(r1.get()).isEqualTo(new PredicateBuilder(rowType).equal(1, "b"));
+
+        FileIndexFilterFallbackPredicateVisitor v2 =
+                new FileIndexFilterFallbackPredicateVisitor(
+                        new HashSet<>(
+                                Collections.singletonList(new FieldRef(0, "a", DataTypes.INT()))));
+        Optional<Predicate> r2 = v2.visit((CompoundPredicate) predicate);
+        assertThat(r2).isPresent();
+        assertThat(r2.get())
+                .isEqualTo(
+                        PredicateBuilder.and(
+                                new PredicateBuilder(rowType).equal(1, "b"),
+                                new PredicateBuilder(rowType).lessThan(2, 2)));
+
+        FileIndexFilterFallbackPredicateVisitor v3 =
+                new FileIndexFilterFallbackPredicateVisitor(
+                        new HashSet<>(
+                                Arrays.asList(
+                                        new FieldRef(0, "a", DataTypes.INT()),
+                                        new FieldRef(1, "b", DataTypes.STRING()),
+                                        new FieldRef(2, "c", DataTypes.INT()))));
+        Optional<Predicate> r3 = v3.visit((CompoundPredicate) predicate);
+        assertThat(r3.isPresent()).isFalse();
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/FileIndexFilterPushDownVisitorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/FileIndexFilterPushDownVisitorTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.fileindex.bloomfilter.BloomFilterFileIndexFactory;
+import org.apache.paimon.fileindex.bsi.BitSliceIndexBitmapFileIndexFactory;
+import org.apache.paimon.predicate.Equal;
+import org.apache.paimon.predicate.LeafPredicate;
+import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link FileIndexOptions}. */
+public class FileIndexFilterPushDownVisitorTest {
+
+    private RowType rowType;
+    private FileIndexFilterPushDownVisitor visitor;
+
+    @BeforeEach
+    public void setup() {
+        this.rowType =
+                RowType.builder()
+                        .field("a", DataTypes.INT())
+                        .field("b", DataTypes.INT())
+                        .field("c", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING()))
+                        .build();
+        Map<String, String> properties = new HashMap<>();
+        properties.put(
+                FileIndexOptions.FILE_INDEX
+                        + "."
+                        + BloomFilterFileIndexFactory.BLOOM_FILTER
+                        + "."
+                        + CoreOptions.COLUMNS,
+                "a,c[hello]");
+        properties.put(
+                FileIndexOptions.FILE_INDEX
+                        + "."
+                        + BloomFilterFileIndexFactory.BLOOM_FILTER
+                        + "."
+                        + "c[hello].fpp",
+                "200");
+        properties.put(
+                FileIndexOptions.FILE_INDEX
+                        + "."
+                        + BitSliceIndexBitmapFileIndexFactory.BSI_INDEX
+                        + "."
+                        + CoreOptions.COLUMNS,
+                "a,b");
+        FileIndexOptions fileIndexOptions = CoreOptions.fromMap(properties).indexColumnsOptions();
+        this.visitor = fileIndexOptions.createFilterPushDownPredicateVisitor(rowType);
+    }
+
+    @Test
+    public void testCreateFilterPushDownPredicateVisitor() {
+        Map<String, List<FileIndexFilterPushDownAnalyzer>> analyzers = visitor.getAnalyzers();
+        assertThat(analyzers.size()).isEqualTo(3);
+        assertThat(analyzers.get("a").size()).isEqualTo(2);
+        assertThat(analyzers.get("b").size()).isEqualTo(1);
+        assertThat(analyzers.get("c[hello]").size()).isEqualTo(1);
+    }
+
+    @Test
+    public void testVisitLeafPredicate() {
+        // test column a with bloom-filter and bsi index
+        assertThat(visitor.visit((LeafPredicate) new PredicateBuilder(rowType).equal(0, 1)))
+                .isTrue();
+        assertThat(visitor.visit((LeafPredicate) new PredicateBuilder(rowType).lessThan(0, 1)))
+                .isTrue();
+        assertThat(visitor.visit((LeafPredicate) new PredicateBuilder(rowType).greaterThan(0, 1)))
+                .isTrue();
+        assertThat(visitor.visit((LeafPredicate) new PredicateBuilder(rowType).startsWith(0, 1)))
+                .isFalse();
+
+        // test column b with bsi index
+        assertThat(visitor.visit((LeafPredicate) new PredicateBuilder(rowType).equal(1, 1)))
+                .isTrue();
+        assertThat(visitor.visit((LeafPredicate) new PredicateBuilder(rowType).lessThan(1, 1)))
+                .isTrue();
+        assertThat(visitor.visit((LeafPredicate) new PredicateBuilder(rowType).greaterThan(1, 1)))
+                .isTrue();
+        assertThat(visitor.visit((LeafPredicate) new PredicateBuilder(rowType).startsWith(0, 1)))
+                .isFalse();
+
+        // test map column c[hello] with bloom-filter index
+        assertThat(
+                        visitor.visit(
+                                new LeafPredicate(
+                                        Equal.INSTANCE,
+                                        DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING()),
+                                        2,
+                                        "c[hello]",
+                                        Collections.singletonList(BinaryString.fromString("a")))))
+                .isFalse();
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
@@ -277,7 +277,7 @@ public class KeyValueFileReaderFactory implements FileReaderFactory<KeyValue> {
                     finalReadKeyType,
                     readValueType,
                     new BulkFormatMappingBuilder(
-                            formatDiscover, readTableFields, fieldsExtractor, filters),
+                            formatDiscover, readTableFields, fieldsExtractor, filters, null),
                     pathFactory.createDataFilePathFactory(partition, bucket),
                     options.fileReaderAsyncThreshold().getBytes(),
                     partition,

--- a/paimon-core/src/main/java/org/apache/paimon/operation/MergeFileSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/MergeFileSplitRead.java
@@ -240,6 +240,15 @@ public class MergeFileSplitRead implements SplitRead<KeyValue> {
     }
 
     @Override
+    public MergeFileSplitRead withIndexFilter(Predicate predicate) {
+        if (predicate == null) {
+            return this;
+        }
+        throw new UnsupportedOperationException(
+                "index should not be pushed down in the LSM merging reader");
+    }
+
+    @Override
     public RecordReader<KeyValue> createReader(DataSplit split) throws IOException {
         if (!split.beforeFiles().isEmpty()) {
             throw new IllegalArgumentException("This read cannot accept split with before files.");

--- a/paimon-core/src/main/java/org/apache/paimon/operation/SplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/SplitRead.java
@@ -44,6 +44,8 @@ public interface SplitRead<T> {
 
     SplitRead<T> withFilter(@Nullable Predicate predicate);
 
+    SplitRead<T> withIndexFilter(@Nullable Predicate predicate);
+
     /** Create a {@link RecordReader} from split. */
     RecordReader<T> createReader(DataSplit split) throws IOException;
 
@@ -71,6 +73,12 @@ public interface SplitRead<T> {
             @Override
             public SplitRead<R> withFilter(@Nullable Predicate predicate) {
                 read.withFilter(predicate);
+                return this;
+            }
+
+            @Override
+            public SplitRead<R> withIndexFilter(@Nullable Predicate predicate) {
+                read.withIndexFilter(predicate);
                 return this;
             }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
@@ -21,6 +21,7 @@ package org.apache.paimon.table;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.KeyValueFileStore;
+import org.apache.paimon.fileindex.FileIndexFilterPushDownVisitor;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.iceberg.IcebergOptions;
@@ -190,5 +191,15 @@ class PrimaryKeyFileStoreTable extends AbstractFileStoreTable {
         }
 
         return callbacks;
+    }
+
+    @Override
+    public FileIndexFilterPushDownVisitor fileIndexFilterPushDownVisitor() {
+        CoreOptions options = coreOptions();
+        if (options.fileIndexReadEnabled() && options.deletionVectorsEnabled()) {
+            return options.indexColumnsOptions()
+                    .createFilterPushDownPredicateVisitor(schema().logicalRowType());
+        }
+        return super.fileIndexFilterPushDownVisitor();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/Table.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/Table.java
@@ -21,6 +21,7 @@ package org.apache.paimon.table;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.annotation.Experimental;
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.fileindex.FileIndexFilterPushDownVisitor;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFileMeta;
@@ -108,6 +109,12 @@ public interface Table extends Serializable {
     /** Reader to read index manifest entry from index manifest file. */
     @Experimental
     SimpleFileReader<IndexManifestEntry> indexManifestFileReader();
+
+    /** Visitor to check if index can push the predicate down. */
+    @Experimental
+    default FileIndexFilterPushDownVisitor fileIndexFilterPushDownVisitor() {
+        return new FileIndexFilterPushDownVisitor();
+    }
 
     /** Rollback table's state to a specific snapshot. */
     @Experimental

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableRead.java
@@ -36,6 +36,13 @@ public interface InnerTableRead extends TableRead {
 
     InnerTableRead withFilter(Predicate predicate);
 
+    default InnerTableRead withIndexFilter(Predicate predicate) {
+        if (predicate == null) {
+            return this;
+        }
+        throw new UnsupportedOperationException();
+    }
+
     /** Use {@link #withReadType(RowType)} instead. */
     @Deprecated
     default InnerTableRead withProjection(int[] projection) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
@@ -52,6 +52,7 @@ public final class KeyValueTableRead extends AbstractDataTableRead<KeyValue> {
     @Nullable private RowType readType = null;
     private boolean forceKeepDelete = false;
     private Predicate predicate = null;
+    private Predicate indexPredicate = null;
     private IOManager ioManager = null;
 
     public KeyValueTableRead(
@@ -84,6 +85,9 @@ public final class KeyValueTableRead extends AbstractDataTableRead<KeyValue> {
         if (readType != null) {
             read = read.withReadType(readType);
         }
+        if (indexPredicate != null) {
+            read = read.withIndexFilter(indexPredicate);
+        }
         read.withFilter(predicate).withIOManager(ioManager);
     }
 
@@ -104,6 +108,13 @@ public final class KeyValueTableRead extends AbstractDataTableRead<KeyValue> {
     protected InnerTableRead innerWithFilter(Predicate predicate) {
         initialized().forEach(r -> r.withFilter(predicate));
         this.predicate = predicate;
+        return this;
+    }
+
+    @Override
+    public InnerTableRead withIndexFilter(Predicate indexPredicate) {
+        initialized().forEach(r -> r.withIndexFilter(indexPredicate));
+        this.indexPredicate = indexPredicate;
         return this;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
@@ -98,6 +98,11 @@ public interface ReadBuilder extends Serializable {
      */
     ReadBuilder withFilter(Predicate predicate);
 
+    /**
+     * Push index filters, when index is empty, fallback to use it to do filter in reader instead.
+     */
+    ReadBuilder withIndexFilter(Predicate predicate);
+
     /** Push partition filter. */
     ReadBuilder withPartitionFilter(Map<String, String> partitionSpec);
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -40,6 +40,8 @@ public class ReadBuilderImpl implements ReadBuilder {
 
     private Predicate filter;
 
+    private Predicate indexFilter;
+
     private Integer limit = null;
 
     private Integer shardIndexOfThisSubtask;
@@ -78,6 +80,12 @@ public class ReadBuilderImpl implements ReadBuilder {
         } else {
             this.filter = PredicateBuilder.and(this.filter, filter);
         }
+        return this;
+    }
+
+    @Override
+    public ReadBuilder withIndexFilter(Predicate indexFilter) {
+        this.indexFilter = indexFilter;
         return this;
     }
 
@@ -175,6 +183,9 @@ public class ReadBuilderImpl implements ReadBuilder {
         InnerTableRead read = table.newRead().withFilter(filter);
         if (readType != null) {
             read.withReadType(readType);
+        }
+        if (indexFilter != null) {
+            read.withIndexFilter(indexFilter);
         }
         return read;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
@@ -84,6 +84,12 @@ public class IncrementalDiffSplitRead implements SplitRead<InternalRow> {
     }
 
     @Override
+    public SplitRead<InternalRow> withIndexFilter(@Nullable Predicate predicate) {
+        mergeRead.withIndexFilter(predicate);
+        return this;
+    }
+
+    @Override
     public RecordReader<InternalRow> createReader(DataSplit split) throws IOException {
         RecordReader<KeyValue> reader =
                 readDiff(

--- a/paimon-flink/paimon-flink-1.15/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
+++ b/paimon-flink/paimon-flink-1.15/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
@@ -51,6 +51,7 @@ public class DataTableSource extends BaseDataTableSource {
                 null,
                 null,
                 null,
+                null,
                 false);
     }
 
@@ -61,6 +62,7 @@ public class DataTableSource extends BaseDataTableSource {
             DynamicTableFactory.Context context,
             @Nullable LogStoreTableFactory logStoreTableFactory,
             @Nullable Predicate predicate,
+            @Nullable Predicate indexPredicate,
             @Nullable int[][] projectFields,
             @Nullable Long limit,
             @Nullable WatermarkStrategy<RowData> watermarkStrategy,
@@ -72,6 +74,7 @@ public class DataTableSource extends BaseDataTableSource {
                 context,
                 logStoreTableFactory,
                 predicate,
+                indexPredicate,
                 projectFields,
                 limit,
                 watermarkStrategy,
@@ -87,6 +90,7 @@ public class DataTableSource extends BaseDataTableSource {
                 context,
                 logStoreTableFactory,
                 predicate,
+                indexPredicate,
                 projectFields,
                 limit,
                 watermarkStrategy,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupCompactDiffRead.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupCompactDiffRead.java
@@ -73,6 +73,14 @@ public class LookupCompactDiffRead extends AbstractDataTableRead<KeyValue> {
     }
 
     @Override
+    public InnerTableRead withIndexFilter(Predicate indexPredicate) {
+        if (indexPredicate == null) {
+            return this;
+        }
+        throw new UnsupportedOperationException("index should not be pushed down in the lookup");
+    }
+
+    @Override
     public InnerTableRead forceKeepDelete() {
         fullPhaseMergeRead.forceKeepDelete();
         incrementalDiffRead.forceKeepDelete();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
@@ -107,6 +107,7 @@ public abstract class BaseDataTableSource extends FlinkTableSource
             DynamicTableFactory.Context context,
             @Nullable LogStoreTableFactory logStoreTableFactory,
             @Nullable Predicate predicate,
+            @Nullable Predicate indexPredicate,
             @Nullable int[][] projectFields,
             @Nullable Long limit,
             @Nullable WatermarkStrategy<RowData> watermarkStrategy,
@@ -117,6 +118,7 @@ public abstract class BaseDataTableSource extends FlinkTableSource
         this.context = context;
         this.logStoreTableFactory = logStoreTableFactory;
         this.predicate = predicate;
+        this.indexPredicate = indexPredicate;
         this.projectFields = projectFields;
         this.limit = limit;
         this.watermarkStrategy = watermarkStrategy;
@@ -198,6 +200,7 @@ public abstract class BaseDataTableSource extends FlinkTableSource
                         .logSourceProvider(logSourceProvider)
                         .projection(projectFields)
                         .predicate(predicate)
+                        .indexPredicate(indexPredicate)
                         .limit(limit)
                         .watermarkStrategy(watermarkStrategy)
                         .dynamicPartitionFilteringFields(dynamicPartitionFilteringFields());
@@ -321,6 +324,11 @@ public abstract class BaseDataTableSource extends FlinkTableSource
         }
 
         if (aggregateExpressions.size() != 1) {
+            return false;
+        }
+
+        // todo: support apply aggregate by indexes
+        if (indexPredicate != null) {
             return false;
         }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
@@ -70,6 +70,7 @@ public class DataTableSource extends BaseDataTableSource
                 null,
                 null,
                 null,
+                null,
                 false);
     }
 
@@ -80,6 +81,7 @@ public class DataTableSource extends BaseDataTableSource
             DynamicTableFactory.Context context,
             @Nullable LogStoreTableFactory logStoreTableFactory,
             @Nullable Predicate predicate,
+            @Nullable Predicate indexPredicate,
             @Nullable int[][] projectFields,
             @Nullable Long limit,
             @Nullable WatermarkStrategy<RowData> watermarkStrategy,
@@ -92,6 +94,7 @@ public class DataTableSource extends BaseDataTableSource
                 context,
                 logStoreTableFactory,
                 predicate,
+                indexPredicate,
                 projectFields,
                 limit,
                 watermarkStrategy,
@@ -108,6 +111,7 @@ public class DataTableSource extends BaseDataTableSource
                 context,
                 logStoreTableFactory,
                 predicate,
+                indexPredicate,
                 projectFields,
                 limit,
                 watermarkStrategy,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkSourceBuilder.java
@@ -85,6 +85,7 @@ public class FlinkSourceBuilder {
     private StreamExecutionEnvironment env;
     @Nullable private int[][] projectedFields;
     @Nullable private Predicate predicate;
+    @Nullable private Predicate indexPredicate;
     @Nullable private LogSourceProvider logSourceProvider;
     @Nullable private Integer parallelism;
     @Nullable private Long limit;
@@ -133,6 +134,11 @@ public class FlinkSourceBuilder {
         return this;
     }
 
+    public FlinkSourceBuilder indexPredicate(Predicate indexPredicate) {
+        this.indexPredicate = indexPredicate;
+        return this;
+    }
+
     public FlinkSourceBuilder limit(@Nullable Long limit) {
         this.limit = limit;
         return this;
@@ -176,6 +182,9 @@ public class FlinkSourceBuilder {
                 table.newReadBuilder().withProjection(projectedFields).withFilter(predicate);
         if (limit != null) {
             readBuilder.withLimit(limit.intValue());
+        }
+        if (indexPredicate != null) {
+            readBuilder.withIndexFilter(indexPredicate);
         }
         return readBuilder.dropStats();
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/statistics/FileStoreTableStatisticsTestBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/statistics/FileStoreTableStatisticsTestBase.java
@@ -153,6 +153,7 @@ public abstract class FileStoreTableStatisticsTestBase {
                         null,
                         null,
                         null,
+                        null,
                         false);
         Assertions.assertThat(partitionFilterSource.reportStatistics().getRowCount()).isEqualTo(5L);
         Map<String, ColStats<?>> colStatsMap = new HashMap<>();
@@ -232,6 +233,7 @@ public abstract class FileStoreTableStatisticsTestBase {
                         null,
                         null,
                         null,
+                        null,
                         false);
         Assertions.assertThat(keyFilterSource.reportStatistics().getRowCount()).isEqualTo(2L);
         Map<String, ColStats<?>> colStatsMap = new HashMap<>();
@@ -307,6 +309,7 @@ public abstract class FileStoreTableStatisticsTestBase {
                         null,
                         null,
                         builder.greaterThan(2, 500L),
+                        null,
                         null,
                         null,
                         null,

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/statistics/PrimaryKeyTableStatisticsTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/statistics/PrimaryKeyTableStatisticsTest.java
@@ -52,6 +52,7 @@ public class PrimaryKeyTableStatisticsTest extends FileStoreTableStatisticsTestB
                         null,
                         null,
                         null,
+                        null,
                         false);
         Assertions.assertThat(keyFilterSource.reportStatistics().getRowCount()).isEqualTo(9L);
         // TODO validate column statistics


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #4530

The filter will push down if the index matches the predicate, if the index does not exist at runtime, it will fallback to using the paimon predicate filter.

For now, we support bloom-filter/bitmap/bsi index, and the bitmap/bsi index supports filter push down and they will use `ApplyBitmapIndexRecordReader` to filter by position.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
org.apache.paimon.table.AppendOnlyFileStoreTableTest#testFileIndexFilterPushDownFallback
org.apache.paimon.table.PrimaryKeyFileStoreTableTest#testDeletionVectorsWithFileIndexFilterPushDownFallback
org.apache.paimon.flink.source.FilterPushDownITCase#testPartitionAndIndexConditionConsuming

### API and Format

<!-- Does this change affect API or storage format -->
No

### Documentation

<!-- Does this change introduce a new feature -->
No