### PR TITLE
[docs] Add missing document for procedures

### DIFF
--- a/docs/content/flink/procedures.md
+++ b/docs/content/flink/procedures.md
@@ -630,5 +630,31 @@ All available procedures are listed below.
          CALL sys.fast_forward(`table` => 'default.T', branch => 'branch1')
       </td>
    </tr>
+   <tr>
+      <td>refresh_object_table</td>
+      <td>
+         CALL sys.refresh_object_table('identifier')
+      </td>
+      <td>
+         To refresh_object_table a object table. Arguments:
+            <li>identifier: the target table identifier. Cannot be empty.</li>
+      </td>
+      <td>
+         CALL sys.refresh_object_table('default.T')
+      </td>
+   </tr>
+   <tr>
+      <td>compact_manifest</td>
+      <td>
+         CALL sys.compact_manifest(`table` => 'identifier')
+      </td>
+      <td>
+         To compact_manifest the manifests. Arguments:
+            <li>identifier: the target table identifier. Cannot be empty.</li>
+      </td>
+      <td>
+         CALL sys.compact_manifest(`table` => 'default.T')
+      </td>
+   </tr>
    </tbody>
 </table>

--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -353,5 +353,31 @@ This section introduce all available spark procedures about paimon.
          CALL sys.mark_partition_done(table => 'default.T', parititions => 'day=2024-07-01;day=2024-07-02')
       </td>
    </tr>
-    </tbody>
+   <tr>
+      <td>refresh_object_table</td>
+      <td>
+         CALL sys.refresh_object_table('identifier')
+      </td>
+      <td>
+         To refresh_object_table a object table. Arguments:
+            <li>identifier: the target table identifier. Cannot be empty.</li>
+      </td>
+      <td>
+         CALL sys.refresh_object_table('default.T')
+      </td>
+   </tr>
+   <tr>
+      <td>compact_manifest</td>
+      <td>
+         CALL sys.compact_manifest(`table` => 'identifier')
+      </td>
+      <td>
+         To compact_manifest the manifests. Arguments:
+            <li>identifier: the target table identifier. Cannot be empty.</li>
+      </td>
+      <td>
+         CALL sys.compact_manifest(`table` => 'default.T')
+      </td>
+   </tr>
+   </tbody>
 </table>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The procedures documentation is missing the `refresh_object_table` and `compact_manifest` descriptions, and we may need to add them to the instructions documentation. Related PR Links: [4327](https://github.com/apache/paimon/pull/4327), [4459](https://github.com/apache/paimon/pull/4459).

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
