### PR TITLE
[hotfix] remove the useless comment

### DIFF
--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/InsertOverwriteTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/InsertOverwriteTableTestBase.scala
@@ -570,7 +570,6 @@ abstract class InsertOverwriteTableTestBase extends PaimonSparkTestBase {
           sql(
             "INSERT INTO t VALUES (1, STRUCT(1, 1)), (2, null), (3, STRUCT(1, null)), (4, STRUCT(null, null))")
           if (format.equals("parquet")) {
-            // todo: fix it, see https://github.com/apache/paimon/issues/4785
             checkAnswer(
               sql("SELECT * FROM t ORDER BY i"),
               Seq(Row(1, Row(1, 1)), Row(2, null), Row(3, Row(1, null)), Row(4, null)))


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Now , [this bug ](https://github.com/apache/paimon/issues/4785)is fixed ,Maybe we should consider removing the useless comment.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
