### PR TITLE
[core] Introduce VariantType

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/ArrowFieldTypeConversion.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/ArrowFieldTypeConversion.java
@@ -40,6 +40,7 @@ import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.types.VariantType;
 
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.Types;
@@ -148,6 +149,11 @@ public class ArrowFieldTypeConversion {
             ArrowType arrowType =
                     new ArrowType.Timestamp(timeUnit, ZoneId.systemDefault().toString());
             return new FieldType(localZonedTimestampType.isNullable(), arrowType, null);
+        }
+
+        @Override
+        public FieldType visit(VariantType variantType) {
+            throw new UnsupportedOperationException();
         }
 
         private TimeUnit getTimeUnit(int precision) {

--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/converter/Arrow2PaimonVectorConverter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/converter/Arrow2PaimonVectorConverter.java
@@ -63,6 +63,7 @@ import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.types.VariantType;
 
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
@@ -421,6 +422,11 @@ public interface Arrow2PaimonVectorConverter {
                             }
                         }
                     };
+        }
+
+        @Override
+        public Arrow2PaimonVectorConverter visit(VariantType variantType) {
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/writer/ArrowFieldWriterFactoryVisitor.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/writer/ArrowFieldWriterFactoryVisitor.java
@@ -39,6 +39,7 @@ import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.types.VariantType;
 
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.complex.ListVector;
@@ -136,6 +137,11 @@ public class ArrowFieldWriterFactoryVisitor implements DataTypeVisitor<ArrowFiel
         return fieldVector ->
                 new ArrowFieldWriters.TimestampWriter(
                         fieldVector, localZonedTimestampType.getPrecision(), null);
+    }
+
+    @Override
+    public ArrowFieldWriterFactory visit(VariantType variantType) {
+        throw new UnsupportedOperationException("Doesn't support VariantType.");
     }
 
     @Override

--- a/paimon-codegen/src/main/scala/org/apache/paimon/codegen/GenerateUtils.scala
+++ b/paimon-codegen/src/main/scala/org/apache/paimon/codegen/GenerateUtils.scala
@@ -19,6 +19,7 @@
 package org.apache.paimon.codegen
 
 import org.apache.paimon.data._
+import org.apache.paimon.data.variant.Variant
 import org.apache.paimon.memory.MemorySegment
 import org.apache.paimon.types._
 import org.apache.paimon.types.DataTypeChecks.{getFieldCount, getFieldTypes, getPrecision, getScale}
@@ -380,6 +381,7 @@ object GenerateUtils {
     case ARRAY => className[InternalArray]
     case MULTISET | MAP => className[InternalMap]
     case ROW => className[InternalRow]
+    case VARIANT => className[Variant]
     case _ =>
       throw new IllegalArgumentException("Illegal type: " + t)
   }
@@ -418,6 +420,8 @@ object GenerateUtils {
         s"$rowTerm.getMap($indexTerm)"
       case ROW =>
         s"$rowTerm.getRow($indexTerm, ${getFieldCount(t)})"
+      case VARIANT =>
+        s"$rowTerm.getVariant($indexTerm)"
       case _ =>
         throw new IllegalArgumentException("Illegal type: " + t)
     }

--- a/paimon-codegen/src/test/java/org/apache/paimon/codegen/EqualiserCodeGeneratorTest.java
+++ b/paimon-codegen/src/test/java/org/apache/paimon/codegen/EqualiserCodeGeneratorTest.java
@@ -30,6 +30,7 @@ import org.apache.paimon.data.serializer.InternalArraySerializer;
 import org.apache.paimon.data.serializer.InternalMapSerializer;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.data.serializer.Serializer;
+import org.apache.paimon.data.variant.GenericVariant;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.DataTypes;
@@ -179,6 +180,13 @@ public class EqualiserCodeGeneratorTest {
                                 GenericRow.of(31, BinaryString.fromString("32")),
                                 GenericRow.of(31, BinaryString.fromString("33"))),
                         new InternalRowSerializer(DataTypes.INT(), DataTypes.VARCHAR(2))));
+        TEST_DATA.put(
+                DataTypeRoot.VARIANT,
+                new GeneratedData(
+                        DataTypes.VARIANT(),
+                        Pair.of(
+                                GenericVariant.fromJson("{\"age\":27,\"city\":\"Beijing\"}"),
+                                GenericVariant.fromJson("{\"age\":27,\"city\":\"Hangzhou\"}"))));
     }
 
     @ParameterizedTest

--- a/paimon-common/src/main/java/org/apache/paimon/PartitionSettedRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/PartitionSettedRow.java
@@ -26,6 +26,7 @@ import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.PartitionInfo;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.RowKind;
 
 /** An implementation of {@link InternalRow} which provides a row the fixed partition value. */
@@ -151,6 +152,13 @@ public class PartitionSettedRow implements InternalRow {
         return partitionInfo.inPartitionRow(pos)
                 ? partition.getBinary(partitionInfo.getRealIndex(pos))
                 : row.getBinary(partitionInfo.getRealIndex(pos));
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return partitionInfo.inPartitionRow(pos)
+                ? partition.getVariant(partitionInfo.getRealIndex(pos))
+                : row.getVariant(partitionInfo.getRealIndex(pos));
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/casting/CastedArray.java
+++ b/paimon-common/src/main/java/org/apache/paimon/casting/CastedArray.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.Variant;
 
 /**
  * An implementation of {@link InternalArray} which provides a casted view of the underlying {@link
@@ -181,6 +182,11 @@ public class CastedArray implements InternalArray {
 
     @Override
     public byte[] getBinary(int pos) {
+        return castElementGetter.getElementOrNull(array, pos);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
         return castElementGetter.getElementOrNull(array, pos);
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/casting/CastedRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/casting/CastedRow.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.RowKind;
 
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
@@ -128,6 +129,11 @@ public class CastedRow implements InternalRow {
 
     @Override
     public byte[] getBinary(int pos) {
+        return castMapping[pos].getFieldOrNull(row);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
         return castMapping[pos].getFieldOrNull(row);
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/casting/DefaultValueRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/casting/DefaultValueRow.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.RowKind;
 
 /**
@@ -179,6 +180,14 @@ public class DefaultValueRow implements InternalRow {
             return row.getRow(pos, numFields);
         }
         return defaultValueRow.getRow(pos, numFields);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        if (!row.isNullAt(pos)) {
+            return row.getVariant(pos);
+        }
+        return defaultValueRow.getVariant(pos);
     }
 
     public static DefaultValueRow from(InternalRow defaultValueRow) {

--- a/paimon-common/src/main/java/org/apache/paimon/data/BinaryArray.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BinaryArray.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.data;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.memory.MemorySegmentUtils;
 import org.apache.paimon.types.DataType;
@@ -83,6 +84,7 @@ public final class BinaryArray extends BinarySection implements InternalArray, D
             case MULTISET:
             case MAP:
             case ROW:
+            case VARIANT:
                 // long and double are 8 bytes;
                 // otherwise it stores the length and offset of the variable-length part for types
                 // such as is string, map, etc.
@@ -232,6 +234,14 @@ public final class BinaryArray extends BinarySection implements InternalArray, D
         int fieldOffset = getElementOffset(pos, 8);
         final long offsetAndSize = MemorySegmentUtils.getLong(segments, fieldOffset);
         return MemorySegmentUtils.readBinary(segments, offset, fieldOffset, offsetAndSize);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        assertIndexIsValid(pos);
+        int fieldOffset = getElementOffset(pos, 8);
+        final long offsetAndLen = MemorySegmentUtils.getLong(segments, fieldOffset);
+        return MemorySegmentUtils.readVariant(segments, offset, offsetAndLen);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/BinaryRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BinaryRow.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.data;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.memory.MemorySegmentUtils;
 import org.apache.paimon.types.DataType;
@@ -333,6 +334,14 @@ public final class BinaryRow extends BinarySection implements InternalRow, DataS
         int fieldOffset = getFieldOffset(pos);
         final long offsetAndLen = segments[0].getLong(fieldOffset);
         return MemorySegmentUtils.readBinary(segments, offset, fieldOffset, offsetAndLen);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        assertIndexIsValid(pos);
+        int fieldOffset = getFieldOffset(pos);
+        final long offsetAndLen = segments[0].getLong(fieldOffset);
+        return MemorySegmentUtils.readVariant(segments, offset, offsetAndLen);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/BinaryWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BinaryWriter.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.serializer.InternalMapSerializer;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.data.serializer.InternalSerializers;
 import org.apache.paimon.data.serializer.Serializer;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.LocalZonedTimestampType;
@@ -66,6 +67,8 @@ public interface BinaryWriter {
     void writeDecimal(int pos, Decimal value, int precision);
 
     void writeTimestamp(int pos, Timestamp value, int precision);
+
+    void writeVariant(int pos, Variant variant);
 
     void writeArray(int pos, InternalArray value, InternalArraySerializer serializer);
 
@@ -139,6 +142,9 @@ public interface BinaryWriter {
             case VARBINARY:
                 writer.writeBinary(pos, (byte[]) o);
                 break;
+            case VARIANT:
+                writer.writeVariant(pos, (Variant) o);
+                break;
             default:
                 throw new UnsupportedOperationException("Not support type: " + type);
         }
@@ -208,6 +214,8 @@ public interface BinaryWriter {
                 return (writer, pos, value) ->
                         writer.writeRow(
                                 pos, (InternalRow) value, (InternalRowSerializer) rowSerializer);
+            case VARIANT:
+                return (writer, pos, value) -> writer.writeVariant(pos, (Variant) value);
             default:
                 String msg =
                         String.format(

--- a/paimon-common/src/main/java/org/apache/paimon/data/DataGetters.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/DataGetters.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.data;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.data.variant.Variant;
 
 /**
  * Getters to get data.
@@ -73,6 +74,9 @@ public interface DataGetters {
 
     /** Returns the binary value at the given position. */
     byte[] getBinary(int pos);
+
+    /** Returns the variant value at the given position. */
+    Variant getVariant(int pos);
 
     /** Returns the array value at the given position. */
     InternalArray getArray(int pos);

--- a/paimon-common/src/main/java/org/apache/paimon/data/GenericArray.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/GenericArray.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.data;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.utils.ArrayUtils;
 
@@ -202,6 +203,11 @@ public final class GenericArray implements InternalArray, Serializable {
     @Override
     public byte[] getBinary(int pos) {
         return (byte[]) getObject(pos);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return (Variant) getObject(pos);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/GenericRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/GenericRow.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.data;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
 
@@ -184,6 +185,11 @@ public final class GenericRow implements InternalRow, Serializable {
     @Override
     public byte[] getBinary(int pos) {
         return (byte[]) this.fields[pos];
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return (Variant) this.fields[pos];
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/InternalArray.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/InternalArray.java
@@ -130,6 +130,9 @@ public interface InternalArray extends DataGetters {
                 final int rowFieldCount = getFieldCount(elementType);
                 elementGetter = (array, pos) -> array.getRow(pos, rowFieldCount);
                 break;
+            case VARIANT:
+                elementGetter = InternalArray::getVariant;
+                break;
             default:
                 String msg =
                         String.format(

--- a/paimon-common/src/main/java/org/apache/paimon/data/InternalRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/InternalRow.java
@@ -221,6 +221,9 @@ public interface InternalRow extends DataGetters {
                 final int rowFieldCount = DataTypeChecks.getFieldCount(fieldType);
                 fieldGetter = row -> row.getRow(fieldPos, rowFieldCount);
                 break;
+            case VARIANT:
+                fieldGetter = row -> row.getVariant(fieldPos);
+                break;
             default:
                 String msg =
                         String.format(

--- a/paimon-common/src/main/java/org/apache/paimon/data/JoinedRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/JoinedRow.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.data;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.RowKind;
 
 import javax.annotation.Nullable;
@@ -221,6 +222,15 @@ public class JoinedRow implements InternalRow {
             return row1.getBinary(pos);
         } else {
             return row2.getBinary(pos - row1.getFieldCount());
+        }
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        if (pos < row1.getFieldCount()) {
+            return row1.getVariant(pos);
+        } else {
+            return row2.getVariant(pos - row1.getFieldCount());
         }
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/data/LazyGenericRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/LazyGenericRow.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.data;
 
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.RowKind;
 
 import java.util.function.Supplier;
@@ -140,6 +141,11 @@ public class LazyGenericRow implements InternalRow {
     @Override
     public byte[] getBinary(int pos) {
         return (byte[]) getField(pos);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return (Variant) getField(pos);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/NestedRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/NestedRow.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.data;
 
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.memory.MemorySegmentUtils;
 import org.apache.paimon.types.RowKind;
@@ -278,6 +279,14 @@ public final class NestedRow extends BinarySection implements InternalRow, DataS
         int fieldOffset = getFieldOffset(pos);
         final long offsetAndLen = MemorySegmentUtils.getLong(segments, fieldOffset);
         return MemorySegmentUtils.readBinary(segments, offset, fieldOffset, offsetAndLen);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        assertIndexIsValid(pos);
+        int fieldOffset = getFieldOffset(pos);
+        final long offsetAndLen = MemorySegmentUtils.getLong(segments, fieldOffset);
+        return MemorySegmentUtils.readVariant(segments, offset, offsetAndLen);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarArray.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarArray.java
@@ -25,6 +25,8 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.GenericVariant;
+import org.apache.paimon.data.variant.Variant;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -119,6 +121,14 @@ public final class ColumnarArray implements InternalArray, DataSetters, Serializ
             return Arrays.copyOfRange(
                     byteArray.data, byteArray.offset, byteArray.offset + byteArray.len);
         }
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        InternalRow row = getRow(pos, 2);
+        byte[] value = row.getBinary(0);
+        byte[] metadata = row.getBinary(1);
+        return new GenericVariant(value, metadata);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarRow.java
@@ -25,6 +25,7 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.RowKind;
 
 import java.io.Serializable;
@@ -138,6 +139,11 @@ public final class ColumnarRow implements InternalRow, DataSetters, Serializable
     @Override
     public byte[] getBinary(int pos) {
         return vectorizedColumnBatch.getBinary(rowId, pos);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return vectorizedColumnBatch.getVariant(rowId, pos);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/VectorizedColumnBatch.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/VectorizedColumnBatch.java
@@ -25,6 +25,8 @@ import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.data.columnar.BytesColumnVector.Bytes;
+import org.apache.paimon.data.variant.GenericVariant;
+import org.apache.paimon.data.variant.Variant;
 
 import java.io.Serializable;
 
@@ -124,6 +126,13 @@ public class VectorizedColumnBatch implements Serializable {
 
     public InternalRow getRow(int rowId, int colId) {
         return ((RowColumnVector) columns[colId]).getRow(rowId);
+    }
+
+    public Variant getVariant(int rowId, int colId) {
+        InternalRow row = getRow(rowId, colId);
+        byte[] value = row.getBinary(0);
+        byte[] metadata = row.getBinary(1);
+        return new GenericVariant(value, metadata);
     }
 
     public InternalMap getMap(int rowId, int colId) {

--- a/paimon-common/src/main/java/org/apache/paimon/data/safe/SafeBinaryArray.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/safe/SafeBinaryArray.java
@@ -25,6 +25,7 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.memory.BytesUtils;
 
 import static org.apache.paimon.data.BinaryArray.calculateHeaderInBytes;
@@ -144,6 +145,11 @@ public final class SafeBinaryArray implements InternalArray {
     @Override
     public byte[] getBinary(int pos) {
         return BytesUtils.readBinary(bytes, offset, getElementOffset(pos, 8), getLong(pos));
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return BytesUtils.readVariant(bytes, offset, getLong(pos));
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/safe/SafeBinaryRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/safe/SafeBinaryRow.java
@@ -25,6 +25,7 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.memory.BytesUtils;
 import org.apache.paimon.types.RowKind;
 
@@ -150,6 +151,11 @@ public final class SafeBinaryRow implements InternalRow {
     @Override
     public byte[] getBinary(int pos) {
         return BytesUtils.readBinary(bytes, offset, getFieldOffset(pos), getLong(pos));
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return BytesUtils.readVariant(bytes, offset, getLong(pos));
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/InternalSerializers.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/InternalSerializers.java
@@ -83,6 +83,8 @@ public final class InternalSerializers {
                 return new InternalMapSerializer(mapType.getKeyType(), mapType.getValueType());
             case ROW:
                 return new InternalRowSerializer(getFieldTypes(type).toArray(new DataType[0]));
+            case VARIANT:
+                return VariantSerializer.INSTANCE;
             default:
                 throw new UnsupportedOperationException(
                         "Unsupported type '" + type + "' to get internal serializer");

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/VariantSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/VariantSerializer.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.data.serializer;
+
+import org.apache.paimon.data.variant.GenericVariant;
+import org.apache.paimon.data.variant.Variant;
+import org.apache.paimon.io.DataInputView;
+import org.apache.paimon.io.DataOutputView;
+
+import java.io.IOException;
+
+/** Type serializer for {@code Variant}. */
+public class VariantSerializer extends SerializerSingleton<Variant> {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final VariantSerializer INSTANCE = new VariantSerializer();
+
+    @Override
+    public Variant copy(Variant from) {
+        return from.copy();
+    }
+
+    @Override
+    public void serialize(Variant record, DataOutputView target) throws IOException {
+        BinarySerializer.INSTANCE.serialize(record.value(), target);
+        BinarySerializer.INSTANCE.serialize(record.metadata(), target);
+    }
+
+    @Override
+    public Variant deserialize(DataInputView source) throws IOException {
+        byte[] value = BinarySerializer.INSTANCE.deserialize(source);
+        byte[] metadata = BinarySerializer.INSTANCE.deserialize(source);
+        return new GenericVariant(value, metadata);
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/data/variant/GenericVariant.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/variant/GenericVariant.java
@@ -183,6 +183,17 @@ public final class GenericVariant implements Variant {
         }
     }
 
+    @Override
+    public long sizeInBytes() {
+        return metadata.length + value.length;
+    }
+
+    @Override
+    public Variant copy() {
+        return new GenericVariant(
+                Arrays.copyOf(value, value.length), Arrays.copyOf(metadata, metadata.length), pos);
+    }
+
     // Get a boolean value from the variant.
     public boolean getBoolean() {
         return GenericVariantUtil.getBoolean(value, pos);

--- a/paimon-common/src/main/java/org/apache/paimon/data/variant/Variant.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/variant/Variant.java
@@ -32,6 +32,10 @@ package org.apache.paimon.data.variant;
  */
 public interface Variant {
 
+    String METADATA = "metadata";
+
+    String VALUE = "value";
+
     /** Returns the variant metadata. */
     byte[] metadata();
 
@@ -49,4 +53,10 @@ public interface Variant {
      * <p>access array's first elem: `$.array[0]`
      */
     Object variantGet(String path);
+
+    /** Returns the size of the variant in bytes. */
+    long sizeInBytes();
+
+    /** Returns a copy of the variant. */
+    Variant copy();
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bitmap/BitmapFileIndexMeta.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bitmap/BitmapFileIndexMeta.java
@@ -41,6 +41,7 @@ import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.types.VariantType;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -372,6 +373,11 @@ public class BitmapFileIndexMeta {
         @Override
         public final R visit(RowType rowType) {
             throw new UnsupportedOperationException("Does not support type row");
+        }
+
+        @Override
+        public final R visit(VariantType rowType) {
+            throw new UnsupportedOperationException("Does not support type variant");
         }
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bloomfilter/FastHash.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bloomfilter/FastHash.java
@@ -42,6 +42,7 @@ import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.types.VariantType;
 
 import net.openhft.hashing.LongHashFunction;
 
@@ -157,6 +158,11 @@ public interface FastHash {
 
                 return getLongHash(((Timestamp) o).toMicros());
             };
+        }
+
+        @Override
+        public FastHash visit(VariantType variantType) {
+            throw new UnsupportedOperationException("Does not support type variant");
         }
 
         @Override

--- a/paimon-common/src/main/java/org/apache/paimon/memory/BytesUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/memory/BytesUtils.java
@@ -18,6 +18,9 @@
 
 package org.apache.paimon.memory;
 
+import org.apache.paimon.data.variant.GenericVariant;
+import org.apache.paimon.data.variant.Variant;
+
 import static org.apache.paimon.data.BinarySection.HIGHEST_FIRST_BIT;
 import static org.apache.paimon.data.BinarySection.HIGHEST_SECOND_TO_EIGHTH_BIT;
 import static org.apache.paimon.memory.MemorySegment.LITTLE_ENDIAN;
@@ -66,5 +69,17 @@ public class BytesUtils {
             }
             return ret;
         }
+    }
+
+    public static Variant readVariant(byte[] bytes, int baseOffset, long offsetAndLen) {
+        int offset = baseOffset + (int) (offsetAndLen >> 32);
+        int totalSize = (int) offsetAndLen;
+        int valueSize = getInt(bytes, offset);
+        int metadataSize = totalSize - 4 - valueSize;
+        byte[] value = new byte[valueSize];
+        byte[] metadata = new byte[metadataSize];
+        System.arraycopy(bytes, offset + 4, value, 0, valueSize);
+        System.arraycopy(bytes, offset + 4 + valueSize, metadata, 0, metadataSize);
+        return new GenericVariant(value, metadata);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/memory/MemorySegmentUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/memory/MemorySegmentUtils.java
@@ -28,6 +28,8 @@ import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.NestedRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.GenericVariant;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.io.DataOutputView;
 import org.apache.paimon.utils.MurmurHashUtils;
 
@@ -1119,6 +1121,16 @@ public class MemorySegmentUtils {
                 return BinaryString.fromAddress(segments, fieldOffset + 1, len);
             }
         }
+    }
+
+    public static Variant readVariant(MemorySegment[] segments, int baseOffset, long offsetAndLen) {
+        int offset = baseOffset + (int) (offsetAndLen >> 32);
+        int totalSize = (int) offsetAndLen;
+        int valueSize = getInt(segments, offset);
+        int metadataSize = totalSize - 4 - valueSize;
+        byte[] value = copyToBytes(segments, offset + 4, valueSize);
+        byte[] metadata = copyToBytes(segments, offset + 4 + valueSize, metadataSize);
+        return new GenericVariant(value, metadata);
     }
 
     /** Gets an instance of {@link InternalMap} from underlying {@link MemorySegment}. */

--- a/paimon-common/src/main/java/org/apache/paimon/sort/hilbert/HilbertIndexer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sort/hilbert/HilbertIndexer.java
@@ -45,6 +45,7 @@ import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.types.VariantType;
 import org.apache.paimon.utils.ConvertBinaryUtil;
 
 import org.davidmoten.hilbert.HilbertCurve;
@@ -257,6 +258,11 @@ public class HilbertIndexer implements Serializable {
                 Object o = fieldGetter.getFieldOrNull(row);
                 return o == null ? PRIMITIVE_EMPTY : ((Timestamp) o).getMillisecond();
             };
+        }
+
+        @Override
+        public HProcessFunction visit(VariantType variantType) {
+            throw new RuntimeException("Unsupported type");
         }
 
         @Override

--- a/paimon-common/src/main/java/org/apache/paimon/types/DataTypeDefaultVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DataTypeDefaultVisitor.java
@@ -109,6 +109,10 @@ public abstract class DataTypeDefaultVisitor<R> implements DataTypeVisitor<R> {
         return defaultMethod(localZonedTimestampType);
     }
 
+    public R visit(VariantType variantType) {
+        return defaultMethod(variantType);
+    }
+
     @Override
     public R visit(ArrayType arrayType) {
         return defaultMethod(arrayType);

--- a/paimon-common/src/main/java/org/apache/paimon/types/DataTypeJsonParser.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DataTypeJsonParser.java
@@ -301,6 +301,7 @@ public final class DataTypeJsonParser {
         NULL,
         RAW,
         LEGACY,
+        VARIANT,
         NOT
     }
 
@@ -515,6 +516,8 @@ public final class DataTypeJsonParser {
                     return parseTimestampType();
                 case TIMESTAMP_LTZ:
                     return parseTimestampLtzType();
+                case VARIANT:
+                    return new VariantType();
                 default:
                     throw parsingError("Unsupported type: " + token().value);
             }

--- a/paimon-common/src/main/java/org/apache/paimon/types/DataTypeRoot.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DataTypeRoot.java
@@ -100,6 +100,8 @@ public enum DataTypeRoot {
             DataTypeFamily.TIMESTAMP,
             DataTypeFamily.EXTENSION),
 
+    VARIANT(DataTypeFamily.PREDEFINED),
+
     ARRAY(DataTypeFamily.CONSTRUCTED, DataTypeFamily.COLLECTION),
 
     MULTISET(DataTypeFamily.CONSTRUCTED, DataTypeFamily.COLLECTION),

--- a/paimon-common/src/main/java/org/apache/paimon/types/DataTypeVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DataTypeVisitor.java
@@ -62,6 +62,8 @@ public interface DataTypeVisitor<R> {
 
     R visit(LocalZonedTimestampType localZonedTimestampType);
 
+    R visit(VariantType variantType);
+
     R visit(ArrayType arrayType);
 
     R visit(MultisetType multisetType);

--- a/paimon-common/src/main/java/org/apache/paimon/types/DataTypes.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DataTypes.java
@@ -151,6 +151,10 @@ public class DataTypes {
         return new MultisetType(elementType);
     }
 
+    public static VariantType VARIANT() {
+        return new VariantType();
+    }
+
     public static OptionalInt getPrecision(DataType dataType) {
         return dataType.accept(PRECISION_EXTRACTOR);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/types/InternalRowToSizeVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/InternalRowToSizeVisitor.java
@@ -212,6 +212,17 @@ public class InternalRowToSizeVisitor
     }
 
     @Override
+    public BiFunction<DataGetters, Integer, Integer> visit(VariantType variantType) {
+        return (row, index) -> {
+            if (row.isNullAt(index)) {
+                return NULL_SIZE;
+            } else {
+                return Math.toIntExact(row.getVariant(index).sizeInBytes());
+            }
+        };
+    }
+
+    @Override
     public BiFunction<DataGetters, Integer, Integer> visit(ArrayType arrayType) {
         return (row, index) -> {
             if (row.isNullAt(index)) {

--- a/paimon-common/src/main/java/org/apache/paimon/types/VariantType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/VariantType.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.types;
+
+import org.apache.paimon.annotation.Public;
+import org.apache.paimon.data.variant.Variant;
+
+/**
+ * Data type of {@link Variant}.
+ *
+ * @since 1.1.0
+ */
+@Public
+public class VariantType extends DataType {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String FORMAT = "VARIANT";
+
+    public VariantType(boolean isNullable) {
+        super(isNullable, DataTypeRoot.VARIANT);
+    }
+
+    public VariantType() {
+        this(true);
+    }
+
+    @Override
+    public int defaultSize() {
+        return 2048;
+    }
+
+    @Override
+    public DataType copy(boolean isNullable) {
+        return new VariantType(isNullable);
+    }
+
+    @Override
+    public String asSQLString() {
+        return withNullability(FORMAT);
+    }
+
+    @Override
+    public <R> R accept(DataTypeVisitor<R> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/InternalRowUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/InternalRowUtils.java
@@ -195,6 +195,8 @@ public class InternalRowUtils {
             case BINARY:
             case VARBINARY:
                 return dataGetters.getBinary(pos);
+            case VARIANT:
+                return dataGetters.getVariant(pos);
             default:
                 throw new UnsupportedOperationException("Unsupported type: " + fieldType);
         }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/KeyProjectedRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/KeyProjectedRow.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.RowKind;
 
 import java.util.Arrays;
@@ -121,6 +122,11 @@ public class KeyProjectedRow implements InternalRow {
     @Override
     public byte[] getBinary(int pos) {
         return row.getBinary(indexMapping[pos]);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return row.getVariant(indexMapping[pos]);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ProjectedArray.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ProjectedArray.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.DataType;
 
 /**
@@ -123,6 +124,11 @@ public class ProjectedArray implements InternalArray {
     @Override
     public byte[] getBinary(int pos) {
         return array.getBinary(indexMapping[pos]);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return array.getVariant(indexMapping[pos]);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ProjectedRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ProjectedRow.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
@@ -138,6 +139,11 @@ public class ProjectedRow implements InternalRow {
     @Override
     public byte[] getBinary(int pos) {
         return row.getBinary(indexMapping[pos]);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return row.getVariant(indexMapping[pos]);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/utils/TypeCheckUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/TypeCheckUtils.java
@@ -31,6 +31,7 @@ import static org.apache.paimon.types.DataTypeRoot.MULTISET;
 import static org.apache.paimon.types.DataTypeRoot.ROW;
 import static org.apache.paimon.types.DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE;
 import static org.apache.paimon.types.DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
+import static org.apache.paimon.types.DataTypeRoot.VARIANT;
 
 /** Utils for type. */
 public class TypeCheckUtils {
@@ -95,8 +96,16 @@ public class TypeCheckUtils {
         return type.getTypeRoot() == ROW;
     }
 
+    public static boolean isVariant(DataType type) {
+        return type.getTypeRoot() == VARIANT;
+    }
+
     public static boolean isComparable(DataType type) {
-        return !isMap(type) && !isMultiset(type) && !isRow(type) && !isArray(type);
+        return !isMap(type)
+                && !isMultiset(type)
+                && !isRow(type)
+                && !isArray(type)
+                && !isVariant(type);
     }
 
     public static boolean isMutable(DataType type) {

--- a/paimon-common/src/main/java/org/apache/paimon/utils/VectorMappingUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/VectorMappingUtils.java
@@ -62,6 +62,7 @@ import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.types.VariantType;
 
 /**
  * This is a util about how to expand the {@link ColumnVector}s with the partition row and index
@@ -319,6 +320,11 @@ public class VectorMappingUtils {
                     return partition.isNullAt(index);
                 }
             };
+        }
+
+        @Override
+        public ColumnVector visit(VariantType variantType) {
+            throw new UnsupportedOperationException("VariantType is not supported.");
         }
 
         @Override

--- a/paimon-common/src/test/java/org/apache/paimon/data/SafeBinaryArrayTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/SafeBinaryArrayTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.data;
 
 import org.apache.paimon.data.safe.SafeBinaryArray;
 import org.apache.paimon.data.serializer.InternalArraySerializer;
+import org.apache.paimon.data.variant.GenericVariant;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 
@@ -124,6 +125,15 @@ class SafeBinaryArrayTest {
                         null,
                         BinaryString.fromString("14611asdfadsaf").toBytes());
         converted = toBinaryArray(DataTypes.BYTES(), new SafeBinaryArray(expected.toBytes(), 0));
+        assertThat(converted).isEqualTo(expected);
+
+        expected =
+                toBinaryArray(
+                        DataTypes.VARIANT(),
+                        GenericVariant.fromJson("{\"age\":27,\"city\":\"Beijing\"}"),
+                        null,
+                        GenericVariant.fromJson("{\"age\":27,\"city\":\"Hangzhou\"}"));
+        converted = toBinaryArray(DataTypes.VARIANT(), new SafeBinaryArray(expected.toBytes(), 0));
         assertThat(converted).isEqualTo(expected);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/sort/zorder/ZIndexer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/zorder/ZIndexer.java
@@ -46,6 +46,7 @@ import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.types.VariantType;
 import org.apache.paimon.utils.ZOrderByteUtils;
 
 import java.io.Serializable;
@@ -346,6 +347,11 @@ public class ZIndexer implements Serializable {
                                         ((Timestamp) o).getMillisecond(), reuse)
                                 .array();
             };
+        }
+
+        @Override
+        public ZProcessFunction visit(VariantType variantType) {
+            throw new RuntimeException("Unsupported type");
         }
 
         @Override

--- a/paimon-core/src/main/java/org/apache/paimon/stats/SimpleStatsEvolution.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/SimpleStatsEvolution.java
@@ -28,6 +28,7 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.format.SimpleColStats;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.ProjectedArray;
@@ -211,6 +212,11 @@ public class SimpleStatsEvolution {
 
         @Override
         public byte[] getBinary(int pos) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Variant getVariant(int pos) {
             throw new UnsupportedOperationException();
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/utils/OffsetRow.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/OffsetRow.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.RowKind;
 
 /** A {@link InternalRow} to wrap row with offset. */
@@ -118,6 +119,11 @@ public class OffsetRow implements InternalRow {
     @Override
     public byte[] getBinary(int pos) {
         return row.getBinary(offset + pos);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return row.getVariant(offset + pos);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/utils/PartialRow.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/PartialRow.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.RowKind;
 
 /** A {@link InternalRow} to wrap row with partial fields. */
@@ -120,6 +121,11 @@ public class PartialRow implements InternalRow {
     @Override
     public byte[] getBinary(int pos) {
         return row.getBinary(pos);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return row.getVariant(pos);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/DataTypeToLogicalType.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/DataTypeToLogicalType.java
@@ -41,6 +41,7 @@ import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.types.VariantType;
 
 import org.apache.flink.table.types.logical.LogicalType;
 
@@ -138,6 +139,11 @@ public class DataTypeToLogicalType implements DataTypeVisitor<LogicalType> {
     public LogicalType visit(LocalZonedTimestampType localZonedTimestampType) {
         return new org.apache.flink.table.types.logical.LocalZonedTimestampType(
                 localZonedTimestampType.isNullable(), localZonedTimestampType.getPrecision());
+    }
+
+    @Override
+    public LogicalType visit(VariantType variantType) {
+        throw new UnsupportedOperationException("VariantType is not supported.");
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowWrapper.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowWrapper.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.RowKind;
 
 import org.apache.flink.table.data.DecimalData;
@@ -119,6 +120,11 @@ public class FlinkRowWrapper implements InternalRow {
     }
 
     @Override
+    public Variant getVariant(int pos) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public InternalArray getArray(int pos) {
         return new FlinkArrayWrapper(row.getArray(pos));
     }
@@ -204,6 +210,11 @@ public class FlinkRowWrapper implements InternalRow {
         @Override
         public byte[] getBinary(int pos) {
             return array.getBinary(pos);
+        }
+
+        @Override
+        public Variant getVariant(int pos) {
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/writer/FieldWriterFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/writer/FieldWriterFactory.java
@@ -43,6 +43,7 @@ import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.types.VariantType;
 
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
@@ -191,6 +192,11 @@ public class FieldWriterFactory implements DataTypeVisitor<FieldWriter> {
             TimestampColumnVector vector = (TimestampColumnVector) column;
             vector.set(rowId, timestamp);
         };
+    }
+
+    @Override
+    public FieldWriter visit(VariantType variantType) {
+        throw new UnsupportedOperationException("Unsupported type: " + variantType);
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetSchemaConverter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetSchemaConverter.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.format.parquet;
 
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
@@ -206,6 +207,19 @@ public class ParquetSchemaConverter {
                 RowType rowType = (RowType) type;
                 return new GroupType(repetition, name, convertToParquetTypes(rowType))
                         .withId(fieldId);
+            case VARIANT:
+                return Types.buildGroup(repetition)
+                        .addField(
+                                Types.primitive(
+                                                PrimitiveType.PrimitiveTypeName.BINARY,
+                                                Type.Repetition.REQUIRED)
+                                        .named(Variant.VALUE))
+                        .addField(
+                                Types.primitive(
+                                                PrimitiveType.PrimitiveTypeName.BINARY,
+                                                Type.Repetition.REQUIRED)
+                                        .named(Variant.METADATA))
+                        .named(name);
             default:
                 throw new UnsupportedOperationException("Unsupported type: " + type);
         }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/NestedColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/NestedColumnReader.java
@@ -35,6 +35,7 @@ import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.MultisetType;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.VariantType;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Preconditions;
 
@@ -94,7 +95,7 @@ public class NestedColumnReader implements ColumnReader<WritableColumnVector> {
     private Pair<LevelDelegation, WritableColumnVector> readData(
             ParquetField field, int readNumber, ColumnVector vector, boolean inside)
             throws IOException {
-        if (field.getType() instanceof RowType) {
+        if (field.getType() instanceof RowType || field.getType() instanceof VariantType) {
             return readRow((ParquetGroupField) field, readNumber, vector, inside);
         } else if (field.getType() instanceof MapType || field.getType() instanceof MultisetType) {
             return readMap((ParquetGroupField) field, readNumber, vector, inside);

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetSplitReaderUtil.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetSplitReaderUtil.java
@@ -31,11 +31,13 @@ import org.apache.paimon.data.columnar.heap.HeapRowVector;
 import org.apache.paimon.data.columnar.heap.HeapShortVector;
 import org.apache.paimon.data.columnar.heap.HeapTimestampVector;
 import org.apache.paimon.data.columnar.writable.WritableColumnVector;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.format.parquet.ParquetSchemaConverter;
 import org.apache.paimon.format.parquet.type.ParquetField;
 import org.apache.paimon.format.parquet.type.ParquetGroupField;
 import org.apache.paimon.format.parquet.type.ParquetPrimitiveField;
 import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.BinaryType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeChecks;
@@ -44,6 +46,7 @@ import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.MultisetType;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.VariantType;
 import org.apache.paimon.utils.StringUtils;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
@@ -128,6 +131,11 @@ public class ParquetSplitReaderUtil {
                                 pages,
                                 ((DecimalType) fieldType).getPrecision());
                 }
+            case VARIANT:
+                List<ColumnReader> fieldReaders = new ArrayList<>();
+                fieldReaders.add(new BytesColumnReader(descriptors.get(0), pages));
+                fieldReaders.add(new BytesColumnReader(descriptors.get(1), pages));
+                return new RowColumnReader(fieldReaders);
             case ARRAY:
             case MAP:
             case MULTISET:
@@ -331,6 +339,11 @@ public class ParquetSplitReaderUtil {
                                     depth + 1);
                 }
                 return new HeapRowVector(batchSize, columnVectors);
+            case VARIANT:
+                WritableColumnVector[] vectors = new WritableColumnVector[2];
+                vectors[0] = new HeapBytesVector(batchSize);
+                vectors[1] = new HeapBytesVector(batchSize);
+                return new HeapRowVector(batchSize, vectors);
             default:
                 throw new UnsupportedOperationException(fieldType + " is not supported now.");
         }
@@ -386,6 +399,29 @@ public class ParquetSplitReaderUtil {
                                 lookupColumnByName(groupColumnIO, fieldNames.get(i))));
             }
 
+            return new ParquetGroupField(
+                    type, repetitionLevel, definitionLevel, required, fieldsBuilder.build());
+        }
+
+        if (type instanceof VariantType) {
+            GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
+            ImmutableList.Builder<ParquetField> fieldsBuilder = ImmutableList.builder();
+            PrimitiveColumnIO value =
+                    (PrimitiveColumnIO) lookupColumnByName(groupColumnIO, Variant.VALUE);
+            fieldsBuilder.add(
+                    new ParquetPrimitiveField(
+                            new BinaryType(),
+                            required,
+                            value.getColumnDescriptor(),
+                            value.getId()));
+            PrimitiveColumnIO metadata =
+                    (PrimitiveColumnIO) lookupColumnByName(groupColumnIO, Variant.METADATA);
+            fieldsBuilder.add(
+                    new ParquetPrimitiveField(
+                            new BinaryType(),
+                            required,
+                            metadata.getColumnDescriptor(),
+                            metadata.getId()));
             return new ParquetGroupField(
                     type, repetitionLevel, definitionLevel, required, fieldsBuilder.build());
         }

--- a/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
+++ b/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
@@ -43,6 +43,7 @@ import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.types.VariantType;
 
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.io.api.Binary;
@@ -278,6 +279,11 @@ public class ParquetFilters {
 
         @Override
         public Operators.Column<?> visit(LocalZonedTimestampType localZonedTimestampType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Operators.Column<?> visit(VariantType variantType) {
             throw new UnsupportedOperationException();
         }
 

--- a/paimon-hive/paimon-hive-common/src/main/java/org/apache/paimon/hive/HiveTypeUtils.java
+++ b/paimon-hive/paimon-hive-common/src/main/java/org/apache/paimon/hive/HiveTypeUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.hive;
 
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.BinaryType;
@@ -42,6 +43,7 @@ import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.types.VariantType;
 
 import org.apache.hadoop.hive.common.type.HiveChar;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
@@ -56,6 +58,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.VarcharTypeInfo;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -215,6 +218,14 @@ public class HiveTypeUtils {
                             .map(DataField::type)
                             .map(type -> type.accept(this))
                             .collect(Collectors.toList());
+            return TypeInfoFactory.getStructTypeInfo(fieldNames, typeInfos);
+        }
+
+        @Override
+        public TypeInfo visit(VariantType variantType) {
+            List<String> fieldNames = Arrays.asList(Variant.VALUE, Variant.METADATA);
+            List<TypeInfo> typeInfos =
+                    Arrays.asList(TypeInfoFactory.binaryTypeInfo, TypeInfoFactory.binaryTypeInfo);
             return TypeInfoFactory.getStructTypeInfo(fieldNames, typeInfos);
         }
 

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/HivePaimonArray.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/objectinspector/HivePaimonArray.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataType;
 
@@ -112,6 +113,11 @@ public class HivePaimonArray implements InternalArray {
     @Override
     public byte[] getBinary(int i) {
         return getAs(i);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        return getAs(pos);
     }
 
     @Override

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkRow.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkRow.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.spark.util.shim.TypeUtils;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataType;
@@ -141,6 +142,11 @@ public class SparkRow implements InternalRow, Serializable {
     @Override
     public byte[] getBinary(int i) {
         return row.getAs(i);
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -298,6 +304,11 @@ public class SparkRow implements InternalRow, Serializable {
         @Override
         public byte[] getBinary(int i) {
             return getAs(i);
+        }
+
+        @Override
+        public Variant getVariant(int pos) {
+            throw new UnsupportedOperationException();
         }
 
         @Override


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Subtask of https://github.com/apache/paimon/issues/4471

- Add a new data type `VariantType`

```java
/**
 * Data type of {@link Variant}.
 *
 * @since 1.1.0
 */
@Public
public class VariantType extends DataType {

    private static final String FORMAT = "VARIANT";
}
```

- Support reading and writing Variant into parquet with java api

```java
FileFormat format = new ParquetFileFormat(new FileFormatFactory.FormatContext(new Options(), 1024, 1024));

RowType writeType = DataTypes.ROW(DataTypes.FIELD(0, "v", DataTypes.VARIANT()));

try (PositionOutputStream out = fileIO.newOutputStream(file, false);
        FormatWriter writer = format.createWriterFactory(writeType).create(out, "zstd")) {
    writer.addElement(
            GenericRow.of(GenericVariant.fromJson("{\"age\":35,\"city\":\"Chicago\"}")));
}

List<InternalRow> result = new ArrayList<>();
try (RecordReader<InternalRow> reader =  format.createReaderFactory(writeType) 
         .createReader( new FormatReaderContext(fileIO, file, fileIO.getFileSize(file)))) {
    InternalRowSerializer serializer = new InternalRowSerializer(writeType);
    reader.forEachRemaining(row -> result.add(serializer.copy(row)));
}

assertThat(result.get(0).getVariant(0).toJson()) .isEqualTo("{\"age\":35,\"city\":\"Chicago\"}");
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
