### PR TITLE
[core] Clear cache when deleting the snapshot

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
@@ -252,7 +252,7 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
             if (expireConfig.isChangelogDecoupled()) {
                 commitChangelog(new Changelog(snapshot));
             }
-            snapshotManager.fileIO().deleteQuietly(snapshotManager.snapshotPath(id));
+            snapshotManager.deleteSnapshot(id);
         }
 
         writeEarliestHint(endExclusiveId);

--- a/paimon-core/src/main/java/org/apache/paimon/table/RollbackHelper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/RollbackHelper.java
@@ -122,7 +122,7 @@ public class RollbackHelper {
             // Ignore the non-existent snapshots
             if (snapshotManager.snapshotExists(i)) {
                 toBeCleaned.add(snapshotManager.snapshot(i));
-                fileIO.deleteQuietly(snapshotManager.snapshotPath(i));
+                snapshotManager.deleteSnapshot(i);
             }
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -183,6 +183,14 @@ public class SnapshotManager implements Serializable {
         }
     }
 
+    public void deleteSnapshot(long snapshotId) {
+        Path path = snapshotPath(snapshotId);
+        if (cache != null) {
+            cache.invalidate(path);
+        }
+        fileIO().deleteQuietly(path);
+    }
+
     public boolean longLivedChangelogExists(long snapshotId) {
         Path path = longLivedChangelogPath(snapshotId);
         try {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/SnapshotHintOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/SnapshotHintOperator.java
@@ -84,9 +84,7 @@ public class SnapshotHintOperator extends AbstractStreamOperator<CloneFileInfo>
             targetTableSnapshotManager.commitLatestHint(snapshotId);
             for (Snapshot snapshot : targetTableSnapshotManager.safelyGetAllSnapshots()) {
                 if (snapshot.id() != snapshotId) {
-                    targetTableSnapshotManager
-                            .fileIO()
-                            .deleteQuietly(targetTableSnapshotManager.snapshotPath(snapshot.id()));
+                    targetTableSnapshotManager.deleteSnapshot(snapshot.id());
                 }
             }
         }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RollbackProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RollbackProcedureTest.scala
@@ -151,4 +151,12 @@ class RollbackProcedureTest extends PaimonSparkTestBase with StreamTest {
     }
   }
 
+  test("Paimon Procedure: rollback with cache") {
+    sql("CREATE TABLE T (id INT)")
+    sql("INSERT INTO T VALUES (1), (2), (3), (4)")
+    sql("DELETE FROM T WHERE id = 1")
+    sql("CALL sys.rollback(table => 'T', version => '1')")
+    sql("DELETE FROM T WHERE id = 1")
+    checkAnswer(sql("SELECT * FROM T ORDER BY id"), Seq(Row(2), Row(3), Row(4)))
+  }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Clear cache when deleting the snapshot

```sql
CREATE TABLE T (id INT);
NSERT INTO T VALUES (1), (2), (3), (4);
DELETE FROM T WHERE id = 1;
CALL sys.rollback(table => 'T', version => '1');
DELETE FROM T WHERE id = 1;
SELECT * FROM T ORDER BY id;
```

```
Job aborted due to stage failure: Task 1 in stage 9.0 failed 1 times, most recent failure: Lost task 1.0 in stage 9.0 (TID 9) (30.221.116.223 executor driver): java.io.FileNotFoundException: File '/private/var/folders/px/y3gybll50ggctcjp2t4r2b500000gp/T/spark-5b259941-137d-4736-968a-5b61e456898a/test.db/T/bucket-0/data-e9507592-0884-457f-86d1-fbfc996225b2-0.parquet' not found, Possible causes: 1.snapshot expires too fast, you can configure 'snapshot.time-retained' option with a larger value. 2.consumption is too slow, you can improve the performance of consumption (For example, increasing parallelism).
	at org.apache.paimon.utils.FileUtils.checkExists(FileUtils.java:113)
	at org.apache.paimon.io.DataFileRecordReader.<init>(DataFileRecordReader.java:55)
	at org.apache.paimon.operation.RawFileSplitRead.createFileReader(RawFileSplitRead.java:242)
	at org.apache.paimon.operation.RawFileSplitRead.lambda$createReader$3(RawFileSplitRead.java:181)
	at org.apache.paimon.mergetree.compact.ConcatRecordReader.create(ConcatRecordReader.java:53)
	at org.apache.paimon.operation.RawFileSplitRead.createReader(RawFileSplitRead.java:189)
	at org.apache.paimon.operation.RawFileSplitRead.createReader(RawFileSplitRead.java:141)
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
