### PR TITLE
[rest] Add isExternal to GetTableResponse

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -401,7 +401,7 @@ public abstract class AbstractCatalog implements Catalog {
     }
 
     protected TableMetadata loadTableMetadata(Identifier identifier) throws TableNotExistException {
-        return new TableMetadata(loadTableSchema(identifier), null);
+        return new TableMetadata(loadTableSchema(identifier), false, null);
     }
 
     protected abstract TableSchema loadTableSchema(Identifier identifier)

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/TableMetadata.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/TableMetadata.java
@@ -26,15 +26,21 @@ import javax.annotation.Nullable;
 public class TableMetadata {
 
     private final TableSchema schema;
+    private final boolean isExternal;
     @Nullable private final String uuid;
 
-    public TableMetadata(TableSchema schema, @Nullable String uuid) {
+    public TableMetadata(TableSchema schema, boolean isExternal, @Nullable String uuid) {
         this.schema = schema;
+        this.isExternal = isExternal;
         this.uuid = uuid;
     }
 
     public TableSchema schema() {
         return schema;
+    }
+
+    public boolean isExternal() {
+        return isExternal;
     }
 
     @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -321,7 +321,7 @@ public class RESTCatalog implements Catalog {
         }
 
         TableSchema schema = TableSchema.create(response.getSchemaId(), response.getSchema());
-        return new TableMetadata(schema, response.getId());
+        return new TableMetadata(schema, response.isExternal(), response.getId());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/rest/responses/GetTableResponse.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/responses/GetTableResponse.java
@@ -32,6 +32,7 @@ public class GetTableResponse implements RESTResponse {
 
     private static final String FIELD_ID = "id";
     private static final String FIELD_NAME = "name";
+    private static final String FIELD_IS_EXTERNAL = "isExternal";
     private static final String FIELD_SCHEMA_ID = "schemaId";
     private static final String FIELD_SCHEMA = "schema";
 
@@ -40,6 +41,9 @@ public class GetTableResponse implements RESTResponse {
 
     @JsonProperty(FIELD_NAME)
     private final String name;
+
+    @JsonProperty(FIELD_IS_EXTERNAL)
+    private final boolean isExternal;
 
     @JsonProperty(FIELD_SCHEMA_ID)
     private final long schemaId;
@@ -51,10 +55,12 @@ public class GetTableResponse implements RESTResponse {
     public GetTableResponse(
             @JsonProperty(FIELD_ID) String id,
             @JsonProperty(FIELD_NAME) String name,
+            @JsonProperty(FIELD_IS_EXTERNAL) boolean isExternal,
             @JsonProperty(FIELD_SCHEMA_ID) long schemaId,
             @JsonProperty(FIELD_SCHEMA) Schema schema) {
         this.id = id;
         this.name = name;
+        this.isExternal = isExternal;
         this.schemaId = schemaId;
         this.schema = schema;
     }
@@ -67,6 +73,11 @@ public class GetTableResponse implements RESTResponse {
     @JsonGetter(FIELD_NAME)
     public String getName() {
         return this.name;
+    }
+
+    @JsonGetter(FIELD_IS_EXTERNAL)
+    public boolean isExternal() {
+        return isExternal;
     }
 
     @JsonGetter(FIELD_SCHEMA_ID)

--- a/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTMessage.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTMessage.java
@@ -230,7 +230,7 @@ public class MockRESTMessage {
         Map<String, String> options = new HashMap<>();
         options.put("option-1", "value-1");
         options.put("option-2", "value-2");
-        return new GetTableResponse(UUID.randomUUID().toString(), "", 1, schema(options));
+        return new GetTableResponse(UUID.randomUUID().toString(), "", false, 1, schema(options));
     }
 
     public static AlterPartitionsRequest alterPartitionsRequest() {

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -572,7 +572,7 @@ public class RESTCatalogServer {
                             table.options(),
                             table.comment().orElse(null));
         }
-        return new GetTableResponse(table.uuid(), table.name(), schemaId, schema);
+        return new GetTableResponse(table.uuid(), table.name(), false, schemaId, schema);
     }
 
     private static MockResponse mockResponse(RESTResponse response, int httpCode) {

--- a/paimon-core/src/test/java/org/apache/paimon/rest/TestRESTCatalog.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/TestRESTCatalog.java
@@ -253,7 +253,7 @@ public class TestRESTCatalog extends FileSystemCatalog {
     protected TableMetadata loadTableMetadata(Identifier identifier) throws TableNotExistException {
         if (tableFullName2Schema.containsKey(identifier.getFullName())) {
             TableSchema tableSchema = tableFullName2Schema.get(identifier.getFullName());
-            return new TableMetadata(tableSchema, "uuid");
+            return new TableMetadata(tableSchema, false, "uuid");
         }
         return super.loadTableMetadata(identifier);
     }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -703,6 +703,7 @@ public class HiveCatalog extends AbstractCatalog {
             throws TableNotExistException {
         return new TableMetadata(
                 loadTableSchema(identifier, table),
+                isExternalTable(table),
                 identifier.getFullName() + "." + table.getCreateTime());
     }
 

--- a/paimon-open-api/rest-catalog-open-api.yaml
+++ b/paimon-open-api/rest-catalog-open-api.yaml
@@ -995,6 +995,8 @@ components:
           type: string
         name:
           type: string
+        isExternal:
+          type: boolean
         schemaId:
           type: integer
           format: int64

--- a/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
+++ b/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
@@ -252,6 +252,7 @@ public class RESTCatalogController {
         return new GetTableResponse(
                 UUID.randomUUID().toString(),
                 "",
+                false,
                 1,
                 new org.apache.paimon.schema.Schema(
                         ImmutableList.of(),


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Add isExternal to REST GetTableResponse, isExternal can be used to distinguish data file io and more things. So it is neccessary to add an isExternal to table response.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
