### PR TITLE
[parquet] Introduce LongIterator to Parquet RowIndexGenerator

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/VectorizedRowIterator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/VectorizedRowIterator.java
@@ -20,6 +20,7 @@ package org.apache.paimon.data.columnar;
 
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.reader.VectorizedRecordIterator;
+import org.apache.paimon.utils.LongIterator;
 
 import javax.annotation.Nullable;
 
@@ -39,7 +40,7 @@ public class VectorizedRowIterator extends ColumnarRowIterator implements Vector
     protected VectorizedRowIterator copy(ColumnVector[] vectors) {
         VectorizedRowIterator newIterator =
                 new VectorizedRowIterator(filePath, row.copy(vectors), recycler);
-        newIterator.reset(positions);
+        newIterator.reset(LongIterator.fromArray(positions));
         return newIterator;
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/LongIterator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/LongIterator.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import java.util.NoSuchElementException;
+
+/** Iterator for long. */
+public interface LongIterator {
+
+    boolean hasNext();
+
+    long next();
+
+    static LongIterator fromRange(final long startInclusive, final long endExclusive) {
+        return new LongIterator() {
+
+            private long i = startInclusive;
+
+            @Override
+            public boolean hasNext() {
+                return i < endExclusive;
+            }
+
+            @Override
+            public long next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                return i++;
+            }
+        };
+    }
+
+    static LongIterator fromArray(final long[] longs) {
+        return new LongIterator() {
+
+            private int i = 0;
+
+            @Override
+            public boolean hasNext() {
+                return i < longs.length;
+            }
+
+            @Override
+            public long next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                return longs[i++];
+            }
+        };
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/utils/LongIteratorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/LongIteratorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LongIteratorTest {
+
+    @Test
+    public void testRange() {
+        LongIterator iterator = LongIterator.fromRange(5, 10);
+        List<Long> list = new ArrayList<>();
+        while (iterator.hasNext()) {
+            list.add(iterator.next());
+        }
+        assertThat(list).containsExactlyInAnyOrder(5L, 6L, 7L, 8L, 9L);
+    }
+
+    @Test
+    public void testFromArray() {
+        long[] array = new long[] {5L, 6L, 7L, 8L, 9L};
+        LongIterator iterator = LongIterator.fromArray(array);
+        List<Long> list = new ArrayList<>();
+        while (iterator.hasNext()) {
+            list.add(iterator.next());
+        }
+        assertThat(list).containsExactlyInAnyOrder(5L, 6L, 7L, 8L, 9L);
+    }
+}

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/newreader/ColumnarBatch.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/newreader/ColumnarBatch.java
@@ -27,6 +27,7 @@ import org.apache.paimon.data.columnar.RowColumnVector;
 import org.apache.paimon.data.columnar.VectorizedColumnBatch;
 import org.apache.paimon.data.columnar.VectorizedRowIterator;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.utils.LongIterator;
 
 import java.util.Arrays;
 
@@ -55,7 +56,7 @@ public class ColumnarBatch {
     }
 
     /** Reset next record position and return self. */
-    public void resetPositions(long[] positions) {
+    public void resetPositions(LongIterator positions) {
         vectorizedRowIterator.reset(positions);
     }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/newreader/VectorizedParquetRecordReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/newreader/VectorizedParquetRecordReader.java
@@ -286,7 +286,7 @@ public class VectorizedParquetRecordReader implements FileRecordReader<InternalR
         }
         rowsReturned += num;
         columnarBatch.setNumRows(num);
-        rowIndexGenerator.populateRowIndex(columnarBatch, num);
+        rowIndexGenerator.populateRowIndex(columnarBatch);
         return true;
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Improve performance, we should let rowIndexes to lazied.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
