### PR TITLE
[docs] Use `config.yaml` for flink version >= 1.19

### DIFF
--- a/docs/content/cdc-ingestion/mysql-cdc.md
+++ b/docs/content/cdc-ingestion/mysql-cdc.md
@@ -261,5 +261,5 @@ to avoid potential name conflict.
 ## FAQ
 
 1. Chinese characters in records ingested from MySQL are garbled.
-* Try to set `env.java.opts: -Dfile.encoding=UTF-8` in `flink-conf.yaml`
+* Try to set `env.java.opts: -Dfile.encoding=UTF-8` in `flink-conf.yaml`(Flink version < 1.19) or `config.yaml`(Flink version >= 1.19)
 (the option is changed to `env.java.opts.all` since Flink-1.17).

--- a/docs/content/flink/quick-start.md
+++ b/docs/content/flink/quick-start.md
@@ -104,7 +104,7 @@ cp flink-shaded-hadoop-2-uber-*.jar <FLINK_HOME>/lib/
 
 **Step 4: Start a Flink Local Cluster**
 
-In order to run multiple Flink jobs at the same time, you need to modify the cluster configuration in `<FLINK_HOME>/conf/flink-conf.yaml`.
+In order to run multiple Flink jobs at the same time, you need to modify the cluster configuration in `<FLINK_HOME>/conf/flink-conf.yaml`(Flink version < 1.19) or `<FLINK_HOME>/conf/config.yaml`(Flink version >= 1.19).
 
 ```yaml
 taskmanager.numberOfTaskSlots: 2

--- a/docs/content/maintenance/write-performance.md
+++ b/docs/content/maintenance/write-performance.md
@@ -28,7 +28,7 @@ under the License.
 
 Paimon's write performance is closely related to checkpoint, so if you need greater write throughput:
 
-1. Flink Configuration (`'flink-conf.yaml'` or `SET` in SQL): Increase the checkpoint interval
+1. Flink Configuration (`'flink-conf.yaml'/'config.yaml'` or `SET` in SQL): Increase the checkpoint interval
    (`'execution.checkpointing.interval'`), increase max concurrent checkpoints to 3
    (`'execution.checkpointing.max-concurrent-checkpoints'`), or just use batch mode.
 2. Increase `write-buffer-size`.


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Starting with Flink 1.19, Flink has officially introduced full support for the standard YAML 1.2 syntax ([FLIP-366](https://cwiki.apache.org/confluence/display/FLINK/FLIP-366%3A+Support+standard+YAML+for+FLINK+configuration?src=contextnavpagetreemode)). The default configuration file has been changed to `config.yaml` and placed in the `conf/` directory.

### Tests

No need

### API and Format

No

### Documentation

No
