### PR TITLE
[flink] Fix the refresh executor not work after reopen

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink.lookup;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
@@ -79,7 +80,7 @@ public abstract class FullCacheLookupTable implements LookupTable {
     protected final int appendUdsFieldNumber;
 
     protected RocksDBStateFactory stateFactory;
-    @Nullable private final ExecutorService refreshExecutor;
+    @Nullable private ExecutorService refreshExecutor;
     private final AtomicReference<Exception> cachedException;
     private final int maxPendingSnapshotCount;
     private final FileStoreTable table;
@@ -127,14 +128,6 @@ public abstract class FullCacheLookupTable implements LookupTable {
         Options options = Options.fromMap(context.table.options());
         this.projectedType = projectedType;
         this.refreshAsync = options.get(LOOKUP_REFRESH_ASYNC);
-        this.refreshExecutor =
-                this.refreshAsync
-                        ? Executors.newSingleThreadExecutor(
-                                new ExecutorThreadFactory(
-                                        String.format(
-                                                "%s-lookup-refresh",
-                                                Thread.currentThread().getName())))
-                        : null;
         this.cachedException = new AtomicReference<>();
         this.maxPendingSnapshotCount = options.get(LOOKUP_REFRESH_ASYNC_PENDING_SNAPSHOT_COUNT);
     }
@@ -147,6 +140,19 @@ public abstract class FullCacheLookupTable implements LookupTable {
     @Override
     public void specifyCacheRowFilter(Filter<InternalRow> filter) {
         this.cacheRowFilter = filter;
+    }
+
+    @Override
+    public void open() throws Exception {
+        this.refreshExecutor =
+                this.refreshAsync
+                        ? Executors.newSingleThreadExecutor(
+                                new ExecutorThreadFactory(
+                                        String.format(
+                                                "%s-lookup-refresh",
+                                                Thread.currentThread().getName())))
+                        : null;
+        openStateFactory();
     }
 
     protected void openStateFactory() throws Exception {
@@ -320,6 +326,11 @@ public abstract class FullCacheLookupTable implements LookupTable {
             stateFactory.close();
             FileIOUtils.deleteDirectory(context.tempPath);
         }
+    }
+
+    @VisibleForTesting
+    public Future<?> getRefreshFuture() {
+        return refreshFuture;
     }
 
     /** Bulk loader for the table. */

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
@@ -142,8 +142,12 @@ public abstract class FullCacheLookupTable implements LookupTable {
         this.cacheRowFilter = filter;
     }
 
-    @Override
-    public void open() throws Exception {
+    protected void init() throws Exception {
+        this.stateFactory =
+                new RocksDBStateFactory(
+                        context.tempPath.toString(),
+                        context.table.coreOptions().toConfiguration(),
+                        null);
         this.refreshExecutor =
                 this.refreshAsync
                         ? Executors.newSingleThreadExecutor(
@@ -152,15 +156,6 @@ public abstract class FullCacheLookupTable implements LookupTable {
                                                 "%s-lookup-refresh",
                                                 Thread.currentThread().getName())))
                         : null;
-        openStateFactory();
-    }
-
-    protected void openStateFactory() throws Exception {
-        this.stateFactory =
-                new RocksDBStateFactory(
-                        context.tempPath.toString(),
-                        context.table.coreOptions().toConfiguration(),
-                        null);
     }
 
     protected void bootstrap() throws Exception {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/NoPrimaryKeyLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/NoPrimaryKeyLookupTable.java
@@ -52,7 +52,7 @@ public class NoPrimaryKeyLookupTable extends FullCacheLookupTable {
 
     @Override
     public void open() throws Exception {
-        openStateFactory();
+        super.open();
         this.state =
                 stateFactory.listState(
                         "join-key-index",

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/NoPrimaryKeyLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/NoPrimaryKeyLookupTable.java
@@ -52,7 +52,7 @@ public class NoPrimaryKeyLookupTable extends FullCacheLookupTable {
 
     @Override
     public void open() throws Exception {
-        super.open();
+        init();
         this.state =
                 stateFactory.listState(
                         "join-key-index",

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyLookupTable.java
@@ -69,7 +69,7 @@ public class PrimaryKeyLookupTable extends FullCacheLookupTable {
 
     @Override
     public void open() throws Exception {
-        super.open();
+        init();
         createTableState();
         bootstrap();
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyLookupTable.java
@@ -69,7 +69,7 @@ public class PrimaryKeyLookupTable extends FullCacheLookupTable {
 
     @Override
     public void open() throws Exception {
-        openStateFactory();
+        super.open();
         createTableState();
         bootstrap();
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/SecondaryIndexLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/SecondaryIndexLookupTable.java
@@ -46,7 +46,7 @@ public class SecondaryIndexLookupTable extends PrimaryKeyLookupTable {
 
     @Override
     public void open() throws Exception {
-        openStateFactory();
+        super.open();
         createTableState();
         this.indexState =
                 stateFactory.setState(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/SecondaryIndexLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/SecondaryIndexLookupTable.java
@@ -46,7 +46,7 @@ public class SecondaryIndexLookupTable extends PrimaryKeyLookupTable {
 
     @Override
     public void open() throws Exception {
-        super.open();
+        init();
         createTableState();
         this.indexState =
                 stateFactory.setState(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

If we use dynamic partition loader, it may reopen the LookupTable after partition changed. After reopen, the refresh executor is shutdown, we should recreate the executor in the open phase.

![image](https://github.com/user-attachments/assets/75b54643-297c-4808-ba2d-1dd3b9e4c15f)

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
