### PR TITLE
[core] SortLookupStoreWriter should support empty record

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/lookup/sort/BlockWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/sort/BlockWriter.java
@@ -83,8 +83,11 @@ public class BlockWriter {
 
     public MemorySlice finish() throws IOException {
         if (positions.isEmpty()) {
-            throw new IllegalStateException();
+            // Do not use alignment mode, as it is impossible to calculate how many records are
+            // inside when reading
+            aligned = false;
         }
+
         if (aligned) {
             block.writeInt(alignedSize);
         } else {

--- a/paimon-common/src/test/java/org/apache/paimon/lookup/sort/SortLookupStoreFactoryTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/lookup/sort/SortLookupStoreFactoryTest.java
@@ -115,6 +115,24 @@ public class SortLookupStoreFactoryTest {
     }
 
     @TestTemplate
+    public void testEmpty() throws IOException {
+        CacheManager cacheManager = new CacheManager(MemorySize.ofMebiBytes(1));
+        SortLookupStoreFactory factory =
+                new SortLookupStoreFactory(Comparator.naturalOrder(), cacheManager, 1024, compress);
+
+        SortLookupStoreWriter writer =
+                factory.createWriter(file, createBloomFiler(bloomFilterEnabled));
+        Context context = writer.close();
+
+        SortLookupStoreReader reader = factory.createReader(file, context);
+        byte[] bytes = toBytes(rnd.nextInt(VALUE_COUNT));
+        assertThat(reader.lookup(bytes)).isNull();
+        reader.close();
+        assertThat(cacheManager.dataCache().asMap()).isEmpty();
+        assertThat(cacheManager.indexCache().asMap()).isEmpty();
+    }
+
+    @TestTemplate
     public void testIntKey() throws IOException {
         RowCompactedSerializer keySerializer =
                 new RowCompactedSerializer(RowType.of(new IntType()));


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In some cases, for example, all records in remote file has been marked deleted. It is possible to build an empty local file to lookup. `BlockWriter.finish` will throw a `IllegalStateException`.

We can fix it by supporting empty record in `SortLookupStoreWriter`.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
