### PR TITLE
[spark] Fix rename table with catalog name

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -73,6 +73,7 @@ import static org.apache.paimon.spark.SparkCatalogOptions.DEFAULT_DATABASE;
 import static org.apache.paimon.spark.SparkTypeUtils.toPaimonType;
 import static org.apache.paimon.spark.util.OptionUtils.copyWithSQLConf;
 import static org.apache.paimon.spark.utils.CatalogUtils.checkNamespace;
+import static org.apache.paimon.spark.utils.CatalogUtils.removeCatalogName;
 import static org.apache.paimon.spark.utils.CatalogUtils.toIdentifier;
 
 /** Spark {@link TableCatalog} for paimon. */
@@ -427,7 +428,10 @@ public class SparkCatalog extends SparkBaseCatalog implements SupportFunction, S
     public void renameTable(Identifier oldIdent, Identifier newIdent)
             throws NoSuchTableException, TableAlreadyExistsException {
         try {
-            catalog.renameTable(toIdentifier(oldIdent), toIdentifier(newIdent), false);
+            catalog.renameTable(
+                    toIdentifier(oldIdent),
+                    toIdentifier(removeCatalogName(newIdent, catalogName)),
+                    false);
         } catch (Catalog.TableNotExistException e) {
             throw new NoSuchTableException(oldIdent);
         } catch (Catalog.TableAlreadyExistException e) {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/utils/CatalogUtils.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/utils/CatalogUtils.java
@@ -38,4 +38,18 @@ public class CatalogUtils {
         checkNamespace(ident.namespace());
         return new org.apache.paimon.catalog.Identifier(ident.namespace()[0], ident.name());
     }
+
+    public static Identifier removeCatalogName(Identifier ident, String catalogName) {
+        String[] namespace = ident.namespace();
+        if (namespace.length > 1) {
+            checkArgument(
+                    namespace[0].equals(catalogName),
+                    "Only supports operations within the same catalog, target catalog name: %s, current catalog name: %s",
+                    namespace[0],
+                    catalogName);
+            return Identifier.of(Arrays.copyOfRange(namespace, 1, namespace.length), ident.name());
+        } else {
+            return ident;
+        }
+    }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
@@ -572,4 +572,18 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
         }
     }
   }
+
+  test("Paimon DDL: rename table with catalog name") {
+    sql("USE default")
+    withTable("t1", "t2") {
+      sql("CREATE TABLE t1 (id INT) USING paimon")
+      sql("INSERT INTO t1 VALUES 1")
+      sql("ALTER TABLE paimon.default.t1 RENAME TO paimon.default.t2")
+      checkAnswer(sql("SELECT * FROM t2"), Row(1))
+
+      assert(intercept[Exception] {
+        sql("ALTER TABLE paimon.default.t2 RENAME TO spark_catalog.default.t2")
+      }.getMessage.contains("Only supports operations within the same catalog"))
+    }
+  }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

```sql
ALTER TABLE paimon.default.t1 RENAME TO paimon.default.t2;
```

```
Paimon only support single namespace, but got [paimon, default]
java.lang.IllegalArgumentException: Paimon only support single namespace, but got [paimon, default]
	at org.apache.paimon.utils.Preconditions.checkArgument(Preconditions.java:149)
	at org.apache.paimon.spark.utils.CatalogUtils.checkNamespace(CatalogUtils.java:31)
	at org.apache.paimon.spark.utils.CatalogUtils.toIdentifier(CatalogUtils.java:38)
	at org.apache.paimon.spark.SparkCatalog.renameTable(SparkCatalog.java:433)
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
