### PR TITLE
[hotfix] Rename MongdbSchemaUtils to MongDBSchemaUtils

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBSchemaUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBSchemaUtils.java
@@ -52,7 +52,7 @@ import static org.apache.paimon.flink.action.cdc.mongodb.MongoDBActionUtils.STAR
  * schema details are provided explicitly, while in the DYNAMIC mode, the schema is inferred from
  * the first document in the collection.
  */
-public class MongodbSchemaUtils {
+public class MongoDBSchemaUtils {
 
     private static final String ID_FIELD = "_id";
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBSyncTableAction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBSyncTableAction.java
@@ -60,7 +60,7 @@ public class MongoDBSyncTableAction extends SyncTableActionBase {
 
     @Override
     protected Schema retrieveSchema() {
-        return MongodbSchemaUtils.getMongodbSchema(cdcSourceConfig);
+        return MongoDBSchemaUtils.getMongodbSchema(cdcSourceConfig);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBSchemaITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mongodb/MongoDBSchemaITCase.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Tests for {@link MongoDBSchemaUtils}. */
-public class MongodbSchemaITCase extends MongoDBActionITCaseBase {
+public class MongoDBSchemaITCase extends MongoDBActionITCaseBase {
 
     @BeforeAll
     public static void initMongoDB() {

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mongodb/MongodbSchemaITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mongodb/MongodbSchemaITCase.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-/** Tests for {@link MongodbSchemaUtils}. */
+/** Tests for {@link MongoDBSchemaUtils}. */
 public class MongodbSchemaITCase extends MongoDBActionITCaseBase {
 
     @BeforeAll
@@ -82,7 +82,7 @@ public class MongodbSchemaITCase extends MongoDBActionITCaseBase {
         mongodbConfig.set(MongoDBSourceOptions.CONNECTION_OPTIONS, "authSource=admin");
         mongodbConfig.set(MongoDBSourceOptions.DATABASE, "testDatabase");
         mongodbConfig.set(MongoDBSourceOptions.COLLECTION, "testCollection");
-        Schema schema = MongodbSchemaUtils.getMongodbSchema(mongodbConfig);
+        Schema schema = MongoDBSchemaUtils.getMongodbSchema(mongodbConfig);
         assertNotNull(schema);
     }
 
@@ -97,7 +97,7 @@ public class MongodbSchemaITCase extends MongoDBActionITCaseBase {
         mongodbConfig.set(MongoDBSourceOptions.COLLECTION, "testCollection");
 
         assertThrows(
-                RuntimeException.class, () -> MongodbSchemaUtils.getMongodbSchema(mongodbConfig));
+                RuntimeException.class, () -> MongoDBSchemaUtils.getMongodbSchema(mongodbConfig));
     }
 
     @Test
@@ -108,7 +108,7 @@ public class MongodbSchemaITCase extends MongoDBActionITCaseBase {
         // Expect an exception to be thrown due to missing necessary settings
         assertThrows(
                 NullPointerException.class,
-                () -> MongodbSchemaUtils.getMongodbSchema(mongodbConfig));
+                () -> MongoDBSchemaUtils.getMongodbSchema(mongodbConfig));
     }
 
     @Test
@@ -123,7 +123,7 @@ public class MongodbSchemaITCase extends MongoDBActionITCaseBase {
         mongodbConfig.set(MongoDBSourceOptions.COLLECTION, "testCollection");
 
         // Call the method and check the results
-        Schema schema = MongodbSchemaUtils.getMongodbSchema(mongodbConfig);
+        Schema schema = MongoDBSchemaUtils.getMongodbSchema(mongodbConfig);
 
         // Verify the schema
         assertNotNull(schema);
@@ -147,7 +147,7 @@ public class MongodbSchemaITCase extends MongoDBActionITCaseBase {
         mongodbConfig.set(MongoDBSourceOptions.COLLECTION, "testCollection");
 
         assertThrows(
-                RuntimeException.class, () -> MongodbSchemaUtils.getMongodbSchema(mongodbConfig));
+                RuntimeException.class, () -> MongoDBSchemaUtils.getMongodbSchema(mongodbConfig));
     }
 
     @Test
@@ -161,6 +161,6 @@ public class MongodbSchemaITCase extends MongoDBActionITCaseBase {
         mongodbConfig.set(MongoDBSourceOptions.COLLECTION, "invalidCollection");
 
         assertThrows(
-                RuntimeException.class, () -> MongodbSchemaUtils.getMongodbSchema(mongodbConfig));
+                RuntimeException.class, () -> MongoDBSchemaUtils.getMongodbSchema(mongodbConfig));
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->
Rename MongdbSchemaUtils to MongDBSchemaUtils, MongodbSchemaITCase to MongoDBSchemaITCase ,and make its naming standardised.
<img width="627" alt="image" src="https://github.com/user-attachments/assets/6ae7c6ee-eb30-42d5-b29d-86ee0650e5ab" />

<img width="684" alt="image" src="https://github.com/user-attachments/assets/b5a2214c-69c0-4463-92ce-84255ccca1db" />

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
