### PR TITLE
[hive] Fix no longer possible to drop the hms table issue when table …

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -534,6 +534,12 @@ public interface Catalog extends AutoCloseable {
             this.identifier = identifier;
         }
 
+        protected TableNotExistException(
+                String customFormat, Identifier identifier, Throwable cause) {
+            super(String.format(customFormat, identifier.getFullName()), cause);
+            this.identifier = identifier;
+        }
+
         public Identifier identifier() {
             return identifier;
         }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -694,7 +694,7 @@ public class HiveCatalog extends AbstractCatalog {
             return tableSchemaInFileSystem(
                             getTableLocation(identifier, table),
                             identifier.getBranchNameOrDefault())
-                    .orElseThrow(() -> new TableNotExistException(identifier));
+                    .orElseThrow(() -> new HmsTableNotExistInFsException(identifier));
         }
 
         if (!formatTableDisabled()) {
@@ -705,7 +705,7 @@ public class HiveCatalog extends AbstractCatalog {
             }
         }
 
-        throw new TableNotExistException(identifier);
+        throw new HmsTableNotExistInFsException(identifier);
     }
 
     @Override
@@ -886,6 +886,31 @@ public class HiveCatalog extends AbstractCatalog {
                         tableOptions.get(HIVE_EXTERNAL_TABLE_PROP.toUpperCase()));
         return CatalogTableType.EXTERNAL.equals(tableType)
                 || "TRUE".equalsIgnoreCase(externalPropValue);
+    }
+
+    @Override
+    public void dropTable(Identifier identifier, boolean ignoreIfNotExists)
+            throws TableNotExistException {
+        checkNotBranch(identifier, "dropTable");
+        checkNotSystemTable(identifier, "dropTable");
+
+        try {
+            getTable(identifier);
+        } catch (TableNotExistException e) {
+            if (e instanceof HmsTableNotExistInFsException) {
+                LOG.warn(
+                        "Table {}.{} exists in Hive metastore, but not exist in file system. will try to drop it in Hive metastore only.",
+                        identifier.getDatabaseName(),
+                        identifier.getTableName());
+                dropHmsTableQuietly(identifier);
+            }
+            if (ignoreIfNotExists) {
+                return;
+            }
+            throw new TableNotExistException(identifier);
+        }
+
+        dropTableImpl(identifier);
     }
 
     @Override
@@ -1646,6 +1671,49 @@ public class HiveCatalog extends AbstractCatalog {
                     this.hiveConf.get(HiveConf.ConfVars.METASTORE_BATCH_RETRIEVE_MAX.varname),
                     e);
             return DEFAULT_TABLE_BATCH_SIZE;
+        }
+    }
+
+    private void dropHmsTableQuietly(Identifier identifier) throws TableNotExistException {
+        try {
+            boolean externalTable = isExternalTable(getHmsTable(identifier));
+            clients.execute(
+                    client ->
+                            client.dropTable(
+                                    identifier.getDatabaseName(),
+                                    identifier.getTableName(),
+                                    !externalTable,
+                                    false,
+                                    true));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn(
+                    "Interrupted in call to drop hms table {} which does not exist in file system",
+                    identifier.getFullName(),
+                    e);
+        } catch (Exception e) {
+            LOG.warn(
+                    "Failed to drop hms table {} which does not exist in file system",
+                    identifier.getFullName(),
+                    e);
+        }
+    }
+
+    /**
+     * Exception for trying to operate on a table which exists in Hive metastore but doesn't exist
+     * in file system.
+     */
+    public static class HmsTableNotExistInFsException extends TableNotExistException {
+
+        protected static final String MSG =
+                "Table %s exists in Hive metastore but does not exist in file system.";
+
+        public HmsTableNotExistInFsException(Identifier identifier) {
+            this(identifier, null);
+        }
+
+        public HmsTableNotExistInFsException(Identifier identifier, Throwable cause) {
+            super(MSG, identifier, cause);
         }
     }
 }

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -45,6 +45,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,6 +63,7 @@ import static org.apache.paimon.hive.HiveCatalog.PAIMON_TABLE_IDENTIFIER;
 import static org.apache.paimon.hive.HiveCatalog.TABLE_TYPE_PROP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -396,6 +399,37 @@ public class HiveCatalogTest extends CatalogTestBase {
         for (int i = 0; i < defaultBatchTables.size(); i++) {
             assertEquals(defaultBatchTables.get(i), invalidBatchSizeTables.get(i));
         }
+
+        catalog.dropDatabase(databaseName, true, true);
+    }
+
+    @Test
+    public void testDropTable() throws Exception {
+        String databaseName = "drop_table_test_db";
+        String tableName = "drop_table_test_table";
+        catalog.dropDatabase(databaseName, true, true);
+        catalog.createDatabase(databaseName, true);
+        Identifier identifier = Identifier.create(databaseName, tableName);
+
+        // test ignore if exists
+        catalog.createTable(
+                identifier, Schema.newBuilder().column("col", DataTypes.INT()).build(), true);
+        Path path = Paths.get(catalog.warehouse(), databaseName.concat(".db"), tableName);
+        catalog.fileIO().delete(new org.apache.paimon.fs.Path(path.toString()), true);
+        List<String> tables = catalog.listTables(databaseName);
+        assertEquals(1, tables.size());
+        catalog.dropTable(identifier, true);
+        List<String> newTables = catalog.listTables(databaseName);
+        assertEquals(0, newTables.size());
+
+        // test not ignore if exists
+        catalog.createTable(
+                identifier, Schema.newBuilder().column("col", DataTypes.INT()).build(), true);
+        catalog.fileIO().delete(new org.apache.paimon.fs.Path(path.toString()), true);
+        tables = catalog.listTables(databaseName);
+        assertEquals(1, tables.size());
+        assertThrows(
+                Catalog.TableNotExistException.class, () -> catalog.dropTable(identifier, false));
 
         catalog.dropDatabase(databaseName, true, true);
     }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -23,9 +23,11 @@ import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
 import org.apache.paimon.catalog.PropertyChange;
+import org.apache.paimon.hive.HiveCatalog;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
+import org.apache.paimon.spark.analysis.SparkTableNotExistInFsException;
 import org.apache.paimon.spark.catalog.SparkBaseCatalog;
 import org.apache.paimon.spark.catalog.SupportFunction;
 import org.apache.paimon.spark.catalog.SupportView;
@@ -246,6 +248,21 @@ public class SparkCatalog extends SparkBaseCatalog implements SupportFunction, S
         }
     }
 
+    @Override
+    public boolean tableExists(Identifier ident) {
+        try {
+            return this.loadTable(ident) != null;
+        } catch (SparkTableNotExistInFsException e) {
+            LOG.warn(
+                    "Table {}.{} exists in Hive metastore, but not in file system, we think table exists in this case",
+                    ident.namespace(),
+                    ident.name());
+            return true;
+        } catch (NoSuchTableException e) {
+            return false;
+        }
+    }
+
     /**
      * Do not annotate with <code>@override</code> here to maintain compatibility with Spark 3.2-.
      *
@@ -448,6 +465,12 @@ public class SparkCatalog extends SparkBaseCatalog implements SupportFunction, S
                         copyWithSQLConf(
                                 paimonTable, catalogName, toIdentifier(ident), extraOptions));
             }
+        } catch (HiveCatalog.HmsTableNotExistInFsException e) {
+            LOG.warn(
+                    "Table {}.{} exists in Hive metastore, but not exist in file system.",
+                    ident.namespace(),
+                    ident.name());
+            throw new SparkTableNotExistInFsException(ident);
         } catch (Catalog.TableNotExistException e) {
             throw new NoSuchTableException(ident);
         }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/analysis/SparkTableNotExistInFsException.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/analysis/SparkTableNotExistInFsException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.analysis;
+
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.connector.catalog.Identifier;
+
+/**
+ * Thrown by spark catalog when a table exists in Hive Metastore but cannot be found in file system.
+ */
+public class SparkTableNotExistInFsException extends NoSuchTableException {
+
+    public SparkTableNotExistInFsException(Identifier ident) {
+        super(ident);
+    }
+}


### PR DESCRIPTION
…not in fs (#4853)

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

Purpose Fix no longer possible to drop the hms table issue when table not in fs

<!-- Linking this pull request to the issue -->
Linked issue: close #4853 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
