### PR TITLE
[core] Refactor MetastoreClient methods to simplify catalog

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -417,7 +417,7 @@ public abstract class AbstractCatalog implements Catalog {
                                         lockFactory().orElse(null),
                                         lockContext().orElse(null),
                                         identifier),
-                                metastoreClientFactory(identifier, tableMeta.schema).orElse(null)));
+                                metastoreClientFactory(identifier).orElse(null)));
         CoreOptions options = table.coreOptions();
         if (options.type() == TableType.OBJECT_TABLE) {
             String objectLocation = options.objectLocation();
@@ -485,8 +485,7 @@ public abstract class AbstractCatalog implements Catalog {
             throws TableNotExistException;
 
     /** Get metastore client factory for the table specified by {@code identifier}. */
-    public Optional<MetastoreClient.Factory> metastoreClientFactory(
-            Identifier identifier, TableSchema schema) {
+    public Optional<MetastoreClient.Factory> metastoreClientFactory(Identifier identifier) {
         return Optional.empty();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/metastore/AddPartitionTagCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/AddPartitionTagCallback.java
@@ -49,7 +49,7 @@ public class AddPartitionTagCallback implements TagCallback {
         LinkedHashMap<String, String> partitionSpec = new LinkedHashMap<>();
         partitionSpec.put(partitionField, tagName);
         try {
-            client.deletePartition(partitionSpec);
+            client.dropPartition(partitionSpec);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/metastore/MetastoreClient.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/MetastoreClient.java
@@ -18,12 +18,9 @@
 
 package org.apache.paimon.metastore;
 
-import org.apache.paimon.data.BinaryRow;
-
 import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * A metastore client related to a table. All methods of this interface operate on the same specific
@@ -31,32 +28,18 @@ import java.util.Map;
  */
 public interface MetastoreClient extends AutoCloseable {
 
-    void addPartition(BinaryRow partition) throws Exception;
+    void addPartition(LinkedHashMap<String, String> partition) throws Exception;
 
-    default void addPartitions(List<BinaryRow> partitions) throws Exception {
-        for (BinaryRow partition : partitions) {
-            addPartition(partition);
-        }
-    }
+    void addPartitions(List<LinkedHashMap<String, String>> partitions) throws Exception;
 
-    void addPartition(LinkedHashMap<String, String> partitionSpec) throws Exception;
+    void dropPartition(LinkedHashMap<String, String> partition) throws Exception;
 
-    default void addPartitionsSpec(List<LinkedHashMap<String, String>> partitionSpecsList)
-            throws Exception {
-        for (LinkedHashMap<String, String> partitionSpecs : partitionSpecsList) {
-            addPartition(partitionSpecs);
-        }
-    }
+    void dropPartitions(List<LinkedHashMap<String, String>> partitions) throws Exception;
 
-    void deletePartition(LinkedHashMap<String, String> partitionSpec) throws Exception;
-
-    void markDone(LinkedHashMap<String, String> partitionSpec) throws Exception;
+    void markPartitionDone(LinkedHashMap<String, String> partition) throws Exception;
 
     default void alterPartition(
-            LinkedHashMap<String, String> partitionSpec,
-            Map<String, String> parameters,
-            long modifyTime,
-            boolean ignoreIfNotExist)
+            LinkedHashMap<String, String> partition, PartitionStats partitionStats)
             throws Exception {
         throw new UnsupportedOperationException();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/metastore/PartitionStats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/PartitionStats.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.metastore;
+
+/** Statistic for partition. */
+public interface PartitionStats {
+
+    long numFiles();
+
+    long totalSize();
+
+    long numRows();
+
+    long lastUpdateTimeMillis();
+
+    static PartitionStats create(
+            long numFiles, long totalSize, long numRows, long lastUpdateTimeMillis) {
+        return new PartitionStats() {
+
+            @Override
+            public long numFiles() {
+                return numFiles;
+            }
+
+            @Override
+            public long totalSize() {
+                return totalSize;
+            }
+
+            @Override
+            public long numRows() {
+                return numRows;
+            }
+
+            @Override
+            public long lastUpdateTimeMillis() {
+                return lastUpdateTimeMillis;
+            }
+
+            @Override
+            public String toString() {
+                return String.format(
+                        "numFiles: %s, totalSize: %s, numRows: %s, lastUpdateTimeMillis: %s",
+                        numFiles, totalSize, numRows, lastUpdateTimeMillis);
+            }
+        };
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
@@ -167,15 +167,13 @@ public class PartitionExpire {
     }
 
     private void deleteMetastorePartitions(List<Map<String, String>> partitions) {
-        if (metastoreClient != null) {
-            partitions.forEach(
-                    partition -> {
-                        try {
-                            metastoreClient.deletePartition(new LinkedHashMap<>(partition));
-                        } catch (Exception e) {
-                            throw new RuntimeException(e);
-                        }
-                    });
+        if (metastoreClient != null && partitions.size() > 0) {
+            try {
+                metastoreClient.addPartitions(
+                        partitions.stream().map(LinkedHashMap::new).collect(Collectors.toList()));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
@@ -169,7 +169,7 @@ public class PartitionExpire {
     private void deleteMetastorePartitions(List<Map<String, String>> partitions) {
         if (metastoreClient != null && partitions.size() > 0) {
             try {
-                metastoreClient.addPartitions(
+                metastoreClient.dropPartitions(
                         partitions.stream().map(LinkedHashMap::new).collect(Collectors.toList()));
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/paimon-core/src/main/java/org/apache/paimon/partition/actions/MarkPartitionDoneEventAction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/actions/MarkPartitionDoneEventAction.java
@@ -39,7 +39,7 @@ public class MarkPartitionDoneEventAction implements PartitionMarkDoneAction {
     public void markDone(String partition) throws Exception {
         LinkedHashMap<String, String> partitionSpec =
                 extractPartitionSpecFromPath(new Path(partition));
-        metastoreClient.markDone(partitionSpec);
+        metastoreClient.markPartitionDone(partitionSpec);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -61,6 +61,7 @@ import org.apache.paimon.table.source.snapshot.StaticFromWatermarkStartingScanne
 import org.apache.paimon.table.source.snapshot.TimeTravelUtil;
 import org.apache.paimon.tag.TagPreview;
 import org.apache.paimon.utils.BranchManager;
+import org.apache.paimon.utils.InternalRowPartitionComputer;
 import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.SegmentsCache;
 import org.apache.paimon.utils.SimpleFileReader;
@@ -469,7 +470,15 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
         if (options.partitionedTableInMetastore()
                 && metastoreClientFactory != null
                 && !tableSchema.partitionKeys().isEmpty()) {
-            callbacks.add(new AddPartitionCommitCallback(metastoreClientFactory.create()));
+            InternalRowPartitionComputer partitionComputer =
+                    new InternalRowPartitionComputer(
+                            options.partitionDefaultName(),
+                            tableSchema.logicalPartitionType(),
+                            tableSchema.partitionKeys().toArray(new String[0]),
+                            options.legacyPartitionName());
+            callbacks.add(
+                    new AddPartitionCommitCallback(
+                            metastoreClientFactory.create(), partitionComputer));
         }
 
         TagPreview tagPreview = TagPreview.create(options);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionStatisticsReporter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionStatisticsReporter.java
@@ -46,8 +46,6 @@ public class PartitionStatisticsReporter implements Closeable {
 
     private static final Logger LOG = LoggerFactory.getLogger(PartitionStatisticsReporter.class);
 
-    private static final String HIVE_LAST_UPDATE_TIME_PROP = "transient_lastDdlTime";
-
     private final MetastoreClient metastoreClient;
     private final SnapshotReader snapshotReader;
     private final SnapshotManager snapshotManager;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionStatisticsReporter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionStatisticsReporter.java
@@ -22,6 +22,7 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.metastore.MetastoreClient;
+import org.apache.paimon.metastore.PartitionStats;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.ScanMode;
@@ -35,15 +36,9 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
-import static org.apache.paimon.catalog.Catalog.LAST_UPDATE_TIME_PROP;
-import static org.apache.paimon.catalog.Catalog.NUM_FILES_PROP;
-import static org.apache.paimon.catalog.Catalog.NUM_ROWS_PROP;
-import static org.apache.paimon.catalog.Catalog.TOTAL_SIZE_PROP;
 import static org.apache.paimon.utils.PartitionPathUtils.extractPartitionSpecFromPath;
 
 /** Action to report the table statistic from the latest snapshot to HMS. */
@@ -64,7 +59,7 @@ public class PartitionStatisticsReporter implements Closeable {
         this.snapshotManager = table.snapshotManager();
     }
 
-    public void report(String partition, long modifyTime) throws Exception {
+    public void report(String partition, long modifyTimeMillis) throws Exception {
         Snapshot snapshot = snapshotManager.latestSnapshot();
         if (snapshot != null) {
             LinkedHashMap<String, String> partitionSpec =
@@ -88,19 +83,11 @@ public class PartitionStatisticsReporter implements Closeable {
                     totalSize += fileMeta.fileSize();
                 }
             }
-            Map<String, String> statistic = new HashMap<>();
-            statistic.put(NUM_FILES_PROP, String.valueOf(fileCount));
-            statistic.put(TOTAL_SIZE_PROP, String.valueOf(totalSize));
-            statistic.put(NUM_ROWS_PROP, String.valueOf(rowCount));
 
-            String modifyTimeSeconds = String.valueOf(modifyTime / 1000);
-            statistic.put(LAST_UPDATE_TIME_PROP, modifyTimeSeconds);
-
-            // just for being compatible with hive metastore
-            statistic.put(HIVE_LAST_UPDATE_TIME_PROP, modifyTimeSeconds);
-
-            LOG.info("alter partition {} with statistic {}.", partitionSpec, statistic);
-            metastoreClient.alterPartition(partitionSpec, statistic, modifyTime, true);
+            PartitionStats partitionStats =
+                    PartitionStats.create(fileCount, totalSize, rowCount, modifyTimeMillis);
+            LOG.info("alter partition {} with statistic {}.", partitionSpec, partitionStats);
+            metastoreClient.alterPartition(partitionSpec, partitionStats);
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/PartitionStatisticsReporterTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/PartitionStatisticsReporterTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.paimon.flink.sink.partition;
 
-import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.metastore.MetastoreClient;
+import org.apache.paimon.metastore.PartitionStats;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.FileStoreTable;
@@ -35,7 +35,6 @@ import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.utils.PartitionPathUtils;
 
-import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.shade.guava30.com.google.common.collect.Lists;
 import org.apache.paimon.shade.guava30.com.google.common.collect.Maps;
 
@@ -86,47 +85,47 @@ public class PartitionStatisticsReporterTest {
         BatchTableCommit committer = table.newBatchWriteBuilder().newCommit();
         committer.commit(messages);
         AtomicBoolean closed = new AtomicBoolean(false);
-        Map<String, Map<String, String>> partitionParams = Maps.newHashMap();
+        Map<String, PartitionStats> partitionParams = Maps.newHashMap();
 
         MetastoreClient client =
                 new MetastoreClient() {
+
                     @Override
-                    public void addPartition(BinaryRow partition) throws Exception {
+                    public void addPartition(LinkedHashMap<String, String> partition) {
                         throw new UnsupportedOperationException();
                     }
 
                     @Override
-                    public void addPartition(LinkedHashMap<String, String> partitionSpec)
-                            throws Exception {
+                    public void addPartitions(List<LinkedHashMap<String, String>> partitions) {
                         throw new UnsupportedOperationException();
                     }
 
                     @Override
-                    public void deletePartition(LinkedHashMap<String, String> partitionSpec)
-                            throws Exception {
+                    public void dropPartition(LinkedHashMap<String, String> partition) {
                         throw new UnsupportedOperationException();
                     }
 
                     @Override
-                    public void markDone(LinkedHashMap<String, String> partitionSpec)
-                            throws Exception {
+                    public void dropPartitions(List<LinkedHashMap<String, String>> partitions) {
+                        throw new UnsupportedOperationException();
+                    }
+
+                    @Override
+                    public void markPartitionDone(LinkedHashMap<String, String> partitionSpec) {
                         throw new UnsupportedOperationException();
                     }
 
                     @Override
                     public void alterPartition(
                             LinkedHashMap<String, String> partitionSpec,
-                            Map<String, String> parameters,
-                            long modifyTime,
-                            boolean ignoreIfNotExist)
-                            throws Exception {
+                            PartitionStats partitionStats) {
                         partitionParams.put(
                                 PartitionPathUtils.generatePartitionPath(partitionSpec),
-                                parameters);
+                                partitionStats);
                     }
 
                     @Override
-                    public void close() throws Exception {
+                    public void close() {
                         closed.set(true);
                     }
                 };
@@ -135,19 +134,9 @@ public class PartitionStatisticsReporterTest {
         long time = 1729598544974L;
         action.report("c1=a/", time);
         Assertions.assertThat(partitionParams).containsKey("c1=a/");
-        Assertions.assertThat(partitionParams.get("c1=a/"))
+        Assertions.assertThat(partitionParams.get("c1=a/").toString())
                 .isEqualTo(
-                        ImmutableMap.of(
-                                "numFiles",
-                                "1",
-                                "totalSize",
-                                "591",
-                                "numRows",
-                                "1",
-                                "lastUpdateTime",
-                                String.valueOf(time / 1000),
-                                "transient_lastDdlTime",
-                                String.valueOf(time / 1000)));
+                        "numFiles: 1, totalSize: 591, numRows: 1, lastUpdateTimeMillis: 1729598544974");
         action.close();
         Assertions.assertThat(closed).isTrue();
     }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonPartitionManagement.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonPartitionManagement.scala
@@ -78,7 +78,7 @@ trait PaimonPartitionManagement extends SupportsAtomicPartitionManagement {
           // sync to metastore with delete partitions
           if (clientFactory != null && fileStoreTable.coreOptions().partitionedTableInMetastore()) {
             metastoreClient = clientFactory.create()
-            toPaimonPartitions(rows).foreach(metastoreClient.deletePartition)
+            metastoreClient.dropPartitions(toPaimonPartitions(rows))
           }
         } finally {
           commit.close()

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonPartitionManagement.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonPartitionManagement.scala
@@ -78,7 +78,7 @@ trait PaimonPartitionManagement extends SupportsAtomicPartitionManagement {
           // sync to metastore with delete partitions
           if (clientFactory != null && fileStoreTable.coreOptions().partitionedTableInMetastore()) {
             metastoreClient = clientFactory.create()
-            metastoreClient.dropPartitions(toPaimonPartitions(rows))
+            metastoreClient.dropPartitions(toPaimonPartitions(rows).toSeq.asJava)
           }
         } finally {
           commit.close()


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
New MetastoreClient API:
```java
/**
 * A metastore client related to a table. All methods of this interface operate on the same specific
 * table.
 */
public interface MetastoreClient extends AutoCloseable {

    void addPartition(LinkedHashMap<String, String> partition) throws Exception;

    void addPartitions(List<LinkedHashMap<String, String>> partitions) throws Exception;

    void dropPartition(LinkedHashMap<String, String> partition) throws Exception;

    void dropPartitions(List<LinkedHashMap<String, String>> partitions) throws Exception;

    void markPartitionDone(LinkedHashMap<String, String> partition) throws Exception;

    default void alterPartition(
            LinkedHashMap<String, String> partition, PartitionStats partitionStats)
            throws Exception {
        throw new UnsupportedOperationException();
    }

    /** Factory to create {@link MetastoreClient}. */
    interface Factory extends Serializable {

        MetastoreClient create();
    }
}
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
