### PR TITLE
[pom] prefer central repo for releases; limit apache-snapshots to snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1029,14 +1029,27 @@ under the License.
     <!--
     <repositories>
         <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>apache-releases</id>
             <name>apache releases</name>
             <url>https://repository.apache.org/content/repositories/releases/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
         <repository>
             <id>apache-snapshots</id>
             <name>apache snapshots</name>
             <url>https://repository.apache.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </repository>
     </repositories>
     -->


### PR DESCRIPTION
### Purpose

- Avoid trying to download release artifacts from Apache snapshot repo.
- Add `central` repo to ensure it's preferred to `repository.apache.org` when downloading release artifacts.

### Tests

Uncommented the `<repositories>` section, and built locally.

```
$ mvn -DskipTests clean package
...
[INFO] ------------------< org.apache.paimon:paimon-parent >-------------------
[INFO] Building Paimon : 1.0-SNAPSHOT                                    [1/52]
[INFO]   from pom.xml
[INFO] --------------------------------[ pom ]---------------------------------
Downloading from central: https://repo.maven.apache.org/maven2/com/diffplug/spotless/spotless-maven-plugin/2.13.0/spotless-maven-plugin-2.13.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/com/diffplug/spotless/spotless-maven-plugin/2.13.0/spotless-maven-plugin-2.13.0.pom (3.2 kB at 17 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/com/diffplug/spotless/spotless-maven-plugin/2.13.0/spotless-maven-plugin-2.13.0.jar
Downloaded from central: https://repo.maven.apache.org/maven2/com/diffplug/spotless/spotless-maven-plugin/2.13.0/spotless-maven-plugin-2.13.0.jar (65 kB at 204 kB/s)
...
[INFO] Reactor Summary for Paimon : 1.0-SNAPSHOT:
...
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  17:29 min
```