### PR TITLE
[flink] Add new TypeMapping options to ignore type change in special cases

### DIFF
--- a/docs/layouts/shortcodes/generated/kafka_sync_database.html
+++ b/docs/layouts/shortcodes/generated/kafka_sync_database.html
@@ -86,6 +86,8 @@ under the License.
                 <li>"char-to-string": maps MySQL CHAR(length)/VARCHAR(length) types to STRING.</li>
                 <li>"longtext-to-bytes": maps MySQL LONGTEXT types to BYTES.</li>
                 <li>"bigint-unsigned-to-bigint": maps MySQL BIGINT UNSIGNED, BIGINT UNSIGNED ZEROFILL, SERIAL to BIGINT. You should ensure overflow won't occur when using this option.</li>
+                <li>"decimal-no-change": Ignore decimal type change.</li>
+                <li>"no-change": Ignore any type change.</li>
             </ul>
         </td>
     </tr>

--- a/docs/layouts/shortcodes/generated/kafka_sync_table.html
+++ b/docs/layouts/shortcodes/generated/kafka_sync_table.html
@@ -58,6 +58,8 @@ under the License.
                 <li>"char-to-string": maps MySQL CHAR(length)/VARCHAR(length) types to STRING.</li>
                 <li>"longtext-to-bytes": maps MySQL LONGTEXT types to BYTES.</li>
                 <li>"bigint-unsigned-to-bigint": maps MySQL BIGINT UNSIGNED, BIGINT UNSIGNED ZEROFILL, SERIAL to BIGINT. You should ensure overflow won't occur when using this option.</li>
+                <li>"decimal-no-change": Ignore decimal type change.</li>
+                <li>"no-change": Ignore any type change.</li>
             </ul>
         </td>
     </tr>

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
@@ -231,6 +231,7 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
                 .withInput(input)
                 .withParserFactory(parserFactory)
                 .withCatalogLoader(catalogLoader())
+                .withTypeMapping(typeMapping)
                 .withDatabase(database)
                 .withTables(tables)
                 .withMode(mode)

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionBase.java
@@ -168,7 +168,8 @@ public abstract class SyncTableActionBase extends SynchronizationActionBase {
                         .withParserFactory(parserFactory)
                         .withTable(fileStoreTable)
                         .withIdentifier(new Identifier(database, table))
-                        .withCatalogLoader(catalogLoader());
+                        .withCatalogLoader(catalogLoader())
+                        .withTypeMapping(typeMapping);
         String sinkParallelism = tableConfig.get(FlinkConnectorOptions.SINK_PARALLELISM.key());
         if (sinkParallelism != null) {
             sinkBuilder.withParallelism(Integer.parseInt(sinkParallelism));

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/TypeMapping.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/TypeMapping.java
@@ -68,6 +68,8 @@ public class TypeMapping implements Serializable {
      *   <li>BIGINT_UNSIGNED_TO_BIGINT: maps MySQL BIGINT UNSIGNED types to Paimon BIGINT. Notice
      *       that there is potential overflow risk, and users should ensure the overflow won't
      *       occur.
+     *   <li>DECIMAL_NO_CHANGE: Ignore DECIMAL type change.
+     *   <li>NO_CHANGE: Ignore any type change
      * </ul>
      */
     public enum TypeMappingMode {
@@ -76,7 +78,9 @@ public class TypeMapping implements Serializable {
         TO_STRING,
         CHAR_TO_STRING,
         LONGTEXT_TO_BYTES,
-        BIGINT_UNSIGNED_TO_BIGINT;
+        BIGINT_UNSIGNED_TO_BIGINT,
+        DECIMAL_NO_CHANGE,
+        NO_CHANGE;
 
         private static final Map<String, TypeMappingMode> TYPE_MAPPING_OPTIONS =
                 Arrays.stream(TypeMappingMode.values())

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcSinkBuilder.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcSinkBuilder.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink.sink.cdc;
 import org.apache.paimon.annotation.Experimental;
 import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.flink.action.cdc.TypeMapping;
 import org.apache.paimon.flink.utils.SingleOutputStreamOperatorUtils;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.BucketMode;
@@ -49,6 +50,7 @@ public class CdcSinkBuilder<T> {
     private Table table = null;
     private Identifier identifier = null;
     private CatalogLoader catalogLoader = null;
+    private TypeMapping typeMapping = null;
 
     @Nullable private Integer parallelism;
 
@@ -82,6 +84,11 @@ public class CdcSinkBuilder<T> {
         return this;
     }
 
+    public CdcSinkBuilder<T> withTypeMapping(TypeMapping typeMapping) {
+        this.typeMapping = typeMapping;
+        return this;
+    }
+
     public DataStreamSink<?> build() {
         Preconditions.checkNotNull(input, "Input DataStream can not be null.");
         Preconditions.checkNotNull(parserFactory, "Event ParserFactory can not be null.");
@@ -109,7 +116,8 @@ public class CdcSinkBuilder<T> {
                                 new UpdatedDataFieldsProcessFunction(
                                         new SchemaManager(dataTable.fileIO(), dataTable.location()),
                                         identifier,
-                                        catalogLoader))
+                                        catalogLoader,
+                                        typeMapping))
                         .name("Schema Evolution");
         schemaChangeProcessFunction.getTransformation().setParallelism(1);
         schemaChangeProcessFunction.getTransformation().setMaxParallelism(1);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/MultiTableUpdatedDataFieldsProcessFunction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/MultiTableUpdatedDataFieldsProcessFunction.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink.sink.cdc;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.flink.action.cdc.TypeMapping;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.FileStoreTable;
@@ -52,8 +53,9 @@ public class MultiTableUpdatedDataFieldsProcessFunction
 
     private final Map<Identifier, SchemaManager> schemaManagers = new HashMap<>();
 
-    public MultiTableUpdatedDataFieldsProcessFunction(CatalogLoader catalogLoader) {
-        super(catalogLoader);
+    public MultiTableUpdatedDataFieldsProcessFunction(
+            CatalogLoader catalogLoader, TypeMapping typeMapping) {
+        super(catalogLoader, typeMapping);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunction.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.sink.cdc;
 
 import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.flink.action.cdc.TypeMapping;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.types.DataField;
@@ -53,8 +54,11 @@ public class UpdatedDataFieldsProcessFunction
     private Set<FieldIdentifier> latestFields;
 
     public UpdatedDataFieldsProcessFunction(
-            SchemaManager schemaManager, Identifier identifier, CatalogLoader catalogLoader) {
-        super(catalogLoader);
+            SchemaManager schemaManager,
+            Identifier identifier,
+            CatalogLoader catalogLoader,
+            TypeMapping typeMapping) {
+        super(catalogLoader, typeMapping);
         this.schemaManager = schemaManager;
         this.identifier = identifier;
         this.latestFields = new HashSet<>();

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunctionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunctionBase.java
@@ -219,7 +219,8 @@ public abstract class UpdatedDataFieldsProcessFunctionBase<I, O> extends Process
         }
 
         boolean allowTypeChange =
-                !this.typeMapping.containsMode(TypeMapping.TypeMappingMode.NO_CHANGE);
+                this.typeMapping == null
+                        || !this.typeMapping.containsMode(TypeMapping.TypeMappingMode.NO_CHANGE);
 
         List<SchemaChange> result = new ArrayList<>();
         for (DataField newField : updatedDataFields) {

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/SchemaEvolutionTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/SchemaEvolutionTest.java
@@ -210,7 +210,8 @@ public class SchemaEvolutionTest extends TableTestBase {
                                 new UpdatedDataFieldsProcessFunction(
                                         new SchemaManager(table.fileIO(), table.location()),
                                         identifier,
-                                        catalogLoader))
+                                        catalogLoader,
+                                        TypeMapping.defaultMapping()))
                         .name("Schema Evolution");
         schemaChangeProcessFunction.getTransformation().setParallelism(1);
         schemaChangeProcessFunction.getTransformation().setMaxParallelism(1);

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlCdcTypeMappingITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlCdcTypeMappingITCase.java
@@ -757,7 +757,7 @@ public class MySqlCdcTypeMappingITCase extends MySqlActionITCaseBase {
     // -------------------------------------- no-change --------------------------------------
 
     @Test
-    @Timeout(60)
+    @Timeout(120)
     public void testNoChange() throws Exception {
         Map<String, String> mySqlConfig = getBasicMySqlConfig();
         mySqlConfig.put("database-name", "char_to_string_test");

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlCdcTypeMappingITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlCdcTypeMappingITCase.java
@@ -757,15 +757,15 @@ public class MySqlCdcTypeMappingITCase extends MySqlActionITCaseBase {
     // -------------------------------------- no-change --------------------------------------
 
     @Test
-    @Timeout(120)
+    @Timeout(60)
     public void testNoChange() throws Exception {
         Map<String, String> mySqlConfig = getBasicMySqlConfig();
-        mySqlConfig.put("database-name", "char_to_string_test");
+        mySqlConfig.put("database-name", "char_no_change_test");
 
         MySqlSyncDatabaseAction action =
                 syncDatabaseActionBuilder(mySqlConfig)
                         .withMode(COMBINED.configString())
-                        .withTypeMappingModes(NO_CHANGE.configString())
+                        .withTypeMappingModes(CHAR_TO_STRING.configString(),NO_CHANGE.configString())
                         .withTableConfig(getBasicTableConfig())
                         .build();
         runActionWithDefaultEnv(action);
@@ -773,7 +773,7 @@ public class MySqlCdcTypeMappingITCase extends MySqlActionITCaseBase {
         FileStoreTable table = getFileStoreTable("t1");
 
         try (Statement statement = getStatement()) {
-            statement.executeUpdate("USE char_to_string_test");
+            statement.executeUpdate("USE char_no_change_test");
 
             // test schema evolution
             RowType rowType =

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlCdcTypeMappingITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlCdcTypeMappingITCase.java
@@ -765,7 +765,8 @@ public class MySqlCdcTypeMappingITCase extends MySqlActionITCaseBase {
         MySqlSyncDatabaseAction action =
                 syncDatabaseActionBuilder(mySqlConfig)
                         .withMode(COMBINED.configString())
-                        .withTypeMappingModes(CHAR_TO_STRING.configString(),NO_CHANGE.configString())
+                        .withTypeMappingModes(
+                                CHAR_TO_STRING.configString(), NO_CHANGE.configString())
                         .withTableConfig(getBasicTableConfig())
                         .build();
         runActionWithDefaultEnv(action);

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlCdcTypeMappingITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlCdcTypeMappingITCase.java
@@ -41,7 +41,6 @@ import static org.apache.paimon.flink.action.cdc.TypeMapping.TypeMappingMode.BIG
 import static org.apache.paimon.flink.action.cdc.TypeMapping.TypeMappingMode.CHAR_TO_STRING;
 import static org.apache.paimon.flink.action.cdc.TypeMapping.TypeMappingMode.DECIMAL_NO_CHANGE;
 import static org.apache.paimon.flink.action.cdc.TypeMapping.TypeMappingMode.LONGTEXT_TO_BYTES;
-import static org.apache.paimon.flink.action.cdc.TypeMapping.TypeMappingMode.NO_CHANGE;
 import static org.apache.paimon.flink.action.cdc.TypeMapping.TypeMappingMode.TINYINT1_NOT_BOOL;
 import static org.apache.paimon.flink.action.cdc.TypeMapping.TypeMappingMode.TO_NULLABLE;
 import static org.apache.paimon.flink.action.cdc.TypeMapping.TypeMappingMode.TO_STRING;
@@ -749,74 +748,6 @@ public class MySqlCdcTypeMappingITCase extends MySqlActionITCaseBase {
                     getFileStoreTable("_new_table"),
                     RowType.of(
                             new DataType[] {DataTypes.INT().notNull(), DataTypes.DECIMAL(10, 2)},
-                            new String[] {"pk", "v"}),
-                    Collections.singletonList("pk"));
-        }
-    }
-
-    // -------------------------------------- no-change --------------------------------------
-
-    @Test
-    @Timeout(60)
-    public void testNoChange() throws Exception {
-        Map<String, String> mySqlConfig = getBasicMySqlConfig();
-        mySqlConfig.put("database-name", "char_no_change_test");
-
-        MySqlSyncDatabaseAction action =
-                syncDatabaseActionBuilder(mySqlConfig)
-                        .withMode(COMBINED.configString())
-                        .withTypeMappingModes(
-                                CHAR_TO_STRING.configString(), NO_CHANGE.configString())
-                        .withTableConfig(getBasicTableConfig())
-                        .build();
-        runActionWithDefaultEnv(action);
-
-        FileStoreTable table = getFileStoreTable("t1");
-
-        try (Statement statement = getStatement()) {
-            statement.executeUpdate("USE char_no_change_test");
-
-            // test schema evolution
-            RowType rowType =
-                    RowType.of(
-                            new DataType[] {
-                                DataTypes.INT().notNull(), DataTypes.VARCHAR(10).notNull()
-                            },
-                            new String[] {"pk", "v1"});
-            waitForResult(
-                    Collections.singletonList("+I[1, 1]"),
-                    table,
-                    rowType,
-                    Collections.singletonList("pk"));
-
-            statement.executeUpdate("ALTER TABLE t1 ADD COLUMN v2 CHAR(1)");
-            statement.executeUpdate("INSERT INTO t1 VALUES (2, '2', 'A'), (3, '3', 'B')");
-
-            rowType =
-                    RowType.of(
-                            new DataType[] {
-                                DataTypes.INT().notNull(),
-                                DataTypes.VARCHAR(10).notNull(),
-                                DataTypes.CHAR(1)
-                            },
-                            new String[] {"pk", "v1", "v2"});
-            waitForResult(
-                    Arrays.asList("+I[1, 1, NULL]", "+I[2, 2, A]", "+I[3, 3, B]"),
-                    table,
-                    rowType,
-                    Collections.singletonList("pk"));
-
-            // test newly created table
-            statement.executeUpdate(
-                    "CREATE TABLE _new_table (pk INT, v VARCHAR(10), PRIMARY KEY (pk))");
-            statement.executeUpdate("INSERT INTO _new_table VALUES (1, 'Paimon')");
-
-            waitingTables("_new_table");
-            waitForResult(
-                    Collections.singletonList("+I[1, Paimon]"),
-                    getFileStoreTable("_new_table"),
-                    RowType.of(
-                            new DataType[] {DataTypes.INT().notNull(), DataTypes.VARCHAR(10)},
                             new String[] {"pk", "v"}),
                     Collections.singletonList("pk"));
         }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkITCase.java
@@ -23,6 +23,7 @@ import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.CatalogUtils;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.FlinkCatalogFactory;
+import org.apache.paimon.flink.action.cdc.TypeMapping;
 import org.apache.paimon.flink.util.AbstractTestBase;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
@@ -173,6 +174,7 @@ public class FlinkCdcSyncDatabaseSinkITCase extends AbstractTestBase {
                 .withTableOptions(Collections.singletonMap(SINK_PARALLELISM.key(), "2"))
                 .withDatabase(DATABASE_NAME)
                 .withCatalogLoader(catalogLoader)
+                .withTypeMapping(TypeMapping.defaultMapping())
                 .build();
 
         // enable failure when running jobs if needed

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/mysql/type_mapping_test_setup.sql
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/mysql/type_mapping_test_setup.sql
@@ -314,3 +314,19 @@ CREATE TABLE t1 (
 );
 
 INSERT INTO t1 VALUES (1, 12345, 56789, 123456789);
+
+
+-- ################################################################################
+--  testDecimalNoChange
+-- ################################################################################
+
+CREATE DATABASE decimal_no_change_test;
+USE decimal_no_change_test;
+
+CREATE TABLE t1 (
+    pk INT,
+    v1 DECIMAL(10,2),
+    PRIMARY KEY (pk)
+);
+
+INSERT INTO t1 VALUES (1, 1.23);

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/mysql/type_mapping_test_setup.sql
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/mysql/type_mapping_test_setup.sql
@@ -330,3 +330,18 @@ CREATE TABLE t1 (
 );
 
 INSERT INTO t1 VALUES (1, 1.23);
+
+-- ################################################################################
+--  testNoChange
+-- ################################################################################
+
+CREATE DATABASE char_no_change_test;
+USE char_no_change_test;
+
+CREATE TABLE t1 (
+    pk INT,
+    v1 VARCHAR(10) NOT NULL,
+    PRIMARY KEY (pk)
+);
+
+INSERT INTO t1 VALUES (1, '1');


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #4783

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
org.apache.paimon.flink.action.cdc.mysql.MySqlCdcTypeMappingITCase#testDecimalNoChange
org.apache.paimon.flink.action.cdc.mysql.MySqlCdcTypeMappingITCase#testNoChange

### API and Format

<!-- Does this change affect API or storage format -->
No
### Documentation

<!-- Does this change introduce a new feature -->
Yes and doc provided