### PR TITLE
[spark] AbstractSparkInternalRow supports fallback equals and hashCode

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/GenericMap.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/GenericMap.java
@@ -64,6 +64,10 @@ public final class GenericMap implements InternalMap, Serializable {
         return map.get(key);
     }
 
+    public boolean contains(Object key) {
+        return map.containsKey(key);
+    }
+
     @Override
     public int size() {
         return map.size();

--- a/paimon-common/src/main/java/org/apache/paimon/utils/InternalRowUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/InternalRowUtils.java
@@ -62,28 +62,26 @@ public class InternalRowUtils {
         }
         if (data1 != null) {
             if (data1 instanceof InternalRow) {
-                int i = 0;
                 RowType rowType = (RowType) dataType;
                 int len = rowType.getFieldCount();
-                while (i < len) {
+                for (int i = 0; i < len; i++) {
                     Object value1 = get((InternalRow) data1, i, rowType.getTypeAt(i));
                     Object value2 = get((InternalRow) data2, i, rowType.getTypeAt(i));
                     if (!equals(value1, value2, rowType.getTypeAt(i))) {
                         return false;
                     }
-                    i += 1;
                 }
             } else if (data1 instanceof InternalArray) {
-                int i = 0;
+                if (((InternalArray) data1).size() != ((InternalArray) data2).size()) {
+                    return false;
+                }
                 ArrayType arrayType = (ArrayType) dataType;
-                int len = ((InternalArray) data1).size();
-                while (i < len) {
+                for (int i = 0; i < ((InternalArray) data1).size(); i++) {
                     Object value1 = get((InternalArray) data1, i, arrayType.getElementType());
                     Object value2 = get((InternalArray) data2, i, arrayType.getElementType());
                     if (!equals(value1, value2, arrayType.getElementType())) {
                         return false;
                     }
-                    i += 1;
                 }
             } else if (data1 instanceof InternalMap) {
                 if (((InternalMap) data1).size() != ((InternalMap) data2).size()) {
@@ -107,7 +105,6 @@ public class InternalRowUtils {
                                     mapType.getKeyType(),
                                     mapType.getValueType());
                 }
-
                 InternalArray keyArray1 = map1.keyArray();
                 for (int i = 0; i < map1.size(); i++) {
                     Object key = get(keyArray1, i, mapType.getKeyType());
@@ -144,21 +141,17 @@ public class InternalRowUtils {
         int result = 0;
         if (data instanceof InternalRow) {
             RowType rowType = (RowType) dataType;
-            int i = 0;
             int len = rowType.getFieldCount();
-            while (i < len) {
+            for (int i = 0; i < len; i++) {
                 Object v = get((InternalRow) data, i, rowType.getTypeAt(i));
                 result = 37 * result + hash(v, rowType.getTypeAt(i));
-                i += 1;
             }
         } else if (data instanceof InternalArray) {
             ArrayType arrayType = (ArrayType) dataType;
-            int i = 0;
             int len = ((InternalArray) data).size();
-            while (i < len) {
+            for (int i = 0; i < len; i++) {
                 Object v = get((InternalArray) data, i, arrayType.getElementType());
                 result = 37 * result + hash(v, arrayType.getElementType());
-                i += 1;
             }
         } else if (data instanceof InternalMap) {
             MapType mapType = (MapType) dataType;

--- a/paimon-common/src/main/java/org/apache/paimon/utils/InternalRowUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/InternalRowUtils.java
@@ -48,12 +48,141 @@ import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 /** Utils for {@link InternalRow} structures. */
 public class InternalRowUtils {
+
+    public static boolean equals(Object data1, Object data2, DataType dataType) {
+        if ((data1 == null) != (data2 == null)) {
+            return false;
+        }
+        if (data1 != null) {
+            if (data1 instanceof InternalRow) {
+                int i = 0;
+                RowType rowType = (RowType) dataType;
+                int len = rowType.getFieldCount();
+                while (i < len) {
+                    Object value1 = get((InternalRow) data1, i, rowType.getTypeAt(i));
+                    Object value2 = get((InternalRow) data2, i, rowType.getTypeAt(i));
+                    if (!equals(value1, value2, rowType.getTypeAt(i))) {
+                        return false;
+                    }
+                    i += 1;
+                }
+            } else if (data1 instanceof InternalArray) {
+                int i = 0;
+                ArrayType arrayType = (ArrayType) dataType;
+                int len = ((InternalArray) data1).size();
+                while (i < len) {
+                    Object value1 = get((InternalArray) data1, i, arrayType.getElementType());
+                    Object value2 = get((InternalArray) data2, i, arrayType.getElementType());
+                    if (!equals(value1, value2, arrayType.getElementType())) {
+                        return false;
+                    }
+                    i += 1;
+                }
+            } else if (data1 instanceof InternalMap) {
+                if (((InternalMap) data1).size() != ((InternalMap) data2).size()) {
+                    return false;
+                }
+                MapType mapType = (MapType) dataType;
+                GenericMap map1;
+                GenericMap map2;
+                if (data1 instanceof GenericMap) {
+                    map1 = (GenericMap) data1;
+                    map2 = (GenericMap) data2;
+                } else {
+                    map1 =
+                            copyToGenericMap(
+                                    (InternalMap) data1,
+                                    mapType.getKeyType(),
+                                    mapType.getValueType());
+                    map2 =
+                            copyToGenericMap(
+                                    (InternalMap) data2,
+                                    mapType.getKeyType(),
+                                    mapType.getValueType());
+                }
+
+                InternalArray keyArray1 = map1.keyArray();
+                for (int i = 0; i < map1.size(); i++) {
+                    Object key = get(keyArray1, i, mapType.getKeyType());
+                    if (!map2.contains(key)
+                            || !equals(map1.get(key), map2.get(key), mapType.getValueType())) {
+                        return false;
+                    }
+                }
+            } else if (data1 instanceof byte[]) {
+                if (!java.util.Arrays.equals((byte[]) data1, (byte[]) data2)) {
+                    return false;
+                }
+            } else if (data1 instanceof Float && java.lang.Float.isNaN((Float) data1)) {
+                if (!java.lang.Float.isNaN((Float) data2)) {
+                    return false;
+                }
+            } else if (data1 instanceof Double && java.lang.Double.isNaN((Double) data1)) {
+                if (!java.lang.Double.isNaN((Double) data2)) {
+                    return false;
+                }
+            } else {
+                if (!data1.equals(data2)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    public static int hash(Object data, DataType dataType) {
+        if (data == null) {
+            return 0;
+        }
+        int result = 0;
+        if (data instanceof InternalRow) {
+            RowType rowType = (RowType) dataType;
+            int i = 0;
+            int len = rowType.getFieldCount();
+            while (i < len) {
+                Object v = get((InternalRow) data, i, rowType.getTypeAt(i));
+                result = 37 * result + hash(v, rowType.getTypeAt(i));
+                i += 1;
+            }
+        } else if (data instanceof InternalArray) {
+            ArrayType arrayType = (ArrayType) dataType;
+            int i = 0;
+            int len = ((InternalArray) data).size();
+            while (i < len) {
+                Object v = get((InternalArray) data, i, arrayType.getElementType());
+                result = 37 * result + hash(v, arrayType.getElementType());
+                i += 1;
+            }
+        } else if (data instanceof InternalMap) {
+            MapType mapType = (MapType) dataType;
+            GenericMap map;
+            if (data instanceof GenericMap) {
+                map = (GenericMap) data;
+            } else {
+                map =
+                        copyToGenericMap(
+                                (InternalMap) data, mapType.getKeyType(), mapType.getValueType());
+            }
+            InternalArray keyArray = map.keyArray();
+            for (int i = 0; i < map.size(); i++) {
+                Object key = get(keyArray, i, mapType.getKeyType());
+                result = 37 * result + hash(key, mapType.getKeyType());
+                result = 37 * result + hash(map.get(key), mapType.getValueType());
+            }
+        } else if (data instanceof byte[]) {
+            result = Arrays.hashCode((byte[]) data);
+        } else {
+            result = data.hashCode();
+        }
+        return result;
+    }
 
     public static InternalRow copyInternalRow(InternalRow row, RowType rowType) {
         if (row instanceof BinaryRow) {
@@ -117,6 +246,11 @@ public class InternalRowUtils {
             return ((BinaryMap) map).copy();
         }
 
+        return copyToGenericMap(map, keyType, valueType);
+    }
+
+    private static GenericMap copyToGenericMap(
+            InternalMap map, DataType keyType, DataType valueType) {
         Map<Object, Object> javaMap = new HashMap<>();
         InternalArray keys = map.keyArray();
         InternalArray values = map.valueArray();
@@ -145,6 +279,10 @@ public class InternalRowUtils {
                 return copyMap(
                         (InternalMap) o, ((MultisetType) type).getElementType(), new IntType());
             }
+        } else if (o instanceof byte[]) {
+            byte[] copy = new byte[((byte[]) o).length];
+            System.arraycopy(((byte[]) o), 0, copy, 0, ((byte[]) o).length);
+            return copy;
         } else if (o instanceof Decimal) {
             return ((Decimal) o).copy();
         }

--- a/paimon-common/src/test/java/org/apache/paimon/utils/InternalRowUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/InternalRowUtilsTest.java
@@ -186,12 +186,40 @@ public class InternalRowUtilsTest {
         row1.setField(4, new GenericArray(new GenericRow[] {GenericRow.of(1), GenericRow.of(10)}));
         Map<BinaryString, InternalRow> map = new HashMap<>();
         map.put(BinaryString.fromString("a"), GenericRow.of(1));
-        map.put(BinaryString.fromString("a"), GenericRow.of(2));
+        map.put(BinaryString.fromString("b"), GenericRow.of(2));
         row1.setField(5, new GenericMap(map));
         row1.setField(6, GenericRow.of(1));
         GenericRow row2 = (GenericRow) InternalRowUtils.copyInternalRow(row1, rowType);
         assertThat(InternalRowUtils.equals(row1, row2, rowType)).isTrue();
         assertThat(InternalRowUtils.hash(row1, rowType))
                 .isEqualTo(InternalRowUtils.hash(row2, rowType));
+    }
+
+    @Test
+    public void testEqualsAndHashCodeNegativeCase() {
+        // different array len
+        RowType rowType = RowType.builder().field("f1", DataTypes.ARRAY(DataTypes.INT())).build();
+        GenericRow rowWithArray1 = new GenericRow(1);
+        rowWithArray1.setField(
+                0, new GenericArray(new GenericRow[] {GenericRow.of(1), GenericRow.of(10)}));
+        GenericRow rowWithArray2 = new GenericRow(1);
+        rowWithArray2.setField(0, new GenericArray(new GenericRow[] {GenericRow.of(1)}));
+        assertThat(InternalRowUtils.equals(rowWithArray1, rowWithArray2, rowType)).isFalse();
+
+        // different map len
+        RowType rowType2 =
+                RowType.builder()
+                        .field("f1", DataTypes.MAP(DataTypes.STRING(), DataTypes.INT()))
+                        .build();
+        Map<BinaryString, InternalRow> map1 = new HashMap<>();
+        map1.put(BinaryString.fromString("a"), GenericRow.of(1));
+        map1.put(BinaryString.fromString("b"), GenericRow.of(2));
+        GenericRow rowWithMap1 = new GenericRow(1);
+        rowWithMap1.setField(0, new GenericMap(map1));
+        Map<BinaryString, InternalRow> map2 = new HashMap<>();
+        map2.put(BinaryString.fromString("a"), GenericRow.of(1));
+        GenericRow rowWithMap2 = new GenericRow(1);
+        rowWithMap2.setField(0, new GenericMap(map2));
+        assertThat(InternalRowUtils.equals(rowWithMap1, rowWithMap2, rowType2)).isFalse();
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/utils/InternalRowUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/InternalRowUtilsTest.java
@@ -21,6 +21,9 @@ package org.apache.paimon.utils;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Decimal;
+import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericMap;
+import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
@@ -37,6 +40,8 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -52,6 +57,7 @@ public class InternalRowUtilsTest {
                     .field("intArray", DataTypes.ARRAY(DataTypes.INT()).nullable())
                     .field("char", DataTypes.CHAR(10).notNull())
                     .field("varchar", DataTypes.VARCHAR(10).notNull())
+                    .field("binary", DataTypes.BINARY(10).notNull())
                     .field("boolean", DataTypes.BOOLEAN().nullable())
                     .field("tinyint", DataTypes.TINYINT())
                     .field("smallint", DataTypes.SMALLINT())
@@ -143,5 +149,49 @@ public class InternalRowUtilsTest {
                                 BinaryString.fromString("b"),
                                 DataTypeRoot.VARCHAR))
                 .isLessThan(0);
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        for (int i = 0; i < 10; i++) {
+            GenericRow row1 = (GenericRow) rowDataGenerator.next();
+            GenericRow row2 = (GenericRow) InternalRowUtils.copyInternalRow(row1, ROW_TYPE);
+            GenericRow row3 = (GenericRow) rowDataGenerator.next();
+            assertThat(InternalRowUtils.equals(row1, row2, ROW_TYPE)).isTrue();
+            assertThat(InternalRowUtils.equals(row1, row3, ROW_TYPE)).isFalse();
+
+            assertThat(InternalRowUtils.hash(row1, ROW_TYPE))
+                    .isEqualTo(InternalRowUtils.hash(row2, ROW_TYPE));
+            assertThat(InternalRowUtils.hash(row1, ROW_TYPE))
+                    .isNotEqualTo(InternalRowUtils.hash(row3, ROW_TYPE));
+        }
+
+        RowType rowType =
+                RowType.builder()
+                        .field("f1", DataTypes.DOUBLE())
+                        .field("f2", DataTypes.FLOAT())
+                        .field("f3", DataTypes.BINARY(3))
+                        .field("f4", DataTypes.STRING())
+                        .field("f5", DataTypes.ARRAY(DataTypes.ROW(DataTypes.INT())))
+                        .field(
+                                "f6",
+                                DataTypes.MAP(DataTypes.STRING(), DataTypes.ROW(DataTypes.INT())))
+                        .field("f7", DataTypes.ROW(DataTypes.INT()))
+                        .build();
+        GenericRow row1 = new GenericRow(7);
+        row1.setField(0, Double.NaN);
+        row1.setField(1, Float.NaN);
+        row1.setField(2, "abc".getBytes());
+        row1.setField(3, null);
+        row1.setField(4, new GenericArray(new GenericRow[] {GenericRow.of(1), GenericRow.of(10)}));
+        Map<BinaryString, InternalRow> map = new HashMap<>();
+        map.put(BinaryString.fromString("a"), GenericRow.of(1));
+        map.put(BinaryString.fromString("a"), GenericRow.of(2));
+        row1.setField(5, new GenericMap(map));
+        row1.setField(6, GenericRow.of(1));
+        GenericRow row2 = (GenericRow) InternalRowUtils.copyInternalRow(row1, rowType);
+        assertThat(InternalRowUtils.equals(row1, row2, rowType)).isTrue();
+        assertThat(InternalRowUtils.hash(row1, rowType))
+                .isEqualTo(InternalRowUtils.hash(row2, rowType));
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

The `AbstractSparkInternalRow` would be passed to Spark, so it is dangerous if it would throw exception when call equals or hashcode. This pr make it fallback to suport if there is an exception.

### Tests

<!-- List UT and IT cases to verify this change -->

Pass CI

### API and Format

<!-- Does this change affect API or storage format -->

no

### Documentation

<!-- Does this change introduce a new feature -->

no