### PR TITLE
[hotfix] remove_orphan_files action shouldn't check table argument (table=null means clean whole database)

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RemoveOrphanFilesActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RemoveOrphanFilesActionFactory.java
@@ -38,7 +38,7 @@ public class RemoveOrphanFilesActionFactory implements ActionFactory {
         RemoveOrphanFilesAction action =
                 new RemoveOrphanFilesAction(
                         params.getRequired(DATABASE),
-                        params.getRequired(TABLE),
+                        params.get(TABLE),
                         params.get(PARALLELISM),
                         catalogConfigMap(params));
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/RemoveOrphanFilesActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/RemoveOrphanFilesActionITCaseBase.java
@@ -175,9 +175,13 @@ public abstract class RemoveOrphanFilesActionITCaseBase extends ActionITCaseBase
                                 "--warehouse",
                                 warehouse,
                                 "--database",
-                                database,
-                                "--table",
-                                "*"));
+                                database));
+
+        if (ThreadLocalRandom.current().nextBoolean()) {
+            args.add("--table");
+            args.add("*");
+        }
+
         RemoveOrphanFilesAction action1 = createAction(RemoveOrphanFilesAction.class, args);
         assertThatCode(action1::run).doesNotThrowAnyException();
 


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
