### PR TITLE
[flink] Bump the flink version from 1.20.0 to 1.20.1

### DIFF
--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/LogStoreE2eTest.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/LogStoreE2eTest.java
@@ -45,7 +45,6 @@ public class LogStoreE2eTest extends E2eTestBase {
     }
 
     @Test
-    @Timeout(240)
     public void testWithPk() throws Exception {
         String catalogDdl =
                 String.format(

--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/LogStoreE2eTest.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/LogStoreE2eTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.tests;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.UUID;
 
@@ -44,6 +45,7 @@ public class LogStoreE2eTest extends E2eTestBase {
     }
 
     @Test
+    @Timeout(240)
     public void testWithPk() throws Exception {
         String catalogDdl =
                 String.format(

--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/LogStoreE2eTest.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/LogStoreE2eTest.java
@@ -20,7 +20,6 @@ package org.apache.paimon.tests;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 
 import java.util.UUID;
 

--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/cdc/MySqlTinyIntConvertE2ETest.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/cdc/MySqlTinyIntConvertE2ETest.java
@@ -24,6 +24,7 @@ import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.sql.Connection;
 import java.sql.Statement;
@@ -36,6 +37,7 @@ public class MySqlTinyIntConvertE2ETest extends MySqlCdcE2eTestBase {
     }
 
     @Test
+    @Timeout(360)
     public void testSyncTable() throws Exception {
         runAction(
                 ACTION_SYNC_TABLE,

--- a/paimon-flink/paimon-flink-1.20/pom.xml
+++ b/paimon-flink/paimon-flink-1.20/pom.xml
@@ -34,7 +34,7 @@ under the License.
     <name>Paimon : Flink : 1.20</name>
 
     <properties>
-        <flink.version>1.20.0</flink.version>
+        <flink.version>1.20.1</flink.version>
     </properties>
 
     <dependencies>

--- a/paimon-flink/paimon-flink-cdc/pom.xml
+++ b/paimon-flink/paimon-flink-cdc/pom.xml
@@ -34,7 +34,7 @@ under the License.
     <name>Paimon : Flink : CDC</name>
 
     <properties>
-        <flink.version>1.20.0</flink.version>
+        <flink.version>1.20.1</flink.version>
         <flink.cdc.version>3.1.1</flink.cdc.version>
         <flink.mongodb.cdc.version>3.1.1</flink.mongodb.cdc.version>
         <avro.version>1.11.4</avro.version>

--- a/paimon-flink/paimon-flink-common/pom.xml
+++ b/paimon-flink/paimon-flink-common/pom.xml
@@ -34,7 +34,7 @@ under the License.
     <name>Paimon : Flink : Common</name>
 
     <properties>
-        <flink.version>1.20.0</flink.version>
+        <flink.version>1.20.1</flink.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@ under the License.
         <test.randomization.seed/>
         <test.unit.pattern>**/*Test.*</test.unit.pattern>
         <test.flink.main.version>1.20</test.flink.main.version>
-        <test.flink.version>1.20.0</test.flink.version>
+        <test.flink.version>1.20.1</test.flink.version>
         <test.flink.connector.kafka.version>3.4.0-1.20</test.flink.connector.kafka.version>
         <test.mysql.connector.java.version>8.0.27</test.mysql.connector.java.version>
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Now that ,flink 1.20.1 has been released, we need to consider upgrading it.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
