### PR TITLE
[spark] Add max_pt function

### DIFF
--- a/docs/content/spark/sql-functions.md
+++ b/docs/content/spark/sql-functions.md
@@ -1,0 +1,55 @@
+---
+title: "SQL Functions"
+weight: 2
+type: docs
+aliases:
+- /spark/sql-functions.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# SQL Functions
+
+This section introduce all available Paimon Spark functions.
+
+
+## max_pt
+
+`max_pt($table_name)`
+
+It accepts a string type literal to specify the table name and return a max-valid-toplevel partition value.
+- **valid**: the partition which contains data files
+- **toplevel**: only return the first partition value if the table has multi-partition columns
+
+It would throw exception when:
+- the table is not a partitioned table
+- the partitioned table does not have partition
+- all of the partitions do not contains data files
+
+**Example**
+
+```sql
+> SELECT max_pt('t');
+ 20250101
+ 
+> SELECT * FROM t where pt = max_pt('t');
+ a, 20250101
+```
+
+**Since: 1.1.0**

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/catalog/SupportFunction.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/catalog/SupportFunction.java
@@ -27,19 +27,14 @@ import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.SupportsNamespaces;
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
 
-import static org.apache.paimon.catalog.Catalog.SYSTEM_DATABASE_NAME;
-
 /** Catalog methods for working with Functions. */
 public interface SupportFunction extends FunctionCatalog, SupportsNamespaces {
 
-    static boolean isFunctionNamespace(String[] namespace) {
+    default boolean isFunctionNamespace(String[] namespace) {
         // Allow for empty namespace, as Spark's bucket join will use `bucket` function with empty
-        // namespace to generate transforms for partitioning. Otherwise, use `sys` namespace.
-        return namespace.length == 0 || isSystemNamespace(namespace);
-    }
-
-    static boolean isSystemNamespace(String[] namespace) {
-        return namespace.length == 1 && namespace[0].equalsIgnoreCase(SYSTEM_DATABASE_NAME);
+        // namespace to generate transforms for partitioning.
+        // Otherwise, check if it is paimon namespace.
+        return namespace.length == 0 || (namespace.length == 1 && namespaceExists(namespace));
     }
 
     @Override
@@ -48,8 +43,6 @@ public interface SupportFunction extends FunctionCatalog, SupportsNamespaces {
             return PaimonFunctions.names().stream()
                     .map(name -> Identifier.of(namespace, name))
                     .toArray(Identifier[]::new);
-        } else if (namespaceExists(namespace)) {
-            return new Identifier[0];
         }
 
         throw new NoSuchNamespaceException(namespace);

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonPartitionManagement.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonPartitionManagement.scala
@@ -38,7 +38,7 @@ import scala.collection.JavaConverters._
 trait PaimonPartitionManagement extends SupportsAtomicPartitionManagement {
   self: SparkTable =>
 
-  private lazy val partitionRowType: RowType = TypeUtils.project(table.rowType, table.partitionKeys)
+  lazy val partitionRowType: RowType = TypeUtils.project(table.rowType, table.partitionKeys)
 
   override lazy val partitionSchema: StructType = SparkTypeUtils.fromPaimonRowType(partitionRowType)
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/ReplacePaimonFunctions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/ReplacePaimonFunctions.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.catalyst.analysis
+
+import org.apache.paimon.spark.{DataConverter, SparkTable, SparkTypeUtils, SparkUtils}
+import org.apache.paimon.spark.catalog.SparkBaseCatalog
+import org.apache.paimon.utils.{InternalRowUtils, TypeUtils}
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.{ApplyFunctionExpression, Cast, Expression, Literal}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.catalog.PaimonCatalogImplicits._
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.unsafe.types.UTF8String
+
+import scala.jdk.CollectionConverters._
+
+/** A rule to replace Paimon functions with literal values. */
+case class ReplacePaimonFunctions(spark: SparkSession) extends Rule[LogicalPlan] {
+  private def replaceMaxPt(func: ApplyFunctionExpression): Expression = {
+    assert(func.children.size == 1)
+    assert(func.children.head.dataType == StringType)
+    if (!func.children.head.isInstanceOf[Literal]) {
+      throw new UnsupportedOperationException("Table name must be a literal")
+    }
+    val tableName = func.children.head.eval().asInstanceOf[UTF8String]
+    if (tableName == null) {
+      throw new UnsupportedOperationException("Table name cannot be null")
+    }
+    val catalogAndIdentifier = SparkUtils
+      .catalogAndIdentifier(
+        spark,
+        tableName.toString,
+        spark.sessionState.catalogManager.currentCatalog)
+    if (!catalogAndIdentifier.catalog().isInstanceOf[SparkBaseCatalog]) {
+      throw new UnsupportedOperationException(
+        s"${catalogAndIdentifier.catalog()} is not a Paimon catalog")
+    }
+
+    val table =
+      catalogAndIdentifier.catalog.asTableCatalog.loadTable(catalogAndIdentifier.identifier())
+    assert(table.isInstanceOf[SparkTable])
+    val sparkTable = table.asInstanceOf[SparkTable]
+    if (sparkTable.table.partitionKeys().size() == 0) {
+      throw new UnsupportedOperationException(s"$table is not a partitioned table")
+    }
+
+    val toplevelPartitionType =
+      TypeUtils.project(sparkTable.table.rowType, sparkTable.table.partitionKeys()).getTypeAt(0)
+    val partitionValues = sparkTable.table.newReadBuilder.newScan
+      .listPartitionEntries()
+      .asScala
+      .filter(_.fileCount() > 0)
+      .map {
+        partitionEntry => InternalRowUtils.get(partitionEntry.partition(), 0, toplevelPartitionType)
+      }
+      .sortWith(InternalRowUtils.compare(_, _, toplevelPartitionType.getTypeRoot) < 0)
+      .map(DataConverter.fromPaimon(_, toplevelPartitionType))
+    if (partitionValues.isEmpty) {
+      throw new UnsupportedOperationException(
+        s"$table has no partitions or none of the partitions have any data")
+    }
+
+    val sparkType = SparkTypeUtils.fromPaimonType(toplevelPartitionType)
+    val literal = Literal(partitionValues.last, sparkType)
+    Cast(literal, func.dataType)
+  }
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    plan.resolveExpressions {
+      case func: ApplyFunctionExpression
+          if func.function.name() == "max_pt" &&
+            func.function.canonicalName().startsWith("paimon") =>
+        replaceMaxPt(func)
+    }
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/extensions/PaimonSparkSessionExtensions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/extensions/PaimonSparkSessionExtensions.scala
@@ -18,7 +18,7 @@
 
 package org.apache.paimon.spark.extensions
 
-import org.apache.paimon.spark.catalyst.analysis.{PaimonAnalysis, PaimonDeleteTable, PaimonIncompatiblePHRRules, PaimonIncompatibleResolutionRules, PaimonMergeInto, PaimonPostHocResolutionRules, PaimonProcedureResolver, PaimonUpdateTable, PaimonViewResolver}
+import org.apache.paimon.spark.catalyst.analysis.{PaimonAnalysis, PaimonDeleteTable, PaimonIncompatiblePHRRules, PaimonIncompatibleResolutionRules, PaimonMergeInto, PaimonPostHocResolutionRules, PaimonProcedureResolver, PaimonUpdateTable, PaimonViewResolver, ReplacePaimonFunctions}
 import org.apache.paimon.spark.catalyst.optimizer.{EvalSubqueriesForDeleteTable, MergePaimonScalarSubqueries}
 import org.apache.paimon.spark.catalyst.plans.logical.PaimonTableValuedFunctions
 import org.apache.paimon.spark.execution.PaimonStrategy
@@ -44,6 +44,7 @@ class PaimonSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
       spark => SparkShimLoader.getSparkShim.createCustomResolution(spark))
     extensions.injectResolutionRule(spark => PaimonIncompatibleResolutionRules(spark))
 
+    extensions.injectPostHocResolutionRule(spark => ReplacePaimonFunctions(spark))
     extensions.injectPostHocResolutionRule(spark => PaimonPostHocResolutionRules(spark))
     extensions.injectPostHocResolutionRule(spark => PaimonIncompatiblePHRRules(spark))
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->

Adds a new Spark function `max_pt`. It accpets a string type literal and return a max-valid-toplevel partition value.
- `valid` means the partition contains data files
- `toplevel` means only return the first partition value if the table has multi-partition columns

`max_pt` will throw exception when:
- the table is not a partitioned table
- the partitioned table does not have partition
- all of the partitions do not contains data files

This pr adds `max_pt` through spark v2 function catalog using a fake scalar function and then adds a rule to replace `max_pt` to a literal value during analysis.

Example:
```sql
SELECT max_pt('t')
=>
20250101
```

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
add `sql-functions` docs