### PR TITLE
[cdc] Support audit time computed clumns during cdc sync database

### DIFF
--- a/.github/workflows/flink-cdc-tests.yml
+++ b/.github/workflows/flink-cdc-tests.yml
@@ -51,6 +51,6 @@ jobs:
           . .github/workflows/utils.sh
           jvm_timezone=$(random_timezone)
           echo "JVM timezone is set to $jvm_timezone"
-          mvn -T 1C -B clean install -pl 'org.apache.paimon:paimon-flink-cdc' -Duser.timezone=$jvm_timezone
+          mvn -T 1C -B clean install -pl 'org.apache.paimon:paimon-flink-cdc' -Duser.timezone=$jvm_timezone -Dtest=org.apache.paimon.flink.action.cdc.kafka.KafkaCanalSyncDatabaseActionITCase.testAuditTime
         env:
           MAVEN_OPTS: -Xmx4096m

--- a/.github/workflows/flink-cdc-tests.yml
+++ b/.github/workflows/flink-cdc-tests.yml
@@ -51,6 +51,6 @@ jobs:
           . .github/workflows/utils.sh
           jvm_timezone=$(random_timezone)
           echo "JVM timezone is set to $jvm_timezone"
-          mvn -T 1C -B clean install -pl 'org.apache.paimon:paimon-flink-cdc' -Duser.timezone=$jvm_timezone -Dtest=org.apache.paimon.flink.action.cdc.kafka.KafkaCanalSyncDatabaseActionITCase.testAuditTime
+          mvn -T 1C -B clean install -pl 'org.apache.paimon:paimon-flink-cdc' -Duser.timezone=$jvm_timezone -Dtest=org.apache.paimon.flink.action.cdc.kafka.KafkaCanalSyncDatabaseActionITCase#testAuditTime
         env:
           MAVEN_OPTS: -Xmx4096m

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
@@ -27,6 +27,7 @@ import org.apache.paimon.flink.sink.cdc.NewTableSchemaBuilder;
 import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecord;
 import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecordEventParser;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.SpecialFields;
 
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -35,7 +36,6 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import static org.apache.paimon.flink.action.MultiTablesSinkMode.COMBINED;
+import static org.apache.paimon.flink.action.cdc.ComputedColumnUtils.buildComputedColumns;
 
 /** Base {@link Action} for synchronizing into one Paimon database. */
 public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
@@ -58,6 +59,9 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
     protected String includingTables = ".*";
     protected List<String> partitionKeys = new ArrayList<>();
     protected List<String> primaryKeys = new ArrayList<>();
+    protected boolean auditTimeEnabled = false;
+    protected List<String> computedColumnArgs = new ArrayList<>();
+    protected List<ComputedColumn> computedColumns = new ArrayList<>();
     @Nullable protected String excludingTables;
     protected String includingDbs = ".*";
     @Nullable protected String excludingDbs;
@@ -165,10 +169,15 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
         return this;
     }
 
+    public SyncDatabaseActionBase withComputedColumnArgs(List<String> computedColumnArgs) {
+        this.computedColumnArgs = computedColumnArgs;
+        return this;
+    }
+
     @Override
     protected FlatMapFunction<CdcSourceRecord, RichCdcMultiplexRecord> recordParse() {
         return syncJobHandler.provideRecordParser(
-                Collections.emptyList(), typeMapping, metadataConverters);
+                this.computedColumns, typeMapping, metadataConverters);
     }
 
     public SyncDatabaseActionBase withPartitionKeyMultiple(
@@ -236,5 +245,11 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
                 .withMode(mode)
                 .withTableOptions(tableConfig)
                 .build();
+    }
+
+    @Override
+    protected void beforeBuildingSourceSink() throws Exception {
+        computedColumns =
+                buildComputedColumns(computedColumnArgs, Arrays.asList(SpecialFields.VALUE_KIND));
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -59,7 +60,6 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
     protected String includingTables = ".*";
     protected List<String> partitionKeys = new ArrayList<>();
     protected List<String> primaryKeys = new ArrayList<>();
-    protected boolean auditTimeEnabled = false;
     protected List<String> computedColumnArgs = new ArrayList<>();
     protected List<ComputedColumn> computedColumns = new ArrayList<>();
     @Nullable protected String excludingTables;
@@ -250,6 +250,6 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
     @Override
     protected void beforeBuildingSourceSink() throws Exception {
         computedColumns =
-                buildComputedColumns(computedColumnArgs, Arrays.asList(SpecialFields.VALUE_KIND));
+                buildComputedColumns(computedColumnArgs, Collections.singletonList(SpecialFields.VALUE_KIND));
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
@@ -250,6 +250,7 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
     @Override
     protected void beforeBuildingSourceSink() throws Exception {
         computedColumns =
-                buildComputedColumns(computedColumnArgs, Collections.singletonList(SpecialFields.VALUE_KIND));
+                buildComputedColumns(
+                        computedColumnArgs, Collections.singletonList(SpecialFields.VALUE_KIND));
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionFactoryBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionFactoryBase.java
@@ -22,8 +22,10 @@ import org.apache.paimon.flink.action.Action;
 import org.apache.paimon.flink.action.ActionFactory;
 import org.apache.paimon.flink.action.MultipleParameterToolAdapter;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
+import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.COMPUTED_COLUMN;
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.EXCLUDING_DBS;
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.EXCLUDING_TABLES;
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.INCLUDING_DBS;
@@ -76,6 +78,11 @@ public abstract class SyncDatabaseActionFactoryBase<T extends SyncDatabaseAction
         if (params.has(TYPE_MAPPING)) {
             String[] options = params.get(TYPE_MAPPING).split(",");
             action.withTypeMapping(TypeMapping.parse(options));
+        }
+
+        if (params.has(COMPUTED_COLUMN)) {
+            action.withComputedColumnArgs(
+                    new ArrayList<>(params.getMultiParameter(COMPUTED_COLUMN)));
         }
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/AbstractJsonRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/AbstractJsonRecordParser.java
@@ -103,7 +103,7 @@ public abstract class AbstractJsonRecordParser extends AbstractRecordParser {
                                             }
                                             return Objects.toString(entry.getValue());
                                         }));
-        evalComputedColumns(rowData, rowTypeBuilder);
+
         return rowData;
     }
 
@@ -123,6 +123,7 @@ public abstract class AbstractJsonRecordParser extends AbstractRecordParser {
             JsonNode jsonNode, RowKind rowKind, List<RichCdcMultiplexRecord> records) {
         RowType.Builder rowTypeBuilder = RowType.builder();
         Map<String, String> rowData = this.extractRowData(jsonNode, rowTypeBuilder);
+        evalComputedColumns(rowKind, rowData, rowTypeBuilder);
         records.add(createRecord(rowKind, rowData, rowTypeBuilder.build().getFields()));
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/AbstractRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/AbstractRecordParser.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-
 /**
  * Provides a base implementation for parsing messages of various formats into {@link
  * RichCdcMultiplexRecord} objects.
@@ -121,7 +120,8 @@ public abstract class AbstractRecordParser
         computedColumns.forEach(
                 computedColumn -> {
                     String argVal;
-                    if (Objects.equals(computedColumn.fieldReference(), SpecialFields.VALUE_KIND.name())) {
+                    if (Objects.equals(
+                            computedColumn.fieldReference(), SpecialFields.VALUE_KIND.name())) {
                         argVal = rowKind.shortString();
                     } else {
                         argVal = rowData.get(computedColumn.fieldReference());

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/AbstractRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/AbstractRecordParser.java
@@ -38,7 +38,9 @@ import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+
 
 /**
  * Provides a base implementation for parsing messages of various formats into {@link
@@ -119,7 +121,7 @@ public abstract class AbstractRecordParser
         computedColumns.forEach(
                 computedColumn -> {
                     String argVal;
-                    if (computedColumn.fieldReference().equals(SpecialFields.VALUE_KIND.name())) {
+                    if (Objects.equals(computedColumn.fieldReference(), SpecialFields.VALUE_KIND.name())) {
                         argVal = rowKind.shortString();
                     } else {
                         argVal = rowData.get(computedColumn.fieldReference());

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/aliyun/AliyunRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/aliyun/AliyunRecordParser.java
@@ -179,7 +179,6 @@ public class AliyunRecordParser extends AbstractJsonRecordParser {
             rowData.put(entry.getKey(), Objects.toString(entry.getValue(), null));
         }
 
-        evalComputedColumns(rowData, rowTypeBuilder);
         return rowData;
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/canal/CanalRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/canal/CanalRecordParser.java
@@ -180,7 +180,6 @@ public class CanalRecordParser extends AbstractJsonRecordParser {
             }
         }
 
-        evalComputedColumns(rowData, rowTypeBuilder);
         return rowData;
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumAvroRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumAvroRecordParser.java
@@ -115,6 +115,7 @@ public class DebeziumAvroRecordParser extends AbstractRecordParser {
             GenericRecord record, RowKind rowKind, List<RichCdcMultiplexRecord> records) {
         RowType.Builder rowTypeBuilder = RowType.builder();
         Map<String, String> rowData = this.extractRowData(record, rowTypeBuilder);
+        evalComputedColumns(rowKind, rowData, rowTypeBuilder);
         records.add(createRecord(rowKind, rowData, rowTypeBuilder.build().getFields()));
     }
 
@@ -158,7 +159,6 @@ public class DebeziumAvroRecordParser extends AbstractRecordParser {
             rowTypeBuilder.field(fieldName, avroToPaimonDataType(schema));
         }
 
-        evalComputedColumns(resultMap, rowTypeBuilder);
         return resultMap;
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumBsonRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumBsonRecordParser.java
@@ -95,8 +95,6 @@ public class DebeziumBsonRecordParser extends DebeziumJsonRecordParser {
             rowTypeBuilder.field(fieldName, DataTypes.STRING());
         }
 
-        evalComputedColumns(resultMap, rowTypeBuilder);
-
         return resultMap;
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumJsonRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumJsonRecordParser.java
@@ -211,8 +211,6 @@ public class DebeziumJsonRecordParser extends AbstractJsonRecordParser {
                             debeziumType, className, parameters.get(fieldName)));
         }
 
-        evalComputedColumns(resultMap, rowTypeBuilder);
-
         return resultMap;
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/CdcActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/CdcActionITCaseBase.java
@@ -130,6 +130,16 @@ public class CdcActionITCaseBase extends ActionITCaseBase {
     protected void waitForResult(
             List<String> expected, FileStoreTable table, RowType rowType, List<String> primaryKeys)
             throws Exception {
+        waitForResult(false, expected, table, rowType, primaryKeys);
+    }
+
+    protected void waitForResult(
+            boolean withRegx,
+            List<String> expected,
+            FileStoreTable table,
+            RowType rowType,
+            List<String> primaryKeys)
+            throws Exception {
         assertThat(table.schema().primaryKeys()).isEqualTo(primaryKeys);
 
         // wait for table schema to become our expected schema
@@ -143,6 +153,13 @@ public class CdcActionITCaseBase extends ActionITCaseBase {
                     if (sameName && sameType) {
                         cnt++;
                     }
+
+                    LOG.info("actual: field: " + field.name() + " " + field.type());
+                    LOG.info(
+                            "expected:rowType: "
+                                    + rowType.getFieldNames().get(i)
+                                    + " "
+                                    + rowType.getFieldTypes().get(i));
                 }
                 if (cnt == rowType.getFieldCount()) {
                     break;
@@ -165,13 +182,38 @@ public class CdcActionITCaseBase extends ActionITCaseBase {
                             rowType);
             List<String> sortedActual = new ArrayList<>(result);
             Collections.sort(sortedActual);
-            if (sortedExpected.equals(sortedActual)) {
-                break;
-            }
+
             LOG.info("actual: " + sortedActual);
             LOG.info("expected: " + sortedExpected);
+
+            if (withRegx) {
+                if (isRegxMatchList(sortedActual, sortedExpected)) {
+                    break;
+                }
+            } else if (sortedExpected.equals(sortedActual)) {
+                break;
+            }
+            LOG.warn("actual: " + sortedActual);
+            LOG.warn("expected: " + sortedExpected);
             Thread.sleep(1000);
         }
+    }
+
+    private boolean isRegxMatchList(List<String> actual, List<String> expected) {
+        if (actual == null && expected == null) {
+            return true;
+        }
+        if (actual.size() != expected.size()) {
+            return false;
+        }
+
+        for (int i = 0; i < actual.size(); i++) {
+            if (!actual.get(i).matches(expected.get(i))) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     protected Map<String, String> getBasicTableConfig() {
@@ -392,6 +434,7 @@ public class CdcActionITCaseBase extends ActionITCaseBase {
         private final List<String> partitionKeys = new ArrayList<>();
         private final List<String> primaryKeys = new ArrayList<>();
         private final List<String> metadataColumn = new ArrayList<>();
+        private final List<String> computedColumnArgs = new ArrayList<>();
         protected Map<String, String> partitionKeyMultiple = new HashMap<>();
 
         public SyncDatabaseActionBuilder(Class<T> clazz, Map<String, String> sourceConfig) {
@@ -464,6 +507,12 @@ public class CdcActionITCaseBase extends ActionITCaseBase {
             return this;
         }
 
+        public SyncDatabaseActionBuilder<T> withComputedColumnArgs(
+                List<String> computedColumnArgs) {
+            this.computedColumnArgs.addAll(computedColumnArgs);
+            return this;
+        }
+
         public SyncDatabaseActionBuilder<T> withPartitionKeyMultiple(
                 Map<String, String> partitionKeyMultiple) {
             if (partitionKeyMultiple != null) {
@@ -499,6 +548,8 @@ public class CdcActionITCaseBase extends ActionITCaseBase {
             args.addAll(mapToArgs("--multiple-table-partition-keys", partitionKeyMultiple));
             args.addAll(listToArgs("--primary-keys", primaryKeys));
             args.addAll(listToArgs("--metadata-column", metadataColumn));
+
+            args.addAll(listToMultiArgs("--computed-column", computedColumnArgs));
 
             return createAction(clazz, args);
         }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/format/aliyun/AliyunJsonRecordParserTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/format/aliyun/AliyunJsonRecordParserTest.java
@@ -18,7 +18,10 @@
 
 package org.apache.paimon.flink.action.cdc.format.aliyun;
 
+import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.flink.action.cdc.CdcSourceRecord;
+import org.apache.paimon.flink.action.cdc.ComputedColumn;
+import org.apache.paimon.flink.action.cdc.ComputedColumnUtils;
 import org.apache.paimon.flink.action.cdc.TypeMapping;
 import org.apache.paimon.flink.action.cdc.kafka.KafkaActionITCaseBase;
 import org.apache.paimon.flink.action.cdc.watermark.MessageQueueCdcTimestampExtractor;
@@ -26,6 +29,7 @@ import org.apache.paimon.flink.sink.cdc.CdcRecord;
 import org.apache.paimon.flink.sink.cdc.RichCdcMultiplexRecord;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.types.RowKind;
+import org.apache.paimon.utils.BinaryStringUtils;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
@@ -43,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /** Test for AliyunJsonRecordParser. */
 public class AliyunJsonRecordParserTest extends KafkaActionITCaseBase {
@@ -51,14 +56,22 @@ public class AliyunJsonRecordParserTest extends KafkaActionITCaseBase {
     private static List<String> insertList = new ArrayList<>();
     private static List<String> updateList = new ArrayList<>();
     private static List<String> deleteList = new ArrayList<>();
+    private static List<ComputedColumn> computedColumns = new ArrayList<>();
 
     private static ObjectMapper objMapper = new ObjectMapper();
+
+    String dateTimeRegex = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}";
 
     @Before
     public void setup() {
         String insertRes = "kafka/aliyun/table/event/event-insert.txt";
         String updateRes = "kafka/aliyun/table/event/event-update-in-one.txt";
         String deleteRes = "kafka/aliyun/table/event/event-delete.txt";
+
+        String[] computedColumnArgs = {
+            "etl_create_time=create_time()", "etl_update_time=update_time()"
+        };
+
         URL url;
         try {
             url = AliyunJsonRecordParserTest.class.getClassLoader().getResource(insertRes);
@@ -76,6 +89,10 @@ public class AliyunJsonRecordParserTest extends KafkaActionITCaseBase {
                     .filter(this::isRecordLine)
                     .forEach(e -> deleteList.add(e));
 
+            computedColumns =
+                    ComputedColumnUtils.buildComputedColumns(
+                            Arrays.asList(computedColumnArgs), Collections.emptyList());
+
         } catch (Exception e) {
             log.error("Fail to init aliyun-json cases", e);
         }
@@ -83,8 +100,9 @@ public class AliyunJsonRecordParserTest extends KafkaActionITCaseBase {
 
     @Test
     public void extractInsertRecord() throws Exception {
+
         AliyunRecordParser parser =
-                new AliyunRecordParser(TypeMapping.defaultMapping(), Collections.emptyList());
+                new AliyunRecordParser(TypeMapping.defaultMapping(), computedColumns);
         for (String json : insertList) {
             // 将json解析为JsonNode对象
             JsonNode rootNode = objMapper.readValue(json, JsonNode.class);
@@ -106,13 +124,31 @@ public class AliyunJsonRecordParserTest extends KafkaActionITCaseBase {
 
             MessageQueueCdcTimestampExtractor extractor = new MessageQueueCdcTimestampExtractor();
             Assert.assertTrue(extractor.extractTimestamp(cdcRecord) > 0);
+
+            Map<String, String> data = records.get(0).toRichCdcRecord().toCdcRecord().data();
+            String createTime = data.get("etl_create_time");
+            String updateTime = data.get("etl_update_time");
+
+            // Mock the real timestamp string which retrieved from store and convert through paimon
+            // Timestamp
+            createTime =
+                    BinaryStringUtils.toTimestamp(BinaryString.fromString(createTime), 6)
+                            .toString();
+            updateTime =
+                    BinaryStringUtils.toTimestamp(BinaryString.fromString(updateTime), 6)
+                            .toString();
+
+            Assert.assertTrue(createTime.matches(dateTimeRegex));
+            Assert.assertTrue(updateTime.matches(dateTimeRegex));
+
+            log.info("createTime: {}, updateTime: {}", createTime, updateTime);
         }
     }
 
     @Test
     public void extractUpdateRecord() throws Exception {
         AliyunRecordParser parser =
-                new AliyunRecordParser(TypeMapping.defaultMapping(), Collections.emptyList());
+                new AliyunRecordParser(TypeMapping.defaultMapping(), computedColumns);
         for (String json : updateList) {
             // 将json解析为JsonNode对象
             JsonNode jsonNode = objMapper.readValue(json, JsonNode.class);
@@ -134,13 +170,24 @@ public class AliyunJsonRecordParserTest extends KafkaActionITCaseBase {
 
             MessageQueueCdcTimestampExtractor extractor = new MessageQueueCdcTimestampExtractor();
             Assert.assertTrue(extractor.extractTimestamp(cdcRecord) > 0);
+
+            Map<String, String> data = records.get(0).toRichCdcRecord().toCdcRecord().data();
+            String createTime = data.get("etl_create_time");
+            String updateTime = data.get("etl_update_time");
+            Assert.assertNull(createTime);
+
+            updateTime =
+                    BinaryStringUtils.toTimestamp(BinaryString.fromString(updateTime), 6)
+                            .toString();
+
+            Assert.assertTrue(updateTime.matches(dateTimeRegex));
         }
     }
 
     @Test
     public void extractDeleteRecord() throws Exception {
         AliyunRecordParser parser =
-                new AliyunRecordParser(TypeMapping.defaultMapping(), Collections.emptyList());
+                new AliyunRecordParser(TypeMapping.defaultMapping(), computedColumns);
         for (String json : deleteList) {
             // 将json解析为JsonNode对象
             JsonNode jsonNode = objMapper.readValue(json, JsonNode.class);
@@ -162,6 +209,17 @@ public class AliyunJsonRecordParserTest extends KafkaActionITCaseBase {
 
             MessageQueueCdcTimestampExtractor extractor = new MessageQueueCdcTimestampExtractor();
             Assert.assertTrue(extractor.extractTimestamp(cdcRecord) > 0);
+
+            Map<String, String> data = records.get(0).toRichCdcRecord().toCdcRecord().data();
+            String createTime = data.get("etl_create_time");
+            String updateTime = data.get("etl_update_time");
+            Assert.assertNull(createTime);
+
+            updateTime =
+                    BinaryStringUtils.toTimestamp(BinaryString.fromString(updateTime), 6)
+                            .toString();
+
+            Assert.assertTrue(updateTime.matches(dateTimeRegex));
         }
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
@@ -767,8 +767,8 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
         // DELETE
         LOG.info("audit delete");
         data = getAuditLogData("t1");
-        Timestamp createTime4 = data.get(0).getTimestamp(2, 3);
-        Timestamp updateTime4 = data.get(0).getTimestamp(3, 3);
+        Timestamp createTime4 = data.get(0).getTimestamp(1, 3);
+        Timestamp updateTime4 = data.get(0).getTimestamp(2, 3);
 
         assertThat(createTime4.equals(createTime1));
         assertThat(updateTime4.toLocalDateTime().isAfter(updateTime3.toLocalDateTime()));

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
@@ -765,13 +765,14 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
         Thread.sleep(1000);
 
         // DELETE
+        FileStoreTable auditLogTable1 = getFileStoreTable("t1$audit_log");
         LOG.info("audit delete");
         writeRecordsToKafka(topic, "kafka/canal/database/audit-time/canal-data-4.txt");
         waitForResult(
                 true,
                 Collections.singletonList(
-                        "\\+I\\[1, B, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\]"),
-                table1,
+                        "\\-D\\[1, C, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\]"),
+                auditLogTable1,
                 rowType1,
                 Arrays.asList("k"));
 
@@ -780,7 +781,7 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
         Timestamp updateTime4 = data.get(0).getTimestamp(3, 3);
 
         assertThat(createTime4.equals(createTime1));
-        assertThat(updateTime3.toLocalDateTime().isAfter(updateTime2.toLocalDateTime()));
+        assertThat(updateTime4.toLocalDateTime().isAfter(updateTime3.toLocalDateTime()));
         assertThat(
                 updateTime3
                                 .toLocalDateTime()

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
@@ -647,7 +647,7 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
     }
 
     @Test
-    @Timeout(180)
+    @Timeout(120)
     public void testAuditTime() throws Exception {
         final String topic = "specify-keys";
         createTestTopic(topic, 1, 1);

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.flink.action.cdc.kafka;
 
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataType;
@@ -29,6 +31,7 @@ import org.junit.jupiter.api.Timeout;
 
 import javax.annotation.Nullable;
 
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -648,7 +651,7 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
     public void testAuditTime() throws Exception {
         final String topic = "specify-keys";
         createTestTopic(topic, 1, 1);
-        writeRecordsToKafka(topic, "kafka/canal/database/specify-keys/canal-data-1.txt");
+        writeRecordsToKafka(topic, "kafka/canal/database/audit-time/canal-data-1.txt");
 
         Map<String, String> kafkaConfig = getBasicKafkaConfig();
         kafkaConfig.put(VALUE_FORMAT.key(), "canal-json");
@@ -657,8 +660,7 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
         KafkaSyncDatabaseAction action =
                 syncDatabaseActionBuilder(kafkaConfig)
                         .withTableConfig(getBasicTableConfig())
-                        .withPartitionKeys("part")
-                        .withPrimaryKeys("k", "part")
+                        .withPrimaryKeys("k")
                         .withComputedColumnArgs(
                                 Arrays.asList(
                                         "etl_create_time=create_time()",
@@ -666,11 +668,10 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
                         .build();
         runActionWithDefaultEnv(action);
 
-        waitingTables("t1", "t2");
+        waitingTables("t1");
 
         FileStoreTable table1 = getFileStoreTable("t1");
-        assertThat(table1.partitionKeys()).containsExactly("part");
-        assertThat(table1.primaryKeys()).containsExactly("k", "part");
+        assertThat(table1.primaryKeys()).containsExactly("k");
 
         RowType rowType1 =
                 RowType.of(
@@ -681,35 +682,103 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
                             DataTypes.TIMESTAMP(),
                             DataTypes.TIMESTAMP()
                         },
-                        new String[] {"k", "part", "v1", "etl_create_time", "etl_update_time"});
-        waitForResult(
-                true,
-                Collections.singletonList(
-                        "\\+I\\[1, 1, A, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\]"),
-                table1,
-                rowType1,
-                Arrays.asList("k", "part"));
-
-        FileStoreTable table2 = getFileStoreTable("t2");
-        assertThat(table2.partitionKeys()).isEmpty();
-        assertThat(table2.primaryKeys()).containsExactly("k");
-
-        RowType rowType2 =
-                RowType.of(
-                        new DataType[] {
-                            DataTypes.INT().notNull(),
-                            DataTypes.VARCHAR(10),
-                            DataTypes.TIMESTAMP(),
-                            DataTypes.TIMESTAMP()
-                        },
                         new String[] {"k", "v1", "etl_create_time", "etl_update_time"});
+
+        // INSERT
         waitForResult(
                 true,
                 Collections.singletonList(
                         "\\+I\\[1, A, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\]"),
-                table2,
-                rowType2,
-                Collections.singletonList("k"));
+                table1,
+                rowType1,
+                Arrays.asList("k"));
+
+        List<InternalRow> data = getData("t1");
+        Timestamp createTime1 = data.get(0).getTimestamp(2, 3);
+        Timestamp updateTime1 = data.get(0).getTimestamp(3, 3);
+
+        assertThat(
+                createTime1
+                                .toLocalDateTime()
+                                .until(Timestamp.now().toLocalDateTime(), ChronoUnit.SECONDS)
+                        < 60);
+        assertThat(
+                updateTime1
+                                .toLocalDateTime()
+                                .until(Timestamp.now().toLocalDateTime(), ChronoUnit.SECONDS)
+                        < 60);
+
+        Thread.sleep(1000);
+
+        // UPDATE1
+        writeRecordsToKafka(topic, "kafka/canal/database/audit-time/canal-data-2.txt");
+        waitForResult(
+                true,
+                Collections.singletonList(
+                        "\\+I\\[1, B, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\]"),
+                table1,
+                rowType1,
+                Arrays.asList("k"));
+
+        data = getData("t1");
+        Timestamp createTime2 = data.get(0).getTimestamp(2, 3);
+        Timestamp updateTime2 = data.get(0).getTimestamp(3, 3);
+
+        assertThat(createTime2.equals(createTime1));
+        assertThat(updateTime2.toLocalDateTime().isAfter(updateTime1.toLocalDateTime()));
+        assertThat(
+                updateTime2
+                                .toLocalDateTime()
+                                .until(Timestamp.now().toLocalDateTime(), ChronoUnit.SECONDS)
+                        < 60);
+
+        Thread.sleep(1000);
+
+        // UPDATE2
+        writeRecordsToKafka(topic, "kafka/canal/database/audit-time/canal-data-3.txt");
+        waitForResult(
+                true,
+                Collections.singletonList(
+                        "\\+I\\[1, B, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\]"),
+                table1,
+                rowType1,
+                Arrays.asList("k"));
+
+        data = getData("t1");
+        Timestamp createTime3 = data.get(0).getTimestamp(2, 3);
+        Timestamp updateTime3 = data.get(0).getTimestamp(3, 3);
+
+        assertThat(createTime3.equals(createTime1));
+        assertThat(updateTime3.toLocalDateTime().isAfter(updateTime2.toLocalDateTime()));
+        assertThat(
+                updateTime3
+                                .toLocalDateTime()
+                                .until(Timestamp.now().toLocalDateTime(), ChronoUnit.SECONDS)
+                        < 60);
+
+        Thread.sleep(1000);
+
+        // DELETE
+        writeRecordsToKafka(topic, "kafka/canal/database/audit-time/canal-data-4.txt");
+        waitForResult(
+                true,
+                Collections.singletonList(
+                        "\\+I\\[1, B, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\]"),
+                table1,
+                rowType1,
+                Arrays.asList("k"));
+
+        data = getData("t1$audit_log");
+        Timestamp createTime4 = data.get(0).getTimestamp(2, 3);
+        Timestamp updateTime4 = data.get(0).getTimestamp(3, 3);
+
+        assertThat(createTime4.equals(createTime1));
+        assertThat(updateTime3.toLocalDateTime().isAfter(updateTime2.toLocalDateTime()));
+        assertThat(
+                updateTime3
+                                .toLocalDateTime()
+                                .until(Timestamp.now().toLocalDateTime(), ChronoUnit.SECONDS)
+                        < 60);
     }
 
     @Test

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
@@ -28,6 +28,8 @@ import org.apache.paimon.types.RowType;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -51,6 +53,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** IT cases for {@link KafkaSyncDatabaseAction}. */
 public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaCanalSyncDatabaseActionITCase.class);
 
     @Test
     @Timeout(60)
@@ -684,6 +687,7 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
                         new String[] {"k", "v1", "etl_create_time", "etl_update_time"});
 
         // INSERT
+        LOG.info("audit insert");
         waitForResult(
                 true,
                 Collections.singletonList(
@@ -710,6 +714,7 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
         Thread.sleep(1000);
 
         // UPDATE1
+        LOG.info("audit update1");
         writeRecordsToKafka(topic, "kafka/canal/database/audit-time/canal-data-2.txt");
         waitForResult(
                 true,
@@ -734,11 +739,12 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
         Thread.sleep(1000);
 
         // UPDATE2
+        LOG.info("audit update2");
         writeRecordsToKafka(topic, "kafka/canal/database/audit-time/canal-data-3.txt");
         waitForResult(
                 true,
                 Collections.singletonList(
-                        "\\+I\\[1, B, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\]"),
+                        "\\+I\\[1, C, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\]"),
                 table1,
                 rowType1,
                 Arrays.asList("k"));
@@ -758,6 +764,7 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
         Thread.sleep(1000);
 
         // DELETE
+        LOG.info("audit delete");
         writeRecordsToKafka(topic, "kafka/canal/database/audit-time/canal-data-4.txt");
         waitForResult(
                 true,

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
@@ -765,18 +765,8 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
         Thread.sleep(1000);
 
         // DELETE
-        FileStoreTable auditLogTable1 = getFileStoreTable("t1$audit_log");
         LOG.info("audit delete");
-        writeRecordsToKafka(topic, "kafka/canal/database/audit-time/canal-data-4.txt");
-        waitForResult(
-                true,
-                Collections.singletonList(
-                        "\\-D\\[1, C, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}, \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\]"),
-                auditLogTable1,
-                rowType1,
-                Arrays.asList("k"));
-
-        data = getData("t1$audit_log");
+        data = getAuditLogData("t1");
         Timestamp createTime4 = data.get(0).getTimestamp(2, 3);
         Timestamp updateTime4 = data.get(0).getTimestamp(3, 3);
 

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
@@ -767,8 +767,8 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
         // DELETE
         LOG.info("audit delete");
         data = getAuditLogData("t1");
-        Timestamp createTime4 = data.get(0).getTimestamp(1, 3);
-        Timestamp updateTime4 = data.get(0).getTimestamp(2, 3);
+        Timestamp createTime4 = data.get(0).getTimestamp(3, 3);
+        Timestamp updateTime4 = data.get(0).getTimestamp(4, 3);
 
         assertThat(createTime4.equals(createTime1));
         assertThat(updateTime4.toLocalDateTime().isAfter(updateTime3.toLocalDateTime()));

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
@@ -53,7 +53,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** IT cases for {@link KafkaSyncDatabaseAction}. */
 public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
-    private static final Logger LOG = LoggerFactory.getLogger(KafkaCanalSyncDatabaseActionITCase.class);
+    private static final Logger LOG =
+            LoggerFactory.getLogger(KafkaCanalSyncDatabaseActionITCase.class);
 
     @Test
     @Timeout(60)

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
@@ -677,7 +677,6 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
                 RowType.of(
                         new DataType[] {
                             DataTypes.INT().notNull(),
-                            DataTypes.INT().notNull(),
                             DataTypes.VARCHAR(10),
                             DataTypes.TIMESTAMP(),
                             DataTypes.TIMESTAMP()

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/audit-time/canal-data-1.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/audit-time/canal-data-1.txt
@@ -16,4 +16,4 @@
  * limitations under the License.
  */
 
-{"data":[{"k":"1","v1":"A"}],"database":"test_audit_time","es":1684770072000,"id":81,"isDdl":false,"mysqlType":{"k":"INT","v1":"VARCHAR(10)"},"old":null,"pkNames":["k"],"sql":"","sqlType":{"k":4,"v1":12},"table":"t1","ts":1684770072286,"type":"INSERT"}
+{"data":[{"k":"1","v1":"A"}],"database":"test_audit_time","es":1684770072000,"id":81,"isDdl":false,"mysqlType":{"k":"INT","v1":"VARCHAR(10)"},"old":[],"pkNames":["k"],"sql":"","sqlType":{"k":4,"v1":12},"table":"t1","ts":1684770072286,"type":"INSERT"}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/audit-time/canal-data-1.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/audit-time/canal-data-1.txt
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{"data":[{"k":"1","v1":"A"}],"database":"test_audit_time","es":1684770072000,"id":81,"isDdl":false,"mysqlType":{"k":"INT","v1":"VARCHAR(10)"},"old":null,"pkNames":["k"],"sql":"","sqlType":{"k":4,"v1":12},"table":"t1","ts":1684770072286,"type":"INSERT"}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/audit-time/canal-data-2.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/audit-time/canal-data-2.txt
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{"data":[{"k":"1","v1":"B"}],"database":"test_audit_time","es":1684770072000,"id":81,"isDdl":false,"mysqlType":{"k":"INT","v1":"VARCHAR(10)"},"old":null,"pkNames":["k"],"sql":"","sqlType":{"k":4,"v1":12},"table":"t1","ts":1684770072286,"type":"UPDATE"}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/audit-time/canal-data-2.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/audit-time/canal-data-2.txt
@@ -16,4 +16,4 @@
  * limitations under the License.
  */
 
-{"data":[{"k":"1","v1":"B"}],"database":"test_audit_time","es":1684770072000,"id":81,"isDdl":false,"mysqlType":{"k":"INT","v1":"VARCHAR(10)"},"old":null,"pkNames":["k"],"sql":"","sqlType":{"k":4,"v1":12},"table":"t1","ts":1684770072286,"type":"UPDATE"}
+{"data":[{"k":"1","v1":"B"}],"database":"test_audit_time","es":1684770072000,"id":81,"isDdl":false,"mysqlType":{"k":"INT","v1":"VARCHAR(10)"},"old":[{"k":"1","v1":"A"}],"pkNames":["k"],"sql":"","sqlType":{"k":4,"v1":12},"table":"t1","ts":1684770072286,"type":"UPDATE"}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/audit-time/canal-data-3.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/audit-time/canal-data-3.txt
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{"data":[{"k":"1","v1":"C"}],"database":"test_audit_time","es":1684770072000,"id":81,"isDdl":false,"mysqlType":{"k":"INT","v1":"VARCHAR(10)"},"old":null,"pkNames":["k"],"sql":"","sqlType":{"k":4,"v1":12},"table":"t1","ts":1684770072286,"type":"UPDATE"}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/audit-time/canal-data-3.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/audit-time/canal-data-3.txt
@@ -16,4 +16,4 @@
  * limitations under the License.
  */
 
-{"data":[{"k":"1","v1":"C"}],"database":"test_audit_time","es":1684770072000,"id":81,"isDdl":false,"mysqlType":{"k":"INT","v1":"VARCHAR(10)"},"old":null,"pkNames":["k"],"sql":"","sqlType":{"k":4,"v1":12},"table":"t1","ts":1684770072286,"type":"UPDATE"}
+{"data":[{"k":"1","v1":"C"}],"database":"test_audit_time","es":1684770072000,"id":81,"isDdl":false,"mysqlType":{"k":"INT","v1":"VARCHAR(10)"},"old":[{"k":"1","v1":"B"}],"pkNames":["k"],"sql":"","sqlType":{"k":4,"v1":12},"table":"t1","ts":1684770072286,"type":"UPDATE"}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/audit-time/canal-data-4.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/audit-time/canal-data-4.txt
@@ -16,5 +16,4 @@
  * limitations under the License.
  */
 
-{"data":[{"k":"1","v1":"D"}],"database":"test_audit_time","es":1684770072000,"id":81,"isDdl":false,"mysqlType":{"k":"INT","v1":"VARCHAR(10)"},"old":null,"pkNames":["k"],"sql":"","sqlType":{"k":4,"v1":12},"table":"t1","ts":1684770072286,"type":"DELETE"}
-
+{"data":[{"k":"1","v1":"C"}],"database":"test_audit_time","es":1684770072000,"id":81,"isDdl":false,"mysqlType":{"k":"INT","v1":"VARCHAR(10)"},"old":null,"pkNames":["k"],"sql":"","sqlType":{"k":4,"v1":12},"table":"t1","ts":1684770072286,"type":"DELETE"}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/audit-time/canal-data-4.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/audit-time/canal-data-4.txt
@@ -16,4 +16,4 @@
  * limitations under the License.
  */
 
-{"data":[{"k":"1","v1":"C"}],"database":"test_audit_time","es":1684770072000,"id":81,"isDdl":false,"mysqlType":{"k":"INT","v1":"VARCHAR(10)"},"old":null,"pkNames":["k"],"sql":"","sqlType":{"k":4,"v1":12},"table":"t1","ts":1684770072286,"type":"DELETE"}
+{"data":[{"k":"1","v1":"C"}],"database":"test_audit_time","es":1684770072000,"id":81,"isDdl":false,"mysqlType":{"k":"INT","v1":"VARCHAR(10)"},"old":[],"pkNames":["k"],"sql":"","sqlType":{"k":4,"v1":12},"table":"t1","ts":1684770072286,"type":"DELETE"}

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/audit-time/canal-data-4.txt
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/kafka/canal/database/audit-time/canal-data-4.txt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{"data":[{"k":"1","v1":"D"}],"database":"test_audit_time","es":1684770072000,"id":81,"isDdl":false,"mysqlType":{"k":"INT","v1":"VARCHAR(10)"},"old":null,"pkNames":["k"],"sql":"","sqlType":{"k":4,"v1":12},"table":"t1","ts":1684770072286,"type":"DELETE"}
+

--- a/paimon-flink/paimon-flink-cdc/src/test/resources/log4j2-test.properties
+++ b/paimon-flink/paimon-flink-cdc/src/test/resources/log4j2-test.properties
@@ -18,7 +18,7 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level = OFF
+rootLogger.level = INFO
 rootLogger.appenderRef.test.ref = TestLogger
 
 appender.testlogger.name = TestLogger

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ActionITCaseBase.java
@@ -32,8 +32,10 @@ import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
+import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.types.RowType;
 
 import org.apache.flink.table.api.TableEnvironment;
@@ -45,6 +47,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -140,6 +143,22 @@ public abstract class ActionITCaseBase extends AbstractTestBase {
         }
         commit.commit(incrementalIdentifier, write.prepareCommit(true, incrementalIdentifier));
         incrementalIdentifier++;
+    }
+
+    protected List<InternalRow> getData(String tableName) throws Exception {
+        List<InternalRow> result = new ArrayList<>();
+
+        FileStoreTable table = this.getFileStoreTable(tableName);
+
+        ReadBuilder readBuilder = table.newReadBuilder();
+        TableScan.Plan plan = readBuilder.newScan().plan();
+        List<Split> splits = plan == null ? Collections.emptyList() : plan.splits();
+        TableRead read = readBuilder.newRead();
+        try (RecordReader<InternalRow> recordReader = read.createReader(splits)) {
+            recordReader.forEachRemaining(result::add);
+        }
+
+        return result;
     }
 
     protected List<String> getResult(TableRead read, List<Split> splits, RowType rowType)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5068

<!-- What is the purpose of the change -->
Support special audition computed columns, especially for cdc sync database

### Tests

<!-- List UT and IT cases to verify this change -->
org.apache.paimon.flink.action.cdc.kafka.KafkaCanalSyncDatabaseActionITCase#testAuditTime
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
