### PR TITLE
[Spark] Allows data with missing columns to be written when enable 'merge-schema'

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/WriteIntoPaimonTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/WriteIntoPaimonTable.scala
@@ -59,7 +59,7 @@ case class WriteIntoPaimonTable(
 
       // For case that some columns is absent in data, we still allow to write once write.merge-schema is true.
       val newTableSchema = SparkTypeUtils.fromPaimonRowType(table.schema().logicalRowType())
-      if (!schemaEqualsIgnoreNullability(newTableSchema, data.schema)) {
+      if (!schemaEqualsIgnoreNullability(newTableSchema, dataSchema)) {
         val resolve = sparkSession.sessionState.conf.resolver
         val cols = newTableSchema.map {
           field =>

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/PaimonUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/PaimonUtils.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Strategy.translateFilterV2WithMapping
 import org.apache.spark.sql.internal.connector.PredicateUtils
 import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.util.PartitioningUtils
 import org.apache.spark.util.{Utils => SparkUtils}
 
@@ -120,5 +120,9 @@ object PaimonUtils {
       spec: TablePartitionSpec,
       partitionColumnNames: Seq[String]): Unit = {
     PartitioningUtils.requireExactMatchedPartitionSpec(tableName, spec, partitionColumnNames)
+  }
+
+  def sameType(left: DataType, right: DataType): Boolean = {
+    left.sameType(right)
   }
 }


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
