### PR TITLE
[core] Use table options if we have not specified partition-expire op…

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpirePartitionsActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpirePartitionsActionFactory.java
@@ -32,18 +32,16 @@ public class ExpirePartitionsActionFactory implements ActionFactory {
 
     @Override
     public Optional<Action> create(MultipleParameterToolAdapter params) {
-        String expireStrategy = params.get(EXPIRE_STRATEGY);
-        String timestampPattern = params.get(TIMESTAMP_PATTERN);
 
         return Optional.of(
                 new ExpirePartitionsAction(
                         params.getRequired(DATABASE),
                         params.getRequired(TABLE),
                         catalogConfigMap(params),
-                        params.getRequired(EXPIRATIONTIME),
-                        params.getRequired(TIMESTAMPFORMATTER),
-                        timestampPattern,
-                        expireStrategy));
+                        params.get(EXPIRATIONTIME),
+                        params.get(TIMESTAMPFORMATTER),
+                        params.get(TIMESTAMP_PATTERN),
+                        params.get(EXPIRE_STRATEGY)));
     }
 
     @Override

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/ExpirePartitionsProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/ExpirePartitionsProcedure.java
@@ -22,7 +22,8 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.FileStore;
 import org.apache.paimon.operation.PartitionExpire;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.utils.TimeUtils;
+import org.apache.paimon.utils.Preconditions;
+import org.apache.paimon.utils.StringUtils;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
@@ -47,7 +48,7 @@ public class ExpirePartitionsProcedure extends BaseProcedure {
     private static final ProcedureParameter[] PARAMETERS =
             new ProcedureParameter[] {
                 ProcedureParameter.required("table", StringType),
-                ProcedureParameter.required("expiration_time", StringType),
+                ProcedureParameter.optional("expiration_time", StringType),
                 ProcedureParameter.optional("timestamp_formatter", StringType),
                 ProcedureParameter.optional("timestamp_pattern", StringType),
                 ProcedureParameter.optional("expire_strategy", StringType),
@@ -87,24 +88,50 @@ public class ExpirePartitionsProcedure extends BaseProcedure {
                 table -> {
                     FileStoreTable fileStoreTable = (FileStoreTable) table;
                     FileStore fileStore = fileStoreTable.store();
-                    Map<String, String> map = new HashMap<>();
-                    map.put(CoreOptions.PARTITION_EXPIRATION_STRATEGY.key(), expireStrategy);
-                    map.put(CoreOptions.PARTITION_TIMESTAMP_FORMATTER.key(), timestampFormatter);
-                    map.put(CoreOptions.PARTITION_TIMESTAMP_PATTERN.key(), timestampPattern);
+
+                    HashMap<String, String> tableOptions =
+                            new HashMap<>(fileStore.options().toMap());
+                    // partition.expiration-time should not be null.
+                    setTableOptions(
+                            tableOptions,
+                            CoreOptions.PARTITION_EXPIRATION_TIME.key(),
+                            expirationTime);
+                    Preconditions.checkArgument(
+                            tableOptions.get(CoreOptions.PARTITION_EXPIRATION_TIME.key()) != null,
+                            String.format(
+                                    "%s should not be null",
+                                    CoreOptions.PARTITION_EXPIRATION_TIME.key()));
+
+                    setTableOptions(
+                            tableOptions,
+                            CoreOptions.PARTITION_TIMESTAMP_FORMATTER.key(),
+                            timestampFormatter);
+                    setTableOptions(
+                            tableOptions,
+                            CoreOptions.PARTITION_TIMESTAMP_PATTERN.key(),
+                            timestampPattern);
+                    setTableOptions(
+                            tableOptions,
+                            CoreOptions.PARTITION_EXPIRATION_STRATEGY.key(),
+                            expireStrategy);
+                    setTableOptions(
+                            tableOptions,
+                            CoreOptions.PARTITION_EXPIRATION_MAX_NUM.key(),
+                            maxExpires != null ? maxExpires.toString() : null);
+
+                    CoreOptions runtimeOptions = CoreOptions.fromMap(tableOptions);
 
                     PartitionExpire partitionExpire =
                             new PartitionExpire(
-                                    TimeUtils.parseDuration(expirationTime),
+                                    runtimeOptions.partitionExpireTime(),
                                     Duration.ofMillis(0L),
                                     createPartitionExpireStrategy(
-                                            CoreOptions.fromMap(map), fileStore.partitionType()),
+                                            runtimeOptions, fileStore.partitionType()),
                                     fileStore.newScan(),
                                     fileStore.newCommit(""),
                                     fileStoreTable.catalogEnvironment().partitionHandler(),
-                                    fileStore.options().partitionExpireMaxNum());
-                    if (maxExpires != null) {
-                        partitionExpire.withMaxExpireNum(maxExpires);
-                    }
+                                    runtimeOptions.partitionExpireMaxNum());
+
                     List<Map<String, String>> expired = partitionExpire.expire(Long.MAX_VALUE);
                     return expired == null || expired.isEmpty()
                             ? new InternalRow[] {
@@ -129,6 +156,12 @@ public class ExpirePartitionsProcedure extends BaseProcedure {
                 return new ExpirePartitionsProcedure(tableCatalog());
             }
         };
+    }
+
+    private void setTableOptions(HashMap<String, String> tableOptions, String key, String value) {
+        if (!StringUtils.isNullOrWhitespaceOnly(value)) {
+            tableOptions.put(key, value);
+        }
     }
 
     @Override


### PR DESCRIPTION
…tions.

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Should use table configuration if no partition expiration parameters are specified.

In most cases, these parameters are configured in the table configuration and do not need to be specified manually.


<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
