### PR TITLE
[spark] Clean empty directory after removing orphan files

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -127,6 +127,11 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
                         .collect(Collectors.toList()));
         candidateDeletes.clear();
 
+        // clean empty directory
+        Set<Path> deletedPaths =
+                deleteFiles.stream().map(Path::getParent).collect(Collectors.toSet());
+        cleanEmptyDirectory(deletedPaths);
+
         return new CleanOrphanFilesResult(
                 deleteFiles.size(), deletedFilesLenInBytes.get(), deleteFiles);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -399,18 +399,21 @@ public abstract class OrphanFilesClean implements Serializable {
     }
 
     /** Try to clean empty partition directories. */
-    protected void tryCleanPartitionDirectory(Set<Path> deletedPaths) {
+    protected void tryCleanPartitionDirectory(Set<Path> partitionDirs) {
         for (int level = 0; level < partitionKeysNum; level++) {
-            deletedPaths.forEach(this::tryDeleteEmptyDirectory);
-            deletedPaths = deletedPaths.stream().map(Path::getParent).collect(Collectors.toSet());
+            partitionDirs =
+                    partitionDirs.stream()
+                            .filter(this::tryDeleteEmptyDirectory)
+                            .map(Path::getParent)
+                            .collect(Collectors.toSet());
         }
     }
 
-    public void tryDeleteEmptyDirectory(Path path) {
+    public boolean tryDeleteEmptyDirectory(Path path) {
         try {
-            fileIO.delete(path, false);
+            return fileIO.delete(path, false);
         } catch (IOException e) {
-            LOG.debug("Failed to delete directory '{}' because it is not empty.", path);
+            return false;
         }
     }
 }

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
@@ -110,7 +110,8 @@ public class RemoveOrphanFilesProcedure extends ProcedureBase {
                                     tableName,
                                     olderThanMillis(olderThan),
                                     createFileCleaner(catalog, dryRun),
-                                    parallelism);
+                                    parallelism,
+                                    dryRun);
                     break;
                 default:
                     throw new IllegalArgumentException(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
@@ -98,7 +98,8 @@ public class RemoveOrphanFilesProcedure extends ProcedureBase {
                                     tableName,
                                     olderThanMillis(olderThan),
                                     createFileCleaner(catalog, dryRun),
-                                    parallelism);
+                                    parallelism,
+                                    dryRun);
                     break;
                 default:
                     throw new IllegalArgumentException(

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedure.java
@@ -90,6 +90,10 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
     public InternalRow[] call(InternalRow args) {
         org.apache.paimon.catalog.Identifier identifier;
         String tableId = args.getString(0);
+        String olderThan = args.isNullAt(1) ? null : args.getString(1);
+        boolean dryRun = !args.isNullAt(2) && args.getBoolean(2);
+        Integer parallelism = args.isNullAt(3) ? null : args.getInt(3);
+
         Preconditions.checkArgument(
                 tableId != null && !tableId.isEmpty(),
                 "Cannot handle an empty tableId for argument %s",
@@ -116,11 +120,10 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
                                     catalog,
                                     identifier.getDatabaseName(),
                                     identifier.getTableName(),
-                                    OrphanFilesClean.olderThanMillis(
-                                            args.isNullAt(1) ? null : args.getString(1)),
-                                    OrphanFilesClean.createFileCleaner(
-                                            catalog, !args.isNullAt(2) && args.getBoolean(2)),
-                                    args.isNullAt(3) ? null : args.getInt(3));
+                                    OrphanFilesClean.olderThanMillis(olderThan),
+                                    OrphanFilesClean.createFileCleaner(catalog, dryRun),
+                                    parallelism,
+                                    dryRun);
                     break;
                 case "DISTRIBUTED":
                     cleanOrphanFilesResult =
@@ -128,11 +131,10 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
                                     catalog,
                                     identifier.getDatabaseName(),
                                     identifier.getTableName(),
-                                    OrphanFilesClean.olderThanMillis(
-                                            args.isNullAt(1) ? null : args.getString(1)),
-                                    OrphanFilesClean.createFileCleaner(
-                                            catalog, !args.isNullAt(2) && args.getBoolean(2)),
-                                    args.isNullAt(3) ? null : args.getInt(3));
+                                    OrphanFilesClean.olderThanMillis(olderThan),
+                                    OrphanFilesClean.createFileCleaner(catalog, dryRun),
+                                    parallelism,
+                                    dryRun);
                     break;
                 default:
                     throw new IllegalArgumentException(

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/orphan/SparkOrphanFilesClean.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/orphan/SparkOrphanFilesClean.scala
@@ -52,7 +52,7 @@ case class SparkOrphanFilesClean(
   with Logging {
 
   def doOrphanClean()
-      : (Dataset[(Long, Long)], (Dataset[BranchAndManifestFile], Dataset[(Long, Long, mutable.HashSet[String])])) = {
+      : (Dataset[(Long, Long)], (Dataset[BranchAndManifestFile], Dataset[(Long, Long, Set[String])])) = {
     import spark.implicits._
 
     val branches = validBranches()
@@ -154,7 +154,7 @@ case class SparkOrphanFilesClean(
           }
           logInfo(
             s"Total cleaned files: $deletedFilesCount, Total cleaned files len : $deletedFilesLenInBytes")
-          Iterator.single((deletedFilesCount, deletedFilesLenInBytes, involvedDirectories))
+          Iterator.single((deletedFilesCount, deletedFilesLenInBytes, involvedDirectories.toSet))
       }
       .cache()
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/orphan/SparkOrphanFilesClean.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/orphan/SparkOrphanFilesClean.scala
@@ -152,7 +152,7 @@ case class SparkOrphanFilesClean(
             deletedFilesLenInBytes += fileInfo.getLong(2)
             specifiedFileCleaner.accept(deletedPath)
             logInfo(s"Cleaned file: $pathToClean")
-            dataDirs.add(deletedPath.getParent.toUri.toString)
+            dataDirs.add(fileInfo.getString(3))
             deletedFilesCount += 1
           }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/orphan/SparkOrphanFilesClean.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/orphan/SparkOrphanFilesClean.scala
@@ -37,7 +37,6 @@ import java.util.concurrent.atomic.AtomicLong
 import java.util.function.Consumer
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 case class SparkOrphanFilesClean(
@@ -51,7 +50,7 @@ case class SparkOrphanFilesClean(
   with Logging {
 
   def doOrphanClean()
-      : (Dataset[(Long, Long)], (Dataset[BranchAndManifestFile], Dataset[(Long, Long, mutable.HashSet[String])])) = {
+      : (Dataset[(Long, Long)], (Dataset[BranchAndManifestFile], Dataset[(Long, Long, ArrayBuffer[String])])) = {
     import spark.implicits._
 
     val branches = validBranches()
@@ -139,7 +138,7 @@ case class SparkOrphanFilesClean(
         it =>
           var deletedFilesCount = 0L
           var deletedFilesLenInBytes = 0L
-          val involvedDirectories = new mutable.HashSet[String]()
+          val involvedDirectories = new ArrayBuffer[String]()
 
           while (it.hasNext) {
             val fileInfo = it.next();
@@ -148,7 +147,7 @@ case class SparkOrphanFilesClean(
             deletedFilesLenInBytes += fileInfo.getLong(2)
             specifiedFileCleaner.accept(deletedPath)
             logInfo(s"Cleaned file: $pathToClean")
-            involvedDirectories += deletedPath.getParent.toUri.toString
+            involvedDirectories.append(deletedPath.getParent.toUri.toString)
             deletedFilesCount += 1
           }
           logInfo(

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedureTest.scala
@@ -219,7 +219,6 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
     checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row(0, 0) :: Nil)
   }
 
-
   test("Paimon procedure: remove orphan files with data file path directory") {
     sql(s"""
            |CREATE TABLE T (id STRING, name STRING)

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedureTest.scala
@@ -219,6 +219,7 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
     checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row(0, 0) :: Nil)
   }
 
+
   test("Paimon procedure: remove orphan files with data file path directory") {
     sql(s"""
            |CREATE TABLE T (id STRING, name STRING)
@@ -240,4 +241,75 @@ class RemoveOrphanFilesProcedureTest extends PaimonSparkTestBase {
       sql(s"CALL sys.remove_orphan_files(table => 'T', older_than => '$older_than')"),
       Row(1, 1) :: Nil)
   }
+
+  test("Paimon procedure: clean empty directory after removing orphan files") {
+    spark.sql("""
+                |CREATE TABLE T (k STRING, pt STRING)
+                |using paimon TBLPROPERTIES ('primary-key'='k,pt', 'bucket'='1',
+                |'snapshot.clean-empty-directories'='false') PARTITIONED BY (pt);
+                |""".stripMargin)
+
+    spark.sql("""
+                |insert into T values
+                |("a", "2024-06-02"),("b", "2024-06-02"),("d", "2024-06-03"),
+                |("c", "2024-06-01"),("Never-expire", "9999-09-09");
+                |
+                |""".stripMargin)
+
+    // by default, no file deleted
+    checkAnswer(spark.sql(s"CALL sys.remove_orphan_files(table => 'T')"), Row(0, 0) :: Nil)
+
+    spark.sql(
+      "CALL sys.expire_partitions(table => 'T' , " +
+        "expiration_time => '1 d', timestamp_formatter => 'yyyy-MM-dd', max_expires => 3);")
+
+    // insert a new snapshot to clean expired partitioned files
+    spark.sql("insert into T values ('Never-expire-2', '9999-09-09')")
+
+    val table = loadTable("T")
+    val fileIO = table.fileIO()
+    val tablePath = table.location()
+
+    val partitionValue = "pt=2024-06-01"
+    val partitionPath = tablePath + "/" + partitionValue
+    val orphanFile1 = new Path(partitionPath, ORPHAN_FILE_1)
+    val orphanFile2 = new Path(partitionPath, ORPHAN_FILE_2)
+    fileIO.writeFile(orphanFile1, "a", true)
+    Thread.sleep(2000)
+    fileIO.writeFile(orphanFile2, "b", true)
+
+    checkAnswer(
+      spark.sql("CALL paimon.sys.expire_snapshots(table => 'T', retain_max => 1)"),
+      Row(2) :: Nil)
+
+    val older_than1 = new java.sql.Timestamp(
+      fileIO.getFileStatus(orphanFile2).getModificationTime - TimeUnit.SECONDS.toMillis(1))
+
+    // partition 'pt=2024-06-01' has one orphan file left
+    assertResult(true)(
+      fileIO
+        .listDirectories(tablePath)
+        .map(status => status.getPath.getName)
+        .contains(partitionValue))
+
+    checkAnswer(
+      spark.sql(
+        s"CALL sys.remove_orphan_files(table => 'T', older_than => '$older_than1', mode => 'distributed')"),
+      Row(1, 1) :: Nil)
+
+    val older_than2 = new java.sql.Timestamp(System.currentTimeMillis())
+
+    checkAnswer(
+      spark.sql(
+        s"CALL sys.remove_orphan_files(table => 'T', older_than => '$older_than2', mode => 'local')"),
+      Row(1, 1) :: Nil)
+
+    // partition 'pt=2024-06-01' has no orphan files, clean empty directory
+    assertResult(false)(
+      fileIO
+        .listDirectories(tablePath)
+        .map(status => status.getPath.getName)
+        .contains(partitionValue))
+  }
+
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Empty directories can not be cleaned after executing `remove_orphan_files`.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
