### PR TITLE
[flink] change the name of MultiTablesReadOperator to avoid using same name with source

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedAwareStreamingSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedAwareStreamingSource.java
@@ -130,7 +130,7 @@ public class CombinedAwareStreamingSource extends CombinedCompactorSource<Tuple2
                         (key, numPartitions) -> key % numPartitions,
                         split -> ((DataSplit) split.f0).bucket())
                 .transform(
-                        name + "-toRow",
+                        "BucketsTableReader",
                         typeInfo,
                         new MultiTablesReadOperator(catalogLoader, true));
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedAwareStreamingSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedAwareStreamingSource.java
@@ -129,6 +129,9 @@ public class CombinedAwareStreamingSource extends CombinedCompactorSource<Tuple2
                 .partitionCustom(
                         (key, numPartitions) -> key % numPartitions,
                         split -> ((DataSplit) split.f0).bucket())
-                .transform(name, typeInfo, new MultiTablesReadOperator(catalogLoader, true));
+                .transform(
+                        name + "-transform",
+                        typeInfo,
+                        new MultiTablesReadOperator(catalogLoader, true));
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedAwareStreamingSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedAwareStreamingSource.java
@@ -130,7 +130,7 @@ public class CombinedAwareStreamingSource extends CombinedCompactorSource<Tuple2
                         (key, numPartitions) -> key % numPartitions,
                         split -> ((DataSplit) split.f0).bucket())
                 .transform(
-                        name + "-transform",
+                        name + "-toRow",
                         typeInfo,
                         new MultiTablesReadOperator(catalogLoader, true));
     }


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
