### PR TITLE
[flink] avoid using 'newHashMapWithExpectedSize' which is internal in flink

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/changelog/ChangelogCompactTaskSerializer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/changelog/ChangelogCompactTaskSerializer.java
@@ -26,10 +26,10 @@ import org.apache.paimon.io.DataOutputView;
 import org.apache.paimon.io.DataOutputViewStreamWrapper;
 
 import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.apache.flink.util.CollectionUtil;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -102,8 +102,7 @@ public class ChangelogCompactTaskSerializer
     private Map<Integer, List<DataFileMeta>> deserializeMap(DataInputView view) throws IOException {
         final int size = view.readInt();
 
-        final Map<Integer, List<DataFileMeta>> map =
-                CollectionUtil.newHashMapWithExpectedSize(size);
+        final Map<Integer, List<DataFileMeta>> map = new HashMap<>(size);
         for (int i = 0; i < size; i++) {
             map.put(view.readInt(), dataFileSerializer.deserializeList(view));
         }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
`newHashMapWithExpectedSize` is internally used in flink, we should avoid using it.

### Tests

<!-- List UT and IT cases to verify this change -->


### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
