### PR TITLE
[spark] Fix rollback not correctly identify tag or snapshot

### DIFF
--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -162,10 +162,12 @@ This section introduce all available spark procedures about paimon.
          To rollback to a specific version of target table. Argument:
             <li>table: the target table identifier. Cannot be empty.</li>
             <li>version: id of the snapshot or name of tag that will roll back to.</li>
+            <li>type: type of version and default is snapshot, user can set it with snapshot or tag.</li>
       </td>
       <td>
           CALL sys.rollback(table => 'default.T', version => 'my_tag')<br/><br/>
-          CALL sys.rollback(table => 'default.T', version => 10)
+          CALL sys.rollback(table => 'default.T', version => 10)<br/><br/>
+          CALL sys.rollback(table => 'default.T', version => '20250122', type => 'tag')
       </td>
     </tr>
     <tr>

--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -161,14 +161,15 @@ This section introduce all available spark procedures about paimon.
       <td>
          To rollback to a specific version of target table, note version/snapshot/tag must set one of them. Argument:
             <li>table: the target table identifier. Cannot be empty.</li>
-            <li>version: id of the snapshot or name of tag that will roll back to.</li>
+            <li>version: id of the snapshot or name of tag that will roll back to, version would be Deprecated.</li>
             <li>snapshot: snapshot that will roll back to.</li>
             <li>tag: tag that will roll back to.</li>
       </td>
       <td>
           CALL sys.rollback(table => 'default.T', version => 'my_tag')<br/><br/>
           CALL sys.rollback(table => 'default.T', version => 10)<br/><br/>
-          CALL sys.rollback(table => 'default.T', version => '20250122', type => 'tag')
+          CALL sys.rollback(table => 'default.T', tag => 'tag1')
+          CALL sys.rollback(table => 'default.T', snapshot => 2)
       </td>
     </tr>
     <tr>

--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -159,10 +159,11 @@ This section introduce all available spark procedures about paimon.
     <tr>
       <td>rollback</td>
       <td>
-         To rollback to a specific version of target table. Argument:
+         To rollback to a specific version of target table, note version/snapshot/tag must set one of them. Argument:
             <li>table: the target table identifier. Cannot be empty.</li>
             <li>version: id of the snapshot or name of tag that will roll back to.</li>
-            <li>type: type of version and default is snapshot, user can set it with snapshot or tag.</li>
+            <li>snapshot: snapshot that will roll back to.</li>
+            <li>tag: tag that will roll back to.</li>
       </td>
       <td>
           CALL sys.rollback(table => 'default.T', version => 'my_tag')<br/><br/>

--- a/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/RollbackProcedureTest.scala
+++ b/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/RollbackProcedureTest.scala
@@ -93,44 +93,4 @@ class RollbackProcedureTest extends PaimonSparkTestBase with StreamTest {
       }
     }
   }
-
-  test("Paimon Procedure: rollback to tag check test") {
-    spark.sql(s"""
-                 |CREATE TABLE T (a INT, b STRING)
-                 |TBLPROPERTIES ('primary-key'='a', 'bucket'='3', 'file.format'='orc')
-                 |""".stripMargin)
-
-    val query = () => spark.sql("SELECT * FROM T ORDER BY a")
-
-    // snapshot-1
-    spark.sql("insert into T select 1, 'a'")
-    checkAnswer(query(), Row(1, "a") :: Nil)
-
-    checkAnswer(
-      spark.sql("CALL paimon.sys.create_tag(table => 'test.T', tag => '20250122', snapshot => 1)"),
-      Row(true) :: Nil)
-
-    // snapshot-2
-    spark.sql("insert into T select 2, 'b'")
-    checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
-
-    // snapshot-3
-    spark.sql("insert into T select 2, 'b2'")
-    checkAnswer(query(), Row(1, "a") :: Row(2, "b2") :: Nil)
-    assertThrows[RuntimeException] {
-      spark.sql("CALL paimon.sys.rollback(table => 'test.T_exception', version => '2')")
-    }
-    // rollback to snapshot
-    checkAnswer(
-      spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '2')"),
-      Row(true) :: Nil)
-    checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
-
-    // rollback to tag
-    checkAnswer(
-      spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '20250122')"),
-      Row(true) :: Nil)
-    checkAnswer(query(), Row(1, "a") :: Nil)
-  }
-
 }

--- a/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/RollbackProcedureTest.scala
+++ b/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/RollbackProcedureTest.scala
@@ -35,7 +35,7 @@ class RollbackProcedureTest extends PaimonSparkTestBase with StreamTest {
           // define a pk table and test `forEachBatch` api
           spark.sql(s"""
                        |CREATE TABLE T (a INT, b STRING)
-                       |TBLPROPERTIES ('primary-key'='a', 'bucket'='3', 'file.format'='orc')
+                       |TBLPROPERTIES ('primary-key'='a', 'bucket'='3')
                        |""".stripMargin)
           val location = loadTable("T").location().toString
 

--- a/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/RollbackProcedureTest.scala
+++ b/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/RollbackProcedureTest.scala
@@ -95,44 +95,42 @@ class RollbackProcedureTest extends PaimonSparkTestBase with StreamTest {
   }
 
   test("Paimon Procedure: rollback to tag check test") {
-          spark.sql(
-            s"""
-               |CREATE TABLE T (a INT, b STRING)
-               |TBLPROPERTIES ('primary-key'='a', 'bucket'='3', 'file.format'='orc')
-               |""".stripMargin)
+    spark.sql(s"""
+                 |CREATE TABLE T (a INT, b STRING)
+                 |TBLPROPERTIES ('primary-key'='a', 'bucket'='3', 'file.format'='orc')
+                 |""".stripMargin)
 
-          val query = () => spark.sql("SELECT * FROM T ORDER BY a")
+    val query = () => spark.sql("SELECT * FROM T ORDER BY a")
 
-            // snapshot-1
-            spark.sql("insert into T select 1, 'a'")
-            checkAnswer(query(), Row(1, "a") :: Nil)
+    // snapshot-1
+    spark.sql("insert into T select 1, 'a'")
+    checkAnswer(query(), Row(1, "a") :: Nil)
 
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.create_tag(table => 'test.T', tag => '20250122', snapshot => 1)"),
-              Row(true) :: Nil)
+    checkAnswer(
+      spark.sql("CALL paimon.sys.create_tag(table => 'test.T', tag => '20250122', snapshot => 1)"),
+      Row(true) :: Nil)
 
-            // snapshot-2
-            spark.sql("insert into T select 2, 'b'")
-            checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
+    // snapshot-2
+    spark.sql("insert into T select 2, 'b'")
+    checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
 
-            // snapshot-3
-            spark.sql("insert into T select 2, 'b2'")
-            checkAnswer(query(), Row(1, "a") :: Row(2, "b2") :: Nil)
-            assertThrows[RuntimeException] {
-              spark.sql("CALL paimon.sys.rollback(table => 'test.T_exception', version => '2')")
-            }
-            // rollback to snapshot
-            checkAnswer(
-              spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '2')"),
-              Row(true) :: Nil)
-            checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
+    // snapshot-3
+    spark.sql("insert into T select 2, 'b2'")
+    checkAnswer(query(), Row(1, "a") :: Row(2, "b2") :: Nil)
+    assertThrows[RuntimeException] {
+      spark.sql("CALL paimon.sys.rollback(table => 'test.T_exception', version => '2')")
+    }
+    // rollback to snapshot
+    checkAnswer(
+      spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '2')"),
+      Row(true) :: Nil)
+    checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
 
-            // rollback to tag
-            checkAnswer(
-              spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '20250122')"),
-              Row(true) :: Nil)
-            checkAnswer(query(), Row(1, "a") :: Nil)
-      }
+    // rollback to tag
+    checkAnswer(
+      spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '20250122')"),
+      Row(true) :: Nil)
+    checkAnswer(query(), Row(1, "a") :: Nil)
+  }
 
 }

--- a/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/RollbackProcedureTest.scala
+++ b/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/RollbackProcedureTest.scala
@@ -35,7 +35,7 @@ class RollbackProcedureTest extends PaimonSparkTestBase with StreamTest {
           // define a pk table and test `forEachBatch` api
           spark.sql(s"""
                        |CREATE TABLE T (a INT, b STRING)
-                       |TBLPROPERTIES ('primary-key'='a', 'bucket'='3')
+                       |TBLPROPERTIES ('primary-key'='a', 'bucket'='3', 'file.format'='orc')
                        |""".stripMargin)
           val location = loadTable("T").location().toString
 
@@ -93,4 +93,46 @@ class RollbackProcedureTest extends PaimonSparkTestBase with StreamTest {
       }
     }
   }
+
+  test("Paimon Procedure: rollback to tag check test") {
+          spark.sql(
+            s"""
+               |CREATE TABLE T (a INT, b STRING)
+               |TBLPROPERTIES ('primary-key'='a', 'bucket'='3', 'file.format'='orc')
+               |""".stripMargin)
+
+          val query = () => spark.sql("SELECT * FROM T ORDER BY a")
+
+            // snapshot-1
+            spark.sql("insert into T select 1, 'a'")
+            checkAnswer(query(), Row(1, "a") :: Nil)
+
+            checkAnswer(
+              spark.sql(
+                "CALL paimon.sys.create_tag(table => 'test.T', tag => '20250122', snapshot => 1)"),
+              Row(true) :: Nil)
+
+            // snapshot-2
+            spark.sql("insert into T select 2, 'b'")
+            checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
+
+            // snapshot-3
+            spark.sql("insert into T select 2, 'b2'")
+            checkAnswer(query(), Row(1, "a") :: Row(2, "b2") :: Nil)
+            assertThrows[RuntimeException] {
+              spark.sql("CALL paimon.sys.rollback(table => 'test.T_exception', version => '2')")
+            }
+            // rollback to snapshot
+            checkAnswer(
+              spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '2')"),
+              Row(true) :: Nil)
+            checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
+
+            // rollback to tag
+            checkAnswer(
+              spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '20250122')"),
+              Row(true) :: Nil)
+            checkAnswer(query(), Row(1, "a") :: Nil)
+      }
+
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RollbackProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RollbackProcedure.java
@@ -71,7 +71,7 @@ public class RollbackProcedure extends BaseProcedure {
                 || (snapshot != null && tag != null)
                 || (tag != null && version != null)) {
             throw new IllegalArgumentException(
-                    "only can set only one of version/snapshot/tag in RollbackProcedure.");
+                    "only can set one of version/snapshot/tag in RollbackProcedure.");
         }
 
         if (version == null && snapshot == null && tag == null) {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RollbackProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RollbackProcedure.java
@@ -82,7 +82,6 @@ public class RollbackProcedure extends BaseProcedure {
                     } else {
                         table.rollbackTo(version);
                     }
-
                     InternalRow outputRow = newInternalRow(true);
                     return new InternalRow[] {outputRow};
                 });

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RollbackProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RollbackProcedure.java
@@ -20,6 +20,7 @@ package org.apache.paimon.spark.procedure;
 
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.utils.TagManager;
+
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
@@ -70,7 +71,8 @@ public class RollbackProcedure extends BaseProcedure {
                 table -> {
                     FileStoreTable fileStoreTable = (FileStoreTable) table;
                     TagManager tagManager = fileStoreTable.tagManager();
-                    if (version.chars().allMatch(Character::isDigit) && !tagManager.tagExists(version)) {
+                    if (version.chars().allMatch(Character::isDigit)
+                            && !tagManager.tagExists(version)) {
                         table.rollbackTo(Long.parseLong(version));
                     } else {
                         table.rollbackTo(version);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RollbackProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RollbackProcedure.java
@@ -71,7 +71,12 @@ public class RollbackProcedure extends BaseProcedure {
                 || (snapshot != null && tag != null)
                 || (tag != null && version != null)) {
             throw new IllegalArgumentException(
-                    "only can set one of version/snapshot/tag in RollbackProcedure.");
+                    "only can set only one of version/snapshot/tag in RollbackProcedure.");
+        }
+
+        if (version == null && snapshot == null && tag == null) {
+            throw new IllegalArgumentException(
+                    "must set one of version/snapshot/tag in RollbackProcedure.");
         }
 
         return modifyPaimonTable(

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RollbackProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RollbackProcedure.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.spark.procedure;
 
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.TagManager;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
@@ -66,7 +68,9 @@ public class RollbackProcedure extends BaseProcedure {
         return modifyPaimonTable(
                 tableIdent,
                 table -> {
-                    if (version.chars().allMatch(Character::isDigit)) {
+                    FileStoreTable fileStoreTable = (FileStoreTable) table;
+                    TagManager tagManager = fileStoreTable.tagManager();
+                    if (version.chars().allMatch(Character::isDigit) && !tagManager.tagExists(version)) {
                         table.rollbackTo(Long.parseLong(version));
                     } else {
                         table.rollbackTo(version);

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RollbackProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RollbackProcedureTest.scala
@@ -126,10 +126,14 @@ class RollbackProcedureTest extends PaimonSparkTestBase with StreamTest {
       Row(true) :: Nil)
     checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
 
+    // digtal version would throw out if not set type = tag
+    assertThrows[RuntimeException] {
+      spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '20250122')")
+    }
+
     // rollback to tag
-    checkAnswer(
-      spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '20250122')"),
-      Row(true) :: Nil)
+    spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '20250122', type => 'tag')")
+
     checkAnswer(query(), Row(1, "a") :: Nil)
   }
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RollbackProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RollbackProcedureTest.scala
@@ -94,6 +94,45 @@ class RollbackProcedureTest extends PaimonSparkTestBase with StreamTest {
     }
   }
 
+  test("Paimon Procedure: rollback to tag check test") {
+    spark.sql(s"""
+                 |CREATE TABLE T (a INT, b STRING)
+                 |TBLPROPERTIES ('primary-key'='a', 'bucket'='3', 'file.format'='orc')
+                 |""".stripMargin)
+
+    val query = () => spark.sql("SELECT * FROM T ORDER BY a")
+
+    // snapshot-1
+    spark.sql("insert into T select 1, 'a'")
+    checkAnswer(query(), Row(1, "a") :: Nil)
+
+    checkAnswer(
+      spark.sql("CALL paimon.sys.create_tag(table => 'test.T', tag => '20250122', snapshot => 1)"),
+      Row(true) :: Nil)
+
+    // snapshot-2
+    spark.sql("insert into T select 2, 'b'")
+    checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
+
+    // snapshot-3
+    spark.sql("insert into T select 2, 'b2'")
+    checkAnswer(query(), Row(1, "a") :: Row(2, "b2") :: Nil)
+    assertThrows[RuntimeException] {
+      spark.sql("CALL paimon.sys.rollback(table => 'test.T_exception', version => '2')")
+    }
+    // rollback to snapshot
+    checkAnswer(
+      spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '2')"),
+      Row(true) :: Nil)
+    checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
+
+    // rollback to tag
+    checkAnswer(
+      spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '20250122')"),
+      Row(true) :: Nil)
+    checkAnswer(query(), Row(1, "a") :: Nil)
+  }
+
   test("Paimon Procedure: rollback to timestamp") {
     failAfter(streamingTimeout) {
       withTempDir {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RollbackProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RollbackProcedureTest.scala
@@ -126,13 +126,22 @@ class RollbackProcedureTest extends PaimonSparkTestBase with StreamTest {
       Row(true) :: Nil)
     checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
 
-    // digtal version would throw out if not set type = tag
+    // version/snapshot/tag can only set one of them
     assertThrows[RuntimeException] {
-      spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '20250122')")
+      spark.sql(
+        "CALL paimon.sys.rollback(table => 'test.T', version => '20250122', tag => '20250122')")
+    }
+
+    assertThrows[RuntimeException] {
+      spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '20250122', snapshot => 1)")
+    }
+
+    assertThrows[RuntimeException] {
+      spark.sql("CALL paimon.sys.rollback(table => 'test.T', tag => '20250122', snapshot => 1)")
     }
 
     // rollback to tag
-    spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '20250122', type => 'tag')")
+    spark.sql("CALL paimon.sys.rollback(table => 'test.T', tag => '20250122')")
 
     checkAnswer(query(), Row(1, "a") :: Nil)
   }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RollbackProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RollbackProcedureTest.scala
@@ -115,16 +115,21 @@ class RollbackProcedureTest extends PaimonSparkTestBase with StreamTest {
     checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
 
     // snapshot-3
-    spark.sql("insert into T select 2, 'b2'")
-    checkAnswer(query(), Row(1, "a") :: Row(2, "b2") :: Nil)
+    spark.sql("insert into T select 3, 'c'")
+    checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Row(3, "c") :: Nil)
+
+    // snapshot-4
+    spark.sql("insert into T select 4, 'd'")
+    checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Row(3, "c") :: Row(4, "d") :: Nil)
+
     assertThrows[RuntimeException] {
-      spark.sql("CALL paimon.sys.rollback(table => 'test.T_exception', version => '2')")
+      spark.sql("CALL paimon.sys.rollback(table => 'test.T_exception', version => '4')")
     }
     // rollback to snapshot
     checkAnswer(
-      spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '2')"),
+      spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '3')"),
       Row(true) :: Nil)
-    checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
+    checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Row(3, "c") :: Nil)
 
     // version/snapshot/tag can only set one of them
     assertThrows[RuntimeException] {
@@ -140,9 +145,12 @@ class RollbackProcedureTest extends PaimonSparkTestBase with StreamTest {
       spark.sql("CALL paimon.sys.rollback(table => 'test.T', tag => '20250122', snapshot => 1)")
     }
 
+    // rollback to snapshot
+    spark.sql("CALL paimon.sys.rollback(table => 'test.T', snapshot => 2)")
+    checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
+
     // rollback to tag
     spark.sql("CALL paimon.sys.rollback(table => 'test.T', tag => '20250122')")
-
     checkAnswer(query(), Row(1, "a") :: Nil)
   }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

Rollback in spark currently cannot  correctly identify tag or snapshot, such as tag named with 20250122 would be handle as snapshot like:
Rollback snapshot '20250122' doesn't exist.
java.lang.IllegalArgumentException: Rollback snapshot '20250122' doesn't exist.
	at org.apache.paimon.utils.Preconditions.checkArgument(Preconditions.java:149)
	at org.apache.paimon.table.AbstractFileStoreTable.rollbackTo(AbstractFileStoreTable.java:572)
	at org.apache.paimon.spark.procedure.RollbackProcedure.lambda$call$0(RollbackProcedure.java:74)
	at org.apache.paimon.spark.procedure.BaseProcedure.execute(BaseProcedure.java:88)
	at org.apache.paimon.spark.procedure.BaseProcedure.modifyPaimonTable(BaseProcedure.java:78)
	at org.apache.paimon.spark.procedure.RollbackProcedure.call(RollbackProcedure.java:68)
	at org.apache.paimon.spark.execution.PaimonCallExec.run(PaimonCallExec.scala:32)
	at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.result$lzycompute(V2CommandExec.scala:43)
	at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.result(V2CommandExec.scala:43)
	at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.executeCollect(V2CommandExec.scala:49)

this pr is aim to fix it with check tag firstly.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
