### PR TITLE
[core]Fix drop table in Hive and jdbc catalog when the file path does not exists.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -268,16 +268,13 @@ public abstract class AbstractCatalog implements Catalog {
             throws TableNotExistException {
         checkNotBranch(identifier, "dropTable");
         checkNotSystemTable(identifier, "dropTable");
-
-        try {
-            getTable(identifier);
-        } catch (TableNotExistException e) {
+        if (!tableExists(identifier)) {
             if (ignoreIfNotExists) {
                 return;
+            } else {
+                throw new TableNotExistException(identifier);
             }
-            throw new TableNotExistException(identifier);
         }
-
         dropTableImpl(identifier);
     }
 
@@ -596,6 +593,10 @@ public abstract class AbstractCatalog implements Catalog {
                                 return s;
                             }
                         });
+    }
+
+    protected boolean tableExists(Identifier identifier) {
+        return tableExistsInFileSystem(getTableLocation(identifier), DEFAULT_MAIN_BRANCH);
     }
 
     /** Table metadata. */

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
@@ -364,6 +364,11 @@ public class JdbcCatalog extends AbstractCatalog {
                         () -> new RuntimeException("There is no paimon table in " + tableLocation));
     }
 
+    protected boolean tableExists(Identifier identifier) {
+        return JdbcUtils.tableExists(
+                connections, catalogKey, identifier.getDatabaseName(), identifier.getTableName());
+    }
+
     @Override
     public boolean caseSensitive() {
         return false;

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -1444,11 +1444,18 @@ public class HiveCatalog extends AbstractCatalog {
 
     protected boolean tableExists(Identifier identifier) {
         try {
-            getHmsTable(identifier);
-        } catch (Exception e) {
-            return false;
+            return clients.run(
+                    client ->
+                            client.tableExists(
+                                    identifier.getDatabaseName(), identifier.getTableName()));
+        } catch (TException e) {
+            throw new RuntimeException(
+                    "Cannot determine if table " + identifier.getFullName() + "exists.", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(
+                    "Interrupted in call to tableExists " + identifier.getFullName(), e);
         }
-        return true;
     }
 
     public int getBatchGetTableSize() {

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -1442,6 +1442,15 @@ public class HiveCatalog extends AbstractCatalog {
         return System.getenv("HIVE_CONF_DIR");
     }
 
+    protected boolean tableExists(Identifier identifier) {
+        try {
+            getHmsTable(identifier);
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
+    }
+
     public int getBatchGetTableSize() {
         try {
             int size =


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Fix drop table in Hive and jdbc catalog when the file path does not exists.
<!-- Linking this pull request to the issue -->
Linked issue: close #4853

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
