### PR TITLE
[docs] Fix typo of BIG_ENDIAN

### DIFF
--- a/docs/content/concepts/spec/fileindex.md
+++ b/docs/content/concepts/spec/fileindex.md
@@ -69,15 +69,15 @@ File index file format. Put all column and offset in the header.
 ｜                BODY                 ｜
 ｜_____________________________________｜    _____________________
 *
-magic:                            8 bytes long, value is 1493475289347502L, BIT_ENDIAN
-version:                          4 bytes int, BIT_ENDIAN
-head length:                      4 bytes int, BIT_ENDIAN
-column number:                    4 bytes int, BIT_ENDIAN
-column x name:                    2 bytes short BIT_ENDIAN and Java modified-utf-8
-index number:                     4 bytes int (how many column items below), BIT_ENDIAN
-index name x:                     2 bytes short BIT_ENDIAN and Java modified-utf-8
-start pos:                        4 bytes int, BIT_ENDIAN
-length:                           4 bytes int, BIT_ENDIAN
+magic:                            8 bytes long, value is 1493475289347502L, BIG_ENDIAN
+version:                          4 bytes int, BIG_ENDIAN
+head length:                      4 bytes int, BIG_ENDIAN
+column number:                    4 bytes int, BIG_ENDIAN
+column x name:                    2 bytes short BIG_ENDIAN and Java modified-utf-8
+index number:                     4 bytes int (how many column items below), BIG_ENDIAN
+index name x:                     2 bytes short BIG_ENDIAN and Java modified-utf-8
+start pos:                        4 bytes int, BIG_ENDIAN
+length:                           4 bytes int, BIG_ENDIAN
 redundant length:                 4 bytes int (for compatibility with later versions, in this version, content is zero)
 redundant bytes:                  var bytes (for compatibility with later version, in this version, is empty)
 BODY:                             column index bytes + column index bytes + column index bytes + .......
@@ -88,7 +88,7 @@ BODY:                             column index bytes + column index bytes + colu
 Define `'file-index.bloom-filter.columns'`.
 
 Content of bloom filter index is simple: 
-- numHashFunctions 4 bytes int, BIT_ENDIAN
+- numHashFunctions 4 bytes int, BIG_ENDIAN
 - bloom filter bytes
 
 This class use (64-bits) long hash. Store the num hash function (one integer) and bit set bytes only. Hash bytes type 
@@ -135,7 +135,7 @@ offset:                        4 bytes int (when it is negative, it represents t
                                  and its position is the inverse of the negative value)
 </pre>
 
-Integer are all BIT_ENDIAN.
+Integer are all BIG_ENDIAN.
 
 ## Index: Bit-Slice Index Bitmap
 

--- a/docs/content/concepts/spec/tableindex.md
+++ b/docs/content/concepts/spec/tableindex.md
@@ -36,7 +36,7 @@ Its structure is very simple, only storing hash values in the file:
 
 HASH_VALUE | HASH_VALUE | HASH_VALUE | HASH_VALUE | ...
 
-HASH_VALUE is the hash value of the primary-key. 4 bytes, BIT_ENDIAN.
+HASH_VALUE is the hash value of the primary-key. 4 bytes, BIG_ENDIAN.
 
 ## Deletion Vectors
 
@@ -49,9 +49,9 @@ The deletion file is a binary file, and the format is as follows:
 
 - First, record version by a byte. Current version is 1.
 - Then, record <size of serialized bin, serialized bin, checksum of serialized bin> in sequence.
-- Size and checksum are BIT_ENDIAN Integer.
+- Size and checksum are BIG_ENDIAN Integer.
 
 For each serialized bin:
 
-- First, record a const magic number by an int (BIT_ENDIAN). Current the magic number is 1581511376.
+- First, record a const magic number by an int (BIG_ENDIAN). Current the magic number is 1581511376.
 - Then, record serialized bitmap. Which is a [RoaringBitmap](https://github.com/RoaringBitmap/RoaringBitmap) (org.roaringbitmap.RoaringBitmap).


### PR DESCRIPTION
### Purpose

Fix the typo of `BIT_ENDIAN` to `BIG_ENDIAN`

### Tests

N/A

### API and Format

N/A

### Documentation

N/A
