### PR TITLE
[core] Fix that sequence fields are mistakenly aggregated by default aggregator in AggregateMergeFunction

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/factory/FieldAggregatorFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/factory/FieldAggregatorFactory.java
@@ -25,10 +25,6 @@ import org.apache.paimon.mergetree.compact.aggregate.FieldAggregator;
 import org.apache.paimon.mergetree.compact.aggregate.FieldIgnoreRetractAgg;
 import org.apache.paimon.types.DataType;
 
-import javax.annotation.Nullable;
-
-import java.util.List;
-
 /** Factory for {@link FieldAggregator}. */
 public interface FieldAggregatorFactory extends Factory {
 
@@ -55,16 +51,5 @@ public interface FieldAggregatorFactory extends Factory {
         return options.fieldAggIgnoreRetract(fieldName)
                 ? new FieldIgnoreRetractAgg(fieldAggregator)
                 : fieldAggregator;
-    }
-
-    @Nullable
-    static String getAggFuncName(String fieldName, List<String> primaryKeys, CoreOptions options) {
-        if (primaryKeys.contains(fieldName)) {
-            // aggregate by primary keys, so they do not aggregate
-            return FieldPrimaryKeyAggFactory.NAME;
-        }
-
-        String aggFunc = options.fieldAggFunc(fieldName);
-        return aggFunc == null ? options.fieldsDefaultFunc() : aggFunc;
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -936,10 +936,8 @@ public class FieldAggregatorTest {
                 FieldAggregatorFactory.create(
                         DataTypes.STRING(),
                         "custom",
-                        false,
-                        false,
-                        CoreOptions.fromMap(new HashMap<>()),
-                        "custom");
+                        "custom",
+                        CoreOptions.fromMap(new HashMap<>()));
 
         Object agg = fieldAggregator.agg("test", "test");
         assertThat(agg).isEqualTo("test");

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PreAggregationITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PreAggregationITCase.java
@@ -1195,6 +1195,24 @@ public class PreAggregationITCase {
             assertThat(batchSql("SELECT * FROM T where v = 1"))
                     .containsExactlyInAnyOrder(Row.of(2, 1, 1));
         }
+
+        @Test
+        public void testSequenceFieldWithDefaultAgg() {
+            sql(
+                    "CREATE TABLE seq_default_agg ("
+                            + " pk INT PRIMARY KEY NOT ENFORCED,"
+                            + " seq INT,"
+                            + " v INT) WITH ("
+                            + " 'merge-engine'='aggregation',"
+                            + " 'sequence.field'='seq',"
+                            + " 'fields.default-aggregate-function'='sum'"
+                            + ")");
+
+            sql("INSERT INTO seq_default_agg VALUES (0, 1, 1)");
+            sql("INSERT INTO seq_default_agg VALUES (0, 2, 2)");
+
+            assertThat(sql("SELECT * FROM seq_default_agg")).containsExactly(Row.of(0, 2, 3));
+        }
     }
 
     /** ITCase for {@link FieldNestedUpdateAgg}. */


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Same as #4897 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
