### PR TITLE
[core] optimize the binlog table read performance

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/system/BinlogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/BinlogTable.java
@@ -102,14 +102,14 @@ public class BinlogTable extends AuditLogTable {
         @Override
         public RecordReader<InternalRow> createReader(Split split) throws IOException {
             DataSplit dataSplit = (DataSplit) split;
+            InternalRow.FieldGetter[] fieldGetters = wrapped.rowType().fieldGetters();
+
             if (dataSplit.isStreaming()) {
                 return new PackChangelogReader(
                         dataRead.createReader(split),
                         (row1, row2) ->
                                 new AuditLogRow(
-                                        readProjection,
-                                        convertToArray(
-                                                row1, row2, wrapped.rowType().fieldGetters())),
+                                        readProjection, convertToArray(row1, row2, fieldGetters)),
                         wrapped.rowType());
             } else {
                 return dataRead.createReader(split)
@@ -117,10 +117,7 @@ public class BinlogTable extends AuditLogTable {
                                 (row) ->
                                         new AuditLogRow(
                                                 readProjection,
-                                                convertToArray(
-                                                        row,
-                                                        null,
-                                                        wrapped.rowType().fieldGetters())));
+                                                convertToArray(row, null, fieldGetters)));
             }
         }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Avoid to construct the rowType for each record.

![image](https://github.com/user-attachments/assets/cecf23f1-952e-4130-879e-02d1929a4345)


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
