### PR TITLE
[refactor] specialize the type of table to FileStoreTable in FileStoreLookupFunction

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -180,19 +180,14 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
                 && new HashSet<>(table.primaryKeys()).equals(new HashSet<>(joinKeys))) {
             if (isRemoteServiceAvailable(table)) {
                 this.lookupTable =
-                        PrimaryKeyPartialLookupTable.createRemoteTable(
-                                table, projection, joinKeys);
+                        PrimaryKeyPartialLookupTable.createRemoteTable(table, projection, joinKeys);
                 LOG.info(
                         "Remote service is available. Created PrimaryKeyPartialLookupTable with remote service.");
             } else {
                 try {
                     this.lookupTable =
                             PrimaryKeyPartialLookupTable.createLocalTable(
-                                    table,
-                                    projection,
-                                    path,
-                                    joinKeys,
-                                    getRequireCachedBucketIds());
+                                    table, projection, path, joinKeys, getRequireCachedBucketIds());
                     LOG.info(
                             "Remote service isn't available. Created PrimaryKeyPartialLookupTable with LocalQueryExecutor.");
                 } catch (UnsupportedOperationException ignore) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -30,7 +30,6 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.OutOfRangeException;
 import org.apache.paimon.utils.FileIOUtils;
 import org.apache.paimon.utils.Filter;
@@ -79,7 +78,7 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
 
     private static final Logger LOG = LoggerFactory.getLogger(FileStoreLookupFunction.class);
 
-    private final Table table;
+    private final FileStoreTable table;
     @Nullable private final PartitionLoader partitionLoader;
     private final List<String> projectFields;
     private final List<String> joinKeys;
@@ -176,22 +175,20 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
                 projectFields,
                 joinKeys);
 
-        FileStoreTable storeTable = (FileStoreTable) table;
-
         LOG.info("Creating lookup table for {}.", table.name());
         if (options.get(LOOKUP_CACHE_MODE) == LookupCacheMode.AUTO
                 && new HashSet<>(table.primaryKeys()).equals(new HashSet<>(joinKeys))) {
-            if (isRemoteServiceAvailable(storeTable)) {
+            if (isRemoteServiceAvailable(table)) {
                 this.lookupTable =
                         PrimaryKeyPartialLookupTable.createRemoteTable(
-                                storeTable, projection, joinKeys);
+                                table, projection, joinKeys);
                 LOG.info(
                         "Remote service is available. Created PrimaryKeyPartialLookupTable with remote service.");
             } else {
                 try {
                     this.lookupTable =
                             PrimaryKeyPartialLookupTable.createLocalTable(
-                                    storeTable,
+                                    table,
                                     projection,
                                     path,
                                     joinKeys,
@@ -210,7 +207,7 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         if (lookupTable == null) {
             FullCacheLookupTable.Context context =
                     new FullCacheLookupTable.Context(
-                            storeTable,
+                            table,
                             projection,
                             predicate,
                             createProjectedPredicate(projection),


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
Pr https://github.com/apache/paimon/pull/5090 changed the type of `table` defined in constructor to `FileStoreTable`, so this pr specialized the type of `table` defined in `FileStoreLookupFunction` to `FileStoreTable`.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
