### PR TITLE
[hive] Batch list tables and skip checking table exists in filesystem with hive catalog

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -436,10 +436,10 @@ public class HiveCatalog extends AbstractCatalog {
     @Override
     protected List<String> listTablesImpl(String databaseName) {
         try {
-            List<String> allTables = clients.run(client -> client.getAllTables(databaseName));
+            List<String> tableNames = clients.run(client -> client.getAllTables(databaseName));
             List<Table> hmsTables =
-                    clients.run(client -> client.getTableObjectsByName(databaseName, allTables));
-            List<String> result = new ArrayList<>(allTables.size());
+                    clients.run(client -> client.getTableObjectsByName(databaseName, tableNames));
+            List<String> result = new ArrayList<>(hmsTables.size());
             for (Table table : hmsTables) {
                 if (isPaimonTable(table) || (!formatTableDisabled() && isFormatTable(table))) {
                     result.add(table.getTableName());

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -437,15 +437,12 @@ public class HiveCatalog extends AbstractCatalog {
     protected List<String> listTablesImpl(String databaseName) {
         try {
             List<String> allTables = clients.run(client -> client.getAllTables(databaseName));
+            List<Table> hmsTables =
+                    clients.run(client -> client.getTableObjectsByName(databaseName, allTables));
             List<String> result = new ArrayList<>(allTables.size());
-            for (String t : allTables) {
-                try {
-                    Identifier identifier = new Identifier(databaseName, t);
-                    Table table = getHmsTable(identifier);
-                    if (isPaimonTable(table) || (!formatTableDisabled() && isFormatTable(table))) {
-                        result.add(t);
-                    }
-                } catch (TableNotExistException ignored) {
+            for (Table table : hmsTables) {
+                if (isPaimonTable(table) || (!formatTableDisabled() && isFormatTable(table))) {
+                    result.add(table.getTableName());
                 }
             }
             return result;

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -442,8 +442,7 @@ public class HiveCatalog extends AbstractCatalog {
                 try {
                     Identifier identifier = new Identifier(databaseName, t);
                     Table table = getHmsTable(identifier);
-                    if (isPaimonTable(identifier, table)
-                            || (!formatTableDisabled() && isFormatTable(table))) {
+                    if (isPaimonTable(table) || (!formatTableDisabled() && isFormatTable(table))) {
                         result.add(t);
                     }
                 } catch (TableNotExistException ignored) {
@@ -478,7 +477,7 @@ public class HiveCatalog extends AbstractCatalog {
 
     private TableSchema getDataTableSchema(Identifier identifier, Table table)
             throws TableNotExistException {
-        if (!isPaimonTable(identifier, table)) {
+        if (!isPaimonTable(table)) {
             throw new TableNotExistException(identifier);
         }
 
@@ -870,7 +869,7 @@ public class HiveCatalog extends AbstractCatalog {
     protected void alterTableImpl(Identifier identifier, List<SchemaChange> changes)
             throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException {
         Table table = getHmsTable(identifier);
-        if (!isPaimonTable(identifier, table)) {
+        if (!isPaimonTable(table)) {
             throw new UnsupportedOperationException("Only data table support alter table.");
         }
 
@@ -1042,12 +1041,6 @@ public class HiveCatalog extends AbstractCatalog {
             throw new RuntimeException(
                     "Interrupted in call to tableExists " + identifier.getFullName(), e);
         }
-    }
-
-    private boolean isPaimonTable(Identifier identifier, Table table) {
-        return isPaimonTable(table)
-                && tableExistsInFileSystem(
-                        getTableLocation(identifier, table), identifier.getBranchNameOrDefault());
     }
 
     private static boolean isPaimonTable(Table table) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

For a database containing thousands of tables on OSS, show tables may take several minutes.

It is enough to compare prop to determine whether it is a paimon table when show tables,  we can skip checking table exists in filesystem. And  the batch list api can reduce the metastore call overhead.

cost: 3min -> 4s

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
