### PR TITLE
[core] Fix that AggregateMergeFunction handles multiple sequence fields mistakenly

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/AggregateMergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/AggregateMergeFunction.java
@@ -26,6 +26,7 @@ import org.apache.paimon.mergetree.compact.MergeFunction;
 import org.apache.paimon.mergetree.compact.MergeFunctionFactory;
 import org.apache.paimon.mergetree.compact.aggregate.factory.FieldAggregatorFactory;
 import org.apache.paimon.mergetree.compact.aggregate.factory.FieldLastNonNullValueAggFactory;
+import org.apache.paimon.mergetree.compact.aggregate.factory.FieldLastValueAggFactory;
 import org.apache.paimon.mergetree.compact.aggregate.factory.FieldPrimaryKeyAggFactory;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.types.DataType;
@@ -149,8 +150,8 @@ public class AggregateMergeFunction implements MergeFunction<KeyValue> {
 
         private String getAggFuncName(String fieldName, List<String> sequenceFields) {
             if (sequenceFields.contains(fieldName)) {
-                // no agg for sequence fields, use last_non_null_value to do cover
-                return FieldLastNonNullValueAggFactory.NAME;
+                // no agg for sequence fields, use last_value to do cover
+                return FieldLastValueAggFactory.NAME;
             }
 
             if (primaryKeys.contains(fieldName)) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
For example, for sequence fields 's0,s1', if input (null, 1), (1, null), the result will be (1, 1) currently which is wrong.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
