### PR TITLE
[core] Skip case checking in catalog

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -48,7 +48,6 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -282,8 +281,6 @@ public abstract class AbstractCatalog implements Catalog {
             throws TableAlreadyExistException, DatabaseNotExistException {
         checkNotBranch(identifier, "createTable");
         checkNotSystemTable(identifier, "createTable");
-        validateIdentifierNameCaseInsensitive(identifier);
-        validateFieldNameCaseInsensitive(schema.rowType().getFieldNames());
         validateAutoCreateClose(schema.options());
         validateCustomTablePath(schema.options());
 
@@ -339,7 +336,6 @@ public abstract class AbstractCatalog implements Catalog {
         checkNotBranch(toTable, "renameTable");
         checkNotSystemTable(fromTable, "renameTable");
         checkNotSystemTable(toTable, "renameTable");
-        validateIdentifierNameCaseInsensitive(toTable);
 
         try {
             getTable(fromTable);
@@ -366,8 +362,6 @@ public abstract class AbstractCatalog implements Catalog {
             Identifier identifier, List<SchemaChange> changes, boolean ignoreIfNotExists)
             throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException {
         checkNotSystemTable(identifier, "alterTable");
-        validateIdentifierNameCaseInsensitive(identifier);
-        validateFieldNameCaseInsensitiveInSchemaChange(changes);
 
         try {
             getTable(identifier);
@@ -569,30 +563,6 @@ public abstract class AbstractCatalog implements Catalog {
         if (isSystemDatabase(database)) {
             throw new ProcessSystemDatabaseException();
         }
-    }
-
-    protected void validateIdentifierNameCaseInsensitive(Identifier identifier) {
-        CatalogUtils.validateCaseInsensitive(
-                caseSensitive(), "Database", identifier.getDatabaseName());
-        CatalogUtils.validateCaseInsensitive(caseSensitive(), "Table", identifier.getObjectName());
-    }
-
-    private void validateFieldNameCaseInsensitiveInSchemaChange(List<SchemaChange> changes) {
-        List<String> fieldNames = new ArrayList<>();
-        for (SchemaChange change : changes) {
-            if (change instanceof SchemaChange.AddColumn) {
-                SchemaChange.AddColumn addColumn = (SchemaChange.AddColumn) change;
-                fieldNames.addAll(Arrays.asList(addColumn.fieldNames()));
-            } else if (change instanceof SchemaChange.RenameColumn) {
-                SchemaChange.RenameColumn rename = (SchemaChange.RenameColumn) change;
-                fieldNames.add(rename.newName());
-            }
-        }
-        validateFieldNameCaseInsensitive(fieldNames);
-    }
-
-    protected void validateFieldNameCaseInsensitive(List<String> fieldNames) {
-        CatalogUtils.validateCaseInsensitive(caseSensitive(), "Field", fieldNames);
     }
 
     private void validateAutoCreateClose(Map<String, String> options) {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
@@ -21,14 +21,10 @@ package org.apache.paimon.catalog;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.schema.SchemaManager;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.apache.paimon.catalog.Catalog.TABLE_DEFAULT_OPTION_PREFIX;
 import static org.apache.paimon.options.OptionsUtils.convertToPropertiesPrefixKey;
-import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Utils for {@link Catalog}. */
 public class CatalogUtils {
@@ -63,26 +59,5 @@ public class CatalogUtils {
 
     public static Map<String, String> tableDefaultOptions(Map<String, String> options) {
         return convertToPropertiesPrefixKey(options, TABLE_DEFAULT_OPTION_PREFIX);
-    }
-
-    /** Validate database, table and field names must be lowercase when not case-sensitive. */
-    public static void validateCaseInsensitive(
-            boolean caseSensitive, String type, String... names) {
-        validateCaseInsensitive(caseSensitive, type, Arrays.asList(names));
-    }
-
-    /** Validate database, table and field names must be lowercase when not case-sensitive. */
-    public static void validateCaseInsensitive(
-            boolean caseSensitive, String type, List<String> names) {
-        if (caseSensitive) {
-            return;
-        }
-        List<String> illegalNames =
-                names.stream().filter(f -> !f.equals(f.toLowerCase())).collect(Collectors.toList());
-        checkArgument(
-                illegalNames.isEmpty(),
-                String.format(
-                        "%s name %s cannot contain upper case in the catalog.",
-                        type, illegalNames));
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/FileSystemCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/FileSystemCatalogTest.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.catalog;
 
 import org.apache.paimon.fs.Path;
-import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.types.DataTypes;
@@ -29,7 +28,6 @@ import org.apache.paimon.shade.guava30.com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link FileSystemCatalog}. */
@@ -39,14 +37,13 @@ public class FileSystemCatalogTest extends CatalogTestBase {
     public void setUp() throws Exception {
         super.setUp();
         Options catalogOptions = new Options();
-        catalogOptions.set(CatalogOptions.CASE_SENSITIVE, false);
         catalog = new FileSystemCatalog(fileIO, new Path(warehouse), catalogOptions);
     }
 
     @Test
     public void testCreateTableCaseSensitive() throws Exception {
         catalog.createDatabase("test_db", false);
-        Identifier identifier = Identifier.create("test_db", "new_table");
+        Identifier identifier = Identifier.create("test_db", "new_TABLE");
         Schema schema =
                 Schema.newBuilder()
                         .column("Pk1", DataTypes.INT())
@@ -64,11 +61,7 @@ public class FileSystemCatalogTest extends CatalogTestBase {
                         .partitionKeys("Pk1", "pk2")
                         .primaryKey("Pk1", "pk2", "pk3")
                         .build();
-
-        // Create table throws Exception if using uppercase when 'allow-upper-case' is false
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> catalog.createTable(identifier, schema, false))
-                .withMessage("Field name [Pk1, Col1] cannot contain upper case in the catalog.");
+        catalog.createTable(identifier, schema, false);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcCatalogTest.java
@@ -87,7 +87,7 @@ public class JdbcCatalogTest extends CatalogTestBase {
     }
 
     @Test
-    public void testCheckIdentifierUpperCase() throws Exception {
+    public void testUpperCase() throws Exception {
         catalog.createDatabase("test_db", false);
         assertThatThrownBy(
                         () ->
@@ -95,17 +95,10 @@ public class JdbcCatalogTest extends CatalogTestBase {
                                         Identifier.create("TEST_DB", "new_table"),
                                         DEFAULT_TABLE_SCHEMA,
                                         false))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Database name [TEST_DB] cannot contain upper case in the catalog.");
+                .isInstanceOf(Exception.class)
+                .hasMessage("Database TEST_DB does not exist.");
 
-        assertThatThrownBy(
-                        () ->
-                                catalog.createTable(
-                                        Identifier.create("test_db", "NEW_TABLE"),
-                                        DEFAULT_TABLE_SCHEMA,
-                                        false))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Table name [NEW_TABLE] cannot contain upper case in the catalog.");
+        catalog.createTable(Identifier.create("test_db", "new_TABLE"), DEFAULT_TABLE_SCHEMA, false);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcCatalogTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.jdbc;
 
+import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogTestBase;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.options.CatalogOptions;
@@ -95,7 +96,7 @@ public class JdbcCatalogTest extends CatalogTestBase {
                                         Identifier.create("TEST_DB", "new_table"),
                                         DEFAULT_TABLE_SCHEMA,
                                         false))
-                .isInstanceOf(Exception.class)
+                .isInstanceOf(Catalog.DatabaseNotExistException.class)
                 .hasMessage("Database TEST_DB does not exist.");
 
         catalog.createTable(Identifier.create("test_db", "new_TABLE"), DEFAULT_TABLE_SCHEMA, false);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.flink.action.cdc;
 
 import org.apache.paimon.catalog.Catalog;
-import org.apache.paimon.catalog.CatalogUtils;
 import org.apache.paimon.flink.action.Action;
 import org.apache.paimon.flink.action.MultiTablesSinkMode;
 import org.apache.paimon.flink.sink.cdc.EventParser;
@@ -152,13 +151,6 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
     public SyncDatabaseActionBase withPrimaryKeys(String... primaryKeys) {
         this.primaryKeys.addAll(Arrays.asList(primaryKeys));
         return this;
-    }
-
-    @Override
-    protected void validateCaseSensitivity() {
-        CatalogUtils.validateCaseInsensitive(caseSensitive, "Database", database);
-        CatalogUtils.validateCaseInsensitive(caseSensitive, "Table prefix", tablePrefix);
-        CatalogUtils.validateCaseInsensitive(caseSensitive, "Table suffix", tableSuffix);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionBase.java
@@ -20,7 +20,6 @@ package org.apache.paimon.flink.action.cdc;
 
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.Catalog;
-import org.apache.paimon.catalog.CatalogUtils;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.action.Action;
@@ -111,12 +110,6 @@ public abstract class SyncTableActionBase extends SynchronizationActionBase {
                 caseSensitive,
                 true,
                 true);
-    }
-
-    @Override
-    protected void validateCaseSensitivity() {
-        CatalogUtils.validateCaseInsensitive(caseSensitive, "Database", database);
-        CatalogUtils.validateCaseInsensitive(caseSensitive, "Table", table);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SynchronizationActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SynchronizationActionBase.java
@@ -114,8 +114,6 @@ public abstract class SynchronizationActionBase extends ActionBase {
 
         catalog.createDatabase(database, true);
 
-        validateCaseSensitivity();
-
         beforeBuildingSourceSink();
 
         DataStream<RichCdcMultiplexRecord> input =
@@ -125,8 +123,6 @@ public abstract class SynchronizationActionBase extends ActionBase {
 
         buildSink(input, parserFactory);
     }
-
-    protected abstract void validateCaseSensitivity();
 
     protected void beforeBuildingSourceSink() throws Exception {}
 

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -85,23 +85,18 @@ public class HiveCatalogTest extends CatalogTestBase {
     @Test
     public void testCheckIdentifierUpperCase() throws Exception {
         catalog.createDatabase("test_db", false);
-        assertThatThrownBy(
-                        () ->
-                                catalog.createTable(
-                                        Identifier.create("TEST_DB", "new_table"),
-                                        DEFAULT_TABLE_SCHEMA,
-                                        false))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Database name [TEST_DB] cannot contain upper case in the catalog.");
-
+        assertThatThrownBy(() -> catalog.createDatabase("TEST_DB", false))
+                .isInstanceOf(Catalog.DatabaseAlreadyExistException.class)
+                .hasMessage("Database TEST_DB already exists.");
+        catalog.createTable(Identifier.create("TEST_DB", "new_table"), DEFAULT_TABLE_SCHEMA, false);
         assertThatThrownBy(
                         () ->
                                 catalog.createTable(
                                         Identifier.create("test_db", "NEW_TABLE"),
                                         DEFAULT_TABLE_SCHEMA,
                                         false))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Table name [NEW_TABLE] cannot contain upper case in the catalog.");
+                .isInstanceOf(Catalog.TableAlreadyExistException.class)
+                .hasMessage("Table test_db.NEW_TABLE already exists.");
     }
 
     private static final String HADOOP_CONF_DIR =

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -577,8 +577,7 @@ public abstract class HiveCatalogITCaseBase {
                                 "  'uri' = '',",
                                 "  'warehouse' = '" + path + "',",
                                 "  'lock.enabled' = 'true',",
-                                "  'table.type' = 'EXTERNAL',",
-                                "  'allow-upper-case' = 'true'",
+                                "  'table.type' = 'EXTERNAL'",
                                 ")"))
                 .await();
         tEnv.executeSql("USE CATALOG paimon_catalog_01").await();
@@ -593,30 +592,6 @@ public abstract class HiveCatalogITCaseBase {
         tEnv.executeSql("DROP TABLE t").await();
         Path tablePath = new Path(path, "test_db.db/t");
         assertThat(tablePath.getFileSystem().exists(tablePath)).isTrue();
-
-        tEnv.executeSql(
-                        String.join(
-                                "\n",
-                                "CREATE CATALOG paimon_catalog_02 WITH (",
-                                "  'type' = 'paimon',",
-                                "  'metastore' = 'hive',",
-                                "  'uri' = '',",
-                                "  'warehouse' = '" + path + "',",
-                                "  'lock.enabled' = 'true',",
-                                "  'table.type' = 'EXTERNAL',",
-                                "  'allow-upper-case' = 'false'",
-                                ")"))
-                .await();
-        tEnv.executeSql("USE CATALOG paimon_catalog_02").await();
-        tEnv.executeSql("USE test_db").await();
-
-        // set case-sensitive = false would throw exception out
-        assertThatThrownBy(
-                        () ->
-                                tEnv.executeSql(
-                                                "CREATE TABLE t1 ( aa INT, Bb STRING ) WITH ( 'file.format' = 'avro' )")
-                                        .await())
-                .isInstanceOf(RuntimeException.class);
     }
 
     @Test
@@ -1007,7 +982,7 @@ public abstract class HiveCatalogITCaseBase {
         // the target table name has upper case.
         assertThatThrownBy(() -> tEnv.executeSql("ALTER TABLE t1 RENAME TO T1"))
                 .hasMessage(
-                        "Could not execute ALTER TABLE my_hive.test_db.t1 RENAME TO my_hive.test_db.T1.");
+                        "Could not execute ALTER TABLE my_hive.test_db.t1 RENAME TO my_hive.test_db.T1");
 
         tEnv.executeSql("ALTER TABLE t1 RENAME TO t3").await();
 

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -1006,7 +1006,8 @@ public abstract class HiveCatalogITCaseBase {
 
         // the target table name has upper case.
         assertThatThrownBy(() -> tEnv.executeSql("ALTER TABLE t1 RENAME TO T1"))
-                .hasMessage("Table name [T1] cannot contain upper case in the catalog.");
+                .hasMessage(
+                        "Could not execute ALTER TABLE my_hive.test_db.t1 RENAME TO my_hive.test_db.T1.");
 
         tEnv.executeSql("ALTER TABLE t1 RENAME TO t3").await();
 
@@ -1168,7 +1169,8 @@ public abstract class HiveCatalogITCaseBase {
                                 tEnv.executeSql(
                                                 "CREATE TABLE tt ( A INT, b STRING, C STRING) WITH ( 'file.format' = 'avro' )")
                                         .await())
-                .hasRootCauseMessage("Table test_db.tt already exists.");
+                .hasRootCauseMessage(
+                        "Table (or view) test_db.tt already exists in Catalog my_hive.");
     }
 
     @Test

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -1160,24 +1160,15 @@ public abstract class HiveCatalogITCaseBase {
 
     @Test
     public void testUpperCase() {
+        tEnv.executeSql("CREATE TABLE T (a INT, b STRING ) WITH ( 'file.format' = 'avro' )");
+        tEnv.executeSql(
+                "CREATE TABLE tT (A INT, b STRING, C STRING) WITH ( 'file.format' = 'avro')");
         assertThatThrownBy(
                         () ->
                                 tEnv.executeSql(
-                                                "CREATE TABLE T ( a INT, b STRING ) WITH ( 'file.format' = 'avro' )")
+                                                "CREATE TABLE tt ( A INT, b STRING, C STRING) WITH ( 'file.format' = 'avro' )")
                                         .await())
-                .hasRootCauseMessage(
-                        String.format(
-                                "Table name [%s] cannot contain upper case in the catalog.", "T"));
-
-        assertThatThrownBy(
-                        () ->
-                                tEnv.executeSql(
-                                                "CREATE TABLE t (A INT, b STRING, C STRING) WITH ( 'file.format' = 'avro')")
-                                        .await())
-                .hasRootCauseMessage(
-                        String.format(
-                                "Field name %s cannot contain upper case in the catalog.",
-                                "[A, C]"));
+                .hasRootCauseMessage("Table test_db.tt already exists.");
     }
 
     @Test

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkGenericCatalogWithHiveTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkGenericCatalogWithHiveTest.java
@@ -69,7 +69,7 @@ public class SparkGenericCatalogWithHiveTest {
                         + " ('file.format'='avro')");
 
         assertThat(spark.sql("SHOW NAMESPACES").collectAsList().stream().map(Object::toString))
-                .containsExactlyInAnyOrder("[default]", "[my_db]", "[my_db1]");
+                .containsExactlyInAnyOrder("[default]", "[my_db]");
 
         assertThat(
                         spark.sql("SHOW TABLES").collectAsList().stream()

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkGenericCatalogWithHiveTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkGenericCatalogWithHiveTest.java
@@ -31,7 +31,6 @@ import java.io.FileNotFoundException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Base tests for spark read. */
 public class SparkGenericCatalogWithHiveTest {
@@ -46,59 +45,6 @@ public class SparkGenericCatalogWithHiveTest {
     @AfterAll
     public static void closeMetastore() throws Exception {
         testHiveMetastore.stop();
-    }
-
-    @Test
-    public void testCreateTableCaseSensitive(@TempDir java.nio.file.Path tempDir) {
-        // firstly, we use hive metastore to creata table, and check the result.
-        Path warehousePath = new Path("file:" + tempDir.toString());
-        SparkSession spark =
-                SparkSession.builder()
-                        .config("spark.sql.warehouse.dir", warehousePath.toString())
-                        // with case-sensitive false
-                        .config("spark.sql.caseSensitive", "false")
-                        // with hive metastore
-                        .config("spark.sql.catalogImplementation", "hive")
-                        .config(
-                                "spark.sql.catalog.spark_catalog",
-                                SparkGenericCatalog.class.getName())
-                        .master("local[2]")
-                        .getOrCreate();
-
-        spark.sql("CREATE DATABASE IF NOT EXISTS my_db1");
-        spark.sql("USE my_db1");
-        spark.sql(
-                "CREATE TABLE IF NOT EXISTS t2 (a INT, Bb INT, c STRING) USING paimon TBLPROPERTIES"
-                        + " ('file.format'='avro')");
-
-        assertThat(
-                        spark.sql("SHOW TABLES").collectAsList().stream()
-                                .map(s -> s.get(1))
-                                .map(Object::toString))
-                .containsExactlyInAnyOrder("t2");
-        spark.close();
-
-        SparkSession spark1 =
-                SparkSession.builder()
-                        .config("spark.sql.warehouse.dir", warehousePath.toString())
-                        // with case-sensitive true
-                        .config("spark.sql.caseSensitive", "true")
-                        // with hive metastore
-                        .config("spark.sql.catalogImplementation", "hive")
-                        .config(
-                                "spark.sql.catalog.spark_catalog",
-                                SparkGenericCatalog.class.getName())
-                        .master("local[2]")
-                        .getOrCreate();
-
-        spark1.sql("USE my_db1");
-        assertThrows(
-                RuntimeException.class,
-                () ->
-                        spark1.sql(
-                                "CREATE TABLE IF NOT EXISTS t3 (a INT, Bb INT, c STRING) USING paimon TBLPROPERTIES"
-                                        + " ('file.format'='avro')"));
-        spark1.close();
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Checked with iceberg and delta, they don't check the case of tables or fields with hive in catalog.

So skip case checking in paimon too, and let the catalog implementation do case checking itself.

For example, table names are always lowercase in hive, so when creating a table with the same lowercase with hive catalog, hive will throw an exception:

```sql
create table t;
-- table exists exception
create table T;
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
