### PR TITLE
[core] Fix invalidate tables with same tableNames in other db issue

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
@@ -178,7 +178,7 @@ public class CachingCatalog extends DelegateCatalog {
 
         // clear all branch tables of this table
         for (Identifier i : tableCache.asMap().keySet()) {
-            if (identifier.getTableName().equals(i.getTableName())) {
+            if (identifier.getTableName().equals(i.getTableName()) && identifier.getDatabaseName().equals(i.getDatabaseName())) {
                 tableCache.invalidate(i);
             }
         }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
@@ -178,7 +178,8 @@ public class CachingCatalog extends DelegateCatalog {
 
         // clear all branch tables of this table
         for (Identifier i : tableCache.asMap().keySet()) {
-            if (identifier.getTableName().equals(i.getTableName()) && identifier.getDatabaseName().equals(i.getDatabaseName())) {
+            if (identifier.getTableName().equals(i.getTableName())
+                    && identifier.getDatabaseName().equals(i.getDatabaseName())) {
                 tableCache.invalidate(i);
             }
         }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Fix invalidate tables with same tableNames in other db issue when dropTable in CachingCatalog
<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
