### PR TITLE
[flink] Support specifying what partitions to scan in Flink

### DIFF
--- a/docs/content/flink/sql-lookup.md
+++ b/docs/content/flink/sql-lookup.md
@@ -143,12 +143,16 @@ CREATE TABLE customers (
 ```sql
 SELECT o.order_id, o.total, c.country, c.zip
 FROM orders AS o
-JOIN customers /*+ OPTIONS('lookup.dynamic-partition'='max_pt()', 'lookup.dynamic-partition.refresh-interval'='1 h') */
+JOIN customers /*+ OPTIONS('scan.partitions'='max_pt()', 'lookup.dynamic-partition.refresh-interval'='1 h') */
 FOR SYSTEM_TIME AS OF o.proc_time AS c
 ON o.customer_id = c.id;
 ```
 
 The Lookup node will automatically refresh the latest partition and query the data of the latest partition.
+
+The option `scan.partitions` can also specify fixed partitions in the form of `key1=value1,key2=value2`.
+Multiple partitions should be separated by semicolon (`;`).
+When specifying fixed partitions, this option can also be used in batch joins.
 
 ## Query Service
 

--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -57,12 +57,6 @@ under the License.
             <td>The cache mode of lookup join.<br /><br />Possible values:<ul><li>"AUTO"</li><li>"FULL"</li></ul></td>
         </tr>
         <tr>
-            <td><h5>lookup.dynamic-partition</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
-            <td>Specific dynamic partition for lookup, supports 'max_pt()' and 'max_two_pt()' currently.</td>
-        </tr>
-        <tr>
             <td><h5>lookup.dynamic-partition.refresh-interval</h5></td>
             <td style="word-wrap: break-word;">1 h</td>
             <td>Duration</td>
@@ -133,6 +127,12 @@ under the License.
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
             <td>Define a custom parallelism for the scan source. By default, if this option is not defined, the planner will derive the parallelism for each statement individually by also considering the global configuration. If user enable the scan.infer-parallelism, the planner will derive the parallelism by inferred parallelism.</td>
+        </tr>
+        <tr>
+            <td><h5>scan.partitions</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Specify the partitions to scan. Partitions should be given in the form of key1=value1,key2=value2. Partition keys not specified will be filled with the value of partition.default-name. Multiple partitions should be separated by semicolon (;). This option can support normal source tables and lookup join tables. For lookup joins, two special values max_pt() and max_two_pt() are also supported, specifying the (two) partition(s) with the largest partition value.</td>
         </tr>
         <tr>
             <td><h5>scan.remove-normalize</h5></td>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -283,12 +283,20 @@ public class FlinkConnectorOptions {
                     .defaultValue(LookupCacheMode.AUTO)
                     .withDescription("The cache mode of lookup join.");
 
-    public static final ConfigOption<String> LOOKUP_DYNAMIC_PARTITION =
-            ConfigOptions.key("lookup.dynamic-partition")
+    public static final ConfigOption<String> SCAN_PARTITIONS =
+            ConfigOptions.key("scan.partitions")
                     .stringType()
                     .noDefaultValue()
+                    .withFallbackKeys("lookup.dynamic-partition")
                     .withDescription(
-                            "Specific dynamic partition for lookup, supports 'max_pt()' and 'max_two_pt()' currently.");
+                            "Specify the partitions to scan. "
+                                    + "Partitions should be given in the form of key1=value1,key2=value2. "
+                                    + "Partition keys not specified will be filled with the value of "
+                                    + CoreOptions.PARTITION_DEFAULT_NAME.key()
+                                    + ". Multiple partitions should be separated by semicolon (;). "
+                                    + "This option can support normal source tables and lookup join tables. "
+                                    + "For lookup joins, two special values max_pt() and max_two_pt() are also supported, "
+                                    + "specifying the (two) partition(s) with the largest partition value.");
 
     public static final ConfigOption<Duration> LOOKUP_DYNAMIC_PARTITION_REFRESH_INTERVAL =
             ConfigOptions.key("lookup.dynamic-partition.refresh-interval")

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -80,7 +80,7 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(FileStoreLookupFunction.class);
 
     private final Table table;
-    @Nullable private final DynamicPartitionLoader partitionLoader;
+    @Nullable private final PartitionLoader partitionLoader;
     private final List<String> projectFields;
     private final List<String> joinKeys;
     @Nullable private final Predicate predicate;
@@ -101,7 +101,10 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
     @Nullable private Filter<InternalRow> cacheRowFilter;
 
     public FileStoreLookupFunction(
-            Table table, int[] projection, int[] joinKeyIndex, @Nullable Predicate predicate) {
+            FileStoreTable table,
+            int[] projection,
+            int[] joinKeyIndex,
+            @Nullable Predicate predicate) {
         if (!TableScanUtils.supportCompactDiffStreamingReading(table)) {
             TableScanUtils.streamingReadingValidate(table);
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PartitionLoader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PartitionLoader.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.lookup;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.flink.FlinkConnectorOptions;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.partition.PartitionPredicate;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.ParameterUtils;
+import org.apache.paimon.utils.Preconditions;
+import org.apache.paimon.utils.RowDataToObjectArrayConverter;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Specify partitions for lookup tables. */
+public abstract class PartitionLoader implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String MAX_PT = "max_pt()";
+    private static final String MAX_TWO_PT = "max_two_pt()";
+
+    protected final FileStoreTable table;
+    private final RowDataToObjectArrayConverter partitionConverter;
+
+    protected transient List<BinaryRow> partitions;
+
+    protected PartitionLoader(FileStoreTable table) {
+        this.table = table;
+        this.partitionConverter =
+                new RowDataToObjectArrayConverter(table.rowType().project(table.partitionKeys()));
+    }
+
+    public void open() {
+        this.partitions = new ArrayList<>();
+    }
+
+    public List<BinaryRow> partitions() {
+        return partitions;
+    }
+
+    public void addPartitionKeysTo(List<String> joinKeys, List<String> projectFields) {
+        List<String> partitionKeys = table.partitionKeys();
+        Preconditions.checkArgument(
+                joinKeys.stream().noneMatch(partitionKeys::contains),
+                "Currently, Paimon lookup table with partitions does not support partition keys in join keys.");
+        joinKeys.addAll(partitionKeys);
+
+        partitionKeys.stream().filter(k -> !projectFields.contains(k)).forEach(projectFields::add);
+    }
+
+    public Predicate createSpecificPartFilter() {
+        Predicate partFilter = null;
+        for (BinaryRow partition : partitions) {
+            if (partFilter == null) {
+                partFilter = createSinglePartFilter(partition);
+            } else {
+                partFilter = PredicateBuilder.or(partFilter, createSinglePartFilter(partition));
+            }
+        }
+        return partFilter;
+    }
+
+    private Predicate createSinglePartFilter(BinaryRow partition) {
+        RowType rowType = table.rowType();
+        List<String> partitionKeys = table.partitionKeys();
+        Object[] partitionSpec = partitionConverter.convert(partition);
+        Map<String, Object> partitionMap = new HashMap<>(partitionSpec.length);
+        for (int i = 0; i < partitionSpec.length; i++) {
+            partitionMap.put(partitionKeys.get(i), partitionSpec[i]);
+        }
+
+        // create partition predicate base on rowType instead of partitionType
+        return PartitionPredicate.createPartitionPredicate(rowType, partitionMap);
+    }
+
+    /** @return true if partition changed. */
+    public abstract boolean checkRefresh();
+
+    @Nullable
+    public static PartitionLoader of(FileStoreTable table) {
+        Options options = Options.fromMap(table.options());
+        String scanPartitions = options.get(FlinkConnectorOptions.SCAN_PARTITIONS);
+        if (scanPartitions == null) {
+            return null;
+        }
+
+        Preconditions.checkArgument(
+                !table.partitionKeys().isEmpty(),
+                "{} is not supported for non-partitioned table.",
+                FlinkConnectorOptions.SCAN_PARTITIONS.key());
+
+        int maxPartitionNum = -1;
+        switch (scanPartitions.toLowerCase()) {
+            case MAX_PT:
+                maxPartitionNum = 1;
+                break;
+            case MAX_TWO_PT:
+                maxPartitionNum = 2;
+                break;
+        }
+
+        if (maxPartitionNum == -1) {
+            return new StaticPartitionLoader(
+                    table, ParameterUtils.getPartitions(scanPartitions.split(";")));
+        } else {
+            Duration refresh =
+                    options.get(FlinkConnectorOptions.LOOKUP_DYNAMIC_PARTITION_REFRESH_INTERVAL);
+            return new DynamicPartitionLoader(table, refresh, maxPartitionNum);
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/StaticPartitionLoader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/StaticPartitionLoader.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.lookup;
+
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.InternalRowPartitionComputer;
+
+import java.util.List;
+import java.util.Map;
+
+/** {@link PartitionLoader} for specified static partitions. */
+public class StaticPartitionLoader extends PartitionLoader {
+
+    private final List<Map<String, String>> scanPartitions;
+
+    protected StaticPartitionLoader(
+            FileStoreTable table, List<Map<String, String>> scanPartitions) {
+        super(table);
+        this.scanPartitions = scanPartitions;
+    }
+
+    @Override
+    public boolean checkRefresh() {
+        if (partitions.isEmpty()) {
+            RowType partitionType = table.schema().logicalPartitionType();
+            InternalRowSerializer serializer = new InternalRowSerializer(partitionType);
+            for (Map<String, String> spec : scanPartitions) {
+                GenericRow row =
+                        InternalRowPartitionComputer.convertSpecToInternalRow(
+                                spec, partitionType, table.coreOptions().partitionDefaultName());
+                partitions.add(serializer.toBinaryRow(row).copy());
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkTableSource.java
@@ -24,6 +24,7 @@ import org.apache.paimon.flink.LogicalTypeConversion;
 import org.apache.paimon.flink.PredicateConverter;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.PartitionPredicateVisitor;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -32,6 +33,7 @@ import org.apache.paimon.table.DataTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.utils.ParameterUtils;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -83,6 +85,7 @@ public abstract class FlinkTableSource
             @Nullable int[][] projectFields,
             @Nullable Long limit) {
         this.table = table;
+
         this.predicate = predicate;
         this.projectFields = projectFields;
         this.limit = limit;
@@ -120,6 +123,33 @@ public abstract class FlinkTableSource
         LOG.info("Consumed filters: {} of {}", consumedFilters, filters);
 
         return Result.of(filters, unConsumedFilters);
+    }
+
+    /**
+     * This method is only used for normal source (not lookup source). Specified partitions in
+     * lookup sources are handled in {@link org.apache.paimon.flink.lookup.PartitionLoader}.
+     */
+    protected Predicate getPredicateWithScanPartitions() {
+        if (table.options().containsKey(FlinkConnectorOptions.SCAN_PARTITIONS.key())) {
+            Predicate partitionPredicate =
+                    PartitionPredicate.createPartitionPredicate(
+                            ParameterUtils.getPartitions(
+                                    table.options()
+                                            .get(FlinkConnectorOptions.SCAN_PARTITIONS.key())
+                                            .split(";")),
+                            table.rowType(),
+                            table.options()
+                                    .getOrDefault(
+                                            CoreOptions.PARTITION_DEFAULT_NAME.key(),
+                                            CoreOptions.PARTITION_DEFAULT_NAME.defaultValue()));
+            if (predicate == null) {
+                return partitionPredicate;
+            } else {
+                return PredicateBuilder.and(predicate, partitionPredicate);
+            }
+        } else {
+            return predicate;
+        }
     }
 
     @Override
@@ -194,7 +224,10 @@ public abstract class FlinkTableSource
     }
 
     private TableScan newTableScan() {
-        return table.newReadBuilder().dropStats().withFilter(predicate).newScan();
+        return table.newReadBuilder()
+                .dropStats()
+                .withFilter(getPredicateWithScanPartitions())
+                .newScan();
     }
 
     /** Split statistics for inferring row count and parallelism size. */

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/SystemTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/SystemTableSource.java
@@ -93,7 +93,7 @@ public class SystemTableSource extends FlinkTableSource {
         if (readType != null) {
             readBuilder.withReadType(readType);
         }
-        readBuilder.withFilter(predicate);
+        readBuilder.withFilter(getPredicateWithScanPartitions());
 
         if (unbounded && table instanceof DataTable) {
             source =

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/FileStoreLookupFunctionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/FileStoreLookupFunctionTest.java
@@ -34,7 +34,6 @@ import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.service.ServiceManager;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
-import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.StreamTableWrite;
 import org.apache.paimon.table.sink.TableCommitImpl;
@@ -103,7 +102,8 @@ public class FileStoreLookupFunctionTest {
         lookupFunction.open(tempDir.toString());
     }
 
-    private FileStoreLookupFunction createLookupFunction(Table table, boolean joinEqualPk) {
+    private FileStoreLookupFunction createLookupFunction(
+            FileStoreTable table, boolean joinEqualPk) {
         return new FileStoreLookupFunction(
                 table, new int[] {0, 1}, joinEqualPk ? new int[] {0, 1} : new int[] {1}, null);
     }
@@ -118,7 +118,7 @@ public class FileStoreLookupFunctionTest {
         conf.set(CoreOptions.SNAPSHOT_NUM_RETAINED_MIN, 2);
         conf.set(RocksDBOptions.LOOKUP_CONTINUOUS_DISCOVERY_INTERVAL, Duration.ofSeconds(1));
         if (dynamicPartition) {
-            conf.set(FlinkConnectorOptions.LOOKUP_DYNAMIC_PARTITION, "max_pt()");
+            conf.set(FlinkConnectorOptions.SCAN_PARTITIONS, "max_pt()");
         }
 
         RowType rowType =
@@ -225,9 +225,9 @@ public class FileStoreLookupFunctionTest {
 
     @Test
     public void testParseWrongTimePeriodsBlacklist() throws Exception {
-        Table table = createFileStoreTable(false, false, false);
+        FileStoreTable table = createFileStoreTable(false, false, false);
 
-        Table table1 =
+        FileStoreTable table1 =
                 table.copy(
                         Collections.singletonMap(
                                 LOOKUP_REFRESH_TIME_PERIODS_BLACKLIST.key(),
@@ -238,7 +238,7 @@ public class FileStoreLookupFunctionTest {
                                 IllegalArgumentException.class,
                                 "Incorrect time periods format: [2024-10-31 12:00,2024-10-31 16:00]."));
 
-        Table table2 =
+        FileStoreTable table2 =
                 table.copy(
                         Collections.singletonMap(
                                 LOOKUP_REFRESH_TIME_PERIODS_BLACKLIST.key(),
@@ -249,7 +249,7 @@ public class FileStoreLookupFunctionTest {
                                 IllegalArgumentException.class,
                                 "Date time format error: [20241031 12:00]"));
 
-        Table table3 =
+        FileStoreTable table3 =
                 table.copy(
                         Collections.singletonMap(
                                 LOOKUP_REFRESH_TIME_PERIODS_BLACKLIST.key(),
@@ -271,7 +271,7 @@ public class FileStoreLookupFunctionTest {
         String left = start.atZone(ZoneId.systemDefault()).format(formatter);
         String right = end.atZone(ZoneId.systemDefault()).format(formatter);
 
-        Table table =
+        FileStoreTable table =
                 createFileStoreTable(false, false, false)
                         .copy(
                                 Collections.singletonMap(


### PR DESCRIPTION
### Purpose

Lookup joins in streaming SQL is the same as normal joins in batch SQL. However, when specifying what partitions to scan in lookup joins, currently user can specify `max_pt()` through SQL hints to read the latest partition, without specifying a fixed partition. Such SQL hint is not supported in batch joins.

Paimon is a streaming-batch unified lake format. To also support streaming-batch unification in SQL, this PR introduces a new option `scan.partitions`, which accepts both `max_pt()` (in lookup joins) and fixed partitions (in all joins). Users only need to change the value of this option to specify different partitions for streaming and batch jobs, and they don't need to change SQL itself.

### Tests

Unit tests and IT cases.

### API and Format

No format changes.

### Documentation

Document is also added.
