### PR TITLE
[core] Fix missing kotlin and okio dependencies when using okhttp3.

### DIFF
--- a/paimon-core/pom.xml
+++ b/paimon-core/pom.xml
@@ -81,7 +81,7 @@ under the License.
 
         <dependency>
             <groupId>com.squareup.okio</groupId>
-            <artifactId>okio-jvm</artifactId>
+            <artifactId>okio</artifactId>
             <version>${okio.version}</version>
         </dependency>
 
@@ -298,7 +298,7 @@ under the License.
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>com.squareup.okhttp3:okhttp</include>
-                                    <include>com.squareup.okio:okio-jvm</include>
+                                    <include>com.squareup.okio:okio</include>
                                     <include>org.jetbrains.kotlin:kotlin-stdlib</include>
                                 </includes>
                             </artifactSet>

--- a/paimon-core/pom.xml
+++ b/paimon-core/pom.xml
@@ -75,13 +75,13 @@ under the License.
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okio</groupId>
-            <artifactId>okio</artifactId>
+            <artifactId>okio-jvm</artifactId>
             <version>${okio.version}</version>
         </dependency>
 
@@ -298,8 +298,8 @@ under the License.
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>com.squareup.okhttp3:okhttp</include>
-                                    <include>com.squareup.okio:okio</include>
-                                    <include>org.jetbrains.kotlin:kotlin-stdlib</include>
+                                    <include>com.squareup.okio:okio-jvm</include>
+                                    <include>org.jetbrains.kotlin:kotlin-stdlib-jdk8</include>
                                 </includes>
                             </artifactSet>
                             <relocations>

--- a/paimon-core/pom.xml
+++ b/paimon-core/pom.xml
@@ -33,8 +33,6 @@ under the License.
 
     <properties>
         <frocksdbjni.version>6.20.3-ververica-2.0</frocksdbjni.version>
-        <kotlin.version>1.8.21</kotlin.version>
-        <okio.version>3.6.0</okio.version>
     </properties>
 
     <dependencies>
@@ -71,18 +69,6 @@ under the License.
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>${okhttp.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.squareup.okio</groupId>
-            <artifactId>okio-jvm</artifactId>
-            <version>${okio.version}</version>
         </dependency>
 
         <!-- test dependencies -->
@@ -299,21 +285,13 @@ under the License.
                                 <includes combine.children="append">
                                     <include>com.squareup.okhttp3:okhttp</include>
                                     <include>com.squareup.okio:okio-jvm</include>
-                                    <include>org.jetbrains.kotlin:kotlin-stdlib-jdk8</include>
+                                    <include>org.jetbrains.kotlin:kotlin-stdlib</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
                                 <relocation>
                                     <pattern>okhttp3</pattern>
                                     <shadedPattern>org.apache.paimon.shade.okhttp3</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>kotlin</pattern>
-                                    <shadedPattern>org.apache.paimon.shade.kotlin</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>okio</pattern>
-                                    <shadedPattern>org.apache.paimon.shade.okio</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/paimon-core/pom.xml
+++ b/paimon-core/pom.xml
@@ -33,6 +33,8 @@ under the License.
 
     <properties>
         <frocksdbjni.version>6.20.3-ververica-2.0</frocksdbjni.version>
+        <kotlin.version>1.8.21</kotlin.version>
+        <okio.version>3.6.0</okio.version>
     </properties>
 
     <dependencies>
@@ -69,6 +71,18 @@ under the License.
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>${okhttp.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio-jvm</artifactId>
+            <version>${okio.version}</version>
         </dependency>
 
         <!-- test dependencies -->
@@ -284,12 +298,22 @@ under the License.
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>com.squareup.okhttp3:okhttp</include>
+                                    <include>com.squareup.okio:okio-jvm</include>
+                                    <include>org.jetbrains.kotlin:kotlin-stdlib</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
                                 <relocation>
                                     <pattern>okhttp3</pattern>
                                     <shadedPattern>org.apache.paimon.shade.okhttp3</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>kotlin</pattern>
+                                    <shadedPattern>org.apache.paimon.shade.kotlin</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>okio</pattern>
+                                    <shadedPattern>org.apache.paimon.shade.okio</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/paimon-core/src/main/resources/META-INF/NOTICE
+++ b/paimon-core/src/main/resources/META-INF/NOTICE
@@ -6,5 +6,5 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 - com.squareup.okhttp3:okhttp:4.12.0
-- com.squareup.okio:okio:3.6.0
-- org.jetbrains.kotlin:kotlin-stdlib:1.8.21
+- com.squareup.okio:okio-jvm:3.6.0
+- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21

--- a/paimon-core/src/main/resources/META-INF/NOTICE
+++ b/paimon-core/src/main/resources/META-INF/NOTICE
@@ -7,4 +7,4 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 - com.squareup.okhttp3:okhttp:4.12.0
 - com.squareup.okio:okio-jvm:3.6.0
-- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.21
+- org.jetbrains.kotlin:kotlin-stdlib:1.8.21

--- a/paimon-core/src/main/resources/META-INF/NOTICE
+++ b/paimon-core/src/main/resources/META-INF/NOTICE
@@ -6,3 +6,5 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 - com.squareup.okhttp3:okhttp:4.12.0
+- com.squareup.okio:okio:3.6.0
+- org.jetbrains.kotlin:kotlin-stdlib:1.8.21


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

![1738921650869](https://github.com/user-attachments/assets/252f2161-fcc6-4cd4-8c9d-1e32d3339a4e)
![1738921686999](https://github.com/user-attachments/assets/76d6dddb-8304-4ffd-b6d4-ed1145a67275)

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
