### PR TITLE
[parquet] parquet reader should not retrun VectorizedRowIterator for nested schema

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarRowIterator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarRowIterator.java
@@ -23,7 +23,6 @@ import org.apache.paimon.data.PartitionInfo;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.reader.FileRecordIterator;
 import org.apache.paimon.reader.RecordReader;
-import org.apache.paimon.reader.VectorizedRecordIterator;
 import org.apache.paimon.utils.RecyclableIterator;
 import org.apache.paimon.utils.VectorMappingUtils;
 
@@ -34,15 +33,15 @@ import javax.annotation.Nullable;
  * {@link ColumnarRow#setRowId}.
  */
 public class ColumnarRowIterator extends RecyclableIterator<InternalRow>
-        implements FileRecordIterator<InternalRow>, VectorizedRecordIterator {
+        implements FileRecordIterator<InternalRow> {
 
-    private final Path filePath;
-    private final ColumnarRow row;
-    private final Runnable recycler;
+    protected final Path filePath;
+    protected final ColumnarRow row;
+    protected final Runnable recycler;
 
-    private int num;
-    private int nextPos;
-    private long nextFilePos;
+    protected int num;
+    protected int nextPos;
+    protected long nextFilePos;
 
     public ColumnarRowIterator(Path filePath, ColumnarRow row, @Nullable Runnable recycler) {
         super(recycler);
@@ -79,7 +78,7 @@ public class ColumnarRowIterator extends RecyclableIterator<InternalRow>
         return this.filePath;
     }
 
-    public ColumnarRowIterator copy(ColumnVector[] vectors) {
+    protected ColumnarRowIterator copy(ColumnVector[] vectors) {
         ColumnarRowIterator newIterator =
                 new ColumnarRowIterator(filePath, row.copy(vectors), recycler);
         newIterator.reset(nextFilePos);
@@ -100,10 +99,5 @@ public class ColumnarRowIterator extends RecyclableIterator<InternalRow>
             return copy(vectors);
         }
         return this;
-    }
-
-    @Override
-    public VectorizedColumnBatch batch() {
-        return row.batch();
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/VectorizedColumnBatch.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/VectorizedColumnBatch.java
@@ -38,12 +38,6 @@ public class VectorizedColumnBatch implements Serializable {
 
     private static final long serialVersionUID = 8180323238728166155L;
 
-    /**
-     * This number is carefully chosen to minimize overhead and typically allows one
-     * VectorizedColumnBatch to fit in cache.
-     */
-    public static final int DEFAULT_SIZE = 2048;
-
     private int numRows;
 
     public final ColumnVector[] columns;

--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/VectorizedRowIterator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/VectorizedRowIterator.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.data.columnar;
+
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.reader.VectorizedRecordIterator;
+
+import javax.annotation.Nullable;
+
+/** A {@link ColumnarRowIterator} with {@link VectorizedRecordIterator}. */
+public class VectorizedRowIterator extends ColumnarRowIterator implements VectorizedRecordIterator {
+
+    public VectorizedRowIterator(Path filePath, ColumnarRow row, @Nullable Runnable recycler) {
+        super(filePath, row, recycler);
+    }
+
+    @Override
+    public VectorizedColumnBatch batch() {
+        return row.batch();
+    }
+
+    @Override
+    protected VectorizedRowIterator copy(ColumnVector[] vectors) {
+        VectorizedRowIterator newIterator =
+                new VectorizedRowIterator(filePath, row.copy(vectors), recycler);
+        newIterator.reset(nextFilePos);
+        return newIterator;
+    }
+}

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcReaderFactory.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.columnar.ColumnVector;
 import org.apache.paimon.data.columnar.ColumnarRow;
 import org.apache.paimon.data.columnar.ColumnarRowIterator;
 import org.apache.paimon.data.columnar.VectorizedColumnBatch;
+import org.apache.paimon.data.columnar.VectorizedRowIterator;
 import org.apache.paimon.fileindex.FileIndexResult;
 import org.apache.paimon.fileindex.bitmap.BitmapIndexResult;
 import org.apache.paimon.format.FormatReaderFactory;
@@ -158,7 +159,7 @@ public class OrcReaderFactory implements FormatReaderFactory {
         private final Pool.Recycler<OrcReaderBatch> recycler;
 
         private final VectorizedColumnBatch paimonColumnBatch;
-        private final ColumnarRowIterator result;
+        private final VectorizedRowIterator result;
 
         protected OrcReaderBatch(
                 final Path filePath,
@@ -169,7 +170,7 @@ public class OrcReaderFactory implements FormatReaderFactory {
             this.recycler = checkNotNull(recycler);
             this.paimonColumnBatch = paimonColumnBatch;
             this.result =
-                    new ColumnarRowIterator(
+                    new VectorizedRowIterator(
                             filePath, new ColumnarRow(paimonColumnBatch), this::recycle);
         }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
@@ -19,10 +19,14 @@
 package org.apache.paimon.format.parquet;
 
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.columnar.ArrayColumnVector;
 import org.apache.paimon.data.columnar.ColumnVector;
 import org.apache.paimon.data.columnar.ColumnarRow;
 import org.apache.paimon.data.columnar.ColumnarRowIterator;
+import org.apache.paimon.data.columnar.MapColumnVector;
+import org.apache.paimon.data.columnar.RowColumnVector;
 import org.apache.paimon.data.columnar.VectorizedColumnBatch;
+import org.apache.paimon.data.columnar.VectorizedRowIterator;
 import org.apache.paimon.data.columnar.heap.ElementCountable;
 import org.apache.paimon.data.columnar.writable.WritableColumnVector;
 import org.apache.paimon.format.FormatReaderFactory;
@@ -525,7 +529,8 @@ public class ParquetReaderFactory implements FormatReaderFactory {
     private static class ParquetReaderBatch {
 
         private final WritableColumnVector[] writableVectors;
-        protected final VectorizedColumnBatch columnarBatch;
+        private final boolean containsNestedColumn;
+        private final VectorizedColumnBatch columnarBatch;
         private final Pool.Recycler<ParquetReaderBatch> recycler;
 
         private final ColumnarRowIterator result;
@@ -536,11 +541,30 @@ public class ParquetReaderFactory implements FormatReaderFactory {
                 VectorizedColumnBatch columnarBatch,
                 Pool.Recycler<ParquetReaderBatch> recycler) {
             this.writableVectors = writableVectors;
+            this.containsNestedColumn =
+                    Arrays.stream(writableVectors)
+                            .anyMatch(
+                                    vector ->
+                                            vector instanceof MapColumnVector
+                                                    || vector instanceof RowColumnVector
+                                                    || vector instanceof ArrayColumnVector);
             this.columnarBatch = columnarBatch;
             this.recycler = recycler;
+
+            /*
+             * See <a href="https://github.com/apache/paimon/pull/3883">Reverted #3883</a>.
+             * If a FileRecordIterator contains a batch and the batch's nested vectors are not compactly,
+             * it's not safe to use VectorizedColumnBatch directly. Currently, we should use {@link #next()}
+             * to handle it row by row.
+             *
+             * <p>TODO: delete this after #3883 is fixed completely.
+             */
             this.result =
-                    new ColumnarRowIterator(
-                            filePath, new ColumnarRow(columnarBatch), this::recycle);
+                    containsNestedColumn
+                            ? new ColumnarRowIterator(
+                                    filePath, new ColumnarRow(columnarBatch), this::recycle)
+                            : new VectorizedRowIterator(
+                                    filePath, new ColumnarRow(columnarBatch), this::recycle);
         }
 
         public void recycle() {


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Another solution for https://github.com/apache/paimon/pull/4748

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
