### PR TITLE
[core] Add a http-report action to reporting partition done to remote servers.

### DIFF
--- a/docs/content/flink/sql-write.md
+++ b/docs/content/flink/sql-write.md
@@ -286,9 +286,9 @@ public class CustomPartitionMarkDoneAction implements PartitionMarkDoneAction {
 
 Paimon also support http-report partition mark done action, this action will report the partition to the remote http server.
 - partition.mark-done-action: http-report
-- partition.mark-done-action.url : Action will report the partition to the remote http server.
-- partition.mark-done-action.timeout : Http client connection timeout and default is 5s.
-- partition.mark-done-action.params : Http client request params in the request body json.
+- partition.mark-done-action.http.url : Action will report the partition to the remote http server.
+- partition.mark-done-action.http.timeout : Http client connection timeout and default is 5s.
+- partition.mark-done-action.http.params : Http client request params in the request body json.
 
 Http Post request body :
 ```json

--- a/docs/content/flink/sql-write.md
+++ b/docs/content/flink/sql-write.md
@@ -288,13 +288,15 @@ Paimon also support http-report partition mark done action, this action will rep
 - partition.mark-done-action: http-report
 - partition.mark-done-action.url : Action will report the partition to the remote http server.
 - partition.mark-done-action.timeout : Http client connection timeout and default is 5s.
+- partition.mark-done-action.params : Http client request params in the request body json.
 
-Http Request body :
+Http Post request body :
 ```json
 {
     "table": "table fullName",
     "path": "table location path",
-    "partition": "mark done partition"
+    "partition": "mark done partition",
+    "params" : "custom params"
 }
 ```
 Http Response body :

--- a/docs/content/flink/sql-write.md
+++ b/docs/content/flink/sql-write.md
@@ -261,11 +261,13 @@ CREATE TABLE my_partitioned_table (
     'partition.time-interval'='1 d',
     'partition.idle-time-to-done'='15 m',
     'partition.mark-done-action'='done-partition'
-    -- You can also customize a PartitionMarkDoneAction to mark the partition completed.
-    -- 'partition.mark-done-action'='done-partition,custom',
-    -- 'partition.mark-done-action.custom.class'='org.apache.paimon.CustomPartitionMarkDoneAction'
 );
 ```
+
+You can also customize a PartitionMarkDoneAction to mark the partition completed.
+- partition.mark-done-action: custom
+- partition.mark-done-action.custom.class: The partition mark done class for implement PartitionMarkDoneAction interface (e.g. org.apache.paimon.CustomPartitionMarkDoneAction).
+
 Define a class CustomPartitionMarkDoneAction to implement the PartitionMarkDoneAction interface.
 ```java
 package org.apache.paimon;
@@ -279,6 +281,26 @@ public class CustomPartitionMarkDoneAction implements PartitionMarkDoneAction {
 
     @Override
     public void close() {}
+}
+```
+
+Paimon also support http-report partition mark done action, this action will report the partition to the remote http server.
+- partition.mark-done-action: http-report
+- partition.mark-done-action.url : Action will report the partition to the remote http server.
+- partition.mark-done-action.timeout : Http client connection timeout and default is 5s.
+
+Http Request body :
+```json
+{
+    "table": "table fullName",
+    "path": "table location path",
+    "partition": "mark done partition"
+}
+```
+Http Response body :
+```json
+{
+    "result": "success"
 }
 ```
 

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -672,22 +672,22 @@ This config option does not affect the default filesystem metastore.</td>
             <td>The partition mark done class for implement PartitionMarkDoneAction interface. Only work in custom mark-done-action.</td>
         </tr>
         <tr>
-            <td><h5>partition.mark-done-action.params</h5></td>
+            <td><h5>partition.mark-done-action.http.params</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Http client request parameters will be written to the request body, This can only be used by http-report partition mark done action.</td>
+            <td>Http client request parameters will be written to the request body, this can only be used by http-report partition mark done action.</td>
         </tr>
         <tr>
-            <td><h5>partition.mark-done-action.timeout</h5></td>
+            <td><h5>partition.mark-done-action.http.timeout</h5></td>
             <td style="word-wrap: break-word;">5 s</td>
             <td>Duration</td>
-            <td>Http client connect timeout, This can only be used by http-report partition mark done action.</td>
+            <td>Http client connection timeout, this can only be used by http-report partition mark done action.</td>
         </tr>
         <tr>
-            <td><h5>partition.mark-done-action.url</h5></td>
+            <td><h5>partition.mark-done-action.http.url</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Mark done action will reports the partition to the remote http server, This can only be used by http-report partition mark done action.</td>
+            <td>Mark done action will reports the partition to the remote http server, this can only be used by http-report partition mark done action.</td>
         </tr>
         <tr>
             <td><h5>partition.timestamp-formatter</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -663,13 +663,25 @@ This config option does not affect the default filesystem metastore.</td>
             <td><h5>partition.mark-done-action</h5></td>
             <td style="word-wrap: break-word;">"success-file"</td>
             <td>String</td>
-            <td>Action to mark a partition done is to notify the downstream application that the partition has finished writing, the partition is ready to be read.<br />1. 'success-file': add '_success' file to directory.<br />2. 'done-partition': add 'xxx.done' partition to metastore.<br />3. 'mark-event': mark partition event to metastore.<br />4. 'custom': use policy class to create a mark-partition policy.<br />Both can be configured at the same time: 'done-partition,success-file,mark-event,custom'.</td>
+            <td>Action to mark a partition done is to notify the downstream application that the partition has finished writing, the partition is ready to be read.<br />1. 'success-file': add '_success' file to directory.<br />2. 'done-partition': add 'xxx.done' partition to metastore.<br />3. 'mark-event': mark partition event to metastore.<br />4. 'http-report': report partition mark done to remote http server.<br />5. 'custom': use policy class to create a mark-partition policy.<br />Both can be configured at the same time: 'done-partition,success-file,mark-event,custom'.</td>
         </tr>
         <tr>
             <td><h5>partition.mark-done-action.custom.class</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
             <td>The partition mark done class for implement PartitionMarkDoneAction interface. Only work in custom mark-done-action.</td>
+        </tr>
+        <tr>
+            <td><h5>partition.mark-done-action.timeout</h5></td>
+            <td style="word-wrap: break-word;">5 s</td>
+            <td>Duration</td>
+            <td>Http client connect timeout, This can only be used by http-report partition mark done action.</td>
+        </tr>
+        <tr>
+            <td><h5>partition.mark-done-action.url</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Mark done action will reports the partition to the remote http server, This can only be used by http-report partition mark done action.</td>
         </tr>
         <tr>
             <td><h5>partition.timestamp-formatter</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -672,6 +672,12 @@ This config option does not affect the default filesystem metastore.</td>
             <td>The partition mark done class for implement PartitionMarkDoneAction interface. Only work in custom mark-done-action.</td>
         </tr>
         <tr>
+            <td><h5>partition.mark-done-action.params</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Http client request parameters will be written to the request body, This can only be used by http-report partition mark done action.</td>
+        </tr>
+        <tr>
             <td><h5>partition.mark-done-action.timeout</h5></td>
             <td style="word-wrap: break-word;">5 s</td>
             <td>Duration</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -2302,6 +2303,12 @@ public class CoreOptions implements Serializable {
         return options.get(PARTITION_MARK_DONE_CUSTOM_CLASS);
     }
 
+    public Set<PartitionMarkDoneAction> partitionMarkDoneActions() {
+        return Arrays.stream(options.get(PARTITION_MARK_DONE_ACTION).split(","))
+                .map(x -> PartitionMarkDoneAction.valueOf(x.replace('-', '_').toUpperCase()))
+                .collect(Collectors.toCollection(HashSet::new));
+    }
+
     public String consumerId() {
         String consumerId = options.get(CONSUMER_ID);
         if (consumerId != null && consumerId.isEmpty()) {
@@ -3198,5 +3205,25 @@ public class CoreOptions implements Serializable {
         INITIALIZING,
         ACTIVATED,
         SUSPENDED
+    }
+
+    /** Partition mark done actions. */
+    public enum PartitionMarkDoneAction {
+        SUCCESS_FILE("success-file"),
+        DONE_PARTITION("done-partition"),
+        MARK_EVENT("mark-event"),
+        HTTP_REPORT("http-report"),
+        CUSTOM("custom");
+
+        private final String value;
+
+        PartitionMarkDoneAction(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1238,25 +1238,25 @@ public class CoreOptions implements Serializable {
                                     + " PartitionMarkDoneAction interface. Only work in custom mark-done-action.");
 
     public static final ConfigOption<String> PARTITION_MARK_DONE_ACTION_URL =
-            key("partition.mark-done-action.url")
+            key("partition.mark-done-action.http.url")
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "Mark done action will reports the partition to the remote http server, This can only be used by http-report partition mark done action.");
+                            "Mark done action will reports the partition to the remote http server, this can only be used by http-report partition mark done action.");
 
     public static final ConfigOption<Duration> PARTITION_MARK_DONE_ACTION_TIMEOUT =
-            key("partition.mark-done-action.timeout")
+            key("partition.mark-done-action.http.timeout")
                     .durationType()
                     .defaultValue(Duration.ofSeconds(5))
                     .withDescription(
-                            "Http client connect timeout, This can only be used by http-report partition mark done action.");
+                            "Http client connection timeout, this can only be used by http-report partition mark done action.");
 
     public static final ConfigOption<String> PARTITION_MARK_DONE_ACTION_PARAMS =
-            key("partition.mark-done-action.params")
+            key("partition.mark-done-action.http.params")
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "Http client request parameters will be written to the request body, This can only be used by http-report partition mark done action.");
+                            "Http client request parameters will be written to the request body, this can only be used by http-report partition mark done action.");
 
     public static final ConfigOption<Boolean> METASTORE_PARTITIONED_TABLE =
             key("metastore.partitioned-table")

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1251,6 +1251,13 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Http client connect timeout, This can only be used by http-report partition mark done action.");
 
+    public static final ConfigOption<String> PARTITION_MARK_DONE_ACTION_PARAMS =
+            key("partition.mark-done-action.params")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Http client request parameters will be written to the request body, This can only be used by http-report partition mark done action.");
+
     public static final ConfigOption<Boolean> METASTORE_PARTITIONED_TABLE =
             key("metastore.partitioned-table")
                     .booleanType()
@@ -2285,6 +2292,10 @@ public class CoreOptions implements Serializable {
 
     public Duration httpReportMarkDoneActionTimeout() {
         return options.get(PARTITION_MARK_DONE_ACTION_TIMEOUT);
+    }
+
+    public String httpReportMarkDoneActionParams() {
+        return options.get(PARTITION_MARK_DONE_ACTION_PARAMS);
     }
 
     public String partitionMarkDoneCustomClass() {

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1220,7 +1220,10 @@ public class CoreOptions implements Serializable {
                                     .text("3. 'mark-event': mark partition event to metastore.")
                                     .linebreak()
                                     .text(
-                                            "4. 'custom': use policy class to create a mark-partition policy.")
+                                            "4. 'http-report': report partition mark done to remote http server.")
+                                    .linebreak()
+                                    .text(
+                                            "5. 'custom': use policy class to create a mark-partition policy.")
                                     .linebreak()
                                     .text(
                                             "Both can be configured at the same time: 'done-partition,success-file,mark-event,custom'.")
@@ -1233,6 +1236,20 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "The partition mark done class for implement"
                                     + " PartitionMarkDoneAction interface. Only work in custom mark-done-action.");
+
+    public static final ConfigOption<String> PARTITION_MARK_DONE_ACTION_URL =
+            key("partition.mark-done-action.url")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Mark done action will reports the partition to the remote http server, This can only be used by http-report partition mark done action.");
+
+    public static final ConfigOption<Duration> PARTITION_MARK_DONE_ACTION_TIMEOUT =
+            key("partition.mark-done-action.timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(5))
+                    .withDescription(
+                            "Http client connect timeout, This can only be used by http-report partition mark done action.");
 
     public static final ConfigOption<Boolean> METASTORE_PARTITIONED_TABLE =
             key("metastore.partitioned-table")
@@ -2260,6 +2277,14 @@ public class CoreOptions implements Serializable {
 
     public String partitionTimestampPattern() {
         return options.get(PARTITION_TIMESTAMP_PATTERN);
+    }
+
+    public String httpReportMarkDoneActionUrl() {
+        return options.get(PARTITION_MARK_DONE_ACTION_URL);
+    }
+
+    public Duration httpReportMarkDoneActionTimeout() {
+        return options.get(PARTITION_MARK_DONE_ACTION_TIMEOUT);
     }
 
     public String partitionMarkDoneCustomClass() {

--- a/paimon-core/src/main/java/org/apache/paimon/partition/actions/HttpReportMarkDoneAction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/actions/HttpReportMarkDoneAction.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.partition.actions;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.rest.DefaultErrorHandler;
+import org.apache.paimon.rest.HttpClient;
+import org.apache.paimon.rest.HttpClientOptions;
+import org.apache.paimon.rest.RESTClient;
+import org.apache.paimon.rest.RESTObjectMapper;
+import org.apache.paimon.rest.RESTRequest;
+import org.apache.paimon.rest.RESTResponse;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.Preconditions;
+import org.apache.paimon.utils.StringUtils;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.apache.paimon.CoreOptions.PARTITION_MARK_DONE_ACTION_URL;
+
+/** Report partition submission information to remote http server. */
+public class HttpReportMarkDoneAction implements PartitionMarkDoneAction {
+
+    private final RESTClient client;
+
+    private final FileStoreTable fileStoreTable;
+
+    private static final String RESPONSE_SUCCESS = "SUCCESS";
+
+    public HttpReportMarkDoneAction(FileStoreTable fileStoreTable, CoreOptions options) {
+        Preconditions.checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(options.httpReportMarkDoneActionUrl()),
+                String.format(
+                        "Parameter %s must be non-empty when you use `http-report` partition mark done action.",
+                        PARTITION_MARK_DONE_ACTION_URL.key()));
+        this.fileStoreTable = fileStoreTable;
+        HttpClientOptions httpClientOptions =
+                new HttpClientOptions(
+                        options.httpReportMarkDoneActionUrl(),
+                        Optional.of(options.httpReportMarkDoneActionTimeout()),
+                        Optional.of(options.httpReportMarkDoneActionTimeout()),
+                        RESTObjectMapper.create(),
+                        1,
+                        DefaultErrorHandler.getInstance());
+        this.client = new HttpClient(httpClientOptions);
+    }
+
+    @Override
+    public void markDone(String partition) throws Exception {
+        HttpReportMarkDoneResponse response =
+                client.post(
+                        null,
+                        new HttpReportMarkDoneRequest(
+                                fileStoreTable.fullName(),
+                                fileStoreTable.location().toString(),
+                                partition),
+                        HttpReportMarkDoneResponse.class,
+                        Collections.emptyMap());
+        Preconditions.checkArgument(
+                reportIsSuccess(response),
+                String.format(
+                        "The http-report actions response attribute `result` should be 'SUCCESS' but is '%s'.",
+                        response.getResult()));
+    }
+
+    public boolean reportIsSuccess(HttpReportMarkDoneResponse response) {
+        return response != null && RESPONSE_SUCCESS.equalsIgnoreCase(response.getResult());
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            this.client.close();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** RestRequest only for HttpReportMarkDoneAction. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class HttpReportMarkDoneRequest implements RESTRequest {
+        private static final String MARK_DONE_PARTITION = "partition";
+        private static final String TABLE = "table";
+        private static final String PATH = "path";
+
+        @JsonProperty(MARK_DONE_PARTITION)
+        private final String partition;
+
+        @JsonProperty(TABLE)
+        private final String table;
+
+        @JsonProperty(PATH)
+        private final String path;
+
+        @JsonCreator
+        public HttpReportMarkDoneRequest(
+                @JsonProperty(TABLE) String table,
+                @JsonProperty(PATH) String path,
+                @JsonProperty(MARK_DONE_PARTITION) String partition) {
+            this.table = table;
+            this.path = path;
+            this.partition = partition;
+        }
+
+        @JsonGetter(MARK_DONE_PARTITION)
+        public String getPartition() {
+            return partition;
+        }
+
+        @JsonGetter(TABLE)
+        public String getTable() {
+            return table;
+        }
+
+        @JsonGetter(PATH)
+        public String getPath() {
+            return path;
+        }
+    }
+
+    /** Response only for HttpReportMarkDoneAction. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class HttpReportMarkDoneResponse implements RESTResponse {
+        private static final String RESULT = "result";
+
+        @JsonProperty(RESULT)
+        private final String result;
+
+        public HttpReportMarkDoneResponse(@JsonProperty(RESULT) String result) {
+            this.result = result;
+        }
+
+        @JsonGetter(RESULT)
+        public String getResult() {
+            return result;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/partition/actions/HttpReportMarkDoneAction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/actions/HttpReportMarkDoneAction.java
@@ -19,11 +19,10 @@
 package org.apache.paimon.partition.actions;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.rest.DefaultErrorHandler;
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.rest.HttpClient;
 import org.apache.paimon.rest.HttpClientOptions;
 import org.apache.paimon.rest.RESTClient;
-import org.apache.paimon.rest.RESTObjectMapper;
 import org.apache.paimon.rest.RESTRequest;
 import org.apache.paimon.rest.RESTResponse;
 import org.apache.paimon.table.FileStoreTable;
@@ -37,7 +36,6 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonPro
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Optional;
 
 import static org.apache.paimon.CoreOptions.PARTITION_MARK_DONE_ACTION_URL;
 
@@ -66,11 +64,9 @@ public class HttpReportMarkDoneAction implements PartitionMarkDoneAction {
         HttpClientOptions httpClientOptions =
                 new HttpClientOptions(
                         options.httpReportMarkDoneActionUrl(),
-                        Optional.of(options.httpReportMarkDoneActionTimeout()),
-                        Optional.of(options.httpReportMarkDoneActionTimeout()),
-                        RESTObjectMapper.create(),
-                        1,
-                        DefaultErrorHandler.getInstance());
+                        options.httpReportMarkDoneActionTimeout(),
+                        options.httpReportMarkDoneActionTimeout(),
+                        1);
         this.client = new HttpClient(httpClientOptions);
     }
 
@@ -108,6 +104,7 @@ public class HttpReportMarkDoneAction implements PartitionMarkDoneAction {
 
     /** RestRequest only for HttpReportMarkDoneAction. */
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @VisibleForTesting
     public static class HttpReportMarkDoneRequest implements RESTRequest {
 
         private static final String MARK_DONE_PARTITION = "partition";
@@ -162,6 +159,7 @@ public class HttpReportMarkDoneAction implements PartitionMarkDoneAction {
 
     /** Response only for HttpReportMarkDoneAction. */
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @VisibleForTesting
     public static class HttpReportMarkDoneResponse implements RESTResponse {
         private static final String RESULT = "result";
 

--- a/paimon-core/src/main/java/org/apache/paimon/partition/actions/HttpReportMarkDoneAction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/actions/HttpReportMarkDoneAction.java
@@ -48,15 +48,21 @@ public class HttpReportMarkDoneAction implements PartitionMarkDoneAction {
 
     private final FileStoreTable fileStoreTable;
 
+    private final String params;
+
     private static final String RESPONSE_SUCCESS = "SUCCESS";
 
     public HttpReportMarkDoneAction(FileStoreTable fileStoreTable, CoreOptions options) {
+
         Preconditions.checkArgument(
                 !StringUtils.isNullOrWhitespaceOnly(options.httpReportMarkDoneActionUrl()),
                 String.format(
                         "Parameter %s must be non-empty when you use `http-report` partition mark done action.",
                         PARTITION_MARK_DONE_ACTION_URL.key()));
+
         this.fileStoreTable = fileStoreTable;
+        this.params = options.httpReportMarkDoneActionParams();
+
         HttpClientOptions httpClientOptions =
                 new HttpClientOptions(
                         options.httpReportMarkDoneActionUrl(),
@@ -74,6 +80,7 @@ public class HttpReportMarkDoneAction implements PartitionMarkDoneAction {
                 client.post(
                         null,
                         new HttpReportMarkDoneRequest(
+                                params,
                                 fileStoreTable.fullName(),
                                 fileStoreTable.location().toString(),
                                 partition),
@@ -105,6 +112,7 @@ public class HttpReportMarkDoneAction implements PartitionMarkDoneAction {
         private static final String MARK_DONE_PARTITION = "partition";
         private static final String TABLE = "table";
         private static final String PATH = "path";
+        private static final String PARAMS = "params";
 
         @JsonProperty(MARK_DONE_PARTITION)
         private final String partition;
@@ -115,11 +123,16 @@ public class HttpReportMarkDoneAction implements PartitionMarkDoneAction {
         @JsonProperty(PATH)
         private final String path;
 
+        @JsonProperty(PARAMS)
+        private final String params;
+
         @JsonCreator
         public HttpReportMarkDoneRequest(
+                @JsonProperty(PARAMS) String params,
                 @JsonProperty(TABLE) String table,
                 @JsonProperty(PATH) String path,
                 @JsonProperty(MARK_DONE_PARTITION) String partition) {
+            this.params = params;
             this.table = table;
             this.path = path;
             this.partition = partition;
@@ -138,6 +151,11 @@ public class HttpReportMarkDoneAction implements PartitionMarkDoneAction {
         @JsonGetter(PATH)
         public String getPath() {
             return path;
+        }
+
+        @JsonGetter(PARAMS)
+        public String getParams() {
+            return params;
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/partition/actions/HttpReportMarkDoneAction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/actions/HttpReportMarkDoneAction.java
@@ -86,14 +86,14 @@ public class HttpReportMarkDoneAction implements PartitionMarkDoneAction {
                                 partition),
                         HttpReportMarkDoneResponse.class,
                         Collections.emptyMap());
-        Preconditions.checkArgument(
+        Preconditions.checkState(
                 reportIsSuccess(response),
                 String.format(
-                        "The http-report actions response attribute `result` should be 'SUCCESS' but is '%s'.",
+                        "The http-report action's response attribute `result` should be 'SUCCESS' but is '%s'.",
                         response.getResult()));
     }
 
-    public boolean reportIsSuccess(HttpReportMarkDoneResponse response) {
+    private boolean reportIsSuccess(HttpReportMarkDoneResponse response) {
         return response != null && RESPONSE_SUCCESS.equalsIgnoreCase(response.getResult());
     }
 
@@ -109,6 +109,7 @@ public class HttpReportMarkDoneAction implements PartitionMarkDoneAction {
     /** RestRequest only for HttpReportMarkDoneAction. */
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class HttpReportMarkDoneRequest implements RESTRequest {
+
         private static final String MARK_DONE_PARTITION = "partition";
         private static final String TABLE = "table";
         private static final String PATH = "path";

--- a/paimon-core/src/main/java/org/apache/paimon/partition/actions/HttpReportMarkDoneException.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/actions/HttpReportMarkDoneException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.partition.actions;
+
+/** Exception for {@link HttpReportMarkDoneAction}. */
+public class HttpReportMarkDoneException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public HttpReportMarkDoneException(Throwable e) {
+        super("Http request exception.", e);
+    }
+
+    public HttpReportMarkDoneException(String msg) {
+        super(msg);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/partition/actions/PartitionMarkDoneAction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/actions/PartitionMarkDoneAction.java
@@ -40,6 +40,7 @@ public interface PartitionMarkDoneAction extends Closeable {
     String SUCCESS_FILE = "success-file";
     String DONE_PARTITION = "done-partition";
     String MARK_EVENT = "mark-event";
+    String HTTP_REPORT = "http-report";
     String CUSTOM = "custom";
 
     void markDone(String partition) throws Exception;
@@ -59,6 +60,9 @@ public interface PartitionMarkDoneAction extends Closeable {
                                 case MARK_EVENT:
                                     return new MarkPartitionDoneEventAction(
                                             createPartitionHandler(fileStoreTable, options));
+                                            createMetastoreClient(fileStoreTable, options));
+                                case HTTP_REPORT:
+                                    return new HttpReportMarkDoneAction(fileStoreTable, options);
                                 case CUSTOM:
                                     return generateCustomMarkDoneAction(cl, options);
                                 default:

--- a/paimon-core/src/main/java/org/apache/paimon/partition/actions/PartitionMarkDoneAction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/actions/PartitionMarkDoneAction.java
@@ -60,7 +60,6 @@ public interface PartitionMarkDoneAction extends Closeable {
                                 case MARK_EVENT:
                                     return new MarkPartitionDoneEventAction(
                                             createPartitionHandler(fileStoreTable, options));
-                                            createMetastoreClient(fileStoreTable, options));
                                 case HTTP_REPORT:
                                     return new HttpReportMarkDoneAction(fileStoreTable, options);
                                 case CUSTOM:

--- a/paimon-core/src/main/java/org/apache/paimon/partition/actions/PartitionMarkDoneAction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/actions/PartitionMarkDoneAction.java
@@ -24,33 +24,27 @@ import org.apache.paimon.table.PartitionHandler;
 import org.apache.paimon.utils.StringUtils;
 
 import java.io.Closeable;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.CoreOptions.METASTORE_PARTITIONED_TABLE;
 import static org.apache.paimon.CoreOptions.PARTITION_MARK_DONE_ACTION;
 import static org.apache.paimon.CoreOptions.PARTITION_MARK_DONE_CUSTOM_CLASS;
+import static org.apache.paimon.CoreOptions.PartitionMarkDoneAction.CUSTOM;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
 /** Action to mark partitions done. */
 public interface PartitionMarkDoneAction extends Closeable {
 
-    String SUCCESS_FILE = "success-file";
-    String DONE_PARTITION = "done-partition";
-    String MARK_EVENT = "mark-event";
-    String HTTP_REPORT = "http-report";
-    String CUSTOM = "custom";
-
     void markDone(String partition) throws Exception;
 
     static List<PartitionMarkDoneAction> createActions(
             ClassLoader cl, FileStoreTable fileStoreTable, CoreOptions options) {
-        return Arrays.stream(options.toConfiguration().get(PARTITION_MARK_DONE_ACTION).split(","))
+        return options.partitionMarkDoneActions().stream()
                 .map(
                         action -> {
-                            switch (action.toLowerCase()) {
+                            switch (action) {
                                 case SUCCESS_FILE:
                                     return new SuccessFileMarkDoneAction(
                                             fileStoreTable.fileIO(), fileStoreTable.location());
@@ -65,7 +59,7 @@ public interface PartitionMarkDoneAction extends Closeable {
                                 case CUSTOM:
                                     return generateCustomMarkDoneAction(cl, options);
                                 default:
-                                    throw new UnsupportedOperationException(action);
+                                    throw new UnsupportedOperationException(action.toString());
                             }
                         })
                 .collect(Collectors.toList());

--- a/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -22,6 +22,7 @@ import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.rest.exceptions.RESTException;
 import org.apache.paimon.rest.responses.ErrorResponse;
+import org.apache.paimon.utils.StringUtils;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
@@ -50,7 +51,7 @@ import static org.apache.paimon.utils.ThreadPoolUtils.createCachedThreadPool;
 public class HttpClient implements RESTClient {
 
     private static final ObjectMapper OBJECT_MAPPER = RESTObjectMapper.create();
-    private static final String THREAD_NAME = "REST-CATALOG-HTTP-CLIENT-THREAD-POOL";
+    private static final String THREAD_NAME = "PAIMON-HTTP-CLIENT-THREAD-POOL";
     private static final MediaType MEDIA_TYPE = MediaType.parse("application/json");
 
     private final OkHttpClient okHttpClient;
@@ -81,7 +82,11 @@ public class HttpClient implements RESTClient {
     public <T extends RESTResponse> T get(
             String path, Class<T> responseType, Map<String, String> headers) {
         Request request =
-                new Request.Builder().url(uri + path).get().headers(Headers.of(headers)).build();
+                new Request.Builder()
+                        .url(getRequestUrl(path))
+                        .get()
+                        .headers(Headers.of(headers))
+                        .build();
         return exec(request, responseType);
     }
 
@@ -92,7 +97,7 @@ public class HttpClient implements RESTClient {
             RequestBody requestBody = buildRequestBody(body);
             Request request =
                     new Request.Builder()
-                            .url(uri + path)
+                            .url(getRequestUrl(path))
                             .post(requestBody)
                             .headers(Headers.of(headers))
                             .build();
@@ -105,7 +110,11 @@ public class HttpClient implements RESTClient {
     @Override
     public <T extends RESTResponse> T delete(String path, Map<String, String> headers) {
         Request request =
-                new Request.Builder().url(uri + path).delete().headers(Headers.of(headers)).build();
+                new Request.Builder()
+                        .url(getRequestUrl(path))
+                        .delete()
+                        .headers(Headers.of(headers))
+                        .build();
         return exec(request, null);
     }
 
@@ -116,7 +125,7 @@ public class HttpClient implements RESTClient {
             RequestBody requestBody = buildRequestBody(body);
             Request request =
                     new Request.Builder()
-                            .url(uri + path)
+                            .url(getRequestUrl(path))
                             .delete(requestBody)
                             .headers(Headers.of(headers))
                             .build();
@@ -167,6 +176,10 @@ public class HttpClient implements RESTClient {
 
     private RequestBody buildRequestBody(RESTRequest body) throws JsonProcessingException {
         return RequestBody.create(OBJECT_MAPPER.writeValueAsBytes(body), MEDIA_TYPE);
+    }
+
+    private String getRequestUrl(String path) {
+        return StringUtils.isNullOrWhitespaceOnly(path) ? uri : uri + path;
     }
 
     private static OkHttpClient createHttpClient(HttpClientOptions httpClientOptions) {

--- a/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -51,7 +51,7 @@ import static org.apache.paimon.utils.ThreadPoolUtils.createCachedThreadPool;
 public class HttpClient implements RESTClient {
 
     private static final ObjectMapper OBJECT_MAPPER = RESTObjectMapper.create();
-    private static final String THREAD_NAME = "PAIMON-HTTP-CLIENT-THREAD-POOL";
+    private static final String THREAD_NAME = "REST-CATALOG-HTTP-CLIENT-THREAD-POOL";
     private static final MediaType MEDIA_TYPE = MediaType.parse("application/json");
 
     private final OkHttpClient okHttpClient;

--- a/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
@@ -24,10 +24,6 @@ import org.apache.paimon.rest.exceptions.BadRequestException;
 import org.apache.paimon.rest.responses.ErrorResponse;
 import org.apache.paimon.rest.responses.ErrorResponseResourceType;
 
-import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
-
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,29 +41,28 @@ public class HttpClientTest {
 
     private static final String MOCK_PATH = "/v1/api/mock";
     private static final String TOKEN = "token";
-    private static final ObjectMapper OBJECT_MAPPER = RESTObjectMapper.create();
 
-    private MockWebServer mockWebServer;
+    private TestHttpWebServer server;
     private HttpClient httpClient;
     private ErrorHandler errorHandler;
     private MockRESTData mockResponseData;
     private String mockResponseDataStr;
-    private ErrorResponse errorResponse;
     private String errorResponseStr;
     private Map<String, String> headers;
 
     @Before
-    public void setUp() throws IOException {
-        mockWebServer = new MockWebServer();
-        mockWebServer.start();
-        String baseUrl = mockWebServer.url("").toString();
+    public void setUp() throws Exception {
+        server = new TestHttpWebServer(MOCK_PATH);
+        server.start();
         errorHandler = DefaultErrorHandler.getInstance();
         HttpClientOptions httpClientOptions =
-                new HttpClientOptions(baseUrl, Duration.ofSeconds(3), Duration.ofSeconds(3), 1);
+                new HttpClientOptions(
+                        server.getBaseUrl(), Duration.ofSeconds(3), Duration.ofSeconds(3), 1);
         mockResponseData = new MockRESTData(MOCK_PATH);
-        mockResponseDataStr = OBJECT_MAPPER.writeValueAsString(mockResponseData);
-        errorResponse = new ErrorResponse(ErrorResponseResourceType.DATABASE, "test", "test", 400);
-        errorResponseStr = OBJECT_MAPPER.writeValueAsString(errorResponse);
+        mockResponseDataStr = server.createResponseBody(mockResponseData);
+        errorResponseStr =
+                server.createResponseBody(
+                        new ErrorResponse(ErrorResponseResourceType.DATABASE, "test", "test", 400));
         httpClient = new HttpClient(httpClientOptions);
         httpClient.setErrorHandler(errorHandler);
         CredentialsProvider credentialsProvider = new BearTokenCredentialsProvider(TOKEN);
@@ -76,19 +71,19 @@ public class HttpClientTest {
 
     @After
     public void tearDown() throws IOException {
-        mockWebServer.shutdown();
+        server.stop();
     }
 
     @Test
     public void testGetSuccess() {
-        mockHttpCallWithCode(mockResponseDataStr, 200);
+        server.enqueueResponse(mockResponseDataStr, 200);
         MockRESTData response = httpClient.get(MOCK_PATH, MockRESTData.class, headers);
         assertEquals(mockResponseData.data(), response.data());
     }
 
     @Test
     public void testGetFail() {
-        mockHttpCallWithCode(errorResponseStr, 400);
+        server.enqueueResponse(errorResponseStr, 400);
         assertThrows(
                 BadRequestException.class,
                 () -> httpClient.get(MOCK_PATH, MockRESTData.class, headers));
@@ -96,7 +91,7 @@ public class HttpClientTest {
 
     @Test
     public void testPostSuccess() {
-        mockHttpCallWithCode(mockResponseDataStr, 200);
+        server.enqueueResponse(mockResponseDataStr, 200);
         MockRESTData response =
                 httpClient.post(MOCK_PATH, mockResponseData, MockRESTData.class, headers);
         assertEquals(mockResponseData.data(), response.data());
@@ -104,7 +99,7 @@ public class HttpClientTest {
 
     @Test
     public void testPostFail() {
-        mockHttpCallWithCode(errorResponseStr, 400);
+        server.enqueueResponse(errorResponseStr, 400);
         assertThrows(
                 BadRequestException.class,
                 () -> httpClient.post(MOCK_PATH, mockResponseData, ErrorResponse.class, headers));
@@ -112,25 +107,13 @@ public class HttpClientTest {
 
     @Test
     public void testDeleteSuccess() {
-        mockHttpCallWithCode(mockResponseDataStr, 200);
+        server.enqueueResponse(mockResponseDataStr, 200);
         assertDoesNotThrow(() -> httpClient.delete(MOCK_PATH, headers));
     }
 
     @Test
     public void testDeleteFail() {
-        mockHttpCallWithCode(errorResponseStr, 400);
+        server.enqueueResponse(errorResponseStr, 400);
         assertThrows(BadRequestException.class, () -> httpClient.delete(MOCK_PATH, headers));
-    }
-
-    private void mockHttpCallWithCode(String body, Integer code) {
-        MockResponse mockResponseObj = generateMockResponse(body, code);
-        mockWebServer.enqueue(mockResponseObj);
-    }
-
-    private MockResponse generateMockResponse(String data, Integer code) {
-        return new MockResponse()
-                .setResponseCode(code)
-                .setBody(data)
-                .addHeader("Content-Type", "application/json");
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/rest/TestHttpWebServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/TestHttpWebServer.java
@@ -87,12 +87,11 @@ public class TestHttpWebServer {
         return objectMapper.writeValueAsString(response);
     }
 
-    public <T extends RESTRequest> T readRequestBody(String body, Class<T> requestType)
-            throws JsonProcessingException {
+    public <T> T readRequestBody(String body, Class<T> requestType) throws JsonProcessingException {
         return objectMapper.readValue(body, requestType);
     }
 
-    public <T extends RESTResponse> T readResponseBody(String body, Class<T> responseType)
+    public <T> T readResponseBody(String body, Class<T> responseType)
             throws JsonProcessingException {
         return objectMapper.readValue(body, responseType);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/rest/TestHttpWebServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/TestHttpWebServer.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/** Mock a http web service locally. */
+public class TestHttpWebServer {
+
+    private MockWebServer mockWebServer;
+    private final ObjectMapper objectMapper = RESTObjectMapper.create();
+    private String baseUrl;
+    private final String path;
+
+    public TestHttpWebServer(String path) {
+        this.path = path;
+    }
+
+    public void start() throws Exception {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        baseUrl = mockWebServer.url(path).toString();
+    }
+
+    public void stop() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    public RecordedRequest takeRequest(long timeout, TimeUnit unit) throws Exception {
+        return mockWebServer.takeRequest(timeout, unit);
+    }
+
+    public void enqueueResponse(String body, Integer code) {
+        MockResponse mockResponseObj = generateMockResponse(body, code);
+        enqueueResponse(mockResponseObj);
+    }
+
+    public void enqueueResponse(MockResponse mockResponseObj) {
+        mockWebServer.enqueue(mockResponseObj);
+    }
+
+    public void enqueueResponse(RESTResponse response, Integer code)
+            throws JsonProcessingException {
+        enqueueResponse(createResponseBody(response), code);
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
+
+    public MockResponse generateMockResponse(String data, Integer code) {
+        return new MockResponse()
+                .setResponseCode(code)
+                .setBody(data)
+                .addHeader("Content-Type", "application/json");
+    }
+
+    public String createResponseBody(RESTResponse response) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(response);
+    }
+
+    public <T extends RESTRequest> T readRequestBody(String body, Class<T> requestType)
+            throws JsonProcessingException {
+        return objectMapper.readValue(body, requestType);
+    }
+
+    public <T extends RESTResponse> T readResponseBody(String body, Class<T> responseType)
+            throws JsonProcessingException {
+        return objectMapper.readValue(body, responseType);
+    }
+}

--- a/paimon-flink/paimon-flink-common/pom.xml
+++ b/paimon-flink/paimon-flink-common/pom.xml
@@ -100,6 +100,14 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-test-utils</artifactId>
             <version>${flink.version}</version>

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MarkPartitionDoneActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MarkPartitionDoneActionITCase.java
@@ -23,7 +23,6 @@ import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.flink.sink.partition.MockCustomPartitionMarkDoneAction;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.partition.actions.HttpReportMarkDoneAction;
-import org.apache.paimon.partition.actions.PartitionMarkDoneAction;
 import org.apache.paimon.partition.file.SuccessFile;
 import org.apache.paimon.rest.TestHttpWebServer;
 import org.apache.paimon.table.FileStoreTable;
@@ -50,6 +49,9 @@ import java.util.stream.Stream;
 import static org.apache.paimon.CoreOptions.PARTITION_MARK_DONE_ACTION;
 import static org.apache.paimon.CoreOptions.PARTITION_MARK_DONE_ACTION_URL;
 import static org.apache.paimon.CoreOptions.PARTITION_MARK_DONE_CUSTOM_CLASS;
+import static org.apache.paimon.CoreOptions.PartitionMarkDoneAction.CUSTOM;
+import static org.apache.paimon.CoreOptions.PartitionMarkDoneAction.HTTP_REPORT;
+import static org.apache.paimon.CoreOptions.PartitionMarkDoneAction.SUCCESS_FILE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** IT cases for {@link MarkPartitionDoneAction}. */
@@ -166,9 +168,7 @@ public class MarkPartitionDoneActionITCase extends ActionITCaseBase {
     public void testCustomPartitionMarkDoneAction(boolean hasPk, String invoker) throws Exception {
 
         Map<String, String> options = new HashMap<>(2);
-        options.put(
-                PARTITION_MARK_DONE_ACTION.key(),
-                PartitionMarkDoneAction.SUCCESS_FILE + "," + PartitionMarkDoneAction.CUSTOM);
+        options.put(PARTITION_MARK_DONE_ACTION.key(), SUCCESS_FILE + "," + CUSTOM);
         options.put(
                 PARTITION_MARK_DONE_CUSTOM_CLASS.key(),
                 MockCustomPartitionMarkDoneAction.class.getName());
@@ -229,11 +229,7 @@ public class MarkPartitionDoneActionITCase extends ActionITCaseBase {
         server.start();
         try {
             Map<String, String> options = new HashMap<>();
-            options.put(
-                    PARTITION_MARK_DONE_ACTION.key(),
-                    PartitionMarkDoneAction.SUCCESS_FILE
-                            + ","
-                            + PartitionMarkDoneAction.HTTP_REPORT);
+            options.put(PARTITION_MARK_DONE_ACTION.key(), SUCCESS_FILE + "," + HTTP_REPORT);
             options.put(PARTITION_MARK_DONE_ACTION_URL.key(), server.getBaseUrl());
 
             FileStoreTable table = prepareTable(hasPk, options);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MarkPartitionDoneActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MarkPartitionDoneActionITCase.java
@@ -165,7 +165,7 @@ public class MarkPartitionDoneActionITCase extends ActionITCaseBase {
     @MethodSource("testArguments")
     public void testCustomPartitionMarkDoneAction(boolean hasPk, String invoker) throws Exception {
 
-        Map<String, String> options = new HashMap<>();
+        Map<String, String> options = new HashMap<>(2);
         options.put(
                 PARTITION_MARK_DONE_ACTION.key(),
                 PartitionMarkDoneAction.SUCCESS_FILE + "," + PartitionMarkDoneAction.CUSTOM);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MarkPartitionDoneActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MarkPartitionDoneActionITCase.java
@@ -234,8 +234,7 @@ public class MarkPartitionDoneActionITCase extends ActionITCaseBase {
 
             FileStoreTable table = prepareTable(hasPk, options);
 
-            HttpReportMarkDoneAction.HttpReportMarkDoneResponse expectResponse =
-                    new HttpReportMarkDoneAction.HttpReportMarkDoneResponse("success");
+            String expectResponse = "{\"result\":\"success\"}";
             server.enqueueResponse(expectResponse, 200);
             server.enqueueResponse(expectResponse, 200);
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MarkPartitionDoneActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MarkPartitionDoneActionITCase.java
@@ -22,8 +22,10 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.flink.sink.partition.MockCustomPartitionMarkDoneAction;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.partition.actions.HttpReportMarkDoneAction;
 import org.apache.paimon.partition.actions.PartitionMarkDoneAction;
 import org.apache.paimon.partition.file.SuccessFile;
+import org.apache.paimon.rest.TestHttpWebServer;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.StreamWriteBuilder;
 import org.apache.paimon.types.DataType;
@@ -31,6 +33,9 @@ import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.SnapshotManager;
 
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -39,9 +44,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static org.apache.paimon.CoreOptions.PARTITION_MARK_DONE_ACTION;
+import static org.apache.paimon.CoreOptions.PARTITION_MARK_DONE_ACTION_URL;
 import static org.apache.paimon.CoreOptions.PARTITION_MARK_DONE_CUSTOM_CLASS;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -211,6 +218,101 @@ public class MarkPartitionDoneActionITCase extends ActionITCaseBase {
 
         assertThat(MockCustomPartitionMarkDoneAction.getMarkedDonePartitions())
                 .containsExactlyInAnyOrder("partKey0=0/partKey1=1/", "partKey0=1/partKey1=0/");
+    }
+
+    @ParameterizedTest
+    @MethodSource("testArguments")
+    public void testHttpReportPartitionMarkDoneAction(boolean hasPk, String invoker)
+            throws Exception {
+
+        TestHttpWebServer server = new TestHttpWebServer("");
+        server.start();
+        try {
+            Map<String, String> options = new HashMap<>();
+            options.put(
+                    PARTITION_MARK_DONE_ACTION.key(),
+                    PartitionMarkDoneAction.SUCCESS_FILE
+                            + ","
+                            + PartitionMarkDoneAction.HTTP_REPORT);
+            options.put(PARTITION_MARK_DONE_ACTION_URL.key(), server.getBaseUrl());
+
+            FileStoreTable table = prepareTable(hasPk, options);
+
+            HttpReportMarkDoneAction.HttpReportMarkDoneResponse expectResponse =
+                    new HttpReportMarkDoneAction.HttpReportMarkDoneResponse("success");
+            server.enqueueResponse(expectResponse, 200);
+            server.enqueueResponse(expectResponse, 200);
+
+            switch (invoker) {
+                case "action":
+                    createAction(
+                                    MarkPartitionDoneAction.class,
+                                    "mark_partition_done",
+                                    "--warehouse",
+                                    warehouse,
+                                    "--database",
+                                    database,
+                                    "--table",
+                                    tableName,
+                                    "--partition",
+                                    "partKey0=0,partKey1=1",
+                                    "--partition",
+                                    "partKey0=1,partKey1=0")
+                            .run();
+                    break;
+                case "procedure_indexed":
+                    executeSQL(
+                            String.format(
+                                    "CALL sys.mark_partition_done('%s.%s', 'partKey0=0,partKey1=1;partKey0=1,partKey1=0')",
+                                    database, tableName));
+                    break;
+                case "procedure_named":
+                    executeSQL(
+                            String.format(
+                                    "CALL sys.mark_partition_done(`table` => '%s.%s', partitions => 'partKey0=0,partKey1=1;partKey0=1,partKey1=0')",
+                                    database, tableName));
+                    break;
+                default:
+                    throw new UnsupportedOperationException(invoker);
+            }
+
+            Path successPath1 = new Path(table.location(), "partKey0=0/partKey1=1/_SUCCESS");
+            SuccessFile successFile1 = SuccessFile.safelyFromPath(table.fileIO(), successPath1);
+            assertThat(successFile1).isNotNull();
+
+            Path successPath2 = new Path(table.location(), "partKey0=1/partKey1=0/_SUCCESS");
+            SuccessFile successFile2 = SuccessFile.safelyFromPath(table.fileIO(), successPath2);
+            assertThat(successFile2).isNotNull();
+
+            RecordedRequest recordedRequest = server.takeRequest(10, TimeUnit.SECONDS);
+            RecordedRequest recordedRequest2 = server.takeRequest(10, TimeUnit.SECONDS);
+
+            assertRequest(server, table, recordedRequest, "partKey0=0/partKey1=1/");
+            assertRequest(server, table, recordedRequest2, "partKey0=1/partKey1=0/");
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            server.stop();
+        }
+    }
+
+    public static void assertRequest(
+            TestHttpWebServer server,
+            FileStoreTable table,
+            RecordedRequest recordedRequest,
+            String exceptPartition)
+            throws JsonProcessingException {
+        String requestBody = recordedRequest.getBody().readUtf8();
+        HttpReportMarkDoneAction.HttpReportMarkDoneRequest request =
+                server.readRequestBody(
+                        requestBody, HttpReportMarkDoneAction.HttpReportMarkDoneRequest.class);
+
+        assertThat(
+                        request.getPath().equals(table.location().toString())
+                                && request.getPartition().equals(exceptPartition)
+                                && request.getTable().equals(table.fullName()))
+                .isTrue();
     }
 
     private FileStoreTable prepareTable(boolean hasPk) throws Exception {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/CustomPartitionMarkDoneActionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/CustomPartitionMarkDoneActionTest.java
@@ -32,8 +32,8 @@ import org.junit.jupiter.api.Test;
 import static org.apache.paimon.CoreOptions.PARTITION_MARK_DONE_ACTION;
 import static org.apache.paimon.CoreOptions.PARTITION_MARK_DONE_CUSTOM_CLASS;
 import static org.apache.paimon.CoreOptions.PARTITION_MARK_DONE_WHEN_END_INPUT;
+import static org.apache.paimon.CoreOptions.PartitionMarkDoneAction.CUSTOM;
 import static org.apache.paimon.flink.sink.partition.PartitionMarkDoneTest.notifyCommits;
-import static org.apache.paimon.partition.actions.PartitionMarkDoneAction.CUSTOM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for custom PartitionMarkDoneAction. */

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/HttpReportMarkDoneActionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/HttpReportMarkDoneActionTest.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.partition;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.fs.FileIOFinder;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.partition.actions.HttpReportMarkDoneAction;
+import org.apache.paimon.partition.actions.HttpReportMarkDoneAction.HttpReportMarkDoneRequest;
+import org.apache.paimon.partition.actions.HttpReportMarkDoneAction.HttpReportMarkDoneResponse;
+import org.apache.paimon.rest.TestHttpWebServer;
+import org.apache.paimon.rest.exceptions.BadRequestException;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.SchemaUtils;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.CatalogEnvironment;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+
+import okhttp3.mockwebserver.RecordedRequest;
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.paimon.CoreOptions.PARTITION_MARK_DONE_ACTION_TIMEOUT;
+import static org.apache.paimon.CoreOptions.PARTITION_MARK_DONE_ACTION_URL;
+import static org.apache.paimon.utils.InternalRowUtilsTest.ROW_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** IT case fo {@link HttpReportMarkDoneAction}. */
+public class HttpReportMarkDoneActionTest {
+
+    private static TestHttpWebServer server;
+
+    private static final String partition = "partition";
+    private static FileStoreTable fileStoreTable;
+    @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+    @Before
+    public void startServer() throws Exception {
+        server = new TestHttpWebServer("");
+        server.start();
+        fileStoreTable = createFileStoreTable();
+    }
+
+    @After
+    public void stopServer() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void testHttpReportMarkDoneActionSuccessResponse() throws Exception {
+        HttpReportMarkDoneAction httpReportMarkDoneAction = createHttpReportMarkDoneAction();
+
+        HttpReportMarkDoneResponse expectedResponse = new HttpReportMarkDoneResponse("success");
+        server.enqueueResponse(expectedResponse, 200);
+
+        httpReportMarkDoneAction.markDone(partition);
+        RecordedRequest request = server.takeRequest(10, TimeUnit.SECONDS);
+        assertRequest(request);
+
+        String expectedResponse2 = "{\"unknow\" :\"unknow\", \"result\" :\"success\"}";
+        server.enqueueResponse(expectedResponse2, 200);
+
+        httpReportMarkDoneAction.markDone(partition);
+        RecordedRequest request2 = server.takeRequest(10, TimeUnit.SECONDS);
+        assertRequest(request2);
+    }
+
+    @Test
+    public void testHttpReportMarkDoneActionFailedResponse() throws Exception {
+        HttpReportMarkDoneAction markDoneAction = createHttpReportMarkDoneAction();
+
+        // status failed.
+        HttpReportMarkDoneResponse failedResponse = new HttpReportMarkDoneResponse("failed");
+        server.enqueueResponse(failedResponse, 200);
+        Assertions.assertThatThrownBy(() -> markDoneAction.markDone(partition))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "The http-report actions response attribute `result` should be 'SUCCESS' but is 'failed'.");
+
+        // Illegal response body.
+        String unExpectResponse = "{\"unknow\" :\"unknow\"}";
+        server.enqueueResponse(unExpectResponse, 200);
+        Assertions.assertThatThrownBy(() -> markDoneAction.markDone(partition))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "The http-report actions response attribute `result` should be 'SUCCESS' but is 'null'.");
+
+        // 400.
+        server.enqueueResponse("", 400);
+        Assertions.assertThatThrownBy(() -> markDoneAction.markDone(partition))
+                .isInstanceOf(BadRequestException.class);
+    }
+
+    public static void assertRequest(RecordedRequest recordedRequest)
+            throws JsonProcessingException {
+        String requestBody = recordedRequest.getBody().readUtf8();
+        HttpReportMarkDoneRequest request =
+                server.readRequestBody(requestBody, HttpReportMarkDoneRequest.class);
+
+        assertThat(
+                        request.getPath().equals(fileStoreTable.location().toString())
+                                && request.getPartition().equals(partition)
+                                && request.getTable().equals(fileStoreTable.fullName()))
+                .isTrue();
+    }
+
+    public static CoreOptions createCoreOptions() {
+        HashMap<String, String> httpOptions = new HashMap<>();
+        httpOptions.put(PARTITION_MARK_DONE_ACTION_URL.key(), server.getBaseUrl());
+        httpOptions.put(PARTITION_MARK_DONE_ACTION_TIMEOUT.key(), "2 s");
+        return new CoreOptions(httpOptions);
+    }
+
+    public HttpReportMarkDoneAction createHttpReportMarkDoneAction() {
+        return new HttpReportMarkDoneAction(fileStoreTable, createCoreOptions());
+    }
+
+    public FileStoreTable createFileStoreTable() throws Exception {
+        org.apache.paimon.fs.Path tablePath =
+                new org.apache.paimon.fs.Path(folder.newFolder().toURI().toString());
+        Options options = new Options();
+        options.set(CoreOptions.PATH, tablePath.toString());
+        TableSchema tableSchema =
+                SchemaUtils.forceCommit(
+                        new SchemaManager(LocalFileIO.create(), tablePath),
+                        new Schema(
+                                ROW_TYPE.getFields(),
+                                Collections.emptyList(),
+                                Collections.emptyList(),
+                                options.toMap(),
+                                ""));
+        return FileStoreTableFactory.create(
+                FileIOFinder.find(tablePath),
+                tablePath,
+                tableSchema,
+                options,
+                CatalogEnvironment.empty());
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/HttpReportMarkDoneActionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/HttpReportMarkDoneActionTest.java
@@ -113,17 +113,17 @@ public class HttpReportMarkDoneActionTest {
         HttpReportMarkDoneResponse failedResponse = new HttpReportMarkDoneResponse("failed");
         server.enqueueResponse(failedResponse, 200);
         Assertions.assertThatThrownBy(() -> markDoneAction.markDone(partition))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(
-                        "The http-report actions response attribute `result` should be 'SUCCESS' but is 'failed'.");
+                        "The http-report action's response attribute `result` should be 'SUCCESS' but is 'failed'.");
 
         // Illegal response body.
         String unExpectResponse = "{\"unknow\" :\"unknow\"}";
         server.enqueueResponse(unExpectResponse, 200);
         Assertions.assertThatThrownBy(() -> markDoneAction.markDone(partition))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(
-                        "The http-report actions response attribute `result` should be 'SUCCESS' but is 'null'.");
+                        "The http-report action's response attribute `result` should be 'SUCCESS' but is 'null'.");
 
         // 400.
         server.enqueueResponse("", 400);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose


In order to coordinate the scheduling of real-time data and offline data, we provide an online web service to receive table partition completion information from the real-time application (flink).

When the real-time program completes writing to a partition, `http-report` action will report the partition to the remote service, when the online service receives the partition done request, it immediately calls the downstream associated offline job.

Compared with other actions, `http-report` action is more time-sensitive and does not require polling or blocking to wait for partitioning to complete. It is passive.

![e9eb1cc86090b7b3ceec09ef7ec5b767](https://github.com/user-attachments/assets/85b40cc1-fdfc-406d-8d38-b6b1c4019c75)


<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
