### PR TITLE
[core] allows to override the default factory by priority .

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/factories/Factory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/factories/Factory.java
@@ -37,4 +37,16 @@ public interface Factory {
      * using "-" (e.g. {@code elasticsearch-7}).
      */
     String identifier();
+
+    /**
+     * This is the priority of the factory, allows you to override the default factory
+     * implementation. The default officially implemented factory priority is 9. If the number is
+     * less than 9, the smaller number will be selected for execution. If the smallest priority also
+     * conflicts, an exception will be thrown.
+     *
+     * @return priority
+     */
+    default int priority() {
+        return 9;
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/factories/FactoryUtil.java
+++ b/paimon-common/src/main/java/org/apache/paimon/factories/FactoryUtil.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceLoader;
@@ -74,6 +75,12 @@ public class FactoryUtil {
                                     .collect(Collectors.joining("\n"))));
         }
         if (matchingFactories.size() > 1) {
+            if (matchingFactories.stream().map(Factory::priority).distinct().count() > 1) {
+                return (T)
+                        matchingFactories.stream()
+                                .min(Comparator.comparingInt(Factory::priority))
+                                .get();
+            }
             throw new FactoryException(
                     String.format(
                             "Multiple factories for identifier '%s' that implement '%s' found in the classpath.\n\n"


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

This is the priority of the factory, allows you to override the default factory implementation. The default officially implemented factory priority is 9. If the number is less than 9, the smaller number will be selected for execution. If the smallest priority also conflicts, an exception will be thrown.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
