### PR TITLE
[core] Remove Catalog.fileio method

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -86,7 +86,8 @@ public abstract class AbstractCatalog implements Catalog {
         return catalogOptions.toMap();
     }
 
-    @Override
+    public abstract String warehouse();
+
     public FileIO fileIO() {
         return fileIO;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.catalog;
 
 import org.apache.paimon.annotation.Public;
-import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
@@ -367,12 +366,6 @@ public interface Catalog extends AutoCloseable {
     }
 
     // ==================== Catalog Information ==========================
-
-    /** Warehouse root path for creating new databases. */
-    String warehouse();
-
-    /** {@link FileIO} of this catalog. It can access {@link #warehouse()} path. */
-    FileIO fileIO();
 
     /** Catalog options for re-creating this catalog. */
     Map<String, String> options();

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.catalog;
 
-import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
@@ -47,18 +46,8 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
-    public String warehouse() {
-        return wrapped.warehouse();
-    }
-
-    @Override
     public Map<String, String> options() {
         return wrapped.options();
-    }
-
-    @Override
-    public FileIO fileIO() {
-        return wrapped.fileIO();
     }
 
     @Override
@@ -199,5 +188,12 @@ public abstract class DelegateCatalog implements Catalog {
     @Override
     public void close() throws Exception {
         wrapped.close();
+    }
+
+    public static Catalog rootCatalog(Catalog catalog) {
+        while (catalog instanceof DelegateCatalog) {
+            catalog = ((DelegateCatalog) catalog).wrapped();
+        }
+        return catalog;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/migrate/IcebergMigrateHadoopMetadataFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/migrate/IcebergMigrateHadoopMetadataFactory.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.iceberg.migrate;
 
 import org.apache.paimon.catalog.Identifier;
-import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.iceberg.IcebergOptions;
 import org.apache.paimon.options.Options;
 
@@ -28,12 +27,12 @@ public class IcebergMigrateHadoopMetadataFactory implements IcebergMigrateMetada
 
     @Override
     public String identifier() {
-        return IcebergOptions.StorageType.HADOOP_CATALOG.toString() + "_migrate";
+        return IcebergOptions.StorageType.HADOOP_CATALOG + "_migrate";
     }
 
     @Override
     public IcebergMigrateHadoopMetadata create(
-            Identifier icebergIdentifier, FileIO fileIO, Options icebergOptions) {
-        return new IcebergMigrateHadoopMetadata(icebergIdentifier, fileIO, icebergOptions);
+            Identifier icebergIdentifier, Options icebergOptions) {
+        return new IcebergMigrateHadoopMetadata(icebergIdentifier, icebergOptions);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/migrate/IcebergMigrateMetadataFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/migrate/IcebergMigrateMetadataFactory.java
@@ -20,12 +20,10 @@ package org.apache.paimon.iceberg.migrate;
 
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.factories.Factory;
-import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.options.Options;
 
 /** Factory to create {@link IcebergMigrateMetadata}. */
 public interface IcebergMigrateMetadataFactory extends Factory {
 
-    IcebergMigrateMetadata create(
-            Identifier icebergIdentifier, FileIO fileIO, Options icebergOptions);
+    IcebergMigrateMetadata create(Identifier icebergIdentifier, Options icebergOptions);
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.operation;
 
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileStatus;
@@ -36,7 +35,6 @@ import org.apache.paimon.utils.DateTimeUtils;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Preconditions;
-import org.apache.paimon.utils.SerializableConsumer;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.SupplierWithIOException;
 import org.apache.paimon.utils.TagManager;
@@ -90,18 +88,17 @@ public abstract class OrphanFilesClean implements Serializable {
     protected final FileStoreTable table;
     protected final FileIO fileIO;
     protected final long olderThanMillis;
-    protected final SerializableConsumer<Path> fileCleaner;
+    protected final boolean dryRun;
     protected final int partitionKeysNum;
     protected final Path location;
 
-    public OrphanFilesClean(
-            FileStoreTable table, long olderThanMillis, SerializableConsumer<Path> fileCleaner) {
+    public OrphanFilesClean(FileStoreTable table, long olderThanMillis, boolean dryRun) {
         this.table = table;
         this.fileIO = table.fileIO();
         this.partitionKeysNum = table.partitionKeys().size();
         this.location = table.location();
         this.olderThanMillis = olderThanMillis;
-        this.fileCleaner = fileCleaner;
+        this.dryRun = dryRun;
     }
 
     protected List<String> validBranches() {
@@ -163,7 +160,20 @@ public abstract class OrphanFilesClean implements Serializable {
         Long fileSize = deleteFileInfo.getRight();
         deletedFilesConsumer.accept(filePath);
         deletedFilesLenInBytesConsumer.accept(fileSize);
-        fileCleaner.accept(filePath);
+        cleanFile(filePath);
+    }
+
+    protected void cleanFile(Path path) {
+        if (!dryRun) {
+            try {
+                if (fileIO.isDir(path)) {
+                    fileIO.deleteDirectoryQuietly(path);
+                } else {
+                    fileIO.deleteQuietly(path);
+                }
+            } catch (IOException ignored) {
+            }
+        }
     }
 
     protected Set<Snapshot> safelyGetAllSnapshots(String branch) throws IOException {
@@ -362,28 +372,6 @@ public abstract class OrphanFilesClean implements Serializable {
         return status.getModificationTime() < olderThanMillis;
     }
 
-    public static SerializableConsumer<Path> createFileCleaner(
-            Catalog catalog, @Nullable Boolean dryRun) {
-        SerializableConsumer<Path> fileCleaner;
-        if (Boolean.TRUE.equals(dryRun)) {
-            fileCleaner = path -> {};
-        } else {
-            FileIO fileIO = catalog.fileIO();
-            fileCleaner =
-                    path -> {
-                        try {
-                            if (fileIO.isDir(path)) {
-                                fileIO.deleteDirectoryQuietly(path);
-                            } else {
-                                fileIO.deleteQuietly(path);
-                            }
-                        } catch (IOException ignored) {
-                        }
-                    };
-        }
-        return fileCleaner;
-    }
-
     public static long olderThanMillis(@Nullable String olderThan) {
         if (isNullOrWhitespaceOnly(olderThan)) {
             return System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1);
@@ -412,10 +400,20 @@ public abstract class OrphanFilesClean implements Serializable {
     }
 
     public boolean tryDeleteEmptyDirectory(Path path) {
+        if (dryRun) {
+            return false;
+        }
+
         try {
             return fileIO.delete(path, false);
         } catch (IOException e) {
             return false;
         }
+    }
+
+    /** Cleaner to clean files. */
+    public interface FileCleaner extends Serializable {
+
+        void clean(String table, Path path);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedCatalog.java
@@ -58,10 +58,7 @@ public class PrivilegedCatalog extends DelegateCatalog {
 
     public static Catalog tryToCreate(Catalog catalog, Options options) {
         if (!(rootCatalog(catalog) instanceof AbstractCatalog)) {
-            throw new IllegalArgumentException(
-                    String.format(
-                            "Catalog %s cannot support Privileged Catalog.",
-                            catalog.getClass().getName()));
+            return catalog;
         }
 
         FileBasedPrivilegeManagerLoader fileBasedPrivilegeManagerLoader =

--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedCatalog.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.privilege;
 
+import org.apache.paimon.catalog.AbstractCatalog;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.DelegateCatalog;
@@ -56,10 +57,17 @@ public class PrivilegedCatalog extends DelegateCatalog {
     }
 
     public static Catalog tryToCreate(Catalog catalog, Options options) {
+        if (!(rootCatalog(catalog) instanceof AbstractCatalog)) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Catalog %s cannot support Privileged Catalog.",
+                            catalog.getClass().getName()));
+        }
+
         FileBasedPrivilegeManagerLoader fileBasedPrivilegeManagerLoader =
                 new FileBasedPrivilegeManagerLoader(
-                        catalog.warehouse(),
-                        catalog.fileIO(),
+                        ((AbstractCatalog) rootCatalog(catalog)).warehouse(),
+                        ((AbstractCatalog) rootCatalog(catalog)).fileIO(),
                         options.get(PrivilegedCatalog.USER),
                         options.get(PrivilegedCatalog.PASSWORD));
         FileBasedPrivilegeManager fileBasedPrivilegeManager =

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -145,11 +145,6 @@ public class RESTCatalog implements Catalog {
     }
 
     @Override
-    public String warehouse() {
-        return context.options().get(WAREHOUSE);
-    }
-
-    @Override
     public Map<String, String> options() {
         return context.options().toMap();
     }
@@ -157,15 +152,6 @@ public class RESTCatalog implements Catalog {
     @Override
     public RESTCatalogLoader catalogLoader() {
         return new RESTCatalogLoader(context);
-    }
-
-    @Override
-    public FileIO fileIO() {
-        // TODO remove Catalog.fileIO
-        if (dataTokenEnabled) {
-            throw new UnsupportedOperationException();
-        }
-        return fileIO;
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -88,7 +88,7 @@ public class RESTCatalogServer {
         Options conf = new Options();
         conf.setString("warehouse", warehouse);
         this.catalog = TestRESTCatalog.create(CatalogContext.create(conf));
-        this.dispatcher = initDispatcher(catalog, authToken);
+        this.dispatcher = initDispatcher(catalog, warehouse, authToken);
         MockWebServer mockWebServer = new MockWebServer();
         mockWebServer.setDispatcher(dispatcher);
         server = mockWebServer;
@@ -106,7 +106,7 @@ public class RESTCatalogServer {
         server.shutdown();
     }
 
-    public static Dispatcher initDispatcher(Catalog catalog, String authToken) {
+    public static Dispatcher initDispatcher(Catalog catalog, String warehouse, String authToken) {
         return new Dispatcher() {
             @Override
             public MockResponse dispatch(RecordedRequest request) {
@@ -119,7 +119,7 @@ public class RESTCatalogServer {
                     if ("/v1/config".equals(request.getPath())) {
                         return new MockResponse()
                                 .setResponseCode(200)
-                                .setBody(getConfigBody(catalog.warehouse()));
+                                .setBody(getConfigBody(warehouse));
                     } else if (DATABASE_URI.equals(request.getPath())) {
                         return databasesApiHandler(catalog, request);
                     } else if (request.getPath().startsWith(DATABASE_URI)) {

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
@@ -27,7 +27,6 @@ import org.apache.flink.table.procedure.ProcedureContext;
 
 import java.util.Locale;
 
-import static org.apache.paimon.operation.OrphanFilesClean.createFileCleaner;
 import static org.apache.paimon.operation.OrphanFilesClean.olderThanMillis;
 
 /**
@@ -97,7 +96,7 @@ public class RemoveOrphanFilesProcedure extends ProcedureBase {
                                     procedureContext.getExecutionEnvironment(),
                                     catalog,
                                     olderThanMillis(olderThan),
-                                    createFileCleaner(catalog, dryRun),
+                                    dryRun,
                                     parallelism,
                                     databaseName,
                                     tableName);
@@ -109,7 +108,6 @@ public class RemoveOrphanFilesProcedure extends ProcedureBase {
                                     databaseName,
                                     tableName,
                                     olderThanMillis(olderThan),
-                                    createFileCleaner(catalog, dryRun),
                                     parallelism,
                                     dryRun);
                     break;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RemoveOrphanFilesAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RemoveOrphanFilesAction.java
@@ -23,7 +23,6 @@ import javax.annotation.Nullable;
 import java.util.Map;
 
 import static org.apache.paimon.flink.orphan.FlinkOrphanFilesClean.executeDatabaseOrphanFiles;
-import static org.apache.paimon.operation.OrphanFilesClean.createFileCleaner;
 import static org.apache.paimon.operation.OrphanFilesClean.olderThanMillis;
 
 /** Action to remove the orphan data files and metadata files. */
@@ -61,7 +60,7 @@ public class RemoveOrphanFilesAction extends ActionBase {
                 env,
                 catalog,
                 olderThanMillis(olderThan),
-                createFileCleaner(catalog, dryRun),
+                dryRun,
                 parallelism == null ? null : Integer.parseInt(parallelism),
                 databaseName,
                 tableName);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
@@ -30,7 +30,6 @@ import org.apache.flink.table.procedure.ProcedureContext;
 
 import java.util.Locale;
 
-import static org.apache.paimon.operation.OrphanFilesClean.createFileCleaner;
 import static org.apache.paimon.operation.OrphanFilesClean.olderThanMillis;
 
 /**
@@ -85,7 +84,7 @@ public class RemoveOrphanFilesProcedure extends ProcedureBase {
                                     procedureContext.getExecutionEnvironment(),
                                     catalog,
                                     olderThanMillis(olderThan),
-                                    createFileCleaner(catalog, dryRun),
+                                    dryRun,
                                     parallelism,
                                     databaseName,
                                     tableName);
@@ -97,7 +96,6 @@ public class RemoveOrphanFilesProcedure extends ProcedureBase {
                                     databaseName,
                                     tableName,
                                     olderThanMillis(olderThan),
-                                    createFileCleaner(catalog, dryRun),
                                     parallelism,
                                     dryRun);
                     break;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
@@ -84,7 +84,7 @@ public class RemoveOrphanFilesProcedure extends ProcedureBase {
                                     procedureContext.getExecutionEnvironment(),
                                     catalog,
                                     olderThanMillis(olderThan),
-                                    dryRun,
+                                    dryRun != null && dryRun,
                                     parallelism,
                                     databaseName,
                                     tableName);
@@ -97,7 +97,7 @@ public class RemoveOrphanFilesProcedure extends ProcedureBase {
                                     tableName,
                                     olderThanMillis(olderThan),
                                     parallelism,
-                                    dryRun);
+                                    dryRun != null && dryRun);
                     break;
                 default:
                     throw new IllegalArgumentException(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/privilege/InitFileBasedPrivilegeProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/privilege/InitFileBasedPrivilegeProcedure.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.procedure.privilege;
 
+import org.apache.paimon.catalog.AbstractCatalog;
 import org.apache.paimon.flink.procedure.ProcedureBase;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.privilege.FileBasedPrivilegeManager;
@@ -28,6 +29,8 @@ import org.apache.flink.table.annotation.ArgumentHint;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.annotation.ProcedureHint;
 import org.apache.flink.table.procedure.ProcedureContext;
+
+import static org.apache.paimon.catalog.DelegateCatalog.rootCatalog;
 
 /**
  * Procedure to initialize file-based privilege system in warehouse. This procedure will
@@ -48,11 +51,18 @@ public class InitFileBasedPrivilegeProcedure extends ProcedureBase {
             throw new IllegalArgumentException("Catalog is already a PrivilegedCatalog");
         }
 
+        if (!(rootCatalog(catalog) instanceof AbstractCatalog)) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Catalog %s cannot support Privileged Catalog.",
+                            catalog.getClass().getName()));
+        }
+
         Options options = new Options(catalog.options());
         PrivilegeManager privilegeManager =
                 new FileBasedPrivilegeManager(
-                        catalog.warehouse(),
-                        catalog.fileIO(),
+                        ((AbstractCatalog) rootCatalog(catalog)).warehouse(),
+                        ((AbstractCatalog) rootCatalog(catalog)).fileIO(),
                         options.get(PrivilegedCatalog.USER),
                         options.get(PrivilegedCatalog.PASSWORD));
         privilegeManager.initializePrivilege(rootPassword);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/privilege/InitFileBasedPrivilegeProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/privilege/InitFileBasedPrivilegeProcedure.java
@@ -55,7 +55,7 @@ public class InitFileBasedPrivilegeProcedure extends ProcedureBase {
             throw new IllegalArgumentException(
                     String.format(
                             "Catalog %s cannot support Privileged Catalog.",
-                            catalog.getClass().getName()));
+                            rootCatalog(catalog).getClass().getName()));
         }
 
         Options options = new Options(catalog.options());

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedure.java
@@ -120,7 +120,6 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
                                     identifier.getDatabaseName(),
                                     identifier.getTableName(),
                                     OrphanFilesClean.olderThanMillis(olderThan),
-                                    OrphanFilesClean.createFileCleaner(catalog, dryRun),
                                     parallelism,
                                     dryRun);
                     break;
@@ -131,7 +130,6 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
                                     identifier.getDatabaseName(),
                                     identifier.getTableName(),
                                     OrphanFilesClean.olderThanMillis(olderThan),
-                                    OrphanFilesClean.createFileCleaner(catalog, dryRun),
                                     parallelism,
                                     dryRun);
                     break;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
RESTCatalog does not have FileIO for catalog. We should remove this.

The side effect of this PR is that PrivilegedCatalog only supports AbstractCatalog, which is acceptable because REST Catalog has its own permission system.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
