### PR TITLE
[core] Alter table set option with empty key filter

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -45,6 +45,7 @@ import org.apache.paimon.table.system.CatalogOptionsTable;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Preconditions;
+import org.apache.paimon.utils.StringUtils;
 
 import javax.annotation.Nullable;
 
@@ -370,6 +371,7 @@ public abstract class AbstractCatalog implements Catalog {
             Identifier identifier, List<SchemaChange> changes, boolean ignoreIfNotExists)
             throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException {
         checkNotSystemTable(identifier, "alterTable");
+        validateEmptyKeyInSchemaChange(changes);
 
         try {
             getTable(identifier);
@@ -545,6 +547,14 @@ public abstract class AbstractCatalog implements Catalog {
                             "The current catalog %s does not support specifying the table path when creating a table.",
                             this.getClass().getSimpleName()));
         }
+    }
+
+    private void validateEmptyKeyInSchemaChange(List<SchemaChange> changes) {
+        changes.removeIf(
+                schemaChange ->
+                        schemaChange instanceof SchemaChange.SetOption
+                                && StringUtils.isEmpty(
+                                        ((SchemaChange.SetOption) schemaChange).key()));
     }
 
     // =============================== Meta in File System =====================================

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -371,7 +371,7 @@ public abstract class AbstractCatalog implements Catalog {
             Identifier identifier, List<SchemaChange> changes, boolean ignoreIfNotExists)
             throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException {
         checkNotSystemTable(identifier, "alterTable");
-        validateEmptyKeyInSchemaChange(changes);
+        changes = filterNonEmptyKeyInSchemaChange(changes);
 
         try {
             getTable(identifier);
@@ -549,12 +549,16 @@ public abstract class AbstractCatalog implements Catalog {
         }
     }
 
-    private void validateEmptyKeyInSchemaChange(List<SchemaChange> changes) {
-        changes.removeIf(
-                schemaChange ->
-                        schemaChange instanceof SchemaChange.SetOption
-                                && StringUtils.isEmpty(
-                                        ((SchemaChange.SetOption) schemaChange).key()));
+    private List<SchemaChange> filterNonEmptyKeyInSchemaChange(List<SchemaChange> changes) {
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+        for (SchemaChange schemaChange : changes) {
+            if (schemaChange instanceof SchemaChange.SetOption
+                    && StringUtils.isEmpty(((SchemaChange.SetOption) schemaChange).key())) {
+                continue;
+            }
+            schemaChanges.add(schemaChange);
+        }
+        return schemaChanges;
     }
 
     // =============================== Meta in File System =====================================

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -54,6 +54,18 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testAlterOptionsWithEmptyKey() {
+        batchSql("ALTER TABLE T SET ('write-manifest-cache' = '1 mb')");
+        batchSql("ALTER TABLE T SET ('' = '2 mb')");
+        assertThat(
+                        batchSql("SHOW CREATE TABLE T")
+                                .toString()
+                                .contains("'write-manifest-cache' = '1 mb'"))
+                .isTrue();
+        assertThat(batchSql("SHOW CREATE TABLE T").toString().contains("'' = '2 mb'")).isFalse();
+    }
+
+    @Test
     public void testAQEWithWriteManifest() {
         batchSql("ALTER TABLE T SET ('write-manifest-cache' = '1 mb')");
         batchSql("INSERT INTO T VALUES (1, 11, 111), (2, 22, 222)");

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
@@ -55,6 +55,23 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
       Assertions.assertTrue(schema("name").nullable)
     }
   }
+
+  test("Paimon DDL: set properties with empty key test") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id STRING, name STRING)
+                 |USING PAIMON
+                 |TBLPROPERTIES ('primary-key'='id')
+                 |""".stripMargin)
+
+    spark.sql(s"""
+                 |alter table T
+                 |SET TBLPROPERTIES ('' = 'b')
+                 |""".stripMargin)
+
+    assert(!spark.sql(s"show create table T").head().getString(0).contains("'' = 'b'"))
+    assert(spark.sql(s"show create table T").head().getString(0).contains("'primary-key' = 'id'"))
+  }
+
   test("Paimon DDL: create primary-key table with not null") {
     withTable("T") {
       sql("""


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx
Currently paimon set properties(options) not filter empty key:

ALTER TABLE T SET ('' = '2 mb');

then show create table : 
CREATE TABLE `PAIMON`.`default`.`T` (
  `a` INT,
  `b` INT,
  `c` INT
) WITH (
  'scan.infer-parallelism' = 'false',
  'path' = '/var/folders/kb/wgkwnwq156g6kcpgldkyjcf00000gp/T/junit3546018753241373391/a5ced1b0-a37b-4879-b035-c14a351168d3/default.db/T',
 **'' = '2 mb'**
  'write-manifest-cache' = '1 mb'
)
this pr filter the empty option key


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
