### PR TITLE
[core][spark] Enable limit pushdown and count optimization for dv table

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/table/source/SplitGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/SplitGeneratorTest.java
@@ -43,10 +43,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SplitGeneratorTest {
 
     public static DataFileMeta newFileFromSequence(
-            String name, int rowCount, long minSequence, long maxSequence) {
+            String name, int fileSize, long minSequence, long maxSequence) {
         return new DataFileMeta(
                 name,
-                rowCount,
+                fileSize,
                 1,
                 EMPTY_ROW,
                 EMPTY_ROW,

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
@@ -21,6 +21,7 @@ package org.apache.paimon.spark
 import org.apache.paimon.predicate.PredicateBuilder
 import org.apache.paimon.spark.aggregate.LocalAggregator
 import org.apache.paimon.table.Table
+import org.apache.paimon.table.source.DataSplit
 
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation
 import org.apache.spark.sql.connector.read.{Scan, SupportsPushDownAggregates, SupportsPushDownLimit}
@@ -36,12 +37,12 @@ class PaimonScanBuilder(table: Table)
   override def pushLimit(limit: Int): Boolean = {
     // It is safe, since we will do nothing if it is the primary table and the split is not `rawConvertible`
     pushDownLimit = Some(limit)
-    // just make a best effort to push down limit
+    // just make the best effort to push down limit
     false
   }
 
   override def supportCompletePushDown(aggregation: Aggregation): Boolean = {
-    // for now we only support complete push down, so there is no difference with `pushAggregation`
+    // for now, we only support complete push down, so there is no difference with `pushAggregation`
     pushAggregation(aggregation)
   }
 
@@ -66,8 +67,11 @@ class PaimonScanBuilder(table: Table)
       val pushedPartitionPredicate = PredicateBuilder.and(pushedPredicates.map(_._2): _*)
       readBuilder.withFilter(pushedPartitionPredicate)
     }
-    val scan = readBuilder.newScan()
-    scan.listPartitionEntries.asScala.foreach(aggregator.update)
+    val dataSplits = readBuilder.newScan().plan().splits().asScala.map(_.asInstanceOf[DataSplit])
+    if (!dataSplits.forall(_.mergedRowCountAvailable())) {
+      return false
+    }
+    dataSplits.foreach(aggregator.update)
     localScan = Some(
       PaimonLocalScan(
         aggregator.result(),


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Since we introduce dv cardinality in #4699, we can enable limit pushdown and count optimization for dv table now

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
