### PR TITLE
[core] Fix race condition for earliest snapshot

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/Changelog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/Changelog.java
@@ -28,6 +28,7 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonPro
 
 import javax.annotation.Nullable;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Map;
 
@@ -106,8 +107,18 @@ public class Changelog extends Snapshot {
 
     public static Changelog fromPath(FileIO fileIO, Path path) {
         try {
+            return tryFromPath(fileIO, path);
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException("Fails to read changelog from path " + path, e);
+        }
+    }
+
+    public static Changelog tryFromPath(FileIO fileIO, Path path) throws FileNotFoundException {
+        try {
             String json = fileIO.readFileUtf8(path);
             return Changelog.fromJson(json);
+        } catch (FileNotFoundException e) {
+            throw e;
         } catch (IOException e) {
             throw new RuntimeException("Fails to read changelog from path " + path, e);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -217,7 +217,13 @@ public class SnapshotManager implements Serializable {
     }
 
     private @Nullable Snapshot earliestSnapshot(boolean includeChangelog) {
-        Long snapshotId = earliestSnapshotId();
+        Long snapshotId = null;
+        if (includeChangelog) {
+            snapshotId = earliestLongLivedChangelogId();
+        }
+        if (snapshotId == null) {
+            snapshotId = earliestSnapshotId();
+        }
         if (snapshotId == null) {
             return null;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -425,8 +425,7 @@ public class SnapshotManager implements Serializable {
         if ((earliestWatermark = earliestSnapShot.watermark()) == null) {
             while (earliest < latest) {
                 earliest++;
-                Snapshot snapshot = snapshot(earliest);
-                earliestWatermark = snapshot.watermark();
+                earliestWatermark = snapshot(earliest).watermark();
                 if (earliestWatermark != null) {
                     break;
                 }

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -141,10 +141,10 @@ public class SnapshotManagerTest {
                             if (millis.size() == 1) {
                                 assertThat(actual).isNull();
                             } else {
-                                assertThat(actual).isEqualTo(firstSnapshotId + i);
+                                assertThat(actual).isLessThanOrEqualTo(firstSnapshotId);
                             }
                         } else {
-                            assertThat(actual).isEqualTo(firstSnapshotId + i - 1);
+                            assertThat(actual).isLessThanOrEqualTo(firstSnapshotId + i - 1);
                         }
                         break;
                     }

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -221,7 +221,7 @@ public class SnapshotManagerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void testlaterOrEqualWatermark(boolean isRaceCondition) throws IOException {
+    public void testLaterOrEqualWatermark(boolean isRaceCondition) throws IOException {
         long millis = Long.MIN_VALUE;
         FileIO localFileIO = LocalFileIO.create();
         SnapshotManager snapshotManager =

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -27,6 +27,10 @@ import org.apache.paimon.fs.local.LocalFileIO;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -56,8 +60,42 @@ public class SnapshotManagerTest {
         }
     }
 
-    @Test
-    public void testEarlierThanTimeMillis() throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testEarliestSnapshot(boolean isRaceCondition) throws IOException {
+        long millis = 1684726826L;
+        FileIO localFileIO = LocalFileIO.create();
+        SnapshotManager snapshotManager =
+                new TestSnapshotManager(localFileIO, new Path(tempDir.toString()), isRaceCondition);
+        // create 10 snapshots
+        for (long i = 0; i < 10; i++) {
+            Snapshot snapshot = createSnapshotWithMillis(i, millis + i * 1000);
+            localFileIO.tryToWriteAtomic(snapshotManager.snapshotPath(i), snapshot.toJson());
+        }
+
+        assertThat(snapshotManager.earliestSnapshot().id()).isEqualTo(isRaceCondition ? 1 : 0);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testEarlierOrEqualWatermark(boolean isRaceCondition) throws IOException {
+        long millis = 1684726826L;
+        FileIO localFileIO = LocalFileIO.create();
+        SnapshotManager snapshotManager =
+                new TestSnapshotManager(localFileIO, new Path(tempDir.toString()), isRaceCondition);
+        // create 10 snapshots
+        for (long i = 0; i < 10; i++) {
+            Snapshot snapshot = createSnapshotWithMillis(i, millis + i * 1000, millis + i * 1000);
+            localFileIO.tryToWriteAtomic(snapshotManager.snapshotPath(i), snapshot.toJson());
+        }
+
+        assertThat(snapshotManager.earlierOrEqualWatermark(millis + 999).id())
+                .isEqualTo(isRaceCondition ? 1 : 0);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testEarlierThanTimeMillis(boolean isRaceCondition) throws IOException {
         long base = System.currentTimeMillis();
         ThreadLocalRandom random = ThreadLocalRandom.current();
 
@@ -70,7 +108,7 @@ public class SnapshotManagerTest {
 
         FileIO localFileIO = LocalFileIO.create();
         SnapshotManager snapshotManager =
-                new SnapshotManager(localFileIO, new Path(tempDir.toString()));
+                new TestSnapshotManager(localFileIO, new Path(tempDir.toString()), isRaceCondition);
         int firstSnapshotId = random.nextInt(1, 100);
         for (int i = 0; i < numSnapshots; i++) {
             Snapshot snapshot = createSnapshotWithMillis(firstSnapshotId + i, millis.get(i));
@@ -90,11 +128,24 @@ public class SnapshotManagerTest {
             Long actual = snapshotManager.earlierThanTimeMills(time, false);
 
             if (millis.get(numSnapshots - 1) < time) {
-                assertThat(actual).isEqualTo(firstSnapshotId + numSnapshots - 1);
+                if (isRaceCondition && millis.size() == 1) {
+                    assertThat(actual).isNull();
+                } else {
+                    assertThat(actual).isEqualTo(firstSnapshotId + numSnapshots - 1);
+                }
             } else {
                 for (int i = 0; i < numSnapshots; i++) {
                     if (millis.get(i) >= time) {
-                        assertThat(actual).isEqualTo(firstSnapshotId + i - 1);
+                        if (isRaceCondition && i == 0) {
+                            // The first snapshot expired during invocation
+                            if (millis.size() == 1) {
+                                assertThat(actual).isNull();
+                            } else {
+                                assertThat(actual).isEqualTo(firstSnapshotId + i);
+                            }
+                        } else {
+                            assertThat(actual).isEqualTo(firstSnapshotId + i - 1);
+                        }
                         break;
                     }
                 }
@@ -102,31 +153,45 @@ public class SnapshotManagerTest {
         }
     }
 
-    @Test
-    public void testEarlierOrEqualTimeMills() throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testEarlierOrEqualTimeMills(boolean isRaceCondition) throws IOException {
         long millis = 1684726826L;
         FileIO localFileIO = LocalFileIO.create();
         SnapshotManager snapshotManager =
-                new SnapshotManager(localFileIO, new Path(tempDir.toString()));
+                new TestSnapshotManager(localFileIO, new Path(tempDir.toString()), isRaceCondition);
         // create 10 snapshots
         for (long i = 0; i < 10; i++) {
             Snapshot snapshot = createSnapshotWithMillis(i, millis + i * 1000);
             localFileIO.tryToWriteAtomic(snapshotManager.snapshotPath(i), snapshot.toJson());
         }
 
-        // there is no snapshot smaller than "millis - 1L" return the earliest snapshot
-        assertThat(snapshotManager.earlierOrEqualTimeMills(millis - 1L).timeMillis())
-                .isEqualTo(millis);
+        if (isRaceCondition) {
+            // The earliest snapshot has expired, so always return the second snapshot
+            assertThat(snapshotManager.earlierOrEqualTimeMills(millis - 1L).timeMillis())
+                    .isEqualTo(millis + 1000L);
+            assertThat(snapshotManager.earlierOrEqualTimeMills(millis + 999).timeMillis())
+                    .isEqualTo(millis + 1000L);
+            assertThat(snapshotManager.earlierOrEqualTimeMills(millis + 1000).timeMillis())
+                    .isEqualTo(millis + 1000L);
+            assertThat(snapshotManager.earlierOrEqualTimeMills(millis + 1001).timeMillis())
+                    .isEqualTo(millis + 1000L);
+        } else {
+            // there is no snapshot smaller than "millis - 1L" return the earliest snapshot
+            assertThat(snapshotManager.earlierOrEqualTimeMills(millis - 1L).timeMillis())
+                    .isEqualTo(millis);
 
-        // smaller than the second snapshot return the first snapshot
-        assertThat(snapshotManager.earlierOrEqualTimeMills(millis + 999).timeMillis())
-                .isEqualTo(millis);
-        // equal to the second snapshot return the second snapshot
-        assertThat(snapshotManager.earlierOrEqualTimeMills(millis + 1000).timeMillis())
-                .isEqualTo(millis + 1000);
-        // larger than the second snapshot return the second snapshot
-        assertThat(snapshotManager.earlierOrEqualTimeMills(millis + 1001).timeMillis())
-                .isEqualTo(millis + 1000);
+            // smaller than the second snapshot return the first snapshot
+            assertThat(snapshotManager.earlierOrEqualTimeMills(millis + 999).timeMillis())
+                    .isEqualTo(millis);
+
+            // equal to the second snapshot return the second snapshot
+            assertThat(snapshotManager.earlierOrEqualTimeMills(millis + 1000).timeMillis())
+                    .isEqualTo(millis + 1000);
+            // larger than the second snapshot return the second snapshot
+            assertThat(snapshotManager.earlierOrEqualTimeMills(millis + 1001).timeMillis())
+                    .isEqualTo(millis + 1000);
+        }
     }
 
     @Test
@@ -154,12 +219,13 @@ public class SnapshotManagerTest {
         assertThat(snapshotManager.laterOrEqualTimeMills(millis + 10001)).isNull();
     }
 
-    @Test
-    public void testlaterOrEqualWatermark() throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testlaterOrEqualWatermark(boolean isRaceCondition) throws IOException {
         long millis = Long.MIN_VALUE;
         FileIO localFileIO = LocalFileIO.create();
         SnapshotManager snapshotManager =
-                new SnapshotManager(localFileIO, new Path(tempDir.toString()));
+                new TestSnapshotManager(localFileIO, new Path(tempDir.toString()), isRaceCondition);
         // create 10 snapshots
         for (long i = 0; i < 10; i++) {
             Snapshot snapshot = createSnapshotWithMillis(i, millis, Long.MIN_VALUE);
@@ -409,5 +475,36 @@ public class SnapshotManagerTest {
         Changelog changelog = createChangelogWithMillis(id, 1L);
         snapshotManager.commitChangelog(changelog, id);
         assertDoesNotThrow(() -> snapshotManager.commitChangelog(changelog, id));
+    }
+
+    /**
+     * Test {@link SnapshotManager} to mock situations when there is a race condition, that the
+     * earliest snapshot is deleted by another thread in the middle of the current thread's
+     * invocation.
+     */
+    private static class TestSnapshotManager extends SnapshotManager {
+        private final boolean isRaceCondition;
+
+        private boolean deleteEarliestSnapshot = false;
+
+        public TestSnapshotManager(FileIO fileIO, Path tablePath, boolean isRaceCondition) {
+            super(fileIO, tablePath);
+            this.isRaceCondition = isRaceCondition;
+        }
+
+        @Override
+        public @Nullable Long earliestSnapshotId() {
+            Long snapshotId = super.earliestSnapshotId();
+            if (isRaceCondition && snapshotId != null && !deleteEarliestSnapshot) {
+                Path snapshotPath = snapshotPath(snapshotId);
+                try {
+                    fileIO().delete(snapshotPath, true);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+                deleteEarliestSnapshot = true;
+            }
+            return snapshotId;
+        }
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3479

<!-- What is the purpose of the change -->
This PR fixes a racing bug about earliest snapshot. When thread A is trying to get the earliest snapshot of a table, while the snapshot is being expired by thread B, thread A might throw exception that it cannot get the snapshot information from the earliest snapshot id.

This PR fixes the bug by adding retrying logic to seek the second earliest snapshot if the first one cannot be found.

Note that, theoretically speaking, any snapshot (including the latest one) could encounter this issue, but the probability is quite small, so this PR only fixes the bug for invocations on the earliest snapshot.

### Tests

<!-- List UT and IT cases to verify this change -->
Tests in SnapshotManagerTest are used to verify against the changes.

### API and Format

<!-- Does this change affect API or storage format -->
This change does not affect API or storage format.

### Documentation

<!-- Does this change introduce a new feature -->
This change does not introduce a new feature.
