### PR TITLE
[filesystem] Fix typo in docs

### DIFF
--- a/docs/content/maintenance/filesystems.md
+++ b/docs/content/maintenance/filesystems.md
@@ -346,7 +346,7 @@ Please refer to [Trino S3](https://trino.io/docs/current/object-storage/file-sys
 
 {{< /tabs >}}
 
-### S3 Complaint Object Stores
+### S3 Compliant Object Stores
 
 The S3 Filesystem also support using S3 compliant object stores such as MinIO, Tencent's COS and IBM’s Cloud Object
 Storage. Just configure your endpoint to the provider of the object store service.


### PR DESCRIPTION
### Documentation

Simply fixes a small typo in the filesystem docs.
