### PR TITLE
[Bug] Add the dependency of RoaringBitmap in paimon-micro-benchmarks.

### DIFF
--- a/paimon-benchmark/paimon-micro-benchmarks/pom.xml
+++ b/paimon-benchmark/paimon-micro-benchmarks/pom.xml
@@ -57,6 +57,12 @@ under the License.
             <version>${log4j.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.roaringbitmap</groupId>
+            <artifactId>RoaringBitmap</artifactId>
+            <version>1.0.5</version>
+        </dependency>
+
         <!-- Orc and parquet dependencies -->
 
         <dependency>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Fix the compilation error when packaging paimon-1.1 in moudle “paimon-micro-benchmarks”.
```shell
[INFO] --- maven-compiler-plugin:3.8.0:testCompile (default-testCompile) @ paimon-micro-benchmarks ---
[INFO] Compiling 11 source files to /paimon/paimon-benchmark/paimon-micro-benchmarks/target/test-classes
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /paimon/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/bitmap/RoaringBitmapBenchmark.java:[26,25] package org.roaringbitmap does not exist
[INFO] 1 error
``` 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
