### PR TITLE
Add http conf and ExponentialHttpRetryInterceptor to handle retry In RESTCatalog

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/rest/ExponentialHttpRetryInterceptor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/ExponentialHttpRetryInterceptor.java
@@ -36,8 +36,9 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * Defines an exponential HTTP request retry interceptor. The following retrievable IOException
- * status codes are defined:
+ * Defines exponential HTTP request retry interceptor.
+ *
+ * <p>The following retrievable IOException
  *
  * <ul>
  *   <li>InterruptedIOException
@@ -47,7 +48,7 @@ import java.util.concurrent.ThreadLocalRandom;
  *   <li>SSLException
  * </ul>
  *
- * The following retrievable HTTP status codes are defined:
+ * <p>The following retrievable HTTP status codes are defined:
  *
  * <ul>
  *   <li>TOO_MANY_REQUESTS (429)
@@ -56,7 +57,7 @@ import java.util.concurrent.ThreadLocalRandom;
  *   <li>GATEWAY_TIMEOUT (504)
  * </ul>
  *
- * The following retrievable HTTP method which is idempotent are defined:
+ * <p>The following retrievable HTTP method which is idempotent are defined:
  *
  * <ul>
  *   <li>GET

--- a/paimon-core/src/main/java/org/apache/paimon/rest/ExponentialHttpRetryInterceptor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/ExponentialHttpRetryInterceptor.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest;
+
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableSet;
+import org.apache.paimon.shade.guava30.com.google.common.net.HttpHeaders;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import javax.net.ssl.SSLException;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.UnknownHostException;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Defines an exponential HTTP request retry interceptor.
+ *
+ * <ul>
+ *   <li>InterruptedIOException
+ *   <li>UnknownHostException
+ *   <li>ConnectException
+ *   <li>NoRouteToHostException
+ *   <li>SSLException
+ * </ul>
+ *
+ * The following retrievable HTTP status codes are defined:
+ *
+ * <ul>
+ *   <li>TOO_MANY_REQUESTS (429)
+ *   <li>BAD_GATEWAY (502)
+ *   <li>SERVICE_UNAVAILABLE (503)
+ *   <li>GATEWAY_TIMEOUT (504)
+ * </ul>
+ *
+ * The following retrievable HTTP method which is idempotent are defined:
+ *
+ * <ul>
+ *   <li>GET
+ *   <li>HEAD
+ *   <li>PUT
+ *   <li>DELETE
+ *   <li>TRACE
+ *   <li>OPTIONS
+ * </ul>
+ */
+public class ExponentialHttpRetryInterceptor implements Interceptor {
+    private final int maxRetries;
+    private final Set<Class<? extends IOException>> nonRetriableExceptions;
+    private final Set<Integer> retrievableCodes;
+    private final Set<String> retrievableMethods;
+
+    public ExponentialHttpRetryInterceptor(int maxRetries) {
+        this.maxRetries = maxRetries;
+        this.retrievableMethods =
+                ImmutableSet.of("GET", "HEAD", "PUT", "DELETE", "TRACE", "OPTIONS");
+        this.retrievableCodes = ImmutableSet.of(429, 503, 502, 504);
+        this.nonRetriableExceptions =
+                ImmutableSet.of(
+                        InterruptedIOException.class,
+                        UnknownHostException.class,
+                        ConnectException.class,
+                        NoRouteToHostException.class,
+                        SSLException.class);
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request request = chain.request();
+        Response response = null;
+
+        for (int retryCount = 1; ; retryCount++) {
+            try {
+                response = chain.proceed(request);
+            } catch (IOException e) {
+                if (needRetry(request.method(), e, retryCount)) {
+                    wait(response, retryCount);
+                    continue;
+                }
+            }
+            if (needRetry(response, retryCount)) {
+                if (response != null) {
+                    response.close();
+                }
+                wait(response, retryCount);
+            } else {
+                return response;
+            }
+        }
+    }
+
+    public boolean needRetry(Response response, int execCount) {
+        if (execCount > maxRetries) {
+            return false;
+        }
+        if (response != null
+                && (response.isSuccessful() || !retrievableCodes.contains(response.code()))) {
+            return false;
+        }
+        return true;
+    }
+
+    public boolean needRetry(String Method, IOException e, int execCount) {
+        if (execCount > maxRetries) {
+            return false;
+        }
+        if (!retrievableMethods.contains(Method)) {
+            return false;
+        }
+        if (nonRetriableExceptions.contains(e.getClass())) {
+            return false;
+        } else {
+            for (Class<? extends IOException> rejectException : nonRetriableExceptions) {
+                if (rejectException.isInstance(e)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    public long getRetryIntervalInMilliseconds(Response response, int execCount) {
+        // a server may send a 429 / 503 with a Retry-After header
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
+        String retryAfterStrInSecond =
+                response == null ? null : response.header(HttpHeaders.RETRY_AFTER);
+        Long retryAfter = null;
+        if (retryAfterStrInSecond != null) {
+            try {
+                retryAfter = Long.parseLong(retryAfterStrInSecond) * 1000;
+            } catch (Throwable ignore) {
+            }
+
+            if (retryAfter != null && retryAfter > 0) {
+                return retryAfter;
+            }
+        }
+
+        int delayMillis = 1000 * (int) Math.min(Math.pow(2.0, (long) execCount - 1.0), 64.0);
+        int jitter = ThreadLocalRandom.current().nextInt(Math.max(1, (int) (delayMillis * 0.1)));
+
+        return delayMillis + jitter;
+    }
+
+    private void wait(Response response, int retryCount) throws InterruptedIOException {
+        try {
+            Thread.sleep(getRetryIntervalInMilliseconds(response, retryCount));
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new InterruptedIOException();
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/rest/ExponentialHttpRetryInterceptor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/ExponentialHttpRetryInterceptor.java
@@ -69,6 +69,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * </ul>
  */
 public class ExponentialHttpRetryInterceptor implements Interceptor {
+
     private final int maxRetries;
     private final Set<Class<? extends IOException>> nonRetriableExceptions;
     private final Set<Integer> retrievableCodes;

--- a/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -200,7 +200,8 @@ public class HttpClient implements RESTClient {
                         CONNECTION_KEEP_ALIVE_DURATION_IN_MS,
                         TimeUnit.MILLISECONDS);
         Dispatcher dispatcher = new Dispatcher(executorService);
-        dispatcher.setMaxRequestsPerHost(httpClientOptions.maxConnectionsPerRoute());
+        // set max requests per host use max connections
+        dispatcher.setMaxRequestsPerHost(httpClientOptions.maxConnections());
         OkHttpClient.Builder builder =
                 new OkHttpClient.Builder()
                         .dispatcher(dispatcher)

--- a/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -202,7 +202,10 @@ public class HttpClient implements RESTClient {
                         .dispatcher(dispatcher)
                         .retryOnConnectionFailure(true)
                         .connectionPool(connectionPool)
-                        .connectionSpecs(Arrays.asList(MODERN_TLS, COMPATIBLE_TLS, CLEARTEXT));
+                        .connectionSpecs(Arrays.asList(MODERN_TLS, COMPATIBLE_TLS, CLEARTEXT))
+                        .addInterceptor(
+                                new ExponentialHttpRetryInterceptor(
+                                        httpClientOptions.maxRetries()));
         httpClientOptions.connectTimeout().ifPresent(builder::connectTimeout);
         httpClientOptions.readTimeout().ifPresent(builder::readTimeout);
 

--- a/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -54,7 +54,7 @@ public class HttpClient implements RESTClient {
 
     private static final String THREAD_NAME = "REST-CATALOG-HTTP-CLIENT-THREAD-POOL";
     private static final MediaType MEDIA_TYPE = MediaType.parse("application/json");
-    private static final int CONNECTION_KEEP_ALIVE_DURATION_IN_MS = 300_000;
+    private static final int CONNECTION_KEEP_ALIVE_DURATION_MS = 300_000;
 
     private final OkHttpClient okHttpClient;
     private final String uri;
@@ -197,7 +197,7 @@ public class HttpClient implements RESTClient {
         ConnectionPool connectionPool =
                 new ConnectionPool(
                         httpClientOptions.maxConnections(),
-                        CONNECTION_KEEP_ALIVE_DURATION_IN_MS,
+                        CONNECTION_KEEP_ALIVE_DURATION_MS,
                         TimeUnit.MILLISECONDS);
         Dispatcher dispatcher = new Dispatcher(executorService);
         // set max requests per host use max connections

--- a/paimon-core/src/main/java/org/apache/paimon/rest/HttpClientOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/HttpClientOptions.java
@@ -32,16 +32,25 @@ public class HttpClientOptions {
     @Nullable private final Duration connectTimeout;
     @Nullable private final Duration readTimeout;
     private final int threadPoolSize;
+    private final int maxConnections;
+    private final int maxConnectionsPerRoute;
+    private final int maxRetries;
 
     public HttpClientOptions(
             String uri,
             @Nullable Duration connectTimeout,
             @Nullable Duration readTimeout,
-            int threadPoolSize) {
+            int threadPoolSize,
+            int maxConnections,
+            int maxConnectionsPerRoute,
+            int maxRetries) {
         this.uri = uri;
         this.connectTimeout = connectTimeout;
         this.readTimeout = readTimeout;
         this.threadPoolSize = threadPoolSize;
+        this.maxConnections = maxConnections;
+        this.maxConnectionsPerRoute = maxConnectionsPerRoute;
+        this.maxRetries = maxRetries;
     }
 
     public static HttpClientOptions create(Options options) {
@@ -49,7 +58,10 @@ public class HttpClientOptions {
                 options.get(RESTCatalogOptions.URI),
                 options.get(RESTCatalogOptions.CONNECTION_TIMEOUT),
                 options.get(RESTCatalogOptions.READ_TIMEOUT),
-                options.get(RESTCatalogOptions.THREAD_POOL_SIZE));
+                options.get(RESTCatalogOptions.THREAD_POOL_SIZE),
+                options.get(RESTCatalogOptions.MAX_CONNECTIONS),
+                options.get(RESTCatalogOptions.MAX_CONNECTIONS_PER_ROUTE),
+                options.get(RESTCatalogOptions.MAX_RETIES));
     }
 
     public String uri() {
@@ -66,5 +78,17 @@ public class HttpClientOptions {
 
     public int threadPoolSize() {
         return threadPoolSize;
+    }
+
+    public int maxConnections() {
+        return maxConnections;
+    }
+
+    public int maxConnectionsPerRoute() {
+        return maxConnectionsPerRoute;
+    }
+
+    public int maxRetries() {
+        return maxRetries;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/rest/HttpClientOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/HttpClientOptions.java
@@ -32,7 +32,6 @@ public class HttpClientOptions {
     @Nullable private final Duration connectTimeout;
     private final int threadPoolSize;
     private final int maxConnections;
-    private final int maxConnectionsPerRoute;
     private final int maxRetries;
 
     public HttpClientOptions(
@@ -40,13 +39,11 @@ public class HttpClientOptions {
             @Nullable Duration connectTimeout,
             int threadPoolSize,
             int maxConnections,
-            int maxConnectionsPerRoute,
             int maxRetries) {
         this.uri = uri;
         this.connectTimeout = connectTimeout;
         this.threadPoolSize = threadPoolSize;
         this.maxConnections = maxConnections;
-        this.maxConnectionsPerRoute = maxConnectionsPerRoute;
         this.maxRetries = maxRetries;
     }
 
@@ -56,7 +53,6 @@ public class HttpClientOptions {
                 options.get(RESTCatalogOptions.CONNECTION_TIMEOUT),
                 options.get(RESTCatalogOptions.THREAD_POOL_SIZE),
                 options.get(RESTCatalogOptions.MAX_CONNECTIONS),
-                options.get(RESTCatalogOptions.MAX_CONNECTIONS_PER_ROUTE),
                 options.get(RESTCatalogOptions.MAX_RETIES));
     }
 
@@ -74,10 +70,6 @@ public class HttpClientOptions {
 
     public int maxConnections() {
         return maxConnections;
-    }
-
-    public int maxConnectionsPerRoute() {
-        return Math.min(maxConnections, maxConnectionsPerRoute);
     }
 
     public int maxRetries() {

--- a/paimon-core/src/main/java/org/apache/paimon/rest/HttpClientOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/HttpClientOptions.java
@@ -30,7 +30,6 @@ public class HttpClientOptions {
 
     private final String uri;
     @Nullable private final Duration connectTimeout;
-    @Nullable private final Duration readTimeout;
     private final int threadPoolSize;
     private final int maxConnections;
     private final int maxConnectionsPerRoute;
@@ -39,14 +38,12 @@ public class HttpClientOptions {
     public HttpClientOptions(
             String uri,
             @Nullable Duration connectTimeout,
-            @Nullable Duration readTimeout,
             int threadPoolSize,
             int maxConnections,
             int maxConnectionsPerRoute,
             int maxRetries) {
         this.uri = uri;
         this.connectTimeout = connectTimeout;
-        this.readTimeout = readTimeout;
         this.threadPoolSize = threadPoolSize;
         this.maxConnections = maxConnections;
         this.maxConnectionsPerRoute = maxConnectionsPerRoute;
@@ -57,7 +54,6 @@ public class HttpClientOptions {
         return new HttpClientOptions(
                 options.get(RESTCatalogOptions.URI),
                 options.get(RESTCatalogOptions.CONNECTION_TIMEOUT),
-                options.get(RESTCatalogOptions.READ_TIMEOUT),
                 options.get(RESTCatalogOptions.THREAD_POOL_SIZE),
                 options.get(RESTCatalogOptions.MAX_CONNECTIONS),
                 options.get(RESTCatalogOptions.MAX_CONNECTIONS_PER_ROUTE),
@@ -72,10 +68,6 @@ public class HttpClientOptions {
         return Optional.ofNullable(connectTimeout);
     }
 
-    public Optional<Duration> readTimeout() {
-        return Optional.ofNullable(readTimeout);
-    }
-
     public int threadPoolSize() {
         return threadPoolSize;
     }
@@ -85,10 +77,10 @@ public class HttpClientOptions {
     }
 
     public int maxConnectionsPerRoute() {
-        return maxConnectionsPerRoute;
+        return Math.min(maxConnections, maxConnectionsPerRoute);
     }
 
     public int maxRetries() {
-        return maxRetries;
+        return Math.max(maxRetries, 0);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalogOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalogOptions.java
@@ -32,17 +32,38 @@ public class RESTCatalogOptions {
                     .noDefaultValue()
                     .withDescription("REST Catalog server's uri.");
 
+    // default  same with iceberg 3min
     public static final ConfigOption<Duration> CONNECTION_TIMEOUT =
             ConfigOptions.key("rest.client.connection-timeout")
                     .durationType()
-                    .noDefaultValue()
+                    .defaultValue(Duration.ofSeconds(180))
                     .withDescription("REST Catalog http client connect timeout.");
 
+    // as read timeout need less than connect timeout default 170s
     public static final ConfigOption<Duration> READ_TIMEOUT =
             ConfigOptions.key("rest.client.read-timeout")
                     .durationType()
-                    .noDefaultValue()
+                    .defaultValue(Duration.ofSeconds(170))
                     .withDescription("REST Catalog http client read timeout.");
+
+    public static final ConfigOption<Integer> MAX_CONNECTIONS =
+            ConfigOptions.key("rest.client..max-connections")
+                    .intType()
+                    .defaultValue(100)
+                    .withDescription("REST Catalog http client's max connections.");
+
+    // need less than max connections default 100
+    public static final ConfigOption<Integer> MAX_CONNECTIONS_PER_ROUTE =
+            ConfigOptions.key("connections-per-route")
+                    .intType()
+                    .defaultValue(100)
+                    .withDescription("REST Catalog http client's max connections per route.");
+
+    public static final ConfigOption<Integer> MAX_RETIES =
+            ConfigOptions.key("rest.client..max-retries")
+                    .intType()
+                    .defaultValue(5)
+                    .withDescription("REST Catalog http client's max retry times.");
 
     public static final ConfigOption<Integer> THREAD_POOL_SIZE =
             ConfigOptions.key("rest.client.num-threads")

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalogOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalogOptions.java
@@ -32,19 +32,12 @@ public class RESTCatalogOptions {
                     .noDefaultValue()
                     .withDescription("REST Catalog server's uri.");
 
-    // default  same with iceberg 3min
+    // default same with iceberg 3min
     public static final ConfigOption<Duration> CONNECTION_TIMEOUT =
             ConfigOptions.key("rest.client.connection-timeout")
                     .durationType()
                     .defaultValue(Duration.ofSeconds(180))
                     .withDescription("REST Catalog http client connect timeout.");
-
-    // as read timeout need less than connect timeout default 170s
-    public static final ConfigOption<Duration> READ_TIMEOUT =
-            ConfigOptions.key("rest.client.read-timeout")
-                    .durationType()
-                    .defaultValue(Duration.ofSeconds(170))
-                    .withDescription("REST Catalog http client read timeout.");
 
     public static final ConfigOption<Integer> MAX_CONNECTIONS =
             ConfigOptions.key("rest.client..max-connections")

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalogOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalogOptions.java
@@ -40,20 +40,13 @@ public class RESTCatalogOptions {
                     .withDescription("REST Catalog http client connect timeout.");
 
     public static final ConfigOption<Integer> MAX_CONNECTIONS =
-            ConfigOptions.key("rest.client..max-connections")
+            ConfigOptions.key("rest.client.max-connections")
                     .intType()
                     .defaultValue(100)
                     .withDescription("REST Catalog http client's max connections.");
 
-    // need less than max connections default 100
-    public static final ConfigOption<Integer> MAX_CONNECTIONS_PER_ROUTE =
-            ConfigOptions.key("connections-per-route")
-                    .intType()
-                    .defaultValue(100)
-                    .withDescription("REST Catalog http client's max connections per route.");
-
     public static final ConfigOption<Integer> MAX_RETIES =
-            ConfigOptions.key("rest.client..max-retries")
+            ConfigOptions.key("rest.client.max-retries")
                     .intType()
                     .defaultValue(5)
                     .withDescription("REST Catalog http client's max retry times.");

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalogOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalogOptions.java
@@ -32,7 +32,6 @@ public class RESTCatalogOptions {
                     .noDefaultValue()
                     .withDescription("REST Catalog server's uri.");
 
-    // default same with iceberg 3min
     public static final ConfigOption<Duration> CONNECTION_TIMEOUT =
             ConfigOptions.key("rest.client.connection-timeout")
                     .durationType()

--- a/paimon-core/src/test/java/org/apache/paimon/rest/ExponentialHttpRetryInterceptorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/ExponentialHttpRetryInterceptorTest.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** Test for {@link ExponentialHttpRetryInterceptor}. */
 class ExponentialHttpRetryInterceptorTest {
     private final int maxRetries = 5;
-    private ExponentialHttpRetryInterceptor interceptor =
+    private final ExponentialHttpRetryInterceptor interceptor =
             new ExponentialHttpRetryInterceptor(maxRetries);
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/rest/ExponentialHttpRetryInterceptorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/ExponentialHttpRetryInterceptorTest.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link ExponentialHttpRetryInterceptor}. */
 class ExponentialHttpRetryInterceptorTest {
+
     private final int maxRetries = 5;
     private final ExponentialHttpRetryInterceptor interceptor =
             new ExponentialHttpRetryInterceptor(maxRetries);

--- a/paimon-core/src/test/java/org/apache/paimon/rest/ExponentialHttpRetryInterceptorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/ExponentialHttpRetryInterceptorTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest;
+
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLException;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.UnknownHostException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link ExponentialHttpRetryInterceptor}. */
+class ExponentialHttpRetryInterceptorTest {
+    private final int maxRetries = 5;
+    private ExponentialHttpRetryInterceptor interceptor =
+            new ExponentialHttpRetryInterceptor(maxRetries);
+
+    @Test
+    void testNeedRetryByMethod() {
+        assertThat(interceptor.needRetry("GET", new IOException(), 1)).isTrue();
+        assertThat(interceptor.needRetry("HEAD", new IOException(), 1)).isTrue();
+        assertThat(interceptor.needRetry("PUT", new IOException(), 1)).isTrue();
+        assertThat(interceptor.needRetry("DELETE", new IOException(), 1)).isTrue();
+        assertThat(interceptor.needRetry("TRACE", new IOException(), 1)).isTrue();
+        assertThat(interceptor.needRetry("OPTIONS", new IOException(), 1)).isTrue();
+        assertThat(interceptor.needRetry("POST", new IOException(), 1)).isFalse();
+        assertThat(interceptor.needRetry("PATCH", new IOException(), 1)).isFalse();
+        assertThat(interceptor.needRetry("CONNECT", new IOException(), 1)).isFalse();
+        assertThat(interceptor.needRetry("GET", new IOException(), maxRetries + 1)).isFalse();
+    }
+
+    @Test
+    void testNeedRetryByException() {
+        assertThat(interceptor.needRetry("GET", new InterruptedIOException(), 1)).isFalse();
+        assertThat(interceptor.needRetry("GET", new UnknownHostException(), 1)).isFalse();
+        assertThat(interceptor.needRetry("GET", new ConnectException(), 1)).isFalse();
+        assertThat(interceptor.needRetry("GET", new NoRouteToHostException(), 1)).isFalse();
+        assertThat(interceptor.needRetry("GET", new SSLException("error"), 1)).isFalse();
+    }
+
+    @Test
+    void testRetryByResponse() {
+        assertThat(interceptor.needRetry(createResponse(429), 1)).isTrue();
+        assertThat(interceptor.needRetry(createResponse(503), 1)).isTrue();
+        assertThat(interceptor.needRetry(createResponse(502), 1)).isTrue();
+        assertThat(interceptor.needRetry(createResponse(504), 1)).isTrue();
+        assertThat(interceptor.needRetry(createResponse(500), 1)).isFalse();
+        assertThat(interceptor.needRetry(createResponse(404), 1)).isFalse();
+        assertThat(interceptor.needRetry(createResponse(200), 1)).isFalse();
+    }
+
+    @Test
+    public void invalidRetryAfterHeader() {
+        Response response = createResponse(429, "Stuff");
+
+        assertThat(interceptor.getRetryIntervalInMilliseconds(response, 3)).isBetween(4000L, 5000L);
+    }
+
+    @Test
+    public void validRetryAfterHeader() {
+        long retryAfter = 3;
+        Response response = createResponse(429, retryAfter + "");
+        assertThat(interceptor.getRetryIntervalInMilliseconds(response, 3))
+                .isEqualTo(retryAfter * 1000);
+    }
+
+    @Test
+    public void exponentialRetry() {
+        ExponentialHttpRetryInterceptor interceptor = new ExponentialHttpRetryInterceptor(10);
+        Response response = createResponse(429, "Stuff");
+
+        // note that the upper limit includes ~10% variability
+        assertThat(interceptor.getRetryIntervalInMilliseconds(response, 0)).isEqualTo(0);
+        assertThat(interceptor.getRetryIntervalInMilliseconds(response, 1)).isBetween(1000L, 2000L);
+        assertThat(interceptor.getRetryIntervalInMilliseconds(response, 2)).isBetween(2000L, 3000L);
+        assertThat(interceptor.getRetryIntervalInMilliseconds(response, 3)).isBetween(4000L, 5000L);
+        assertThat(interceptor.getRetryIntervalInMilliseconds(response, 4)).isBetween(8000L, 9000L);
+        assertThat(interceptor.getRetryIntervalInMilliseconds(response, 5))
+                .isBetween(16000L, 18000L);
+        assertThat(interceptor.getRetryIntervalInMilliseconds(response, 6))
+                .isBetween(32000L, 36000L);
+        assertThat(interceptor.getRetryIntervalInMilliseconds(response, 7))
+                .isBetween(64000L, 72000L);
+        assertThat(interceptor.getRetryIntervalInMilliseconds(response, 10))
+                .isBetween(64000L, 72000L);
+    }
+
+    public static Response createResponse(int httpCode) {
+        return createResponse(httpCode, "");
+    }
+
+    public static Response createResponse(int httpCode, String retryAfter) {
+        return new Response.Builder()
+                .code(httpCode)
+                .message("message")
+                .protocol(Protocol.HTTP_1_1)
+                .request(new Request.Builder().url("http://example.com").build())
+                .addHeader(HttpHeaders.RETRY_AFTER, retryAfter)
+                .build();
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
@@ -56,14 +56,7 @@ public class HttpClientTest {
         server.start();
         errorHandler = DefaultErrorHandler.getInstance();
         HttpClientOptions httpClientOptions =
-                new HttpClientOptions(
-                        server.getBaseUrl(),
-                        Duration.ofSeconds(3),
-                        Duration.ofSeconds(3),
-                        1,
-                        10,
-                        10,
-                        2);
+                new HttpClientOptions(server.getBaseUrl(), Duration.ofSeconds(3), 1, 10, 10, 2);
         mockResponseData = new MockRESTData(MOCK_PATH);
         mockResponseDataStr = server.createResponseBody(mockResponseData);
         errorResponseStr =
@@ -128,13 +121,7 @@ public class HttpClientTest {
         HttpClient httpClient =
                 new HttpClient(
                         new HttpClientOptions(
-                                server.getBaseUrl(),
-                                Duration.ofSeconds(30),
-                                Duration.ofSeconds(30),
-                                1,
-                                10,
-                                10,
-                                2));
+                                server.getBaseUrl(), Duration.ofSeconds(30), 1, 10, 10, 2));
         server.enqueueResponse(mockResponseDataStr, 429);
         server.enqueueResponse(mockResponseDataStr, 200);
         assertDoesNotThrow(() -> httpClient.get(MOCK_PATH, MockRESTData.class, headers));

--- a/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
@@ -56,7 +56,7 @@ public class HttpClientTest {
         server.start();
         errorHandler = DefaultErrorHandler.getInstance();
         HttpClientOptions httpClientOptions =
-                new HttpClientOptions(server.getBaseUrl(), Duration.ofSeconds(3), 1, 10, 10, 2);
+                new HttpClientOptions(server.getBaseUrl(), Duration.ofSeconds(3), 1, 10, 2);
         mockResponseData = new MockRESTData(MOCK_PATH);
         mockResponseDataStr = server.createResponseBody(mockResponseData);
         errorResponseStr =
@@ -121,7 +121,7 @@ public class HttpClientTest {
         HttpClient httpClient =
                 new HttpClient(
                         new HttpClientOptions(
-                                server.getBaseUrl(), Duration.ofSeconds(30), 1, 10, 10, 2));
+                                server.getBaseUrl(), Duration.ofSeconds(30), 1, 10, 2));
         server.enqueueResponse(mockResponseDataStr, 429);
         server.enqueueResponse(mockResponseDataStr, 200);
         assertDoesNotThrow(() -> httpClient.get(MOCK_PATH, MockRESTData.class, headers));

--- a/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
@@ -57,7 +57,13 @@ public class HttpClientTest {
         errorHandler = DefaultErrorHandler.getInstance();
         HttpClientOptions httpClientOptions =
                 new HttpClientOptions(
-                        server.getBaseUrl(), Duration.ofSeconds(3), Duration.ofSeconds(3), 1);
+                        server.getBaseUrl(),
+                        Duration.ofSeconds(3),
+                        Duration.ofSeconds(3),
+                        1,
+                        10,
+                        10,
+                        2);
         mockResponseData = new MockRESTData(MOCK_PATH);
         mockResponseDataStr = server.createResponseBody(mockResponseData);
         errorResponseStr =

--- a/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
@@ -122,4 +122,21 @@ public class HttpClientTest {
         server.enqueueResponse(errorResponseStr, 400);
         assertThrows(BadRequestException.class, () -> httpClient.delete(MOCK_PATH, headers));
     }
+
+    @Test
+    public void testRetry() {
+        HttpClient httpClient =
+                new HttpClient(
+                        new HttpClientOptions(
+                                server.getBaseUrl(),
+                                Duration.ofSeconds(30),
+                                Duration.ofSeconds(30),
+                                1,
+                                10,
+                                10,
+                                2));
+        server.enqueueResponse(mockResponseDataStr, 429);
+        server.enqueueResponse(mockResponseDataStr, 200);
+        assertDoesNotThrow(() -> httpClient.get(MOCK_PATH, MockRESTData.class, headers));
+    }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Support define max connections and retry when failing for RESTCatalog client
Linked issue: #4540

### Tests
- ExponentialHttpRetryInterceptorTest
- HttpClientTest.testRetry

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
