### PR TITLE
[common] Using a faster deserialization method in RoaringBitmap32

### DIFF
--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/bitmap/RoaringBitmapBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/bitmap/RoaringBitmapBenchmark.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.benchmark.bitmap;
+
+import org.apache.paimon.benchmark.Benchmark;
+import org.apache.paimon.fs.local.LocalFileIO;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.roaringbitmap.RoaringBitmap;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Benchmark for {@link RoaringBitmap}. */
+public class RoaringBitmapBenchmark {
+
+    public static final int ROW_COUNT = 10000000;
+
+    @TempDir Path tempDir;
+
+    @Test
+    public void testDeserialize() throws Exception {
+        Random random = new Random();
+        RoaringBitmap bitmap = new RoaringBitmap();
+        for (int i = 0; i < ROW_COUNT; i++) {
+            if (random.nextBoolean()) {
+                bitmap.add(i);
+            }
+        }
+
+        File file = new File(tempDir.toFile(), "bitmap32-deserialize-benchmark");
+        assertThat(file.createNewFile()).isTrue();
+        try (FileOutputStream output = new FileOutputStream(file);
+                DataOutputStream dos = new DataOutputStream(output)) {
+            bitmap.serialize(dos);
+        }
+
+        Benchmark benchmark =
+                new Benchmark("bitmap32-deserialize-benchmark", 100)
+                        .setNumWarmupIters(1)
+                        .setOutputPerIteration(true);
+
+        benchmark.addCase(
+                "deserialize(DataInput)",
+                10,
+                () -> {
+                    try (LocalFileIO.LocalSeekableInputStream seekableStream =
+                                    new LocalFileIO.LocalSeekableInputStream(file);
+                            DataInputStream input = new DataInputStream(seekableStream)) {
+                        new RoaringBitmap().deserialize(input);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+
+        benchmark.addCase(
+                "deserialize(DataInput, byte[])",
+                10,
+                () -> {
+                    try (LocalFileIO.LocalSeekableInputStream seekableStream =
+                                    new LocalFileIO.LocalSeekableInputStream(file);
+                            DataInputStream input = new DataInputStream(seekableStream)) {
+                        new RoaringBitmap().deserialize(input, null);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+
+        benchmark.addCase(
+                "deserialize(ByteBuffer)",
+                10,
+                () -> {
+                    try (LocalFileIO.LocalSeekableInputStream seekableStream =
+                                    new LocalFileIO.LocalSeekableInputStream(file);
+                            DataInputStream input = new DataInputStream(seekableStream)) {
+                        byte[] bytes = new byte[(int) file.length()];
+                        input.readFully(bytes);
+                        new RoaringBitmap().deserialize(ByteBuffer.wrap(bytes));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+
+        benchmark.run();
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/RoaringBitmap32.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/RoaringBitmap32.java
@@ -85,8 +85,19 @@ public class RoaringBitmap32 {
         roaringBitmap.serialize(out);
     }
 
+    public byte[] serialize() {
+        roaringBitmap.runOptimize();
+        ByteBuffer buffer = ByteBuffer.allocate(roaringBitmap.serializedSizeInBytes());
+        roaringBitmap.serialize(buffer);
+        return buffer.array();
+    }
+
     public void deserialize(DataInput in) throws IOException {
-        roaringBitmap.deserialize(in);
+        roaringBitmap.deserialize(in, null);
+    }
+
+    public void deserialize(ByteBuffer buffer) throws IOException {
+        roaringBitmap.deserialize(buffer);
     }
 
     @Override
@@ -103,17 +114,6 @@ public class RoaringBitmap32 {
 
     public void clear() {
         roaringBitmap.clear();
-    }
-
-    public byte[] serialize() {
-        roaringBitmap.runOptimize();
-        ByteBuffer buffer = ByteBuffer.allocate(roaringBitmap.serializedSizeInBytes());
-        roaringBitmap.serialize(buffer);
-        return buffer.array();
-    }
-
-    public void deserialize(byte[] rbmBytes) throws IOException {
-        roaringBitmap.deserialize(ByteBuffer.wrap(rbmBytes));
     }
 
     public void flip(final long rangeStart, final long rangeEnd) {

--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/BitmapDeletionVector.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/BitmapDeletionVector.java
@@ -21,9 +21,9 @@ package org.apache.paimon.deletionvectors;
 import org.apache.paimon.utils.RoaringBitmap32;
 
 import java.io.ByteArrayOutputStream;
-import java.io.DataInput;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Objects;
 
 /**
@@ -93,10 +93,10 @@ public class BitmapDeletionVector implements DeletionVector {
         }
     }
 
-    public static DeletionVector deserializeFromDataInput(DataInput bis) throws IOException {
-        RoaringBitmap32 roaringBitmap = new RoaringBitmap32();
-        roaringBitmap.deserialize(bis);
-        return new BitmapDeletionVector(roaringBitmap);
+    public static DeletionVector deserializeFromByteBuffer(ByteBuffer buffer) throws IOException {
+        RoaringBitmap32 bitmap = new RoaringBitmap32();
+        bitmap.deserialize(buffer);
+        return new BitmapDeletionVector(bitmap);
     }
 
     private void checkPosition(long position) {

--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVector.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVector.java
@@ -103,7 +103,7 @@ public interface DeletionVector {
             ByteBuffer buffer = ByteBuffer.wrap(bytes);
             int magicNum = buffer.getInt();
             if (magicNum == BitmapDeletionVector.MAGIC_NUMBER) {
-                return BitmapDeletionVector.deserializeFromByteBuffer(buffer.slice());
+                return BitmapDeletionVector.deserializeFromByteBuffer(buffer);
             } else {
                 throw new RuntimeException("Invalid magic number: " + magicNum);
             }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldRoaringBitmap32Agg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldRoaringBitmap32Agg.java
@@ -22,6 +22,7 @@ import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.utils.RoaringBitmap32;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 /** roaring bitmap aggregate a field of a row. */
 public class FieldRoaringBitmap32Agg extends FieldAggregator {
@@ -43,8 +44,8 @@ public class FieldRoaringBitmap32Agg extends FieldAggregator {
         }
 
         try {
-            roaringBitmapAcc.deserialize((byte[]) accumulator);
-            roaringBitmapInput.deserialize((byte[]) inputField);
+            roaringBitmapAcc.deserialize(ByteBuffer.wrap((byte[]) accumulator));
+            roaringBitmapInput.deserialize(ByteBuffer.wrap((byte[]) inputField));
             roaringBitmapAcc.or(roaringBitmapInput);
             return roaringBitmapAcc.serialize();
         } catch (IOException e) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

In `RoaringBitmap`, the `deserialize(java.io.DataInput, byte[])` function has a better performance to deserialize the `BitmapContainer`.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
No.

### API and Format

<!-- Does this change affect API or storage format -->
No.

### Documentation

<!-- Does this change introduce a new feature -->
No.
