### PR TITLE
[core] Check that all fields with aggregate functions in partial-update should be protected by sequence-group

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
@@ -549,8 +549,9 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
                 String aggFuncName = getAggFuncName(options, fieldName);
                 if (aggFuncName != null) {
                     checkArgument(
-                            !fieldSeqComparators.isEmpty(),
-                            "Must use sequence group for aggregation functions.");
+                            fieldSeqComparators.containsKey(fieldNames.indexOf(fieldName)),
+                            "Must use sequence group for aggregation functions but not found for field %s.",
+                            fieldName);
                     fieldAggregators.put(
                             i,
                             () ->

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.mergetree.compact.aggregate.FieldAggregator;
 import org.apache.paimon.mergetree.compact.aggregate.factory.FieldAggregatorFactory;
+import org.apache.paimon.mergetree.compact.aggregate.factory.FieldLastNonNullValueAggFactory;
 import org.apache.paimon.mergetree.compact.aggregate.factory.FieldPrimaryKeyAggFactory;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.types.DataField;
@@ -548,8 +549,11 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
 
                 String aggFuncName = getAggFuncName(options, fieldName);
                 if (aggFuncName != null) {
+                    // last_non_null_value doesn't require sequence group
                     checkArgument(
-                            fieldSeqComparators.containsKey(fieldNames.indexOf(fieldName)),
+                            aggFuncName.equals(FieldLastNonNullValueAggFactory.NAME)
+                                    || fieldSeqComparators.containsKey(
+                                            fieldNames.indexOf(fieldName)),
                             "Must use sequence group for aggregation functions but not found for field %s.",
                             fieldName);
                     fieldAggregators.put(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
For example,
```
CREATE TABLE SG
(
    pk   INT,
    f0   INT,
    g0   INT,
    f1   INT,
    g1   INT,
    PRIMARY KEY (pk) NOT ENFORCED
) WITH (
      'merge-engine' = 'partial-update',
      'fields.g0.sequence-group' = 'f0',
      'fields.f0.aggregate-function' = 'listagg',
      'fields.f1.aggregate-function' = 'listagg'
);
```
The `f1` lack sequence-group but there's no exception.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
