### PR TITLE
[spark] Fix relativeBucketPath with data-file.path-directory

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
@@ -130,20 +130,19 @@ public class FileStorePathFactory {
     }
 
     public Path bucketPath(BinaryRow partition, int bucket) {
-        Path dataFileRoot = this.root;
-        if (dataFilePathDirectory != null) {
-            dataFileRoot = new Path(dataFileRoot, dataFilePathDirectory);
-        }
-        return new Path(dataFileRoot + "/" + relativePartitionAndBucketPath(partition, bucket));
+        return new Path(root, relativeBucketPath(partition, bucket));
     }
 
-    public Path relativePartitionAndBucketPath(BinaryRow partition, int bucket) {
+    public Path relativeBucketPath(BinaryRow partition, int bucket) {
+        Path relativeBucketPath = new Path(BUCKET_PATH_PREFIX + bucket);
         String partitionPath = getPartitionString(partition);
-        String fullPath =
-                partitionPath.isEmpty()
-                        ? BUCKET_PATH_PREFIX + bucket
-                        : partitionPath + "/" + BUCKET_PATH_PREFIX + bucket;
-        return new Path(fullPath);
+        if (!partitionPath.isEmpty()) {
+            relativeBucketPath = new Path(partitionPath, relativeBucketPath);
+        }
+        if (dataFilePathDirectory != null) {
+            relativeBucketPath = new Path(dataFilePathDirectory, relativeBucketPath);
+        }
+        return relativeBucketPath;
     }
 
     /** IMPORTANT: This method is NOT THREAD SAFE. */

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
@@ -245,12 +245,12 @@ trait PaimonCommand extends WithFileStoreTable with ExpressionHelper with SQLCon
           val relativeFilePath = location.toUri.relativize(new URI(filePath)).toString
           val (partition, bucket) = dataFileToPartitionAndBucket.toMap.apply(relativeFilePath)
           val pathFactory = my_table.store().pathFactory()
-          val partitionAndBucket = pathFactory
-            .relativePartitionAndBucketPath(partition, bucket)
+          val relativeBucketPath = pathFactory
+            .relativeBucketPath(partition, bucket)
             .toString
 
           SparkDeletionVectors(
-            partitionAndBucket,
+            relativeBucketPath,
             SerializationUtils.serializeBinaryRow(partition),
             bucket,
             Seq((new Path(filePath).getName, dv.serializeToBytes()))

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/SparkDataFileMeta.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/SparkDataFileMeta.scala
@@ -35,7 +35,7 @@ case class SparkDataFileMeta(
 
   def relativePath(fileStorePathFactory: FileStorePathFactory): String = {
     fileStorePathFactory
-      .relativePartitionAndBucketPath(partition, bucket)
+      .relativeBucketPath(partition, bucket)
       .toUri
       .toString + "/" + dataFileMeta.fileName()
   }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/SparkDeletionVectors.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/SparkDeletionVectors.scala
@@ -36,7 +36,7 @@ case class SparkDeletionVectors(
 ) {
   def relativePaths(fileStorePathFactory: FileStorePathFactory): Seq[String] = {
     val prefix = fileStorePathFactory
-      .relativePartitionAndBucketPath(SerializationUtils.deserializeBinaryRow(partition), bucket)
+      .relativeBucketPath(SerializationUtils.deserializeBinaryRow(partition), bucket)
       .toUri
       .toString + "/"
     dataFileAndDeletionVector.map(prefix + _._1)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Fix relativeBucketPath with data-file.path-directory

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
