### PR TITLE
refine CommitMessage toString

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/io/CompactIncrement.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/CompactIncrement.java
@@ -78,16 +78,10 @@ public class CompactIncrement {
     @Override
     public String toString() {
         return String.format(
-                "CompactIncrement {compactBefore = [\n%s\n], compactAfter = [\n%s\n], changelogFiles = [\n%s\n]}",
-                compactBefore.stream()
-                        .map(DataFileMeta::fileName)
-                        .collect(Collectors.joining(",\n")),
-                compactAfter.stream()
-                        .map(DataFileMeta::fileName)
-                        .collect(Collectors.joining(",\n")),
-                changelogFiles.stream()
-                        .map(DataFileMeta::fileName)
-                        .collect(Collectors.joining(",\n")));
+                "CompactIncrement {compactBefore = %s, compactAfter = %s, changelogFiles = %s}",
+                compactBefore.stream().map(DataFileMeta::fileName).collect(Collectors.toList()),
+                compactAfter.stream().map(DataFileMeta::fileName).collect(Collectors.toList()),
+                changelogFiles.stream().map(DataFileMeta::fileName).collect(Collectors.toList()));
     }
 
     public static CompactIncrement emptyIncrement() {

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataIncrement.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataIncrement.java
@@ -82,10 +82,9 @@ public class DataIncrement {
     @Override
     public String toString() {
         return String.format(
-                "NewFilesIncrement {newFiles = [\n%s\n], changelogFiles = [\n%s\n]}",
-                newFiles.stream().map(DataFileMeta::fileName).collect(Collectors.joining(",\n")),
-                changelogFiles.stream()
-                        .map(DataFileMeta::fileName)
-                        .collect(Collectors.joining(",\n")));
+                "DataIncrement {newFiles = %s, deletedFiles = %s, changelogFiles = %s}",
+                newFiles.stream().map(DataFileMeta::fileName).collect(Collectors.toList()),
+                deletedFiles.stream().map(DataFileMeta::fileName).collect(Collectors.toList()),
+                changelogFiles.stream().map(DataFileMeta::fileName).collect(Collectors.toList()));
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/io/IndexIncrement.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/IndexIncrement.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /** Incremental index files. */
 public class IndexIncrement {
@@ -77,11 +78,11 @@ public class IndexIncrement {
 
     @Override
     public String toString() {
-        return "IndexIncrement{"
-                + "newIndexFiles="
-                + newIndexFiles
-                + ",deletedIndexFiles="
-                + deletedIndexFiles
-                + "}";
+        return String.format(
+                "IndexIncrement {newIndexFiles = %s, deletedIndexFiles = %s}",
+                newIndexFiles.stream().map(IndexFileMeta::fileName).collect(Collectors.toList()),
+                deletedIndexFiles.stream()
+                        .map(IndexFileMeta::fileName)
+                        .collect(Collectors.toList()));
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #4938

<!-- What is the purpose of the change -->
* Include `deletedFiles` in `DataIncrement#toString`
* Unifying `toString` format of `DataIncrement`, `CompactIncrement` and `IndexIncrement` to formatting `List`s of file names, inlined and spaces around equal sign

### Tests

<!-- List UT and IT cases to verify this change -->
N/A

### API and Format

<!-- Does this change affect API or storage format -->
N/A

### Documentation

<!-- Does this change introduce a new feature -->
N/A