### PR TITLE
[core] TypeUtils: remove quotes of map value

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
@@ -222,11 +222,16 @@ public class TypeUtils {
                                                         entry.getKey(), keyType, isCdcValue);
                                         Object value = null;
                                         if (!entry.getValue().isNull()) {
-                                            value =
+                                            if (entry.getValue().isTextual()) {
+                                                value = entry.getValue().asText();
+                                            }
+                                            else {
+                                                value =
                                                     castFromStringInternal(
                                                             entry.getValue().toString(),
                                                             valueType,
                                                             isCdcValue);
+                                            }
                                         }
                                         resultMap.put(key, value);
                                     });

--- a/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
@@ -223,14 +223,17 @@ public class TypeUtils {
                                         Object value = null;
                                         if (!entry.getValue().isNull()) {
                                             if (entry.getValue().isTextual()) {
-                                                value = entry.getValue().asText();
-                                            }
-                                            else {
                                                 value =
-                                                    castFromStringInternal(
-                                                            entry.getValue().toString(),
-                                                            valueType,
-                                                            isCdcValue);
+                                                        castFromStringInternal(
+                                                                entry.getValue().asText(),
+                                                                valueType,
+                                                                isCdcValue);
+                                            } else {
+                                                value =
+                                                        castFromStringInternal(
+                                                                entry.getValue().toString(),
+                                                                valueType,
+                                                                isCdcValue);
                                             }
                                         }
                                         resultMap.put(key, value);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Fix https://github.com/apache/paimon/issues/4920
Sinking cdc with map type, value surrouned with double quotes.
To prevent generating quotes, 
first check if value is text.


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
https://github.com/apache/paimon/issues/4920#issuecomment-2630112634

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
