### PR TITLE
[Iceberg]Add Iceberg database / table options as alias when generating Iceberg metadata

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
@@ -95,16 +95,16 @@ public class IcebergOptions {
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "Hive database name for Iceberg Hive Catalog. " +
-                                    "Set this as an iceberg database alias if using a centralized Catalog.");
+                            "Hive database name for Iceberg Hive Catalog. "
+                                    + "Set this as an iceberg database alias if using a centralized Catalog.");
 
     public static final ConfigOption<String> HIVE_TABLE =
             key("metadata.iceberg.table")
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "Hive table name for Iceberg Hive Catalog." +
-                                    "Set this as an iceberg table alias if using a centralized Catalog.");
+                            "Hive table name for Iceberg Hive Catalog."
+                                    + "Set this as an iceberg table alias if using a centralized Catalog.");
 
     /** Where to store Iceberg metadata. */
     public enum StorageType implements DescribedEnum {

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
@@ -90,6 +90,22 @@ public class IcebergOptions {
                     .defaultValue("org.apache.hadoop.hive.metastore.HiveMetaStoreClient")
                     .withDescription("Hive client class name for Iceberg Hive Catalog.");
 
+    public static final ConfigOption<String> HIVE_DATABASE =
+            key("metadata.iceberg.database")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Hive database name for Iceberg Hive Catalog. " +
+                                    "Set this as an iceberg database alias if using a centralized Catalog.");
+
+    public static final ConfigOption<String> HIVE_TABLE =
+            key("metadata.iceberg.table")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Hive table name for Iceberg Hive Catalog." +
+                                    "Set this as an iceberg table alias if using a centralized Catalog.");
+
     /** Where to store Iceberg metadata. */
     public enum StorageType implements DescribedEnum {
         DISABLED("disabled", "Disable Iceberg compatibility support."),


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #4810
Add Iceberg database / table options as alias when generating Iceberg metadata.
<!-- What is the purpose of the change -->

### Tests
1. IcebergHiveMetadataCommitterITCaseBase
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->
This change does not affect API or storage format

### Documentation

<!-- Does this change introduce a new feature -->
