### PR TITLE
[spark] Fix delete with partial non-convertible partition filter

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkFilterConverter.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkFilterConverter.java
@@ -40,6 +40,8 @@ import org.apache.spark.sql.sources.StringContains;
 import org.apache.spark.sql.sources.StringEndsWith;
 import org.apache.spark.sql.sources.StringStartsWith;
 
+import javax.annotation.Nullable;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -76,10 +78,12 @@ public class SparkFilterConverter {
         this.builder = new PredicateBuilder(rowType);
     }
 
+    @Nullable
     public Predicate convertIgnoreFailure(Filter filter) {
         return convert(filter, true);
     }
 
+    @Nullable
     public Predicate convert(Filter filter, boolean ignoreFailure) {
         try {
             return convert(filter);

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/expressions/ExpressionHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/expressions/ExpressionHelper.scala
@@ -185,7 +185,7 @@ trait ExpressionHelper extends PredicateHelper {
     if (filters.isEmpty) {
       None
     } else {
-      val predicates = filters.map(converter.convert(_, ignorePartialFailure)).filter(_ != null)
+      val predicates = filters.map(converter.convert(_, ignorePartialFailure))
       Some(PredicateBuilder.and(predicates: _*))
     }
   }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/expressions/ExpressionHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/expressions/ExpressionHelper.scala
@@ -180,12 +180,11 @@ trait ExpressionHelper extends PredicateHelper {
           }
           filter
       })
-      .toArray
 
-    if (filters.isEmpty) {
+    val predicates = filters.map(converter.convert(_, ignorePartialFailure)).filter(_ != null)
+    if (predicates.isEmpty) {
       None
     } else {
-      val predicates = filters.map(converter.convert(_, ignorePartialFailure))
       Some(PredicateBuilder.and(predicates: _*))
     }
   }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/expressions/ExpressionHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/expressions/ExpressionHelper.scala
@@ -167,13 +167,13 @@ trait ExpressionHelper extends PredicateHelper {
       condition: Expression,
       output: Seq[Attribute],
       rowType: RowType,
-      ignoreFailure: Boolean = false): Option[Predicate] = {
+      ignorePartialFailure: Boolean = false): Option[Predicate] = {
     val converter = new SparkFilterConverter(rowType)
     val filters = normalizeExprs(Seq(condition), output)
       .flatMap(splitConjunctivePredicates(_).flatMap {
         f =>
           val filter = translateFilter(f, supportNestedPredicatePushdown = true)
-          if (filter.isEmpty && !ignoreFailure) {
+          if (filter.isEmpty && !ignorePartialFailure) {
             throw new RuntimeException(
               "Exec update failed:" +
                 s" cannot translate expression to source filter: $f")
@@ -185,7 +185,7 @@ trait ExpressionHelper extends PredicateHelper {
     if (filters.isEmpty) {
       None
     } else {
-      val predicates = filters.map(converter.convert(_, ignoreFailure))
+      val predicates = filters.map(converter.convert(_, ignorePartialFailure)).filter(_ != null)
       Some(PredicateBuilder.and(predicates: _*))
     }
   }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/expressions/ExpressionHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/expressions/ExpressionHelper.scala
@@ -185,7 +185,7 @@ trait ExpressionHelper extends PredicateHelper {
     if (filters.isEmpty) {
       None
     } else {
-      val predicates = filters.map(converter.convertIgnoreFailure)
+      val predicates = filters.map(converter.convert(_, ignoreFailure))
       Some(PredicateBuilder.and(predicates: _*))
     }
   }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
@@ -101,7 +101,7 @@ trait PaimonCommand extends WithFileStoreTable with ExpressionHelper with SQLCon
     }
     if (condition != TrueLiteral) {
       val filter =
-        convertConditionToPaimonPredicate(condition, output, rowType, ignoreFailure = true)
+        convertConditionToPaimonPredicate(condition, output, rowType, ignorePartialFailure = true)
       filter.foreach(snapshotReader.withFilter)
     }
 

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkFilterConverterTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkFilterConverterTest.java
@@ -57,7 +57,7 @@ import java.util.List;
 
 import static org.apache.paimon.data.BinaryString.fromString;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link SparkFilterConverter}. */
 public class SparkFilterConverterTest {
@@ -225,7 +225,9 @@ public class SparkFilterConverterTest {
         SparkFilterConverter converter = new SparkFilterConverter(rowType);
 
         Not not = Not.apply(StringStartsWith.apply("name", "paimon"));
-        catchThrowableOfType(() -> converter.convert(not), UnsupportedOperationException.class);
+        assertThatThrownBy(() -> converter.convert(not, false))
+                .hasMessageContaining("Not(StringStartsWith(name,paimon)) is unsupported.");
+        assertThat(converter.convert(not, true)).isNull();
         assertThat(converter.convertIgnoreFailure(not)).isNull();
     }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DeleteFromTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DeleteFromTableTestBase.scala
@@ -374,4 +374,14 @@ abstract class DeleteFromTableTestBase extends PaimonSparkTestBase {
       Row(1, "20240601") :: Nil
     )
   }
+
+  test(s"Paimon Delete: delete with non-convertible partition filter") {
+    sql("CREATE TABLE T (id INT, p STRING) PARTITIONED BY (p)")
+    sql("INSERT INTO T VALUES (2, '2024-12-16'), (3, '2024-12-17'), (4, '2024-12-18')")
+    sql("DELETE FROM T WHERE p >= date_sub('2024-12-17', 0) AND p < '2024-12-18'")
+    checkAnswer(
+      sql("SELECT * FROM T ORDER BY id"),
+      Seq(Row(2, "2024-12-16"), Row(4, "2024-12-18"))
+    )
+  }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Currently paimon `delete where` supports directly dropping partitions when all filters are partition filter. Therefore we can not allow partial success for this filter conversion.

```sql
CREATE TABLE T (id INT, p STRING) PARTITIONED BY (p);
INSERT INTO T VALUES (2, '2024-12-16'), (3, '2024-12-17'), (4, '2024-12-18');
DELETE FROM T WHERE p >= date_sub('2024-12-17', 0) AND p < '2024-12-18';
SELECT * FROM T ORDER BY id;
```

before
```
+---+----------+
| id|         p|
+---+----------+
|  4|2024-12-18|
+---+----------+
```

after
```
+---+----------+
| id|         p|
+---+----------+
|  2|2024-12-16|
|  4|2024-12-18|
+---+----------+
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
