### PR TITLE
[flink] Support parallelismConfigurable

### DIFF
--- a/paimon-flink/paimon-flink-1.15/src/main/java/org/apache/paimon/flink/utils/ParallelismUtils.java
+++ b/paimon-flink/paimon-flink-1.15/src/main/java/org/apache/paimon/flink/utils/ParallelismUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.utils;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+
+/** Utility methods about Flink operator parallelism to resolve compatibility issues. */
+public class ParallelismUtils {
+    /**
+     * Configures the parallelism of the target stream to be the same as the source stream. In Flink
+     * 1.17+, this method will also configure {@link Transformation#isParallelismConfigured()}.
+     */
+    public static void forwardParallelism(
+            SingleOutputStreamOperator<?> targetStream, DataStream<?> sourceStream) {
+        targetStream.setParallelism(sourceStream.getParallelism());
+    }
+
+    public static void setParallelism(
+            SingleOutputStreamOperator<?> targetStream,
+            int parallelism,
+            boolean parallelismConfigured) {
+        targetStream.setParallelism(parallelism);
+    }
+}

--- a/paimon-flink/paimon-flink-1.16/src/main/java/org/apache/paimon/flink/utils/ParallelismUtils.java
+++ b/paimon-flink/paimon-flink-1.16/src/main/java/org/apache/paimon/flink/utils/ParallelismUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.utils;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+
+/** Utility methods about Flink operator parallelism to resolve compatibility issues. */
+public class ParallelismUtils {
+    /**
+     * Configures the parallelism of the target stream to be the same as the source stream. In Flink
+     * 1.17+, this method will also configure {@link Transformation#isParallelismConfigured()}.
+     */
+    public static void forwardParallelism(
+            SingleOutputStreamOperator<?> targetStream, DataStream<?> sourceStream) {
+        targetStream.setParallelism(sourceStream.getParallelism());
+    }
+
+    public static void setParallelism(
+            SingleOutputStreamOperator<?> targetStream,
+            int parallelism,
+            boolean parallelismConfigured) {
+        targetStream.setParallelism(parallelism);
+    }
+}

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcSinkBuilder.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcSinkBuilder.java
@@ -35,6 +35,7 @@ import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import javax.annotation.Nullable;
 
 import static org.apache.paimon.flink.sink.FlinkStreamPartitioner.partition;
+import static org.apache.paimon.flink.utils.ParallelismUtils.forwardParallelism;
 
 /**
  * Builder for sink when syncing records into one Paimon table.
@@ -99,8 +100,8 @@ public class CdcSinkBuilder<T> {
         SingleOutputStreamOperator<CdcRecord> parsed =
                 input.forward()
                         .process(new CdcParsingProcessFunction<>(parserFactory))
-                        .name("Side Output")
-                        .setParallelism(input.getParallelism());
+                        .name("Side Output");
+        forwardParallelism(parsed, input);
 
         DataStream<Void> schemaChangeProcessFunction =
                 SingleOutputStreamOperatorUtils.getSideOutput(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -69,6 +69,8 @@ import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_OPERATOR_UID_SU
 import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_USE_MANAGED_MEMORY;
 import static org.apache.paimon.flink.FlinkConnectorOptions.generateCustomUid;
 import static org.apache.paimon.flink.utils.ManagedMemoryUtils.declareManagedMemory;
+import static org.apache.paimon.flink.utils.ParallelismUtils.forwardParallelism;
+import static org.apache.paimon.flink.utils.ParallelismUtils.setParallelism;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Abstract sink of paimon. */
@@ -182,7 +184,7 @@ public abstract class FlinkSink<T> implements Serializable {
 
     public DataStreamSink<?> sinkFrom(DataStream<T> input, String initialCommitUser) {
         // do the actually writing action, no snapshot generated in this stage
-        DataStream<Committable> written = doWrite(input, initialCommitUser, input.getParallelism());
+        DataStream<Committable> written = doWrite(input, initialCommitUser, null);
         // commit the committable to generate a new snapshot
         return doCommit(written, initialCommitUser);
     }
@@ -216,17 +218,19 @@ public abstract class FlinkSink<T> implements Serializable {
         boolean writeOnly = table.coreOptions().writeOnly();
         SingleOutputStreamOperator<Committable> written =
                 input.transform(
-                                (writeOnly ? WRITER_WRITE_ONLY_NAME : WRITER_NAME)
-                                        + " : "
-                                        + table.name(),
-                                new CommittableTypeInfo(),
-                                createWriteOperatorFactory(
-                                        createWriteProvider(
-                                                env.getCheckpointConfig(),
-                                                isStreaming,
-                                                hasSinkMaterializer(input)),
-                                        commitUser))
-                        .setParallelism(parallelism == null ? input.getParallelism() : parallelism);
+                        (writeOnly ? WRITER_WRITE_ONLY_NAME : WRITER_NAME) + " : " + table.name(),
+                        new CommittableTypeInfo(),
+                        createWriteOperatorFactory(
+                                createWriteProvider(
+                                        env.getCheckpointConfig(),
+                                        isStreaming,
+                                        hasSinkMaterializer(input)),
+                                commitUser));
+        if (parallelism == null) {
+            setParallelism(written, input.getParallelism(), false);
+        } else {
+            written.setParallelism(parallelism);
+        }
 
         Options options = Options.fromMap(table.options());
 
@@ -240,7 +244,7 @@ public abstract class FlinkSink<T> implements Serializable {
         }
 
         if (options.get(PRECOMMIT_COMPACT)) {
-            written =
+            SingleOutputStreamOperator<Committable> newWritten =
                     written.transform(
                                     "Changelog Compact Coordinator",
                                     new EitherTypeInfo<>(
@@ -250,8 +254,9 @@ public abstract class FlinkSink<T> implements Serializable {
                             .transform(
                                     "Changelog Compact Worker",
                                     new CommittableTypeInfo(),
-                                    new ChangelogCompactWorkerOperator(table))
-                            .setParallelism(written.getParallelism());
+                                    new ChangelogCompactWorkerOperator(table));
+            forwardParallelism(newWritten, written);
+            written = newWritten;
         }
 
         return written;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
@@ -33,6 +33,7 @@ import org.apache.paimon.table.Table;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.DataFormatConverters;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
@@ -59,6 +60,8 @@ import static org.apache.paimon.flink.FlinkConnectorOptions.CLUSTERING_STRATEGY;
 import static org.apache.paimon.flink.FlinkConnectorOptions.MIN_CLUSTERING_SAMPLE_FACTOR;
 import static org.apache.paimon.flink.sink.FlinkSink.isStreaming;
 import static org.apache.paimon.flink.sink.FlinkStreamPartitioner.partition;
+import static org.apache.paimon.flink.utils.ParallelismUtils.forwardParallelism;
+import static org.apache.paimon.flink.utils.ParallelismUtils.setParallelism;
 import static org.apache.paimon.table.BucketMode.BUCKET_UNAWARE;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.Preconditions.checkState;
@@ -102,13 +105,14 @@ public class FlinkSinkBuilder {
 
         DataFormatConverters.RowConverter converter =
                 new DataFormatConverters.RowConverter(fieldDataTypes);
-        this.input =
+        SingleOutputStreamOperator<RowData> newInput =
                 input.transform(
-                                "Map",
-                                InternalTypeInfo.of(rowType),
-                                new StreamMapWithForwardingRecordAttributes<>(
-                                        (MapFunction<Row, RowData>) converter::toInternal))
-                        .setParallelism(input.getParallelism());
+                        "Map",
+                        InternalTypeInfo.of(rowType),
+                        new StreamMapWithForwardingRecordAttributes<>(
+                                (MapFunction<Row, RowData>) converter::toInternal));
+        setParallelism(newInput, input.getParallelism(), false);
+        this.input = newInput;
         return this;
     }
 
@@ -217,13 +221,14 @@ public class FlinkSinkBuilder {
         input = trySortInput(input);
         DataStream<InternalRow> input = mapToInternalRow(this.input, table.rowType());
         if (table.coreOptions().localMergeEnabled() && table.schema().primaryKeys().size() > 0) {
-            input =
+            SingleOutputStreamOperator<InternalRow> newInput =
                     input.forward()
                             .transform(
                                     "local merge",
                                     input.getType(),
-                                    new LocalMergeOperator.Factory(table.schema()))
-                            .setParallelism(input.getParallelism());
+                                    new LocalMergeOperator.Factory(table.schema()));
+            forwardParallelism(newInput, input);
+            input = newInput;
         }
 
         BucketMode bucketMode = table.bucketMode();
@@ -243,12 +248,14 @@ public class FlinkSinkBuilder {
 
     protected DataStream<InternalRow> mapToInternalRow(
             DataStream<RowData> input, org.apache.paimon.types.RowType rowType) {
-        return input.transform(
+        SingleOutputStreamOperator<InternalRow> result =
+                input.transform(
                         "Map",
                         org.apache.paimon.flink.utils.InternalTypeInfo.fromRowType(rowType),
                         new StreamMapWithForwardingRecordAttributes<>(
-                                (MapFunction<RowData, InternalRow>) FlinkRowWrapper::new))
-                .setParallelism(input.getParallelism());
+                                (MapFunction<RowData, InternalRow>) FlinkRowWrapper::new));
+        forwardParallelism(result, input);
+        return result;
     }
 
     protected DataStreamSink<?> buildDynamicBucketSink(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkStreamPartitioner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkStreamPartitioner.java
@@ -73,9 +73,7 @@ public class FlinkStreamPartitioner<T> extends StreamPartitioner<T> {
         FlinkStreamPartitioner<T> partitioner = new FlinkStreamPartitioner<>(channelComputer);
         PartitionTransformation<T> partitioned =
                 new PartitionTransformation<>(input.getTransformation(), partitioner);
-        if (parallelism != null) {
-            partitioned.setParallelism(parallelism);
-        }
+        partitioned.setParallelism(parallelism == null ? input.getParallelism() : parallelism);
         return new DataStream<>(input.getExecutionEnvironment(), partitioned);
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/GlobalDynamicBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/index/GlobalDynamicBucketSink.java
@@ -39,6 +39,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 
 import javax.annotation.Nullable;
@@ -83,7 +84,7 @@ public class GlobalDynamicBucketSink extends FlinkWriteSink<Tuple2<InternalRow, 
         // input -- bootstrap -- shuffle by key hash --> bucket-assigner -- shuffle by bucket -->
         // writer --> committer
 
-        DataStream<Tuple2<KeyPartOrRow, InternalRow>> bootstraped =
+        SingleOutputStreamOperator<Tuple2<KeyPartOrRow, InternalRow>> bootstraped =
                 input.transform(
                                 "INDEX_BOOTSTRAP",
                                 new InternalTypeInfo<>(
@@ -110,7 +111,7 @@ public class GlobalDynamicBucketSink extends FlinkWriteSink<Tuple2<InternalRow, 
         // 2. bucket-assigner
         TupleTypeInfo<Tuple2<InternalRow, Integer>> rowWithBucketType =
                 new TupleTypeInfo<>(input.getType(), BasicTypeInfo.INT_TYPE_INFO);
-        DataStream<Tuple2<InternalRow, Integer>> bucketAssigned =
+        SingleOutputStreamOperator<Tuple2<InternalRow, Integer>> bucketAssigned =
                 partitionByKeyHash
                         .transform(
                                 "cross-partition-bucket-assigner",

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/ParallelismUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/ParallelismUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.utils;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+
+/** Utility methods about Flink operator parallelism to resolve compatibility issues. */
+public class ParallelismUtils {
+    /**
+     * Configures the parallelism of the target stream to be the same as the source stream. In Flink
+     * 1.17+, this method will also configure {@link Transformation#isParallelismConfigured()}.
+     */
+    public static void forwardParallelism(
+            SingleOutputStreamOperator<?> targetStream, DataStream<?> sourceStream) {
+        setParallelism(
+                targetStream,
+                sourceStream.getParallelism(),
+                sourceStream.getTransformation().isParallelismConfigured());
+    }
+
+    public static void setParallelism(
+            SingleOutputStreamOperator<?> targetStream,
+            int parallelism,
+            boolean parallelismConfigured) {
+        // In Flink, SingleOutputStreamOperator#setParallelism wraps Transformation#setParallelism
+        // and provide additional checks and validations. In order to enable the checks in
+        // SingleOutputStreamOperator as well as the parallelismConfigured ability in
+        // Transformation, this method would invoke both setParallelism methods.
+
+        targetStream.setParallelism(parallelism);
+
+        targetStream.getTransformation().setParallelism(parallelism, parallelismConfigured);
+    }
+}


### PR DESCRIPTION
### Purpose

In Flink 1.17+, the parameter `parallelismConfigurable` is introduced to support specifying operator's initial parallelism while dynamically changing parallelism in some situations (like in AQE). This PR adds this parameter to Paimon Flink operators where parallelism does not affect correctness, and can be changed by Flink infra according to detailed needs.

Related PR: #4975

<!-- What is the purpose of the change -->

### Tests

Flink batch execution mode enables AQE by default, so existing batch tests like BatchFileStoreITCase can verify the correctness of these changes.

### API and Format

This change does not affect API or storage format.

### Documentation

This change does not introduce a new feature that needs documentation.
