### PR TITLE
[Bug] use snapshot when SnapshotReaderImpl.toChangesPlan

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
@@ -391,14 +391,14 @@ public class SnapshotReaderImpl implements SnapshotReader {
                 groupByPartFiles(plan.files(FileKind.DELETE));
         Map<BinaryRow, Map<Integer, List<DataFileMeta>>> dataFiles =
                 groupByPartFiles(plan.files(FileKind.ADD));
-
-        return toChangesPlan(true, plan, plan.snapshot().id() - 1, beforeFiles, dataFiles);
+        Snapshot beforeSnapshot = snapshotManager.snapshot(plan.snapshot().id() - 1);
+        return toChangesPlan(true, plan, beforeSnapshot, beforeFiles, dataFiles);
     }
 
     private Plan toChangesPlan(
             boolean isStreaming,
             FileStoreScan.Plan plan,
-            long beforeSnapshotId,
+            Snapshot beforeSnapshot,
             Map<BinaryRow, Map<Integer, List<DataFileMeta>>> beforeFiles,
             Map<BinaryRow, Map<Integer, List<DataFileMeta>>> dataFiles) {
         Snapshot snapshot = plan.snapshot();
@@ -416,7 +416,7 @@ public class SnapshotReaderImpl implements SnapshotReader {
         Map<Pair<BinaryRow, Integer>, List<IndexFileMeta>> beforDeletionIndexFilesMap =
                 deletionVectors
                         ? indexFileHandler.scan(
-                                beforeSnapshotId, DELETION_VECTORS_INDEX, beforeFiles.keySet())
+                                beforeSnapshot, DELETION_VECTORS_INDEX, beforeFiles.keySet())
                         : Collections.emptyMap();
         Map<Pair<BinaryRow, Integer>, List<IndexFileMeta>> deletionIndexFilesMap =
                 deletionVectors
@@ -476,7 +476,7 @@ public class SnapshotReaderImpl implements SnapshotReader {
                 groupByPartFiles(plan.files(FileKind.ADD));
         Map<BinaryRow, Map<Integer, List<DataFileMeta>>> beforeFiles =
                 groupByPartFiles(scan.withSnapshot(before).plan().files(FileKind.ADD));
-        return toChangesPlan(false, plan, before.id(), beforeFiles, dataFiles);
+        return toChangesPlan(false, plan, before, beforeFiles, dataFiles);
     }
 
     private RecordComparator partitionComparator() {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -302,12 +302,14 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
     @Test
     public void testIncrementBetweenReadWithSnapshotExpiration() throws Exception {
         String tableName = "T";
-        batchSql(String.format("INSERT INTO %s VALUES (1, 11, 111), (2, 22, 222)", tableName));
+        batchSql(String.format("INSERT INTO %s VALUES (1, 11, 111)", tableName));
 
         paimonTable(tableName).createTag("tag1", 1);
 
-        batchSql(String.format("INSERT INTO %s VALUES (3, 33, 333)", tableName));
+        batchSql(String.format("INSERT INTO %s VALUES (2, 22, 222)", tableName));
         paimonTable(tableName).createTag("tag2", 2);
+        batchSql(String.format("INSERT INTO %s VALUES (3, 33, 333)", tableName));
+        paimonTable(tableName).createTag("tag3", 3);
 
         // expire snapshot 1
         Map<String, String> expireOptions = new HashMap<>();
@@ -322,7 +324,7 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
                                 String.format(
                                         "SELECT * FROM %s /*+ OPTIONS('incremental-between' = 'tag1,tag2', 'deletion-vectors.enabled' = 'true') */",
                                         tableName)))
-                .containsExactlyInAnyOrder(Row.of(3, 33, 333));
+                .containsExactlyInAnyOrder(Row.of(2, 22, 222));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Fix `incremental-between` when then snapshot id reference snapshot file has deleted bug

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
