### PR TITLE
[spark] Fix the result of migrate database procedure

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateDatabaseProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/MigrateDatabaseProcedure.java
@@ -31,6 +31,7 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,9 +118,9 @@ public class MigrateDatabaseProcedure extends BaseProcedure {
         String retStr =
                 String.format(
                         "migrate database is finished, success cnt: %s , failed cnt: %s",
-                        String.valueOf(successCount), String.valueOf(errorCount));
+                        successCount, errorCount);
 
-        return new InternalRow[] {newInternalRow(retStr)};
+        return new InternalRow[] {newInternalRow(UTF8String.fromString(retStr))};
     }
 
     public static Map<String, String> mapDataToHashMap(MapData mapData) {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/MigrateDatabaseProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/MigrateDatabaseProcedureTest.scala
@@ -21,7 +21,9 @@ package org.apache.paimon.spark.procedure
 import org.apache.paimon.spark.PaimonHiveTestBase
 
 import org.apache.spark.sql.Row
+
 class MigrateDatabaseProcedureTest extends PaimonHiveTestBase {
+
   Seq("parquet", "orc", "avro").foreach(
     format => {
       test(s"Paimon migrate database procedure: migrate $format non-partitioned database") {
@@ -45,8 +47,11 @@ class MigrateDatabaseProcedureTest extends PaimonHiveTestBase {
 
           spark.sql(s"INSERT INTO hive_tbl VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
 
-          spark.sql(
-            s"CALL sys.migrate_database(source_type => 'hive', database => '$hiveDbName', options => 'file.format=$format')")
+          checkAnswer(
+            spark.sql(
+              s"CALL sys.migrate_database(source_type => 'hive', database => '$hiveDbName', options => 'file.format=$format')"),
+            Seq(Row("migrate database is finished, success cnt: 2 , failed cnt: 0"))
+          )
 
           checkAnswer(
             spark.sql(s"SELECT * FROM hive_tbl ORDER BY id"),
@@ -57,7 +62,6 @@ class MigrateDatabaseProcedureTest extends PaimonHiveTestBase {
 
           rows1 = spark.sql("SHOW CREATE TABLE hive_tbl1").collect()
           assert(rows1.apply(0).toString().contains("USING paimon"))
-
         }
       }
     })


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

```sql
CALL sys.migrate_database(source_type => 'hive', database => '$hiveDbName', options => 'file.format=$format')
```

```
java.lang.String cannot be cast to org.apache.spark.unsafe.types.UTF8String
java.lang.ClassCastException: java.lang.String cannot be cast to org.apache.spark.unsafe.types.UTF8String
	at org.apache.spark.sql.catalyst.expressions.BaseGenericInternalRow.getUTF8String(rows.scala:45)
	at org.apache.spark.sql.catalyst.expressions.BaseGenericInternalRow.getUTF8String$(rows.scala:45)
	at org.apache.spark.sql.catalyst.expressions.GenericInternalRow.getUTF8String(rows.scala:165)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.apply(Unknown Source)
	at org.apache.spark.sql.execution.CommandResultExec.$anonfun$unsafeRows$1(CommandResultExec.scala:48)
	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:286)
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
