### PR TITLE
[Core]Refactor the orphan clean and expire function

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFilePathFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFilePathFactory.java
@@ -110,6 +110,14 @@ public class DataFilePathFactory {
         return new Path(aligned.externalPathDir().map(Path::new).orElse(parent), fileName);
     }
 
+    public Path toAlignedPath(String fileName, FileEntry aligned) {
+        Optional<String> externalPathDir =
+                Optional.ofNullable(aligned.externalPath())
+                        .map(Path::new)
+                        .map(p -> p.getParent().toUri().toString());
+        return new Path(externalPathDir.map(Path::new).orElse(parent), fileName);
+    }
+
     public static Path dataFileToFileIndexPath(Path dataFilePath) {
         return new Path(dataFilePath.getParent(), dataFilePath.getName() + INDEX_PATH_SUFFIX);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -97,7 +97,7 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
         // specially handle to clear snapshot dir
         cleanSnapshotDir(branches, deleteFiles::add, deletedFilesLenInBytes::addAndGet);
 
-        // delete candidate files
+        // get candidate files
         Map<String, Pair<Path, Long>> candidates = getCandidateDeletingFiles();
         if (candidates.isEmpty()) {
             return new CleanOrphanFilesResult(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -262,6 +262,14 @@ public abstract class OrphanFilesClean implements Serializable {
         paimonFileDirs.add(pathFactory.statisticsPath());
         paimonFileDirs.addAll(listFileDirs(pathFactory.dataFilePath(), partitionKeysNum));
 
+        // add external data paths
+        String dataFileExternalPaths = table.store().options().dataFileExternalPaths();
+        if (dataFileExternalPaths != null) {
+            String[] externalPathArr = dataFileExternalPaths.split(",");
+            for (String externalPath : externalPathArr) {
+                paimonFileDirs.addAll(listFileDirs(new Path(externalPath), partitionKeysNum));
+            }
+        }
         return paimonFileDirs;
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -25,6 +25,7 @@ import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.DataFilePathFactory;
 import org.apache.paimon.io.IndexIncrement;
 import org.apache.paimon.manifest.FileEntry;
 import org.apache.paimon.manifest.FileKind;
@@ -58,6 +59,7 @@ import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.CommitIncrement;
 import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.RecordWriter;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
@@ -643,11 +645,17 @@ public class TestFileStore extends KeyValueFileStore {
                         .flatMap(m -> manifestFile.read(m.fileName()).stream())
                         .collect(Collectors.toList());
         entries = new ArrayList<>(FileEntry.mergeEntries(entries));
+        Map<Pair<BinaryRow, Integer>, DataFilePathFactory> dataFilePathFactoryMap = new HashMap<>();
+
         for (ManifestEntry entry : entries) {
-            result.add(
-                    new Path(
-                            pathFactory.bucketPath(entry.partition(), entry.bucket()),
-                            entry.file().fileName()));
+            Pair<BinaryRow, Integer> bucket = Pair.of(entry.partition(), entry.bucket());
+            DataFilePathFactory dataFilePathFactory =
+                    dataFilePathFactoryMap.computeIfAbsent(
+                            bucket,
+                            b ->
+                                    pathFactory.createDataFilePathFactory(
+                                            entry.partition(), entry.bucket()));
+            result.add(dataFilePathFactory.toPath(entry));
         }
 
         // Add 'DELETE' 'APPEND' file in snapshot
@@ -666,10 +674,14 @@ public class TestFileStore extends KeyValueFileStore {
                 if (entry.kind() == FileKind.DELETE
                         && entry.file().fileSource().orElse(FileSource.APPEND)
                                 == FileSource.APPEND) {
-                    result.add(
-                            new Path(
-                                    pathFactory.bucketPath(entry.partition(), entry.bucket()),
-                                    entry.file().fileName()));
+                    Pair<BinaryRow, Integer> bucket = Pair.of(entry.partition(), entry.bucket());
+                    DataFilePathFactory dataFilePathFactory =
+                            dataFilePathFactoryMap.computeIfAbsent(
+                                    bucket,
+                                    b ->
+                                            pathFactory.createDataFilePathFactory(
+                                                    entry.partition(), entry.bucket()));
+                    result.add(dataFilePathFactory.toPath(entry));
                 }
             }
         }
@@ -694,6 +706,7 @@ public class TestFileStore extends KeyValueFileStore {
         // changelog file
         result.add(changelogPath);
 
+        Map<Pair<BinaryRow, Integer>, DataFilePathFactory> dataFilePathFactoryMap = new HashMap<>();
         // data file
         // not all manifests contains useful data file
         // (1) produceChangelog = 'true': data file in changelog manifests
@@ -716,10 +729,14 @@ public class TestFileStore extends KeyValueFileStore {
                             .collect(Collectors.toList());
             for (ManifestEntry entry : files) {
                 if (entry.file().fileSource().orElse(FileSource.APPEND) == FileSource.APPEND) {
-                    result.add(
-                            new Path(
-                                    pathFactory.bucketPath(entry.partition(), entry.bucket()),
-                                    entry.file().fileName()));
+                    Pair<BinaryRow, Integer> bucket = Pair.of(entry.partition(), entry.bucket());
+                    DataFilePathFactory dataFilePathFactory =
+                            dataFilePathFactoryMap.computeIfAbsent(
+                                    bucket,
+                                    b ->
+                                            pathFactory.createDataFilePathFactory(
+                                                    entry.partition(), entry.bucket()));
+                    result.add(dataFilePathFactory.toPath(entry));
                 }
             }
         } else if (changelog.changelogManifestList() != null) {
@@ -731,10 +748,14 @@ public class TestFileStore extends KeyValueFileStore {
                             .flatMap(m -> manifestFile.read(m.fileName()).stream())
                             .collect(Collectors.toList());
             for (ManifestEntry entry : files) {
-                result.add(
-                        new Path(
-                                pathFactory.bucketPath(entry.partition(), entry.bucket()),
-                                entry.file().fileName()));
+                Pair<BinaryRow, Integer> bucket = Pair.of(entry.partition(), entry.bucket());
+                DataFilePathFactory dataFilePathFactory =
+                        dataFilePathFactoryMap.computeIfAbsent(
+                                bucket,
+                                b ->
+                                        pathFactory.createDataFilePathFactory(
+                                                entry.partition(), entry.bucket()));
+                result.add(dataFilePathFactory.toPath(entry));
             }
         }
         return result;

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -115,14 +115,6 @@ public class ExpireSnapshotsTest {
                         .filter(p -> !filesInUse.contains(p))
                         .collect(Collectors.toList());
 
-        for (int i = 0; i < unusedFileList.size(); i++) {
-            System.out.println("qihouliang111= " + unusedFileList.get(i));
-        }
-
-        for (Path path : filesInUse) {
-            System.out.println("qihouliang222= " + path);
-        }
-
         // shuffle list
         ThreadLocalRandom random = ThreadLocalRandom.current();
         for (int i = unusedFileList.size() - 1; i > 0; i--) {

--- a/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
@@ -90,14 +90,14 @@ public class LocalOrphanFilesCleanTest {
     private static final Random RANDOM = new Random(System.currentTimeMillis());
 
     @TempDir private java.nio.file.Path tempDir;
-    private static Path tablePath;
+    @TempDir private java.nio.file.Path tmpExternalPath;
+    private Path tablePath;
     private FileIO fileIO;
     private RowType rowType;
     private FileStoreTable table;
     private TableWriteImpl<?> write;
     private TableCommitImpl commit;
     private Path manifestDir;
-    @TempDir private java.nio.file.Path tmpExternalPath;
     private long incrementalIdentifier;
     private List<Path> manuallyAddedFiles;
 

--- a/paimon-flink/paimon-flink-common/pom.xml
+++ b/paimon-flink/paimon-flink-common/pom.xml
@@ -184,12 +184,6 @@ under the License.
             <version>${okhttp.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-core</artifactId>
-            <version>1.18.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 

--- a/paimon-flink/paimon-flink-common/pom.xml
+++ b/paimon-flink/paimon-flink-common/pom.xml
@@ -184,6 +184,12 @@ under the License.
             <version>${okhttp.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>1.18.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ExpireTagsActionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ExpireTagsActionTest.java
@@ -69,11 +69,6 @@ public class ExpireTagsActionTest extends ActionITCaseBase {
     }
 
     public void expireTags() throws Exception {
-        bEnv.executeSql(
-                "CREATE TABLE T (id STRING, name STRING,"
-                        + " PRIMARY KEY (id) NOT ENFORCED)"
-                        + " WITH ('bucket'='1', 'write-only'='true')");
-
         FileStoreTable table = getFileStoreTable("T");
 
         // generate 5 snapshots


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Due to the introduction of an external path[1], the data file may not exist in the warehouse path,
so the expire function needs to be refactored.
This job is a part of this job[2]

[1] https://github.com/apache/paimon/pull/4751
[2] https://cwiki.apache.org/confluence/display/PAIMON/PIP-29%3A+Introduce+Table+Multi-Location++Management

### Tests

Refactor the LocalOrphanFilesCleanTest

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
