### PR TITLE
[spark] Purge file need refresh table avoid FileNotFound

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/PurgeFilesProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/PurgeFilesProcedure.java
@@ -82,6 +82,7 @@ public class PurgeFilesProcedure extends BaseProcedure {
                                                 throw new RuntimeException(e);
                                             }
                                         });
+                        spark().catalog().refreshTable(table.fullName());
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/PurgeFilesProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/PurgeFilesProcedureTest.scala
@@ -36,7 +36,6 @@ class PurgeFilesProcedureTest extends PaimonSparkTestBase {
     spark.sql("CALL paimon.sys.purge_files(table => 'test.T')")
     checkAnswer(spark.sql("select * from test.T"), Nil)
 
-    spark.sql("refresh table test.T");
     spark.sql("insert into T select '2', 'aa'");
     checkAnswer(spark.sql("select * from test.T"), Row("2", "aa") :: Nil)
   }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx
PurgeFileProcedure in spark not refresh catalog and this would lead to FileNotFound because of catalog cache, user need start a new spark job or session to avoid it, this pr is aim to fix it.

error as:
```
java.io.FileNotFoundException: File '/spark-6341d25d-5b46-414e-983f-0c606a3a8866/test.db/T/bucket-0/data-00564938-11af-44dd-8337-85787c7e3e14-0.parquet' not found, Possible causes: 1.snapshot expires too fast, you can configure 'snapshot.time-retained' option with a larger value. 2.consumption is too slow, you can improve the performance of consumption (For example, increasing parallelism).
	at org.apache.paimon.utils.FileUtils.checkExists(FileUtils.java:113)
	at org.apache.paimon.io.DataFileRecordReader.<init>(DataFileRecordReader.java:55)
	at org.apache.paimon.operation.RawFileSplitRead.createFileReader(RawFileSplitRead.java:220)
	at org.apache.paimon.operation.RawFileSplitRead.lambda$createReader$3(RawFileSplitRead.java:179)
	at org.apache.paimon.mergetree.compact.ConcatRecordReader.create(ConcatRecordReader.java:53)
	at org.apache.paimon.operation.RawFileSplitRead.createReader(RawFileSplitRead.java:187)
	at org.apache.paimon.operation.RawFileSplitRead.createReader(RawFileSplitRead.java:139)
	at org.apache.paimon.table.AppendOnlyFileStoreTable$1.reader(AppendOnlyFileStoreTable.java:130)
	at org.apache.paimon.table.source.AbstractDataTableRead.createReader(AbstractDataTableRead.java:92)
	at org.apache.paimon.spark.PaimonPartitionReaderFactory.$anonfun$createReader$1(PaimonPartitionReaderFactory.scala:56)
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
