### PR TITLE
[iceberg] Support skipping AWS Glue archive

### DIFF
--- a/docs/content/migration/iceberg-compatibility.md
+++ b/docs/content/migration/iceberg-compatibility.md
@@ -389,6 +389,12 @@ you also need to set some (or all) of the following table options when creating 
       <td>String</td>
       <td>Hive client class name for Iceberg Hive Catalog.</td>
     </tr>
+    <tr>
+      <td><h5>metadata.iceberg.glue.skip-archive</h5></td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Skip archive for AWS Glue catalog.</td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/layouts/shortcodes/generated/iceberg_configuration.html
+++ b/docs/layouts/shortcodes/generated/iceberg_configuration.html
@@ -45,6 +45,12 @@ under the License.
             <td>Metastore database name for Iceberg Catalog. Set this as an iceberg database alias if using a centralized Catalog.</td>
         </tr>
         <tr>
+            <td><h5>metadata.iceberg.glue.skip-archive</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Skip archive for AWS Glue catalog.</td>
+        </tr>
+        <tr>
             <td><h5>metadata.iceberg.hadoop-conf-dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
@@ -106,6 +106,12 @@ public class IcebergOptions {
                             "Metastore table name for Iceberg Catalog."
                                     + "Set this as an iceberg table alias if using a centralized Catalog.");
 
+    public static final ConfigOption<Boolean> GLUE_SKIP_ARCHIVE =
+            key("metadata.iceberg.glue.skip-archive")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Skip archive for AWS Glue catalog.");
+
     /** Where to store Iceberg metadata. */
     public enum StorageType implements DescribedEnum {
         DISABLED("disabled", "Disable Iceberg compatibility support."),

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitterITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitterITCaseBase.java
@@ -164,7 +164,8 @@ public abstract class IcebergHiveMetadataCommitterITCaseBase {
         tEnv.executeSql("CREATE DATABASE my_paimon.test_db");
         tEnv.executeSql(
                 "CREATE TABLE my_paimon.test_db.t ( pt INT, id INT, data STRING ) PARTITIONED BY (pt) WITH "
-                        + "( 'metadata.iceberg.storage' = 'hive-catalog', 'metadata.iceberg.uri' = '', 'file.format' = 'avro' )");
+                        + "( 'metadata.iceberg.storage' = 'hive-catalog', 'metadata.iceberg.uri' = '', 'file.format' = 'avro',"
+                        + " 'metadata.iceberg.glue.skip-archive' = 'true' )");
         tEnv.executeSql(
                         "INSERT INTO my_paimon.test_db.t VALUES "
                                 + "(1, 1, 'apple'), (1, 2, 'pear'), (2, 1, 'cat'), (2, 2, 'dog')")


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Paimon's Iceberg compatibility layer [suggests](https://paimon.apache.org/docs/1.0/migration/iceberg-compatibility/#:~:text=Note%3A%20You%20can%20use%20this%20repo%20to%20build%20the%20required%20jar%2C%20include%20it%20in%20your%20path%20and%20configure%20the%20AWSCatalogMetastoreClient.) using https://github.com/promotedai/aws-glue-data-catalog-client-for-apache-hive-metastore to connect to AWS Glue catalog. This AWS Glue client package supports skipping Glue archive, however, Paimon is never skipping archive when using that client.

<!-- Linking this pull request to the issue -->
Linked issue: close #4967

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

Added the new option in the test for table options.

### API and Format

<!-- Does this change affect API or storage format -->
The default behavior has not changed in this PR. By default, skip-archive is false.

It is worth noting that in Iceberg the default is true (https://github.com/apache/iceberg/pull/6916) and we also would like to skip Glue archives for our current use case. Let me know if you would like me to change the default to true in this PR.

### Documentation

<!-- Does this change introduce a new feature -->

A new table option is introduced. The docs/layouts/shortcodes/generated/iceberg_configuration.html file was re-generated with:

```
mvn package -Pgenerate-docs -DskipTests -pl paimon-docs/
```