### PR TITLE
[spark] Integrate Variant with Spark4

### DIFF
--- a/paimon-spark/paimon-spark-4.0/src/test/scala/org/apache/paimon/spark/sql/VariantTest.scala
+++ b/paimon-spark/paimon-spark-4.0/src/test/scala/org/apache/paimon/spark/sql/VariantTest.scala
@@ -16,17 +16,6 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.spark.data
+package org.apache.paimon.spark.sql
 
-import org.apache.paimon.spark.AbstractSparkInternalRow
-import org.apache.paimon.types.RowType
-
-import org.apache.spark.unsafe.types.VariantVal
-
-class Spark4InternalRow(rowType: RowType) extends AbstractSparkInternalRow(rowType) {
-
-  override def getVariant(i: Int): VariantVal = {
-    val v = row.getVariant(i)
-    new VariantVal(v.value(), v.metadata())
-  }
-}
+class VariantTest extends VariantTestBase {}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkRow.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkRow.java
@@ -35,6 +35,7 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.DateTimeUtils;
 
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.paimon.shims.SparkShimLoader;
 
 import java.io.Serializable;
 import java.sql.Date;
@@ -146,7 +147,7 @@ public class SparkRow implements InternalRow, Serializable {
 
     @Override
     public Variant getVariant(int pos) {
-        throw new UnsupportedOperationException();
+        return SparkShimLoader.getSparkShim().toPaimonVariant(row.getAs(pos));
     }
 
     @Override
@@ -307,8 +308,8 @@ public class SparkRow implements InternalRow, Serializable {
         }
 
         @Override
-        public Variant getVariant(int pos) {
-            throw new UnsupportedOperationException();
+        public Variant getVariant(int i) {
+            return SparkShimLoader.getSparkShim().toPaimonVariant(getAs(i));
         }
 
         @Override

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkRow.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkRow.java
@@ -146,8 +146,8 @@ public class SparkRow implements InternalRow, Serializable {
     }
 
     @Override
-    public Variant getVariant(int pos) {
-        return SparkShimLoader.getSparkShim().toPaimonVariant(row.getAs(pos));
+    public Variant getVariant(int i) {
+        return SparkShimLoader.getSparkShim().toPaimonVariant(row.getAs(i));
     }
 
     @Override

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/paimon/shims/SparkShim.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/paimon/shims/SparkShim.scala
@@ -18,6 +18,7 @@
 
 package org.apache.spark.sql.paimon.shims
 
+import org.apache.paimon.data.variant.Variant
 import org.apache.paimon.spark.data.{SparkArrayData, SparkInternalRow}
 import org.apache.paimon.types.{DataType, RowType}
 
@@ -33,7 +34,7 @@ import org.apache.spark.sql.types.StructType
 import java.util.{Map => JMap}
 
 /**
- * A spark shim trait. It declare methods which have incompatible implementations between Spark 3
+ * A spark shim trait. It declares methods which have incompatible implementations between Spark 3
  * and Spark 4. The specific SparkShim implementation will be loaded through Service Provider
  * Interface.
  */
@@ -62,4 +63,10 @@ trait SparkShim {
 
   def convertToExpression(spark: SparkSession, column: Column): Expression
 
+  // for variant
+  def toPaimonVariant(o: Object): Variant
+
+  def isSparkVariantType(dataType: org.apache.spark.sql.types.DataType): Boolean
+
+  def SparkVariantType(): org.apache.spark.sql.types.DataType
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/VariantTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/VariantTestBase.scala
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+import org.apache.paimon.spark.PaimonSparkTestBase
+
+import org.apache.spark.sql.Row
+
+abstract class VariantTestBase extends PaimonSparkTestBase {
+
+  test("Paimon Variant: read and write variant") {
+    sql("CREATE TABLE T (id INT, v VARIANT)")
+    sql("""
+          |INSERT INTO T VALUES
+          | (1, parse_json('{"age":26,"city":"Beijing"}')),
+          | (2, parse_json('{"age":27,"city":"Hangzhou"}'))
+          | """.stripMargin)
+
+    checkAnswer(
+      sql(
+        "SELECT id, variant_get(v, '$.age', 'int'), variant_get(v, '$.city', 'string') FROM T ORDER BY id"),
+      Seq(Row(1, 26, "Beijing"), Row(2, 27, "Hangzhou"))
+    )
+    checkAnswer(
+      sql(
+        "SELECT variant_get(v, '$.city', 'string') FROM T WHERE variant_get(v, '$.age', 'int') == 26"),
+      Seq(Row("Beijing"))
+    )
+    checkAnswer(
+      sql("SELECT * FROM T WHERE variant_get(v, '$.age', 'int') == 27"),
+      sql("""SELECT 2, parse_json('{"age":27,"city":"Hangzhou"}')""")
+    )
+  }
+
+  test("Paimon Variant: read and write array variant") {
+    sql("CREATE TABLE T (id INT, v ARRAY<VARIANT>)")
+    sql(
+      """
+        |INSERT INTO T VALUES
+        | (1, array(parse_json('{"age":26,"city":"Beijing"}'), parse_json('{"age":27,"city":"Hangzhou"}'))),
+        | (2, array(parse_json('{"age":27,"city":"Shanghai"}')))
+        | """.stripMargin)
+
+    withSparkSQLConf("spark.sql.ansi.enabled" -> "false") {
+      checkAnswer(
+        sql(
+          "SELECT id, variant_get(v[1], '$.age', 'int'), variant_get(v[0], '$.city', 'string') FROM T ORDER BY id"),
+        Seq(Row(1, 27, "Beijing"), Row(2, null, "Shanghai"))
+      )
+    }
+  }
+
+  test("Paimon Variant: complex json") {
+    val json =
+      """
+        |{
+        |  "object" : {
+        |    "name" : "Apache Paimon",
+        |    "age" : 2,
+        |    "address" : {
+        |      "street" : "Main St",
+        |      "city" : "Hangzhou"
+        |    }
+        |  },
+        |  "array" : [ 1, 2, 3, 4, 5 ],
+        |  "string" : "Hello, World!",
+        |  "long" : 12345678901234,
+        |  "double" : 1.0123456789012346,
+        |  "decimal" : 100.99,
+        |  "boolean1" : true,
+        |  "boolean2" : false,
+        |  "nullField" : null
+        |}
+        |""".stripMargin
+
+    sql("CREATE TABLE T (v VARIANT)")
+    sql(s"""
+           |INSERT INTO T VALUES parse_json('$json')
+           | """.stripMargin)
+
+    checkAnswer(
+      sql("""
+            |SELECT
+            | variant_get(v, '$.object', 'string'),
+            | variant_get(v, '$.object.name', 'string'),
+            | variant_get(v, '$.object.address.street', 'string'),
+            | variant_get(v, '$["object"]["address"].city', 'string'),
+            | variant_get(v, '$.array', 'string'),
+            | variant_get(v, '$.array[0]', 'int'),
+            | variant_get(v, '$.array[3]', 'int'),
+            | variant_get(v, '$.string', 'string'),
+            | variant_get(v, '$.double', 'double'),
+            | variant_get(v, '$.decimal', 'decimal(5,2)'),
+            | variant_get(v, '$.boolean1', 'boolean'),
+            | variant_get(v, '$.boolean2', 'boolean'),
+            | variant_get(v, '$.nullField', 'string')
+            |FROM T
+            |""".stripMargin),
+      Seq(
+        Row(
+          """{"address":{"city":"Hangzhou","street":"Main St"},"age":2,"name":"Apache Paimon"}""",
+          "Apache Paimon",
+          "Main St",
+          "Hangzhou",
+          "[1,2,3,4,5]",
+          1,
+          4,
+          "Hello, World!",
+          1.0123456789012346,
+          100.99,
+          true,
+          false,
+          null
+        ))
+    )
+  }
+}

--- a/paimon-spark/paimon-spark3-common/src/main/scala/org/apache/spark/sql/paimon/shims/Spark3Shim.scala
+++ b/paimon-spark/paimon-spark3-common/src/main/scala/org/apache/spark/sql/paimon/shims/Spark3Shim.scala
@@ -18,6 +18,7 @@
 
 package org.apache.spark.sql.paimon.shims
 
+import org.apache.paimon.data.variant.Variant
 import org.apache.paimon.spark.catalyst.analysis.Spark3ResolutionRules
 import org.apache.paimon.spark.catalyst.parser.extensions.PaimonSpark3SqlExtensionsParser
 import org.apache.paimon.spark.data.{Spark3ArrayData, Spark3InternalRow, SparkArrayData, SparkInternalRow}
@@ -71,4 +72,11 @@ class Spark3Shim extends SparkShim {
 
   override def convertToExpression(spark: SparkSession, column: Column): Expression = column.expr
 
+  override def toPaimonVariant(o: Object): Variant = throw new UnsupportedOperationException()
+
+  override def isSparkVariantType(dataType: org.apache.spark.sql.types.DataType): Boolean =
+    throw new UnsupportedOperationException()
+
+  override def SparkVariantType(): org.apache.spark.sql.types.DataType =
+    throw new UnsupportedOperationException()
 }

--- a/paimon-spark/paimon-spark4-common/src/main/scala/org/apache/paimon/spark/data/Spark4ArrayData.scala
+++ b/paimon-spark/paimon-spark4-common/src/main/scala/org/apache/paimon/spark/data/Spark4ArrayData.scala
@@ -24,6 +24,8 @@ import org.apache.spark.unsafe.types.VariantVal
 
 class Spark4ArrayData(override val elementType: DataType) extends AbstractSparkArrayData {
 
-  override def getVariant(ordinal: Int): VariantVal = throw new UnsupportedOperationException
-
+  override def getVariant(ordinal: Int): VariantVal = {
+    val v = paimonArray.getVariant(ordinal)
+    new VariantVal(v.value(), v.metadata())
+  }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Subtask of #4471

- Integrate Variant with Spark4

```sql
CREATE TABLE t (v VARIANT) USING paimon;

INSERT INTO t VALUES parse_json('{"age":26,"city":"Beijing"}');

SELECT variant_get(v, '$.age', 'int') FROM t;
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
