### PR TITLE
[bug] Fix sys.clone doc demo

### DIFF
--- a/docs/content/flink/clone-tables.md
+++ b/docs/content/flink/clone-tables.md
@@ -58,14 +58,14 @@ Example: Clone `test_db.test_table` from source warehouse to target warehouse.
 
 ```sql
 CALL sys.clone(
-    'warehouse' => 's3:///path/to/warehouse_source',
-    'database' => 'test_db',
-    'table' => 'test_table',
-    'catalog_conf' => 's3.endpoint=https://****.com;s3.access-key=*****;s3.secret-key=*****',
-    'target_warehouse' => 's3:///path/to/warehouse_target',
-    'target_database' => 'test_db',
-    'target_table' => 'test_table',
-    'target_catalog_conf' => 's3.endpoint=https://****.com;s3.access-key=*****;s3.secret-key=*****'
+    `warehouse` => 's3:///path/to/warehouse_source',
+    `database` => 'test_db',
+    `table` => 'test_table',
+    `catalog_conf` => 's3.endpoint=https://****.com;s3.access-key=*****;s3.secret-key=*****',
+    `target_warehouse` => 's3:///path/to/warehouse_target',
+    `target_database` => 'test_db',
+    `target_table` => 'test_table',
+    `target_catalog_conf` => 's3.endpoint=https://****.com;s3.access-key=*****;s3.secret-key=*****'
 );
 ```
 


### PR DESCRIPTION
### Purpose
Fix sys.clone doc demo: as the key must use `` not ''


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
