### PR TITLE
[refactor] Clean unused codes in Lock

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -267,8 +267,7 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
         SnapshotManager snapshotManager = snapshotManager();
         SnapshotCommit snapshotCommit = catalogEnvironment.snapshotCommit(snapshotManager);
         if (snapshotCommit == null) {
-            snapshotCommit =
-                    new RenamingSnapshotCommit(snapshotManager, Lock.emptyFactory().create());
+            snapshotCommit = new RenamingSnapshotCommit(snapshotManager, Lock.empty());
         }
         return new FileStoreCommitImpl(
                 snapshotCommit,

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
@@ -134,7 +134,7 @@ public class FileSystemCatalog extends AbstractCatalog {
                 lockFactory
                         .map(factory -> factory.createLock(lockContext().orElse(null)))
                         .map(l -> Lock.fromCatalog(l, identifier))
-                        .orElseGet(() -> Lock.emptyFactory().create())) {
+                        .orElseGet(Lock::empty)) {
             return lock.runWithLock(callable);
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/RenamingSnapshotCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/RenamingSnapshotCommit.java
@@ -99,7 +99,7 @@ public class RenamingSnapshotCommit implements SnapshotCommit {
                     Optional.ofNullable(lockFactory)
                             .map(factory -> factory.createLock(lockContext))
                             .map(l -> Lock.fromCatalog(l, identifier))
-                            .orElseGet(() -> Lock.emptyFactory().create());
+                            .orElseGet(Lock::empty);
             return new RenamingSnapshotCommit(snapshotManager, lock);
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/Lock.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/Lock.java
@@ -22,7 +22,6 @@ import org.apache.paimon.annotation.Public;
 import org.apache.paimon.catalog.CatalogLock;
 import org.apache.paimon.catalog.Identifier;
 
-import java.io.Serializable;
 import java.util.concurrent.Callable;
 
 /**
@@ -36,24 +35,8 @@ public interface Lock extends AutoCloseable {
     /** Run with lock. */
     <T> T runWithLock(Callable<T> callable) throws Exception;
 
-    /** A factory to create {@link Lock}. */
-    interface Factory extends Serializable {
-        Lock create();
-    }
-
-    static Factory emptyFactory() {
-        return new EmptyFactory();
-    }
-
-    /** A {@link Factory} creating empty lock. */
-    class EmptyFactory implements Factory {
-
-        private static final long serialVersionUID = 1L;
-
-        @Override
-        public Lock create() {
-            return new EmptyLock();
-        }
+    static Lock empty() {
+        return new EmptyLock();
     }
 
     /** An empty lock. */

--- a/paimon-core/src/main/java/org/apache/paimon/operation/Lock.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/Lock.java
@@ -20,11 +20,7 @@ package org.apache.paimon.operation;
 
 import org.apache.paimon.annotation.Public;
 import org.apache.paimon.catalog.CatalogLock;
-import org.apache.paimon.catalog.CatalogLockContext;
-import org.apache.paimon.catalog.CatalogLockFactory;
 import org.apache.paimon.catalog.Identifier;
-
-import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.util.concurrent.Callable;
@@ -45,41 +41,8 @@ public interface Lock extends AutoCloseable {
         Lock create();
     }
 
-    static Factory factory(
-            @Nullable CatalogLockFactory lockFactory,
-            @Nullable CatalogLockContext lockContext,
-            Identifier tablePath) {
-        return lockFactory == null
-                ? new EmptyFactory()
-                : new LockFactory(lockFactory, lockContext, tablePath);
-    }
-
     static Factory emptyFactory() {
         return new EmptyFactory();
-    }
-
-    /** A {@link Factory} creating lock from catalog. */
-    class LockFactory implements Factory {
-
-        private static final long serialVersionUID = 1L;
-
-        private final CatalogLockFactory lockFactory;
-        private final CatalogLockContext lockContext;
-        private final Identifier tablePath;
-
-        public LockFactory(
-                CatalogLockFactory lockFactory,
-                CatalogLockContext lockContext,
-                Identifier tablePath) {
-            this.lockFactory = lockFactory;
-            this.lockContext = lockContext;
-            this.tablePath = tablePath;
-        }
-
-        @Override
-        public Lock create() {
-            return fromCatalog(lockFactory.createLock(lockContext), tablePath);
-        }
     }
 
     /** A {@link Factory} creating empty lock. */

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -318,7 +318,7 @@ public class RESTCatalogServer {
         FileStoreTable table =
                 (FileStoreTable) catalog.getTable(Identifier.create(databaseName, tableName));
         RenamingSnapshotCommit commit =
-                new RenamingSnapshotCommit(table.snapshotManager(), Lock.emptyFactory().create());
+                new RenamingSnapshotCommit(table.snapshotManager(), Lock.empty());
         String branchName = requestBody.getIdentifier().getBranchName();
         if (branchName == null) {
             branchName = "main";


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
After #4911 , the `LockFactory` is not used any more.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
