### PR TITLE
[spark] SparkGenericCatalog support tag DDL

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
@@ -18,7 +18,7 @@
 
 package org.apache.paimon.spark.execution
 
-import org.apache.paimon.spark.{SparkCatalog, SparkUtils}
+import org.apache.paimon.spark.{SparkCatalog, SparkGenericCatalog, SparkUtils}
 import org.apache.paimon.spark.catalog.SupportView
 import org.apache.paimon.spark.catalyst.analysis.ResolvedPaimonView
 import org.apache.paimon.spark.catalyst.plans.logical.{CreateOrReplaceTagCommand, CreatePaimonView, DeleteTagCommand, DropPaimonView, PaimonCallCommand, RenameTagCommand, ResolvedIdentifier, ShowPaimonViews, ShowTagsCommand}
@@ -124,6 +124,8 @@ case class PaimonStrategy(spark: SparkSession)
         SparkUtils.catalogAndIdentifier(spark, identifier.asJava, catalogManager.currentCatalog)
       catalogAndIdentifier.catalog match {
         case paimonCatalog: SparkCatalog =>
+          Some((paimonCatalog, catalogAndIdentifier.identifier()))
+        case paimonCatalog: SparkGenericCatalog =>
           Some((paimonCatalog, catalogAndIdentifier.identifier()))
         case _ =>
           None


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests
```sql
--conf spark.sql.catalog.spark_catalog=org.apache.paimon.spark.SparkGenericCatalog \
--conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions \
```

```sql
ALTER TABLE test_paimon_v1 CREATE TAG `TAG-1`
```

```
java.lang.AssertionError: assertion failed: No plan for Create tag: TAG-1 for table: ArrayBuffer(test_paimon_v1)
```



### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
