### PR TITLE
[core] Avoid the unnecessary key value copy

### DIFF
--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/TableWriterBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/TableWriterBenchmark.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.benchmark;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.disk.IOManagerImpl;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.BatchTableCommit;
@@ -80,6 +81,7 @@ public class TableWriterBenchmark extends TableBenchmark {
     public void testParquet() throws Exception {
         Options options = new Options();
         options.set(CoreOptions.FILE_FORMAT, CoreOptions.FILE_FORMAT_PARQUET);
+        options.set(CoreOptions.CHANGELOG_PRODUCER, CoreOptions.ChangelogProducer.LOOKUP);
         innerTest("parquet", options);
         /*
          * Java HotSpot(TM) 64-Bit Server VM 1.8.0_301-b09 on Mac OS X 10.16
@@ -104,6 +106,21 @@ public class TableWriterBenchmark extends TableBenchmark {
          */
     }
 
+    @Test
+    public void testParquetLookupCompaction() throws Exception {
+        Options options = new Options();
+        options.set(CoreOptions.FILE_FORMAT, CoreOptions.FILE_FORMAT_PARQUET);
+        options.set(CoreOptions.CHANGELOG_PRODUCER, CoreOptions.ChangelogProducer.LOOKUP);
+        innerTest("parquet", options);
+        /*
+         * OpenJDK 64-Bit Server VM 11.0.24+0 on Mac OS X 14.5
+         * Apple M3 Pro
+         * parquet:         Best/Avg Time(ms)    Row Rate(K/s)      Per Row(ns)   Relative
+         * -------------------------------------------------------------------------------
+         * parquet_write     31918 / 32666             94.0          10639.3       1.0X
+         */
+    }
+
     public void innerTest(String name, Options options) throws Exception {
         options.set(CoreOptions.BUCKET, 1);
         Table table = createTable(options, "T");
@@ -119,6 +136,7 @@ public class TableWriterBenchmark extends TableBenchmark {
                 () -> {
                     BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
                     BatchTableWrite write = writeBuilder.newWrite();
+                    write.withIOManager(new IOManagerImpl(tempFile.toString()));
                     BatchTableCommit commit = writeBuilder.newCommit();
                     for (int i = 0; i < valuesPerIteration; i++) {
                         try {

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueSerializer.java
@@ -36,6 +36,7 @@ public class KeyValueSerializer extends ObjectSerializer<KeyValue> {
     private static final long serialVersionUID = 1L;
 
     private final int keyArity;
+    private final int valueArity;
 
     private final GenericRow reusedMeta;
     private final JoinedRow reusedKeyWithMeta;
@@ -49,7 +50,7 @@ public class KeyValueSerializer extends ObjectSerializer<KeyValue> {
         super(KeyValue.schema(keyType, valueType));
 
         this.keyArity = keyType.getFieldCount();
-        int valueArity = valueType.getFieldCount();
+        this.valueArity = valueType.getFieldCount();
 
         this.reusedMeta = new GenericRow(2);
         this.reusedKeyWithMeta = new JoinedRow();
@@ -84,5 +85,15 @@ public class KeyValueSerializer extends ObjectSerializer<KeyValue> {
 
     public KeyValue getReusedKv() {
         return reusedKv;
+    }
+
+    public KeyValue getCopiedKv() {
+        InternalRow row = rowSerializer.copy(reusedKey.getOriginalRow());
+        return new KeyValue()
+                .replace(
+                        new OffsetRow(keyArity, 0).replace(row),
+                        reusedKv.sequenceNumber(),
+                        reusedKv.valueKind(),
+                        new OffsetRow(valueArity, keyArity + 2).replace(row));
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/DeduplicateMergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/DeduplicateMergeFunction.java
@@ -58,6 +58,11 @@ public class DeduplicateMergeFunction implements MergeFunction<KeyValue> {
         return latestKv;
     }
 
+    @Override
+    public boolean requireCopy() {
+        return false;
+    }
+
     public static MergeFunctionFactory<KeyValue> factory() {
         return new Factory(false);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapper.java
@@ -21,7 +21,6 @@ package org.apache.paimon.mergetree.compact;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.deletionvectors.DeletionVectorsMaintainer;
 import org.apache.paimon.lookup.LookupStrategy;
 import org.apache.paimon.mergetree.LookupLevels.PositionedKeyValue;
@@ -69,8 +68,6 @@ public class LookupChangelogMergeFunctionWrapper<T>
     private final Comparator<KeyValue> comparator;
 
     private final LinkedList<KeyValue> candidates = new LinkedList<>();
-    private final InternalRowSerializer keySerializer;
-    private final InternalRowSerializer valueSerializer;
 
     public LookupChangelogMergeFunctionWrapper(
             MergeFunctionFactory<KeyValue> mergeFunctionFactory,
@@ -89,9 +86,6 @@ public class LookupChangelogMergeFunctionWrapper<T>
                     deletionVectorsMaintainer != null,
                     "deletionVectorsMaintainer should not be null, there is a bug.");
         }
-        LookupMergeFunction lookupMergeFunction = (LookupMergeFunction) mergeFunction;
-        this.keySerializer = lookupMergeFunction.getKeySerializer();
-        this.valueSerializer = lookupMergeFunction.getValueSerializer();
         this.mergeFunction = mergeFunctionFactory.create();
         this.lookup = lookup;
         this.valueEqualiser = valueEqualiser;
@@ -107,7 +101,7 @@ public class LookupChangelogMergeFunctionWrapper<T>
 
     @Override
     public void add(KeyValue kv) {
-        candidates.add(kv.copy(keySerializer, valueSerializer));
+        candidates.add(kv);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeFunction.java
@@ -44,4 +44,6 @@ public interface MergeFunction<T> {
 
     /** Get current merged value. */
     T getResult();
+
+    boolean requireCopy();
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
@@ -273,6 +273,11 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
         return reused.replace(currentKey, latestSequenceNumber, rowKind, row);
     }
 
+    @Override
+    public boolean requireCopy() {
+        return false;
+    }
+
     public static MergeFunctionFactory<KeyValue> factory(
             Options options, RowType rowType, List<String> primaryKeys) {
         return new Factory(options, rowType, primaryKeys);

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/AggregateMergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/AggregateMergeFunction.java
@@ -96,6 +96,11 @@ public class AggregateMergeFunction implements MergeFunction<KeyValue> {
         return reused.replace(latestKv.key(), latestKv.sequenceNumber(), RowKind.INSERT, row);
     }
 
+    @Override
+    public boolean requireCopy() {
+        return false;
+    }
+
     public static MergeFunctionFactory<KeyValue> factory(
             Options conf,
             List<String> tableNames,

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
@@ -79,9 +79,7 @@ class PrimaryKeyFileStoreTable extends AbstractFileStoreTable {
             MergeFunctionFactory<KeyValue> mfFactory =
                     PrimaryKeyTableUtils.createMergeFunctionFactory(tableSchema, extractor);
             if (options.needLookup()) {
-                mfFactory =
-                        LookupMergeFunction.wrap(
-                                mfFactory, new RowType(extractor.keyFields(tableSchema)), rowType);
+                mfFactory = LookupMergeFunction.wrap(mfFactory);
             }
 
             lazyStore =

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyTableUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyTableUtils.java
@@ -69,8 +69,7 @@ public class PrimaryKeyTableUtils {
                         rowType.getFieldTypes(),
                         tableSchema.primaryKeys());
             case FIRST_ROW:
-                return FirstRowMergeFunction.factory(
-                        conf, new RowType(extractor.keyFields(tableSchema)), rowType);
+                return FirstRowMergeFunction.factory(conf);
             default:
                 throw new UnsupportedOperationException("Unsupported merge engine: " + mergeEngine);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/OffsetRow.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/OffsetRow.java
@@ -41,6 +41,10 @@ public class OffsetRow implements InternalRow {
         this.offset = offset;
     }
 
+    public InternalRow getOriginalRow() {
+        return row;
+    }
+
     public OffsetRow replace(InternalRow row) {
         this.row = row;
         return this;

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/SortBufferWriteBufferTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/SortBufferWriteBufferTestBase.java
@@ -43,7 +43,6 @@ import org.apache.paimon.utils.ReusingTestData;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
 
-import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 
 import java.io.EOFException;
@@ -234,11 +233,7 @@ public abstract class SortBufferWriteBufferTestBase {
                             Collections.singletonList("value"),
                             Collections.singletonList(DataTypes.BIGINT()),
                             Collections.emptyList());
-            return LookupMergeFunction.wrap(
-                            aggMergeFunction,
-                            RowType.of(DataTypes.INT()),
-                            RowType.of(DataTypes.BIGINT()))
-                    .create();
+            return LookupMergeFunction.wrap(aggMergeFunction).create();
         }
     }
 
@@ -257,11 +252,7 @@ public abstract class SortBufferWriteBufferTestBase {
 
         @Override
         protected MergeFunction<KeyValue> createMergeFunction() {
-            return FirstRowMergeFunction.factory(
-                            new Options(),
-                            new RowType(Lists.list(new DataField(0, "f0", new IntType()))),
-                            new RowType(Lists.list(new DataField(1, "f1", new BigIntType()))))
-                    .create();
+            return FirstRowMergeFunction.factory(new Options()).create();
         }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
@@ -28,17 +28,14 @@ import org.apache.paimon.mergetree.compact.aggregate.AggregateMergeFunction;
 import org.apache.paimon.mergetree.compact.aggregate.FieldAggregator;
 import org.apache.paimon.mergetree.compact.aggregate.factory.FieldLastValueAggFactory;
 import org.apache.paimon.mergetree.compact.aggregate.factory.FieldSumAggFactory;
-import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
-import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.UserDefinedSeqComparator;
 import org.apache.paimon.utils.ValueEqualiserSupplier;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 
-import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -69,10 +66,7 @@ public class LookupChangelogMergeFunctionWrapperTest {
         Map<InternalRow, KeyValue> highLevel = new HashMap<>();
         LookupChangelogMergeFunctionWrapper function =
                 new LookupChangelogMergeFunctionWrapper(
-                        LookupMergeFunction.wrap(
-                                DeduplicateMergeFunction.factory(),
-                                RowType.of(DataTypes.INT()),
-                                RowType.of(DataTypes.INT())),
+                        LookupMergeFunction.wrap(DeduplicateMergeFunction.factory()),
                         highLevel::get,
                         changelogRowDeduplicate ? EQUALISER : null,
                         LookupStrategy.from(false, true, false, false),
@@ -234,10 +228,7 @@ public class LookupChangelogMergeFunctionWrapperTest {
                 ValueEqualiserSupplier.fromIgnoreFields(valueType, ignoreFields);
         LookupChangelogMergeFunctionWrapper function =
                 new LookupChangelogMergeFunctionWrapper(
-                        LookupMergeFunction.wrap(
-                                DeduplicateMergeFunction.factory(),
-                                RowType.of(DataTypes.INT()),
-                                valueType),
+                        LookupMergeFunction.wrap(DeduplicateMergeFunction.factory()),
                         highLevel::get,
                         logDedupEqualSupplier.get(),
                         LookupStrategy.from(false, true, false, false),
@@ -295,9 +286,7 @@ public class LookupChangelogMergeFunctionWrapperTest {
                                                 new FieldAggregator[] {
                                                     new FieldSumAggFactory()
                                                             .create(DataTypes.INT(), null, null)
-                                                }),
-                                RowType.of(DataTypes.INT()),
-                                RowType.of(DataTypes.INT())),
+                                                })),
                         key -> null,
                         changelogRowDeduplicate ? EQUALISER : null,
                         LookupStrategy.from(false, true, false, false),
@@ -384,9 +373,7 @@ public class LookupChangelogMergeFunctionWrapperTest {
                                                 new FieldAggregator[] {
                                                     new FieldLastValueAggFactory()
                                                             .create(DataTypes.INT(), null, null)
-                                                }),
-                                RowType.of(DataTypes.INT()),
-                                RowType.of(DataTypes.INT())),
+                                                })),
                         highLevel::get,
                         null,
                         LookupStrategy.from(false, true, false, false),
@@ -454,14 +441,7 @@ public class LookupChangelogMergeFunctionWrapperTest {
         Set<InternalRow> highLevel = new HashSet<>();
         FirstRowMergeFunctionWrapper function =
                 new FirstRowMergeFunctionWrapper(
-                        projection ->
-                                new FirstRowMergeFunction(
-                                        new RowType(
-                                                Lists.list(new DataField(0, "f0", new IntType()))),
-                                        new RowType(
-                                                Lists.list(new DataField(1, "f1", new IntType()))),
-                                        false),
-                        highLevel::contains);
+                        projection -> new FirstRowMergeFunction(false), highLevel::contains);
 
         // Without level-0
         function.reset();

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/SortMergeReaderTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/SortMergeReaderTestBase.java
@@ -22,14 +22,9 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.CoreOptions.SortEngine;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.reader.RecordReader;
-import org.apache.paimon.types.BigIntType;
-import org.apache.paimon.types.DataField;
-import org.apache.paimon.types.IntType;
-import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.ReusingTestData;
 import org.apache.paimon.utils.TestReusingRecordReader;
 
-import org.assertj.core.util.Lists;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -127,10 +122,7 @@ public abstract class SortMergeReaderTestBase extends CombiningRecordReaderTestB
 
         @Override
         protected MergeFunction<KeyValue> createMergeFunction() {
-            RowType keyType = new RowType(Lists.list(new DataField(0, "f0", new IntType())));
-            RowType valueType = new RowType(Lists.list(new DataField(1, "f1", new BigIntType())));
-            return new LookupMergeFunction(
-                    new FirstRowMergeFunction(keyType, valueType, false), keyType, valueType);
+            return new LookupMergeFunction(new FirstRowMergeFunction(false));
         }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/MergeFileSplitReadTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/MergeFileSplitReadTest.java
@@ -344,6 +344,11 @@ public class MergeFileSplitReadTest {
                     GenericRow.of(total));
         }
 
+        @Override
+        public boolean requireCopy() {
+            return false;
+        }
+
         private long count(InternalRow value) {
             checkArgument(!value.isNullAt(0), "Value count should not be null.");
             return value.getLong(0);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LookupChangelogWithAggITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LookupChangelogWithAggITCase.java
@@ -90,10 +90,18 @@ public class LookupChangelogWithAggITCase extends CatalogITCaseBase {
                         + "'fields.v.aggregate-function'='sum')");
         BlockingIterator<Row, Row> iterator = streamSqlBlockIter("SELECT * FROM T");
 
+        // merge by sort buffer
         sql("INSERT INTO T VALUES (1, 1), (2, 2), (1, 3), (1, 4), (1, 5)");
         assertThat(iterator.collect(2)).containsExactlyInAnyOrder(Row.of(1, 13), Row.of(2, 2));
-
         iterator.close();
+
+        // merge by compaction
+        sql("INSERT INTO T VALUES (1, 3), (2, 2), (3, 1)");
+        sql("INSERT INTO T VALUES (1, 2), (2, 2), (3, 2)");
+        sql("INSERT INTO T VALUES (1, 1), (2, 2), (3, 3)");
+
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(Row.of(1, 19), Row.of(2, 8), Row.of(3, 6));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5103

1. skip the copy process during the compaction, because the KeyValue of the same key are from the different reader, and will not read the next key, before the same key are all processed
2. copy the underlying BinaryRow directly for the sort write buffer


```
Apple M3 Pro
parquet:                                                                                             Best/Avg Time(ms)    Row Rate(K/s)      Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
OPERATORTEST_parquet_write                                                                              39571 / 39979             75.8          13190.3       1.0X


OpenJDK 64-Bit Server VM 11.0.24+0 on Mac OS X 14.5
Apple M3 Pro
parquet:                                                                                             Best/Avg Time(ms)    Row Rate(K/s)      Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
OPERATORTEST_parquet_write                                                                              31918 / 32666             94.0          10639.3       1.0X
```

The lookup compaction writer speed gains about 25%




<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
