### PR TITLE
[test] Remove the loggingTimer to fix the CDC build error

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaDebeziumAvroSyncTableActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaDebeziumAvroSyncTableActionITCase.java
@@ -72,7 +72,6 @@ public class KafkaDebeziumAvroSyncTableActionITCase extends KafkaActionITCaseBas
 
     @BeforeEach
     public void setup() {
-        super.setup();
         // Init avro serializer for kafka key/value
         Map<String, Object> props = new HashMap<>();
         props.put(SCHEMA_REGISTRY_URL_CONFIG, getSchemaRegistryUrl());


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Remove the loggingTimer, it has the thread-safe problem and will cause the build to fail. It just prints some logs periodically and doesn't do anything else.

See https://github.com/apache/paimon/actions/runs/12517312341/job/34917869427

```text
Error: Exception in thread "Debug Logging Timer" java.lang.RuntimeException: Failed to execute logging action
	at org.apache.paimon.flink.action.cdc.kafka.KafkaActionITCaseBase$2.run(KafkaActionITCaseBase.java:206)
	at java.util.TimerThread.mainLoop(Timer.java:555)
	at java.util.TimerThread.run(Timer.java:505)
Caused by: java.util.ConcurrentModificationException: KafkaConsumer is not safe for multi-threaded access
	at org.apache.kafka.clients.consumer.KafkaConsumer.acquire(KafkaConsumer.java:2491)
	at org.apache.kafka.clients.consumer.KafkaConsumer.acquireAndEnsureOpen(KafkaConsumer.java:2475)
	at org.apache.kafka.clients.consumer.KafkaConsumer.beginningOffsets(KafkaConsumer.java:2176)
	at org.apache.kafka.clients.consumer.KafkaConsumer.beginningOffsets(KafkaConsumer.java:2155)
	at org.apache.paimon.flink.action.cdc.kafka.KafkaActionITCaseBase.logTopicPartitionStatus(KafkaActionITCaseBase.java:243)
	at org.apache.paimon.flink.action.cdc.kafka.KafkaActionITCaseBase.lambda$setup$0(KafkaActionITCaseBase.java:179)
	at org.apache.paimon.flink.action.cdc.kafka.KafkaActionITCaseBase$2.run(KafkaActionITCaseBase.java:204)
	... 2 more
Error: Exception in thread "Debug Logging Timer" java.lang.RuntimeException: Failed to execute logging action
	at org.apache.paimon.flink.action.cdc.kafka.KafkaActionITCaseBase$2.run(KafkaActionITCaseBase.java:206)
	at java.util.TimerThread.mainLoop(Timer.java:555)
	at java.util.TimerThread.run(Timer.java:505)
Caused by: java.util.ConcurrentModificationException: KafkaConsumer is not safe for multi-threaded access
	at org.apache.kafka.clients.consumer.KafkaConsumer.acquire(KafkaConsumer.java:2491)
	at org.apache.kafka.clients.consumer.KafkaConsumer.acquireAndEnsureOpen(KafkaConsumer.java:2475)
	at org.apache.kafka.clients.consumer.KafkaConsumer.beginningOffsets(KafkaConsumer.java:2176)
	at org.apache.kafka.clients.consumer.KafkaConsumer.beginningOffsets(KafkaConsumer.java:2155)
	at org.apache.paimon.flink.action.cdc.kafka.KafkaActionITCaseBase.logTopicPartitionStatus(KafkaActionITCaseBase.java:243)
	at org.apache.paimon.flink.action.cdc.kafka.KafkaActionITCaseBase.lambda$setup$0(KafkaActionITCaseBase.java:179)
	at org.apache.paimon.flink.action.cdc.kafka.KafkaActionITCaseBase$2.run(KafkaActionITCaseBase.java:204)
	... 2 more
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
