### PR TITLE
[core] Enables buffer spill when targetFileSize is greater than the w…

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -1048,7 +1048,7 @@ If the data size allocated for the sorting task is uneven,which may lead to perf
             <td><h5>write-buffer-spillable</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Boolean</td>
-            <td>Whether the write buffer can be spillable. Enabled by default when using object storage.</td>
+            <td>Whether the write buffer can be spillable. Enabled by default when using object storage or when 'target-file-size' is greater than 'write-buffer-size'.</td>
         </tr>
         <tr>
             <td><h5>write-manifest-cache</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -479,7 +479,7 @@ public class CoreOptions implements Serializable {
                     .booleanType()
                     .noDefaultValue()
                     .withDescription(
-                            "Whether the write buffer can be spillable. Enabled by default when using object storage.");
+                            "Whether the write buffer can be spillable. Enabled by default when using object storage or when 'target-file-size' is greater than 'write-buffer-size'.");
 
     public static final ConfigOption<Boolean> WRITE_BUFFER_FOR_APPEND =
             key("write-buffer-for-append")
@@ -1957,9 +1957,14 @@ public class CoreOptions implements Serializable {
         return options.get(WRITE_BUFFER_SIZE).getBytes();
     }
 
-    public boolean writeBufferSpillable(boolean usingObjectStore, boolean isStreaming) {
+    public boolean writeBufferSpillable(
+            boolean usingObjectStore, boolean isStreaming, boolean hasPrimaryKey) {
         // if not streaming mode, we turn spillable on by default.
-        return options.getOptional(WRITE_BUFFER_SPILLABLE).orElse(usingObjectStore || !isStreaming);
+        return options.getOptional(WRITE_BUFFER_SPILLABLE)
+                .orElse(
+                        usingObjectStore
+                                || !isStreaming
+                                || targetFileSize(hasPrimaryKey) > writeBufferSize());
     }
 
     public MemorySize writeBufferSpillDiskSize() {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreWrite.java
@@ -125,7 +125,7 @@ public abstract class AppendOnlyFileStoreWrite extends MemoryFileStoreWrite<Inte
                 pathFactory.createDataFilePathFactory(partition, bucket),
                 restoreIncrement,
                 options.useWriteBufferForAppend() || forceBufferSpill,
-                options.writeBufferSpillable(fileIO.isObjectStore(), isStreamingMode)
+                options.writeBufferSpillable(fileIO.isObjectStore(), isStreamingMode, false)
                         || forceBufferSpill,
                 options.fileCompression(),
                 options.spillCompressOptions(),

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -229,7 +229,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
 
     @VisibleForTesting
     public boolean bufferSpillable() {
-        return options.writeBufferSpillable(fileIO.isObjectStore(), isStreamingMode);
+        return options.writeBufferSpillable(fileIO.isObjectStore(), isStreamingMode, true);
     }
 
     private CompactManager createCompactManager(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/WriterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/WriterOperatorTest.java
@@ -87,6 +87,7 @@ public class WriterOperatorTest {
         Options options = new Options();
         options.set("bucket", "1");
         options.set("write-buffer-size", "256 b");
+        options.set("write-buffer-spillable", "false");
         options.set("page-size", "32 b");
 
         FileStoreTable table =
@@ -332,6 +333,7 @@ public class WriterOperatorTest {
         Options options = new Options();
         options.set("bucket", "1");
         options.set("write-buffer-size", "256 b");
+        options.set("write-buffer-spillable", "false");
         options.set("page-size", "32 b");
 
         FileStoreTable fileStoreTable =


### PR DESCRIPTION
…rite buffer size.

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

The purpose of this PR is to reduce small files.

When I set `target-file-size=1GB` and  `write-buffer-for-append=true,  write-buffer-size=256m`,
 I found that my final file size is always smaller than `write-buffer-size=256m` and will never reach the 1gb I expected.
This resulted in a lot of small files being generated.

So when `target-file-size` is greater than `write-buffer-size`, spill should be enabled automatically.


<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
