### PR TITLE
[test] Fix AppendOnlyWriterTest file format is error

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -141,6 +141,8 @@ public class AppendOnlyWriterTest {
         assertThat(meta.minSequenceNumber()).isEqualTo(0);
         assertThat(meta.maxSequenceNumber()).isEqualTo(0);
         assertThat(meta.level()).isEqualTo(DataFileMeta.DUMMY_LEVEL);
+        assertThat(meta.fileName().substring(meta.fileName().lastIndexOf(".") + 1))
+                .isEqualTo(CoreOptions.FILE_FORMAT_AVRO);
     }
 
     @Test
@@ -519,7 +521,7 @@ public class AppendOnlyWriterTest {
     private DataFilePathFactory createPathFactory() {
         return new DataFilePathFactory(
                 new Path(tempDir + "/dt=" + PART + "/bucket-0"),
-                CoreOptions.FILE_FORMAT.defaultValue().toString(),
+                CoreOptions.FILE_FORMAT_AVRO,
                 CoreOptions.DATA_FILE_PREFIX.defaultValue(),
                 CoreOptions.CHANGELOG_FILE_PREFIX.defaultValue(),
                 CoreOptions.FILE_SUFFIX_INCLUDE_COMPRESSION.defaultValue(),


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5040 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
```java
 assertThat(meta.fileName().substring(meta.fileName().lastIndexOf(".") + 1))
                .isEqualTo(CoreOptions.FILE_FORMAT_AVRO);
```

### API and Format

<!-- Does this change affect API or storage format -->

No change

### Documentation

<!-- Does this change introduce a new feature -->

No change
