### PR TITLE
[core] Add dialects to View

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -68,7 +68,6 @@ import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
-import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.view.View;
 import org.apache.paimon.view.ViewImpl;
@@ -528,12 +527,14 @@ public class RESTCatalog implements Catalog {
                                     identifier.getDatabaseName(), identifier.getTableName()),
                             GetViewResponse.class,
                             headers());
+            ViewSchema schema = response.getSchema();
             return new ViewImpl(
                     identifier,
-                    response.getSchema().rowType(),
-                    response.getSchema().query(),
-                    response.getSchema().comment(),
-                    response.getSchema().options());
+                    schema.fields(),
+                    schema.query(),
+                    schema.dialects(),
+                    schema.comment(),
+                    schema.options());
         } catch (NoSuchResourceException e) {
             throw new ViewNotExistException(identifier);
         }
@@ -559,10 +560,11 @@ public class RESTCatalog implements Catalog {
         try {
             ViewSchema schema =
                     new ViewSchema(
-                            new RowType(view.rowType().getFields()),
-                            view.options(),
+                            view.rowType().getFields(),
+                            view.query(),
+                            view.dialects(),
                             view.comment().orElse(null),
-                            view.query());
+                            view.options());
             CreateViewRequest request = new CreateViewRequest(identifier, schema);
             client.post(resourcePaths.views(identifier.getDatabaseName()), request, headers());
         } catch (NoSuchResourceException e) {

--- a/paimon-core/src/main/java/org/apache/paimon/view/View.java
+++ b/paimon-core/src/main/java/org/apache/paimon/view/View.java
@@ -38,6 +38,14 @@ public interface View {
     /** Returns the view representation. */
     String query();
 
+    /** Returns the view representation for dialects. */
+    Map<String, String> dialects();
+
+    /** Returns the view representation for given dialect. */
+    default String query(String dialect) {
+        return dialects().getOrDefault(dialect, query());
+    }
+
     /** Optional comment of this view. */
     Optional<String> comment();
 

--- a/paimon-core/src/main/java/org/apache/paimon/view/ViewSchema.java
+++ b/paimon-core/src/main/java/org/apache/paimon/view/ViewSchema.java
@@ -18,7 +18,7 @@
 
 package org.apache.paimon.view;
 
-import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.DataField;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
@@ -28,19 +28,28 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonPro
 
 import javax.annotation.Nullable;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 /** Schema for view. */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ViewSchema {
-    private static final String FIELD_FIELDS = "rowType";
-    private static final String FIELD_OPTIONS = "options";
-    private static final String FIELD_COMMENT = "comment";
+
+    private static final String FIELD_FIELDS = "fields";
     private static final String FIELD_QUERY = "query";
+    private static final String FIELD_DIALECTS = "dialects";
+    private static final String FIELD_COMMENT = "comment";
+    private static final String FIELD_OPTIONS = "options";
+
+    @JsonProperty(FIELD_FIELDS)
+    private final List<DataField> fields;
 
     @JsonProperty(FIELD_QUERY)
     private final String query;
+
+    @JsonProperty(FIELD_DIALECTS)
+    private final Map<String, String> dialects;
 
     @Nullable
     @JsonProperty(FIELD_COMMENT)
@@ -50,37 +59,33 @@ public class ViewSchema {
     @JsonProperty(FIELD_OPTIONS)
     private final Map<String, String> options;
 
-    @JsonProperty(FIELD_FIELDS)
-    private final RowType rowType;
-
     @JsonCreator
     public ViewSchema(
-            @JsonProperty(FIELD_FIELDS) RowType rowType,
-            @JsonProperty(FIELD_OPTIONS) Map<String, String> options,
+            @JsonProperty(FIELD_FIELDS) List<DataField> fields,
+            @JsonProperty(FIELD_QUERY) String query,
+            @JsonProperty(FIELD_DIALECTS) Map<String, String> dialects,
             @Nullable @JsonProperty(FIELD_COMMENT) String comment,
-            @JsonProperty(FIELD_QUERY) String query) {
+            @JsonProperty(FIELD_OPTIONS) Map<String, String> options) {
+        this.fields = fields;
+        this.query = query;
+        this.dialects = dialects;
         this.options = options;
         this.comment = comment;
-        this.query = query;
-        this.rowType = rowType;
-    }
-
-    public ViewSchema(
-            String query, @Nullable String comment, Map<String, String> options, RowType rowType) {
-        this.query = query;
-        this.comment = comment;
-        this.options = options;
-        this.rowType = rowType;
     }
 
     @JsonGetter(FIELD_FIELDS)
-    public RowType rowType() {
-        return rowType;
+    public List<DataField> fields() {
+        return fields;
     }
 
     @JsonGetter(FIELD_QUERY)
     public String query() {
         return query;
+    }
+
+    @JsonGetter(FIELD_DIALECTS)
+    public Map<String, String> dialects() {
+        return dialects;
     }
 
     @Nullable
@@ -100,14 +105,15 @@ public class ViewSchema {
             return false;
         }
         ViewSchema that = (ViewSchema) o;
-        return Objects.equals(query, that.query)
+        return Objects.equals(fields, that.fields)
+                && Objects.equals(query, that.query)
+                && Objects.equals(dialects, that.dialects)
                 && Objects.equals(comment, that.comment)
-                && Objects.equals(options, that.options)
-                && Objects.equals(rowType, that.rowType);
+                && Objects.equals(options, that.options);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(query, comment, options, rowType);
+        return Objects.hash(fields, query, dialects, comment, options);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -933,7 +933,14 @@ public abstract class CatalogTestBase {
         Map<String, String> options = new HashMap<>();
         options.put("key1", "v1");
         options.put("key2", "v2");
-        View view = new ViewImpl(identifier, rowType, query, comment, options);
+
+        Map<String, String> dialects = new HashMap<>();
+        if (supportsViewDialects()) {
+            dialects.put("flink", "SELECT * FROM FLINK_TABLE");
+            dialects.put("spark", "SELECT * FROM SPARK_TABLE");
+        }
+        View view =
+                new ViewImpl(identifier, rowType.getFields(), query, dialects, comment, options);
 
         assertThatThrownBy(() -> catalog.createView(identifier, view, false))
                 .isInstanceOf(Catalog.DatabaseNotExistException.class);
@@ -952,6 +959,7 @@ public abstract class CatalogTestBase {
         assertThat(catalogView.fullName()).isEqualTo(view.fullName());
         assertThat(catalogView.rowType()).isEqualTo(view.rowType());
         assertThat(catalogView.query()).isEqualTo(view.query());
+        assertThat(catalogView.dialects()).isEqualTo(view.dialects());
         assertThat(catalogView.comment()).isEqualTo(view.comment());
         assertThat(catalogView.options()).containsAllEntriesOf(view.options());
 
@@ -1136,6 +1144,10 @@ public abstract class CatalogTestBase {
 
     protected boolean supportsView() {
         return false;
+    }
+
+    protected boolean supportsViewDialects() {
+        return true;
     }
 
     protected void checkPartition(Partition expected, Partition actual) {

--- a/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTMessage.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTMessage.java
@@ -261,10 +261,11 @@ public class MockRESTMessage {
                         new DataField(0, "f0", new IntType()),
                         new DataField(1, "f1", new IntType()));
         return new ViewSchema(
-                new RowType(fields),
-                Collections.singletonMap("pt", "1"),
+                fields,
+                "select * from t1",
+                Collections.emptyMap(),
                 "comment",
-                "select * from t1");
+                Collections.singletonMap("pt", "1"));
     }
 
     private static Partition partition() {

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -505,13 +505,15 @@ public class RESTCatalogServer {
                 CreateViewRequest requestBody =
                         OBJECT_MAPPER.readValue(
                                 request.getBody().readUtf8(), CreateViewRequest.class);
+                ViewSchema schema = requestBody.getSchema();
                 ViewImpl view =
                         new ViewImpl(
                                 requestBody.getIdentifier(),
-                                requestBody.getSchema().rowType(),
-                                requestBody.getSchema().query(),
-                                requestBody.getSchema().comment(),
-                                requestBody.getSchema().options());
+                                schema.fields(),
+                                schema.query(),
+                                schema.dialects(),
+                                schema.comment(),
+                                schema.options());
                 catalog.createView(requestBody.getIdentifier(), view, false);
                 return new MockResponse().setResponseCode(200);
             default:
@@ -529,10 +531,11 @@ public class RESTCatalogServer {
                 View view = catalog.getView(identifier);
                 ViewSchema schema =
                         new ViewSchema(
-                                view.rowType(),
-                                view.options(),
+                                view.rowType().getFields(),
+                                view.query(),
+                                view.dialects(),
                                 view.comment().orElse(null),
-                                view.query());
+                                view.options());
                 response = new GetViewResponse("id", identifier.getTableName(), schema);
                 return mockResponse(response, 200);
             case "DELETE":

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -347,13 +347,9 @@ public class FlinkCatalog extends AbstractCatalog {
                 org.apache.flink.table.api.Schema.newBuilder()
                         .fromRowDataType(fromLogicalToDataType(toLogicalType(view.rowType())))
                         .build();
+        String query = view.query("flink");
         return Optional.of(
-                CatalogView.of(
-                        schema,
-                        view.comment().orElse(null),
-                        view.query(),
-                        view.query(),
-                        view.options()));
+                CatalogView.of(schema, view.comment().orElse(null), query, query, view.options()));
     }
 
     @Override
@@ -455,11 +451,13 @@ public class FlinkCatalog extends AbstractCatalog {
                                         column.getName(),
                                         toDataType(column.getDataType().getLogicalType()),
                                         column.getComment().orElse(null)));
+        String query = table.getOriginalQuery();
         View view =
                 new ViewImpl(
                         identifier,
-                        builder.build(),
-                        table.getOriginalQuery(),
+                        builder.build().getFields(),
+                        query,
+                        Collections.singletonMap("flink", query),
                         table.getComment(),
                         table.getOptions());
         try {

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -749,7 +749,13 @@ public class HiveCatalog extends AbstractCatalog {
         RowType rowType = HiveTableUtils.createRowType(table);
         Map<String, String> options = new HashMap<>(table.getParameters());
         String comment = options.remove(COMMENT_PROP);
-        return new ViewImpl(identifier, rowType, table.getViewExpandedText(), comment, options);
+        return new ViewImpl(
+                identifier,
+                rowType.getFields(),
+                table.getViewExpandedText(),
+                Collections.emptyMap(),
+                comment,
+                options);
     }
 
     @Override

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -483,4 +483,9 @@ public class HiveCatalogTest extends CatalogTestBase {
     protected boolean supportsAlterDatabase() {
         return true;
     }
+
+    @Override
+    protected boolean supportsViewDialects() {
+        return false;
+    }
 }

--- a/paimon-open-api/rest-catalog-open-api.yaml
+++ b/paimon-open-api/rest-catalog-open-api.yaml
@@ -1310,16 +1310,22 @@ components:
     ViewSchema:
       type: object
       properties:
-        rowType:
-          $ref: '#/components/schemas/RowType'
-        options:
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataField'
+        query:
+          type: string
+        dialects:
           type: object
           additionalProperties:
             type: string
         comment:
           type: string
-        query:
-          type: string
+        options:
+          type: object
+          additionalProperties:
+            type: string
     Partition:
       type: object
       properties:

--- a/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
+++ b/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
@@ -46,7 +46,6 @@ import org.apache.paimon.rest.responses.ListTablesResponse;
 import org.apache.paimon.rest.responses.ListViewsResponse;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.IntType;
-import org.apache.paimon.types.RowType;
 import org.apache.paimon.view.ViewSchema;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
@@ -555,10 +554,11 @@ public class RESTCatalogController {
                         new DataField(1, "f1", new IntType()));
         ViewSchema schema =
                 new ViewSchema(
-                        new RowType(fields),
-                        Collections.singletonMap("pt", "1"),
+                        fields,
+                        "select * from t1",
+                        Collections.emptyMap(),
                         "comment",
-                        "select * from t1");
+                        Collections.singletonMap("pt", "1"));
         return new GetViewResponse("id", "name", schema);
     }
 

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/catalog/SupportView.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/catalog/SupportView.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.spark.catalog;
 
 import org.apache.paimon.catalog.Catalog;
-import org.apache.paimon.spark.SparkTypeUtils;
 import org.apache.paimon.view.View;
 import org.apache.paimon.view.ViewImpl;
 
@@ -27,9 +26,11 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.types.StructType;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.paimon.spark.SparkTypeUtils.toPaimonRowType;
 import static org.apache.paimon.spark.utils.CatalogUtils.checkNamespace;
 import static org.apache.paimon.spark.utils.CatalogUtils.toIdentifier;
 
@@ -64,8 +65,9 @@ public interface SupportView extends WithPaimonCatalog {
                             paimonIdent,
                             new ViewImpl(
                                     paimonIdent,
-                                    SparkTypeUtils.toPaimonRowType(schema),
+                                    toPaimonRowType(schema).getFields(),
                                     queryText,
+                                    Collections.singletonMap("spark", queryText),
                                     comment,
                                     properties),
                             ignoreIfExists);

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonViewResolver.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonViewResolver.scala
@@ -59,7 +59,7 @@ case class PaimonViewResolver(spark: SparkSession)
   }
 
   private def createViewRelation(nameParts: Seq[String], view: View): LogicalPlan = {
-    val parsedPlan = parseViewText(nameParts.toArray.mkString("."), view.query)
+    val parsedPlan = parseViewText(nameParts.toArray.mkString("."), view.query("spark"))
 
     val aliases = SparkTypeUtils.fromPaimonRowType(view.rowType()).fields.zipWithIndex.map {
       case (expected, pos) =>

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonViewExec.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonViewExec.scala
@@ -129,7 +129,7 @@ case class ShowCreatePaimonViewExec(output: Seq[Attribute], catalog: SupportView
     showDataColumns(view, builder)
     showComment(view, builder)
     showProperties(view, builder)
-    builder ++= s"AS\n${view.query}\n"
+    builder ++= s"AS\n${view.query("spark")}\n"
 
     Seq(new GenericInternalRow(values = Array(UTF8String.fromString(builder.toString))))
   }
@@ -203,7 +203,7 @@ case class DescribePaimonViewExec(
     rows += row("# Detailed View Information", "", "")
     rows += row("Name", view.fullName(), "")
     rows += row("Comment", view.comment().orElse(""), "")
-    rows += row("View Text", view.query, "")
+    rows += row("View Text", view.query("spark"), "")
     rows += row(
       "View Query Output Columns",
       view.rowType().getFieldNames.asScala.mkString("[", ", ", "]"),


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In many scenarios, the dialects of each engine are different. We can provide View with dialect fields to provide space for future extensions.

However, there is currently no operation to control dialects, and multiple dialects can only be written directly through the API when creating a View.

Perhaps in the future, we can consider adding some procedures to add, modify, or delete dialects.

Some information in Iceberg community: https://lists.apache.org/thread/k6szpr5smyrh37sy563xpgjor4g6pr81

They seem more inclined to use `Substrait` to only save intermediate states, but that solution appears to be very complex and difficult to control.

BTW, this PR also change `RowType rowType` to `List<DataField> fields` in `ViewSchema`, this is good to be consistent with Table `Schema`.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
