### PR TITLE
[flink] Infer parallelism only in situation of parallelism is not set.

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/DataTableSourceTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/DataTableSourceTest.java
@@ -82,7 +82,6 @@ class DataTableSourceTest {
         PaimonDataStreamScanProvider runtimeProvider = runtimeProvider(tableSource);
         StreamExecutionEnvironment sEnv1 = StreamExecutionEnvironment.createLocalEnvironment();
         sEnv1.setParallelism(-1);
-        System.out.println(sEnv1.getParallelism());
         DataStream<RowData> sourceStream1 =
                 runtimeProvider.produceDataStream(s -> Optional.empty(), sEnv1);
         assertThat(sourceStream1.getParallelism()).isEqualTo(1);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/DataTableSourceTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/DataTableSourceTest.java
@@ -81,6 +81,8 @@ class DataTableSourceTest {
                         null);
         PaimonDataStreamScanProvider runtimeProvider = runtimeProvider(tableSource);
         StreamExecutionEnvironment sEnv1 = StreamExecutionEnvironment.createLocalEnvironment();
+        sEnv1.setParallelism(-1);
+        System.out.println(sEnv1.getParallelism());
         DataStream<RowData> sourceStream1 =
                 runtimeProvider.produceDataStream(s -> Optional.empty(), sEnv1);
         assertThat(sourceStream1.getParallelism()).isEqualTo(1);
@@ -117,8 +119,7 @@ class DataTableSourceTest {
         StreamExecutionEnvironment sEnv1 = StreamExecutionEnvironment.createLocalEnvironment();
         DataStream<RowData> sourceStream1 =
                 runtimeProvider.produceDataStream(s -> Optional.empty(), sEnv1);
-        // parallelism = 1 for table with -1 bucket.
-        assertThat(sourceStream1.getParallelism()).isEqualTo(1);
+        assertThat(sourceStream1.getParallelism()).isEqualTo(12);
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/DataTableSourceTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/DataTableSourceTest.java
@@ -119,7 +119,7 @@ class DataTableSourceTest {
         StreamExecutionEnvironment sEnv1 = StreamExecutionEnvironment.createLocalEnvironment();
         DataStream<RowData> sourceStream1 =
                 runtimeProvider.produceDataStream(s -> Optional.empty(), sEnv1);
-        assertThat(sourceStream1.getParallelism()).isEqualTo(12);
+        assertThat(sourceStream1.getParallelism()).isEqualTo(sEnv1.getParallelism());
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/SourceMetricsITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/SourceMetricsITCase.java
@@ -84,7 +84,9 @@ public class SourceMetricsITCase {
         tEnv.executeSql("INSERT INTO T VALUES (1, 10), (2, 20), (3, 30)").await();
         tEnv.executeSql(
                 "CREATE TEMPORARY TABLE B ( k INT, v INT ) WITH ( 'connector' = 'blackhole' )");
-        TableResult tableResult = tEnv.executeSql("INSERT INTO B SELECT * FROM T");
+        TableResult tableResult =
+                tEnv.executeSql(
+                        "INSERT INTO B SELECT * FROM T/*+ OPTIONS('scan.parallelism'='1')*/");
         JobClient client = tableResult.getJobClient().get();
         JobID jobId = client.getJobID();
         tableResult.await();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/util/ReadWriteTableTestUtil.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/util/ReadWriteTableTestUtil.java
@@ -81,6 +81,8 @@ public class ReadWriteTableTestUtil {
         sEnv = StreamTableEnvironment.create(sExeEnv);
 
         bExeEnv = buildBatchEnv(parallelism, "none");
+        // set no default parallelism
+        bExeEnv.setParallelism(-1);
         bEnv = StreamTableEnvironment.create(bExeEnv, EnvironmentSettings.inBatchMode());
 
         ReadWriteTableTestUtil.warehouse = warehouse;


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
default.parallelism is not working because scan.infer-parallelism is default true

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
