### PR TITLE
[Parquet] Fix parquet decimal type match.

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/newreader/ParquetVectorUpdaterFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/newreader/ParquetVectorUpdaterFactory.java
@@ -79,13 +79,8 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 /** Updater Factory to get {@link ParquetVectorUpdater}. */
 public class ParquetVectorUpdaterFactory {
 
-    private final LogicalTypeAnnotation logicalTypeAnnotation;
-
-    ParquetVectorUpdaterFactory(LogicalTypeAnnotation logicalTypeAnnotation) {
-        this.logicalTypeAnnotation = logicalTypeAnnotation;
-    }
-
-    public ParquetVectorUpdater getUpdater(ColumnDescriptor descriptor, DataType paimonType) {
+    public static ParquetVectorUpdater getUpdater(
+            ColumnDescriptor descriptor, DataType paimonType) {
         return paimonType.accept(UpdaterFactoryVisitor.INSTANCE).apply(descriptor);
     }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/newreader/ParquetVectorUpdaterFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/newreader/ParquetVectorUpdaterFactory.java
@@ -65,7 +65,6 @@ import org.apache.parquet.schema.PrimitiveType;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.math.RoundingMode;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.TimeUnit;
@@ -759,7 +758,9 @@ public class ParquetVectorUpdaterFactory {
             LogicalTypeAnnotation typeAnnotation =
                     descriptor.getPrimitiveType().getLogicalTypeAnnotation();
             int parquetScale = ((DecimalLogicalTypeAnnotation) typeAnnotation).getScale();
-            checkArgument(parquetScale == paimonType.getScale(), "Scale should be match between paimon decimal type and parquet decimal type in file");
+            checkArgument(
+                    parquetScale == paimonType.getScale(),
+                    "Scale should be match between paimon decimal type and parquet decimal type in file");
             this.arrayLen = descriptor.getPrimitiveType().getTypeLength();
         }
 
@@ -775,8 +776,7 @@ public class ParquetVectorUpdaterFactory {
 
             int precision = paimonType.getPrecision();
             if (ParquetSchemaConverter.is32BitDecimal(precision)) {
-                ((HeapIntVector) values).setInt(
-                        offset, (int) heapBinaryToLong(binary));
+                ((HeapIntVector) values).setInt(offset, (int) heapBinaryToLong(binary));
             } else if (ParquetSchemaConverter.is64BitDecimal(precision)) {
                 ((HeapLongVector) values).setLong(offset, heapBinaryToLong(binary));
             } else {
@@ -810,8 +810,7 @@ public class ParquetVectorUpdaterFactory {
             Binary binary = dictionary.decodeToBinary(dictionaryIds.getInt(offset));
             int precision = paimonType.getPrecision();
             if (ParquetSchemaConverter.is32BitDecimal(precision)) {
-                ((HeapIntVector) values).setInt(
-                        offset, (int) heapBinaryToLong(binary));
+                ((HeapIntVector) values).setInt(offset, (int) heapBinaryToLong(binary));
             } else if (ParquetSchemaConverter.is64BitDecimal(precision)) {
                 ((HeapLongVector) values).setLong(offset, heapBinaryToLong(binary));
             } else {

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/newreader/VectorizedColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/newreader/VectorizedColumnReader.java
@@ -120,7 +120,7 @@ public class VectorizedColumnReader {
     }
 
     private boolean isLazyDecodingSupported(
-            PrimitiveType.PrimitiveTypeName typeName, DataType sparkType) {
+            PrimitiveType.PrimitiveTypeName typeName, DataType paimonType) {
         return true;
     }
 

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetReadWriteTest.java
@@ -83,6 +83,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -99,6 +100,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.format.parquet.ParquetSchemaConverter.computeMinBytesForDecimalPrecision;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -154,6 +157,16 @@ public class ParquetReadWriteTest {
                                     .build(),
                             new MapType(
                                     new TimestampType(6), new VarCharType(VarCharType.MAX_LENGTH)))
+                    .build();
+
+    private static final RowType DECIMAL_TYPE =
+            RowType.builder()
+                    .fields(
+                            new DecimalType(3, 2),
+                            new DecimalType(6, 2),
+                            new DecimalType(9, 2),
+                            new DecimalType(12, 2),
+                            new DecimalType(32, 2))
                     .build();
 
     private static final RowType NESTED_ARRAY_MAP_TYPE =
@@ -476,6 +489,36 @@ public class ParquetReadWriteTest {
                 new InternalRowSerializer(NESTED_ARRAY_MAP_TYPE);
         reader.forEachRemaining(row -> results.add(internalRowSerializer.copy(row)));
         compareNestedRow(rows, results);
+    }
+
+    @Test
+    public void testDecimalWithFixedLengthRead() throws Exception {
+        int number = new Random().nextInt(1000) + 100;
+        Path path = createDecimalFile(number, folder, 10);
+
+        ParquetReaderFactory format =
+                new ParquetReaderFactory(new Options(), DECIMAL_TYPE, 500, FilterCompat.NOOP);
+        RecordReader<InternalRow> reader =
+                format.createReader(
+                        new FormatReaderContext(
+                                new LocalFileIO(), path, new LocalFileIO().getFileSize(path)));
+        List<InternalRow> results = new ArrayList<>(number);
+        InternalRowSerializer internalRowSerializer = new InternalRowSerializer(DECIMAL_TYPE);
+        reader.forEachRemaining(row -> results.add(internalRowSerializer.copy(row)));
+
+        BigDecimal decimalValue0 = new BigDecimal("123.67");
+        BigDecimal decimalValue1 = new BigDecimal("12345.67");
+        BigDecimal decimalValue2 = new BigDecimal("1234567.67");
+        BigDecimal decimalValue3 = new BigDecimal("123456789123.67");
+        BigDecimal decimalValue4 = new BigDecimal("123456789123456789123456789123.67");
+
+        for (InternalRow internalRow : results) {
+            assertThat(internalRow.getDecimal(0, 3, 2).toBigDecimal()).isEqualTo(decimalValue0);
+            assertThat(internalRow.getDecimal(1, 6, 2).toBigDecimal()).isEqualTo(decimalValue1);
+            assertThat(internalRow.getDecimal(2, 9, 2).toBigDecimal()).isEqualTo(decimalValue2);
+            assertThat(internalRow.getDecimal(3, 12, 2).toBigDecimal()).isEqualTo(decimalValue3);
+            assertThat(internalRow.getDecimal(4, 32, 2).toBigDecimal()).isEqualTo(decimalValue4);
+        }
     }
 
     @Test
@@ -964,6 +1007,90 @@ public class ParquetReadWriteTest {
             }
         } catch (Exception e) {
             throw new RuntimeException("Create nested data by parquet origin writer failed.");
+        }
+        return path;
+    }
+
+    private Path createDecimalFile(int rowNum, File tmpDir, int rowGroupSize) {
+        Path path = new Path(tmpDir.getPath(), UUID.randomUUID().toString());
+        Configuration conf = new Configuration();
+        conf.setInt("parquet.block.size", rowGroupSize);
+        List<Type> types = new ArrayList<>();
+
+        for (DataField dataField : DECIMAL_TYPE.getFields()) {
+            String name = dataField.name();
+            int fieldId = dataField.id();
+            int precision = ((DecimalType) dataField.type()).getPrecision();
+            int scale = ((DecimalType) dataField.type()).getScale();
+            Type.Repetition repetition =
+                    dataField.type().isNullable()
+                            ? Type.Repetition.OPTIONAL
+                            : Type.Repetition.REQUIRED;
+
+            types.add(
+                    Types.primitive(FIXED_LEN_BYTE_ARRAY, repetition)
+                            .as(LogicalTypeAnnotation.decimalType(scale, precision))
+                            .length(computeMinBytesForDecimalPrecision(precision))
+                            .named(name)
+                            .withId(fieldId));
+        }
+
+        MessageType schema = new MessageType("paimon_schema", types);
+
+        List<Binary> decimalBytesList = new ArrayList<>();
+
+        BigDecimal decimalValue = new BigDecimal("123.67");
+        int scale = 2;
+        byte[] decimalBytes =
+                decimalValue.setScale(scale, RoundingMode.HALF_UP).unscaledValue().toByteArray();
+        Binary binaryValue = Binary.fromByteArray(decimalBytes);
+        decimalBytesList.add(binaryValue);
+
+        decimalValue = new BigDecimal("12345.67");
+        decimalBytes =
+                decimalValue.setScale(scale, RoundingMode.HALF_UP).unscaledValue().toByteArray();
+        binaryValue = Binary.fromByteArray(decimalBytes);
+        decimalBytesList.add(binaryValue);
+
+        decimalValue = new BigDecimal("1234567.67");
+        decimalBytes =
+                decimalValue.setScale(scale, RoundingMode.HALF_UP).unscaledValue().toByteArray();
+        binaryValue = Binary.fromByteArray(decimalBytes);
+        decimalBytesList.add(binaryValue);
+
+        decimalValue = new BigDecimal("123456789123.67");
+        decimalBytes =
+                decimalValue.setScale(scale, RoundingMode.HALF_UP).unscaledValue().toByteArray();
+        binaryValue = Binary.fromByteArray(decimalBytes);
+        decimalBytesList.add(binaryValue);
+
+        decimalValue = new BigDecimal("123456789123456789123456789123.67");
+        decimalBytes =
+                decimalValue.setScale(scale, RoundingMode.HALF_UP).unscaledValue().toByteArray();
+        binaryValue = Binary.fromByteArray(decimalBytes);
+        decimalBytesList.add(binaryValue);
+
+        try (ParquetWriter<Group> writer =
+                ExampleParquetWriter.builder(
+                                HadoopOutputFile.fromPath(
+                                        new org.apache.hadoop.fs.Path(path.toString()), conf))
+                        .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
+                        .withConf(new Configuration())
+                        .withType(schema)
+                        .build()) {
+            SimpleGroupFactory simpleGroupFactory = new SimpleGroupFactory(schema);
+            for (int i = 0; i < rowNum; i++) {
+
+                Group row = simpleGroupFactory.newGroup();
+
+                for (int j = 0; j < DECIMAL_TYPE.getFields().size(); j++) {
+                    row.append("f" + j, decimalBytesList.get(j));
+                }
+
+                writer.write(row);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Create data by parquet origin writer failed.", e);
         }
         return path;
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Fix lenth bytes to decimal type should be convert according to paimon decimal type scale.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
