### PR TITLE
[spark] Fix update table with char type

### DIFF
--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/UpdateTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/UpdateTableTestBase.scala
@@ -22,6 +22,7 @@ import org.apache.paimon.CoreOptions
 import org.apache.paimon.spark.PaimonSparkTestBase
 import org.apache.paimon.spark.catalyst.analysis.Update
 
+import org.apache.spark.sql.Row
 import org.assertj.core.api.Assertions.{assertThat, assertThatThrownBy}
 
 abstract class UpdateTableTestBase extends PaimonSparkTestBase {
@@ -348,5 +349,12 @@ abstract class UpdateTableTestBase extends PaimonSparkTestBase {
     assertThatThrownBy(
       () => spark.sql("UPDATE T SET s.c2 = 'a_new', s = struct(11, 'a_new') WHERE s.c1 = 1"))
       .hasMessageContaining("Conflicting update/insert on attrs: s.c2, s")
+  }
+
+  test("Paimon update: update table with char type") {
+    sql("CREATE TABLE T (id INT, s STRING, c CHAR(1))")
+    sql("INSERT INTO T VALUES (1, 's', 'a')")
+    sql("UPDATE T SET c = 'b' WHERE id = 1")
+    checkAnswer(sql("SELECT * FROM T"), Seq(Row(1, "s", "b")))
   }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

```sql
CREATE TABLE T (id INT, s STRING, c CHAR(1));
INSERT INTO T VALUES (1, 's', 'a');
UPDATE T SET c = 'b' WHERE id = 1;
```

```
UPDATE TABLE is not supported temporarily.
org.apache.spark.SparkUnsupportedOperationException: UPDATE TABLE is not supported temporarily.
	at org.apache.spark.sql.errors.QueryExecutionErrors$.ddlUnsupportedTemporarilyError(QueryExecutionErrors.scala:1089)
	at org.apache.spark.sql.execution.SparkStrategies$BasicOperators$.apply(SparkStrategies.scala:935)
	at org.apache.spark.sql.catalyst.planning.QueryPlanner.$anonfun$plan$1(QueryPlanner.scala:63)
```

Note that this PR actually ignores the `read side padding` in the `Project`, so if the char type is used and `spark.sql.legacy.charVarcharAsString` is set to true (default is false), and the char type is written in a non-standard way, the reading of char will lack padding. However the current Spark's DSV2 `RewriteRowLevelCommand` also does not consider this situation, so we will skip it as well.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
