### PR TITLE
[spark] Fix load function with SparkGenericCatalog

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/catalog/SupportFunction.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/catalog/SupportFunction.java
@@ -29,6 +29,8 @@ import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
 
 import java.util.Arrays;
 
+import scala.Option;
+
 import static org.apache.paimon.catalog.Catalog.SYSTEM_DATABASE_NAME;
 
 /** Catalog methods for working with Functions. */
@@ -54,7 +56,8 @@ public interface SupportFunction extends FunctionCatalog, SupportsNamespaces {
             return new Identifier[0];
         }
 
-        throw new RuntimeException("Namespace " + Arrays.toString(namespace) + " is not valid");
+        throw new NoSuchNamespaceException(
+                "Namespace " + Arrays.toString(namespace) + " is not valid", Option.empty());
     }
 
     @Override
@@ -66,6 +69,7 @@ public interface SupportFunction extends FunctionCatalog, SupportsNamespaces {
             }
         }
 
-        throw new RuntimeException("Function " + ident + " is not a paimon function");
+        throw new NoSuchFunctionException(
+                "Function " + ident + " is not a paimon function", Option.empty());
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/catalog/SupportFunction.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/catalog/SupportFunction.java
@@ -27,10 +27,6 @@ import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.SupportsNamespaces;
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
 
-import java.util.Arrays;
-
-import scala.Option;
-
 import static org.apache.paimon.catalog.Catalog.SYSTEM_DATABASE_NAME;
 
 /** Catalog methods for working with Functions. */
@@ -56,8 +52,7 @@ public interface SupportFunction extends FunctionCatalog, SupportsNamespaces {
             return new Identifier[0];
         }
 
-        throw new NoSuchNamespaceException(
-                "Namespace " + Arrays.toString(namespace) + " is not valid", Option.empty());
+        throw new NoSuchNamespaceException(namespace);
     }
 
     @Override
@@ -69,7 +64,6 @@ public interface SupportFunction extends FunctionCatalog, SupportsNamespaces {
             }
         }
 
-        throw new NoSuchFunctionException(
-                "Function " + ident + " is not a paimon function", Option.empty());
+        throw new NoSuchFunctionException(ident);
     }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonFunctionTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonFunctionTest.scala
@@ -108,6 +108,7 @@ class PaimonFunctionTest extends PaimonHiveTestBase {
 }
 
 private class MyIntSum extends UserDefinedAggregateFunction {
+
   override def inputSchema: StructType = new StructType().add("input", IntegerType)
 
   override def bufferSchema: StructType = new StructType().add("buffer", IntegerType)
@@ -121,7 +122,7 @@ private class MyIntSum extends UserDefinedAggregateFunction {
   }
 
   override def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
-    buffer.update(0, input.getInt(0) + buffer.getInt(0))
+    buffer.update(0, buffer.getInt(0) + input.getInt(0))
   }
 
   override def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonFunctionTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonFunctionTest.scala
@@ -23,6 +23,8 @@ import org.apache.paimon.spark.catalog.functions.PaimonFunctions
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.connector.catalog.{FunctionCatalog, Identifier}
+import org.apache.spark.sql.expressions.{MutableAggregationBuffer, UserDefinedAggregateFunction}
+import org.apache.spark.sql.types.{DataType, IntegerType, StructType}
 
 class PaimonFunctionTest extends PaimonHiveTestBase {
 
@@ -84,5 +86,49 @@ class PaimonFunctionTest extends PaimonHiveTestBase {
           Row(5, "x5", 5, "x5"))
       )
     }
+  }
+
+  test("Paimon function: show and load function with SparkGenericCatalog") {
+    sql(s"USE $sparkCatalogName")
+    sql(s"USE $hiveDbName")
+    sql("CREATE FUNCTION myIntSum AS 'org.apache.paimon.spark.sql.MyIntSum'")
+    checkAnswer(
+      sql(s"SHOW FUNCTIONS FROM $hiveDbName LIKE 'myIntSum'"),
+      Row("spark_catalog.test_hive.myintsum"))
+
+    withTable("t") {
+      sql("CREATE TABLE t (id INT)")
+      sql("INSERT INTO t VALUES (1), (2), (3)")
+      checkAnswer(sql("SELECT myIntSum(id) FROM t"), Row(6))
+    }
+
+    sql("DROP FUNCTION myIntSum")
+    checkAnswer(sql(s"SHOW FUNCTIONS FROM $hiveDbName LIKE 'myIntSum'"), Seq.empty)
+  }
+}
+
+private class MyIntSum extends UserDefinedAggregateFunction {
+  override def inputSchema: StructType = new StructType().add("input", IntegerType)
+
+  override def bufferSchema: StructType = new StructType().add("buffer", IntegerType)
+
+  override def dataType: DataType = IntegerType
+
+  override def deterministic: Boolean = true
+
+  override def initialize(buffer: MutableAggregationBuffer): Unit = {
+    buffer.update(0, 0)
+  }
+
+  override def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
+    buffer.update(0, input.getInt(0) + buffer.getInt(0))
+  }
+
+  override def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {
+    buffer1.update(0, buffer1.getInt(0) + buffer2.getInt(0))
+  }
+
+  override def evaluate(buffer: Row): Any = {
+    buffer.getInt(0)
   }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

`loadFunction` in `SparkGenericCatalog` should throw `NoSuchFunctionException` instead of `RuntimeException`, fix this

```
Function test_hive.myIntSum is not a paimon function
java.lang.RuntimeException: Function test_hive.myIntSum is not a paimon function
	at org.apache.paimon.spark.catalog.SupportFunction.loadFunction(SupportFunction.java:67)
	at org.apache.paimon.spark.SparkGenericCatalog.loadFunction(SparkGenericCatalog.java:379)
	at org.apache.spark.sql.connector.catalog.FunctionCatalog.functionExists(FunctionCatalog.java:60)
	at org.apache.spark.sql.catalyst.analysis.Analyzer$LookupFunctions$$anonfun$apply$20.applyOrElse(Analyzer.scala:2075)
	at org.apache.spark.sql.catalyst.analysis.Analyzer$LookupFunctions$$anonfun$apply$20.applyOrElse(Analyzer.scala:2066)
	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$transformDownWithPruning$1(TreeNode.scala:461)
	at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(origin.scala:76)
	at org.apache.spark.sql.catalyst.trees.TreeNode.transformDownWithPruning(TreeNode.scala:461)
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
