### PR TITLE
[common] Upgrade the RoaringBitmap version from 1.0.5 to 1.2.1

### DIFF
--- a/paimon-common/pom.xml
+++ b/paimon-common/pom.xml
@@ -144,7 +144,7 @@ under the License.
         <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>
-            <version>1.0.5</version>
+            <version>1.2.1</version>
         </dependency>
 
         <dependency>

--- a/paimon-common/src/main/resources/META-INF/NOTICE
+++ b/paimon-common/src/main/resources/META-INF/NOTICE
@@ -5,7 +5,7 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
-- org.roaringbitmap:RoaringBitmap:1.0.5
+- org.roaringbitmap:RoaringBitmap:1.2.1
 - org.apache.datasketches:datasketches-java:4.2.0
 - org.apache.datasketches:datasketches-memory:2.2.0
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Upgrade the RoaringBitmap version from 1.0.5 to 1.2.1, in order to fix some bug.
For example: 
* https://github.com/RoaringBitmap/RoaringBitmap/pull/722
* https://github.com/RoaringBitmap/RoaringBitmap/pull/724
* https://github.com/RoaringBitmap/RoaringBitmap/pull/736
* https://github.com/RoaringBitmap/RoaringBitmap/pull/739

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
