### PR TITLE
[flink] Bugfix expire snapshot don't work when some snapshot between …

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
@@ -115,7 +115,12 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
 
         // protected by 'snapshot.expire.limit'
         // (the maximum number of snapshots allowed to expire at a time)
-        maxExclusive = Math.min(maxExclusive, earliest + maxDeletes);
+        long maxExclusiveByExpireLimit = earliest + maxDeletes;
+        while (!snapshotManager.snapshotExists(maxExclusiveByExpireLimit)) {
+            // Ensure maxExclusive exist, deal some snapshot between earliest and latest is deleted
+            maxExclusiveByExpireLimit++;
+        }
+        maxExclusive = Math.min(maxExclusive, maxExclusiveByExpireLimit);
 
         for (long id = min; id < maxExclusive; id++) {
             // Early exit the loop for 'snapshot.time-retained'


### PR DESCRIPTION
### Purpose
When performing snapshot expiration, identify whether the maxExclusiveSnapshotID exists to prevent the expiration failing due to its absence. This ensures that the expired work can proceed, the earliest snapshot ID can be updated, and the issue of repetitive failure in the expiration process is avoided.


Linked issue: #4743


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
