### PR TITLE
[core]  fix the timezone conversion for timestamp_ltz data_type in OrcFileFormat

### DIFF
--- a/docs/layouts/shortcodes/generated/orc_configuration.html
+++ b/docs/layouts/shortcodes/generated/orc_configuration.html
@@ -38,5 +38,11 @@ under the License.
             <td>Double</td>
             <td>If the number of distinct keys in a dictionary is greater than this fraction of the total number of non-null rows, turn off dictionary encoding in orc. Use 0 to always disable dictionary encoding. Use 1 to always use dictionary encoding.</td>
         </tr>
+        <tr>
+            <td><h5>orc.timestamp-ltz.legacy.type</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>This option is used to be compatible with the paimon-orc‘s old behavior for the `timestamp_ltz` data type.</td>
+        </tr>
     </tbody>
 </table>

--- a/paimon-format/src/main/java/org/apache/paimon/format/OrcOptions.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/OrcOptions.java
@@ -41,4 +41,11 @@ public class OrcOptions {
                                     + "fraction of the total number of non-null rows, turn off "
                                     + "dictionary encoding in orc. Use 0 to always disable dictionary encoding. "
                                     + "Use 1 to always use dictionary encoding.");
+
+    public static final ConfigOption<Boolean> ORC_TIMESTAMP_LTZ_LEGACY_TYPE =
+            key("orc.timestamp-ltz.legacy.type")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "This option is used to be compatible with the paimon-orc‘s old behavior for the `timestamp_ltz` data type.");
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcReaderFactory.java
@@ -69,6 +69,7 @@ public class OrcReaderFactory implements FormatReaderFactory {
     protected final List<OrcFilters.Predicate> conjunctPredicates;
     protected final int batchSize;
     protected final boolean deletionVectorsEnabled;
+    protected final boolean legacyTimestampLtzType;
 
     /**
      * @param hadoopConfig the hadoop config for orc reader.
@@ -80,13 +81,15 @@ public class OrcReaderFactory implements FormatReaderFactory {
             final RowType readType,
             final List<OrcFilters.Predicate> conjunctPredicates,
             final int batchSize,
-            final boolean deletionVectorsEnabled) {
+            final boolean deletionVectorsEnabled,
+            final boolean legacyTimestampLtzType) {
         this.hadoopConfig = checkNotNull(hadoopConfig);
         this.schema = convertToOrcSchema(readType);
         this.tableType = readType;
         this.conjunctPredicates = checkNotNull(conjunctPredicates);
         this.batchSize = batchSize;
         this.deletionVectorsEnabled = deletionVectorsEnabled;
+        this.legacyTimestampLtzType = legacyTimestampLtzType;
     }
 
     // ------------------------------------------------------------------------
@@ -131,7 +134,10 @@ public class OrcReaderFactory implements FormatReaderFactory {
             DataType type = tableFieldTypes.get(i);
             vectors[i] =
                     createPaimonVector(
-                            orcBatch.cols[tableFieldNames.indexOf(name)], orcBatch, type);
+                            orcBatch.cols[tableFieldNames.indexOf(name)],
+                            orcBatch,
+                            type,
+                            legacyTimestampLtzType);
         }
         return new OrcReaderBatch(filePath, orcBatch, new VectorizedColumnBatch(vectors), recycler);
     }

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/filter/OrcSimpleStatsExtractor.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/filter/OrcSimpleStatsExtractor.java
@@ -56,11 +56,15 @@ public class OrcSimpleStatsExtractor implements SimpleStatsExtractor {
 
     private final RowType rowType;
     private final SimpleColStatsCollector.Factory[] statsCollectors;
+    private final boolean legacyTimestampLtzType;
 
     public OrcSimpleStatsExtractor(
-            RowType rowType, SimpleColStatsCollector.Factory[] statsCollectors) {
+            RowType rowType,
+            SimpleColStatsCollector.Factory[] statsCollectors,
+            boolean legacyTimestampLtzType) {
         this.rowType = rowType;
         this.statsCollectors = statsCollectors;
+        this.legacyTimestampLtzType = legacyTimestampLtzType;
         Preconditions.checkArgument(
                 rowType.getFieldCount() == statsCollectors.length,
                 "The stats collector is not aligned to write schema.");
@@ -228,7 +232,6 @@ public class OrcSimpleStatsExtractor implements SimpleStatsExtractor {
                                 nullCount);
                 break;
             case TIMESTAMP_WITHOUT_TIME_ZONE:
-            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
                 assertStatsClass(field, stats, TimestampColumnStatistics.class);
                 TimestampColumnStatistics timestampStats = (TimestampColumnStatistics) stats;
                 fieldStats =
@@ -236,6 +239,22 @@ public class OrcSimpleStatsExtractor implements SimpleStatsExtractor {
                                 Timestamp.fromSQLTimestamp(timestampStats.getMinimum()),
                                 Timestamp.fromSQLTimestamp(timestampStats.getMaximum()),
                                 nullCount);
+                break;
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                assertStatsClass(field, stats, TimestampColumnStatistics.class);
+                TimestampColumnStatistics timestampLtzStats = (TimestampColumnStatistics) stats;
+                fieldStats =
+                        legacyTimestampLtzType
+                                ? new SimpleColStats(
+                                        Timestamp.fromSQLTimestamp(timestampLtzStats.getMinimum()),
+                                        Timestamp.fromSQLTimestamp(timestampLtzStats.getMaximum()),
+                                        nullCount)
+                                : new SimpleColStats(
+                                        Timestamp.fromInstant(
+                                                timestampLtzStats.getMinimum().toInstant()),
+                                        Timestamp.fromInstant(
+                                                timestampLtzStats.getMaximum().toInstant()),
+                                        nullCount);
                 break;
             default:
                 fieldStats = new SimpleColStats(null, null, nullCount);

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/AbstractOrcColumnVector.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/AbstractOrcColumnVector.java
@@ -62,6 +62,14 @@ public abstract class AbstractOrcColumnVector
 
     public static org.apache.paimon.data.columnar.ColumnVector createPaimonVector(
             ColumnVector vector, VectorizedRowBatch orcBatch, DataType dataType) {
+        return createPaimonVector(vector, orcBatch, dataType, false);
+    }
+
+    public static org.apache.paimon.data.columnar.ColumnVector createPaimonVector(
+            ColumnVector vector,
+            VectorizedRowBatch orcBatch,
+            DataType dataType,
+            boolean legacyTimestampLtzType) {
         if (vector instanceof LongColumnVector) {
             if (dataType.getTypeRoot() == DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
                 return new OrcLegacyTimestampColumnVector((LongColumnVector) vector, orcBatch);
@@ -75,7 +83,7 @@ public abstract class AbstractOrcColumnVector
         } else if (vector instanceof DecimalColumnVector) {
             return new OrcDecimalColumnVector((DecimalColumnVector) vector, orcBatch);
         } else if (vector instanceof TimestampColumnVector) {
-            return new OrcTimestampColumnVector(vector, orcBatch);
+            return new OrcTimestampColumnVector(vector, orcBatch, dataType, legacyTimestampLtzType);
         } else if (vector instanceof ListColumnVector) {
             return new OrcArrayColumnVector(
                     (ListColumnVector) vector, orcBatch, (ArrayType) dataType);

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/writer/RowDataVectorizer.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/writer/RowDataVectorizer.java
@@ -29,18 +29,22 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.apache.paimon.format.orc.writer.FieldWriterFactory.WRITER_FACTORY;
-
 /** A {@link Vectorizer} of {@link InternalRow} type element. */
 public class RowDataVectorizer extends Vectorizer<InternalRow> {
 
     private final List<FieldWriter> fieldWriters;
 
     public RowDataVectorizer(TypeDescription schema, DataType[] fieldTypes) {
+        this(schema, fieldTypes, false);
+    }
+
+    public RowDataVectorizer(
+            TypeDescription schema, DataType[] fieldTypes, boolean legacyTimestampLtzType) {
         super(schema);
+        FieldWriterFactory fieldWriterFactory = new FieldWriterFactory(legacyTimestampLtzType);
         this.fieldWriters =
                 Arrays.stream(fieldTypes)
-                        .map(t -> t.accept(WRITER_FACTORY))
+                        .map(t -> t.accept(fieldWriterFactory))
                         .collect(Collectors.toList());
     }
 

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFormatReadWriteTest.java
@@ -18,20 +18,200 @@
 
 package org.apache.paimon.format.orc;
 
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.format.FileFormatFactory;
 import org.apache.paimon.format.FormatReadWriteTest;
+import org.apache.paimon.format.FormatReaderContext;
+import org.apache.paimon.format.FormatWriter;
+import org.apache.paimon.format.OrcOptions;
+import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** An orc {@link FormatReadWriteTest}. */
 public class OrcFormatReadWriteTest extends FormatReadWriteTest {
+
+    private final FileFormat legacyFormat =
+            new OrcFileFormat(
+                    new FileFormatFactory.FormatContext(
+                            new Options(
+                                    new HashMap<String, String>() {
+                                        {
+                                            put(
+                                                    OrcOptions.ORC_TIMESTAMP_LTZ_LEGACY_TYPE.key(),
+                                                    "true");
+                                        }
+                                    }),
+                            1024,
+                            1024));
+
+    private final FileFormat newFormat =
+            new OrcFileFormat(
+                    new FileFormatFactory.FormatContext(
+                            new Options(
+                                    new HashMap<String, String>() {
+                                        {
+                                            put(
+                                                    OrcOptions.ORC_TIMESTAMP_LTZ_LEGACY_TYPE.key(),
+                                                    "false");
+                                        }
+                                    }),
+                            1024,
+                            1024));
 
     protected OrcFormatReadWriteTest() {
         super("orc");
     }
 
+    @Test
+    public void testTimestampLTZWithLegacyWriteAndRead() throws IOException {
+        RowType rowType = DataTypes.ROW(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE());
+        InternalRowSerializer serializer = new InternalRowSerializer(rowType);
+        PositionOutputStream out = fileIO.newOutputStream(file, false);
+        FormatWriter writer = legacyFormat.createWriterFactory(rowType).create(out, "zstd");
+        Timestamp localTimestamp =
+                Timestamp.fromLocalDateTime(
+                        LocalDateTime.parse(
+                                "2024-12-12 10:10:10",
+                                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        GenericRow record = GenericRow.of(localTimestamp);
+        writer.addElement(record);
+        writer.close();
+        out.close();
+
+        RecordReader<InternalRow> reader =
+                legacyFormat
+                        .createReaderFactory(rowType)
+                        .createReader(
+                                new FormatReaderContext(fileIO, file, fileIO.getFileSize(file)));
+        List<InternalRow> result = new ArrayList<>();
+        reader.forEachRemaining(row -> result.add(serializer.copy(row)));
+
+        assertThat(result).containsExactly(GenericRow.of(localTimestamp));
+    }
+
+    @Test
+    public void testTimestampLTZWithNewWriteAndRead() throws IOException {
+        RowType rowType = DataTypes.ROW(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE());
+        InternalRowSerializer serializer = new InternalRowSerializer(rowType);
+        PositionOutputStream out = fileIO.newOutputStream(file, false);
+        FormatWriter writer = newFormat.createWriterFactory(rowType).create(out, "zstd");
+        Timestamp localTimestamp =
+                Timestamp.fromLocalDateTime(
+                        LocalDateTime.parse(
+                                "2024-12-12 10:10:10",
+                                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        GenericRow record = GenericRow.of(localTimestamp);
+        writer.addElement(record);
+        writer.close();
+        out.close();
+
+        RecordReader<InternalRow> reader =
+                newFormat
+                        .createReaderFactory(rowType)
+                        .createReader(
+                                new FormatReaderContext(fileIO, file, fileIO.getFileSize(file)));
+        List<InternalRow> result = new ArrayList<>();
+        reader.forEachRemaining(row -> result.add(serializer.copy(row)));
+
+        assertThat(result).containsExactly(GenericRow.of(localTimestamp));
+    }
+
+    @Test
+    public void testTimestampLTZWithNewWriteAndLegacyRead() throws IOException {
+        RowType rowType = DataTypes.ROW(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE());
+        InternalRowSerializer serializer = new InternalRowSerializer(rowType);
+        PositionOutputStream out = fileIO.newOutputStream(file, false);
+        FormatWriter writer = newFormat.createWriterFactory(rowType).create(out, "zstd");
+        Timestamp localTimestamp =
+                Timestamp.fromLocalDateTime(
+                        LocalDateTime.parse(
+                                "2024-12-12 10:10:10",
+                                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        GenericRow record = GenericRow.of(localTimestamp);
+        writer.addElement(record);
+        writer.close();
+        out.close();
+
+        RecordReader<InternalRow> reader =
+                legacyFormat
+                        .createReaderFactory(rowType)
+                        .createReader(
+                                new FormatReaderContext(fileIO, file, fileIO.getFileSize(file)));
+        List<InternalRow> result = new ArrayList<>();
+        reader.forEachRemaining(row -> result.add(serializer.copy(row)));
+        Timestamp shiftedTimestamp =
+                Timestamp.fromEpochMillis(
+                        localTimestamp.getMillisecond()
+                                + TimeZone.getDefault().getOffset(localTimestamp.getMillisecond()),
+                        localTimestamp.getNanoOfMillisecond());
+
+        assertThat(result).containsExactly(GenericRow.of(shiftedTimestamp));
+    }
+
+    @Test
+    public void testTimestampLTZWithLegacyWriteAndNewRead() throws IOException {
+        RowType rowType = DataTypes.ROW(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE());
+        InternalRowSerializer serializer = new InternalRowSerializer(rowType);
+        PositionOutputStream out = fileIO.newOutputStream(file, false);
+        FormatWriter writer = legacyFormat.createWriterFactory(rowType).create(out, "zstd");
+        Timestamp localTimestamp =
+                Timestamp.fromLocalDateTime(
+                        LocalDateTime.parse(
+                                "2024-12-12 10:10:10",
+                                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        GenericRow record = GenericRow.of(localTimestamp);
+        writer.addElement(record);
+        writer.close();
+        out.close();
+
+        RecordReader<InternalRow> reader =
+                newFormat
+                        .createReaderFactory(rowType)
+                        .createReader(
+                                new FormatReaderContext(fileIO, file, fileIO.getFileSize(file)));
+        List<InternalRow> result = new ArrayList<>();
+        reader.forEachRemaining(row -> result.add(serializer.copy(row)));
+        Timestamp shiftedTimestamp =
+                Timestamp.fromEpochMillis(
+                        localTimestamp.getMillisecond()
+                                - TimeZone.getDefault().getOffset(localTimestamp.getMillisecond()),
+                        localTimestamp.getNanoOfMillisecond());
+
+        assertThat(result).containsExactly(GenericRow.of(shiftedTimestamp));
+    }
+
     @Override
     protected FileFormat fileFormat() {
-        return new OrcFileFormat(new FileFormatFactory.FormatContext(new Options(), 1024, 1024));
+        return new OrcFileFormat(
+                new FileFormatFactory.FormatContext(
+                        new Options(
+                                new HashMap<String, String>() {
+                                    {
+                                        put(
+                                                OrcOptions.ORC_TIMESTAMP_LTZ_LEGACY_TYPE.key(),
+                                                "false");
+                                    }
+                                }),
+                        1024,
+                        1024));
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcReaderFactoryTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcReaderFactoryTest.java
@@ -278,6 +278,7 @@ class OrcReaderFactoryTest {
                 Projection.of(selectedFields).project(formatType),
                 conjunctPredicates,
                 BATCH_SIZE,
+                false,
                 false);
     }
 


### PR DESCRIPTION

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5066


### Tests
OrcFormatReadWriteTest#testTimestampLTZWithLegacyWriteAndRead
OrcFormatReadWriteTest#testTimestampLTZWithNewWriteAndRead
OrcFormatReadWriteTest#testTimestampLTZWithNewWriteAndLegacyRead
OrcFormatReadWriteTest#testTimestampLTZWithLegacyWriteAndNewRead


### API and Format

orc-format

### Documentation

