### PR TITLE
[core] Check file size after write bundle of records

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/io/RollingFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/RollingFileWriter.java
@@ -65,9 +65,9 @@ public class RollingFileWriter<T, R> implements FileWriter<T, List<R>> {
     }
 
     @VisibleForTesting
-    boolean rollingFile() throws IOException {
+    boolean rollingFile(boolean forceCheck) throws IOException {
         return currentWriter.reachTargetSize(
-                recordCount % CHECK_ROLLING_RECORD_CNT == 0, targetFileSize);
+                forceCheck || recordCount % CHECK_ROLLING_RECORD_CNT == 0, targetFileSize);
     }
 
     @Override
@@ -81,7 +81,7 @@ public class RollingFileWriter<T, R> implements FileWriter<T, List<R>> {
             currentWriter.write(row);
             recordCount += 1;
 
-            if (rollingFile()) {
+            if (rollingFile(false)) {
                 closeCurrentWriter();
             }
         } catch (Throwable e) {
@@ -105,7 +105,7 @@ public class RollingFileWriter<T, R> implements FileWriter<T, List<R>> {
             currentWriter.writeBundle(bundle);
             recordCount += bundle.rowCount();
 
-            if (rollingFile()) {
+            if (rollingFile(true)) {
                 closeCurrentWriter();
             }
         } catch (Throwable e) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
If we write bundle, we can't precisely reach the `CHECK_ROLLING_RECORD_CNT`. So we need to force check target file size.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
