### PR TITLE
[core] Support upper bound in dynamic bucket mode

### DIFF
--- a/docs/content/primary-key-table/data-distribution.md
+++ b/docs/content/primary-key-table/data-distribution.md
@@ -48,6 +48,7 @@ Paimon will automatically expand the number of buckets.
 
 - Option1: `'dynamic-bucket.target-row-num'`: controls the target row number for one bucket.
 - Option2: `'dynamic-bucket.initial-buckets'`: controls the number of initialized bucket.
+- Option3: `'dynamic-bucket.max-buckets'`: controls the number of max buckets.
 
 {{< hint info >}}
 Dynamic Bucket only support single write job. Please do not start multiple jobs to write to the same partition

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -291,6 +291,12 @@ under the License.
             <td>Initial buckets for a partition in assigner operator for dynamic bucket mode.</td>
         </tr>
         <tr>
+            <td><h5>dynamic-bucket.max-buckets-per-assigner</h5></td>
+            <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
+            <td>Max buckets per assigner operator for a partition in dynamic bucket mode, It should either be equal to -1 (unlimited), or it must be greater than 0 (fixed upper bound).</td>
+        </tr>
+        <tr>
             <td><h5>dynamic-bucket.target-row-num</h5></td>
             <td style="word-wrap: break-word;">2000000</td>
             <td>Long</td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -291,10 +291,10 @@ under the License.
             <td>Initial buckets for a partition in assigner operator for dynamic bucket mode.</td>
         </tr>
         <tr>
-            <td><h5>dynamic-bucket.max-buckets-per-assigner</h5></td>
+            <td><h5>dynamic-bucket.max-buckets</h5></td>
             <td style="word-wrap: break-word;">-1</td>
             <td>Integer</td>
-            <td>Max buckets per assigner operator for a partition in dynamic bucket mode, It should either be equal to -1 (unlimited), or it must be greater than 0 (fixed upper bound).</td>
+            <td>Max buckets for a partition in dynamic bucket mode, It should either be equal to -1 (unlimited), or it must be greater than 0 (fixed upper bound).</td>
         </tr>
         <tr>
             <td><h5>dynamic-bucket.target-row-num</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1076,12 +1076,12 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Initial buckets for a partition in assigner operator for dynamic bucket mode.");
 
-    public static final ConfigOption<Integer> DYNAMIC_BUCKET_MAX_BUCKETS_PER_ASSIGNER =
-            key("dynamic-bucket.max-buckets-per-assigner")
+    public static final ConfigOption<Integer> DYNAMIC_BUCKET_MAX_BUCKETS =
+            key("dynamic-bucket.max-buckets")
                     .intType()
                     .defaultValue(-1)
                     .withDescription(
-                            "Max buckets per assigner operator for a partition in dynamic bucket mode, It should "
+                            "Max buckets for a partition in dynamic bucket mode, It should "
                                     + "either be equal to -1 (unlimited), or it must be greater than 0 (fixed upper bound).");
 
     public static final ConfigOption<Integer> DYNAMIC_BUCKET_ASSIGNER_PARALLELISM =
@@ -2227,8 +2227,8 @@ public class CoreOptions implements Serializable {
         return options.get(DYNAMIC_BUCKET_INITIAL_BUCKETS);
     }
 
-    public Integer dynamicBucketMaxBucketsPerAssigner() {
-        return options.get(DYNAMIC_BUCKET_MAX_BUCKETS_PER_ASSIGNER);
+    public Integer dynamicBucketMaxBuckets() {
+        return options.get(DYNAMIC_BUCKET_MAX_BUCKETS);
     }
 
     public Integer dynamicBucketAssignerParallelism() {

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1076,6 +1076,14 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Initial buckets for a partition in assigner operator for dynamic bucket mode.");
 
+    public static final ConfigOption<Integer> DYNAMIC_BUCKET_MAX_BUCKETS_PER_ASSIGNER =
+            key("dynamic-bucket.max-buckets-per-assigner")
+                    .intType()
+                    .defaultValue(-1)
+                    .withDescription(
+                            "Max buckets per assigner operator for a partition in dynamic bucket mode, It should "
+                                    + "either be equal to -1 (unlimited), or it must be greater than 0 (fixed upper bound).");
+
     public static final ConfigOption<Integer> DYNAMIC_BUCKET_ASSIGNER_PARALLELISM =
             key("dynamic-bucket.assigner-parallelism")
                     .intType()
@@ -2217,6 +2225,10 @@ public class CoreOptions implements Serializable {
 
     public Integer dynamicBucketInitialBuckets() {
         return options.get(DYNAMIC_BUCKET_INITIAL_BUCKETS);
+    }
+
+    public Integer dynamicBucketMaxBucketsPerAssigner() {
+        return options.get(DYNAMIC_BUCKET_MAX_BUCKETS_PER_ASSIGNER);
     }
 
     public Integer dynamicBucketAssignerParallelism() {

--- a/paimon-core/src/main/java/org/apache/paimon/index/HashBucketAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/HashBucketAssigner.java
@@ -45,6 +45,7 @@ public class HashBucketAssigner implements BucketAssigner {
     private final int numAssigners;
     private final int assignId;
     private final long targetBucketRowNumber;
+    private final int maxBucketsNum;
 
     private final Map<BinaryRow, PartitionIndex> partitionIndex;
 
@@ -55,7 +56,8 @@ public class HashBucketAssigner implements BucketAssigner {
             int numChannels,
             int numAssigners,
             int assignId,
-            long targetBucketRowNumber) {
+            long targetBucketRowNumber,
+            int maxBucketsNum) {
         this.snapshotManager = snapshotManager;
         this.commitUser = commitUser;
         this.indexFileHandler = indexFileHandler;
@@ -64,6 +66,7 @@ public class HashBucketAssigner implements BucketAssigner {
         this.assignId = assignId;
         this.targetBucketRowNumber = targetBucketRowNumber;
         this.partitionIndex = new HashMap<>();
+        this.maxBucketsNum = maxBucketsNum;
     }
 
     /** Assign a bucket for key hash of a record. */
@@ -84,7 +87,7 @@ public class HashBucketAssigner implements BucketAssigner {
             this.partitionIndex.put(partition, index);
         }
 
-        int assigned = index.assign(hash, this::isMyBucket);
+        int assigned = index.assign(hash, this::isMyBucket, maxBucketsNum);
         if (LOG.isDebugEnabled()) {
             LOG.debug(
                     "Assign " + assigned + " to the partition " + partition + " key hash " + hash);

--- a/paimon-core/src/main/java/org/apache/paimon/index/HashBucketAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/HashBucketAssigner.java
@@ -46,6 +46,7 @@ public class HashBucketAssigner implements BucketAssigner {
     private final int assignId;
     private final long targetBucketRowNumber;
     private final int maxBucketsNum;
+    private int maxBucketId;
 
     private final Map<BinaryRow, PartitionIndex> partitionIndex;
 
@@ -87,10 +88,13 @@ public class HashBucketAssigner implements BucketAssigner {
             this.partitionIndex.put(partition, index);
         }
 
-        int assigned = index.assign(hash, this::isMyBucket, maxBucketsNum);
+        int assigned = index.assign(hash, this::isMyBucket, maxBucketsNum, maxBucketId);
         if (LOG.isDebugEnabled()) {
             LOG.debug(
                     "Assign " + assigned + " to the partition " + partition + " key hash " + hash);
+        }
+        if (assigned > maxBucketId) {
+            maxBucketId = assigned;
         }
         return assigned;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/index/PartitionIndex.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/PartitionIndex.java
@@ -64,7 +64,7 @@ public class PartitionIndex {
         this.accessed = true;
     }
 
-    public int assign(int hash, IntPredicate bucketFilter, int maxBucketsNum) {
+    public int assign(int hash, IntPredicate bucketFilter, int maxBucketsNum, int maxBucketId) {
         accessed = true;
 
         // 1. is it a key that has appeared before
@@ -88,10 +88,6 @@ public class PartitionIndex {
             }
         }
 
-        int maxBucketId =
-                totalBucket.isEmpty()
-                        ? 0
-                        : totalBucket.stream().mapToInt(Integer::intValue).max().getAsInt();
         if (-1 == maxBucketsNum || totalBucket.isEmpty() || maxBucketId < maxBucketsNum - 1) {
             // 3. create a new bucket
             for (int i = 0; i < Short.MAX_VALUE; i++) {

--- a/paimon-core/src/main/java/org/apache/paimon/index/PartitionIndex.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/PartitionIndex.java
@@ -24,13 +24,9 @@ import org.apache.paimon.table.sink.KeyAndBucketExtractor;
 import org.apache.paimon.utils.Int2ShortHashMap;
 import org.apache.paimon.utils.IntIterator;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -43,7 +39,6 @@ import static org.apache.paimon.index.HashIndexFile.HASH_INDEX;
 
 /** Bucket Index Per Partition. */
 public class PartitionIndex {
-    private static final Logger LOG = LoggerFactory.getLogger(PartitionIndex.class);
 
     public final Int2ShortHashMap hash2Bucket;
 
@@ -101,24 +96,31 @@ public class PartitionIndex {
             // 3. create a new bucket
             for (int i = 0; i < Short.MAX_VALUE; i++) {
                 if (bucketFilter.test(i) && !totalBucket.contains(i)) {
-                    nonFullBucketInformation.put(i, 1L);
-                    totalBucket.add(i);
-                    hash2Bucket.put(hash, (short) i);
-                    return i;
+                    // The new bucketId may still be larger than the upper bound
+                    if (-1 == maxBucketsNum || i <= maxBucketsNum - 1) {
+                        nonFullBucketInformation.put(i, 1L);
+                        totalBucket.add(i);
+                        hash2Bucket.put(hash, (short) i);
+                        return i;
+                    } else {
+                        // No need to enter the next iteration when upper bound exceeded
+                        break;
+                    }
                 }
             }
-
-            throw new RuntimeException(
-                    String.format(
-                            "Too more bucket %s, you should increase target bucket row number %s.",
-                            maxBucketId, targetBucketRowNumber));
-        } else {
-            // exceed buckets upper bound
-            int bucket =
-                    KeyAndBucketExtractor.bucketWithUpperBound(totalBucket, hash, maxBucketsNum);
-            hash2Bucket.put(hash, (short) bucket);
-            return bucket;
+            if (-1 == maxBucketsNum) {
+                throw new RuntimeException(
+                        String.format(
+                                "Too more bucket %s, you should increase target bucket row number %s.",
+                                maxBucketId, targetBucketRowNumber));
+            }
         }
+
+        // 4. exceed buckets upper bound
+        int bucket =
+                KeyAndBucketExtractor.bucketWithUpperBound(totalBucket, hash, totalBucket.size());
+        hash2Bucket.put(hash, (short) bucket);
+        return bucket;
     }
 
     public static PartitionIndex loadIndex(
@@ -152,43 +154,5 @@ public class PartitionIndex {
             }
         }
         return new PartitionIndex(mapBuilder.build(), buckets, targetBucketRowNumber);
-    }
-
-    public static int[] getMaxBucketsPerAssigner(int maxBuckets, int assigners) {
-        int[] maxBucketsArr = new int[assigners];
-        if (-1 == maxBuckets) {
-            Arrays.fill(maxBucketsArr, -1);
-            return maxBucketsArr;
-        }
-        if (0 >= maxBuckets) {
-            throw new IllegalArgumentException(
-                    "Max-buckets should either be equal to -1 (unlimited), or it must be greater than 0 (fixed upper bound).");
-        }
-        int avg = maxBuckets / assigners;
-        int remainder = maxBuckets % assigners;
-        for (int i = 0; i < assigners; i++) {
-            maxBucketsArr[i] = avg;
-            if (remainder > 0) {
-                maxBucketsArr[i]++;
-                remainder--;
-            }
-        }
-        LOG.info(
-                "After distributing max-buckets '{}' to '{}' assigners evenly, maxBuckets layout: '{}'.",
-                maxBuckets,
-                assigners,
-                Arrays.toString(maxBucketsArr));
-        return maxBucketsArr;
-    }
-
-    public static int getSpecifiedMaxBuckets(int[] maxBucketsArr, int assignerId) {
-        int length = maxBucketsArr.length;
-        if (length == 0) {
-            throw new IllegalStateException("maxBuckets layout should exists!");
-        } else if (assignerId < length) {
-            return maxBucketsArr[assignerId];
-        } else {
-            return -1 == maxBucketsArr[0] ? -1 : 0;
-        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/index/SimpleHashBucketAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/SimpleHashBucketAssigner.java
@@ -35,6 +35,7 @@ public class SimpleHashBucketAssigner implements BucketAssigner {
     private final int assignId;
     private final long targetBucketRowNumber;
     private final int maxBucketsNum;
+    private int maxBucketId;
 
     private final Map<BinaryRow, SimplePartitionIndex> partitionIndex;
 
@@ -55,7 +56,11 @@ public class SimpleHashBucketAssigner implements BucketAssigner {
             index = new SimplePartitionIndex();
             this.partitionIndex.put(partition, index);
         }
-        return index.assign(hash);
+        int assigned = index.assign(hash);
+        if (assigned > maxBucketId) {
+            maxBucketId = assigned;
+        }
+        return assigned;
     }
 
     @Override
@@ -89,13 +94,6 @@ public class SimpleHashBucketAssigner implements BucketAssigner {
             Long num = bucketInformation.computeIfAbsent(currentBucket, i -> 0L);
 
             if (num >= targetBucketRowNumber) {
-                int maxBucketId =
-                        bucketInformation.isEmpty()
-                                ? 0
-                                : bucketInformation.keySet().stream()
-                                        .mapToInt(Integer::intValue)
-                                        .max()
-                                        .getAsInt();
                 if (-1 == maxBucketsNum
                         || bucketInformation.isEmpty()
                         || maxBucketId < maxBucketsNum - 1) {

--- a/paimon-core/src/main/java/org/apache/paimon/index/SimpleHashBucketAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/SimpleHashBucketAssigner.java
@@ -28,8 +28,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.paimon.index.PartitionIndex.cacheBucketAndGet;
-
 /** When we need to overwrite the table, we should use this to avoid loading index. */
 public class SimpleHashBucketAssigner implements BucketAssigner {
 
@@ -91,11 +89,11 @@ public class SimpleHashBucketAssigner implements BucketAssigner {
             Long num = bucketInformation.computeIfAbsent(currentBucket, i -> 0L);
             if (num >= targetBucketRowNumber) {
                 if (-1 != maxBucketsNum && bucketInformation.size() >= maxBucketsNum) {
-                    return cacheBucketAndGet(
-                            hash2Bucket,
-                            hash,
+                    int bucket =
                             KeyAndBucketExtractor.bucketWithUpperBound(
-                                    bucketInformation.keySet(), hash, maxBucketsNum));
+                                    bucketInformation.keySet(), hash, maxBucketsNum);
+                    hash2Bucket.put(hash, (short) bucket);
+                    return bucket;
                 } else {
                     loadNewBucket();
                 }

--- a/paimon-core/src/main/java/org/apache/paimon/index/SimpleHashBucketAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/SimpleHashBucketAssigner.java
@@ -28,6 +28,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.paimon.index.PartitionIndex.cacheBucketAndGet;
+
 /** When we need to overwrite the table, we should use this to avoid loading index. */
 public class SimpleHashBucketAssigner implements BucketAssigner {
 
@@ -89,11 +91,11 @@ public class SimpleHashBucketAssigner implements BucketAssigner {
             Long num = bucketInformation.computeIfAbsent(currentBucket, i -> 0L);
             if (num >= targetBucketRowNumber) {
                 if (-1 != maxBucketsNum && bucketInformation.size() >= maxBucketsNum) {
-                    int bucket =
+                    return cacheBucketAndGet(
+                            hash2Bucket,
+                            hash,
                             KeyAndBucketExtractor.bucketWithUpperBound(
-                                    bucketInformation.keySet(), hash, maxBucketsNum);
-                    hash2Bucket.put(hash, (short) bucket);
-                    return bucket;
+                                    bucketInformation.keySet(), hash, maxBucketsNum));
                 } else {
                     loadNewBucket();
                 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/KeyAndBucketExtractor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/KeyAndBucketExtractor.java
@@ -21,6 +21,13 @@ package org.apache.paimon.table.sink;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.types.RowKind;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.apache.paimon.CoreOptions.DYNAMIC_BUCKET_MAX_BUCKETS_PER_ASSIGNER;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /**
@@ -31,6 +38,7 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
  * @param <T> type of record
  */
 public interface KeyAndBucketExtractor<T> {
+    Logger LOG = LoggerFactory.getLogger(KeyAndBucketExtractor.class);
 
     void setRecord(T record);
 
@@ -50,5 +58,18 @@ public interface KeyAndBucketExtractor<T> {
     static int bucket(int hashcode, int numBuckets) {
         checkArgument(numBuckets > 0, "Num bucket is illegal: " + numBuckets);
         return Math.abs(hashcode % numBuckets);
+    }
+
+    static int bucketWithUpperBound(Set<Integer> bucketsSet, int hashcode, int maxBucketsNum) {
+        checkArgument(maxBucketsNum > 0, "Num max-buckets is illegal: " + maxBucketsNum);
+        LOG.debug(
+                "Assign record (hashcode '{}') to new bucket exceed upper bound '{}' defined in '{}', Stop creating new buckets.",
+                hashcode,
+                maxBucketsNum,
+                DYNAMIC_BUCKET_MAX_BUCKETS_PER_ASSIGNER.key());
+        return bucketsSet.stream()
+                .skip(ThreadLocalRandom.current().nextInt(maxBucketsNum))
+                .findFirst()
+                .orElse(0);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/KeyAndBucketExtractor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/KeyAndBucketExtractor.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.apache.paimon.CoreOptions.DYNAMIC_BUCKET_MAX_BUCKETS_PER_ASSIGNER;
+import static org.apache.paimon.CoreOptions.DYNAMIC_BUCKET_MAX_BUCKETS;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /**
@@ -66,7 +66,7 @@ public interface KeyAndBucketExtractor<T> {
                 "Assign record (hashcode '{}') to new bucket exceed upper bound '{}' defined in '{}', Stop creating new buckets.",
                 hashcode,
                 maxBucketsNum,
-                DYNAMIC_BUCKET_MAX_BUCKETS_PER_ASSIGNER.key());
+                DYNAMIC_BUCKET_MAX_BUCKETS.key());
         return bucketsSet.stream()
                 .skip(ThreadLocalRandom.current().nextInt(maxBucketsNum))
                 .findFirst()

--- a/paimon-core/src/test/java/org/apache/paimon/index/HashBucketAssignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/HashBucketAssignerTest.java
@@ -37,8 +37,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.apache.paimon.index.PartitionIndex.getMaxBucketsPerAssigner;
-import static org.apache.paimon.index.PartitionIndex.getSpecifiedMaxBuckets;
 import static org.apache.paimon.io.DataFileTestUtils.row;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -122,11 +120,11 @@ public class HashBucketAssignerTest extends PrimaryKeyTableTestBase {
         assertThat(assigner.assign(row(1), 8)).isEqualTo(0);
 
         // full
-        assertThat(assigner.assign(row(1), 10)).isEqualTo(2);
-        assertThat(assigner.assign(row(1), 12)).isEqualTo(2);
-        assertThat(assigner.assign(row(1), 14)).isEqualTo(2);
-        assertThat(assigner.assign(row(1), 16)).isEqualTo(2);
-        assertThat(assigner.assign(row(1), 18)).isEqualTo(2);
+        assertThat(assigner.assign(row(1), 10)).isEqualTo(0);
+        assertThat(assigner.assign(row(1), 12)).isEqualTo(0);
+        assertThat(assigner.assign(row(1), 14)).isEqualTo(0);
+        assertThat(assigner.assign(row(1), 16)).isEqualTo(0);
+        assertThat(assigner.assign(row(1), 18)).isEqualTo(0);
 
         // another partition
         assertThat(assigner.assign(row(2), 12)).isEqualTo(0);
@@ -154,39 +152,9 @@ public class HashBucketAssignerTest extends PrimaryKeyTableTestBase {
     }
 
     @Test
-    public void testMultiAssigners() {
-        int[] maxBucketsArr = getMaxBucketsPerAssigner(4, 2);
-        Assertions.assertThat(maxBucketsArr).isEqualTo(new int[] {2, 2});
-
-        maxBucketsArr = getMaxBucketsPerAssigner(8, 3);
-        Assertions.assertThat(maxBucketsArr).isEqualTo(new int[] {3, 3, 2});
-
-        maxBucketsArr = getMaxBucketsPerAssigner(3, 2);
-        Assertions.assertThat(maxBucketsArr).isEqualTo(new int[] {2, 1});
-
-        Assertions.assertThat(getSpecifiedMaxBuckets(maxBucketsArr, 0)).isEqualTo(2);
-        Assertions.assertThat(getSpecifiedMaxBuckets(maxBucketsArr, 1)).isEqualTo(1);
-        Assertions.assertThat(getSpecifiedMaxBuckets(maxBucketsArr, 2)).isEqualTo(0);
-
-        maxBucketsArr = getMaxBucketsPerAssigner(-1, 2);
-        Assertions.assertThat(maxBucketsArr).isEqualTo(new int[] {-1, -1});
-
-        Assertions.assertThat(getSpecifiedMaxBuckets(maxBucketsArr, 0)).isEqualTo(-1);
-        Assertions.assertThat(getSpecifiedMaxBuckets(maxBucketsArr, 1)).isEqualTo(-1);
-        Assertions.assertThat(getSpecifiedMaxBuckets(maxBucketsArr, 2)).isEqualTo(-1);
-
-        assertThatThrownBy(() -> getMaxBucketsPerAssigner(-10, 2))
-                .hasMessageContaining(
-                        "Max-buckets should either be equal to -1 (unlimited), or it must be greater than 0 (fixed upper bound).");
-    }
-
-    @Test
     public void testAssignWithUpperBoundMultiAssigners() {
-        int[] maxBucketsArr = getMaxBucketsPerAssigner(3, 2);
-        Assertions.assertThat(maxBucketsArr).isEqualTo(new int[] {2, 1});
-
-        HashBucketAssigner assigner0 = createAssigner(2, 2, 0, maxBucketsArr[0]);
-        HashBucketAssigner assigner1 = createAssigner(2, 2, 1, maxBucketsArr[1]);
+        HashBucketAssigner assigner0 = createAssigner(2, 2, 0, 3);
+        HashBucketAssigner assigner1 = createAssigner(2, 2, 1, 3);
 
         // assigner0: assign
         assertThat(assigner0.assign(row(1), 0)).isEqualTo(0);

--- a/paimon-core/src/test/java/org/apache/paimon/index/HashBucketAssignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/HashBucketAssignerTest.java
@@ -27,9 +27,12 @@ import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.sink.StreamTableCommit;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -63,7 +66,21 @@ public class HashBucketAssignerTest extends PrimaryKeyTableTestBase {
                 numChannels,
                 numAssigners,
                 assignId,
-                5);
+                5,
+                -1);
+    }
+
+    private HashBucketAssigner createAssigner(
+            int numChannels, int numAssigners, int assignId, int maxBucketsNum) {
+        return new HashBucketAssigner(
+                table.snapshotManager(),
+                commitUser,
+                fileHandler,
+                numChannels,
+                numAssigners,
+                assignId,
+                5,
+                maxBucketsNum);
     }
 
     @Test
@@ -92,8 +109,52 @@ public class HashBucketAssignerTest extends PrimaryKeyTableTestBase {
     }
 
     @Test
-    public void testPartitionCopy() {
-        HashBucketAssigner assigner = createAssigner(1, 1, 0);
+    public void testAssignWithUpperBound() {
+        HashBucketAssigner assigner = createAssigner(2, 2, 0, 2);
+
+        // assign
+        assertThat(assigner.assign(row(1), 0)).isEqualTo(0);
+        assertThat(assigner.assign(row(1), 2)).isEqualTo(0);
+        assertThat(assigner.assign(row(1), 4)).isEqualTo(0);
+        assertThat(assigner.assign(row(1), 6)).isEqualTo(0);
+        assertThat(assigner.assign(row(1), 8)).isEqualTo(0);
+
+        // full
+        assertThat(assigner.assign(row(1), 10)).isEqualTo(2);
+        assertThat(assigner.assign(row(1), 12)).isEqualTo(2);
+        assertThat(assigner.assign(row(1), 14)).isEqualTo(2);
+        assertThat(assigner.assign(row(1), 16)).isEqualTo(2);
+        assertThat(assigner.assign(row(1), 18)).isEqualTo(2);
+
+        // another partition
+        assertThat(assigner.assign(row(2), 12)).isEqualTo(0);
+
+        // read assigned
+        assertThat(assigner.assign(row(1), 6)).isEqualTo(0);
+
+        // not mine
+        assertThatThrownBy(() -> assigner.assign(row(1), 1))
+                .hasMessageContaining("This is a bug, record assign id");
+
+        // exceed upper bound
+        // partition 1
+        int hash = 18;
+        for (int i = 0; i < 200; i++) {
+            int bucket = assigner.assign(row(1), hash += 2);
+            Assertions.assertThat(bucket).isIn(0, 2);
+        }
+        // partition 2
+        hash = 12;
+        for (int i = 0; i < 200; i++) {
+            int bucket = assigner.assign(row(2), hash += 2);
+            Assertions.assertThat(bucket).isIn(0, 2);
+        }
+    }
+
+    @ParameterizedTest(name = "maxBucket: {0}")
+    @ValueSource(ints = {-1, 1, 2})
+    public void testPartitionCopy(int maxBucketsNum) {
+        HashBucketAssigner assigner = createAssigner(1, 1, 0, maxBucketsNum);
 
         BinaryRow partition = row(1);
         assertThat(assigner.assign(partition, 0)).isEqualTo(0);
@@ -142,6 +203,34 @@ public class HashBucketAssignerTest extends PrimaryKeyTableTestBase {
         assertThat(assigner0.assign(row(1), 11)).isEqualTo(0);
         assertThat(assigner0.assign(row(1), 14)).isEqualTo(0);
         assertThat(assigner0.assign(row(1), 17)).isEqualTo(3);
+    }
+
+    @Test
+    public void testAssignRestoreWithUpperBound() {
+        IndexFileMeta bucket0 = fileHandler.writeHashIndex(new int[] {2, 5});
+        IndexFileMeta bucket2 = fileHandler.writeHashIndex(new int[] {4, 7});
+        commit.commit(
+                0,
+                Arrays.asList(
+                        createCommitMessage(row(1), 0, bucket0),
+                        createCommitMessage(row(1), 2, bucket2)));
+
+        HashBucketAssigner assigner0 = createAssigner(3, 3, 0, 1);
+        HashBucketAssigner assigner2 = createAssigner(3, 3, 2, 1);
+
+        // read assigned
+        assertThat(assigner0.assign(row(1), 2)).isEqualTo(0);
+        assertThat(assigner2.assign(row(1), 4)).isEqualTo(2);
+        assertThat(assigner0.assign(row(1), 5)).isEqualTo(0);
+        assertThat(assigner2.assign(row(1), 7)).isEqualTo(2);
+
+        // new assign
+        assertThat(assigner0.assign(row(1), 8)).isEqualTo(0);
+        assertThat(assigner0.assign(row(1), 11)).isEqualTo(0);
+        assertThat(assigner0.assign(row(1), 14)).isEqualTo(0);
+        assertThat(assigner2.assign(row(1), 16)).isEqualTo(2);
+        // exceed buckets limits
+        assertThat(assigner0.assign(row(1), 17)).isEqualTo(0);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/index/SimpleHashBucketAssignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/SimpleHashBucketAssignerTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.apache.paimon.index.PartitionIndex.getMaxBucketsPerAssigner;
 import static org.apache.paimon.io.DataFileTestUtils.row;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -72,27 +71,19 @@ public class SimpleHashBucketAssignerTest {
             Assertions.assertThat(bucket).isEqualTo(2);
         }
 
-        for (int i = 0; i < 100; i++) {
-            int bucket = simpleHashBucketAssigner.assign(binaryRow, hash++);
-            Assertions.assertThat(bucket).isEqualTo(4);
-        }
-
         // exceed upper bound
         for (int i = 0; i < 200; i++) {
             int bucket = simpleHashBucketAssigner.assign(binaryRow, hash++);
-            Assertions.assertThat(bucket).isIn(0, 2, 4);
+            Assertions.assertThat(bucket).isIn(0, 2);
         }
     }
 
     @Test
     public void testAssignWithUpperBoundMultiAssigners() {
-        int[] maxBucketsArr = getMaxBucketsPerAssigner(3, 2);
-        Assertions.assertThat(maxBucketsArr).isEqualTo(new int[] {2, 1});
-
         SimpleHashBucketAssigner simpleHashBucketAssigner0 =
-                new SimpleHashBucketAssigner(2, 0, 100, maxBucketsArr[0]);
+                new SimpleHashBucketAssigner(2, 0, 100, 3);
         SimpleHashBucketAssigner simpleHashBucketAssigner1 =
-                new SimpleHashBucketAssigner(2, 1, 100, maxBucketsArr[1]);
+                new SimpleHashBucketAssigner(2, 1, 100, 3);
 
         BinaryRow binaryRow = BinaryRow.EMPTY_ROW;
         int hash = 0;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/HashBucketAssignerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/HashBucketAssignerOperator.java
@@ -70,8 +70,8 @@ public class HashBucketAssignerOperator<T> extends AbstractStreamOperator<Tuple2
     public void initializeState(StateInitializationContext context) throws Exception {
         super.initializeState(context);
 
-        // Each job can only have one user name and this name must be consistent across restarts.
-        // We cannot use job id as commit user name here because user may change job id by creating
+        // Each job can only have one username and this name must be consistent across restarts.
+        // We cannot use job id as commit username here because user may change job id by creating
         // a savepoint, stop the job and then resume from savepoint.
         String commitUser =
                 StateUtils.getSingleValueFromState(
@@ -80,9 +80,11 @@ public class HashBucketAssignerOperator<T> extends AbstractStreamOperator<Tuple2
         int numberTasks = RuntimeContextUtils.getNumberOfParallelSubtasks(getRuntimeContext());
         int taskId = RuntimeContextUtils.getIndexOfThisSubtask(getRuntimeContext());
         long targetRowNum = table.coreOptions().dynamicBucketTargetRowNum();
+        Integer maxBucketsNum = table.coreOptions().dynamicBucketMaxBucketsPerAssigner();
         this.assigner =
                 overwrite
-                        ? new SimpleHashBucketAssigner(numberTasks, taskId, targetRowNum)
+                        ? new SimpleHashBucketAssigner(
+                                numberTasks, taskId, targetRowNum, maxBucketsNum)
                         : new HashBucketAssigner(
                                 table.snapshotManager(),
                                 commitUser,
@@ -90,7 +92,8 @@ public class HashBucketAssignerOperator<T> extends AbstractStreamOperator<Tuple2
                                 numberTasks,
                                 MathUtils.min(numAssigners, numberTasks),
                                 taskId,
-                                targetRowNum);
+                                targetRowNum,
+                                maxBucketsNum);
         this.extractor = extractorFunction.apply(table.schema());
     }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/BucketProcessor.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/BucketProcessor.scala
@@ -101,9 +101,6 @@ case class DynamicBucketProcessor(
   private val targetBucketRowNumber = fileStoreTable.coreOptions.dynamicBucketTargetRowNum
   private val rowType = fileStoreTable.rowType
   private val commitUser = UUID.randomUUID.toString
-  private val maxBucketsArr = PartitionIndex.getMaxBucketsPerAssigner(
-    fileStoreTable.coreOptions.dynamicBucketMaxBuckets,
-    numAssigners)
 
   def processPartition(rowIterator: Iterator[Row]): Iterator[Row] = {
     val rowPartitionKeyExtractor = new RowPartitionKeyExtractor(fileStoreTable.schema)
@@ -115,7 +112,7 @@ case class DynamicBucketProcessor(
       numAssigners,
       TaskContext.getPartitionId(),
       targetBucketRowNumber,
-      PartitionIndex.getSpecifiedMaxBuckets(maxBucketsArr, TaskContext.getPartitionId)
+      fileStoreTable.coreOptions.dynamicBucketMaxBuckets
     )
 
     new Iterator[Row]() {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/BucketProcessor.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/BucketProcessor.scala
@@ -99,6 +99,7 @@ case class DynamicBucketProcessor(
 ) extends BucketProcessor[Row] {
 
   private val targetBucketRowNumber = fileStoreTable.coreOptions.dynamicBucketTargetRowNum
+  private val maxBucketsNum = fileStoreTable.coreOptions.dynamicBucketMaxBucketsPerAssigner()
   private val rowType = fileStoreTable.rowType
   private val commitUser = UUID.randomUUID.toString
 
@@ -111,7 +112,8 @@ case class DynamicBucketProcessor(
       numSparkPartitions,
       numAssigners,
       TaskContext.getPartitionId(),
-      targetBucketRowNumber
+      targetBucketRowNumber,
+      maxBucketsNum
     )
 
     new Iterator[Row]() {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -176,9 +176,6 @@ case class PaimonSparkWriter(table: FileStoreTable) {
         val numAssigners = Option(table.coreOptions.dynamicBucketInitialBuckets)
           .map(initialBuckets => Math.min(initialBuckets.toInt, assignerParallelism))
           .getOrElse(assignerParallelism)
-        val maxBucketsArr = PartitionIndex.getMaxBucketsPerAssigner(
-          table.coreOptions.dynamicBucketMaxBuckets,
-          numAssigners)
 
         def partitionByKey(): DataFrame = {
           repartitionByKeyPartitionHash(
@@ -200,7 +197,7 @@ case class PaimonSparkWriter(table: FileStoreTable) {
                   numAssigners,
                   TaskContext.getPartitionId(),
                   table.coreOptions.dynamicBucketTargetRowNum,
-                  PartitionIndex.getSpecifiedMaxBuckets(maxBucketsArr, TaskContext.getPartitionId)
+                  table.coreOptions.dynamicBucketMaxBuckets
                 )
               row => {
                 val sparkRow = new SparkRow(rowType, row)

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -196,7 +196,8 @@ case class PaimonSparkWriter(table: FileStoreTable) {
                 new SimpleHashBucketAssigner(
                   numAssigners,
                   TaskContext.getPartitionId(),
-                  table.coreOptions.dynamicBucketTargetRowNum)
+                  table.coreOptions.dynamicBucketTargetRowNum,
+                  table.coreOptions.dynamicBucketMaxBucketsPerAssigner())
               row => {
                 val sparkRow = new SparkRow(rowType, row)
                 assigner.assign(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
In dynamic bucket mode, unlimited buckets lead to an unpredicable number of small files, which lead to stability problems. so we should support upper bound in dynamic bucket mode.

<!-- Linking this pull request to the issue -->
Linked issue: close #4942 

<!-- What is the purpose of the change -->

### Tests
HashBucketAssignerTest
SimpleHashBucketAssignerTest
- Use new feature, Produce 3 buckets after inserting 12 rows
<img width="1312" alt="image" src="https://github.com/user-attachments/assets/76c43eb0-e8c9-4b08-998f-578feae35e0b" />
<img width="1498" alt="image" src="https://github.com/user-attachments/assets/fe30b501-1007-4739-a0a2-0475079fcb39" />

- Not use new feature, Produce 6 buckets after inserting 12 rows
<img width="1020" alt="image" src="https://github.com/user-attachments/assets/52695512-331a-43b0-ac81-f4561bd62bae" />
<img width="1498" alt="image" src="https://github.com/user-attachments/assets/4e105427-4d35-493c-9c98-8c9add57a1ae" />


<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation
docs/layouts/shortcodes/generated/core_configuration.html
<!-- Does this change introduce a new feature -->
