### PR TITLE
[core] Fix incremental query with delete after minor compact

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
@@ -98,7 +98,7 @@ public class IncrementalDiffSplitRead implements SplitRead<InternalRow> {
                                 split.bucket(),
                                 split.dataFiles(),
                                 split.deletionFiles().orElse(null),
-                                false),
+                                forceKeepDelete),
                         mergeRead.keyComparator(),
                         mergeRead.createUdsComparator(),
                         mergeRead.mergeSorter(),


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Due to the possibility that the before files and after files may offset each other during incremental read, while there are also new deletes in after files, we cannot drop deletes when reading after files.

```
//            tag1                          tag2
// l0         f(+I 10001),f(+I 10002)       f(-D 999)
// l1
// l2
// l3
// l4                                       f(+I 10001,10002)
// l5         f(+I 1-10000)                 f(+I 1-10000)

// before files: f(+I 10001), f(+I 10002)
// after files:  f(-D 999),   f(+I 10001,10002)
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
