### PR TITLE
[flink] supports the log system to use the insert-only format.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -805,6 +805,13 @@ public class CoreOptions implements Serializable {
                     .defaultValue("debezium-json")
                     .withDescription("Specify the message format of log system.");
 
+    @ExcludeFromDocumentation("Confused without log system")
+    public static final ConfigOption<Boolean> LOG_IGNORE_DELETE =
+            key("log.ignore-delete")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Specify whether the log system ignores delete records.");
+
     public static final ConfigOption<Boolean> AUTO_CREATE =
             key("auto-create")
                     .booleanType()

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/kafka/KafkaLogStoreFactory.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/kafka/KafkaLogStoreFactory.java
@@ -87,7 +87,7 @@ public class KafkaLogStoreFactory implements LogStoreTableFactory {
                             .createRuntimeDecoder(sourceContext, keyType);
         }
         DeserializationSchema<RowData> valueDeserializer =
-                LogStoreTableFactory.getValueDecodingFormat(helper)
+                LogStoreTableFactory.getValueDecodingFormat(helper, primaryKey.length != 0)
                         .createRuntimeDecoder(sourceContext, physicalType);
         Options options = toOptions(helper.getOptions());
         Long timestampMills = options.get(SCAN_TIMESTAMP_MILLIS);
@@ -127,7 +127,7 @@ public class KafkaLogStoreFactory implements LogStoreTableFactory {
                             .createRuntimeEncoder(sinkContext, keyType);
         }
         SerializationSchema<RowData> valueSerializer =
-                LogStoreTableFactory.getValueEncodingFormat(helper)
+                LogStoreTableFactory.getValueEncodingFormat(helper, primaryKey.length != 0)
                         .createRuntimeEncoder(sinkContext, physicalType);
         Options options = toOptions(helper.getOptions());
         return new KafkaLogSinkProvider(

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/kafka/KafkaLogTestUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/kafka/KafkaLogTestUtils.java
@@ -175,7 +175,21 @@ public class KafkaLogTestUtils {
 
     public static DynamicTableFactory.Context testContext(
             String servers, LogChangelogMode changelogMode, boolean keyed) {
-        return testContext("table", servers, changelogMode, LogConsistency.TRANSACTIONAL, keyed);
+        return testContext(servers, changelogMode, keyed, Collections.emptyMap());
+    }
+
+    public static DynamicTableFactory.Context testContext(
+            String servers,
+            LogChangelogMode changelogMode,
+            boolean keyed,
+            Map<String, String> dynamicOptions) {
+        return testContext(
+                "table",
+                servers,
+                changelogMode,
+                LogConsistency.TRANSACTIONAL,
+                keyed,
+                dynamicOptions);
     }
 
     static DynamicTableFactory.Context testContext(
@@ -183,7 +197,8 @@ public class KafkaLogTestUtils {
             String servers,
             LogChangelogMode changelogMode,
             LogConsistency consistency,
-            boolean keyed) {
+            boolean keyed,
+            Map<String, String> dynamicOptions) {
         return testContext(
                 name,
                 servers,
@@ -191,7 +206,7 @@ public class KafkaLogTestUtils {
                 consistency,
                 RowType.of(new IntType(), new IntType()),
                 keyed ? new int[] {0} : new int[0],
-                new HashMap<>());
+                dynamicOptions);
     }
 
     public static DynamicTableFactory.Context testContext(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
@@ -65,6 +65,7 @@ import java.util.stream.IntStream;
 import static org.apache.paimon.CoreOptions.CHANGELOG_PRODUCER;
 import static org.apache.paimon.CoreOptions.LOG_CHANGELOG_MODE;
 import static org.apache.paimon.CoreOptions.LOG_CONSISTENCY;
+import static org.apache.paimon.CoreOptions.LOG_IGNORE_DELETE;
 import static org.apache.paimon.CoreOptions.MergeEngine.FIRST_ROW;
 import static org.apache.paimon.flink.FlinkConnectorOptions.LOOKUP_ASYNC;
 import static org.apache.paimon.flink.FlinkConnectorOptions.LOOKUP_ASYNC_THREAD_NUMBER;
@@ -147,6 +148,10 @@ public abstract class BaseDataTableSource extends FlinkTableSource
             if (logStoreTableFactory == null
                     && options.get(CHANGELOG_PRODUCER) != ChangelogProducer.NONE) {
                 return ChangelogMode.all();
+            }
+
+            if (logStoreTableFactory != null && options.get(LOG_IGNORE_DELETE)) {
+                return ChangelogMode.insertOnly();
             }
 
             // optimization: transaction consistency and all changelog mode avoid the generation of


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5061 

<!-- What is the purpose of the change -->
[flink] supports the log system to use the insert-only format.
### Tests

<!-- List UT and IT cases to verify this change -->
- org.apache.paimon.flink.kafka.KafkaLogSerializationTest#testNonKeyedWithInsertOnlyFormat
- org.apache.paimon.flink.kafka.KafkaLogSerializationTest#testKeyedWithInsertOnlyFormat

### API and Format

<!-- Does this change affect API or storage format -->
Logstore can use the `ValueEncodingFormat` of `insert_only`.
### Documentation

<!-- Does this change introduce a new feature -->
