### PR TITLE
[parquet] Fix file index result filter the row ranges missing rowgroup offset problem

### DIFF
--- a/paimon-format/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/paimon-format/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -761,6 +761,7 @@ public class ParquetFileReader implements Closeable {
                             getColumnIndexStore(blockIndex),
                             paths.keySet(),
                             blocks.get(blockIndex).getRowCount(),
+                            blocks.get(blockIndex).getRowIndexOffset(),
                             fileIndexResult);
             blockRowRanges.set(blockIndex, rowRanges);
         }

--- a/paimon-format/src/main/java/org/apache/parquet/internal/filter2/columnindex/ColumnIndexFilter.java
+++ b/paimon-format/src/main/java/org/apache/parquet/internal/filter2/columnindex/ColumnIndexFilter.java
@@ -67,6 +67,7 @@ public class ColumnIndexFilter implements Visitor<RowRanges> {
     private final ColumnIndexStore columnIndexStore;
     private final Set<ColumnPath> columns;
     private final long rowCount;
+    private final long rowIndexOffset;
     @Nullable private final FileIndexResult fileIndexResult;
     private RowRanges allRows;
 
@@ -89,6 +90,7 @@ public class ColumnIndexFilter implements Visitor<RowRanges> {
             ColumnIndexStore columnIndexStore,
             Set<ColumnPath> paths,
             long rowCount,
+            long rowIndexOffset,
             @Nullable FileIndexResult fileIndexResult) {
         return filter.accept(
                 new FilterCompat.Visitor<RowRanges>() {
@@ -102,6 +104,7 @@ public class ColumnIndexFilter implements Visitor<RowRanges> {
                                                     columnIndexStore,
                                                     paths,
                                                     rowCount,
+                                                    rowIndexOffset,
                                                     fileIndexResult));
                         } catch (MissingOffsetIndexException e) {
                             LOGGER.info(e.getMessage());
@@ -125,10 +128,12 @@ public class ColumnIndexFilter implements Visitor<RowRanges> {
             ColumnIndexStore columnIndexStore,
             Set<ColumnPath> paths,
             long rowCount,
+            long rowIndexOffset,
             @Nullable FileIndexResult fileIndexResult) {
         this.columnIndexStore = columnIndexStore;
         this.columns = paths;
         this.rowCount = rowCount;
+        this.rowIndexOffset = rowIndexOffset;
         this.fileIndexResult = fileIndexResult;
     }
 
@@ -227,7 +232,7 @@ public class ColumnIndexFilter implements Visitor<RowRanges> {
             return allRows();
         }
 
-        return RowRanges.create(rowCount, func.apply(ci), oi, fileIndexResult);
+        return RowRanges.create(rowCount, rowIndexOffset, func.apply(ci), oi, fileIndexResult);
     }
 
     @Override


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Fix #4780 filter row ranges missing rowgroup offset.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
