### PR TITLE
[core] Introduce Table.fileIO interface to public fileIO to file operation

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
@@ -185,7 +185,7 @@ public class CatalogUtils {
         TableSchema schema = metadata.schema();
         CoreOptions options = CoreOptions.fromMap(schema.options());
         if (options.type() == TableType.FORMAT_TABLE) {
-            return toFormatTable(identifier, schema);
+            return toFormatTable(identifier, schema, dataFileIO);
         }
 
         CatalogEnvironment catalogEnv =
@@ -249,7 +249,8 @@ public class CatalogUtils {
         return table;
     }
 
-    private static FormatTable toFormatTable(Identifier identifier, TableSchema schema) {
+    private static FormatTable toFormatTable(
+            Identifier identifier, TableSchema schema, Function<Path, FileIO> fileIO) {
         Map<String, String> options = schema.options();
         FormatTable.Format format =
                 FormatTable.parseFormat(
@@ -258,6 +259,7 @@ public class CatalogUtils {
                                 CoreOptions.FILE_FORMAT.defaultValue()));
         String location = options.get(CoreOptions.PATH.key());
         return FormatTable.builder()
+                .fileIO(fileIO.apply(new Path(location)))
                 .identifier(identifier)
                 .rowType(schema.logicalRowType())
                 .partitionKeys(schema.partitionKeys())

--- a/paimon-core/src/main/java/org/apache/paimon/table/DataTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/DataTable.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.table;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.source.DataTableScan;
@@ -53,6 +52,4 @@ public interface DataTable extends InnerTable {
     DataTable switchToBranch(String branchName);
 
     Path location();
-
-    FileIO fileIO();
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/KnownSplitsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/KnownSplitsTable.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.table;
 
+import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.InnerTableScan;
@@ -30,6 +31,7 @@ import java.util.Map;
  * A table to hold some known data splits. For now, it is only used by internal for Spark engine.
  */
 public class KnownSplitsTable implements ReadonlyTable {
+
     private final InnerTable origin;
     private final DataSplit[] splits;
 
@@ -69,6 +71,11 @@ public class KnownSplitsTable implements ReadonlyTable {
     @Override
     public Map<String, String> options() {
         return origin.options();
+    }
+
+    @Override
+    public FileIO fileIO() {
+        return origin.fileIO();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/Table.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/Table.java
@@ -21,6 +21,7 @@ package org.apache.paimon.table;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.annotation.Experimental;
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFileMeta;
@@ -85,6 +86,9 @@ public interface Table extends Serializable {
     Optional<Statistics> statistics();
 
     // ================= Table Operations ====================
+
+    /** File io of this table. */
+    FileIO fileIO();
 
     /** Copy this table with adding dynamic options. */
     Table copy(Map<String, String> dynamicOptions);

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AggregationFieldsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AggregationFieldsTable.java
@@ -101,6 +101,11 @@ public class AggregationFieldsTable implements ReadonlyTable {
     }
 
     @Override
+    public FileIO fileIO() {
+        return fileIO;
+    }
+
+    @Override
     public InnerTableScan newScan() {
         return new SchemasScan();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AllTableOptionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AllTableOptionsTable.java
@@ -23,6 +23,8 @@ import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.table.ReadonlyTable;
@@ -89,6 +91,12 @@ public class AllTableOptionsTable implements ReadonlyTable {
     @Override
     public List<String> primaryKeys() {
         return Collections.singletonList("table_name");
+    }
+
+    @Override
+    public FileIO fileIO() {
+        // pass a useless file io, should never use this.
+        return new LocalFileIO();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/BranchesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/BranchesTable.java
@@ -105,6 +105,11 @@ public class BranchesTable implements ReadonlyTable {
     }
 
     @Override
+    public FileIO fileIO() {
+        return dataTable.fileIO();
+    }
+
+    @Override
     public InnerTableScan newScan() {
         return new BranchesScan();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/BucketsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/BucketsTable.java
@@ -25,6 +25,7 @@ import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.manifest.BucketEntry;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
@@ -95,6 +96,11 @@ public class BucketsTable implements ReadonlyTable {
     @Override
     public List<String> primaryKeys() {
         return Arrays.asList("partition", "bucket");
+    }
+
+    @Override
+    public FileIO fileIO() {
+        return storeTable.fileIO();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/CatalogOptionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/CatalogOptionsTable.java
@@ -22,6 +22,8 @@ import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
@@ -91,6 +93,12 @@ public class CatalogOptionsTable implements ReadonlyTable {
     @Override
     public List<String> primaryKeys() {
         return Collections.singletonList("key");
+    }
+
+    @Override
+    public FileIO fileIO() {
+        // pass a useless file io, should never use this.
+        return new LocalFileIO();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ConsumersTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ConsumersTable.java
@@ -99,6 +99,11 @@ public class ConsumersTable implements ReadonlyTable {
     }
 
     @Override
+    public FileIO fileIO() {
+        return dataTable.fileIO();
+    }
+
+    @Override
     public InnerTableScan newScan() {
         return new ConsumersTable.ConsumersScan();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/FilesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/FilesTable.java
@@ -27,6 +27,7 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.LazyGenericRow;
 import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFilePathFactory;
 import org.apache.paimon.manifest.FileSource;
@@ -136,6 +137,11 @@ public class FilesTable implements ReadonlyTable {
     @Override
     public List<String> primaryKeys() {
         return Collections.singletonList("file_path");
+    }
+
+    @Override
+    public FileIO fileIO() {
+        return storeTable.fileIO();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ManifestsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ManifestsTable.java
@@ -26,6 +26,7 @@ import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.manifest.ManifestList;
 import org.apache.paimon.predicate.Predicate;
@@ -116,6 +117,11 @@ public class ManifestsTable implements ReadonlyTable {
     @Override
     public List<String> primaryKeys() {
         return Collections.singletonList("file_name");
+    }
+
+    @Override
+    public FileIO fileIO() {
+        return dataTable.fileIO();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/OptionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/OptionsTable.java
@@ -92,6 +92,11 @@ public class OptionsTable implements ReadonlyTable {
     }
 
     @Override
+    public FileIO fileIO() {
+        return fileIO;
+    }
+
+    @Override
     public InnerTableScan newScan() {
         return new OptionsScan();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/PartitionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/PartitionsTable.java
@@ -25,6 +25,7 @@ import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
@@ -95,6 +96,11 @@ public class PartitionsTable implements ReadonlyTable {
     @Override
     public List<String> primaryKeys() {
         return Collections.singletonList("partition");
+    }
+
+    @Override
+    public FileIO fileIO() {
+        return storeTable.fileIO();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SchemasTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SchemasTable.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.predicate.And;
 import org.apache.paimon.predicate.CompoundPredicate;
@@ -115,6 +116,11 @@ public class SchemasTable implements ReadonlyTable {
     @Override
     public List<String> primaryKeys() {
         return Collections.singletonList("schema_id");
+    }
+
+    @Override
+    public FileIO fileIO() {
+        return dataTable.fileIO();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SnapshotsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SnapshotsTable.java
@@ -135,6 +135,11 @@ public class SnapshotsTable implements ReadonlyTable {
     }
 
     @Override
+    public FileIO fileIO() {
+        return dataTable.fileIO();
+    }
+
+    @Override
     public InnerTableScan newScan() {
         return new SnapshotsScan();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/StatisticTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/StatisticTable.java
@@ -22,6 +22,7 @@ import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.EmptyRecordReader;
@@ -91,6 +92,11 @@ public class StatisticTable implements ReadonlyTable {
     @Override
     public List<String> primaryKeys() {
         return Collections.singletonList("snapshot_id");
+    }
+
+    @Override
+    public FileIO fileIO() {
+        return dataTable.fileIO();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/TableIndexesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/TableIndexesTable.java
@@ -25,6 +25,7 @@ import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.index.DeletionVectorMeta;
 import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.index.IndexFileMetaSerializer;
@@ -115,6 +116,11 @@ public class TableIndexesTable implements ReadonlyTable {
     @Override
     public List<String> primaryKeys() {
         return Collections.singletonList("file_name");
+    }
+
+    @Override
+    public FileIO fileIO() {
+        return dataTable.fileIO();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/TagsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/TagsTable.java
@@ -121,6 +121,11 @@ public class TagsTable implements ReadonlyTable {
     }
 
     @Override
+    public FileIO fileIO() {
+        return dataTable.fileIO();
+    }
+
+    @Override
     public InnerTableScan newScan() {
         return new TagsScan();
     }

--- a/paimon-core/src/test/java/org/apache/paimon/rest/TestRESTCatalog.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/TestRESTCatalog.java
@@ -235,6 +235,8 @@ public class TestRESTCatalog extends FileSystemCatalog {
 
     @Override
     public void createFormatTable(Identifier identifier, Schema schema) {
+        Map<String, String> options = new HashMap<>(schema.options());
+        options.put("path", "/tmp/format_table");
         TableSchema tableSchema =
                 new TableSchema(
                         1L,
@@ -242,7 +244,7 @@ public class TestRESTCatalog extends FileSystemCatalog {
                         1,
                         schema.partitionKeys(),
                         schema.primaryKeys(),
-                        schema.options(),
+                        options,
                         schema.comment());
         tableFullName2Schema.put(identifier.getFullName(), tableSchema);
     }


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In some cases, the computing engine needs to obtain FileIO to operate some files on its own, including metadata files and data files. Previously, the engine obtained FileIO by converting the table into a DataTable.

We can directly expose the Table FileIO interface.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
