### PR TITLE
[spark] Support push down v2 filter

### DIFF
--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -35,7 +35,7 @@ case class PaimonScan(
     filters: Seq[Predicate],
     reservedFilters: Seq[Filter],
     override val pushDownLimit: Option[Int],
-    disableBucketedScan: Boolean = true)
+    bucketedScanDisabled: Boolean = true)
   extends PaimonBaseScan(table, requiredSchema, filters, reservedFilters, pushDownLimit)
   with SupportsRuntimeFiltering {
 

--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -35,7 +35,7 @@ case class PaimonScan(
     filters: Seq[Predicate],
     reservedFilters: Seq[Filter],
     override val pushDownLimit: Option[Int],
-    disableBucketedScan: Boolean = false)
+    disableBucketedScan: Boolean = true)
   extends PaimonBaseScan(table, requiredSchema, filters, reservedFilters, pushDownLimit)
   with SupportsRuntimeFiltering {
 
@@ -57,11 +57,9 @@ case class PaimonScan(
       case _ => None
     }
     if (partitionFilter.nonEmpty) {
-      this.runtimeFilters = filters
       readBuilder.withFilter(partitionFilter.head)
       // set inputPartitions null to trigger to get the new splits.
       inputPartitions = null
     }
   }
-
 }

--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -35,6 +35,7 @@ case class PaimonScan(
     filters: Seq[Predicate],
     reservedFilters: Seq[Filter],
     override val pushDownLimit: Option[Int],
+    // no usage, just for compile compatibility
     bucketedScanDisabled: Boolean = true)
   extends PaimonBaseScan(table, requiredSchema, filters, reservedFilters, pushDownLimit)
   with SupportsRuntimeFiltering {

--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonSplitScanBuilder.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonSplitScanBuilder.scala
@@ -18,27 +18,12 @@
 
 package org.apache.paimon.spark
 
-import org.apache.paimon.predicate.Predicate
-import org.apache.paimon.table.Table
+import org.apache.paimon.table.KnownSplitsTable
 
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.connector.read.LocalScan
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.connector.read.Scan
 
-/** A scan does not require [[RDD]] to execute */
-case class PaimonLocalScan(
-    rows: Array[InternalRow],
-    readSchema: StructType,
-    table: Table,
-    filters: Array[Predicate])
-  extends LocalScan {
-
-  override def description(): String = {
-    val pushedFiltersStr = if (filters.nonEmpty) {
-      ", PushedFilters: [" + filters.mkString(",") + "]"
-    } else {
-      ""
-    }
-    s"PaimonLocalScan: [${table.name}]" + pushedFiltersStr
+class PaimonSplitScanBuilder(table: KnownSplitsTable) extends PaimonScanBuilder(table) {
+  override def build(): Scan = {
+    PaimonSplitScan(table, table.splits(), requiredSchema, pushedPaimonPredicates)
   }
 }

--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/catalyst/analysis/expressions/ExpressionHelper.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/catalyst/analysis/expressions/ExpressionHelper.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.catalyst.analysis.expressions
+
+import org.apache.paimon.predicate.{Predicate, PredicateBuilder}
+import org.apache.paimon.spark.SparkFilterConverter
+import org.apache.paimon.types.RowType
+
+import org.apache.spark.sql.PaimonUtils.{normalizeExprs, translateFilter}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+
+trait ExpressionHelper extends ExpressionHelperBase {
+
+  def convertConditionToPaimonPredicate(
+      condition: Expression,
+      output: Seq[Attribute],
+      rowType: RowType,
+      ignorePartialFailure: Boolean = false): Option[Predicate] = {
+    val converter = new SparkFilterConverter(rowType)
+    val filters = normalizeExprs(Seq(condition), output)
+      .flatMap(splitConjunctivePredicates(_).flatMap {
+        f =>
+          val filter = translateFilter(f, supportNestedPredicatePushdown = true)
+          if (filter.isEmpty && !ignorePartialFailure) {
+            throw new RuntimeException(
+              "Exec update failed:" +
+                s" cannot translate expression to source filter: $f")
+          }
+          filter
+      })
+
+    val predicates = filters.map(converter.convert(_, ignorePartialFailure)).filter(_ != null)
+    if (predicates.isEmpty) {
+      None
+    } else {
+      Some(PredicateBuilder.and(predicates: _*))
+    }
+  }
+}

--- a/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/sql/PaimonPushDownTest.scala
+++ b/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/sql/PaimonPushDownTest.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, Literal}
+import org.apache.spark.sql.catalyst.plans.logical.Filter
+
+class PaimonPushDownTest extends PaimonPushDownTestBase {
+
+  override def checkFilterExists(sql: String): Boolean = {
+    spark
+      .sql(sql)
+      .queryExecution
+      .optimizedPlan
+      .find {
+        case Filter(_: Expression, _) => true
+        case _ => false
+      }
+      .isDefined
+  }
+
+  override def checkEqualToFilterExists(sql: String, name: String, value: Literal): Boolean = {
+    spark
+      .sql(sql)
+      .queryExecution
+      .optimizedPlan
+      .find {
+        case Filter(c: Expression, _) =>
+          c.find {
+            case EqualTo(a: AttributeReference, r: Literal) =>
+              a.name.equals(name) && r.equals(value)
+            case _ => false
+          }.isDefined
+        case _ => false
+      }
+      .isDefined
+  }
+}

--- a/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -24,10 +24,9 @@ import org.apache.paimon.table.source.{DataSplit, Split}
 
 import org.apache.spark.sql.PaimonUtils.fieldReference
 import org.apache.spark.sql.connector.expressions._
-import org.apache.spark.sql.connector.expressions.filter.{Predicate => SparkPredicate}
-import org.apache.spark.sql.connector.read.{SupportsReportOrdering, SupportsReportPartitioning, SupportsRuntimeV2Filtering}
+import org.apache.spark.sql.connector.read.{SupportsReportPartitioning, SupportsRuntimeFiltering}
 import org.apache.spark.sql.connector.read.partitioning.{KeyGroupedPartitioning, Partitioning, UnknownPartitioning}
-import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.sources.{Filter, In}
 import org.apache.spark.sql.types.StructType
 
 import scala.collection.JavaConverters._
@@ -40,9 +39,8 @@ case class PaimonScan(
     override val pushDownLimit: Option[Int],
     bucketedScanDisabled: Boolean = false)
   extends PaimonBaseScan(table, requiredSchema, filters, reservedFilters, pushDownLimit)
-  with SupportsRuntimeV2Filtering
-  with SupportsReportPartitioning
-  with SupportsReportOrdering {
+  with SupportsRuntimeFiltering
+  with SupportsReportPartitioning {
 
   def disableBucketedScan(): PaimonScan = {
     copy(bucketedScanDisabled = true)
@@ -85,52 +83,6 @@ case class PaimonScan(
       .getOrElse(new UnknownPartitioning(0))
   }
 
-  // Since Spark 3.4
-  override def outputOrdering(): Array[SortOrder] = {
-    if (
-      !shouldDoBucketedScan || lazyInputPartitions.exists(
-        !_.isInstanceOf[PaimonBucketedInputPartition])
-    ) {
-      return Array.empty
-    }
-
-    val primaryKeys = table match {
-      case fileStoreTable: FileStoreTable => fileStoreTable.primaryKeys().asScala
-      case _ => Seq.empty
-    }
-    if (primaryKeys.isEmpty) {
-      return Array.empty
-    }
-
-    val allSplitsKeepOrdering = lazyInputPartitions.toSeq
-      .map(_.asInstanceOf[PaimonBucketedInputPartition])
-      .map(_.splits.asInstanceOf[Seq[DataSplit]])
-      .forall {
-        splits =>
-          // Only support report ordering if all matches:
-          // - one `Split` per InputPartition (TODO: Re-construct splits using minKey/maxKey)
-          // - `Split` is not rawConvertible so that the merge read can happen
-          // - `Split` only contains one data file so it always sorted even without merge read
-          splits.size < 2 && splits.forall {
-            split => !split.rawConvertible() || split.dataFiles().size() < 2
-          }
-      }
-    if (!allSplitsKeepOrdering) {
-      return Array.empty
-    }
-
-    // Multi-primary keys are fine:
-    // `Array(a, b)` satisfies the required ordering `Array(a)`
-    primaryKeys
-      .map(Expressions.identity)
-      .map {
-        sortExpr =>
-          // Primary key can not be null, the null ordering is no matter.
-          Expressions.sort(sortExpr, SortDirection.ASCENDING)
-      }
-      .toArray
-  }
-
   override def getInputPartitions(splits: Array[Split]): Seq[PaimonInputPartition] = {
     if (!shouldDoBucketedScan || splits.exists(!_.isInstanceOf[DataSplit])) {
       return super.getInputPartitions(splits)
@@ -157,16 +109,15 @@ case class PaimonScan(
       .map(fieldReference)
   }
 
-  override def filter(predicates: Array[SparkPredicate]): Unit = {
-    val converter = SparkV2FilterConverter(table.rowType())
-    val partitionKeys = table.partitionKeys().asScala.toSeq
-    val partitionFilter = predicates.flatMap {
-      case p if SparkV2FilterConverter.isSupportedRuntimeFilter(p, partitionKeys) =>
-        converter.convert(p, ignoreFailure = true)
+  override def filter(filters: Array[Filter]): Unit = {
+    val converter = new SparkFilterConverter(table.rowType())
+    val partitionFilter = filters.flatMap {
+      case in @ In(attr, _) if table.partitionKeys().contains(attr) =>
+        Some(converter.convert(in))
       case _ => None
     }
     if (partitionFilter.nonEmpty) {
-      readBuilder.withFilter(partitionFilter.toList.asJava)
+      readBuilder.withFilter(partitionFilter.head)
       // set inputPartitions null to trigger to get the new splits.
       inputPartitions = null
     }

--- a/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/spark/sql/internal/connector/PredicateUtils.scala
+++ b/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/spark/sql/internal/connector/PredicateUtils.scala
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.internal.connector
+
+import org.apache.spark.sql.catalyst.CatalystTypeConverters
+import org.apache.spark.sql.connector.expressions.{LiteralValue, NamedReference}
+import org.apache.spark.sql.connector.expressions.filter.{And => V2And, Not => V2Not, Or => V2Or, Predicate}
+import org.apache.spark.sql.sources.{AlwaysFalse, AlwaysTrue, And, EqualNullSafe, EqualTo, Filter, GreaterThan, GreaterThanOrEqual, In, IsNotNull, IsNull, LessThan, LessThanOrEqual, Not, Or, StringContains, StringEndsWith, StringStartsWith}
+import org.apache.spark.sql.types.StringType
+
+// Copy from Spark 3.4+
+private[sql] object PredicateUtils {
+
+  def toV1(predicate: Predicate): Option[Filter] = {
+
+    def isValidBinaryPredicate(): Boolean = {
+      if (
+        predicate.children().length == 2 &&
+        predicate.children()(0).isInstanceOf[NamedReference] &&
+        predicate.children()(1).isInstanceOf[LiteralValue[_]]
+      ) {
+        true
+      } else {
+        false
+      }
+    }
+
+    predicate.name() match {
+      case "IN" if predicate.children()(0).isInstanceOf[NamedReference] =>
+        val attribute = predicate.children()(0).toString
+        val values = predicate.children().drop(1)
+        if (values.length > 0) {
+          if (!values.forall(_.isInstanceOf[LiteralValue[_]])) return None
+          val dataType = values(0).asInstanceOf[LiteralValue[_]].dataType
+          if (!values.forall(_.asInstanceOf[LiteralValue[_]].dataType.sameType(dataType))) {
+            return None
+          }
+          val inValues = values.map(
+            v =>
+              CatalystTypeConverters.convertToScala(
+                v.asInstanceOf[LiteralValue[_]].value,
+                dataType))
+          Some(In(attribute, inValues))
+        } else {
+          Some(In(attribute, Array.empty[Any]))
+        }
+
+      case "=" | "<=>" | ">" | "<" | ">=" | "<=" if isValidBinaryPredicate() =>
+        val attribute = predicate.children()(0).toString
+        val value = predicate.children()(1).asInstanceOf[LiteralValue[_]]
+        val v1Value = CatalystTypeConverters.convertToScala(value.value, value.dataType)
+        val v1Filter = predicate.name() match {
+          case "=" => EqualTo(attribute, v1Value)
+          case "<=>" => EqualNullSafe(attribute, v1Value)
+          case ">" => GreaterThan(attribute, v1Value)
+          case ">=" => GreaterThanOrEqual(attribute, v1Value)
+          case "<" => LessThan(attribute, v1Value)
+          case "<=" => LessThanOrEqual(attribute, v1Value)
+        }
+        Some(v1Filter)
+
+      case "IS_NULL" | "IS_NOT_NULL"
+          if predicate.children().length == 1 &&
+            predicate.children()(0).isInstanceOf[NamedReference] =>
+        val attribute = predicate.children()(0).toString
+        val v1Filter = predicate.name() match {
+          case "IS_NULL" => IsNull(attribute)
+          case "IS_NOT_NULL" => IsNotNull(attribute)
+        }
+        Some(v1Filter)
+
+      case "STARTS_WITH" | "ENDS_WITH" | "CONTAINS" if isValidBinaryPredicate() =>
+        val attribute = predicate.children()(0).toString
+        val value = predicate.children()(1).asInstanceOf[LiteralValue[_]]
+        if (!value.dataType.sameType(StringType)) return None
+        val v1Value = value.value.toString
+        val v1Filter = predicate.name() match {
+          case "STARTS_WITH" =>
+            StringStartsWith(attribute, v1Value)
+          case "ENDS_WITH" =>
+            StringEndsWith(attribute, v1Value)
+          case "CONTAINS" =>
+            StringContains(attribute, v1Value)
+        }
+        Some(v1Filter)
+
+      case "ALWAYS_TRUE" | "ALWAYS_FALSE" if predicate.children().isEmpty =>
+        val v1Filter = predicate.name() match {
+          case "ALWAYS_TRUE" => AlwaysTrue()
+          case "ALWAYS_FALSE" => AlwaysFalse()
+        }
+        Some(v1Filter)
+
+      case "AND" =>
+        val and = predicate.asInstanceOf[V2And]
+        val left = toV1(and.left())
+        val right = toV1(and.right())
+        if (left.nonEmpty && right.nonEmpty) {
+          Some(And(left.get, right.get))
+        } else {
+          None
+        }
+
+      case "OR" =>
+        val or = predicate.asInstanceOf[V2Or]
+        val left = toV1(or.left())
+        val right = toV1(or.right())
+        if (left.nonEmpty && right.nonEmpty) {
+          Some(Or(left.get, right.get))
+        } else if (left.nonEmpty) {
+          left
+        } else {
+          right
+        }
+
+      case "NOT" =>
+        val child = toV1(predicate.asInstanceOf[V2Not].child())
+        if (child.nonEmpty) {
+          Some(Not(child.get))
+        } else {
+          None
+        }
+
+      case _ => None
+    }
+  }
+
+  def toV1(predicates: Array[Predicate]): Array[Filter] = {
+    predicates.flatMap(toV1(_))
+  }
+}

--- a/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/PaimonPushDownTest.scala
+++ b/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/PaimonPushDownTest.scala
@@ -16,29 +16,6 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.spark
+package org.apache.paimon.spark.sql
 
-import org.apache.paimon.predicate.Predicate
-import org.apache.paimon.table.Table
-
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.connector.read.LocalScan
-import org.apache.spark.sql.types.StructType
-
-/** A scan does not require [[RDD]] to execute */
-case class PaimonLocalScan(
-    rows: Array[InternalRow],
-    readSchema: StructType,
-    table: Table,
-    filters: Array[Predicate])
-  extends LocalScan {
-
-  override def description(): String = {
-    val pushedFiltersStr = if (filters.nonEmpty) {
-      ", PushedFilters: [" + filters.mkString(",") + "]"
-    } else {
-      ""
-    }
-    s"PaimonLocalScan: [${table.name}]" + pushedFiltersStr
-  }
-}
+class PaimonPushDownTest extends PaimonPushDownTestBase {}

--- a/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/PaimonPushDownTest.scala
+++ b/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/PaimonPushDownTest.scala
@@ -16,29 +16,6 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.spark
+package org.apache.paimon.spark.sql
 
-import org.apache.paimon.predicate.Predicate
-import org.apache.paimon.table.Table
-
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.connector.read.LocalScan
-import org.apache.spark.sql.types.StructType
-
-/** A scan does not require [[RDD]] to execute */
-case class PaimonLocalScan(
-    rows: Array[InternalRow],
-    readSchema: StructType,
-    table: Table,
-    filters: Array[Predicate])
-  extends LocalScan {
-
-  override def description(): String = {
-    val pushedFiltersStr = if (filters.nonEmpty) {
-      ", PushedFilters: [" + filters.mkString(",") + "]"
-    } else {
-      ""
-    }
-    s"PaimonLocalScan: [${table.name}]" + pushedFiltersStr
-  }
-}
+class PaimonPushDownTest extends PaimonPushDownTestBase {}

--- a/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/PaimonPushDownTest.scala
+++ b/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/PaimonPushDownTest.scala
@@ -16,29 +16,6 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.spark
+package org.apache.paimon.spark.sql
 
-import org.apache.paimon.predicate.Predicate
-import org.apache.paimon.table.Table
-
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.connector.read.LocalScan
-import org.apache.spark.sql.types.StructType
-
-/** A scan does not require [[RDD]] to execute */
-case class PaimonLocalScan(
-    rows: Array[InternalRow],
-    readSchema: StructType,
-    table: Table,
-    filters: Array[Predicate])
-  extends LocalScan {
-
-  override def description(): String = {
-    val pushedFiltersStr = if (filters.nonEmpty) {
-      ", PushedFilters: [" + filters.mkString(",") + "]"
-    } else {
-      ""
-    }
-    s"PaimonLocalScan: [${table.name}]" + pushedFiltersStr
-  }
-}
+class PaimonPushDownTest extends PaimonPushDownTestBase {}

--- a/paimon-spark/paimon-spark-4.0/src/test/scala/org/apache/paimon/spark/sql/PaimonPushDownTest.scala
+++ b/paimon-spark/paimon-spark-4.0/src/test/scala/org/apache/paimon/spark/sql/PaimonPushDownTest.scala
@@ -16,29 +16,6 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.spark
+package org.apache.paimon.spark.sql
 
-import org.apache.paimon.predicate.Predicate
-import org.apache.paimon.table.Table
-
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.connector.read.LocalScan
-import org.apache.spark.sql.types.StructType
-
-/** A scan does not require [[RDD]] to execute */
-case class PaimonLocalScan(
-    rows: Array[InternalRow],
-    readSchema: StructType,
-    table: Table,
-    filters: Array[Predicate])
-  extends LocalScan {
-
-  override def description(): String = {
-    val pushedFiltersStr = if (filters.nonEmpty) {
-      ", PushedFilters: [" + filters.mkString(",") + "]"
-    } else {
-      ""
-    }
-    s"PaimonLocalScan: [${table.name}]" + pushedFiltersStr
-  }
-}
+class PaimonPushDownTest extends PaimonPushDownTestBase {}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkFilterConverter.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkFilterConverter.java
@@ -49,7 +49,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.paimon.predicate.PredicateBuilder.convertJavaObject;
 
-/** Conversion from {@link Filter} to {@link Predicate}. */
+/** Conversion from {@link Filter} to {@link Predicate}, remove it when Spark 3.2 is dropped. */
 public class SparkFilterConverter {
 
     public static final List<String> SUPPORT_FILTERS =

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -49,8 +49,6 @@ abstract class PaimonBaseScan(
   with ColumnPruningAndPushDown
   with StatisticsHelper {
 
-  protected var runtimeFilters: Array[Filter] = Array.empty
-
   protected var inputPartitions: Seq[PaimonInputPartition] = _
 
   override val coreOptions: CoreOptions = CoreOptions.fromMap(table.options())

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScanBuilder.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScanBuilder.scala
@@ -18,77 +18,31 @@
 
 package org.apache.paimon.spark
 
-import org.apache.paimon.predicate.{PartitionPredicateVisitor, Predicate}
+import org.apache.paimon.predicate.Predicate
 import org.apache.paimon.table.Table
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns}
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownRequiredColumns}
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 
-import scala.collection.mutable
-
 abstract class PaimonBaseScanBuilder(table: Table)
   extends ScanBuilder
-  with SupportsPushDownFilters
   with SupportsPushDownRequiredColumns
   with Logging {
 
   protected var requiredSchema: StructType = SparkTypeUtils.fromPaimonRowType(table.rowType())
 
-  protected var pushedPredicates: Array[(Filter, Predicate)] = Array.empty
+  protected var pushedPaimonPredicates: Array[Predicate] = Array.empty
 
-  protected var partitionFilters: Array[Filter] = Array.empty
+  protected var reservedFilters: Array[Filter] = Array.empty
 
-  protected var postScanFilters: Array[Filter] = Array.empty
+  protected var hasPostScanPredicates = false
 
   protected var pushDownLimit: Option[Int] = None
 
   override def build(): Scan = {
-    PaimonScan(table, requiredSchema, pushedPredicates.map(_._2), partitionFilters, pushDownLimit)
-  }
-
-  /**
-   * Pushes down filters, and returns filters that need to be evaluated after scanning. <p> Rows
-   * should be returned from the data source if and only if all of the filters match. That is,
-   * filters must be interpreted as ANDed together.
-   */
-  override def pushFilters(filters: Array[Filter]): Array[Filter] = {
-    val pushable = mutable.ArrayBuffer.empty[(Filter, Predicate)]
-    val postScan = mutable.ArrayBuffer.empty[Filter]
-    val partitionFilter = mutable.ArrayBuffer.empty[Filter]
-
-    val converter = new SparkFilterConverter(table.rowType)
-    val visitor = new PartitionPredicateVisitor(table.partitionKeys())
-    filters.foreach {
-      filter =>
-        val predicate = converter.convertIgnoreFailure(filter)
-        if (predicate == null) {
-          postScan.append(filter)
-        } else {
-          pushable.append((filter, predicate))
-          if (predicate.visit(visitor)) {
-            partitionFilter.append(filter)
-          } else {
-            postScan.append(filter)
-          }
-        }
-    }
-
-    if (pushable.nonEmpty) {
-      this.pushedPredicates = pushable.toArray
-    }
-    if (partitionFilter.nonEmpty) {
-      this.partitionFilters = partitionFilter.toArray
-    }
-    if (postScan.nonEmpty) {
-      this.postScanFilters = postScan.toArray
-    }
-    postScan.toArray
-  }
-
-  override def pushedFilters(): Array[Filter] = {
-    pushedPredicates.map(_._1)
+    PaimonScan(table, requiredSchema, pushedPaimonPredicates, reservedFilters, pushDownLimit)
   }
 
   override def pruneColumns(requiredSchema: StructType): Unit = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -162,7 +162,7 @@ case class PaimonScan(
     val partitionKeys = table.partitionKeys().asScala.toSeq
     val partitionFilter = predicates.flatMap {
       case p if SparkV2FilterConverter.isSupportedRuntimeFilter(p, partitionKeys) =>
-        converter.convert(p, ignoreFailure = true)
+        converter.convert(p)
       case _ => None
     }
     if (partitionFilter.nonEmpty) {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
@@ -52,7 +52,7 @@ class PaimonScanBuilder(table: Table)
     val visitor = new PartitionPredicateVisitor(table.partitionKeys())
     predicates.foreach {
       predicate =>
-        converter.convert(predicate, ignoreFailure = true) match {
+        converter.convert(predicate) match {
           case Some(paimonPredicate) =>
             pushable.append((predicate, paimonPredicate))
             if (paimonPredicate.visit(visitor)) {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonSplitScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonSplitScan.scala
@@ -26,9 +26,9 @@ import org.apache.paimon.table.source.{DataSplit, Split}
 import org.apache.spark.sql.connector.read.{Batch, Scan}
 import org.apache.spark.sql.types.StructType
 
-class PaimonSplitScanBuilder(table: KnownSplitsTable) extends PaimonBaseScanBuilder(table) {
+class PaimonSplitScanBuilder(table: KnownSplitsTable) extends PaimonScanBuilder(table) {
   override def build(): Scan = {
-    PaimonSplitScan(table, table.splits(), requiredSchema, pushedPredicates.map(_._2))
+    PaimonSplitScan(table, table.splits(), requiredSchema, pushedPaimonPredicates)
   }
 }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkV2FilterConverter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkV2FilterConverter.scala
@@ -37,16 +37,16 @@ case class SparkV2FilterConverter(rowType: RowType) {
 
   val builder = new PredicateBuilder(rowType)
 
-  def convert(sparkPredicate: SparkPredicate, ignoreFailure: Boolean): Option[Predicate] = {
+  def convert(sparkPredicate: SparkPredicate, ignoreFailure: Boolean = true): Option[Predicate] = {
     try {
       Some(convert(sparkPredicate))
     } catch {
       case _ if ignoreFailure => None
-      case e: Exception => throw e
+      case e: Throwable => throw e
     }
   }
 
-  def convert(sparkPredicate: SparkPredicate): Predicate = {
+  private def convert(sparkPredicate: SparkPredicate): Predicate = {
     sparkPredicate.name() match {
       case EQUAL_TO =>
         BinaryPredicate.unapply(sparkPredicate) match {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
@@ -63,6 +63,7 @@ trait PaimonCommand extends WithFileStoreTable with ExpressionHelper with SQLCon
   def convertPartitionFilterToMap(
       filter: Filter,
       partitionRowType: RowType): Map[String, String] = {
+    // todo: replace it with SparkV2FilterConverter when we drop Spark3.2
     val converter = new SparkFilterConverter(partitionRowType)
     splitConjunctiveFilters(filter).map {
       case EqualNullSafe(attribute, value) =>

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/PaimonUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/PaimonUtils.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.connector.expressions.FieldReference
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Strategy.translateFilterV2WithMapping
+import org.apache.spark.sql.internal.connector.PredicateUtils
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.PartitioningUtils
@@ -72,6 +73,10 @@ object PaimonUtils {
 
   def translateFilterV2(predicate: Expression): Option[Predicate] = {
     translateFilterV2WithMapping(predicate, None)
+  }
+
+  def filterV2ToV1(predicate: Predicate): Option[Filter] = {
+    PredicateUtils.toV1(predicate)
   }
 
   def fieldReference(name: String): FieldReference = {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/SparkV2FilterConverterTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/SparkV2FilterConverterTestBase.scala
@@ -21,10 +21,13 @@ package org.apache.paimon.spark.sql
 import org.apache.paimon.data.{BinaryString, Decimal, Timestamp}
 import org.apache.paimon.predicate.PredicateBuilder
 import org.apache.paimon.spark.{PaimonSparkTestBase, SparkV2FilterConverter}
+import org.apache.paimon.spark.util.shim.TypeUtils.treatPaimonTimestampTypeAsSparkTimestampType
+import org.apache.paimon.table.source.DataSplit
 import org.apache.paimon.types.RowType
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.PaimonUtils.translateFilterV2
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.plans.logical.Filter
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 
@@ -54,8 +57,25 @@ abstract class SparkV2FilterConverterTestBase extends PaimonSparkTestBase {
           | decimal_col DECIMAL(10, 5),
           | boolean_col BOOLEAN,
           | date_col DATE,
-          | binary BINARY
+          | binary_col BINARY
           |) USING paimon
+          |""".stripMargin)
+
+    sql("""
+          |INSERT INTO test_tbl VALUES
+          |('hello', 1, 1, 1, 1, 1.0, 1.0, 12.12345, true, date('2025-01-15'), binary('b1'))
+          |""".stripMargin)
+    sql("""
+          |INSERT INTO test_tbl VALUES
+          |('world', 2, 2, 2, 2, 2.0, 2.0, 22.12345, false, date('2025-01-16'), binary('b2'))
+          |""".stripMargin)
+    sql("""
+          |INSERT INTO test_tbl VALUES
+          |('hi', 3, 3, 3, 3, 3.0, 3.0, 32.12345, false, date('2025-01-17'), binary('b3'))
+          |""".stripMargin)
+    sql("""
+          |INSERT INTO test_tbl VALUES
+          |('paimon', 4, 4, null, 4, 4.0, 4.0, 42.12345, true, date('2025-01-18'), binary('b4'))
           |""".stripMargin)
   }
 
@@ -71,147 +91,269 @@ abstract class SparkV2FilterConverterTestBase extends PaimonSparkTestBase {
   lazy val converter: SparkV2FilterConverter = SparkV2FilterConverter(rowType)
 
   test("V2Filter: all types") {
-    var actual = converter.convert(v2Filter("string_col = 'hello'"))
+    var filter = "string_col = 'hello'"
+    var actual = converter.convert(v2Filter(filter))
     assert(actual.equals(builder.equal(0, BinaryString.fromString("hello"))))
+    checkAnswer(sql(s"SELECT string_col from test_tbl WHERE $filter"), Seq(Row("hello")))
+    assert(scanFilesCount(filter) == 1)
 
-    actual = converter.convert(v2Filter("byte_col = 1"))
+    filter = "byte_col = 1"
+    actual = converter.convert(v2Filter(filter))
     assert(actual.equals(builder.equal(1, 1.toByte)))
+    checkAnswer(sql(s"SELECT byte_col from test_tbl WHERE $filter"), Seq(Row(1.toByte)))
+    assert(scanFilesCount(filter) == 1)
 
-    actual = converter.convert(v2Filter("short_col = 1"))
+    filter = "short_col = 1"
+    actual = converter.convert(v2Filter(filter))
     assert(actual.equals(builder.equal(2, 1.toShort)))
+    checkAnswer(sql(s"SELECT short_col from test_tbl WHERE $filter"), Seq(Row(1.toShort)))
+    assert(scanFilesCount(filter) == 1)
 
-    actual = converter.convert(v2Filter("int_col = 1"))
+    filter = "int_col = 1"
+    actual = converter.convert(v2Filter(filter))
     assert(actual.equals(builder.equal(3, 1)))
+    checkAnswer(sql(s"SELECT int_col from test_tbl WHERE $filter"), Seq(Row(1)))
+    assert(scanFilesCount(filter) == 1)
 
-    actual = converter.convert(v2Filter("long_col = 1"))
+    filter = "long_col = 1"
+    actual = converter.convert(v2Filter(filter))
     assert(actual.equals(builder.equal(4, 1L)))
+    checkAnswer(sql(s"SELECT long_col from test_tbl WHERE $filter"), Seq(Row(1L)))
+    assert(scanFilesCount(filter) == 1)
 
-    actual = converter.convert(v2Filter("float_col = 1.0"))
+    filter = "float_col = 1.0"
+    actual = converter.convert(v2Filter(filter))
     assert(actual.equals(builder.equal(5, 1.0f)))
+    checkAnswer(sql(s"SELECT float_col from test_tbl WHERE $filter"), Seq(Row(1.0f)))
+    assert(scanFilesCount(filter) == 1)
 
-    actual = converter.convert(v2Filter("double_col = 1.0"))
+    filter = "double_col = 1.0"
+    actual = converter.convert(v2Filter(filter))
     assert(actual.equals(builder.equal(6, 1.0d)))
+    checkAnswer(sql(s"SELECT double_col from test_tbl WHERE $filter"), Seq(Row(1.0d)))
+    assert(scanFilesCount(filter) == 1)
 
-    actual = converter.convert(v2Filter("decimal_col = 12.12345"))
+    filter = "decimal_col = 12.12345"
+    actual = converter.convert(v2Filter(filter))
     assert(
       actual.equals(
         builder.equal(7, Decimal.fromBigDecimal(new java.math.BigDecimal("12.12345"), 10, 5))))
+    checkAnswer(
+      sql(s"SELECT decimal_col from test_tbl WHERE $filter"),
+      Seq(Row(new java.math.BigDecimal("12.12345"))))
+    assert(scanFilesCount(filter) == 1)
 
-    actual = converter.convert(v2Filter("boolean_col = true"))
+    filter = "boolean_col = true"
+    actual = converter.convert(v2Filter(filter))
     assert(actual.equals(builder.equal(8, true)))
+    checkAnswer(sql(s"SELECT boolean_col from test_tbl WHERE $filter"), Seq(Row(true), Row(true)))
+    assert(scanFilesCount(filter) == 2)
 
-    actual = converter.convert(v2Filter("date_col = cast('2025-01-15' as date)"))
+    filter = "date_col = date('2025-01-15')"
+    actual = converter.convert(v2Filter(filter))
     val localDate = LocalDate.parse("2025-01-15")
     val epochDay = localDate.toEpochDay.toInt
     assert(actual.equals(builder.equal(9, epochDay)))
+    checkAnswer(
+      sql(s"SELECT date_col from test_tbl WHERE $filter"),
+      sql("SELECT date('2025-01-15')"))
+    assert(scanFilesCount(filter) == 1)
 
+    filter = "binary_col = binary('b1')"
     intercept[UnsupportedOperationException] {
-      actual = converter.convert(v2Filter("binary = binary('b1')"))
+      actual = converter.convert(v2Filter(filter))
     }
+    checkAnswer(sql(s"SELECT binary_col from test_tbl WHERE $filter"), sql("SELECT binary('b1')"))
+    assert(scanFilesCount(filter) == 4)
   }
 
   test("V2Filter: timestamp and timestamp_ntz") {
     withTimeZone("Asia/Shanghai") {
       withTable("ts_tbl", "ts_ntz_tbl") {
         sql("CREATE TABLE ts_tbl (ts_col TIMESTAMP) USING paimon")
+        sql("INSERT INTO ts_tbl VALUES (timestamp'2025-01-15 00:00:00.123')")
+        sql("INSERT INTO ts_tbl VALUES (timestamp'2025-01-16 00:00:00.123')")
+
+        val filter1 = "ts_col = timestamp'2025-01-15 00:00:00.123'"
         val rowType1 = loadTable("ts_tbl").rowType()
         val converter1 = SparkV2FilterConverter(rowType1)
-        val actual1 =
-          converter1.convert(v2Filter("ts_col = timestamp'2025-01-15 00:00:00.123'", "ts_tbl"))
-        assert(
-          actual1.equals(new PredicateBuilder(rowType1)
+        val actual1 = converter1.convert(v2Filter(filter1, "ts_tbl"))
+        if (treatPaimonTimestampTypeAsSparkTimestampType()) {
+          assert(actual1.equals(new PredicateBuilder(rowType1)
+            .equal(0, Timestamp.fromLocalDateTime(LocalDateTime.parse("2025-01-15T00:00:00.123")))))
+        } else {
+          assert(actual1.equals(new PredicateBuilder(rowType1)
             .equal(0, Timestamp.fromLocalDateTime(LocalDateTime.parse("2025-01-14T16:00:00.123")))))
+        }
+        checkAnswer(
+          sql(s"SELECT ts_col from ts_tbl WHERE $filter1"),
+          sql("SELECT timestamp'2025-01-15 00:00:00.123'"))
+        assert(scanFilesCount(filter1, "ts_tbl") == 1)
 
         // Spark support TIMESTAMP_NTZ since Spark 3.4
         if (gteqSpark3_4) {
           sql("CREATE TABLE ts_ntz_tbl (ts_ntz_col TIMESTAMP_NTZ) USING paimon")
+          sql("INSERT INTO ts_ntz_tbl VALUES (timestamp_ntz'2025-01-15 00:00:00.123')")
+          sql("INSERT INTO ts_ntz_tbl VALUES (timestamp_ntz'2025-01-16 00:00:00.123')")
+          val filter2 = "ts_ntz_col = timestamp_ntz'2025-01-15 00:00:00.123'"
           val rowType2 = loadTable("ts_ntz_tbl").rowType()
           val converter2 = SparkV2FilterConverter(rowType2)
-          val actual2 = converter2.convert(
-            v2Filter("ts_ntz_col = timestamp_ntz'2025-01-15 00:00:00.123'", "ts_ntz_tbl"))
+          val actual2 = converter2.convert(v2Filter(filter2, "ts_ntz_tbl"))
           assert(actual2.equals(new PredicateBuilder(rowType2)
             .equal(0, Timestamp.fromLocalDateTime(LocalDateTime.parse("2025-01-15T00:00:00.123")))))
+          checkAnswer(
+            sql(s"SELECT ts_ntz_col from ts_ntz_tbl WHERE $filter2"),
+            sql("SELECT timestamp_ntz'2025-01-15 00:00:00.123'"))
+          assert(scanFilesCount(filter2, "ts_ntz_tbl") == 1)
         }
       }
     }
   }
 
   test("V2Filter: EqualTo") {
-    val actual = converter.convert(v2Filter("int_col = 1"))
+    val filter = "int_col = 1"
+    val actual = converter.convert(v2Filter(filter))
     assert(actual.equals(builder.equal(3, 1)))
+    checkAnswer(sql(s"SELECT int_col from test_tbl WHERE $filter ORDER BY int_col"), Seq(Row(1)))
+    assert(scanFilesCount(filter) == 1)
   }
 
   test("V2Filter: EqualNullSafe") {
-    var actual = converter.convert(v2Filter("int_col <=> 1"))
+    var filter = "int_col <=> 1"
+    var actual = converter.convert(v2Filter(filter))
     assert(actual.equals(builder.equal(3, 1)))
+    checkAnswer(sql(s"SELECT int_col from test_tbl WHERE $filter ORDER BY int_col"), Seq(Row(1)))
+    assert(scanFilesCount(filter) == 1)
 
-    actual = converter.convert(v2Filter("int_col <=> null"))
+    filter = "int_col <=> null"
+    actual = converter.convert(v2Filter(filter))
     assert(actual.equals(builder.isNull(3)))
+    checkAnswer(sql(s"SELECT int_col from test_tbl WHERE $filter ORDER BY int_col"), Seq(Row(null)))
+    assert(scanFilesCount(filter) == 1)
   }
 
   test("V2Filter: GreaterThan") {
-    val actual = converter.convert(v2Filter("int_col > 1"))
-    assert(actual.equals(builder.greaterThan(3, 1)))
+    val filter = "int_col > 2"
+    val actual = converter.convert(v2Filter(filter))
+    assert(actual.equals(builder.greaterThan(3, 2)))
+    checkAnswer(sql(s"SELECT int_col from test_tbl WHERE $filter ORDER BY int_col"), Seq(Row(3)))
+    assert(scanFilesCount(filter) == 1)
   }
 
   test("V2Filter: GreaterThanOrEqual") {
-    val actual = converter.convert(v2Filter("int_col >= 1"))
-    assert(actual.equals(builder.greaterOrEqual(3, 1)))
+    val filter = "int_col >= 2"
+    val actual = converter.convert(v2Filter(filter))
+    assert(actual.equals(builder.greaterOrEqual(3, 2)))
+    checkAnswer(
+      sql(s"SELECT int_col from test_tbl WHERE $filter ORDER BY int_col"),
+      Seq(Row(2), Row(3)))
+    assert(scanFilesCount(filter) == 2)
   }
 
   test("V2Filter: LessThan") {
-    val actual = converter.convert(v2Filter("int_col < 1"))
-    assert(actual.equals(builder.lessThan(3, 1)))
+    val filter = "int_col < 2"
+    val actual = converter.convert(v2Filter("int_col < 2"))
+    assert(actual.equals(builder.lessThan(3, 2)))
+    checkAnswer(sql(s"SELECT int_col from test_tbl WHERE $filter ORDER BY int_col"), Seq(Row(1)))
+    assert(scanFilesCount(filter) == 1)
   }
 
   test("V2Filter: LessThanOrEqual") {
-    val actual = converter.convert(v2Filter("int_col <= 1"))
-    assert(actual.equals(builder.lessOrEqual(3, 1)))
+    val filter = "int_col <= 2"
+    val actual = converter.convert(v2Filter("int_col <= 2"))
+    assert(actual.equals(builder.lessOrEqual(3, 2)))
+    checkAnswer(
+      sql(s"SELECT int_col from test_tbl WHERE $filter ORDER BY int_col "),
+      Seq(Row(1), Row(2)))
+    assert(scanFilesCount(filter) == 2)
   }
 
   test("V2Filter: In") {
-    val actual = converter.convert(v2Filter("int_col IN (1, 2, 3)"))
-    assert(actual.equals(builder.in(3, List(1, 2, 3).map(_.asInstanceOf[AnyRef]).asJava)))
+    val filter = "int_col IN (1, 2)"
+    val actual = converter.convert(v2Filter("int_col IN (1, 2)"))
+    assert(actual.equals(builder.in(3, List(1, 2).map(_.asInstanceOf[AnyRef]).asJava)))
+    checkAnswer(
+      sql(s"SELECT int_col from test_tbl WHERE $filter ORDER BY int_col"),
+      Seq(Row(1), Row(2)))
+    assert(scanFilesCount(filter) == 2)
   }
 
   test("V2Filter: IsNull") {
-    val actual = converter.convert(v2Filter("int_col IS NULL"))
+    val filter = "int_col IS NULL"
+    val actual = converter.convert(v2Filter(filter))
     assert(actual.equals(builder.isNull(3)))
+    checkAnswer(sql(s"SELECT int_col from test_tbl WHERE $filter ORDER BY int_col"), Seq(Row(null)))
+    assert(scanFilesCount(filter) == 1)
   }
 
   test("V2Filter: IsNotNull") {
-    val actual = converter.convert(v2Filter("int_col IS NOT NULL"))
+    val filter = "int_col IS NOT NULL"
+    val actual = converter.convert(v2Filter(filter))
     assert(actual.equals(builder.isNotNull(3)))
+    checkAnswer(
+      sql(s"SELECT int_col from test_tbl WHERE $filter ORDER BY int_col"),
+      Seq(Row(1), Row(2), Row(3)))
+    assert(scanFilesCount(filter) == 3)
   }
 
   test("V2Filter: And") {
-    val actual = converter.convert(v2Filter("int_col > 1 AND int_col < 10"))
-    assert(actual.equals(PredicateBuilder.and(builder.greaterThan(3, 1), builder.lessThan(3, 10))))
+    val filter = "int_col > 1 AND int_col < 3"
+    val actual = converter.convert(v2Filter(filter))
+    assert(actual.equals(PredicateBuilder.and(builder.greaterThan(3, 1), builder.lessThan(3, 3))))
+    checkAnswer(sql(s"SELECT int_col from test_tbl WHERE $filter ORDER BY int_col"), Seq(Row(2)))
+    assert(scanFilesCount(filter) == 1)
   }
 
   test("V2Filter: Or") {
-    val actual = converter.convert(v2Filter("int_col > 1 OR int_col < 10"))
-    assert(actual.equals(PredicateBuilder.or(builder.greaterThan(3, 1), builder.lessThan(3, 10))))
+    val filter = "int_col > 2 OR int_col IS NULL"
+    val actual = converter.convert(v2Filter(filter))
+    assert(actual.equals(PredicateBuilder.or(builder.greaterThan(3, 2), builder.isNull(3))))
+    checkAnswer(
+      sql(s"SELECT int_col from test_tbl WHERE $filter ORDER BY int_col"),
+      Seq(Row(null), Row(3)))
+    assert(scanFilesCount(filter) == 2)
   }
 
   test("V2Filter: Not") {
-    val actual = converter.convert(v2Filter("NOT (int_col > 1)"))
-    assert(actual.equals(builder.greaterThan(3, 1).negate().get()))
+    val filter = "NOT (int_col > 2)"
+    val actual = converter.convert(v2Filter(filter))
+    assert(actual.equals(builder.greaterThan(3, 2).negate().get()))
+    checkAnswer(
+      sql(s"SELECT int_col from test_tbl WHERE $filter ORDER BY int_col"),
+      Seq(Row(1), Row(2)))
+    assert(scanFilesCount(filter) == 2)
   }
 
   test("V2Filter: StartWith") {
-    val actual = converter.convert(v2Filter("string_col LIKE 'h%'"))
+    val filter = "string_col LIKE 'h%'"
+    val actual = converter.convert(v2Filter(filter))
     assert(actual.equals(builder.startsWith(0, BinaryString.fromString("h"))))
+    checkAnswer(
+      sql(s"SELECT string_col from test_tbl WHERE $filter ORDER BY string_col"),
+      Seq(Row("hello"), Row("hi")))
+    assert(scanFilesCount(filter) == 2)
   }
 
   test("V2Filter: EndWith") {
-    val actual = converter.convert(v2Filter("string_col LIKE '%o'"))
+    val filter = "string_col LIKE '%o'"
+    val actual = converter.convert(v2Filter(filter))
     assert(actual.equals(builder.endsWith(0, BinaryString.fromString("o"))))
+    checkAnswer(
+      sql(s"SELECT string_col from test_tbl WHERE $filter ORDER BY string_col"),
+      Seq(Row("hello")))
+    // EndWith does not have file skipping effect now.
+    assert(scanFilesCount(filter) == 4)
   }
 
   test("V2Filter: Contains") {
-    val actual = converter.convert(v2Filter("string_col LIKE '%e%'"))
+    val filter = "string_col LIKE '%e%'"
+    val actual = converter.convert(v2Filter(filter))
     assert(actual.equals(builder.contains(0, BinaryString.fromString("e"))))
+    checkAnswer(
+      sql(s"SELECT string_col from test_tbl WHERE $filter ORDER BY string_col"),
+      Seq(Row("hello")))
+    // Contains does not have file skipping effect now.
+    assert(scanFilesCount(filter) == 4)
   }
 
   private def v2Filter(str: String, tableName: String = "test_tbl"): Predicate = {
@@ -220,5 +362,12 @@ abstract class SparkV2FilterConverterTestBase extends PaimonSparkTestBase {
       .get
       .condition
     translateFilterV2(condition).get
+  }
+
+  private def scanFilesCount(str: String, tableName: String = "test_tbl"): Int = {
+    getPaimonScan(s"SELECT * FROM $tableName WHERE $str").lazyInputPartitions
+      .flatMap(_.splits)
+      .map(_.asInstanceOf[DataSplit].dataFiles().size())
+      .sum
   }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Support push down v2 filter

```scala
class PaimonScanBuilder extends SupportsPushDownV2Filters

class PaimonScan extends SupportsRuntimeV2Filtering
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
