### PR TITLE
[iceberg] support migrating iceberg table which had suffered schema evolution

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergDataFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergDataFileMeta.java
@@ -83,6 +83,9 @@ public class IcebergDataFileMeta {
     private final InternalMap lowerBounds;
     private final InternalMap upperBounds;
 
+    // only used for iceberg migrate
+    private long schemaId = 0;
+
     IcebergDataFileMeta(
             Content content,
             String filePath,
@@ -199,6 +202,15 @@ public class IcebergDataFileMeta {
 
     public InternalMap upperBounds() {
         return upperBounds;
+    }
+
+    public long schemaId() {
+        return schemaId;
+    }
+
+    public IcebergDataFileMeta withSchemaId(long schemaId) {
+        this.schemaId = schemaId;
+        return this;
     }
 
     public static RowType schema(RowType partitionType) {

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/migrate/IcebergMigrator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/migrate/IcebergMigrator.java
@@ -43,19 +43,26 @@ import org.apache.paimon.migrate.FileMetaUtils;
 import org.apache.paimon.migrate.Migrator;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.utils.JsonSerdeUtil;
 import org.apache.paimon.utils.Preconditions;
 
+import org.apache.avro.file.DataFileStream;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -136,15 +143,28 @@ public class IcebergMigrator implements Migrator {
 
     @Override
     public void executeMigrate() throws Exception {
-        Schema paimonSchema = icebergSchemaToPaimonSchema(icebergMetadata);
+        List<TableSchema> paimonSchemas = icebergSchemasToPaimonSchemas(icebergMetadata);
+        Preconditions.checkArgument(
+                !paimonSchemas.isEmpty(),
+                "paimon schemas transformed from iceberg table is empty.");
         Identifier paimonIdentifier = Identifier.create(paimonDatabaseName, paimonTableName);
 
         paimonCatalog.createDatabase(paimonDatabaseName, true);
-        paimonCatalog.createTable(paimonIdentifier, paimonSchema, false);
+        TableSchema firstSchema = paimonSchemas.get(0);
+        Preconditions.checkArgument(firstSchema.id() == 0, "Unexpected, first schema id is not 0.");
+        paimonCatalog.createTable(paimonIdentifier, firstSchema.toSchema(), false);
 
         try {
             FileStoreTable paimonTable = (FileStoreTable) paimonCatalog.getTable(paimonIdentifier);
             FileIO fileIO = paimonTable.fileIO();
+            SchemaManager schemaManager = paimonTable.schemaManager();
+            // commit all the iceberg schemas
+            for (int i = 1; i < paimonSchemas.size(); i++) {
+                LOG.info(
+                        "commit new schema from iceberg, new schema id:{}",
+                        paimonSchemas.get(i).id());
+                schemaManager.commit(paimonSchemas.get(i));
+            }
 
             IcebergManifestFile manifestFile =
                     IcebergManifestFile.create(paimonTable, icebergMetaPathFactory);
@@ -157,25 +177,36 @@ public class IcebergMigrator implements Migrator {
             // check manifest file with 'DELETE' kind
             checkAndFilterManifestFiles(icebergManifestFileMetas);
 
-            // get all live iceberg entries
-            List<IcebergManifestEntry> icebergEntries =
-                    icebergManifestFileMetas.stream()
-                            .flatMap(fileMeta -> manifestFile.read(fileMeta).stream())
-                            .filter(IcebergManifestEntry::isLive)
-                            .collect(Collectors.toList());
-            if (icebergEntries.isEmpty()) {
+            Map<Long, List<IcebergManifestEntry>> icebergEntries = new HashMap<>();
+            for (IcebergManifestFileMeta icebergManifestFileMeta : icebergManifestFileMetas) {
+                long schemaId =
+                        getSchemaIdFromIcebergManifestFile(
+                                new Path(icebergManifestFileMeta.manifestPath()), fileIO);
+                List<IcebergManifestEntry> entries = manifestFile.read(icebergManifestFileMeta);
+                icebergEntries
+                        .computeIfAbsent(schemaId, v -> new ArrayList<>())
+                        .addAll(
+                                entries.stream()
+                                        .filter(IcebergManifestEntry::isLive)
+                                        .collect(Collectors.toList()));
+            }
+
+            List<IcebergDataFileMeta> icebergDataFileMetas = new ArrayList<>();
+            // write schema id to IcebergDataFileMeta
+            for (Map.Entry<Long, List<IcebergManifestEntry>> kv : icebergEntries.entrySet()) {
+                icebergDataFileMetas.addAll(
+                        kv.getValue().stream()
+                                .map(entry -> entry.file().withSchemaId(kv.getKey()))
+                                .collect(Collectors.toList()));
+            }
+
+            if (icebergDataFileMetas.isEmpty()) {
                 LOG.info(
-                        "No live manifest entry in iceberg table for snapshot {}, iceberg table meta path is {}.",
+                        "No live iceberg data files in iceberg table for snapshot {}, iceberg table meta path is {}.",
                         icebergMetadata.currentSnapshotId(),
                         icebergLatestMetadataLocation);
                 return;
             }
-
-            List<IcebergDataFileMeta> icebergDataFileMetas =
-                    icebergEntries.stream()
-                            .map(IcebergManifestEntry::file)
-                            .collect(Collectors.toList());
-
             // Again, check if delete File exists
             checkAndFilterDataFiles(icebergDataFileMetas);
 
@@ -246,10 +277,21 @@ public class IcebergMigrator implements Migrator {
         paimonCatalog.renameTable(targetTableId, sourceTableId, ignoreIfNotExists);
     }
 
-    public Schema icebergSchemaToPaimonSchema(IcebergMetadata icebergMetadata) {
-        // get iceberg current schema
-        IcebergSchema icebergSchema =
-                icebergMetadata.schemas().get(icebergMetadata.currentSchemaId());
+    public List<TableSchema> icebergSchemasToPaimonSchemas(IcebergMetadata icebergMetadata) {
+        return icebergMetadata.schemas().stream()
+                .map(
+                        icebergSchema -> {
+                            LOG.info(
+                                    "Convert iceberg schema to paimon schema, iceberg schema id: {}",
+                                    icebergSchema.schemaId());
+                            return TableSchema.create(
+                                    icebergSchema.schemaId(),
+                                    icebergSchemaToPaimonSchema(icebergSchema));
+                        })
+                .collect(Collectors.toList());
+    }
+
+    public Schema icebergSchemaToPaimonSchema(IcebergSchema icebergSchema) {
 
         // get iceberg current partition spec
         int currentPartitionSpecId = icebergMetadata.defaultSpecId();
@@ -289,6 +331,18 @@ public class IcebergMigrator implements Migrator {
         }
     }
 
+    public long getSchemaIdFromIcebergManifestFile(Path manifestPath, FileIO fileIO) {
+
+        try (DataFileStream<GenericRecord> dataFileStream =
+                new DataFileStream<>(
+                        fileIO.newInputStream(manifestPath), new GenericDatumReader<>())) {
+            String schema = dataFileStream.getMetaString("schema");
+            return JsonSerdeUtil.fromJson(schema, IcebergSchema.class).schemaId();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private static List<DataFileMeta> construct(
             List<IcebergDataFileMeta> icebergDataFileMetas,
             FileIO fileIO,
@@ -318,7 +372,9 @@ public class IcebergMigrator implements Migrator {
                     e);
         }
         String format = icebergDataFileMeta.fileFormat();
-        return FileMetaUtils.constructFileMeta(format, status, fileIO, table, dir, rollback);
+        long schemaId = icebergDataFileMeta.schemaId();
+        return FileMetaUtils.constructFileMeta(
+                format, status, fileIO, table, dir, rollback, schemaId);
     }
 
     private MigrateTask importUnPartitionedTable(

--- a/paimon-core/src/main/java/org/apache/paimon/migrate/FileMetaUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/migrate/FileMetaUtils.java
@@ -129,6 +129,47 @@ public class FileMetaUtils {
         }
     }
 
+    public static DataFileMeta constructFileMeta(
+            String format,
+            FileStatus fileStatus,
+            FileIO fileIO,
+            Table table,
+            Path dir,
+            Map<Path, Path> rollback,
+            long schemaId) {
+
+        try {
+            RowType rowTypeWithSchemaId =
+                    ((FileStoreTable) table).schemaManager().schema(schemaId).logicalRowType();
+            SimpleColStatsCollector.Factory[] factories =
+                    StatsCollectorFactories.createStatsFactories(
+                            ((FileStoreTable) table).coreOptions(),
+                            rowTypeWithSchemaId.getFieldNames());
+
+            SimpleStatsExtractor simpleStatsExtractor =
+                    FileFormat.fromIdentifier(
+                                    format,
+                                    ((FileStoreTable) table).coreOptions().toConfiguration())
+                            .createStatsExtractor(rowTypeWithSchemaId, factories)
+                            .orElseThrow(
+                                    () ->
+                                            new RuntimeException(
+                                                    "Can't get table stats extractor for format "
+                                                            + format));
+            Path newPath = renameFile(fileIO, fileStatus.getPath(), dir, format, rollback);
+            return constructFileMeta(
+                    newPath.getName(),
+                    fileStatus.getLen(),
+                    newPath,
+                    simpleStatsExtractor,
+                    fileIO,
+                    table,
+                    schemaId);
+        } catch (IOException e) {
+            throw new RuntimeException("error when construct file meta", e);
+        }
+    }
+
     // -----------------------------private method---------------------------------------------
 
     private static Path renameFile(
@@ -152,7 +193,29 @@ public class FileMetaUtils {
             FileIO fileIO,
             Table table)
             throws IOException {
-        SimpleStatsConverter statsArraySerializer = new SimpleStatsConverter(table.rowType());
+        return constructFileMeta(
+                fileName,
+                fileSize,
+                path,
+                simpleStatsExtractor,
+                fileIO,
+                table,
+                ((FileStoreTable) table).schema().id());
+    }
+
+    private static DataFileMeta constructFileMeta(
+            String fileName,
+            long fileSize,
+            Path path,
+            SimpleStatsExtractor simpleStatsExtractor,
+            FileIO fileIO,
+            Table table,
+            long schemaId)
+            throws IOException {
+        RowType rowTypeWithSchemaId =
+                ((FileStoreTable) table).schemaManager().schema(schemaId).logicalRowType();
+
+        SimpleStatsConverter statsArraySerializer = new SimpleStatsConverter(rowTypeWithSchemaId);
 
         Pair<SimpleColStats[], SimpleStatsExtractor.FileInfo> fileInfo =
                 simpleStatsExtractor.extractWithFileInfo(fileIO, path);
@@ -165,7 +228,7 @@ public class FileMetaUtils {
                 stats,
                 0,
                 0,
-                ((FileStoreTable) table).schema().id(),
+                schemaId,
                 Collections.emptyList(),
                 null,
                 FileSource.APPEND,

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -769,7 +769,7 @@ public class SchemaManager implements Serializable {
     }
 
     @VisibleForTesting
-    boolean commit(TableSchema newSchema) throws Exception {
+    public boolean commit(TableSchema newSchema) throws Exception {
         SchemaValidation.validateTableSchema(newSchema);
         SchemaValidation.validateFallbackBranch(this, newSchema);
         Path schemaPath = toSchemaPath(newSchema.id());


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
In pr https://github.com/apache/paimon/pull/4639 and https://github.com/apache/paimon/pull/4878, we had supported migrating iceberg table managed by hadoop-catalog or hive-catalog to paimon. This pr aims to support migrating the iceberg table which had suffered once or several times schema evolution.

Paimon stores the schema-id in each DataFileMeta for reading data files which had suffered schema evolution, so we extract the schema-id used by each iceberg data file and record it in the corresponding paimon DataFileMeta, and this makes paimon can handle the schema evolution case.

### Tests

<!-- List UT and IT cases to verify this change -->
IcebergMigrateTest#testDeleteColumn
IcebergMigrateTest#testRenameColumn
IcebergMigrateTest#testAddColumn
IcebergMigrateTest#testReorderColumn
IcebergMigrateTest#testUpdateColumn
IcebergMigrateTest#testMigrateWithRandomIcebergEvolution

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
