### PR TITLE
[spark] Fix writing null struct col

### DIFF
--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/WithTableOptions.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/WithTableOptions.scala
@@ -27,4 +27,5 @@ trait WithTableOptions {
 
   protected val withPk: Seq[Boolean] = Seq(true, false)
 
+  protected def fileFormats(fn: String => Unit): Unit = Seq("parquet", "orc", "avro").foreach(fn)
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

```sql
CREATE TABLE t (i INT, s STRUCT<f1: INT, f2: INT>);
INSERT INTO t VALUES ((1, null), (2, STRUCT(null, null));
SELECT s FROM t;
```

before
```
[null,null], [null,null]
```

after
```
-- orc and avro
null, [null,null]
```

There is still bug with reading parquet, which fix involves core changes, add an issue to track it https://github.com/apache/paimon/issues/4785

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
