### PR TITLE
[bug] Fix type bug when using Boolean in bitmap for file index

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bitmap/BitmapFileIndexMeta.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bitmap/BitmapFileIndexMeta.java
@@ -176,6 +176,11 @@ public class BitmapFileIndexMeta {
                             public ThrowableConsumer visitDouble() {
                                 return o -> out.writeDouble((double) o);
                             }
+
+                            @Override
+                            public ThrowableConsumer visitBoolean() {
+                                return o -> out.writeBoolean((Boolean) o);
+                            }
                         });
 
         out.writeInt(rowCount);
@@ -234,6 +239,11 @@ public class BitmapFileIndexMeta {
                             public ThrowableSupplier visitDouble() {
                                 return in::readDouble;
                             }
+
+                            @Override
+                            public ThrowableSupplier visitBoolean() {
+                                return in::readBoolean;
+                            }
                         });
 
         rowCount = in.readInt();
@@ -275,6 +285,8 @@ public class BitmapFileIndexMeta {
 
         public abstract R visitDouble();
 
+        public abstract R visitBoolean();
+
         @Override
         public final R visit(CharType charType) {
             return visitBinaryString();
@@ -287,7 +299,7 @@ public class BitmapFileIndexMeta {
 
         @Override
         public final R visit(BooleanType booleanType) {
-            return visitByte();
+            return visitBoolean();
         }
 
         @Override


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Fix type bug when using Boolean in bitmap for file index. Current use byte will cause: 
`java.lang.ClassCastException：class java.lang.Boolean cannot be cast to class java.lang.Byte`

### Tests
TestBitmapFileIndex.testBitmapIndexForBooleanType
<!-- List UT and IT cases to verify this change -->

### API and Format
NO
<!-- Does this change affect API or storage format -->

### Documentation
NO
<!-- Does this change introduce a new feature -->
