### PR TITLE
[core] Introduce DeleteTagsByTimestampProcedure to delete tags by timestamp

### DIFF
--- a/docs/content/flink/procedures.md
+++ b/docs/content/flink/procedures.md
@@ -230,6 +230,23 @@ All available procedures are listed below.
       </td>
    </tr>
    <tr>
+      <td>delete_tags_timestamp</td>
+      <td>
+         -- Use named argument<br/>
+         CALL [catalog.]sys.delete_tags_timestamp(`table` => 'identifier', order_than_timestamp => 1736932554000) <br/><br/>
+         -- Use indexed argument<br/>
+         CALL [catalog.]sys.delete_tags_timestamp('identifier', timestamp)
+      </td>
+      <td>
+         To delete a tag. Arguments:
+            <li>identifier: the target table identifier. Cannot be empty.</li>
+            <li>order_than_timestamp: would delete tags which create time older than the timestamp.</li>
+      </td>
+      <td>
+         CALL sys.order_than_timestamp(`table` => 'default.T', order_than_timestamp => 1736932554000)
+      </td>
+   </tr>
+   <tr>
       <td>replace_tag</td>
       <td>
          -- Use named argument<br/>

--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -146,6 +146,15 @@ This section introduce all available spark procedures about paimon.
       <td>CALL sys.delete_tag(table => 'default.T', tag => 'my_tag')</td>
     </tr>
     <tr>
+      <td>delete_tags_timestamp</td>
+      <td>
+         To delete a tag which create time order than a specified timestamp. Arguments:
+            <li>table: the target table identifier. Cannot be empty.</li>
+            <li>order_than_timestamp: would delete tags which create time older than the timestamp.</li>
+      </td>
+      <td>CALL sys.delete_tags_timestamp(table => 'default.T', order_than_timestamp => 1736932554000)</td>
+    </tr>
+    <tr>
       <td>expire_tags</td>
       <td>
          To expire tags by time. Arguments:

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/DeleteTagsByTimestampProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/DeleteTagsByTimestampProcedure.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.procedure;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.FileStatus;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.utils.TagManager;
+
+import org.apache.flink.table.procedure.ProcedureContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Delete tag by timestamp procedure. Usage:
+ *
+ * <pre><code>
+ *  CALL sys.delete_tags_timestamp('tableId', 1736932554000)
+ * </code></pre>
+ */
+public class DeleteTagsByTimestampProcedure extends ProcedureBase {
+    public static final String IDENTIFIER = "delete_tags_timestamp";
+
+    public String[] call(ProcedureContext procedureContext, String tableId, Long timestamp)
+            throws Catalog.TableNotExistException {
+        Table table = catalog.getTable(Identifier.fromString(tableId));
+        FileStoreTable fileStoreTable = (FileStoreTable) table;
+        TagManager tagManager = fileStoreTable.tagManager();
+        FileIO fileIO = fileStoreTable.fileIO();
+        List<String> deleteTags = new ArrayList<>();
+        try {
+            for (String tagName : fileStoreTable.tagManager().allTagNames()) {
+                FileStatus fileStatus = fileIO.listStatus(tagManager.tagPath(tagName))[0];
+                if (fileStatus.getModificationTime() < timestamp) {
+                    deleteTags.add(tagName);
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (deleteTags.size() > 0) {
+            table.deleteTags(String.join(",", deleteTags));
+        }
+
+        return new String[] {"Success"};
+    }
+
+    @Override
+    public String identifier() {
+        return IDENTIFIER;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/DeleteTagsByTimestampProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/DeleteTagsByTimestampProcedure.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.procedure;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.FileStatus;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.utils.TagManager;
+
+import org.apache.flink.table.annotation.ArgumentHint;
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.ProcedureHint;
+import org.apache.flink.table.procedure.ProcedureContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Delete tag by timestamp procedure. Usage:
+ *
+ * <pre><code>
+ *  CALL sys.delete_tags_timestamp('tableId', 1736932554000)
+ * </code></pre>
+ */
+public class DeleteTagsByTimestampProcedure extends ProcedureBase {
+
+    public static final String IDENTIFIER = "delete_tags_timestamp";
+
+    @ProcedureHint(
+            argument = {
+                @ArgumentHint(name = "table", type = @DataTypeHint("STRING")),
+                @ArgumentHint(name = "order_than_timestamp", type = @DataTypeHint("BIGINT"))
+            })
+    public String[] call(ProcedureContext procedureContext, String tableId, Long timestamp)
+            throws Catalog.TableNotExistException {
+        Table table = catalog.getTable(Identifier.fromString(tableId));
+        FileStoreTable fileStoreTable = (FileStoreTable) table;
+        TagManager tagManager = fileStoreTable.tagManager();
+        FileIO fileIO = fileStoreTable.fileIO();
+        List<String> deleteTags = new ArrayList<>();
+        try {
+            for (String tagName : fileStoreTable.tagManager().allTagNames()) {
+                FileStatus fileStatus = fileIO.listStatus(tagManager.tagPath(tagName))[0];
+                if (fileStatus.getModificationTime() < timestamp) {
+                    deleteTags.add(tagName);
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (deleteTags.size() > 0) {
+            table.deleteTags(String.join(",", deleteTags));
+        }
+
+        return new String[] {"Success"};
+    }
+
+    @Override
+    public String identifier() {
+        return IDENTIFIER;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/resources/META-INF/services/org.apache.paimon.factories.Factory
+++ b/paimon-flink/paimon-flink-common/src/main/resources/META-INF/services/org.apache.paimon.factories.Factory
@@ -53,6 +53,7 @@ org.apache.paimon.flink.procedure.CreateTagProcedure
 org.apache.paimon.flink.procedure.CreateTagFromTimestampProcedure
 org.apache.paimon.flink.procedure.CreateTagFromWatermarkProcedure
 org.apache.paimon.flink.procedure.DeleteTagProcedure
+org.apache.paimon.flink.procedure.DeleteTagsByTimestampProcedure
 org.apache.paimon.flink.procedure.ExpireTagsProcedure
 org.apache.paimon.flink.procedure.ReplaceTagProcedure
 org.apache.paimon.flink.procedure.CreateBranchProcedure

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/TagActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/TagActionITCase.java
@@ -267,36 +267,36 @@ public class TagActionITCase extends ActionITCaseBase {
             case "procedure_indexed":
                 executeSQL(
                         String.format(
-                                "CALL sys.create_tag('%s.%s', 'tag1', 1)", database, tableName));
+                                "CALL sys.create_tag('%s.%s', 'A', 1)", database, tableName));
                 break;
             case "procedure_named":
                 executeSQL(
                         String.format(
-                                "CALL sys.create_tag(`table` => '%s.%s', tag => 'tag1', snapshot_id => cast(1 as bigint))",
+                                "CALL sys.create_tag(`table` => '%s.%s', tag => 'A', snapshot_id => cast(1 as bigint))",
                                 database, tableName));
                 break;
             default:
                 throw new UnsupportedOperationException(invoker);
         }
-        assertThat(tagManager.tagExists("tag1")).isTrue();
+        assertThat(tagManager.tagExists("A")).isTrue();
 
         writeData(rowData(2L, BinaryString.fromString("Hello")));
         switch (invoker) {
             case "procedure_indexed":
                 executeSQL(
                         String.format(
-                                "CALL sys.create_tag('%s.%s', 'tag2', 2)", database, tableName));
+                                "CALL sys.create_tag('%s.%s', 'B', 2)", database, tableName));
                 break;
             case "procedure_named":
                 executeSQL(
                         String.format(
-                                "CALL sys.create_tag(`table` => '%s.%s', tag => 'tag2', snapshot_id => cast(2 as bigint))",
+                                "CALL sys.create_tag(`table` => '%s.%s', tag => 'B', snapshot_id => cast(2 as bigint))",
                                 database, tableName));
                 break;
             default:
                 throw new UnsupportedOperationException(invoker);
         }
-        assertThat(tagManager.tagExists("tag2")).isTrue();
+        assertThat(tagManager.tagExists("B")).isTrue();
 
         long ts = System.currentTimeMillis();
 
@@ -305,18 +305,18 @@ public class TagActionITCase extends ActionITCaseBase {
             case "procedure_indexed":
                 executeSQL(
                         String.format(
-                                "CALL sys.create_tag('%s.%s', 'tag3', 3)", database, tableName));
+                                "CALL sys.create_tag('%s.%s', 'C', 3)", database, tableName));
                 break;
             case "procedure_named":
                 executeSQL(
                         String.format(
-                                "CALL sys.create_tag(`table` => '%s.%s', tag => 'tag3', snapshot_id => cast(3 as bigint))",
+                                "CALL sys.create_tag(`table` => '%s.%s', tag => 'C', snapshot_id => cast(3 as bigint))",
                                 database, tableName));
                 break;
             default:
                 throw new UnsupportedOperationException(invoker);
         }
-        assertThat(tagManager.tagExists("tag3")).isTrue();
+        assertThat(tagManager.tagExists("C")).isTrue();
 
         switch (invoker) {
             case "procedure_indexed":
@@ -334,10 +334,9 @@ public class TagActionITCase extends ActionITCaseBase {
             default:
                 throw new UnsupportedOperationException(invoker);
         }
-        assertThat(tagManager.tagCount() == 1).isTrue();
-        assertThat(tagManager.tagExists("tag1")).isFalse();
-        assertThat(tagManager.tagExists("tag2")).isFalse();
-        assertThat(tagManager.tagExists("tag3")).isTrue();
+        assertThat(tagManager.tagExists("A")).isFalse();
+        assertThat(tagManager.tagExists("B")).isFalse();
+        assertThat(tagManager.tagExists("C")).isTrue();
     }
 
     @ParameterizedTest(name = "{0}")

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/TagActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/TagActionITCase.java
@@ -266,8 +266,7 @@ public class TagActionITCase extends ActionITCaseBase {
         switch (invoker) {
             case "procedure_indexed":
                 executeSQL(
-                        String.format(
-                                "CALL sys.create_tag('%s.%s', 'A', 1)", database, tableName));
+                        String.format("CALL sys.create_tag('%s.%s', 'A', 1)", database, tableName));
                 break;
             case "procedure_named":
                 executeSQL(
@@ -284,8 +283,7 @@ public class TagActionITCase extends ActionITCaseBase {
         switch (invoker) {
             case "procedure_indexed":
                 executeSQL(
-                        String.format(
-                                "CALL sys.create_tag('%s.%s', 'B', 2)", database, tableName));
+                        String.format("CALL sys.create_tag('%s.%s', 'B', 2)", database, tableName));
                 break;
             case "procedure_named":
                 executeSQL(
@@ -304,8 +302,7 @@ public class TagActionITCase extends ActionITCaseBase {
         switch (invoker) {
             case "procedure_indexed":
                 executeSQL(
-                        String.format(
-                                "CALL sys.create_tag('%s.%s', 'C', 3)", database, tableName));
+                        String.format("CALL sys.create_tag('%s.%s', 'C', 3)", database, tableName));
                 break;
             case "procedure_named":
                 executeSQL(

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkProcedures.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkProcedures.java
@@ -25,6 +25,7 @@ import org.apache.paimon.spark.procedure.CreateTagFromTimestampProcedure;
 import org.apache.paimon.spark.procedure.CreateTagProcedure;
 import org.apache.paimon.spark.procedure.DeleteBranchProcedure;
 import org.apache.paimon.spark.procedure.DeleteTagProcedure;
+import org.apache.paimon.spark.procedure.DeleteTagsByTimestampProcedure;
 import org.apache.paimon.spark.procedure.ExpirePartitionsProcedure;
 import org.apache.paimon.spark.procedure.ExpireSnapshotsProcedure;
 import org.apache.paimon.spark.procedure.ExpireTagsProcedure;
@@ -82,6 +83,7 @@ public class SparkProcedures {
         procedureBuilders.put("rename_tag", RenameTagProcedure::builder);
         procedureBuilders.put(
                 "create_tag_from_timestamp", CreateTagFromTimestampProcedure::builder);
+        procedureBuilders.put("delete_tags_timestamp", DeleteTagsByTimestampProcedure::builder);
         procedureBuilders.put("delete_tag", DeleteTagProcedure::builder);
         procedureBuilders.put("expire_tags", ExpireTagsProcedure::builder);
         procedureBuilders.put("create_branch", CreateBranchProcedure::builder);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/DeleteTagsByTimestampProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/DeleteTagsByTimestampProcedure.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.procedure;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.FileStatus;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.TagManager;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.spark.sql.types.DataTypes.LongType;
+import static org.apache.spark.sql.types.DataTypes.StringType;
+
+/** A procedure to delete tags by time. */
+public class DeleteTagsByTimestampProcedure extends BaseProcedure {
+
+    private static final ProcedureParameter[] PARAMETERS =
+            new ProcedureParameter[] {
+                ProcedureParameter.required("table", StringType),
+                ProcedureParameter.required("order_than_timestamp", LongType)
+            };
+
+    private static final StructType OUTPUT_TYPE =
+            new StructType(
+                    new StructField[] {
+                        new StructField("result", DataTypes.BooleanType, true, Metadata.empty())
+                    });
+
+    protected DeleteTagsByTimestampProcedure(TableCatalog tableCatalog) {
+        super(tableCatalog);
+    }
+
+    @Override
+    public ProcedureParameter[] parameters() {
+        return PARAMETERS;
+    }
+
+    @Override
+    public StructType outputType() {
+        return OUTPUT_TYPE;
+    }
+
+    @Override
+    public InternalRow[] call(InternalRow args) {
+        Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
+        Long timestamp = args.getLong(1);
+        return modifyPaimonTable(
+                tableIdent,
+                table -> {
+                    FileStoreTable fileStoreTable = (FileStoreTable) table;
+                    TagManager tagManager = fileStoreTable.tagManager();
+                    FileIO fileIO = fileStoreTable.fileIO();
+                    List<String> deleteTags = new ArrayList<>();
+                    try {
+                        for (String tagName : fileStoreTable.tagManager().allTagNames()) {
+                            FileStatus fileStatus =
+                                    fileIO.listStatus(tagManager.tagPath(tagName))[0];
+                            if (fileStatus.getModificationTime() < timestamp) {
+                                deleteTags.add(tagName);
+                            }
+                        }
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+
+                    if (deleteTags.size() > 0) {
+                        table.deleteTags(String.join(",", deleteTags));
+                    }
+                    InternalRow outputRow = newInternalRow(true);
+                    return new InternalRow[] {outputRow};
+                });
+    }
+
+    public static ProcedureBuilder builder() {
+        return new BaseProcedure.Builder<DeleteTagsByTimestampProcedure>() {
+            @Override
+            public DeleteTagsByTimestampProcedure doBuild() {
+                return new DeleteTagsByTimestampProcedure(tableCatalog());
+            }
+        };
+    }
+
+    @Override
+    public String description() {
+        return "DeleteTagsByTimeProcedure";
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx
Currently user delete tags can only according to tag names，actually user may need delete their tags according to a time （such as history auto-create tags which not contain retained expire time），need introduce a quick way to delete all tags which earlier than a time，this pr is aimed to support it.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
