### PR TITLE
[core] Return empty instead of throwing exception when getting system table's latestSnapshotId

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/ReadonlyTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ReadonlyTable.java
@@ -111,10 +111,7 @@ public interface ReadonlyTable extends InnerTable {
 
     @Override
     default OptionalLong latestSnapshotId() {
-        throw new UnsupportedOperationException(
-                String.format(
-                        "Readonly Table %s does not support currentSnapshot.",
-                        this.getClass().getSimpleName()));
+        return OptionalLong.empty();
     }
 
     @Override


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Engines may call latestSnapshotId interface at table level, however when it comes to system table, it will throw an exception. I suppose it better to return empty now that the return value is an Optional.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
no need