### PR TITLE
[pom] Fix RoaringBitmap dependency problem in partial building

### DIFF
--- a/paimon-benchmark/paimon-micro-benchmarks/pom.xml
+++ b/paimon-benchmark/paimon-micro-benchmarks/pom.xml
@@ -57,6 +57,12 @@ under the License.
             <version>${log4j.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.roaringbitmap</groupId>
+            <artifactId>RoaringBitmap</artifactId>
+            <version>${roaringbitmap.version}</version>
+        </dependency>
+
         <!-- Orc and parquet dependencies -->
 
         <dependency>

--- a/paimon-common/pom.xml
+++ b/paimon-common/pom.xml
@@ -144,7 +144,7 @@ under the License.
         <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>
-            <version>1.2.1</version>
+            <version>${roaringbitmap.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@ under the License.
         <parquet.version>1.13.1</parquet.version>
         <orc.version>1.9.2</orc.version>
         <protobuf-java.version>3.19.6</protobuf-java.version>
+        <roaringbitmap.version>1.2.1</roaringbitmap.version>
 
         <!-- Can be set to any value to reproduce a specific build. -->
         <test.randomization.seed/>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
See https://github.com/apache/paimon/pull/4859

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
