### PR TITLE
[rest] Add name to GetTableResponse and remove path

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -25,7 +25,6 @@ import org.apache.paimon.rest.responses.ErrorResponse;
 import org.apache.paimon.utils.StringUtils;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
 import okhttp3.Dispatcher;
 import okhttp3.Headers;
@@ -45,12 +44,12 @@ import java.util.concurrent.SynchronousQueue;
 import static okhttp3.ConnectionSpec.CLEARTEXT;
 import static okhttp3.ConnectionSpec.COMPATIBLE_TLS;
 import static okhttp3.ConnectionSpec.MODERN_TLS;
+import static org.apache.paimon.rest.RESTObjectMapper.OBJECT_MAPPER;
 import static org.apache.paimon.utils.ThreadPoolUtils.createCachedThreadPool;
 
 /** HTTP client for REST catalog. */
 public class HttpClient implements RESTClient {
 
-    private static final ObjectMapper OBJECT_MAPPER = RESTObjectMapper.create();
     private static final String THREAD_NAME = "REST-CATALOG-HTTP-CLIENT-THREAD-POOL";
     private static final MediaType MEDIA_TYPE = MediaType.parse("application/json");
 

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -78,6 +78,7 @@ import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static org.apache.paimon.CoreOptions.METASTORE_PARTITIONED_TABLE;
+import static org.apache.paimon.CoreOptions.PATH;
 import static org.apache.paimon.catalog.CatalogUtils.checkNotBranch;
 import static org.apache.paimon.catalog.CatalogUtils.checkNotSystemDatabase;
 import static org.apache.paimon.catalog.CatalogUtils.checkNotSystemTable;
@@ -471,14 +472,17 @@ public class RESTCatalog implements Catalog {
             throw new TableNoPermissionException(identifier, e);
         }
 
+        TableSchema schema = TableSchema.create(response.getSchemaId(), response.getSchema());
         FileStoreTable table =
                 FileStoreTableFactory.create(
                         fileIO(),
-                        new Path(response.getPath()),
-                        TableSchema.create(response.getSchemaId(), response.getSchema()),
-                        // TODO add uuid from server
+                        new Path(schema.options().get(PATH.key())),
+                        schema,
                         new CatalogEnvironment(
-                                identifier, null, Lock.emptyFactory(), catalogLoader()));
+                                identifier,
+                                response.getId(),
+                                Lock.emptyFactory(),
+                                catalogLoader()));
         CoreOptions options = table.coreOptions();
         if (options.type() == TableType.OBJECT_TABLE) {
             String objectLocation = options.objectLocation();

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTObjectMapper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTObjectMapper.java
@@ -34,7 +34,9 @@ import static org.apache.paimon.utils.JsonSerdeUtil.registerJsonObjects;
 /** Object mapper for REST request and response. */
 public class RESTObjectMapper {
 
-    public static ObjectMapper create() {
+    public static final ObjectMapper OBJECT_MAPPER = RESTObjectMapper.create();
+
+    private static ObjectMapper create() {
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
@@ -43,7 +45,7 @@ public class RESTObjectMapper {
         return mapper;
     }
 
-    public static Module createPaimonRestJacksonModule() {
+    private static Module createPaimonRestJacksonModule() {
         SimpleModule module = new SimpleModule("Paimon_REST");
         registerJsonObjects(
                 module,

--- a/paimon-core/src/main/java/org/apache/paimon/rest/responses/GetDatabaseResponse.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/responses/GetDatabaseResponse.java
@@ -35,8 +35,12 @@ import static org.apache.paimon.rest.RESTCatalogInternalOptions.DATABASE_COMMENT
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GetDatabaseResponse implements RESTResponse, Database {
 
+    private static final String FIELD_ID = "id";
     private static final String FIELD_NAME = "name";
     private static final String FIELD_OPTIONS = "options";
+
+    @JsonProperty(FIELD_ID)
+    private final String id;
 
     @JsonProperty(FIELD_NAME)
     private final String name;
@@ -46,10 +50,17 @@ public class GetDatabaseResponse implements RESTResponse, Database {
 
     @JsonCreator
     public GetDatabaseResponse(
+            @JsonProperty(FIELD_ID) String id,
             @JsonProperty(FIELD_NAME) String name,
             @JsonProperty(FIELD_OPTIONS) Map<String, String> options) {
+        this.id = id;
         this.name = name;
         this.options = options;
+    }
+
+    @JsonGetter(FIELD_ID)
+    public String getId() {
+        return id;
     }
 
     @JsonGetter(FIELD_NAME)

--- a/paimon-core/src/main/java/org/apache/paimon/rest/responses/GetTableResponse.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/responses/GetTableResponse.java
@@ -30,12 +30,16 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonPro
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GetTableResponse implements RESTResponse {
 
-    private static final String FIELD_PATH = "path";
+    private static final String FIELD_ID = "id";
+    private static final String FIELD_NAME = "name";
     private static final String FIELD_SCHEMA_ID = "schemaId";
     private static final String FIELD_SCHEMA = "schema";
 
-    @JsonProperty(FIELD_PATH)
-    private final String path;
+    @JsonProperty(FIELD_ID)
+    private final String id;
+
+    @JsonProperty(FIELD_NAME)
+    private final String name;
 
     @JsonProperty(FIELD_SCHEMA_ID)
     private final long schemaId;
@@ -45,17 +49,24 @@ public class GetTableResponse implements RESTResponse {
 
     @JsonCreator
     public GetTableResponse(
-            @JsonProperty(FIELD_PATH) String path,
+            @JsonProperty(FIELD_ID) String id,
+            @JsonProperty(FIELD_NAME) String name,
             @JsonProperty(FIELD_SCHEMA_ID) long schemaId,
             @JsonProperty(FIELD_SCHEMA) Schema schema) {
-        this.path = path;
+        this.id = id;
+        this.name = name;
         this.schemaId = schemaId;
         this.schema = schema;
     }
 
-    @JsonGetter(FIELD_PATH)
-    public String getPath() {
-        return this.path;
+    @JsonGetter(FIELD_ID)
+    public String getId() {
+        return this.id;
+    }
+
+    @JsonGetter(FIELD_NAME)
+    public String getName() {
+        return this.name;
     }
 
     @JsonGetter(FIELD_SCHEMA_ID)

--- a/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
@@ -24,6 +24,8 @@ import org.apache.paimon.rest.exceptions.BadRequestException;
 import org.apache.paimon.rest.responses.ErrorResponse;
 import org.apache.paimon.rest.responses.ErrorResponseResourceType;
 
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,6 +34,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
 
+import static org.apache.paimon.rest.RESTObjectMapper.OBJECT_MAPPER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
@@ -24,8 +24,6 @@ import org.apache.paimon.rest.exceptions.BadRequestException;
 import org.apache.paimon.rest.responses.ErrorResponse;
 import org.apache.paimon.rest.responses.ErrorResponseResourceType;
 
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,7 +32,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
 
-import static org.apache.paimon.rest.RESTObjectMapper.OBJECT_MAPPER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTMessage.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTMessage.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.rest;
 
-import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.rest.requests.AlterDatabaseRequest;
@@ -55,6 +54,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.apache.paimon.rest.RESTCatalogInternalOptions.DATABASE_COMMENT;
 
@@ -81,7 +81,7 @@ public class MockRESTMessage {
         Map<String, String> options = new HashMap<>();
         options.put("a", "b");
         options.put(DATABASE_COMMENT.key(), "comment");
-        return new GetDatabaseResponse(name, options);
+        return new GetDatabaseResponse(UUID.randomUUID().toString(), name, options);
     }
 
     public static ListDatabasesResponse listDatabasesResponse(String name) {
@@ -226,18 +226,11 @@ public class MockRESTMessage {
         return schemaChanges;
     }
 
-    public static GetTableResponse getTableResponseEnablePartition() {
-        Map<String, String> options = new HashMap<>();
-        options.put("option-1", "value-1");
-        options.put(CoreOptions.METASTORE_PARTITIONED_TABLE.key(), "true");
-        return new GetTableResponse("/tmp/2", 1, schema(options));
-    }
-
     public static GetTableResponse getTableResponse() {
         Map<String, String> options = new HashMap<>();
         options.put("option-1", "value-1");
         options.put("option-2", "value-2");
-        return new GetTableResponse("/tmp/1", 1, schema(options));
+        return new GetTableResponse(UUID.randomUUID().toString(), "", 1, schema(options));
     }
 
     public static MockResponse mockResponse(String body, int httpCode) {

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -116,4 +116,9 @@ class RESTCatalogTest extends CatalogTestBase {
                         ""),
                 true);
     }
+
+    // TODO implement this
+    @Override
+    @Test
+    public void testTableUUID() {}
 }

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTObjectMapperTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTObjectMapperTest.java
@@ -40,7 +40,6 @@ import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.IntType;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.Test;
 
@@ -48,13 +47,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.paimon.rest.RESTObjectMapper.OBJECT_MAPPER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /** Test for {@link RESTObjectMapper}. */
 public class RESTObjectMapperTest {
-
-    private static final ObjectMapper OBJECT_MAPPER = RESTObjectMapper.create();
 
     @Test
     public void configResponseParseTest() throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/rest/TestHttpWebServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/TestHttpWebServer.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.rest;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -28,11 +27,12 @@ import okhttp3.mockwebserver.RecordedRequest;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.paimon.rest.RESTObjectMapper.OBJECT_MAPPER;
+
 /** Mock a http web service locally. */
 public class TestHttpWebServer {
 
     private MockWebServer mockWebServer;
-    private final ObjectMapper objectMapper = RESTObjectMapper.create();
     private String baseUrl;
     private final String path;
 
@@ -63,17 +63,8 @@ public class TestHttpWebServer {
         mockWebServer.enqueue(mockResponseObj);
     }
 
-    public void enqueueResponse(RESTResponse response, Integer code)
-            throws JsonProcessingException {
-        enqueueResponse(createResponseBody(response), code);
-    }
-
     public String getBaseUrl() {
         return baseUrl;
-    }
-
-    public ObjectMapper getObjectMapper() {
-        return objectMapper;
     }
 
     public MockResponse generateMockResponse(String data, Integer code) {
@@ -84,15 +75,10 @@ public class TestHttpWebServer {
     }
 
     public String createResponseBody(RESTResponse response) throws JsonProcessingException {
-        return objectMapper.writeValueAsString(response);
+        return OBJECT_MAPPER.writeValueAsString(response);
     }
 
     public <T> T readRequestBody(String body, Class<T> requestType) throws JsonProcessingException {
-        return objectMapper.readValue(body, requestType);
-    }
-
-    public <T> T readResponseBody(String body, Class<T> responseType)
-            throws JsonProcessingException {
-        return objectMapper.readValue(body, responseType);
+        return OBJECT_MAPPER.readValue(body, requestType);
     }
 }

--- a/paimon-open-api/rest-catalog-open-api.yaml
+++ b/paimon-open-api/rest-catalog-open-api.yaml
@@ -664,7 +664,9 @@ components:
     GetTableResponse:
       type: object
       properties:
-        path:
+        id:
+          type: string
+        name:
           type: string
         schemaId:
           type: integer
@@ -850,6 +852,8 @@ components:
     GetDatabaseResponse:
       type: object
       properties:
+        id:
+          type: string
         name:
           type: string
         options:

--- a/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
+++ b/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
@@ -56,6 +56,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /** RESTCatalog management APIs. */
 @CrossOrigin(origins = "http://localhost:8081")
@@ -141,7 +142,7 @@ public class RESTCatalogController {
     public GetDatabaseResponse getDatabases(
             @PathVariable String prefix, @PathVariable String database) {
         Map<String, String> options = new HashMap<>();
-        return new GetDatabaseResponse("name", options);
+        return new GetDatabaseResponse(UUID.randomUUID().toString(), "name", options);
     }
 
     @Operation(
@@ -234,6 +235,7 @@ public class RESTCatalogController {
             @PathVariable String database,
             @PathVariable String table) {
         return new GetTableResponse(
+                UUID.randomUUID().toString(),
                 "",
                 1,
                 new org.apache.paimon.schema.Schema(
@@ -261,6 +263,7 @@ public class RESTCatalogController {
             @PathVariable String database,
             @RequestBody CreateTableRequest request) {
         return new GetTableResponse(
+                UUID.randomUUID().toString(),
                 "",
                 1,
                 new org.apache.paimon.schema.Schema(
@@ -293,6 +296,7 @@ public class RESTCatalogController {
             @PathVariable String table,
             @RequestBody AlterTableRequest request) {
         return new GetTableResponse(
+                UUID.randomUUID().toString(),
                 "",
                 1,
                 new org.apache.paimon.schema.Schema(
@@ -344,6 +348,7 @@ public class RESTCatalogController {
             @PathVariable String table,
             @RequestBody RenameTableRequest request) {
         return new GetTableResponse(
+                UUID.randomUUID().toString(),
                 "",
                 1,
                 new org.apache.paimon.schema.Schema(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
1. Table name should be added in `GetTableResponse`, for example, get bundle tables should return `List<GetTableResponse>`.
2. path should be removed, because it should be in options.
3. Add id to table and database.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
