### PR TITLE
[cdc] fix default scan.startup.mode to earliest-offset when it is not set by user

### DIFF
--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/LogStoreE2eTest.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/LogStoreE2eTest.java
@@ -45,7 +45,6 @@ public class LogStoreE2eTest extends E2eTestBase {
     }
 
     @Test
-    @Timeout(240)
     public void testWithPk() throws Exception {
         String catalogDdl =
                 String.format(

--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/LogStoreE2eTest.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/LogStoreE2eTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.tests;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.UUID;
 
@@ -44,6 +45,7 @@ public class LogStoreE2eTest extends E2eTestBase {
     }
 
     @Test
+    @Timeout(240)
     public void testWithPk() throws Exception {
         String catalogDdl =
                 String.format(

--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/LogStoreE2eTest.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/LogStoreE2eTest.java
@@ -20,7 +20,6 @@ package org.apache.paimon.tests;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 
 import java.util.UUID;
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaActionUtils.java
@@ -92,9 +92,13 @@ public class KafkaActionUtils {
                 .setGroupId(kafkaPropertiesGroupId(kafkaConfig));
 
         Properties properties = createKafkaProperties(kafkaConfig);
-
-        StartupMode startupMode =
-                fromOption(kafkaConfig.get(KafkaConnectorOptions.SCAN_STARTUP_MODE));
+        // If it is not set by user, then we should set the default value to EARLIEST.
+        StartupMode startupMode = StartupMode.EARLIEST;
+        boolean containsScanStartupMode =
+                kafkaConfig.contains(KafkaConnectorOptions.SCAN_STARTUP_MODE);
+        if (containsScanStartupMode) {
+            startupMode = fromOption(kafkaConfig.get(KafkaConnectorOptions.SCAN_STARTUP_MODE));
+        }
         // see
         // https://github.com/apache/flink/blob/f32052a12309cfe38f66344cf6d4ab39717e44c8/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSource.java#L434
         switch (startupMode) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5120

If it is not set by user, then we should set the default value to EARLIEST.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
