### PR TITLE
[core] fix the issue where streaming reading of overwrite data would fail when retract type data appeared.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalChangelogReadProvider.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalChangelogReadProvider.java
@@ -60,20 +60,20 @@ public class IncrementalChangelogReadProvider implements SplitReadProvider {
                             ConcatRecordReader.create(
                                     () ->
                                             new ReverseReader(
-                                                    read.createNoMergeReader(
+                                                    read.createMergeReader(
                                                             split.partition(),
                                                             split.bucket(),
                                                             split.beforeFiles(),
                                                             split.beforeDeletionFiles()
                                                                     .orElse(null),
-                                                            true)),
+                                                            false)),
                                     () ->
-                                            read.createNoMergeReader(
+                                            read.createMergeReader(
                                                     split.partition(),
                                                     split.bucket(),
                                                     split.dataFiles(),
                                                     split.deletionFiles().orElse(null),
-                                                    true));
+                                                    false));
                     return unwrap(reader);
                 };
 


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #4696 

<!-- What is the purpose of the change -->
[core] fix the issue where streaming reading of overwrite data would fail when retract type data appeared.

### Tests

<!-- List UT and IT cases to verify this change -->

- org.apache.paimon.flink.ReadWriteTableITCase#testStreamingReadOverwriteWithDeleteRecords

### API and Format

<!-- Does this change affect API or storage format -->
No
### Documentation

<!-- Does this change introduce a new feature -->
No