### PR TITLE
[core] Add manifest cache to the FallbackReadFileStoreTable

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
@@ -23,6 +23,7 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.options.Options;
@@ -41,6 +42,7 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.Preconditions;
+import org.apache.paimon.utils.SegmentsCache;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -99,6 +101,12 @@ public class FallbackReadFileStoreTable extends DelegatedFileStoreTable {
     @Override
     public FileStoreTable switchToBranch(String branchName) {
         return new FallbackReadFileStoreTable(switchWrappedToBranch(branchName), fallback);
+    }
+
+    @Override
+    public void setManifestCache(SegmentsCache<Path> manifestCache) {
+        super.setManifestCache(manifestCache);
+        fallback.setManifestCache(manifestCache);
     }
 
     private FileStoreTable switchWrappedToBranch(String branchName) {
@@ -284,6 +292,13 @@ public class FallbackReadFileStoreTable extends DelegatedFileStoreTable {
         public Scan withMetricsRegistry(MetricRegistry metricRegistry) {
             mainScan.withMetricsRegistry(metricRegistry);
             fallbackScan.withMetricsRegistry(metricRegistry);
+            return this;
+        }
+
+        @Override
+        public InnerTableScan dropStats() {
+            mainScan.dropStats();
+            fallbackScan.dropStats();
             return this;
         }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5064

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
