### PR TITLE
[spark] Avoid explicitly creating catalog in PaimonTableValuedFunctions

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkGenericCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkGenericCatalog.java
@@ -288,12 +288,6 @@ public class SparkGenericCatalog extends SparkBaseCatalog implements CatalogExte
         Map<String, String> newOptions = new HashMap<>(options.asCaseSensitiveMap());
         fillAliyunConfigurations(newOptions, hadoopConf);
         fillCommonConfigurations(newOptions, sqlConf);
-
-        // if spark is case-insensitive, set allow upper case to catalog
-        if (!sqlConf.caseSensitiveAnalysis()) {
-            newOptions.put(ALLOW_UPPER_CASE.key(), "true");
-        }
-
         return new CaseInsensitiveStringMap(newOptions);
     }
 
@@ -313,13 +307,16 @@ public class SparkGenericCatalog extends SparkBaseCatalog implements CatalogExte
             String warehouse = sqlConf.warehousePath();
             options.put(WAREHOUSE.key(), warehouse);
         }
+
         if (!options.containsKey(METASTORE.key())) {
             String metastore = sqlConf.getConf(StaticSQLConf.CATALOG_IMPLEMENTATION());
             if (HiveCatalogOptions.IDENTIFIER.equals(metastore)) {
                 options.put(METASTORE.key(), metastore);
             }
         }
+
         options.put(CatalogOptions.FORMAT_TABLE_ENABLED.key(), "false");
+
         String sessionCatalogDefaultDatabase = SQLConfUtils.defaultDatabase(sqlConf);
         if (options.containsKey(DEFAULT_DATABASE.key())) {
             String userDefineDefaultDatabase = options.get(DEFAULT_DATABASE.key());
@@ -332,6 +329,11 @@ public class SparkGenericCatalog extends SparkBaseCatalog implements CatalogExte
             }
         } else {
             options.put(DEFAULT_DATABASE.key(), sessionCatalogDefaultDatabase);
+        }
+
+        // if spark is case-insensitive, set allow upper case to catalog
+        if (!sqlConf.caseSensitiveAnalysis()) {
+            options.put(ALLOW_UPPER_CASE.key(), "true");
         }
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Avoid explicitly creating catalog in PaimonTableValuedFunctions,  which will miss some automatic fill configurations

```
Caused by: java.lang.NullPointerException: Paimon 'warehouse' path must be set

        at org.apache.paimon.utils.Preconditions.checkNotNull(Preconditions.java:65)

        at org.apache.paimon.catalog.CatalogFactory.warehouse(CatalogFactory.java:55)

        at org.apache.paimon.catalog.CatalogFactory.createCatalog(CatalogFactory.java:83)

        at org.apache.paimon.catalog.CatalogFactory.createCatalog(CatalogFactory.java:66)

        at org.apache.paimon.spark.SparkCatalog.initialize(SparkCatalog.java:76)

        at org.apache.paimon.spark.catalyst.plans.logical.PaimonTableValuedFunctions$.resolvePaimonTableValuedFunction(PaimonTableValuedFunctions.scala:67)
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
