### PR TITLE
[core] support null value for record-level.time-field

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/table/RecordLevelExpireWithMillisecondTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/RecordLevelExpireWithMillisecondTest.java
@@ -38,7 +38,6 @@ import java.time.Duration;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RecordLevelExpireWithMillisecondTest extends PrimaryKeyTableTestBase {
     @Override
@@ -102,8 +101,10 @@ class RecordLevelExpireWithMillisecondTest extends PrimaryKeyTableTestBase {
         assertThat(query(new int[] {0, 1}))
                 .containsExactlyInAnyOrder(GenericRow.of(1, 4), GenericRow.of(1, 5));
 
-        // null time field for record-level expire is not supported yet.
-        assertThatThrownBy(() -> compact(1))
-                .hasMessageContaining("Time field for record-level expire should not be null.");
+        writeCommit(GenericRow.of(1, 5, currentSecs + 60 * 60 * 1000));
+        // compact, merged
+        compact(1);
+        assertThat(query(new int[] {0, 1}))
+                .containsExactlyInAnyOrder(GenericRow.of(1, 4), GenericRow.of(1, 5));
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/RecordLevelExpireWithTimestampBaseTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/RecordLevelExpireWithTimestampBaseTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 abstract class RecordLevelExpireWithTimestampBaseTest extends PrimaryKeyTableTestBase {
 
@@ -67,8 +66,10 @@ abstract class RecordLevelExpireWithTimestampBaseTest extends PrimaryKeyTableTes
         assertThat(query(new int[] {0, 1}))
                 .containsExactlyInAnyOrder(GenericRow.of(1, 3), GenericRow.of(1, 5));
 
-        // null time field for record-level expire is not supported yet.
-        assertThatThrownBy(() -> compact(1))
-                .hasMessageContaining("Time field for record-level expire should not be null.");
+        writeCommit(GenericRow.of(1, 5, timestamp3));
+        // compact, merged
+        compact(1);
+        assertThat(query(new int[] {0, 1}))
+                .containsExactlyInAnyOrder(GenericRow.of(1, 3), GenericRow.of(1, 5));
     }
 }


### PR DESCRIPTION

### Purpose

Return true for RecordLevelExpire reader filter when time field is null.

Linked issue: close #4821 

### Tests

RecordLevelExpireWithNullFieldTest

### API and Format


### Documentation

