### PR TITLE
[hive] Ignore path comparison when creating external table

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -262,7 +262,9 @@ public class SchemaManager implements Serializable {
             Map<String, String> newOptions = newSchema.options();
             newOptions.forEach(
                     (key, value) -> {
+                        // ignore `owner` and `path`
                         if (!key.equals(Catalog.OWNER_PROP)
+                                && !key.equals(CoreOptions.PATH.key())
                                 && (!existsOptions.containsKey(key)
                                         || !existsOptions.get(key).equals(value))) {
                             throw new RuntimeException(

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTestBase.scala
@@ -553,6 +553,27 @@ abstract class DDLWithHiveCatalogTestBase extends PaimonHiveTestBase {
     }
   }
 
+  test("Paimon DDL with hive catalog: create external based on managed table location") {
+    Seq(sparkCatalogName, paimonHiveCatalogName).foreach {
+      catalogName =>
+        spark.sql(s"USE $catalogName")
+        withDatabase("paimon_db") {
+          spark.sql(s"CREATE DATABASE IF NOT EXISTS paimon_db")
+          spark.sql(s"USE paimon_db")
+          withTable("external_tbl", "managed_tbl") {
+            spark.sql(s"CREATE TABLE managed_tbl (id INT) USING paimon")
+            spark.sql("INSERT INTO managed_tbl VALUES (1)")
+            checkAnswer(spark.sql("SELECT * FROM managed_tbl"), Row(1))
+
+            val tablePath = loadTable("paimon_db", "managed_tbl").location().toString
+            spark.sql(s"CREATE TABLE external_tbl (id INT) USING paimon LOCATION '$tablePath'")
+            checkAnswer(spark.sql("SELECT * FROM external_tbl"), Row(1))
+            assert(loadTable("paimon_db", "external_tbl").location().toString.equals(tablePath))
+          }
+        }
+    }
+  }
+
   test("Paimon DDL with hive catalog: case sensitive") {
     Seq(sparkCatalogName, paimonHiveCatalogName).foreach {
       catalogName =>

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTestBase.scala
@@ -553,7 +553,7 @@ abstract class DDLWithHiveCatalogTestBase extends PaimonHiveTestBase {
     }
   }
 
-  test("Paimon DDL with hive catalog: create external based on managed table location") {
+  test("Paimon DDL with hive catalog: create external table on managed table location") {
     Seq(sparkCatalogName, paimonHiveCatalogName).foreach {
       catalogName =>
         spark.sql(s"USE $catalogName")


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Ignore path comparison when creating external table, because the original table may not have the 'path' attribute

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
