### PR TITLE
[core] Support auto create tag with custom duration

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -931,7 +931,7 @@ If the data size allocated for the sorting task is uneven,which may lead to perf
             <td>What frequency is used to generate tags.<br /><br />Possible values:<ul><li>"daily": Generate a tag every day.</li><li>"hourly": Generate a tag every hour.</li><li>"two-hours": Generate a tag every two hours.</li><li>"custom-duration": Generate a tag with custom duration.</li></ul></td>
         </tr>
         <tr>
-            <td><h5>tag.create-custom-duration</h5></td>
+            <td><h5>tag.creation-period-duration</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
             <td>The custom duration for tag auto create periods.If user set it, tag.creation-period would be invalid.</td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -931,10 +931,10 @@ If the data size allocated for the sorting task is uneven,which may lead to perf
             <td>What frequency is used to generate tags.<br /><br />Possible values:<ul><li>"daily": Generate a tag every day.</li><li>"hourly": Generate a tag every hour.</li><li>"two-hours": Generate a tag every two hours.</li><li>"custom-duration": Generate a tag with custom duration.</li></ul></td>
         </tr>
         <tr>
-            <td><h5>tag.custom-duration</h5></td>
+            <td><h5>tag.create-custom-duration</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
-            <td>The custom duration for tag auto create periods.</td>
+            <td>The custom duration for tag auto create periods.If user set it, tag.creation-period would be invalid.</td>
         </tr>
         <tr>
             <td><h5>tag.default-time-retained</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -928,7 +928,7 @@ If the data size allocated for the sorting task is uneven,which may lead to perf
             <td><h5>tag.creation-period</h5></td>
             <td style="word-wrap: break-word;">daily</td>
             <td><p>Enum</p></td>
-            <td>What frequency is used to generate tags.<br /><br />Possible values:<ul><li>"daily": Generate a tag every day.</li><li>"hourly": Generate a tag every hour.</li><li>"two-hours": Generate a tag every two hours.</li><li>"custom-duration": Generate a tag with custom duration.</li></ul></td>
+            <td>What frequency is used to generate tags.<br /><br />Possible values:<ul><li>"daily": Generate a tag every day.</li><li>"hourly": Generate a tag every hour.</li><li>"two-hours": Generate a tag every two hours.</li></ul></td>
         </tr>
         <tr>
             <td><h5>tag.creation-period-duration</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -928,7 +928,13 @@ If the data size allocated for the sorting task is uneven,which may lead to perf
             <td><h5>tag.creation-period</h5></td>
             <td style="word-wrap: break-word;">daily</td>
             <td><p>Enum</p></td>
-            <td>What frequency is used to generate tags.<br /><br />Possible values:<ul><li>"daily": Generate a tag every day.</li><li>"hourly": Generate a tag every hour.</li><li>"two-hours": Generate a tag every two hours.</li></ul></td>
+            <td>What frequency is used to generate tags.<br /><br />Possible values:<ul><li>"daily": Generate a tag every day.</li><li>"hourly": Generate a tag every hour.</li><li>"two-hours": Generate a tag every two hours.</li><li>"custom-duration": Generate a tag with custom duration.</li></ul></td>
+        </tr>
+        <tr>
+            <td><h5>tag.custom-duration</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>The custom duration for tag auto create periods.</td>
         </tr>
         <tr>
             <td><h5>tag.default-time-retained</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -934,7 +934,7 @@ If the data size allocated for the sorting task is uneven,which may lead to perf
             <td><h5>tag.creation-period-duration</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
-            <td>The custom duration for tag auto create periods.If user set it, tag.creation-period would be invalid.</td>
+            <td>The period duration for tag auto create periods.If user set it, tag.creation-period would be invalid.</td>
         </tr>
         <tr>
             <td><h5>tag.default-time-retained</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1247,7 +1247,7 @@ public class CoreOptions implements Serializable {
                     .durationType()
                     .noDefaultValue()
                     .withDescription(
-                            "The custom duration for tag auto create periods.If user set it, tag.creation-period would be invalid.");
+                            "The period duration for tag auto create periods.If user set it, tag.creation-period would be invalid.");
 
     public static final ConfigOption<Integer> TAG_NUM_RETAINED_MAX =
             key("tag.num-retained-max")

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1242,6 +1242,12 @@ public class CoreOptions implements Serializable {
                     .defaultValue(TagPeriodFormatter.WITH_DASHES)
                     .withDescription("The date format for tag periods.");
 
+    public static final ConfigOption<Duration> TAG_CUSTOM_DURATION =
+            key("tag.custom-duration")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription("The custom duration for tag auto create periods.");
+
     public static final ConfigOption<Integer> TAG_NUM_RETAINED_MAX =
             key("tag.num-retained-max")
                     .intType()
@@ -2238,6 +2244,10 @@ public class CoreOptions implements Serializable {
         return options.get(TAG_PERIOD_FORMATTER);
     }
 
+    public Optional<Duration> tagCustomDuration() {
+        return options.getOptional(TAG_CUSTOM_DURATION);
+    }
+
     @Nullable
     public Integer tagNumRetainedMax() {
         return options.get(TAG_NUM_RETAINED_MAX);
@@ -2874,7 +2884,9 @@ public class CoreOptions implements Serializable {
     public enum TagCreationPeriod implements DescribedEnum {
         DAILY("daily", "Generate a tag every day."),
         HOURLY("hourly", "Generate a tag every hour."),
-        TWO_HOURS("two-hours", "Generate a tag every two hours.");
+        TWO_HOURS("two-hours", "Generate a tag every two hours."),
+
+        CUSTOM_DURATION("custom-duration", "Generate a tag with custom duration.");
 
         private final String value;
         private final String description;

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2885,8 +2885,7 @@ public class CoreOptions implements Serializable {
     public enum TagCreationPeriod implements DescribedEnum {
         DAILY("daily", "Generate a tag every day."),
         HOURLY("hourly", "Generate a tag every hour."),
-        TWO_HOURS("two-hours", "Generate a tag every two hours."),
-        CUSTOM_DURATION("custom-duration", "Generate a tag with custom duration.");
+        TWO_HOURS("two-hours", "Generate a tag every two hours.");
 
         private final String value;
         private final String description;

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1243,7 +1243,7 @@ public class CoreOptions implements Serializable {
                     .withDescription("The date format for tag periods.");
 
     public static final ConfigOption<Duration> TAG_CUSTOM_DURATION =
-            key("tag.create-custom-duration")
+            key("tag.creation-period-duration")
                     .durationType()
                     .noDefaultValue()
                     .withDescription(

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1242,7 +1242,7 @@ public class CoreOptions implements Serializable {
                     .defaultValue(TagPeriodFormatter.WITH_DASHES)
                     .withDescription("The date format for tag periods.");
 
-    public static final ConfigOption<Duration> TAG_CUSTOM_DURATION =
+    public static final ConfigOption<Duration> TAG_PERIOD_DURATION =
             key("tag.creation-period-duration")
                     .durationType()
                     .noDefaultValue()
@@ -2245,8 +2245,8 @@ public class CoreOptions implements Serializable {
         return options.get(TAG_PERIOD_FORMATTER);
     }
 
-    public Optional<Duration> tagCustomDuration() {
-        return options.getOptional(TAG_CUSTOM_DURATION);
+    public Optional<Duration> tagPeriodDuration() {
+        return options.getOptional(TAG_PERIOD_DURATION);
     }
 
     @Nullable

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2885,7 +2885,6 @@ public class CoreOptions implements Serializable {
         DAILY("daily", "Generate a tag every day."),
         HOURLY("hourly", "Generate a tag every hour."),
         TWO_HOURS("two-hours", "Generate a tag every two hours."),
-
         CUSTOM_DURATION("custom-duration", "Generate a tag with custom duration.");
 
         private final String value;

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1243,10 +1243,10 @@ public class CoreOptions implements Serializable {
                     .withDescription("The date format for tag periods.");
 
     public static final ConfigOption<Duration> TAG_CUSTOM_DURATION =
-            key("tag.custom-duration")
+            key("tag.create-custom-duration")
                     .durationType()
                     .noDefaultValue()
-                    .withDescription("The custom duration for tag auto create periods.");
+                    .withDescription("The custom duration for tag auto create periods.If user set it, tag.creation-period would be invalid.");
 
     public static final ConfigOption<Integer> TAG_NUM_RETAINED_MAX =
             key("tag.num-retained-max")

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1246,7 +1246,8 @@ public class CoreOptions implements Serializable {
             key("tag.create-custom-duration")
                     .durationType()
                     .noDefaultValue()
-                    .withDescription("The custom duration for tag auto create periods.If user set it, tag.creation-period would be invalid.");
+                    .withDescription(
+                            "The custom duration for tag auto create periods.If user set it, tag.creation-period would be invalid.");
 
     public static final ConfigOption<Integer> TAG_NUM_RETAINED_MAX =
             key("tag.num-retained-max")

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagPeriodHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagPeriodHandler.java
@@ -229,12 +229,12 @@ public interface TagPeriodHandler {
         }
     }
 
-    /** Two Hours {@link TagPeriodHandler}. */
-    class CustomDurationTagPeriodHandler extends BaseTagPeriodHandler {
+    /** Period duration {@link TagPeriodHandler}. */
+    class PeriodDurationTagPeriodHandler extends BaseTagPeriodHandler {
 
         Duration customDuration;
 
-        public CustomDurationTagPeriodHandler(Duration duration) {
+        public PeriodDurationTagPeriodHandler(Duration duration) {
             this.customDuration = duration;
         }
 
@@ -251,7 +251,7 @@ public interface TagPeriodHandler {
 
     static TagPeriodHandler create(CoreOptions options) {
         if (options.tagPeriodDuration().isPresent()) {
-            return new CustomDurationTagPeriodHandler(options.tagPeriodDuration().get());
+            return new PeriodDurationTagPeriodHandler(options.tagPeriodDuration().get());
         }
 
         switch (options.tagCreationPeriod()) {

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagPeriodHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagPeriodHandler.java
@@ -250,8 +250,8 @@ public interface TagPeriodHandler {
     }
 
     static TagPeriodHandler create(CoreOptions options) {
-        if (options.tagCustomDuration().isPresent()) {
-            return new CustomDurationTagPeriodHandler(options.tagCustomDuration().get());
+        if (options.tagPeriodDuration().isPresent()) {
+            return new CustomDurationTagPeriodHandler(options.tagPeriodDuration().get());
         }
 
         switch (options.tagCreationPeriod()) {

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagPeriodHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagPeriodHandler.java
@@ -250,6 +250,10 @@ public interface TagPeriodHandler {
     }
 
     static TagPeriodHandler create(CoreOptions options) {
+        if (options.tagCustomDuration().isPresent()) {
+            return new CustomDurationTagPeriodHandler(options.tagCustomDuration().get());
+        }
+
         switch (options.tagCreationPeriod()) {
             case DAILY:
                 return new DailyTagPeriodHandler(options.tagPeriodFormatter());
@@ -257,12 +261,6 @@ public interface TagPeriodHandler {
                 return new HourlyTagPeriodHandler(options.tagPeriodFormatter());
             case TWO_HOURS:
                 return new TwoHoursTagPeriodHandler();
-            case CUSTOM_DURATION:
-                if (!options.tagCustomDuration().isPresent()) {
-                    throw new IllegalArgumentException(
-                            "tag.custom-duration must be set if use custom-duration");
-                }
-                return new CustomDurationTagPeriodHandler(options.tagCustomDuration().get());
             default:
                 throw new UnsupportedOperationException(
                         "Unsupported " + options.tagCreationPeriod());

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagPeriodHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagPeriodHandler.java
@@ -232,15 +232,15 @@ public interface TagPeriodHandler {
     /** Period duration {@link TagPeriodHandler}. */
     class PeriodDurationTagPeriodHandler extends BaseTagPeriodHandler {
 
-        Duration customDuration;
+        Duration periodDuration;
 
         public PeriodDurationTagPeriodHandler(Duration duration) {
-            this.customDuration = duration;
+            this.periodDuration = duration;
         }
 
         @Override
         protected Duration onePeriod() {
-            return customDuration;
+            return periodDuration;
         }
 
         @Override

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/CustomDurationTagsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/CustomDurationTagsTableTest.java
@@ -41,9 +41,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** Unit tests for {@link TagsTable}. */
 public class CustomDurationTagsTableTest extends TableTestBase {
 
-    private static final String tableName = "TagTestTable";
+    private static final String tableName = "3TagTestTable";
     private TagsTable tagsTable;
-    private TagManager tagManager;
     private FileStoreTable table;
 
     @BeforeEach
@@ -56,8 +55,7 @@ public class CustomDurationTagsTableTest extends TableTestBase {
                         .column("sales", DataTypes.INT())
                         .primaryKey("product_id")
                         .option("tag.automatic-creation", "watermark")
-                        .option("tag.creation-period", "custom-duration")
-                        .option("tag.custom-duration", "120 s")
+                        .option("tag.create-custom-duration", "120 s")
                         .build();
         catalog.createTable(identifier, schema, true);
         table = (FileStoreTable) catalog.getTable(identifier);
@@ -75,11 +73,10 @@ public class CustomDurationTagsTableTest extends TableTestBase {
                                 .getMillisecond()));
 
         tagsTable = (TagsTable) catalog.getTable(identifier(tableName + "$tags"));
-        tagManager = table.store().newTagManager();
     }
 
     @Test
-    void testTagsTable() throws Exception {
+    void testCreateTagsWithCustomDuration() throws Exception {
         List<InternalRow> result = read(tagsTable);
         assertThat(result.size()).isEqualTo(2);
         assertThat(result.get(0).getString(0).toString()).isEqualTo("202501071158");

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/CustomDurationTagsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/CustomDurationTagsTableTest.java
@@ -54,7 +54,7 @@ public class CustomDurationTagsTableTest extends TableTestBase {
                         .column("sales", DataTypes.INT())
                         .primaryKey("product_id")
                         .option("tag.automatic-creation", "watermark")
-                        .option("tag.create-custom-duration", "120 s")
+                        .option("tag.creation-period-duration", "120 s")
                         .build();
         catalog.createTable(identifier, schema, true);
         table = (FileStoreTable) catalog.getTable(identifier);

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/CustomDurationTagsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/CustomDurationTagsTableTest.java
@@ -27,7 +27,6 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.TableTestBase;
 import org.apache.paimon.table.sink.TableCommitImpl;
 import org.apache.paimon.types.DataTypes;
-import org.apache.paimon.utils.TagManager;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/CustomDurationTagsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/CustomDurationTagsTableTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.system;
+
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.manifest.ManifestCommittable;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.table.sink.TableCommitImpl;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.utils.TagManager;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link TagsTable}. */
+public class CustomDurationTagsTableTest extends TableTestBase {
+
+    private static final String tableName = "TagTestTable";
+    private TagsTable tagsTable;
+    private TagManager tagManager;
+    private FileStoreTable table;
+
+    @BeforeEach
+    void before() throws Exception {
+        Identifier identifier = identifier(tableName);
+        Schema schema =
+                Schema.newBuilder()
+                        .column("product_id", DataTypes.INT())
+                        .column("price", DataTypes.INT())
+                        .column("sales", DataTypes.INT())
+                        .primaryKey("product_id")
+                        .option("tag.automatic-creation", "watermark")
+                        .option("tag.creation-period", "custom-duration")
+                        .option("tag.custom-duration", "120 s")
+                        .build();
+        catalog.createTable(identifier, schema, true);
+        table = (FileStoreTable) catalog.getTable(identifier);
+        TableCommitImpl commit = table.newCommit(commitUser).ignoreEmptyCommit(false);
+
+        commit.commit(
+                new ManifestCommittable(
+                        0,
+                        Timestamp.fromLocalDateTime(LocalDateTime.parse("2025-01-07T12:00:01"))
+                                .getMillisecond()));
+        commit.commit(
+                new ManifestCommittable(
+                        1,
+                        Timestamp.fromLocalDateTime(LocalDateTime.parse("2025-01-07T15:00:01"))
+                                .getMillisecond()));
+
+        tagsTable = (TagsTable) catalog.getTable(identifier(tableName + "$tags"));
+        tagManager = table.store().newTagManager();
+    }
+
+    @Test
+    void testTagsTable() throws Exception {
+        List<InternalRow> result = read(tagsTable);
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result.get(0).getString(0).toString()).isEqualTo("202501071158");
+        assertThat(result.get(1).getString(0).toString()).isEqualTo("202501071458");
+    }
+
+    @Override
+    public void after() throws IOException {
+        table.deleteTag("202501071158");
+        table.deleteTag("202501071458");
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/PeriodDurationTagsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/PeriodDurationTagsTableTest.java
@@ -38,7 +38,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for {@link TagsTable}. */
-public class CustomDurationTagsTableTest extends TableTestBase {
+public class PeriodDurationTagsTableTest extends TableTestBase {
 
     private static final String tableName = "3TagTestTable";
     private TagsTable tagsTable;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx
Currently auto create tag only can be set with fixed hour or day and can not specify a custom duration，such as user want to create tag every 30min，this pr is aim to support it.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
CustomDurationTagsTableTest

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
