### PR TITLE
[rest] Optimize partition methods to let rest return table not partitioned

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/rest/DefaultErrorHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/DefaultErrorHandler.java
@@ -23,10 +23,10 @@ import org.apache.paimon.rest.exceptions.BadRequestException;
 import org.apache.paimon.rest.exceptions.ForbiddenException;
 import org.apache.paimon.rest.exceptions.NoSuchResourceException;
 import org.apache.paimon.rest.exceptions.NotAuthorizedException;
+import org.apache.paimon.rest.exceptions.NotImplementedException;
 import org.apache.paimon.rest.exceptions.RESTException;
 import org.apache.paimon.rest.exceptions.ServiceFailureException;
 import org.apache.paimon.rest.exceptions.ServiceUnavailableException;
-import org.apache.paimon.rest.exceptions.UnsupportedOperationException;
 import org.apache.paimon.rest.responses.ErrorResponse;
 
 /** Default error handler. */
@@ -61,7 +61,7 @@ public class DefaultErrorHandler extends ErrorHandler {
             case 500:
                 throw new ServiceFailureException("Server error: %s", message);
             case 501:
-                throw new UnsupportedOperationException(message);
+                throw new NotImplementedException(message);
             case 503:
                 throw new ServiceUnavailableException("Service unavailable: %s", message);
             default:

--- a/paimon-core/src/main/java/org/apache/paimon/rest/exceptions/NotImplementedException.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/exceptions/NotImplementedException.java
@@ -18,10 +18,10 @@
 
 package org.apache.paimon.rest.exceptions;
 
-/** Exception thrown on HTTP 501 - UnsupportedOperationException. */
-public class UnsupportedOperationException extends RESTException {
+/** Exception thrown on HTTP 501 - NotImplementedException. */
+public class NotImplementedException extends RESTException {
 
-    public UnsupportedOperationException(String message, Object... args) {
+    public NotImplementedException(String message, Object... args) {
         super(String.format(message, args));
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/rest/DefaultErrorHandlerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/DefaultErrorHandlerTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.rest.exceptions.BadRequestException;
 import org.apache.paimon.rest.exceptions.ForbiddenException;
 import org.apache.paimon.rest.exceptions.NoSuchResourceException;
 import org.apache.paimon.rest.exceptions.NotAuthorizedException;
+import org.apache.paimon.rest.exceptions.NotImplementedException;
 import org.apache.paimon.rest.exceptions.RESTException;
 import org.apache.paimon.rest.exceptions.ServiceFailureException;
 import org.apache.paimon.rest.exceptions.ServiceUnavailableException;
@@ -70,7 +71,7 @@ public class DefaultErrorHandlerTest {
                 ServiceFailureException.class,
                 () -> defaultErrorHandler.accept(generateErrorResponse(500)));
         assertThrows(
-                org.apache.paimon.rest.exceptions.UnsupportedOperationException.class,
+                NotImplementedException.class,
                 () -> defaultErrorHandler.accept(generateErrorResponse(501)));
         assertThrows(
                 RESTException.class, () -> defaultErrorHandler.accept(generateErrorResponse(502)));


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
At present, our partition interface will be called twice, once to retrieve the table and once for the actual partition operation. In fact, we don't need to retrieve the table, we just need to let the server determine whether it is a partition table by itself.

This PR has also changed the exception name, `NotImplementedException` is less likely to conflict and better.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
