### PR TITLE
[core] Do not use Collections.unmodifiableMap to avoid stack overflow

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/metrics/MetricGroupImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metrics/MetricGroupImpl.java
@@ -21,7 +21,6 @@ package org.apache.paimon.metrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -51,7 +50,7 @@ public class MetricGroupImpl implements MetricGroup {
 
     @Override
     public Map<String, String> getAllVariables() {
-        return Collections.unmodifiableMap(variables);
+        return variables;
     }
 
     @Override
@@ -117,7 +116,7 @@ public class MetricGroupImpl implements MetricGroup {
 
     @Override
     public Map<String, Metric> getMetrics() {
-        return Collections.unmodifiableMap(metrics);
+        return metrics;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/schema/TableSchema.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/TableSchema.java
@@ -115,7 +115,7 @@ public class TableSchema implements Serializable {
         this.highestFieldId = highestFieldId;
         this.partitionKeys = partitionKeys;
         this.primaryKeys = primaryKeys;
-        this.options = Collections.unmodifiableMap(options);
+        this.options = options;
         this.comment = comment;
         this.timeMillis = timeMillis;
 

--- a/paimon-core/src/test/java/org/apache/paimon/schema/TableSchemaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/TableSchemaTest.java
@@ -31,6 +31,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.apache.paimon.CoreOptions.AGG_FUNCTION;
 import static org.apache.paimon.CoreOptions.BUCKET;
 import static org.apache.paimon.CoreOptions.FIELDS_PREFIX;
@@ -44,14 +46,31 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TableSchemaTest {
 
     @Test
+    public void testTableSchemaCopy() {
+        Map<String, String> options = new HashMap<>();
+        options.put("my-key", "my-value");
+        TableSchema schema =
+                new TableSchema(
+                        1,
+                        singletonList(new DataField(0, "f0", DataTypes.INT())),
+                        10,
+                        emptyList(),
+                        emptyList(),
+                        options,
+                        "");
+        schema = schema.copy(schema.options());
+        assertThat(schema.options()).isSameAs(options);
+    }
+
+    @Test
     public void testCrossPartition() {
         List<DataField> fields =
                 Arrays.asList(
                         new DataField(0, "f0", DataTypes.INT()),
                         new DataField(1, "f1", DataTypes.INT()),
                         new DataField(2, "f2", DataTypes.INT()));
-        List<String> partitionKeys = Collections.singletonList("f0");
-        List<String> primaryKeys = Collections.singletonList("f1");
+        List<String> partitionKeys = singletonList("f0");
+        List<String> primaryKeys = singletonList("f1");
         Map<String, String> options = new HashMap<>();
 
         TableSchema schema =
@@ -130,8 +149,8 @@ public class TableSchemaTest {
                         new DataField(1, "f1", DataTypes.INT()),
                         new DataField(2, "f2", DataTypes.INT()),
                         new DataField(3, "f3", DataTypes.INT()));
-        List<String> partitionKeys = Collections.singletonList("f0");
-        List<String> primaryKeys = Collections.singletonList("f1");
+        List<String> partitionKeys = singletonList("f0");
+        List<String> primaryKeys = singletonList("f1");
         Map<String, String> options = new HashMap<>();
 
         TableSchema schema =
@@ -168,7 +187,7 @@ public class TableSchemaTest {
                         new DataField(0, "f0", DataTypes.INT()),
                         new DataField(1, "f1", DataTypes.INT()),
                         new DataField(2, "f2", DataTypes.INT()));
-        List<String> primaryKeys = Collections.singletonList("f0");
+        List<String> primaryKeys = singletonList("f0");
         Map<String, String> options = new HashMap<>();
         options.put(MERGE_ENGINE.key(), CoreOptions.MergeEngine.AGGREGATE.toString());
         options.put(FIELDS_PREFIX + ".f1." + AGG_FUNCTION, "max");
@@ -186,8 +205,8 @@ public class TableSchemaTest {
                         new DataField(0, "f0", DataTypes.INT()),
                         new DataField(1, "f1", DataTypes.INT()),
                         new DataField(2, "f2", DataTypes.INT()));
-        List<String> partitionKeys = Collections.singletonList("f0");
-        List<String> primaryKeys = Collections.singletonList("f1");
+        List<String> partitionKeys = singletonList("f0");
+        List<String> primaryKeys = singletonList("f1");
         Map<String, String> options = new HashMap<>();
 
         TableSchema schema =
@@ -200,7 +219,6 @@ public class TableSchemaTest {
 
     static RowType newRowType(boolean isNullable, int fieldId) {
         return new RowType(
-                isNullable,
-                Collections.singletonList(new DataField(fieldId, "nestedField", DataTypes.INT())));
+                isNullable, singletonList(new DataField(fieldId, "nestedField", DataTypes.INT())));
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/metrics/FlinkMetricGroup.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/metrics/FlinkMetricGroup.java
@@ -24,7 +24,6 @@ import org.apache.paimon.metrics.Histogram;
 import org.apache.paimon.metrics.Metric;
 import org.apache.paimon.metrics.MetricGroup;
 
-import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -75,7 +74,7 @@ public class FlinkMetricGroup implements MetricGroup {
 
     @Override
     public Map<String, String> getAllVariables() {
-        return Collections.unmodifiableMap(variables);
+        return variables;
     }
 
     @Override


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Exception:
```
java.lang.StackOverflowError: null
	at java.util.Collections$UnmodifiableMap.get(Collections.java:1456) ~[?:1.8.0_372]
	at java.util.Collections$UnmodifiableMap.get(Collections.java:1456) ~[?:1.8.0_372]
	at java.util.Collections$UnmodifiableMap.get(Collections.java:1456) ~[?:1.8.0_372]
	at java.util.Collections$UnmodifiableMap.get(Collections.java:1456) ~[?:1.8.0_372]
	at java.util.Collections$UnmodifiableMap.get(Collections.java:1456) ~[?:1.8.0_372]
	at java.util.Collections$UnmodifiableMap.get(Collections.java:1456) ~[?:1.8.0_372]
	at java.util.Collections$UnmodifiableMap.get(Collections.java:1456) ~[?:1.8.0_372]
	at java.util.Collections$UnmodifiableMap.get(Collections.java:1456) ~[?:1.8.0_372]
	at java.util.Coll
```

`AbstractFileStoreTable.copyWithLatestSchema` may introduce too many nested unmodifiableMap.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
