### PR TITLE
[core] Introduce SnapshotCommit to abstract atomically commit

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -19,6 +19,8 @@
 package org.apache.paimon;
 
 import org.apache.paimon.CoreOptions.ExternalPathStrategy;
+import org.apache.paimon.catalog.RenamingSnapshotCommit;
+import org.apache.paimon.catalog.SnapshotCommit;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.deletionvectors.DeletionVectorsIndexFile;
 import org.apache.paimon.fs.FileIO;
@@ -31,6 +33,7 @@ import org.apache.paimon.manifest.ManifestList;
 import org.apache.paimon.metastore.AddPartitionTagCallback;
 import org.apache.paimon.operation.ChangelogDeletion;
 import org.apache.paimon.operation.FileStoreCommitImpl;
+import org.apache.paimon.operation.Lock;
 import org.apache.paimon.operation.ManifestsReader;
 import org.apache.paimon.operation.PartitionExpire;
 import org.apache.paimon.operation.SnapshotDeletion;
@@ -261,7 +264,14 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
 
     @Override
     public FileStoreCommitImpl newCommit(String commitUser, List<CommitCallback> callbacks) {
+        SnapshotManager snapshotManager = snapshotManager();
+        SnapshotCommit snapshotCommit = catalogEnvironment.snapshotCommit(snapshotManager);
+        if (snapshotCommit == null) {
+            snapshotCommit =
+                    new RenamingSnapshotCommit(snapshotManager, Lock.emptyFactory().create());
+        }
         return new FileStoreCommitImpl(
+                snapshotCommit,
                 fileIO,
                 schemaManager,
                 tableName,
@@ -270,7 +280,7 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 options,
                 options.partitionDefaultName(),
                 pathFactory(),
-                snapshotManager(),
+                snapshotManager,
                 manifestFileFactory(),
                 manifestListFactory(),
                 indexManifestFileFactory(),

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -24,7 +24,6 @@ import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileStatus;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.operation.FileStoreCommit;
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.schema.Schema;
@@ -367,9 +366,10 @@ public abstract class AbstractCatalog implements Catalog {
 
     @Override
     public Table getTable(Identifier identifier) throws TableNotExistException {
-        Lock.Factory lockFactory =
-                Lock.factory(lockFactory().orElse(null), lockContext().orElse(null), identifier);
-        return CatalogUtils.loadTable(this, identifier, this::loadTableMetadata, lockFactory);
+        SnapshotCommit.Factory commitFactory =
+                new RenamingSnapshotCommit.Factory(
+                        lockFactory().orElse(null), lockContext().orElse(null));
+        return CatalogUtils.loadTable(this, identifier, this::loadTableMetadata, commitFactory);
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
@@ -23,7 +23,6 @@ import org.apache.paimon.TableType;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.PartitionEntry;
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.schema.SchemaManager;
@@ -173,7 +172,7 @@ public class CatalogUtils {
             Catalog catalog,
             Identifier identifier,
             TableMetadata.Loader metadataLoader,
-            Lock.Factory lockFactory)
+            SnapshotCommit.Factory commitFactory)
             throws Catalog.TableNotExistException {
         if (SYSTEM_DATABASE_NAME.equals(identifier.getDatabaseName())) {
             return CatalogUtils.createGlobalSystemTable(identifier.getTableName(), catalog);
@@ -188,7 +187,7 @@ public class CatalogUtils {
 
         CatalogEnvironment catalogEnv =
                 new CatalogEnvironment(
-                        identifier, metadata.uuid(), lockFactory, catalog.catalogLoader());
+                        identifier, metadata.uuid(), catalog.catalogLoader(), commitFactory);
         Path path = new Path(schema.options().get(PATH.key()));
         FileStoreTable table =
                 FileStoreTableFactory.create(catalog.fileIO(), path, schema, catalogEnv);

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import static org.apache.paimon.options.CatalogOptions.CASE_SENSITIVE;
@@ -117,20 +118,30 @@ public class FileSystemCatalog extends AbstractCatalog {
 
     @Override
     public void createTableImpl(Identifier identifier, Schema schema) {
-        uncheck(() -> schemaManager(identifier).createTable(schema));
+        SchemaManager schemaManager = schemaManager(identifier);
+        try {
+            runWithLock(identifier, () -> uncheck(() -> schemaManager.createTable(schema)));
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public <T> T runWithLock(Identifier identifier, Callable<T> callable) throws Exception {
+        Optional<CatalogLockFactory> lockFactory = lockFactory();
+        try (Lock lock =
+                lockFactory
+                        .map(factory -> factory.createLock(lockContext().orElse(null)))
+                        .map(l -> Lock.fromCatalog(l, identifier))
+                        .orElseGet(() -> Lock.emptyFactory().create())) {
+            return lock.runWithLock(callable);
+        }
     }
 
     private SchemaManager schemaManager(Identifier identifier) {
         Path path = getTableLocation(identifier);
-        CatalogLock catalogLock =
-                lockFactory().map(fac -> fac.createLock(assertGetLockContext())).orElse(null);
-        return new SchemaManager(fileIO, path, identifier.getBranchNameOrDefault())
-                .withLock(catalogLock == null ? null : Lock.fromCatalog(catalogLock, identifier));
-    }
-
-    private CatalogLockContext assertGetLockContext() {
-        return lockContext()
-                .orElseThrow(() -> new RuntimeException("No lock context when lock is enabled."));
+        return new SchemaManager(fileIO, path, identifier.getBranchNameOrDefault());
     }
 
     @Override
@@ -143,7 +154,17 @@ public class FileSystemCatalog extends AbstractCatalog {
     @Override
     protected void alterTableImpl(Identifier identifier, List<SchemaChange> changes)
             throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException {
-        schemaManager(identifier).commitChanges(changes);
+        SchemaManager schemaManager = schemaManager(identifier);
+        try {
+            runWithLock(identifier, () -> schemaManager.commitChanges(changes));
+        } catch (TableNotExistException
+                | ColumnAlreadyExistException
+                | ColumnNotExistException
+                | RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     protected static <T> T uncheck(Callable<T> callable) {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Identifier.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Identifier.java
@@ -92,7 +92,7 @@ public class Identifier implements Serializable {
         this.database = database;
 
         StringBuilder builder = new StringBuilder(table);
-        if (branch != null) {
+        if (branch != null && !"main".equalsIgnoreCase(branch)) {
             builder.append(Catalog.SYSTEM_TABLE_SPLITTER)
                     .append(Catalog.SYSTEM_BRANCH_PREFIX)
                     .append(branch);

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/RenamingSnapshotCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/RenamingSnapshotCommit.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.catalog;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.operation.Lock;
+import org.apache.paimon.utils.SnapshotManager;
+
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+import static org.apache.paimon.utils.BranchManager.DEFAULT_MAIN_BRANCH;
+
+/**
+ * A {@link SnapshotCommit} using file renaming to commit.
+ *
+ * <p>Note that when the file system is local or HDFS, rename is atomic. But if the file system is
+ * object storage, we need additional lock protection.
+ */
+public class RenamingSnapshotCommit implements SnapshotCommit {
+
+    private final SnapshotManager snapshotManager;
+    private final FileIO fileIO;
+    private final Lock lock;
+
+    public RenamingSnapshotCommit(SnapshotManager snapshotManager, Lock lock) {
+        this.snapshotManager = snapshotManager;
+        this.fileIO = snapshotManager.fileIO();
+        this.lock = lock;
+    }
+
+    @Override
+    public boolean commit(Snapshot snapshot, @Nullable String branch) throws Exception {
+        Path newSnapshotPath =
+                branch == null || branch.equals(DEFAULT_MAIN_BRANCH)
+                        ? snapshotManager.snapshotPath(snapshot.id())
+                        : snapshotManager.copyWithBranch(branch).snapshotPath(snapshot.id());
+
+        Callable<Boolean> callable =
+                () -> {
+                    boolean committed = fileIO.tryToWriteAtomic(newSnapshotPath, snapshot.toJson());
+                    if (committed) {
+                        snapshotManager.commitLatestHint(snapshot.id());
+                    }
+                    return committed;
+                };
+        return lock.runWithLock(
+                () ->
+                        // fs.rename may not returns false if target file
+                        // already exists, or even not atomic
+                        // as we're relying on external locking, we can first
+                        // check if file exist then rename to work around this
+                        // case
+                        !fileIO.exists(newSnapshotPath) && callable.call());
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.lock.close();
+    }
+
+    /** Factory to create {@link RenamingSnapshotCommit}. */
+    public static class Factory implements SnapshotCommit.Factory {
+
+        private static final long serialVersionUID = 1L;
+
+        @Nullable private final CatalogLockFactory lockFactory;
+        @Nullable private final CatalogLockContext lockContext;
+
+        public Factory(
+                @Nullable CatalogLockFactory lockFactory,
+                @Nullable CatalogLockContext lockContext) {
+            this.lockFactory = lockFactory;
+            this.lockContext = lockContext;
+        }
+
+        @Override
+        public SnapshotCommit create(Identifier identifier, SnapshotManager snapshotManager) {
+            Lock lock =
+                    Optional.ofNullable(lockFactory)
+                            .map(factory -> factory.createLock(lockContext))
+                            .map(l -> Lock.fromCatalog(l, identifier))
+                            .orElseGet(() -> Lock.emptyFactory().create());
+            return new RenamingSnapshotCommit(snapshotManager, lock);
+        }
+
+        @VisibleForTesting
+        @Nullable
+        public CatalogLockFactory lockFactory() {
+            return lockFactory;
+        }
+
+        @VisibleForTesting
+        @Nullable
+        public CatalogLockContext lockContext() {
+            return lockContext;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/RenamingSnapshotCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/RenamingSnapshotCommit.java
@@ -30,8 +30,6 @@ import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 
-import static org.apache.paimon.utils.BranchManager.DEFAULT_MAIN_BRANCH;
-
 /**
  * A {@link SnapshotCommit} using file renaming to commit.
  *
@@ -51,9 +49,9 @@ public class RenamingSnapshotCommit implements SnapshotCommit {
     }
 
     @Override
-    public boolean commit(Snapshot snapshot, @Nullable String branch) throws Exception {
+    public boolean commit(Snapshot snapshot, String branch) throws Exception {
         Path newSnapshotPath =
-                branch == null || branch.equals(DEFAULT_MAIN_BRANCH)
+                snapshotManager.branch().equals(branch)
                         ? snapshotManager.snapshotPath(snapshot.id())
                         : snapshotManager.copyWithBranch(branch).snapshotPath(snapshot.id());
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/SnapshotCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/SnapshotCommit.java
@@ -21,14 +21,12 @@ package org.apache.paimon.catalog;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.utils.SnapshotManager;
 
-import javax.annotation.Nullable;
-
 import java.io.Serializable;
 
 /** Interface to commit snapshot atomically. */
 public interface SnapshotCommit extends AutoCloseable {
 
-    boolean commit(Snapshot snapshot, @Nullable String branch) throws Exception;
+    boolean commit(Snapshot snapshot, String branch) throws Exception;
 
     /** Factory to create {@link SnapshotCommit}. */
     interface Factory extends Serializable {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/SnapshotCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/SnapshotCommit.java
@@ -16,27 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.rest;
+package org.apache.paimon.catalog;
 
-import org.apache.paimon.catalog.CatalogLoader;
-import org.apache.paimon.fs.FileIO;
-import org.apache.paimon.options.Options;
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.utils.SnapshotManager;
 
-/** Loader to create {@link RESTCatalog}. */
-public class RESTCatalogLoader implements CatalogLoader {
+import javax.annotation.Nullable;
 
-    private static final long serialVersionUID = 1L;
+import java.io.Serializable;
 
-    private final Options options;
-    private final FileIO fileIO;
+/** Interface to commit snapshot atomically. */
+public interface SnapshotCommit extends AutoCloseable {
 
-    public RESTCatalogLoader(Options options, FileIO fileIO) {
-        this.options = options;
-        this.fileIO = fileIO;
-    }
+    boolean commit(Snapshot snapshot, @Nullable String branch) throws Exception;
 
-    @Override
-    public RESTCatalog load() {
-        return new RESTCatalog(options, fileIO);
+    /** Factory to create {@link SnapshotCommit}. */
+    interface Factory extends Serializable {
+        SnapshotCommit create(Identifier identifier, SnapshotManager snapshotManager);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
@@ -57,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.jdbc.JdbcCatalogLock.acquireTimeout;
@@ -289,7 +290,8 @@ public class JdbcCatalog extends AbstractCatalog {
     protected void createTableImpl(Identifier identifier, Schema schema) {
         try {
             // create table file
-            getSchemaManager(identifier).createTable(schema);
+            SchemaManager schemaManager = getSchemaManager(identifier);
+            runWithLock(identifier, () -> schemaManager.createTable(schema));
             // Update schema metadata
             Path path = getTableLocation(identifier);
             int insertRecord =
@@ -350,10 +352,19 @@ public class JdbcCatalog extends AbstractCatalog {
 
     @Override
     protected void alterTableImpl(Identifier identifier, List<SchemaChange> changes)
-            throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException {
+            throws ColumnAlreadyExistException, TableNotExistException, ColumnNotExistException {
         assertMainBranch(identifier);
         SchemaManager schemaManager = getSchemaManager(identifier);
-        schemaManager.commitChanges(changes);
+        try {
+            runWithLock(identifier, () -> schemaManager.commitChanges(changes));
+        } catch (TableNotExistException
+                | ColumnAlreadyExistException
+                | ColumnNotExistException
+                | RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to alter table " + identifier.getFullName(), e);
+        }
     }
 
     @Override
@@ -384,9 +395,9 @@ public class JdbcCatalog extends AbstractCatalog {
         return Optional.of(new JdbcCatalogLockContext(catalogKey, options));
     }
 
-    private Lock lock(Identifier identifier) {
+    public <T> T runWithLock(Identifier identifier, Callable<T> callable) throws Exception {
         if (!lockEnabled()) {
-            return new Lock.EmptyLock();
+            return callable.call();
         }
         JdbcCatalogLock lock =
                 new JdbcCatalogLock(
@@ -394,7 +405,7 @@ public class JdbcCatalog extends AbstractCatalog {
                         catalogKey,
                         checkMaxSleep(options.toMap()),
                         acquireTimeout(options.toMap()));
-        return Lock.fromCatalog(lock, identifier);
+        return Lock.fromCatalog(lock, identifier).runWithLock(callable);
     }
 
     @Override
@@ -403,7 +414,7 @@ public class JdbcCatalog extends AbstractCatalog {
     }
 
     private SchemaManager getSchemaManager(Identifier identifier) {
-        return new SchemaManager(fileIO, getTableLocation(identifier)).withLock(lock(identifier));
+        return new SchemaManager(fileIO, getTableLocation(identifier));
     }
 
     private Map<String, String> fetchProperties(String databaseName) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
@@ -32,9 +32,6 @@ import java.util.Map;
 /** Commit operation which provides commit and overwrite. */
 public interface FileStoreCommit extends AutoCloseable {
 
-    /** With global lock. */
-    FileStoreCommit withLock(Lock lock);
-
     FileStoreCommit ignoreEmptyCommit(boolean ignoreEmptyCommit);
 
     FileStoreCommit withPartitionExpire(PartitionExpire partitionExpire);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -21,10 +21,10 @@ package org.apache.paimon.operation;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.catalog.SnapshotCommit;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.FileIO;
-import org.apache.paimon.fs.Path;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFilePathFactory;
 import org.apache.paimon.manifest.FileEntry;
@@ -75,7 +75,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.deletionvectors.DeletionVectorsIndexFile.DELETION_VECTORS_INDEX;
@@ -85,7 +84,6 @@ import static org.apache.paimon.manifest.ManifestEntry.recordCountAdd;
 import static org.apache.paimon.manifest.ManifestEntry.recordCountDelete;
 import static org.apache.paimon.partition.PartitionPredicate.createBinaryPartitions;
 import static org.apache.paimon.partition.PartitionPredicate.createPartitionPredicate;
-import static org.apache.paimon.utils.BranchManager.DEFAULT_MAIN_BRANCH;
 import static org.apache.paimon.utils.InternalRowPartitionComputer.partToSimpleString;
 
 /**
@@ -94,12 +92,12 @@ import static org.apache.paimon.utils.InternalRowPartitionComputer.partToSimpleS
  * <p>This class provides an atomic commit method to the user.
  *
  * <ol>
- *   <li>Before calling {@link FileStoreCommitImpl#commit}, if user cannot determine if this commit
- *       is done before, user should first call {@link FileStoreCommitImpl#filterCommitted}.
+ *   <li>Before calling {@link #commit(ManifestCommittable, Map)}, if user cannot determine if this
+ *       commit is done before, user should first call {@link #filterCommitted}.
  *   <li>Before committing, it will first check for conflicts by checking if all files to be removed
  *       currently exists, and if modified files have overlapping key ranges with existing files.
- *   <li>After that it use the external {@link FileStoreCommitImpl#lock} (if provided) or the atomic
- *       rename of the file system to ensure atomicity.
+ *   <li>After that it use the external {@link SnapshotCommit} (if provided) or the atomic rename of
+ *       the file system to ensure atomicity.
  *   <li>If commit fails due to conflicts or exception it tries its best to clean up and aborts.
  *   <li>If atomic rename fails it tries again after reading the latest snapshot from step 2.
  * </ol>
@@ -112,6 +110,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
     private static final Logger LOG = LoggerFactory.getLogger(FileStoreCommitImpl.class);
 
+    private final SnapshotCommit snapshotCommit;
     private final FileIO fileIO;
     private final SchemaManager schemaManager;
     private final String tableName;
@@ -135,15 +134,15 @@ public class FileStoreCommitImpl implements FileStoreCommit {
     private final List<CommitCallback> commitCallbacks;
     private final StatsFileHandler statsFileHandler;
     private final BucketMode bucketMode;
-    private long commitTimeout;
+    private final long commitTimeout;
     private final int commitMaxRetries;
 
-    @Nullable private Lock lock;
     private boolean ignoreEmptyCommit;
     private CommitMetrics commitMetrics;
     @Nullable private PartitionExpire partitionExpire;
 
     public FileStoreCommitImpl(
+            SnapshotCommit snapshotCommit,
             FileIO fileIO,
             SchemaManager schemaManager,
             String tableName,
@@ -170,6 +169,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             List<CommitCallback> commitCallbacks,
             int commitMaxRetries,
             long commitTimeout) {
+        this.snapshotCommit = snapshotCommit;
         this.fileIO = fileIO;
         this.schemaManager = schemaManager;
         this.tableName = tableName;
@@ -198,17 +198,10 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         this.commitMaxRetries = commitMaxRetries;
         this.commitTimeout = commitTimeout;
 
-        this.lock = null;
         this.ignoreEmptyCommit = true;
         this.commitMetrics = null;
         this.statsFileHandler = statsFileHandler;
         this.bucketMode = bucketMode;
-    }
-
-    @Override
-    public FileStoreCommit withLock(Lock lock) {
-        this.lock = lock;
-        return this;
     }
 
     @Override
@@ -846,10 +839,6 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         long startMillis = System.currentTimeMillis();
         long newSnapshotId =
                 latestSnapshot == null ? Snapshot.FIRST_SNAPSHOT_ID : latestSnapshot.id() + 1;
-        Path newSnapshotPath =
-                branchName.equals(DEFAULT_MAIN_BRANCH)
-                        ? snapshotManager.snapshotPath(newSnapshotId)
-                        : snapshotManager.copyWithBranch(branchName).snapshotPath(newSnapshotId);
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Ready to commit table files to snapshot {}", newSnapshotId);
@@ -1016,27 +1005,19 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             cleanUpNoReuseTmpManifests(baseManifestList, mergeBeforeManifests, mergeAfterManifests);
             throw new RuntimeException(
                     String.format(
-                            "Exception occurs when preparing snapshot #%d (path %s) by user %s "
+                            "Exception occurs when preparing snapshot #%d by user %s "
                                     + "with hash %s and kind %s. Clean up.",
-                            newSnapshotId,
-                            newSnapshotPath.toString(),
-                            commitUser,
-                            identifier,
-                            commitKind.name()),
+                            newSnapshotId, commitUser, identifier, commitKind.name()),
                     e);
         }
 
-        if (commitSnapshotImpl(newSnapshot, newSnapshotPath)) {
+        if (commitSnapshotImpl(newSnapshot)) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug(
                         String.format(
-                                "Successfully commit snapshot #%d (path %s) by user %s "
+                                "Successfully commit snapshot #%d by user %s "
                                         + "with identifier %s and kind %s.",
-                                newSnapshotId,
-                                newSnapshotPath,
-                                commitUser,
-                                identifier,
-                                commitKind.name()));
+                                newSnapshotId, commitUser, identifier, commitKind.name()));
             }
             commitCallbacks.forEach(callback -> callback.call(deltaFiles, newSnapshot));
             return new SuccessResult();
@@ -1046,15 +1027,10 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         long commitTime = (System.currentTimeMillis() - startMillis) / 1000;
         LOG.warn(
                 String.format(
-                        "Atomic commit failed for snapshot #%d (path %s) by user %s "
+                        "Atomic commit failed for snapshot #%d by user %s "
                                 + "with identifier %s and kind %s after %s seconds. "
                                 + "Clean up and try again.",
-                        newSnapshotId,
-                        newSnapshotPath,
-                        commitUser,
-                        identifier,
-                        commitKind.name(),
-                        commitTime));
+                        newSnapshotId, commitUser, identifier, commitKind.name(), commitTime));
         cleanUpNoReuseTmpManifests(baseManifestList, mergeBeforeManifests, mergeAfterManifests);
         return new RetryResult(
                 deltaManifestList,
@@ -1163,12 +1139,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         latestSnapshot.watermark(),
                         latestSnapshot.statistics());
 
-        Path newSnapshotPath =
-                branchName.equals(DEFAULT_MAIN_BRANCH)
-                        ? snapshotManager.snapshotPath(newSnapshot.id())
-                        : snapshotManager.copyWithBranch(branchName).snapshotPath(newSnapshot.id());
-
-        if (!commitSnapshotImpl(newSnapshot, newSnapshotPath)) {
+        if (!commitSnapshotImpl(newSnapshot)) {
             return new ManifestCompactResult(
                     baseManifestList, deltaManifestList, mergeBeforeManifests, mergeAfterManifests);
         } else {
@@ -1176,39 +1147,18 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         }
     }
 
-    private boolean commitSnapshotImpl(Snapshot newSnapshot, Path newSnapshotPath) {
+    private boolean commitSnapshotImpl(Snapshot newSnapshot) {
         try {
-            Callable<Boolean> callable =
-                    () -> {
-                        boolean committed =
-                                fileIO.tryToWriteAtomic(newSnapshotPath, newSnapshot.toJson());
-                        if (committed) {
-                            snapshotManager.commitLatestHint(newSnapshot.id());
-                        }
-                        return committed;
-                    };
-            if (lock != null) {
-                return lock.runWithLock(
-                        () ->
-                                // fs.rename may not returns false if target file
-                                // already exists, or even not atomic
-                                // as we're relying on external locking, we can first
-                                // check if file exist then rename to work around this
-                                // case
-                                !fileIO.exists(newSnapshotPath) && callable.call());
-            } else {
-                return callable.call();
-            }
+            return snapshotCommit.commit(newSnapshot, branchName);
         } catch (Throwable e) {
             // exception when performing the atomic rename,
             // we cannot clean up because we can't determine the success
             throw new RuntimeException(
                     String.format(
-                            "Exception occurs when committing snapshot #%d (path %s) by user %s "
+                            "Exception occurs when committing snapshot #%d by user %s "
                                     + "with identifier %s and kind %s. "
                                     + "Cannot clean up because we can't determine the success.",
                             newSnapshot.id(),
-                            newSnapshotPath,
                             commitUser,
                             newSnapshot.commitIdentifier(),
                             newSnapshot.commitKind().name()),
@@ -1505,6 +1455,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         for (CommitCallback callback : commitCallbacks) {
             IOUtils.closeQuietly(callback);
         }
+        IOUtils.closeQuietly(snapshotCommit);
     }
 
     private static class LevelIdentifier {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
@@ -95,11 +95,6 @@ public class PartitionExpire {
                 maxExpireNum);
     }
 
-    public PartitionExpire withLock(Lock lock) {
-        this.commit.withLock(lock);
-        return this;
-    }
-
     public PartitionExpire withMaxExpireNum(int maxExpireNum) {
         this.maxExpireNum = maxExpireNum;
         return this;

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -18,9 +18,9 @@
 
 package org.apache.paimon.rest;
 
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
-import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.CatalogUtils;
 import org.apache.paimon.catalog.Database;
 import org.apache.paimon.catalog.Identifier;
@@ -29,7 +29,6 @@ import org.apache.paimon.catalog.TableMetadata;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.operation.FileStoreCommit;
-import org.apache.paimon.operation.Lock;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
@@ -42,6 +41,7 @@ import org.apache.paimon.rest.exceptions.ServiceFailureException;
 import org.apache.paimon.rest.requests.AlterDatabaseRequest;
 import org.apache.paimon.rest.requests.AlterPartitionsRequest;
 import org.apache.paimon.rest.requests.AlterTableRequest;
+import org.apache.paimon.rest.requests.CommitTableRequest;
 import org.apache.paimon.rest.requests.CreateDatabaseRequest;
 import org.apache.paimon.rest.requests.CreatePartitionsRequest;
 import org.apache.paimon.rest.requests.CreateTableRequest;
@@ -49,6 +49,7 @@ import org.apache.paimon.rest.requests.DropPartitionsRequest;
 import org.apache.paimon.rest.requests.MarkDonePartitionsRequest;
 import org.apache.paimon.rest.requests.RenameTableRequest;
 import org.apache.paimon.rest.responses.AlterDatabaseResponse;
+import org.apache.paimon.rest.responses.CommitTableResponse;
 import org.apache.paimon.rest.responses.ConfigResponse;
 import org.apache.paimon.rest.responses.CreateDatabaseResponse;
 import org.apache.paimon.rest.responses.ErrorResponseResourceType;
@@ -69,6 +70,8 @@ import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -154,7 +157,7 @@ public class RESTCatalog implements Catalog {
     }
 
     @Override
-    public CatalogLoader catalogLoader() {
+    public RESTCatalogLoader catalogLoader() {
         return new RESTCatalogLoader(options, fileIO);
     }
 
@@ -278,9 +281,24 @@ public class RESTCatalog implements Catalog {
 
     @Override
     public Table getTable(Identifier identifier) throws TableNotExistException {
-        // TODO add lock from server
         return CatalogUtils.loadTable(
-                this, identifier, this::loadTableMetadata, Lock.emptyFactory());
+                this,
+                identifier,
+                this::loadTableMetadata,
+                new RESTSnapshotCommitFactory(catalogLoader()));
+    }
+
+    public boolean commitSnapshot(
+            Identifier identifier, Snapshot snapshot, @Nullable String branch) {
+        CommitTableRequest request = new CommitTableRequest(identifier, snapshot, branch);
+        CommitTableResponse response =
+                client.post(
+                        resourcePaths.commitTable(
+                                identifier.getDatabaseName(), identifier.getTableName()),
+                        request,
+                        CommitTableResponse.class,
+                        headers());
+        return response.isSuccess();
     }
 
     private TableMetadata loadTableMetadata(Identifier identifier) throws TableNotExistException {

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -71,8 +71,6 @@ import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -288,9 +286,8 @@ public class RESTCatalog implements Catalog {
                 new RESTSnapshotCommitFactory(catalogLoader()));
     }
 
-    public boolean commitSnapshot(
-            Identifier identifier, Snapshot snapshot, @Nullable String branch) {
-        CommitTableRequest request = new CommitTableRequest(identifier, snapshot, branch);
+    public boolean commitSnapshot(Identifier identifier, Snapshot snapshot) {
+        CommitTableRequest request = new CommitTableRequest(identifier, snapshot);
         CommitTableResponse response =
                 client.post(
                         resourcePaths.commitTable(

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTSnapshotCommitFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTSnapshotCommitFactory.java
@@ -23,8 +23,6 @@ import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.catalog.SnapshotCommit;
 import org.apache.paimon.utils.SnapshotManager;
 
-import javax.annotation.Nullable;
-
 /** Factory to create {@link SnapshotCommit} for REST Catalog. */
 public class RESTSnapshotCommitFactory implements SnapshotCommit.Factory {
 
@@ -41,8 +39,11 @@ public class RESTSnapshotCommitFactory implements SnapshotCommit.Factory {
         RESTCatalog catalog = loader.load();
         return new SnapshotCommit() {
             @Override
-            public boolean commit(Snapshot snapshot, @Nullable String branch) {
-                return catalog.commitSnapshot(identifier, snapshot, branch);
+            public boolean commit(Snapshot snapshot, String branch) {
+                Identifier newIdentifier =
+                        new Identifier(
+                                identifier.getDatabaseName(), identifier.getTableName(), branch);
+                return catalog.commitSnapshot(newIdentifier, snapshot);
             }
 
             @Override

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTSnapshotCommitFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTSnapshotCommitFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.SnapshotCommit;
+import org.apache.paimon.utils.SnapshotManager;
+
+import javax.annotation.Nullable;
+
+/** Factory to create {@link SnapshotCommit} for REST Catalog. */
+public class RESTSnapshotCommitFactory implements SnapshotCommit.Factory {
+
+    private static final long serialVersionUID = 1L;
+
+    private final RESTCatalogLoader loader;
+
+    public RESTSnapshotCommitFactory(RESTCatalogLoader loader) {
+        this.loader = loader;
+    }
+
+    @Override
+    public SnapshotCommit create(Identifier identifier, SnapshotManager snapshotManager) {
+        RESTCatalog catalog = loader.load();
+        return new SnapshotCommit() {
+            @Override
+            public boolean commit(Snapshot snapshot, @Nullable String branch) {
+                return catalog.commitSnapshot(identifier, snapshot, branch);
+            }
+
+            @Override
+            public void close() throws Exception {
+                catalog.close();
+            }
+        };
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/rest/ResourcePaths.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/ResourcePaths.java
@@ -66,6 +66,10 @@ public class ResourcePaths {
         return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, tableName, "rename");
     }
 
+    public String commitTable(String databaseName, String tableName) {
+        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, tableName, "commit");
+    }
+
     public String partitions(String databaseName, String tableName) {
         return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, tableName, "partitions");
     }

--- a/paimon-core/src/main/java/org/apache/paimon/rest/requests/CommitTableRequest.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/requests/CommitTableRequest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest.requests;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.rest.RESTRequest;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+/** Request for committing snapshot to table. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CommitTableRequest implements RESTRequest {
+
+    private static final String FIELD_IDENTIFIER = "identifier";
+    private static final String FIELD_SNAPSHOT = "snapshot";
+    private static final String FIELD_BRANCH = "branch";
+
+    @JsonProperty(FIELD_IDENTIFIER)
+    private final Identifier identifier;
+
+    @JsonProperty(FIELD_SNAPSHOT)
+    private final Snapshot snapshot;
+
+    @JsonProperty(FIELD_BRANCH)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Nullable
+    private final String branch;
+
+    @JsonCreator
+    public CommitTableRequest(
+            @JsonProperty(FIELD_IDENTIFIER) Identifier identifier,
+            @JsonProperty(FIELD_SNAPSHOT) Snapshot snapshot,
+            @JsonProperty(FIELD_BRANCH) @Nullable String branch) {
+        this.identifier = identifier;
+        this.snapshot = snapshot;
+        this.branch = branch;
+    }
+
+    @JsonGetter(FIELD_IDENTIFIER)
+    public Identifier getIdentifier() {
+        return identifier;
+    }
+
+    @JsonGetter(FIELD_SNAPSHOT)
+    public Snapshot getSnapshot() {
+        return snapshot;
+    }
+
+    @JsonGetter(FIELD_BRANCH)
+    @Nullable
+    public String getBranch() {
+        return branch;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/rest/requests/CommitTableRequest.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/requests/CommitTableRequest.java
@@ -25,10 +25,7 @@ import org.apache.paimon.rest.RESTRequest;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
-
-import javax.annotation.Nullable;
 
 /** Request for committing snapshot to table. */
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -36,7 +33,6 @@ public class CommitTableRequest implements RESTRequest {
 
     private static final String FIELD_IDENTIFIER = "identifier";
     private static final String FIELD_SNAPSHOT = "snapshot";
-    private static final String FIELD_BRANCH = "branch";
 
     @JsonProperty(FIELD_IDENTIFIER)
     private final Identifier identifier;
@@ -44,19 +40,12 @@ public class CommitTableRequest implements RESTRequest {
     @JsonProperty(FIELD_SNAPSHOT)
     private final Snapshot snapshot;
 
-    @JsonProperty(FIELD_BRANCH)
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @Nullable
-    private final String branch;
-
     @JsonCreator
     public CommitTableRequest(
             @JsonProperty(FIELD_IDENTIFIER) Identifier identifier,
-            @JsonProperty(FIELD_SNAPSHOT) Snapshot snapshot,
-            @JsonProperty(FIELD_BRANCH) @Nullable String branch) {
+            @JsonProperty(FIELD_SNAPSHOT) Snapshot snapshot) {
         this.identifier = identifier;
         this.snapshot = snapshot;
-        this.branch = branch;
     }
 
     @JsonGetter(FIELD_IDENTIFIER)
@@ -67,11 +56,5 @@ public class CommitTableRequest implements RESTRequest {
     @JsonGetter(FIELD_SNAPSHOT)
     public Snapshot getSnapshot() {
         return snapshot;
-    }
-
-    @JsonGetter(FIELD_BRANCH)
-    @Nullable
-    public String getBranch() {
-        return branch;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/rest/responses/CommitTableResponse.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/responses/CommitTableResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest.responses;
+
+import org.apache.paimon.rest.RESTResponse;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Response for committing snapshot to table. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CommitTableResponse implements RESTResponse {
+
+    private static final String FIELD_SUCCESS = "success";
+
+    @JsonProperty(FIELD_SUCCESS)
+    private final boolean success;
+
+    @JsonCreator
+    public CommitTableResponse(@JsonProperty(FIELD_SUCCESS) boolean success) {
+        this.success = success;
+    }
+
+    @JsonGetter(FIELD_SUCCESS)
+    public boolean isSuccess() {
+        return success;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -451,7 +451,6 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
                 snapshotExpire,
                 options.writeOnly() ? null : store().newPartitionExpire(commitUser),
                 options.writeOnly() ? null : store().newTagCreationManager(),
-                catalogEnvironment.lockFactory().create(),
                 CoreOptions.fromMap(options()).consumerExpireTime(),
                 new ConsumerManager(fileIO, path, snapshotManager().branch()),
                 options.snapshotExpireExecutionMode(),

--- a/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
@@ -18,9 +18,11 @@
 
 package org.apache.paimon.table;
 
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.Identifier;
-import org.apache.paimon.operation.Lock;
+import org.apache.paimon.catalog.SnapshotCommit;
+import org.apache.paimon.utils.SnapshotManager;
 
 import javax.annotation.Nullable;
 
@@ -33,22 +35,22 @@ public class CatalogEnvironment implements Serializable {
 
     @Nullable private final Identifier identifier;
     @Nullable private final String uuid;
-    private final Lock.Factory lockFactory;
     @Nullable private final CatalogLoader catalogLoader;
+    @Nullable private final SnapshotCommit.Factory commitFactory;
 
     public CatalogEnvironment(
             @Nullable Identifier identifier,
             @Nullable String uuid,
-            Lock.Factory lockFactory,
-            @Nullable CatalogLoader catalogLoader) {
+            @Nullable CatalogLoader catalogLoader,
+            @Nullable SnapshotCommit.Factory commitFactory) {
         this.identifier = identifier;
         this.uuid = uuid;
-        this.lockFactory = lockFactory;
         this.catalogLoader = catalogLoader;
+        this.commitFactory = commitFactory;
     }
 
     public static CatalogEnvironment empty() {
-        return new CatalogEnvironment(null, null, Lock.emptyFactory(), null);
+        return new CatalogEnvironment(null, null, null, null);
     }
 
     @Nullable
@@ -61,8 +63,12 @@ public class CatalogEnvironment implements Serializable {
         return uuid;
     }
 
-    public Lock.Factory lockFactory() {
-        return lockFactory;
+    @Nullable
+    public SnapshotCommit snapshotCommit(SnapshotManager snapshotManager) {
+        if (commitFactory == null) {
+            return null;
+        }
+        return commitFactory.create(identifier, snapshotManager);
     }
 
     @Nullable
@@ -71,5 +77,10 @@ public class CatalogEnvironment implements Serializable {
             return null;
         }
         return PartitionHandler.create(catalogLoader.load(), identifier);
+    }
+
+    @VisibleForTesting
+    public SnapshotCommit.Factory commitFactory() {
+        return commitFactory;
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/PartitionExpireTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/PartitionExpireTest.java
@@ -133,7 +133,7 @@ public class PartitionExpireTest {
                 };
 
         CatalogEnvironment env =
-                new CatalogEnvironment(null, null, Lock.emptyFactory(), null) {
+                new CatalogEnvironment(null, null, null, null) {
 
                     @Override
                     public PartitionHandler partitionHandler() {

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -289,7 +289,11 @@ public class RESTCatalogServer {
                 (FileStoreTable) catalog.getTable(Identifier.create(databaseName, tableName));
         RenamingSnapshotCommit commit =
                 new RenamingSnapshotCommit(table.snapshotManager(), Lock.emptyFactory().create());
-        boolean success = commit.commit(requestBody.getSnapshot(), requestBody.getBranch());
+        String branchName = requestBody.getIdentifier().getBranchName();
+        if (branchName == null) {
+            branchName = "main";
+        }
+        boolean success = commit.commit(requestBody.getSnapshot(), branchName);
         CommitTableResponse response = new CommitTableResponse(success);
         return mockResponse(response, 200);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -22,17 +22,21 @@ import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.Database;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.RenamingSnapshotCommit;
+import org.apache.paimon.operation.Lock;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.rest.requests.AlterPartitionsRequest;
 import org.apache.paimon.rest.requests.AlterTableRequest;
+import org.apache.paimon.rest.requests.CommitTableRequest;
 import org.apache.paimon.rest.requests.CreateDatabaseRequest;
 import org.apache.paimon.rest.requests.CreatePartitionsRequest;
 import org.apache.paimon.rest.requests.CreateTableRequest;
 import org.apache.paimon.rest.requests.DropPartitionsRequest;
 import org.apache.paimon.rest.requests.MarkDonePartitionsRequest;
 import org.apache.paimon.rest.requests.RenameTableRequest;
+import org.apache.paimon.rest.responses.CommitTableResponse;
 import org.apache.paimon.rest.responses.CreateDatabaseResponse;
 import org.apache.paimon.rest.responses.ErrorResponse;
 import org.apache.paimon.rest.responses.ErrorResponseResourceType;
@@ -120,6 +124,8 @@ public class RESTCatalogServer {
                         boolean isTable = resources.length == 3 && "tables".equals(resources[1]);
                         boolean isTableRename =
                                 resources.length == 4 && "rename".equals(resources[3]);
+                        boolean isTableCommit =
+                                resources.length == 4 && "commit".equals(resources[3]);
                         boolean isPartitions =
                                 resources.length == 4
                                         && "tables".equals(resources[1])
@@ -175,6 +181,9 @@ public class RESTCatalogServer {
                             return partitionsApiHandler(catalog, request, databaseName, tableName);
                         } else if (isTableRename) {
                             return renameTableApiHandler(
+                                    catalog, request, databaseName, resources[2]);
+                        } else if (isTableCommit) {
+                            return commitTableApiHandler(
                                     catalog, request, databaseName, resources[2]);
                         } else if (isTable) {
                             String tableName = resources[2];
@@ -268,6 +277,20 @@ public class RESTCatalogServer {
                         catalog,
                         requestBody.getNewIdentifier().getDatabaseName(),
                         requestBody.getNewIdentifier().getTableName());
+        return mockResponse(response, 200);
+    }
+
+    private static MockResponse commitTableApiHandler(
+            Catalog catalog, RecordedRequest request, String databaseName, String tableName)
+            throws Exception {
+        CommitTableRequest requestBody =
+                OBJECT_MAPPER.readValue(request.getBody().readUtf8(), CommitTableRequest.class);
+        FileStoreTable table =
+                (FileStoreTable) catalog.getTable(Identifier.create(databaseName, tableName));
+        RenamingSnapshotCommit commit =
+                new RenamingSnapshotCommit(table.snapshotManager(), Lock.emptyFactory().create());
+        boolean success = commit.commit(requestBody.getSnapshot(), requestBody.getBranch());
+        CommitTableResponse response = new CommitTableResponse(success);
         return mockResponse(response, 200);
     }
 

--- a/paimon-open-api/rest-catalog-open-api.yaml
+++ b/paimon-open-api/rest-catalog-open-api.yaml
@@ -406,6 +406,54 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         "500":
           description: Internal Server Error
+  /v1/{prefix}/databases/{database}/tables/{table}/commit:
+    post:
+      tags:
+        - table
+      summary: Commit table
+      operationId: commitTable
+      parameters:
+        - name: prefix
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: database
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: table
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CommitTableRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommitTableResponse'
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "409":
+          description: Resource has exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
   /v1/{prefix}/databases/{database}/tables/{table}/partitions:
     get:
       tags:
@@ -900,6 +948,27 @@ components:
       properties:
         newIdentifier:
           $ref: '#/components/schemas/Identifier'
+    CommitTableRequest:
+      type: object
+      properties:
+        identifier:
+          $ref: '#/components/schemas/Identifier'
+        snapshot:
+          $ref: '#/components/schemas/Snapshot'
+        branch:
+          type: string
+    Snapshot:
+      type: object
+      properties:
+        version:
+          type: integer
+        id:
+          type: integer
+    CommitTableResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
     AlterDatabaseRequest:
       type: object
       properties:

--- a/paimon-open-api/rest-catalog-open-api.yaml
+++ b/paimon-open-api/rest-catalog-open-api.yaml
@@ -955,8 +955,6 @@ components:
           $ref: '#/components/schemas/Identifier'
         snapshot:
           $ref: '#/components/schemas/Snapshot'
-        branch:
-          type: string
     Snapshot:
       type: object
       properties:

--- a/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
+++ b/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
@@ -23,6 +23,7 @@ import org.apache.paimon.rest.ResourcePaths;
 import org.apache.paimon.rest.requests.AlterDatabaseRequest;
 import org.apache.paimon.rest.requests.AlterPartitionsRequest;
 import org.apache.paimon.rest.requests.AlterTableRequest;
+import org.apache.paimon.rest.requests.CommitTableRequest;
 import org.apache.paimon.rest.requests.CreateDatabaseRequest;
 import org.apache.paimon.rest.requests.CreatePartitionsRequest;
 import org.apache.paimon.rest.requests.CreateTableRequest;
@@ -30,6 +31,7 @@ import org.apache.paimon.rest.requests.DropPartitionsRequest;
 import org.apache.paimon.rest.requests.MarkDonePartitionsRequest;
 import org.apache.paimon.rest.requests.RenameTableRequest;
 import org.apache.paimon.rest.responses.AlterDatabaseResponse;
+import org.apache.paimon.rest.responses.CommitTableResponse;
 import org.apache.paimon.rest.responses.ConfigResponse;
 import org.apache.paimon.rest.responses.CreateDatabaseResponse;
 import org.apache.paimon.rest.responses.ErrorResponse;
@@ -358,6 +360,30 @@ public class RESTCatalogController {
                         ImmutableList.of(),
                         new HashMap<>(),
                         "comment"));
+    }
+
+    @Operation(
+            summary = "Commit table",
+            tags = {"table"})
+    @ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                content = {@Content(schema = @Schema(implementation = CommitTableResponse.class))}),
+        @ApiResponse(
+                responseCode = "404",
+                description = "Resource not found",
+                content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
+        @ApiResponse(
+                responseCode = "500",
+                content = {@Content(schema = @Schema())})
+    })
+    @PostMapping("/v1/{prefix}/databases/{database}/tables/{table}/commit")
+    public CommitTableResponse commitTable(
+            @PathVariable String prefix,
+            @PathVariable String database,
+            @PathVariable String table,
+            @RequestBody CommitTableRequest request) {
+        return new CommitTableResponse(true);
     }
 
     @Operation(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
For `RESTCatalog`, it has no lock implementation, so for multiple jobs committing, we should abstract `SnapshotCommit` interface:

```java
/** Interface to commit snapshot atomically. */
public interface SnapshotCommit extends AutoCloseable {

    boolean commit(Snapshot snapshot, String branch) throws Exception;

    /** Factory to create {@link SnapshotCommit}. */
    interface Factory extends Serializable {
        SnapshotCommit create(Identifier identifier, SnapshotManager snapshotManager);
    }
}
```

- For non-RESTCatalog, just be `RenamingSnapshotCommit` to be compatible to history implementation.
- And for RESTCatalog, it submits `CommitTableRequest` to REST server to do single thread committing.

And for Schema changing, we don't really the lock, all schema changes happened in Catalog, we can lock them in Catalog.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
