### PR TITLE
[flink] Introduce max_two_pt for Flink lookup join

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/DynamicPartitionLoader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/DynamicPartitionLoader.java
@@ -111,7 +111,7 @@ public class DynamicPartitionLoader implements Serializable {
                         .sorted(comparator.reversed())
                         .collect(Collectors.toList());
 
-        if (newPartitions.size() <= 1) {
+        if (newPartitions.size() <= maxPartitionNum) {
             return newPartitions;
         } else {
             return newPartitions.subList(0, maxPartitionNum);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/DynamicPartitionLoader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/DynamicPartitionLoader.java
@@ -31,9 +31,10 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static org.apache.paimon.flink.FlinkConnectorOptions.LOOKUP_DYNAMIC_PARTITION;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -45,22 +46,27 @@ public class DynamicPartitionLoader implements Serializable {
 
     private static final String MAX_PT = "max_pt()";
 
+    private static final String MAX_TWO_PT = "max_two_pt()";
+
     private final Table table;
     private final Duration refreshInterval;
+    private final int maxPartitionNum;
 
     private Comparator<InternalRow> comparator;
 
     private LocalDateTime lastRefresh;
-    @Nullable private BinaryRow partition;
+    private List<BinaryRow> partitions;
 
-    private DynamicPartitionLoader(Table table, Duration refreshInterval) {
+    private DynamicPartitionLoader(Table table, Duration refreshInterval, int maxPartitionNum) {
         this.table = table;
         this.refreshInterval = refreshInterval;
+        this.maxPartitionNum = maxPartitionNum;
     }
 
     public void open() {
         RowType partitionType = table.rowType().project(table.partitionKeys());
         this.comparator = CodeGenUtils.newRecordComparator(partitionType.getFieldTypes());
+        this.partitions = Collections.emptyList();
     }
 
     public void addPartitionKeysTo(List<String> joinKeys, List<String> projectFields) {
@@ -71,9 +77,8 @@ public class DynamicPartitionLoader implements Serializable {
         partitionKeys.stream().filter(k -> !projectFields.contains(k)).forEach(projectFields::add);
     }
 
-    @Nullable
-    public BinaryRow partition() {
-        return partition;
+    public List<BinaryRow> partitions() {
+        return partitions;
     }
 
     /** @return true if partition changed. */
@@ -83,14 +88,34 @@ public class DynamicPartitionLoader implements Serializable {
             return false;
         }
 
-        BinaryRow previous = this.partition;
-        partition =
-                table.newReadBuilder().newScan().listPartitions().stream()
-                        .max(comparator)
-                        .orElse(null);
+        List<BinaryRow> newPartitions = getMaxPartitions();
         lastRefresh = LocalDateTime.now();
 
-        return !Objects.equals(previous, partition);
+        if (newPartitions.size() != partitions.size()) {
+            partitions = newPartitions;
+            return true;
+        } else {
+            for (int i = 0; i < newPartitions.size(); i++) {
+                if (comparator.compare(newPartitions.get(i), partitions.get(i)) != 0) {
+                    partitions = newPartitions;
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private List<BinaryRow> getMaxPartitions() {
+        List<BinaryRow> newPartitions =
+                table.newReadBuilder().newScan().listPartitions().stream()
+                        .sorted(comparator.reversed())
+                        .collect(Collectors.toList());
+
+        if (newPartitions.size() <= 1) {
+            return newPartitions;
+        } else {
+            return newPartitions.subList(0, maxPartitionNum);
+        }
     }
 
     @Nullable
@@ -101,13 +126,21 @@ public class DynamicPartitionLoader implements Serializable {
             return null;
         }
 
-        if (!dynamicPartition.equalsIgnoreCase(MAX_PT)) {
-            throw new UnsupportedOperationException(
-                    "Unsupported dynamic partition pattern: " + dynamicPartition);
+        int maxPartitionNum;
+        switch (dynamicPartition.toLowerCase()) {
+            case MAX_PT:
+                maxPartitionNum = 1;
+                break;
+            case MAX_TWO_PT:
+                maxPartitionNum = 2;
+                break;
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported dynamic partition pattern: " + dynamicPartition);
         }
 
         Duration refresh =
                 options.get(FlinkConnectorOptions.LOOKUP_DYNAMIC_PARTITION_REFRESH_INTERVAL);
-        return new DynamicPartitionLoader(table, refresh);
+        return new DynamicPartitionLoader(table, refresh, maxPartitionNum);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -28,6 +28,7 @@ import org.apache.paimon.flink.FlinkRowWrapper;
 import org.apache.paimon.flink.utils.TableScanUtils;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.OutOfRangeException;
@@ -203,9 +204,9 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         if (partitionLoader != null) {
             partitionLoader.open();
             partitionLoader.checkRefresh();
-            BinaryRow partition = partitionLoader.partition();
-            if (partition != null) {
-                lookupTable.specificPartitionFilter(createSpecificPartFilter(partition));
+            List<BinaryRow> partitions = partitionLoader.partitions();
+            if (!partitions.isEmpty()) {
+                lookupTable.specificPartitionFilter(createSpecificPartFilter(partitions));
             }
         }
 
@@ -236,17 +237,17 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
             tryRefresh();
 
             InternalRow key = new FlinkRowWrapper(keyRow);
-            if (partitionLoader != null) {
-                if (partitionLoader.partition() == null) {
-                    return Collections.emptyList();
-                }
-                key = JoinedRow.join(key, partitionLoader.partition());
+            if (partitionLoader == null) {
+                return lookupInternal(key);
             }
 
-            List<InternalRow> results = lookupTable.get(key);
-            List<RowData> rows = new ArrayList<>(results.size());
-            for (InternalRow matchedRow : results) {
-                rows.add(new FlinkRowData(matchedRow));
+            if (partitionLoader.partitions().isEmpty()) {
+                return Collections.emptyList();
+            }
+
+            List<RowData> rows = new ArrayList<>();
+            for (BinaryRow partition : partitionLoader.partitions()) {
+                rows.addAll(lookupInternal(JoinedRow.join(key, partition)));
             }
             return rows;
         } catch (OutOfRangeException | ReopenException e) {
@@ -257,7 +258,28 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         }
     }
 
-    private Predicate createSpecificPartFilter(BinaryRow partition) {
+    private List<RowData> lookupInternal(InternalRow key) throws IOException {
+        List<RowData> rows = new ArrayList<>();
+        List<InternalRow> lookupResults = lookupTable.get(key);
+        for (InternalRow matchedRow : lookupResults) {
+            rows.add(new FlinkRowData(matchedRow));
+        }
+        return rows;
+    }
+
+    private Predicate createSpecificPartFilter(List<BinaryRow> partitions) {
+        Predicate partFilter = null;
+        for (BinaryRow partition : partitions) {
+            if (partFilter == null) {
+                partFilter = createSinglePartFilter(partition);
+            } else {
+                partFilter = PredicateBuilder.or(partFilter, createSinglePartFilter(partition));
+            }
+        }
+        return partFilter;
+    }
+
+    private Predicate createSinglePartFilter(BinaryRow partition) {
         RowType rowType = table.rowType();
         List<String> partitionKeys = table.partitionKeys();
         Object[] partitionSpec =
@@ -291,15 +313,15 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         // 2. refresh dynamic partition
         if (partitionLoader != null) {
             boolean partitionChanged = partitionLoader.checkRefresh();
-            BinaryRow partition = partitionLoader.partition();
-            if (partition == null) {
+            List<BinaryRow> partitions = partitionLoader.partitions();
+            if (partitions.isEmpty()) {
                 // no data to be load, fast exit
                 return;
             }
 
             if (partitionChanged) {
                 // reopen with latest partition
-                lookupTable.specificPartitionFilter(createSpecificPartFilter(partition));
+                lookupTable.specificPartitionFilter(createSpecificPartFilter(partitions));
                 lookupTable.close();
                 lookupTable.open();
                 // no need to refresh the lookup table because it is reopened


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
There is a scenario: the Join job is calculating the T day data, and the dim table is writing the (T + 1) day data, we can load two partitions data, so the Join job won't lose result when day is converting from T to T + 1.


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
