### PR TITLE
[core] Fix predicate literals cast in filter pushdown after schema evolution

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/casting/CastExecutors.java
+++ b/paimon-common/src/main/java/org/apache/paimon/casting/CastExecutors.java
@@ -18,32 +18,18 @@
 
 package org.apache.paimon.casting;
 
-import org.apache.paimon.data.Decimal;
-import org.apache.paimon.predicate.Equal;
-import org.apache.paimon.predicate.GreaterOrEqual;
-import org.apache.paimon.predicate.GreaterThan;
-import org.apache.paimon.predicate.In;
-import org.apache.paimon.predicate.LeafFunction;
-import org.apache.paimon.predicate.LeafPredicate;
-import org.apache.paimon.predicate.LessOrEqual;
-import org.apache.paimon.predicate.LessThan;
-import org.apache.paimon.predicate.NotEqual;
-import org.apache.paimon.predicate.NotIn;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeFamily;
 import org.apache.paimon.types.DataTypeRoot;
-import org.apache.paimon.types.DecimalType;
 
 import javax.annotation.Nullable;
 
-import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /** Cast executors for input type and output type. */
@@ -116,138 +102,32 @@ public class CastExecutors {
     }
 
     /**
-     * When filter a field witch was evolved from/to a numeric type, we should carefully handle the
-     * precision match and overflow problem.
+     * If a field type is modified, pushing down a filter of it is dangerous. This method tries to
+     * cast the literals of filter to its original type. It only cast the literals when the CastRule
+     * is in whitelist. Otherwise, return Optional.empty().
      */
-    @Nullable
-    public static List<Object> safelyCastLiteralsWithNumericEvolution(
-            LeafPredicate predicate, DataType outputType) {
-        DataType inputType = predicate.type();
+    public static Optional<List<Object>> castLiteralsWithEvolution(
+            List<Object> literals, DataType inputType, DataType outputType) {
         if (inputType.equalsIgnoreNullable(outputType)) {
-            return predicate.literals();
+            return Optional.of(literals);
         }
-
-        List<Object> literals = predicate.literals();
 
         CastRule<?, ?> castRule = INSTANCE.internalResolve(inputType, outputType);
         if (castRule == null) {
-            return literals;
+            return Optional.empty();
         }
 
-        if (castRule instanceof DecimalToDecimalCastRule) {
-            if (((DecimalType) inputType).getPrecision() < ((DecimalType) outputType).getPrecision()
-                    && containsEqualCheck(predicate)) {
-                // For example, alter 111.321 from DECIMAL(6, 3) to DECIMAL(5, 2).
-                // The query result is 111.32 which is truncated from 111.321.
-                // If we query with filter f = 111.32 and push down it, 111.321 will be filtered
-                // out mistakenly.
-                // But if we query with filter f > 111.32, although 111.321 will be retrieved,
-                // the engine will filter out it finally.
-                return null;
-            }
-            // Pushing down higher precision filter is always correct.
-            return literals;
-        } else if (castRule instanceof NumericPrimitiveToDecimalCastRule) {
-            if (inputType.is(DataTypeFamily.INTEGER_NUMERIC) && containsEqualCheck(predicate)) {
-                // the reason is same as DecimalToDecimalCastRule
-                return null;
-            }
-            return literals.stream()
-                    .map(literal -> (Number) literal)
-                    .map(
-                            literal ->
-                                    inputType.is(DataTypeFamily.INTEGER_NUMERIC)
-                                            ? BigDecimal.valueOf(literal.longValue())
-                                            : BigDecimal.valueOf(literal.doubleValue()))
-                    .map(bd -> Decimal.fromBigDecimal(bd, bd.precision(), bd.scale()))
-                    .collect(Collectors.toList());
-        } else if (castRule instanceof DecimalToNumericPrimitiveCastRule) {
-            if (outputType.is(DataTypeFamily.INTEGER_NUMERIC)
-                    && (containsPartialCheck(predicate) || containsNotEqualCheck(predicate))) {
-                // For example, alter 111 from INT to DECIMAL(5, 2). The query result is 111.00
-                // If we query with filter f < 111.01 and push down it as f < 111, 111 will be
-                // filtered out mistakenly. Also, we shouldn't push down f <> 111.01.
-                // But if we query with filter f = 111.01 and push down it as f = 111, although 111
-                // will be retrieved, the engine will filter out it finally.
-                // TODO: maybe we can scale the partial filter. For example, f < 111.01 can be
-                // transfer to f < 112.
-                return null;
-            } else if (outputType.is(DataTypeFamily.APPROXIMATE_NUMERIC)
-                    && containsEqualCheck(predicate)) {
-                // For example, alter 111.321 from DOUBLE to DECIMAL(5, 2). The query result is
-                // 111.32.
-                // If we query with filter f = 111.32 and push down it, 111.321 will be filtered
-                // out mistakenly.
-                // But if we query with filter f > 111.32 or f <> 111.32, although 111.321 will be
-                // retrieved, the engine will filter out it finally.
-                return null;
-            }
-            castLiterals(castRule, inputType, outputType, literals);
-        } else if (castRule instanceof NumericPrimitiveCastRule) {
+        if (castRule instanceof NumericPrimitiveCastRule) {
             if (inputType.is(DataTypeFamily.INTEGER_NUMERIC)
                     && outputType.is(DataTypeFamily.INTEGER_NUMERIC)) {
                 if (integerScaleLargerThan(inputType.getTypeRoot(), outputType.getTypeRoot())) {
                     // Pushing down higher scale integer numeric filter is always correct.
-                    return literals;
+                    return Optional.of(literals);
                 }
             }
-
-            // Pushing down float filter is dangerous because the filter result is unpredictable.
-            // For example, (double) 0.1F in Java is 0.10000000149011612.
-
-            // Pushing down lower scale filter is also dangerous because of overflow.
-            // For example, alter 383 from INT to TINYINT, the query result is (byte) 383 == 127.
-            // If we push down filter f = 127, 383 will be filtered out which is wrong.
-
-            // So we don't push down these filters.
-            return null;
-        } else if (castRule instanceof NumericToStringCastRule
-                || castRule instanceof StringToDecimalCastRule
-                || castRule instanceof StringToNumericPrimitiveCastRule) {
-            // Pushing down filters related to STRING is dangerous because string comparison is
-            // different from number comparison and string literal to number might have precision
-            // and overflow problem.
-            // For example, alter '111' from STRING to INT, the query result is 111.
-            // If we query with filter f > 2 and push down it as f > '2', '111' will be filtered
-            // out mistakenly.
-            return null;
         }
 
-        // Non numeric related cast rule
-        return castLiterals(castRule, inputType, outputType, literals);
-    }
-
-    private static List<Object> castLiterals(
-            CastRule<?, ?> castRule,
-            DataType inputType,
-            DataType outputType,
-            List<Object> literals) {
-        CastExecutor<Object, Objects> castExecutor =
-                (CastExecutor<Object, Objects>) castRule.create(inputType, outputType);
-        return literals.stream()
-                .map(l -> castExecutor == null ? l : castExecutor.cast(l))
-                .collect(Collectors.toList());
-    }
-
-    private static boolean containsEqualCheck(LeafPredicate predicate) {
-        LeafFunction function = predicate.function();
-        return function instanceof In
-                || function instanceof Equal
-                || function instanceof GreaterOrEqual
-                || function instanceof LessOrEqual;
-    }
-
-    private static boolean containsPartialCheck(LeafPredicate predicate) {
-        LeafFunction function = predicate.function();
-        return function instanceof LessThan
-                || function instanceof LessOrEqual
-                || function instanceof GreaterThan
-                || function instanceof GreaterOrEqual;
-    }
-
-    private static boolean containsNotEqualCheck(LeafPredicate predicate) {
-        LeafFunction function = predicate.function();
-        return function instanceof NotIn || function instanceof NotEqual;
+        return Optional.empty();
     }
 
     private static boolean integerScaleLargerThan(DataTypeRoot a, DataTypeRoot b) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
@@ -109,7 +109,9 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
         Predicate dataPredicate =
                 dataFilterMapping.computeIfAbsent(
                         entry.file().schemaId(),
-                        id -> simpleStatsEvolutions.convertFilter(entry.file().schemaId(), filter));
+                        id ->
+                                simpleStatsEvolutions.tryDevolveFilter(
+                                        entry.file().schemaId(), filter));
 
         try (FileIndexPredicate predicate =
                 new FileIndexPredicate(embeddedIndexBytes, dataRowType)) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreScan.java
@@ -158,7 +158,7 @@ public class KeyValueFileStoreScan extends AbstractFileStoreScan {
                     schemaId2DataFilter.computeIfAbsent(
                             entry.file().schemaId(),
                             id ->
-                                    fieldValueStatsConverters.convertFilter(
+                                    fieldValueStatsConverters.tryDevolveFilter(
                                             entry.file().schemaId(), valueFilter));
             return predicate.evaluate(dataPredicate).remain();
         } catch (IOException e) {

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaEvolutionUtil.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaEvolutionUtil.java
@@ -276,8 +276,10 @@ public class SchemaEvolutionUtil {
     }
 
     /**
-     * Create predicate list from data fields. We will visit all predicate in filters, reset it's
-     * field index, name and type, and ignore predicate if the field is not exist.
+     * When pushing down filters after schema evolution, we should devolve the literals from new
+     * types (in dataFields) to original types (in tableFields). We will visit all predicate in
+     * filters, reset its field index, name and type, and ignore predicate if the field is not
+     * exist.
      *
      * @param tableFields the table fields
      * @param dataFields the underlying data fields
@@ -285,7 +287,7 @@ public class SchemaEvolutionUtil {
      * @return the data filters
      */
     @Nullable
-    public static List<Predicate> createDataFilters(
+    public static List<Predicate> devolveDataFilters(
             List<DataField> tableFields, List<DataField> dataFields, List<Predicate> filters) {
         if (filters == null) {
             return null;
@@ -308,29 +310,19 @@ public class SchemaEvolutionUtil {
                         return Optional.empty();
                     }
 
-                    DataType dataValueType = dataField.type().copy(true);
-                    DataType predicateType = predicate.type().copy(true);
-                    CastExecutor<Object, Object> castExecutor =
-                            dataValueType.equals(predicateType)
-                                    ? null
-                                    : (CastExecutor<Object, Object>)
-                                            CastExecutors.resolve(
-                                                    predicate.type(), dataField.type());
-                    // Convert value from predicate type to underlying data type which may lose
-                    // information, for example, convert double value to int. But it doesn't matter
-                    // because it just for predicate push down and the data will be filtered
-                    // correctly after reading.
-                    List<Object> literals =
-                            predicate.literals().stream()
-                                    .map(v -> castExecutor == null ? v : castExecutor.cast(v))
-                                    .collect(Collectors.toList());
-                    return Optional.of(
-                            new LeafPredicate(
-                                    predicate.function(),
-                                    dataField.type(),
-                                    indexOf(dataField, idToDataFields),
-                                    dataField.name(),
-                                    literals));
+                    List<Object> evolvedLiterals =
+                            CastExecutors.safelyCastLiteralsWithNumericEvolution(
+                                    predicate, dataField.type());
+
+                    return evolvedLiterals == null
+                            ? Optional.empty()
+                            : Optional.of(
+                                    new LeafPredicate(
+                                            predicate.function(),
+                                            dataField.type(),
+                                            indexOf(dataField, idToDataFields),
+                                            dataField.name(),
+                                            evolvedLiterals));
                 };
 
         for (Predicate predicate : filters) {

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaEvolutionUtil.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaEvolutionUtil.java
@@ -310,19 +310,16 @@ public class SchemaEvolutionUtil {
                         return Optional.empty();
                     }
 
-                    List<Object> devolvedLiterals =
-                            CastExecutors.safelyCastLiteralsWithNumericEvolution(
-                                    predicate, dataField.type());
-
-                    return devolvedLiterals == null
-                            ? Optional.empty()
-                            : Optional.of(
-                                    new LeafPredicate(
-                                            predicate.function(),
-                                            dataField.type(),
-                                            indexOf(dataField, idToDataFields),
-                                            dataField.name(),
-                                            devolvedLiterals));
+                    return CastExecutors.castLiteralsWithEvolution(
+                                    predicate.literals(), predicate.type(), dataField.type())
+                            .map(
+                                    literals ->
+                                            new LeafPredicate(
+                                                    predicate.function(),
+                                                    dataField.type(),
+                                                    indexOf(dataField, idToDataFields),
+                                                    dataField.name(),
+                                                    literals));
                 };
 
         for (Predicate predicate : filters) {

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaEvolutionUtil.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaEvolutionUtil.java
@@ -310,11 +310,11 @@ public class SchemaEvolutionUtil {
                         return Optional.empty();
                     }
 
-                    List<Object> evolvedLiterals =
+                    List<Object> devolvedLiterals =
                             CastExecutors.safelyCastLiteralsWithNumericEvolution(
                                     predicate, dataField.type());
 
-                    return evolvedLiterals == null
+                    return devolvedLiterals == null
                             ? Optional.empty()
                             : Optional.of(
                                     new LeafPredicate(
@@ -322,7 +322,7 @@ public class SchemaEvolutionUtil {
                                             dataField.type(),
                                             indexOf(dataField, idToDataFields),
                                             dataField.name(),
-                                            evolvedLiterals));
+                                            devolvedLiterals));
                 };
 
         for (Predicate predicate : filters) {

--- a/paimon-core/src/main/java/org/apache/paimon/stats/SimpleStatsEvolutions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/SimpleStatsEvolutions.java
@@ -82,13 +82,13 @@ public class SimpleStatsEvolutions {
         if (tableSchemaId == dataSchemaId) {
             return filter;
         }
-        List<Predicate> evolved =
+        List<Predicate> devolved =
                 Objects.requireNonNull(
                         SchemaEvolutionUtil.devolveDataFilters(
                                 schemaFields.apply(tableSchemaId),
                                 schemaFields.apply(dataSchemaId),
                                 Collections.singletonList(filter)));
-        return evolved.isEmpty() ? null : evolved.get(0);
+        return devolved.isEmpty() ? null : devolved.get(0);
     }
 
     public List<DataField> tableDataFields() {

--- a/paimon-core/src/main/java/org/apache/paimon/stats/SimpleStatsEvolutions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/SimpleStatsEvolutions.java
@@ -77,15 +77,18 @@ public class SimpleStatsEvolutions {
                 });
     }
 
-    public Predicate convertFilter(long dataSchemaId, Predicate filter) {
-        return tableSchemaId == dataSchemaId
-                ? filter
-                : Objects.requireNonNull(
-                                SchemaEvolutionUtil.createDataFilters(
-                                        schemaFields.apply(tableSchemaId),
-                                        schemaFields.apply(dataSchemaId),
-                                        Collections.singletonList(filter)))
-                        .get(0);
+    @Nullable
+    public Predicate tryDevolveFilter(long dataSchemaId, Predicate filter) {
+        if (tableSchemaId == dataSchemaId) {
+            return filter;
+        }
+        List<Predicate> evolved =
+                Objects.requireNonNull(
+                        SchemaEvolutionUtil.devolveDataFilters(
+                                schemaFields.apply(tableSchemaId),
+                                schemaFields.apply(dataSchemaId),
+                                Collections.singletonList(filter)));
+        return evolved.isEmpty() ? null : evolved.get(0);
     }
 
     public List<DataField> tableDataFields() {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/FormatReaderMapping.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/FormatReaderMapping.java
@@ -290,7 +290,7 @@ public class FormatReaderMapping {
             List<Predicate> dataFilters =
                     tableSchema.id() == dataSchema.id()
                             ? filters
-                            : SchemaEvolutionUtil.createDataFilters(
+                            : SchemaEvolutionUtil.devolveDataFilters(
                                     tableSchema.fields(), dataSchema.fields(), filters);
 
             // Skip pushing down partition filters to reader.

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaEvolutionUtilTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaEvolutionUtilTest.java
@@ -18,10 +18,8 @@
 
 package org.apache.paimon.schema;
 
-import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.predicate.Equal;
 import org.apache.paimon.predicate.IsNotNull;
 import org.apache.paimon.predicate.IsNull;
 import org.apache.paimon.predicate.LeafPredicate;
@@ -38,7 +36,6 @@ import org.apache.paimon.utils.Projection;
 
 import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -288,30 +285,5 @@ public class SchemaEvolutionUtilTest {
         assertThat(child1.function()).isEqualTo(IsNull.INSTANCE);
         assertThat(child1.fieldName()).isEqualTo("b");
         assertThat(child1.index()).isEqualTo(1);
-    }
-
-    @Test
-    public void testColumnTypeFilter() {
-        // alter d from INT to DECIMAL(10, 2)
-        // filter d = 11.01 will be devolved to d = 11
-        List<Predicate> predicates = new ArrayList<>();
-        predicates.add(
-                new LeafPredicate(
-                        Equal.INSTANCE,
-                        DataTypes.DECIMAL(10, 2),
-                        0,
-                        "d",
-                        Collections.singletonList(
-                                Decimal.fromBigDecimal(new BigDecimal("11.01"), 10, 2))));
-        List<Predicate> filters =
-                SchemaEvolutionUtil.devolveDataFilters(tableFields2, dataFields, predicates);
-        assert filters != null;
-        assertThat(filters.size()).isEqualTo(1);
-
-        LeafPredicate child = (LeafPredicate) filters.get(0);
-        // Validate value 11 with index 3
-        assertThat(child.test(GenericRow.of(0, 0, 0, 11))).isTrue();
-        // Validate value 12 with index 3
-        assertThat(child.test(GenericRow.of(1, 0, 0, 12))).isFalse();
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaEvolutionUtilTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaEvolutionUtilTest.java
@@ -265,7 +265,7 @@ public class SchemaEvolutionUtilTest {
     }
 
     @Test
-    public void testEvolveDataFilters() {
+    public void testDevolveDataFilters() {
         List<Predicate> predicates = new ArrayList<>();
         predicates.add(
                 new LeafPredicate(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FilterPushdownWithSchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FilterPushdownWithSchemaChangeITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink;
 
+import org.apache.paimon.casting.CastExecutors;
 import org.apache.paimon.testutils.junit.parameterized.ParameterizedTestExtension;
 import org.apache.paimon.testutils.junit.parameterized.Parameters;
 
@@ -31,7 +32,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** TODO all file format tests. */
+/** ITCase for {@link CastExecutors#safelyCastLiteralsWithNumericEvolution}. */
 @ExtendWith(ParameterizedTestExtension.class)
 public class FilterPushdownWithSchemaChangeITCase extends CatalogITCaseBase {
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FilterPushdownWithSchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FilterPushdownWithSchemaChangeITCase.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.paimon.testutils.junit.parameterized.ParameterizedTestExtension;
+import org.apache.paimon.testutils.junit.parameterized.Parameters;
+
+import org.apache.flink.types.Row;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** TODO all file format tests. */
+@ExtendWith(ParameterizedTestExtension.class)
+public class FilterPushdownWithSchemaChangeITCase extends CatalogITCaseBase {
+
+    private final String fileFormat;
+
+    public FilterPushdownWithSchemaChangeITCase(String fileFormat) {
+        this.fileFormat = fileFormat;
+    }
+
+    @SuppressWarnings("unused")
+    @Parameters(name = "file-format = {0}")
+    public static List<String> fileFormat() {
+        return Arrays.asList("parquet", "orc", "avro");
+    }
+
+    @TestTemplate
+    public void testDecimalToDecimal() {
+        // to higher precision
+        sql(
+                "CREATE TABLE T ("
+                        + "  id INT,"
+                        + "  f DECIMAL(5, 2)"
+                        + ") with ("
+                        + "  'file.format' = '%s'"
+                        + ")",
+                fileFormat);
+        sql("INSERT INTO T VALUES (1, 111.32)");
+        sql("ALTER TABLE T MODIFY (f DECIMAL(6, 3))");
+        assertThat(sql("SELECT * FROM T WHERE f < 111.321"))
+                .containsExactly(Row.of(1, new BigDecimal("111.320")));
+        assertThat(sql("SELECT * FROM T WHERE f = 111.321")).isEmpty();
+        assertThat(sql("SELECT * FROM T WHERE f = 111.320"))
+                .containsExactly(Row.of(1, new BigDecimal("111.320")));
+        assertThat(sql("SELECT * FROM T WHERE f <> 111.321"))
+                .containsExactly(Row.of(1, new BigDecimal("111.320")));
+
+        sql("DROP TABLE T");
+
+        // to lower precision
+        sql(
+                "CREATE TABLE T ("
+                        + "  id INT,"
+                        + "  f DECIMAL(6, 3)"
+                        + ") with ("
+                        + "  'file.format' = '%s'"
+                        + ")",
+                fileFormat);
+        sql("INSERT INTO T VALUES (1, 111.321), (2, 111.331)");
+        sql("ALTER TABLE T MODIFY (f DECIMAL(5, 2))");
+        assertThat(sql("SELECT * FROM T WHERE f > 111.32"))
+                .containsExactly(Row.of(2, new BigDecimal("111.33")));
+        assertThat(sql("SELECT * FROM T WHERE f = 111.32"))
+                .containsExactly(Row.of(1, new BigDecimal("111.32")));
+        assertThat(sql("SELECT * FROM T WHERE f <> 111.32"))
+                .containsExactly(Row.of(2, new BigDecimal("111.33")));
+    }
+
+    @TestTemplate
+    public void testNumericPrimitiveToDecimal() {
+        String ddl =
+                "CREATE TABLE T ("
+                        + "  id INT,"
+                        + "  f DECIMAL(5, 2)"
+                        + ") with ("
+                        + "  'file.format' = '%s'"
+                        + ")";
+
+        // to higher precision
+        sql(ddl, fileFormat);
+        sql("INSERT INTO T VALUES (1, 111.32)");
+        sql("ALTER TABLE T MODIFY (f DOUBLE)");
+        assertThat(sql("SELECT * FROM T WHERE f < 111.321")).containsExactly(Row.of(1, 111.32));
+        assertThat(sql("SELECT * FROM T WHERE f = 111.321")).isEmpty();
+        assertThat(sql("SELECT * FROM T WHERE f = 111.320")).containsExactly(Row.of(1, 111.32));
+        assertThat(sql("SELECT * FROM T WHERE f <> 111.321")).containsExactly(Row.of(1, 111.32));
+
+        sql("DROP TABLE T");
+
+        // to lower precision
+        sql(ddl, fileFormat);
+        sql("INSERT INTO T VALUES (1, 111.32), (2, 112.33)");
+        sql("ALTER TABLE T MODIFY (f INT)");
+        assertThat(sql("SELECT * FROM T WHERE f < 112")).containsExactly(Row.of(1, 111));
+        assertThat(sql("SELECT * FROM T WHERE f > 112")).isEmpty();
+        assertThat(sql("SELECT * FROM T WHERE f = 111")).containsExactly(Row.of(1, 111));
+        assertThat(sql("SELECT * FROM T WHERE f <> 111")).containsExactly(Row.of(2, 112));
+    }
+
+    @TestTemplate
+    public void testDecimalToNumericPrimitive() {
+        // to higher precision
+        sql(
+                "CREATE TABLE T ("
+                        + "  id INT,"
+                        + "  f INT"
+                        + ") with ("
+                        + "  'file.format' = '%s'"
+                        + ")",
+                fileFormat);
+        sql("INSERT INTO T VALUES (1, 111)");
+        sql("ALTER TABLE T MODIFY (f DECIMAL(5, 2))");
+        assertThat(sql("SELECT * FROM T WHERE f < 111.01"))
+                .containsExactly(Row.of(1, new BigDecimal("111.00")));
+        assertThat(sql("SELECT * FROM T WHERE f = 111.01")).isEmpty();
+        assertThat(sql("SELECT * FROM T WHERE f = 111.00"))
+                .containsExactly(Row.of(1, new BigDecimal("111.00")));
+        assertThat(sql("SELECT * FROM T WHERE f <> 111.01"))
+                .containsExactly(Row.of(1, new BigDecimal("111.00")));
+
+        sql("DROP TABLE T");
+
+        // to lower precision
+        sql(
+                "CREATE TABLE T ("
+                        + "  id INT,"
+                        + "  f DOUBLE"
+                        + ") with ("
+                        + "  'file.format' = '%s'"
+                        + ")",
+                fileFormat);
+        sql("INSERT INTO T VALUES (1, 111.321), (2, 111.331)");
+        sql("ALTER TABLE T MODIFY (f DECIMAL(5, 2))");
+        assertThat(sql("SELECT * FROM T WHERE f > 111.32"))
+                .containsExactly(Row.of(2, new BigDecimal("111.33")));
+        assertThat(sql("SELECT * FROM T WHERE f = 111.32"))
+                .containsExactly(Row.of(1, new BigDecimal("111.32")));
+        assertThat(sql("SELECT * FROM T WHERE f <> 111.32"))
+                .containsExactly(Row.of(2, new BigDecimal("111.33")));
+    }
+
+    @TestTemplate
+    public void testNumericPrimitive() {
+        // no checks for high scale to low scale because we don't pushdown it
+
+        // integer to higher scale integer
+        sql(
+                "CREATE TABLE T ("
+                        + "  id INT,"
+                        + "  f TINYINT"
+                        + ") with ("
+                        + "  'file.format' = '%s'"
+                        + ")",
+                fileFormat);
+        sql("INSERT INTO T VALUES (1, CAST (127 AS TINYINT))");
+        sql("ALTER TABLE T MODIFY (f INT)");
+        // (byte) 383 == 127
+        assertThat(sql("SELECT * FROM T WHERE f < 128")).containsExactly(Row.of(1, 127));
+        assertThat(sql("SELECT * FROM T WHERE f < 383")).containsExactly(Row.of(1, 127));
+        assertThat(sql("SELECT * FROM T WHERE f = 127")).containsExactly(Row.of(1, 127));
+        assertThat(sql("SELECT * FROM T WHERE f = 383")).isEmpty();
+        assertThat(sql("SELECT * FROM T WHERE f <> 127")).isEmpty();
+        assertThat(sql("SELECT * FROM T WHERE f <> 383")).containsExactly(Row.of(1, 127));
+    }
+
+    @TestTemplate
+    public void testNumericToString() {
+        // no more string related tests because we don't push down it
+        sql(
+                "CREATE TABLE T ("
+                        + "  id INT,"
+                        + "  f STRING"
+                        + ") with ("
+                        + "  'file.format' = '%s'"
+                        + ");",
+                fileFormat);
+        sql("INSERT INTO T VALUES (1, '1'), (2, '111')");
+        sql("ALTER TABLE T MODIFY (f INT)");
+        assertThat(sql("SELECT * FROM T WHERE f > 2")).containsExactly(Row.of(2, 111));
+        assertThat(sql("SELECT * FROM T WHERE f = 1")).containsExactly(Row.of(1, 1));
+        assertThat(sql("SELECT * FROM T WHERE f <> 1")).containsExactly(Row.of(2, 111));
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FilterPushdownWithSchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FilterPushdownWithSchemaChangeITCase.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink;
 import org.apache.paimon.casting.CastExecutors;
 import org.apache.paimon.testutils.junit.parameterized.ParameterizedTestExtension;
 import org.apache.paimon.testutils.junit.parameterized.Parameters;
+import org.apache.paimon.types.DataType;
 
 import org.apache.flink.types.Row;
 import org.junit.jupiter.api.TestTemplate;
@@ -32,7 +33,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** ITCase for {@link CastExecutors#safelyCastLiteralsWithNumericEvolution}. */
+/** ITCase for {@link CastExecutors#castLiteralsWithEvolution(List, DataType, DataType)}. */
 @ExtendWith(ParameterizedTestExtension.class)
 public class FilterPushdownWithSchemaChangeITCase extends CatalogITCaseBase {
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Reproduce case:
```
CREATE TABLE T (
  id INT,
  f DECIMAL(5,2),
);
INSERT INTO T VALUES (1, 111.32);
ALTER TABLE T MODIFY (f DECIMAL(6, 3));
SELECT * FROM T WHERE f < 111.321;
```
The result is empty but expected 111.320

There are also same problem for other field cast Scenario.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
