### PR TITLE
[flink] Introduce scan bounded to force bounded in streaming job

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -111,6 +111,12 @@ under the License.
             <td>If true, it will add a compact coordinator and worker operator after the writer operator,in order to compact several changelog files (for primary key tables) or newly created data files (for unaware bucket tables) from the same partition into large ones, which can decrease the number of small files. </td>
         </tr>
         <tr>
+            <td><h5>scan.bounded</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Boolean</td>
+            <td>Bounded mode for Paimon consumer. By default, Paimon automatically selects bounded mode based on the mode of the Flink job.</td>
+        </tr>
+        <tr>
             <td><h5>scan.infer-parallelism</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/paimon-flink/paimon-flink-1.15/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
+++ b/paimon-flink/paimon-flink-1.15/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
@@ -38,13 +38,13 @@ public class DataTableSource extends BaseDataTableSource {
     public DataTableSource(
             ObjectIdentifier tableIdentifier,
             Table table,
-            boolean streaming,
+            boolean unbounded,
             DynamicTableFactory.Context context,
             @Nullable LogStoreTableFactory logStoreTableFactory) {
         this(
                 tableIdentifier,
                 table,
-                streaming,
+                unbounded,
                 context,
                 logStoreTableFactory,
                 null,
@@ -57,7 +57,7 @@ public class DataTableSource extends BaseDataTableSource {
     public DataTableSource(
             ObjectIdentifier tableIdentifier,
             Table table,
-            boolean streaming,
+            boolean unbounded,
             DynamicTableFactory.Context context,
             @Nullable LogStoreTableFactory logStoreTableFactory,
             @Nullable Predicate predicate,
@@ -68,7 +68,7 @@ public class DataTableSource extends BaseDataTableSource {
         super(
                 tableIdentifier,
                 table,
-                streaming,
+                unbounded,
                 context,
                 logStoreTableFactory,
                 predicate,
@@ -83,7 +83,7 @@ public class DataTableSource extends BaseDataTableSource {
         return new DataTableSource(
                 tableIdentifier,
                 table,
-                streaming,
+                unbounded,
                 context,
                 logStoreTableFactory,
                 predicate,

--- a/paimon-flink/paimon-flink-common/pom.xml
+++ b/paimon-flink/paimon-flink-common/pom.xml
@@ -125,6 +125,10 @@ under the License.
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -444,6 +444,14 @@ public class FlinkConnectorOptions {
                                     + "${UID_PREFIX}_${TABLE_NAME}_${USER_UID_SUFFIX}. If the uid suffix is not set, flink will "
                                     + "automatically generate the operator uid, which may be incompatible when the topology changes.");
 
+    public static final ConfigOption<Boolean> SCAN_BOUNDED =
+            key("scan.bounded")
+                    .booleanType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Bounded mode for Paimon consumer. "
+                                    + "By default, Paimon automatically selects bounded mode based on the mode of the Flink job.");
+
     public static List<ConfigOption<?>> getOptions() {
         final Field[] fields = FlinkConnectorOptions.class.getFields();
         final List<ConfigOption<?>> list = new ArrayList<>(fields.length);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
@@ -56,13 +56,13 @@ public class DataTableSource extends BaseDataTableSource
     public DataTableSource(
             ObjectIdentifier tableIdentifier,
             Table table,
-            boolean streaming,
+            boolean unbounded,
             DynamicTableFactory.Context context,
             @Nullable LogStoreTableFactory logStoreTableFactory) {
         this(
                 tableIdentifier,
                 table,
-                streaming,
+                unbounded,
                 context,
                 logStoreTableFactory,
                 null,
@@ -76,7 +76,7 @@ public class DataTableSource extends BaseDataTableSource
     public DataTableSource(
             ObjectIdentifier tableIdentifier,
             Table table,
-            boolean streaming,
+            boolean unbounded,
             DynamicTableFactory.Context context,
             @Nullable LogStoreTableFactory logStoreTableFactory,
             @Nullable Predicate predicate,
@@ -88,7 +88,7 @@ public class DataTableSource extends BaseDataTableSource
         super(
                 tableIdentifier,
                 table,
-                streaming,
+                unbounded,
                 context,
                 logStoreTableFactory,
                 predicate,
@@ -104,7 +104,7 @@ public class DataTableSource extends BaseDataTableSource
         return new DataTableSource(
                 tableIdentifier,
                 table,
-                streaming,
+                unbounded,
                 context,
                 logStoreTableFactory,
                 predicate,
@@ -117,7 +117,7 @@ public class DataTableSource extends BaseDataTableSource
 
     @Override
     public TableStats reportStatistics() {
-        if (streaming) {
+        if (unbounded) {
             return TableStats.UNKNOWN;
         }
         Optional<Statistics> optionStatistics = table.statistics();
@@ -142,13 +142,13 @@ public class DataTableSource extends BaseDataTableSource
     @Override
     public List<String> listAcceptedFilterFields() {
         // note that streaming query doesn't support dynamic filtering
-        return streaming ? Collections.emptyList() : table.partitionKeys();
+        return unbounded ? Collections.emptyList() : table.partitionKeys();
     }
 
     @Override
     public void applyDynamicFiltering(List<String> candidateFilterFields) {
         checkState(
-                !streaming,
+                !unbounded,
                 "Cannot apply dynamic filtering to Paimon table '%s' when streaming reading.",
                 table.name());
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkTableSource.java
@@ -108,7 +108,7 @@ public abstract class FlinkTableSource
                 unConsumedFilters.add(filter);
             } else {
                 Predicate p = predicateOptional.get();
-                if (isStreaming() || !p.visit(onlyPartFieldsVisitor)) {
+                if (isUnbounded() || !p.visit(onlyPartFieldsVisitor)) {
                     unConsumedFilters.add(filter);
                 } else {
                     consumedFilters.add(filter);
@@ -137,7 +137,7 @@ public abstract class FlinkTableSource
         this.limit = limit;
     }
 
-    public abstract boolean isStreaming();
+    public abstract boolean isUnbounded();
 
     @Nullable
     protected Integer inferSourceParallelism(StreamExecutionEnvironment env) {
@@ -150,7 +150,7 @@ public abstract class FlinkTableSource
         }
         Integer parallelism = options.get(FlinkConnectorOptions.SCAN_PARALLELISM);
         if (parallelism == null && options.get(FlinkConnectorOptions.INFER_SCAN_PARALLELISM)) {
-            if (isStreaming()) {
+            if (isUnbounded()) {
                 parallelism = Math.max(1, options.get(CoreOptions.BUCKET));
             } else {
                 scanSplitsForInference();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/SystemTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/SystemTableSource.java
@@ -42,15 +42,14 @@ import javax.annotation.Nullable;
 /** A {@link FlinkTableSource} for system table. */
 public class SystemTableSource extends FlinkTableSource {
 
-    private final boolean isStreamingMode;
+    private final boolean unbounded;
     private final int splitBatchSize;
     private final FlinkConnectorOptions.SplitAssignMode splitAssignMode;
     private final ObjectIdentifier tableIdentifier;
 
-    public SystemTableSource(
-            Table table, boolean isStreamingMode, ObjectIdentifier tableIdentifier) {
+    public SystemTableSource(Table table, boolean unbounded, ObjectIdentifier tableIdentifier) {
         super(table);
-        this.isStreamingMode = isStreamingMode;
+        this.unbounded = unbounded;
         Options options = Options.fromMap(table.options());
         this.splitBatchSize = options.get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_BATCH_SIZE);
         this.splitAssignMode = options.get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_ASSIGN_MODE);
@@ -59,7 +58,7 @@ public class SystemTableSource extends FlinkTableSource {
 
     public SystemTableSource(
             Table table,
-            boolean isStreamingMode,
+            boolean unbounded,
             @Nullable Predicate predicate,
             @Nullable int[][] projectFields,
             @Nullable Long limit,
@@ -67,7 +66,7 @@ public class SystemTableSource extends FlinkTableSource {
             FlinkConnectorOptions.SplitAssignMode splitAssignMode,
             ObjectIdentifier tableIdentifier) {
         super(table, predicate, projectFields, limit);
-        this.isStreamingMode = isStreamingMode;
+        this.unbounded = unbounded;
         this.splitBatchSize = splitBatchSize;
         this.splitAssignMode = splitAssignMode;
         this.tableIdentifier = tableIdentifier;
@@ -96,7 +95,7 @@ public class SystemTableSource extends FlinkTableSource {
         }
         readBuilder.withFilter(predicate);
 
-        if (isStreamingMode && table instanceof DataTable) {
+        if (unbounded && table instanceof DataTable) {
             source =
                     new ContinuousFileStoreSource(
                             readBuilder, table.options(), limit, BucketMode.HASH_FIXED, rowData);
@@ -125,7 +124,7 @@ public class SystemTableSource extends FlinkTableSource {
     public SystemTableSource copy() {
         return new SystemTableSource(
                 table,
-                isStreamingMode,
+                unbounded,
                 predicate,
                 projectFields,
                 limit,
@@ -140,7 +139,7 @@ public class SystemTableSource extends FlinkTableSource {
     }
 
     @Override
-    public boolean isStreaming() {
-        return isStreamingMode;
+    public boolean isUnbounded() {
+        return unbounded;
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
We need to introduce the pattern of running bounded reads in stream jobs, which is useful in certain application scenarios, such as broadcasting a Paimon table to the stream operator.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

`BatchFileStoreITCase.testScanBounded`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
