### PR TITLE
[core] Tolerate the NoSuchObjectException when report the partition s…

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/metastore/MetastoreClient.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/MetastoreClient.java
@@ -55,7 +55,8 @@ public interface MetastoreClient extends AutoCloseable {
     default void alterPartition(
             LinkedHashMap<String, String> partitionSpec,
             Map<String, String> parameters,
-            long modifyTime)
+            long modifyTime,
+            boolean ignoreIfNotExist)
             throws Exception {
         throw new UnsupportedOperationException();
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/HmsReporter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/HmsReporter.java
@@ -93,7 +93,7 @@ public class HmsReporter implements Closeable {
             statistic.put(HIVE_LAST_UPDATE_TIME_PROP, String.valueOf(modifyTime / 1000));
 
             LOG.info("alter partition {} with statistic {}.", partitionSpec, statistic);
-            metastoreClient.alterPartition(partitionSpec, statistic, modifyTime);
+            metastoreClient.alterPartition(partitionSpec, statistic, modifyTime, true);
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/AddDonePartitionActionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/AddDonePartitionActionTest.java
@@ -66,7 +66,8 @@ class AddDonePartitionActionTest {
                     public void alterPartition(
                             LinkedHashMap<String, String> partitionSpec,
                             Map<String, String> parameters,
-                            long modifyTime)
+                            long modifyTime,
+                            boolean ignoreIfNotExist)
                             throws Exception {
                         throw new UnsupportedOperationException();
                     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/HmsReporterTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/HmsReporterTest.java
@@ -117,7 +117,8 @@ public class HmsReporterTest {
                     public void alterPartition(
                             LinkedHashMap<String, String> partitionSpec,
                             Map<String, String> parameters,
-                            long modifyTime)
+                            long modifyTime,
+                            boolean ignoreIfNotExist)
                             throws Exception {
                         partitionParams.put(
                                 PartitionPathUtils.generatePartitionPath(partitionSpec),

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveMetastoreClient.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveMetastoreClient.java
@@ -124,17 +124,28 @@ public class HiveMetastoreClient implements MetastoreClient {
     public void alterPartition(
             LinkedHashMap<String, String> partitionSpec,
             Map<String, String> parameters,
-            long modifyTime)
+            long modifyTime,
+            boolean ignoreIfNotExist)
             throws Exception {
         List<String> partitionValues = new ArrayList<>(partitionSpec.values());
         int currentTime = (int) (modifyTime / 1000);
-        Partition hivePartition =
-                clients.run(
-                        client ->
-                                client.getPartition(
-                                        identifier.getDatabaseName(),
-                                        identifier.getObjectName(),
-                                        partitionValues));
+        Partition hivePartition;
+        try {
+            hivePartition =
+                    clients.run(
+                            client ->
+                                    client.getPartition(
+                                            identifier.getDatabaseName(),
+                                            identifier.getObjectName(),
+                                            partitionValues));
+        } catch (NoSuchObjectException e) {
+            if (ignoreIfNotExist) {
+                return;
+            } else {
+                throw e;
+            }
+        }
+
         hivePartition.setValues(partitionValues);
         hivePartition.setLastAccessTime(currentTime);
         hivePartition.getParameters().putAll(parameters);


### PR DESCRIPTION
…tatistic

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

We may report to the hms when the partition has been expired, we should handle this case.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
