### PR TITLE
[core] remove nullable check for record-level.time-field

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -203,12 +203,6 @@ public class SchemaValidation {
                                 "The record level time field type should be one of INT, BIGINT, or TIMESTAMP, but field type is %s.",
                                 dataType));
             }
-            if (dataType.isNullable()) {
-                throw new IllegalArgumentException(
-                        String.format(
-                                "Time field %s for record-level expire should be not null.",
-                                recordLevelTimeField));
-            }
         }
 
         if (options.mergeEngine() == MergeEngine.FIRST_ROW) {

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/PrimaryKeyTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/PrimaryKeyTableTestBase.java
@@ -123,7 +123,11 @@ public abstract class PrimaryKeyTableTestBase {
                         r -> {
                             GenericRow newR = new GenericRow(projection.length);
                             for (int i = 0; i < projection.length; i++) {
-                                newR.setField(i, r.getInt(i));
+                                if (r.isNullAt(i)) {
+                                    newR.setField(i, null);
+                                } else {
+                                    newR.setField(i, r.getInt(i));
+                                }
                             }
                             rows.add(newR);
                         });

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import static org.apache.paimon.CoreOptions.BUCKET;
 import static org.apache.paimon.CoreOptions.SCAN_SNAPSHOT_ID;
 import static org.apache.paimon.schema.SchemaValidation.validateTableSchema;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -110,8 +111,7 @@ class SchemaValidationTest {
         Map<String, String> options = new HashMap<>(2);
         options.put(CoreOptions.RECORD_LEVEL_TIME_FIELD.key(), "f0");
         options.put(CoreOptions.RECORD_LEVEL_EXPIRE_TIME.key(), "1 m");
-        assertThatThrownBy(() -> validateTableSchemaExec(options))
-                .hasMessageContaining("Time field f0 for record-level expire should be not null");
+        assertThatCode(() -> validateTableSchemaExec(options)).doesNotThrowAnyException();
 
         options.put(CoreOptions.RECORD_LEVEL_TIME_FIELD.key(), "f10");
         assertThatThrownBy(() -> validateTableSchemaExec(options))

--- a/paimon-core/src/test/java/org/apache/paimon/table/RecordLevelExpireWithTimestampBaseTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/RecordLevelExpireWithTimestampBaseTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 abstract class RecordLevelExpireWithTimestampBaseTest extends PrimaryKeyTableTestBase {
 
@@ -61,5 +62,13 @@ abstract class RecordLevelExpireWithTimestampBaseTest extends PrimaryKeyTableTes
         // compact, expired
         compact(1);
         assertThat(query(new int[] {0, 1})).containsExactlyInAnyOrder(GenericRow.of(1, 3));
+
+        writeCommit(GenericRow.of(1, 5, null));
+        assertThat(query(new int[] {0, 1}))
+                .containsExactlyInAnyOrder(GenericRow.of(1, 3), GenericRow.of(1, 5));
+
+        // null time field for record-level expire is not supported yet.
+        assertThatThrownBy(() -> compact(1))
+                .hasMessageContaining("Time field for record-level expire should not be null.");
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/RecordLevelExpireWithTimestampLTZTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/RecordLevelExpireWithTimestampLTZTest.java
@@ -46,7 +46,7 @@ class RecordLevelExpireWithTimestampLTZTest extends RecordLevelExpireWithTimesta
                 Schema.newBuilder()
                         .column("pt", DataTypes.INT())
                         .column("pk", DataTypes.INT())
-                        .column("col1", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE().notNull())
+                        .column("col1", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE())
                         .partitionKeys("pt")
                         .primaryKey("pk", "pt")
                         .options(tableOptions().toMap())

--- a/paimon-core/src/test/java/org/apache/paimon/table/RecordLevelExpireWithTimestampTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/RecordLevelExpireWithTimestampTest.java
@@ -46,7 +46,7 @@ class RecordLevelExpireWithTimestampTest extends RecordLevelExpireWithTimestampB
                 Schema.newBuilder()
                         .column("pt", DataTypes.INT())
                         .column("pk", DataTypes.INT())
-                        .column("col1", DataTypes.TIMESTAMP().notNull())
+                        .column("col1", DataTypes.TIMESTAMP())
                         .partitionKeys("pt")
                         .primaryKey("pk", "pt")
                         .options(tableOptions().toMap())


### PR DESCRIPTION
### Purpose

Linked issue: close #4821 

We should not enforce not nullable check for record-level.time-field for two reasons:

1, When creating paimon tables using  Spark SQL or Hive SQL, users cannot specify certain fields are not nullable;

2, In certain cases like #4821, Paimon writer will inevitably write null time field into data files. Not nullable datatype will cause parquet reader fail with following msgs:
![image](https://github.com/user-attachments/assets/44182f14-2593-4e45-ab28-17faf3f136d5)

### Tests

### API and Format


### Documentation

