### PR TITLE
[core] ObjectRefresh with iterative list and batched commit

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/object/ObjectRefresh.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/object/ObjectRefresh.java
@@ -35,7 +35,7 @@ import java.util.Collections;
 /** Util class for refreshing object table. */
 public class ObjectRefresh {
 
-    private static final long COMMIT_BATCH_SIZE = 1000;
+    private static final long COMMIT_BATCH_SIZE = 10_000;
 
     public static long refresh(ObjectTable table) throws Exception {
         long totalObjs = 0;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #4971 

<!-- What is the purpose of the change -->
* Take advantage of iterative list to lower memory requirement.
* Commit object refresh entries in batches to improve performance.

### Tests

<!-- List UT and IT cases to verify this change -->
Use existing tests `ObjectTableITCase` and `ObjectTableTest`.

### API and Format

<!-- Does this change affect API or storage format -->
N/A

### Documentation

<!-- Does this change introduce a new feature -->
N/A