### PR TITLE
[hotfix] Fix earliestSnapshot stability

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -129,7 +129,11 @@ public class SnapshotManagerTest {
 
             if (millis.get(numSnapshots - 1) < time) {
                 if (isRaceCondition && millis.size() == 1) {
-                    assertThat(actual).isNull();
+                    if (tries == 0) {
+                        assertThat(actual).isLessThanOrEqualTo(firstSnapshotId);
+                    } else {
+                        assertThat(actual).isNull();
+                    }
                 } else {
                     assertThat(actual).isEqualTo(firstSnapshotId + numSnapshots - 1);
                 }
@@ -138,7 +142,7 @@ public class SnapshotManagerTest {
                     if (millis.get(i) >= time) {
                         if (isRaceCondition && i == 0) {
                             // The first snapshot expired during invocation
-                            if (millis.size() == 1) {
+                            if (millis.size() == 1 && tries > 0) {
                                 assertThat(actual).isNull();
                             } else {
                                 assertThat(actual).isLessThanOrEqualTo(firstSnapshotId);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

This PR fixes earliestSnapshot test case failures.
* Improve earliestSnapshot retry number according to latest snapshot id
* Fix SnapshotManager#earlierThanTimeMills return value when earliest snapshot cannot be found
* Fix test case expected result according to invocation time.

<!-- What is the purpose of the change -->

### Tests

SnapshotManagerTest

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
