### PR TITLE
[core] Fix listPartitions ArrayIndexOutOfBoundsException for release-1.0

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
@@ -75,7 +75,7 @@ public class CatalogUtils {
         InternalRowPartitionComputer computer =
                 new InternalRowPartitionComputer(
                         options.get(PARTITION_DEFAULT_NAME),
-                        table.rowType(),
+                        table.rowType().project(table.partitionKeys()),
                         table.partitionKeys().toArray(new String[0]),
                         options.get(PARTITION_GENERATE_LEGCY_NAME));
         List<PartitionEntry> partitionEntries =

--- a/paimon-core/src/test/java/org/apache/paimon/table/FallbackReadFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FallbackReadFileStoreTableTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.CatalogUtils;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileIOFinder;
@@ -57,7 +58,7 @@ public class FallbackReadFileStoreTableTest {
                     new DataType[] {
                         DataTypes.INT(), DataTypes.INT(),
                     },
-                    new String[] {"pt", "a"});
+                    new String[] {"a", "pt"});
 
     @TempDir java.nio.file.Path tempDir;
 
@@ -81,14 +82,14 @@ public class FallbackReadFileStoreTableTest {
         FileStoreTable mainTable = createTable();
 
         // write data into partition 1 and 2.
-        writeDataIntoTable(mainTable, 0, rowData(1, 10), rowData(2, 20));
+        writeDataIntoTable(mainTable, 0, rowData(10, 1), rowData(20, 2));
 
         mainTable.createBranch(branchName);
 
         FileStoreTable branchTable = createTableFromBranch(mainTable, branchName);
 
         // write data into partition for branch only
-        writeDataIntoTable(branchTable, 0, rowData(3, 60));
+        writeDataIntoTable(branchTable, 0, rowData(60, 3));
 
         FallbackReadFileStoreTable fallbackTable =
                 new FallbackReadFileStoreTable(mainTable, branchTable);
@@ -105,6 +106,7 @@ public class FallbackReadFileStoreTableTest {
                         .collect(Collectors.toList());
         // this should contain all partitions
         assertThat(partitionsFromFallbackTable).containsExactlyInAnyOrder(1, 2, 3);
+        assertThat(CatalogUtils.listPartitionsFromFileSystem(mainTable)).size().isEqualTo(2);
     }
 
     @Test
@@ -114,14 +116,14 @@ public class FallbackReadFileStoreTableTest {
         FileStoreTable mainTable = createTable();
 
         // write data into partition 1 and 2.
-        writeDataIntoTable(mainTable, 0, rowData(1, 10), rowData(1, 30), rowData(2, 20));
+        writeDataIntoTable(mainTable, 0, rowData(10, 1), rowData(30, 1), rowData(20, 2));
 
         mainTable.createBranch(branchName);
 
         FileStoreTable branchTable = createTableFromBranch(mainTable, branchName);
 
         // write data into partition for branch only
-        writeDataIntoTable(branchTable, 0, rowData(1, 50), rowData(3, 60), rowData(4, 70));
+        writeDataIntoTable(branchTable, 0, rowData(50, 1), rowData(60, 3), rowData(70, 4));
 
         FallbackReadFileStoreTable fallbackTable =
                 new FallbackReadFileStoreTable(mainTable, branchTable);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
When calling listPartitions interface, it may occurs ArrayIndexOutOfBoundsException.
```
 java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
        at org.apache.paimon.utils.InternalRowPartitionComputer.<init>(InternalRowPartitionComputer.java:64)
        at org.apache.paimon.catalog.CatalogUtils.listPartitionsFromFileSystem(CatalogUtils.java:80)
        at org.apache.paimon.catalog.AbstractCatalog.listPartitions(AbstractCatalog.java:198)
```
This PR fixs the problem.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
added

### API and Format

<!-- Does this change affect API or storage format -->
no.

### Documentation

<!-- Does this change introduce a new feature -->
no.