### PR TITLE
[core] Support parsing row type json without field id

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/types/DataTypeJsonParser.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/DataTypeJsonParser.java
@@ -26,8 +26,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.apache.paimon.utils.Preconditions.checkState;
 
 /**
  * Parser for creating instances of {@link org.apache.paimon.types.DataType} from a serialized
@@ -36,9 +39,20 @@ import java.util.stream.Stream;
 public final class DataTypeJsonParser {
 
     public static DataField parseDataField(JsonNode json) {
-        int id = json.get("id").asInt();
+        return parseDataField(json, null);
+    }
+
+    private static DataField parseDataField(JsonNode json, AtomicInteger fieldId) {
+        int id;
+        JsonNode idNode = json.get("id");
+        if (idNode != null) {
+            checkState(fieldId == null || fieldId.get() == -1, "Partial field id is not allowed.");
+            id = idNode.asInt();
+        } else {
+            id = fieldId.incrementAndGet();
+        }
         String name = json.get("name").asText();
-        DataType type = parseDataType(json.get("type"));
+        DataType type = parseDataType(json.get("type"), fieldId);
         JsonNode descriptionNode = json.get("description");
         String description = null;
         if (descriptionNode != null) {
@@ -48,26 +62,30 @@ public final class DataTypeJsonParser {
     }
 
     public static DataType parseDataType(JsonNode json) {
+        return parseDataType(json, new AtomicInteger(-1));
+    }
+
+    public static DataType parseDataType(JsonNode json, AtomicInteger fieldId) {
         if (json.isTextual()) {
             return parseAtomicTypeSQLString(json.asText());
         } else if (json.isObject()) {
             String typeString = json.get("type").asText();
             if (typeString.startsWith("ARRAY")) {
-                DataType element = parseDataType(json.get("element"));
+                DataType element = parseDataType(json.get("element"), fieldId);
                 return new ArrayType(!typeString.contains("NOT NULL"), element);
             } else if (typeString.startsWith("MULTISET")) {
-                DataType element = parseDataType(json.get("element"));
+                DataType element = parseDataType(json.get("element"), fieldId);
                 return new MultisetType(!typeString.contains("NOT NULL"), element);
             } else if (typeString.startsWith("MAP")) {
-                DataType key = parseDataType(json.get("key"));
-                DataType value = parseDataType(json.get("value"));
+                DataType key = parseDataType(json.get("key"), fieldId);
+                DataType value = parseDataType(json.get("value"), fieldId);
                 return new MapType(!typeString.contains("NOT NULL"), key, value);
             } else if (typeString.startsWith("ROW")) {
                 JsonNode fieldArray = json.get("fields");
                 Iterator<JsonNode> iterator = fieldArray.elements();
                 List<DataField> fields = new ArrayList<>(fieldArray.size());
                 while (iterator.hasNext()) {
-                    fields.add(parseDataField(iterator.next()));
+                    fields.add(parseDataField(iterator.next(), fieldId));
                 }
                 return new RowType(!typeString.contains("NOT NULL"), fields);
             }

--- a/paimon-common/src/main/java/org/apache/paimon/types/RowType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/types/RowType.java
@@ -356,7 +356,11 @@ public final class RowType extends DataType {
     }
 
     public static Builder builder() {
-        return builder(true, new AtomicInteger(-1));
+        return builder(new AtomicInteger(-1));
+    }
+
+    public static Builder builder(AtomicInteger fieldId) {
+        return builder(true, fieldId);
     }
 
     public static Builder builder(boolean isNullable, AtomicInteger fieldId) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

As part of #4471, in order to support variant shredding, we need a way to indicate which fields require shredding. To reuse the code, we utilize the existing RowType JSON parser. 

E.g. If we want to shred field v with age int and city string, we can create table like this:

```sql
CREATE TABLE T (v VARIANT)
TBLPROPERTIES (
'fields.v.shredding-schema' = '{"type":"ROW","fields":[{"name":"age","type":"INT"},{"name":"city","type":"STRING"}]}'
)
```

To reduce user conf, support parsing row type json without field id

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
