### PR TITLE
[core] Resolve data loss caused by JDBC connection expiration.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/client/ClientPool.java
+++ b/paimon-common/src/main/java/org/apache/paimon/client/ClientPool.java
@@ -20,6 +20,7 @@ package org.apache.paimon.client;
 
 import java.io.Closeable;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /** Client pool for using multiple clients to execute actions. */
 public interface ClientPool<C, E extends Exception> {
@@ -38,12 +39,13 @@ public interface ClientPool<C, E extends Exception> {
     void execute(ExecuteAction<C, E> action) throws E, InterruptedException;
 
     /** Default implementation for {@link ClientPool}. */
-    abstract class ClientPoolImpl<C, E extends Exception> implements Closeable, ClientPool<C, E> {
-        protected ClientPoolImpl(int poolSize) {
-            initPool(poolSize);
+    abstract class ClientPoolImpl<C, P, E extends Exception>
+            implements Closeable, ClientPool<C, E> {
+        protected ClientPoolImpl(Supplier<P> supplier) {
+            initPool(supplier);
         }
 
-        protected abstract void initPool(int poolSize);
+        protected abstract void initPool(Supplier<P> supplier);
 
         protected abstract C getClient(long timeout, TimeUnit unit) throws E, InterruptedException;
 

--- a/paimon-core/pom.xml
+++ b/paimon-core/pom.xml
@@ -249,7 +249,14 @@ under the License.
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
-            <version>1.2.8</version>
+            <version>1.2.24</version>
+        </dependency>
+
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.28</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/paimon-core/pom.xml
+++ b/paimon-core/pom.xml
@@ -246,6 +246,11 @@ under the License.
             <version>42.7.3</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>druid</artifactId>
+            <version>1.2.8</version>
+        </dependency>
 
     </dependencies>
 

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcClientPool.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcClientPool.java
@@ -20,12 +20,14 @@ package org.apache.paimon.jdbc;
 
 import org.apache.paimon.client.ClientPool;
 
+import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidDataSourceFactory;
+
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.Properties;
-import java.util.function.Supplier;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -34,10 +36,18 @@ public class JdbcClientPool extends ClientPool.ClientPoolImpl<Connection, SQLExc
 
     private static final Pattern PROTOCOL_PATTERN = Pattern.compile("jdbc:([^:]+):(.*)");
 
+    private String dbUrl;
+
+    private Map<String, String> props;
+
     private final String protocol;
 
+    private volatile DruidDataSource dataSource;
+
     public JdbcClientPool(int poolSize, String dbUrl, Map<String, String> props) {
-        super(poolSize, clientSupplier(dbUrl, props));
+        super(poolSize);
+        this.dbUrl = dbUrl;
+        this.props = props;
         Matcher matcher = PROTOCOL_PATTERN.matcher(dbUrl);
         if (matcher.matches()) {
             this.protocol = matcher.group(1);
@@ -46,28 +56,42 @@ public class JdbcClientPool extends ClientPool.ClientPoolImpl<Connection, SQLExc
         }
     }
 
-    private static Supplier<Connection> clientSupplier(String dbUrl, Map<String, String> props) {
-        return () -> {
-            try {
-                Properties dbProps =
-                        JdbcUtils.extractJdbcConfiguration(props, JdbcCatalog.PROPERTY_PREFIX);
-                return DriverManager.getConnection(dbUrl, dbProps);
-            } catch (SQLException e) {
-                throw new RuntimeException(String.format("Failed to connect: %s", dbUrl), e);
-            }
-        };
-    }
-
     public String getProtocol() {
         return protocol;
     }
 
     @Override
-    protected void close(Connection client) {
+    protected void initPool(int poolSize) {
         try {
-            client.close();
-        } catch (SQLException e) {
-            throw new RuntimeException("Failed to close connection", e);
+            Properties dbProps =
+                    JdbcUtils.extractJdbcConfiguration(props, JdbcCatalog.PROPERTY_PREFIX);
+            dbProps.setProperty(DruidDataSourceFactory.PROP_URL, dbUrl);
+            dbProps.setProperty(DruidDataSourceFactory.PROP_MAXACTIVE, String.valueOf(poolSize));
+            dataSource = (DruidDataSource) DruidDataSourceFactory.createDataSource(dbProps);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create datasource", e);
+        }
+    }
+
+    @Override
+    protected Connection getClient(long timeout, TimeUnit unit) throws SQLException {
+        if (this.dataSource == null) {
+            throw new IllegalStateException("Cannot get a client from a closed pool");
+        }
+        return dataSource.getConnection(unit.toMillis(timeout));
+    }
+
+    @Override
+    protected void recycleClient(Connection client) throws SQLException {
+        client.close();
+    }
+
+    @Override
+    protected void closePool() {
+        DruidDataSource dataSource = this.dataSource;
+        this.dataSource = null;
+        if (dataSource != null) {
+            dataSource.close();
         }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcClientPoolTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcClientPoolTest.java
@@ -42,8 +42,9 @@ public class JdbcClientPoolTest {
         props.put("jdbc.autoReconnect", "true");
         props.put("jdbc.testOnBorrow", "true");
         props.put("jdbc.validationQuery", "SELECT 1");
-        return new JdbcClientPool(
-                10, "jdbc:mysql://127.0.0.1:33306/mysql?user=root&password=123456", props);
+
+        String testUrl = "jdbc:mysql://127.0.0.1:33306/mysql?user=root&password=123456";
+        return new JdbcClientPool(10, testUrl, props);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcClientPoolTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcClientPoolTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Tests for {@link JdbcClientPool} */
+/** Tests for {@link JdbcClientPool}. */
 public class JdbcClientPoolTest {
     public JdbcClientPool connections;
 

--- a/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcClientPoolTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcClientPoolTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.jdbc;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.collect.Maps;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link JdbcClientPool} */
+public class JdbcClientPoolTest {
+    public JdbcClientPool connections;
+
+    @BeforeEach
+    public void setUp() {
+        connections = initConnections(Maps.newHashMap());
+    }
+
+    private JdbcClientPool initConnections(HashMap<String, String> props) {
+        props.put("jdbc.autoReconnect", "true");
+        props.put("jdbc.testOnBorrow", "true");
+        props.put("jdbc.validationQuery", "SELECT 1");
+        return new JdbcClientPool(
+                10, "jdbc:mysql://127.0.0.1:33306/mysql?user=root&password=123456", props);
+    }
+
+    @Test
+    public void testGetClient() throws SQLException, InterruptedException {
+        Connection client = connections.getClient(10, TimeUnit.SECONDS);
+        String lockId = "jdbc.testDb.testTable";
+        assertThat(JdbcUtils.acquire(connections, lockId, 1000)).isTrue();
+    }
+}

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/HiveClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/HiveClientPool.java
@@ -51,9 +51,9 @@ public class HiveClientPool
             int poolSize, Configuration conf, String clientClassName) {
         return () -> {
             LinkedBlockingDeque<IMetaStoreClient> clients = new LinkedBlockingDeque<>();
+            HiveConf hiveConf = new HiveConf(conf, HiveClientPool.class);
+            hiveConf.addResource(conf);
             for (int i = 0; i < poolSize; i++) {
-                HiveConf hiveConf = new HiveConf(conf, HiveClientPool.class);
-                hiveConf.addResource(conf);
                 clients.add(
                         new RetryingMetaStoreClientFactory()
                                 .createClient(hiveConf, clientClassName));

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/HiveClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/HiveClientPool.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.thrift.TException;
-import org.checkerframework.checker.units.qual.C;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5084

<!-- What is the purpose of the change -->
Fix the JDBC connection expiration used by the lock, which causes data loss when committing the snapshot.

### Tests

JdbcClientPoolTest is used to test the creation of the connection pool and validate the connectivity of the connections.

### API and Format

Does this change affect API or storage format 

### Documentation

 Does this change introduce a new feature
