### PR TITLE
[common] A FileIO API to list files iteratively

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
@@ -117,7 +117,7 @@ public interface FileIO extends Serializable {
      */
     default FileStatus[] listFiles(Path path, boolean recursive) throws IOException {
         List<FileStatus> files = new ArrayList<>();
-        try (FileStatusIterator iter = listFilesIterative(path, recursive)) {
+        try (RemoteIterator<FileStatus> iter = listFilesIterative(path, recursive)) {
             while (iter.hasNext()) {
                 files.add(iter.next());
             }
@@ -131,10 +131,11 @@ public interface FileIO extends Serializable {
      * @param path given path
      * @param recursive if set to <code>true</code> will recursively list files in subdirectories,
      *     otherwise only files in the current directory will be listed
-     * @return an {@link FileStatusIterator} over the statuses of the files in the given path
+     * @return an {@link RemoteIterator} over {@link FileStatus} of the files in the given path
      */
-    default FileStatusIterator listFilesIterative(Path path, boolean recursive) throws IOException {
-        return new FileStatusIterator() {
+    default RemoteIterator<FileStatus> listFilesIterative(Path path, boolean recursive)
+            throws IOException {
+        return new RemoteIterator<FileStatus>() {
             private Queue<FileStatus> files = new LinkedList<>();
             private Queue<Path> subdirStack = new LinkedList<>(Collections.singletonList(path));
 

--- a/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
@@ -41,7 +41,6 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -151,25 +150,7 @@ public interface FileIO extends Serializable {
     default Pair<FileStatus[], String> listFilesPaged(
             Path path, boolean recursive, long pageSize, @Nullable String continuationToken)
             throws IOException {
-        FileStatus[] all = listFiles(path, recursive);
-        FileStatus[] paged =
-                Arrays.stream(all)
-                        .sorted(Comparator.comparing(FileStatus::getPath))
-                        .filter(
-                                f ->
-                                        continuationToken == null
-                                                || f.getPath()
-                                                                .toUri()
-                                                                .toString()
-                                                                .compareTo(continuationToken)
-                                                        > 0)
-                        .limit(pageSize)
-                        .toArray(FileStatus[]::new);
-        String nextToken =
-                paged.length < pageSize
-                        ? null
-                        : paged[paged.length - 1].getPath().toUri().toString();
-        return Pair.of(paged, nextToken);
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
@@ -134,6 +134,15 @@ public interface FileIO extends Serializable {
     }
 
     /**
+     * Tests whether {@link #listFilesPaged} is supported.
+     *
+     * @return whether {@link #listFilesPaged} is supported
+     */
+    default boolean supportsListFilesPaged() {
+        return false;
+    }
+
+    /**
      * List the statuses of the files in the given path in non-overlapping pages, if the path is a
      * directory.
      *

--- a/paimon-common/src/main/java/org/apache/paimon/fs/FileStatusIterator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/FileStatusIterator.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fs;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/** An iterator for lazily listing {@link FileStatus}. */
+public interface FileStatusIterator extends Closeable {
+
+    /**
+     * Checks if there are more statuses to be iterated.
+     *
+     * @return whether there are more elements to be iterated
+     * @throws IOException - if failed to list statuses lazily
+     */
+    boolean hasNext() throws IOException;
+
+    /**
+     * Gets the next status to be iterated.
+     *
+     * @return the next status
+     * @throws IOException - if failed to list statuses lazily
+     */
+    FileStatus next() throws IOException;
+
+    /**
+     * Closes the iterator and its associated resources.
+     *
+     * @throws IOException - if failed to close the iterator
+     */
+    void close() throws IOException;
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fs/RemoteIterator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/RemoteIterator.java
@@ -21,24 +21,24 @@ package org.apache.paimon.fs;
 import java.io.Closeable;
 import java.io.IOException;
 
-/** An iterator for lazily listing {@link FileStatus}. */
-public interface FileStatusIterator extends Closeable {
+/** An iterator for lazily listing remote entries. */
+public interface RemoteIterator<E> extends Closeable {
 
     /**
-     * Checks if there are more statuses to be iterated.
+     * Checks if there are more entries to be iterated.
      *
      * @return whether there are more elements to be iterated
-     * @throws IOException - if failed to list statuses lazily
+     * @throws IOException - if failed to list entries lazily
      */
     boolean hasNext() throws IOException;
 
     /**
-     * Gets the next status to be iterated.
+     * Gets the next entry to be iterated.
      *
-     * @return the next status
-     * @throws IOException - if failed to list statuses lazily
+     * @return the next entry
+     * @throws IOException - if failed to list entries lazily
      */
-    FileStatus next() throws IOException;
+    E next() throws IOException;
 
     /**
      * Closes the iterator and its associated resources.

--- a/paimon-common/src/test/java/org/apache/paimon/fs/FileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/FileIOTest.java
@@ -36,6 +36,8 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
@@ -158,6 +160,10 @@ public class FileIOTest {
             // omitted
             FileStatus[] statuses = fileIO.listFiles(new Path(tempDir.toUri()), true);
             assertThat(statuses.length).isEqualTo(2);
+            statuses =
+                    Arrays.stream(statuses)
+                            .sorted(Comparator.comparing(FileStatus::getPath))
+                            .toArray(FileStatus[]::new);
             assertThat(statuses[0].getPath()).isEqualTo(fileA);
             assertThat(statuses[1].getPath()).isEqualTo(fileBC);
         }


### PR DESCRIPTION
### Purpose

Linked issue: close #4791

<!-- What is the purpose of the change -->

Proposing `FileIO#listFilesPaged` and its non-iterative sibling `FileIO#listFiles` .

### Tests

* `FileIOTest#testListFiles`
* ~`FileIOTest#testListFilesPaged`~

### API and Format

Adding `listFilesPaged` method to `FileIO` interface.

### Documentation

As described in the methods' JavaDocs.