### PR TITLE
[spark] Support stream write toTable

### DIFF
--- a/docs/content/spark/sql-write.md
+++ b/docs/content/spark/sql-write.md
@@ -227,13 +227,20 @@ spark.sql(s"""
 val inputData = MemoryStream[(Int, String)]
 val df = inputData.toDS().toDF("k", "v")
 
-// Streaming Write to paimon table.
+// Streaming Write to paimon table, you can specify either the target table path or the table name.
 val stream = df
   .writeStream
   .outputMode("append")
   .option("checkpointLocation", "/path/to/checkpoint")
   .format("paimon")
   .start("/path/to/paimon/sink/table")
+
+val stream = df
+  .writeStream
+  .outputMode("append")
+  .option("checkpointLocation", "/path/to/checkpoint")
+  .format("paimon")
+  .toTable("tableName")
 ```
 
 ## Schema Evolution

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkTable.scala
@@ -134,7 +134,7 @@ case class SparkTable(table: Table)
             None,
             None,
             compressed = false,
-            properties = properties.asScala.toMap),
+            properties = props),
           owner = props.getOrElse(TableCatalog.PROP_OWNER, ""),
           schema = schema,
           provider = Some(SparkSource.NAME)

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/PaimonUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/PaimonUtils.scala
@@ -21,6 +21,7 @@ package org.apache.spark.sql
 import org.apache.spark.executor.OutputMetrics
 import org.apache.spark.rdd.InputFileBlockHolder
 import org.apache.spark.sql.catalyst.analysis.Resolver
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -124,5 +125,9 @@ object PaimonUtils {
 
   def sameType(left: DataType, right: DataType): Boolean = {
     left.sameType(right)
+  }
+
+  trait V2TableWithV1Fallback extends org.apache.spark.sql.connector.catalog.V2TableWithV1Fallback {
+    def v1Table: CatalogTable
   }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

to #4355, support

```
df
.writeStream
.option("checkpointLocation", checkpointDir.getCanonicalPath)
.format("paimon")
.toTable("T")
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
