### PR TITLE
[core] Introduce DelayedLookupCompactManager to support delayed lookup compaction

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -147,6 +147,24 @@ under the License.
             <td>Specifies the commit user prefix.</td>
         </tr>
         <tr>
+            <td><h5>compaction.lookup-delay.l0-file-trigger</h5></td>
+            <td style="word-wrap: break-word;">5</td>
+            <td>Integer</td>
+            <td>The L0 file trigger for a delayed lookup compaction. A delayed lookup compaction will only be performed when L0 files reach this config value.</td>
+        </tr>
+        <tr>
+            <td><h5>compaction.lookup-delay.partition-threshold</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>The threshold of partitioned pk table to perform delayed lookup compaction. Delayed lookup compaction can be configured with a less frequent compaction strategy to sacrifice timeliness for overall resource usage saving. This option is only valid for a partitioned pk table when CoreOptions#needLookup() is true.</td>
+        </tr>
+        <tr>
+            <td><h5>compaction.lookup-delay.stop-trigger</h5></td>
+            <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
+            <td>The stop trigger for a delayed lookup compaction. For every stop trigger, a forced lookup compaction will be performed to flush L0 files to higher level.</td>
+        </tr>
+        <tr>
             <td><h5>compaction.max-size-amplification-percent</h5></td>
             <td style="word-wrap: break-word;">200</td>
             <td>Integer</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -627,6 +627,33 @@ public class CoreOptions implements Serializable {
                                             text("Default value of Bucketed Append Table is '5'."))
                                     .build());
 
+    public static final ConfigOption<Duration> LOOKUP_DELAY_PARTITION_THRESHOLD =
+            key("compaction.lookup-delay.partition-threshold")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The threshold of partitioned pk table to perform delayed lookup compaction. "
+                                    + "Delayed lookup compaction can be configured with a less frequent "
+                                    + "compaction strategy to sacrifice timeliness for overall resource usage saving. "
+                                    + "This option is only valid for a partitioned pk table when "
+                                    + "CoreOptions#needLookup() is true.");
+
+    public static final ConfigOption<Integer> LOOKUP_DELAY_L0_FILE_TRIGGER =
+            key("compaction.lookup-delay.l0-file-trigger")
+                    .intType()
+                    .defaultValue(5)
+                    .withDescription(
+                            "The L0 file trigger for a delayed lookup compaction. A delayed lookup compaction "
+                                    + "will only be performed when L0 files reach this config value.");
+
+    public static final ConfigOption<Integer> LOOKUP_DELAY_STOP_TRIGGER =
+            key("compaction.lookup-delay.stop-trigger")
+                    .intType()
+                    .defaultValue(LOOKUP_DELAY_L0_FILE_TRIGGER.defaultValue() * 2)
+                    .withDescription(
+                            "The stop trigger for a delayed lookup compaction. For every stop trigger, "
+                                    + "a forced lookup compaction will be performed to flush L0 files to higher level.");
+
     public static final ConfigOption<ChangelogProducer> CHANGELOG_PRODUCER =
             key("changelog-producer")
                     .enumType(ChangelogProducer.class)
@@ -2041,6 +2068,19 @@ public class CoreOptions implements Serializable {
     @Nullable
     public Duration optimizedCompactionInterval() {
         return options.get(COMPACTION_OPTIMIZATION_INTERVAL);
+    }
+
+    @Nullable
+    public Duration lookupDelayPartitionThreshold() {
+        return options.get(LOOKUP_DELAY_PARTITION_THRESHOLD);
+    }
+
+    public int lookupDelayL0FileTrigger() {
+        return options.get(LOOKUP_DELAY_L0_FILE_TRIGGER);
+    }
+
+    public int lookupDelayStopTrigger() {
+        return options.get(LOOKUP_DELAY_STOP_TRIGGER);
     }
 
     public int numSortedRunStopTrigger() {

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -215,6 +215,11 @@ public class AppendOnlyWriter implements BatchRecordWriter, MemoryOwner {
         return compactManager.isCompacting();
     }
 
+    @Override
+    public boolean hasDelayedCompact() {
+        return compactManager.hasDelayedCompact();
+    }
+
     @VisibleForTesting
     void flush(boolean waitForLatestCompaction, boolean forcedFullCompaction) throws Exception {
         List<DataFileMeta> flushedFiles = sinkWriter.flush();

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -217,7 +217,7 @@ public class AppendOnlyWriter implements BatchRecordWriter, MemoryOwner {
 
     @Override
     public boolean hasDelayedCompact() {
-        return compactManager.hasDelayedCompact();
+        return false;
     }
 
     @VisibleForTesting

--- a/paimon-core/src/main/java/org/apache/paimon/append/BucketedAppendCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/BucketedAppendCompactManager.java
@@ -186,6 +186,11 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
         return result;
     }
 
+    @Override
+    public boolean hasDelayedCompact() {
+        return false;
+    }
+
     @VisibleForTesting
     Optional<List<DataFileMeta>> pickCompactBefore() {
         if (toCompact.isEmpty()) {

--- a/paimon-core/src/main/java/org/apache/paimon/compact/CompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/CompactManager.java
@@ -54,4 +54,9 @@ public interface CompactManager extends Closeable {
 
     /** Check if a compaction is in progress, or if a compaction result remains to be fetched. */
     boolean isCompacting();
+
+    /**
+     * Check if the {@code CompactManager} has delayed compacts need to be triggered in the future.
+     */
+    boolean hasDelayedCompact();
 }

--- a/paimon-core/src/main/java/org/apache/paimon/compact/NoopCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/NoopCompactManager.java
@@ -76,5 +76,10 @@ public class NoopCompactManager implements CompactManager {
     }
 
     @Override
+    public boolean hasDelayedCompact() {
+        return false;
+    }
+
+    @Override
     public void close() throws IOException {}
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeWriter.java
@@ -284,6 +284,11 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
     }
 
     @Override
+    public boolean hasDelayedCompact() {
+        return compactManager.hasDelayedCompact();
+    }
+
+    @Override
     public void sync() throws Exception {
         trySyncLatestCompaction(true);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeWriter.java
@@ -142,7 +142,7 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
     }
 
     @VisibleForTesting
-    CompactManager compactManager() {
+    public CompactManager compactManager() {
         return compactManager;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/DelayedLookupCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/DelayedLookupCompactManager.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree.compact;
+
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.deletionvectors.DeletionVectorsMaintainer;
+import org.apache.paimon.mergetree.Levels;
+import org.apache.paimon.operation.metrics.CompactionMetrics;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Compact manager to perform the delayed lookup compaction. */
+public class DelayedLookupCompactManager extends MergeTreeCompactManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DelayedLookupCompactManager.class);
+    private final CompactStrategy strategy;
+    private final LocalDateTime currentPartitionDate;
+    private final Duration delayPartitionThreshold;
+    private final int l0FileTriggerThreshold;
+    private final int stopTriggerThreshold;
+
+    private final AtomicInteger triggerCount = new AtomicInteger(0);
+
+    public DelayedLookupCompactManager(
+            ExecutorService executor,
+            Levels levels,
+            CompactStrategy strategy,
+            Comparator<InternalRow> keyComparator,
+            long compactionFileSize,
+            int numSortedRunStopTrigger,
+            CompactRewriter rewriter,
+            @Nullable CompactionMetrics.Reporter metricsReporter,
+            @Nullable DeletionVectorsMaintainer dvMaintainer,
+            boolean lazyGenDeletionFile,
+            LocalDateTime currentPartitionDate,
+            Duration delayPartitionThreshold,
+            int l0FileTriggerThreshold,
+            int stopTriggerThreshold) {
+        super(
+                executor,
+                levels,
+                strategy,
+                keyComparator,
+                compactionFileSize,
+                numSortedRunStopTrigger,
+                rewriter,
+                metricsReporter,
+                dvMaintainer,
+                lazyGenDeletionFile);
+        this.strategy = strategy;
+        this.currentPartitionDate = currentPartitionDate;
+        this.delayPartitionThreshold = delayPartitionThreshold;
+        this.l0FileTriggerThreshold = l0FileTriggerThreshold;
+        this.stopTriggerThreshold = stopTriggerThreshold;
+    }
+
+    @Override
+    public void triggerCompaction(boolean fullCompaction) {
+        if (isDelayedCompactPartition()) {
+            if (shouldTriggerDelayedLookupCompact()) {
+                triggerCount.set(0);
+                super.triggerCompaction(fullCompaction);
+            } else {
+                LOG.info(
+                        "Skip to trigger this lookup compaction because the compaction trigger count {} has not reached "
+                                + "the stop trigger threshold {} or l0 file size {} is less than l0 file trigger threshold {}.",
+                        triggerCount.get(),
+                        stopTriggerThreshold,
+                        level0Files(),
+                        l0FileTriggerThreshold);
+                triggerCount.incrementAndGet();
+            }
+        } else {
+            super.triggerCompaction(fullCompaction);
+        }
+    }
+
+    @Override
+    public boolean hasDelayedCompact() {
+        return strategy instanceof ForceUpLevel0Compaction && level0Files() > 0;
+    }
+
+    @VisibleForTesting
+    public boolean shouldTriggerDelayedLookupCompact() {
+        if (level0Files() >= l0FileTriggerThreshold) {
+            LOG.info("Trigger delayed lookup compact for L0 file count: {}", level0Files());
+            return true;
+        } else if (triggerCount.get() >= stopTriggerThreshold) {
+            LOG.info("Trigger delayed lookup compact for stopTrigger count: {}", triggerCount);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @VisibleForTesting
+    public boolean isDelayedCompactPartition() {
+        if (delayPartitionThreshold == null) {
+            return false;
+        }
+        LocalDateTime delayedCompactPartition = LocalDateTime.now().minus(delayPartitionThreshold);
+        // For delayedCompactPartitionThreshold=20250120, any data insert into partitions<=20250120
+        // should be delayed compact.
+        boolean result = !currentPartitionDate.isAfter(delayedCompactPartition);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "Current partition Date: {}, delayed compact partition threshold: {}, delayed compact partition result: {}.",
+                    currentPartitionDate.format(DateTimeFormatter.BASIC_ISO_DATE),
+                    delayedCompactPartition.format(DateTimeFormatter.BASIC_ISO_DATE),
+                    result);
+        }
+        return result;
+    }
+
+    private int level0Files() {
+        return levels().level0().size();
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManager.java
@@ -240,6 +240,11 @@ public class MergeTreeCompactManager extends CompactFutureManager {
         return result;
     }
 
+    @Override
+    public boolean hasDelayedCompact() {
+        return false;
+    }
+
     private void reportLevel0FileCount() {
         if (metricsReporter != null) {
             metricsReporter.reportLevel0FileCount(levels.level0().size());

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -290,9 +290,12 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
         //
         // Condition 2: No compaction is in progress. That is, no more changelog will be
         // produced.
+        //
+        // Condition 3: The writer has no delayed compaction.
         return writerContainer ->
                 writerContainer.lastModifiedCommitIdentifier < latestCommittedIdentifier
-                        && !writerContainer.writer.isCompacting();
+                        && !writerContainer.writer.isCompacting()
+                        && !writerContainer.writer.hasDelayedCompact();
     }
 
     protected static <T>
@@ -397,7 +400,7 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
         return result;
     }
 
-    protected WriterContainer<T> getWriterWrapper(BinaryRow partition, int bucket) {
+    public WriterContainer<T> getWriterWrapper(BinaryRow partition, int bucket) {
         Map<Integer, WriterContainer<T>> buckets = writers.get(partition);
         if (buckets == null) {
             buckets = new HashMap<>();
@@ -552,7 +555,7 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
     }
 
     @VisibleForTesting
-    Map<BinaryRow, Map<Integer, WriterContainer<T>>> writers() {
+    public Map<BinaryRow, Map<Integer, WriterContainer<T>>> writers() {
         return writers;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionTimeExtractor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionTimeExtractor.java
@@ -18,6 +18,11 @@
 
 package org.apache.paimon.partition;
 
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.RowDataToObjectArrayConverter;
+
 import javax.annotation.Nullable;
 
 import java.time.LocalDate;
@@ -30,6 +35,7 @@ import java.time.format.ResolverStyle;
 import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -79,9 +85,20 @@ public class PartitionTimeExtractor {
     @Nullable private final String pattern;
     @Nullable private final String formatter;
 
+    public PartitionTimeExtractor(CoreOptions options) {
+        this(options.partitionTimestampPattern(), options.partitionTimestampFormatter());
+    }
+
     public PartitionTimeExtractor(@Nullable String pattern, @Nullable String formatter) {
         this.pattern = pattern;
         this.formatter = formatter;
+    }
+
+    public LocalDateTime extract(BinaryRow partition, RowType partitionType) {
+        RowDataToObjectArrayConverter toObjectArrayConverter =
+                new RowDataToObjectArrayConverter(partitionType);
+        Object[] array = toObjectArrayConverter.convert(partition);
+        return extract(partitionType.getFieldNames(), Arrays.asList(array));
     }
 
     public LocalDateTime extract(LinkedHashMap<String, String> spec) {

--- a/paimon-core/src/main/java/org/apache/paimon/postpone/PostponeBucketWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/postpone/PostponeBucketWriter.java
@@ -89,6 +89,11 @@ public class PostponeBucketWriter implements RecordWriter<KeyValue> {
     }
 
     @Override
+    public boolean hasDelayedCompact() {
+        return false;
+    }
+
+    @Override
     public void sync() throws Exception {}
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/utils/RecordWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/RecordWriter.java
@@ -68,6 +68,11 @@ public interface RecordWriter<T> {
     boolean isCompacting();
 
     /**
+     * Check if the {@code RecordWriter} has delayed compacts need to be triggered in the future.
+     */
+    boolean hasDelayedCompact();
+
+    /**
      * Sync the writer. The structure related to file reading and writing is thread unsafe, there
      * are asynchronous threads inside the writer, which should be synced before reading data.
      */

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/DelayedLookupCompactManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/DelayedLookupCompactManagerTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree.compact;
+
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.mergetree.Levels;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link MergeTreeCompactManager}. */
+public class DelayedLookupCompactManagerTest extends MergeTreeCompactManagerTest {
+
+    @Test
+    public void testDelayedLookupCompactionBeforeThreshold()
+            throws ExecutionException, InterruptedException {
+        List<LevelMinMax> inputs =
+                Arrays.asList(
+                        new LevelMinMax(0, 1, 5),
+                        new LevelMinMax(0, 3, 6),
+                        new LevelMinMax(0, 6, 8),
+                        new LevelMinMax(1, 1, 4),
+                        new LevelMinMax(1, 6, 8),
+                        new LevelMinMax(1, 10, 10),
+                        new LevelMinMax(2, 1, 3),
+                        new LevelMinMax(2, 4, 6));
+        List<DataFileMeta> files = new ArrayList<>();
+        for (int i = 0; i < inputs.size(); i++) {
+            LevelMinMax minMax = inputs.get(i);
+            files.add(minMax.toFile(i));
+        }
+
+        Levels levels = new Levels(comparator, files, 3);
+
+        CompactStrategy strategy = new ForceUpLevel0Compaction(new UniversalCompaction(0, 0, 5));
+
+        DelayedLookupCompactManager oldManager =
+                new DelayedLookupCompactManager(
+                        service,
+                        levels,
+                        strategy,
+                        comparator,
+                        2,
+                        Integer.MAX_VALUE,
+                        new TestRewriter(true),
+                        null,
+                        null,
+                        false,
+                        LocalDateTime.now().minusDays(2),
+                        Duration.ofDays(2),
+                        5,
+                        5);
+
+        // delayed lookup compaction not triggered
+        assertThat(oldManager.isDelayedCompactPartition()).isTrue();
+        assertThat(oldManager.shouldTriggerDelayedLookupCompact()).isFalse();
+        assertThat(oldManager.hasDelayedCompact()).isTrue();
+
+        // trigger delayed lookup compaction by stop trigger
+        oldManager.triggerCompaction(false);
+        assertThat(oldManager.getCompactionResult(true)).isEmpty();
+
+        oldManager.triggerCompaction(false);
+        oldManager.triggerCompaction(false);
+        oldManager.triggerCompaction(false);
+        oldManager.triggerCompaction(false);
+
+        assertThat(oldManager.shouldTriggerDelayedLookupCompact()).isTrue();
+        oldManager.triggerCompaction(false);
+        assertThat(oldManager.getCompactionResult(true)).isPresent();
+        assertThat(oldManager.hasDelayedCompact()).isFalse();
+
+        // trigger delayed lookup compaction by l0 file count
+        oldManager.addNewFile((new LevelMinMax(0, 11, 12)).toFile(inputs.size()));
+        oldManager.addNewFile((new LevelMinMax(0, 13, 14)).toFile(inputs.size() + 1));
+        oldManager.addNewFile((new LevelMinMax(0, 15, 16)).toFile(inputs.size() + 2));
+        oldManager.addNewFile((new LevelMinMax(0, 17, 18)).toFile(inputs.size() + 3));
+        assertThat(oldManager.shouldTriggerDelayedLookupCompact()).isFalse();
+        oldManager.addNewFile((new LevelMinMax(0, 15, 16)).toFile(inputs.size() + 4));
+        oldManager.addNewFile((new LevelMinMax(0, 17, 18)).toFile(inputs.size() + 6));
+        assertThat(oldManager.shouldTriggerDelayedLookupCompact()).isTrue();
+        oldManager.triggerCompaction(false);
+        assertThat(oldManager.getCompactionResult(true)).isPresent();
+    }
+
+    @Test
+    public void testDelayedLookupCompactionAfterThreshold()
+            throws ExecutionException, InterruptedException {
+        List<LevelMinMax> inputs =
+                Arrays.asList(
+                        new LevelMinMax(0, 1, 5),
+                        new LevelMinMax(0, 3, 6),
+                        new LevelMinMax(0, 6, 8),
+                        new LevelMinMax(1, 1, 4),
+                        new LevelMinMax(1, 6, 8),
+                        new LevelMinMax(1, 10, 10),
+                        new LevelMinMax(2, 1, 3),
+                        new LevelMinMax(2, 4, 6));
+        List<DataFileMeta> files = new ArrayList<>();
+        for (int i = 0; i < inputs.size(); i++) {
+            LevelMinMax minMax = inputs.get(i);
+            files.add(minMax.toFile(i));
+        }
+
+        Levels levels = new Levels(comparator, files, 3);
+
+        CompactStrategy strategy = new ForceUpLevel0Compaction(new UniversalCompaction(0, 0, 5));
+
+        DelayedLookupCompactManager newManager =
+                new DelayedLookupCompactManager(
+                        service,
+                        levels,
+                        strategy,
+                        comparator,
+                        2,
+                        Integer.MAX_VALUE,
+                        new TestRewriter(true),
+                        null,
+                        null,
+                        false,
+                        LocalDateTime.now().minusDays(1),
+                        Duration.ofDays(2),
+                        5,
+                        5);
+
+        // compaction will trigger immediately for new partitions
+        assertThat(newManager.isDelayedCompactPartition()).isFalse();
+        assertThat(newManager.shouldTriggerDelayedLookupCompact()).isFalse();
+        newManager.triggerCompaction(false);
+        assertThat(newManager.getCompactionResult(true)).isPresent();
+        assertThat(newManager.hasDelayedCompact()).isFalse();
+
+        // stop-trigger not working for new partitions
+        newManager.triggerCompaction(false);
+        newManager.triggerCompaction(false);
+        newManager.triggerCompaction(false);
+        newManager.triggerCompaction(false);
+        newManager.triggerCompaction(false);
+        newManager.triggerCompaction(false);
+        assertThat(newManager.shouldTriggerDelayedLookupCompact()).isFalse();
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManagerTest.java
@@ -49,9 +49,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** Test for {@link MergeTreeCompactManager}. */
 public class MergeTreeCompactManagerTest {
 
-    private final Comparator<InternalRow> comparator = Comparator.comparingInt(o -> o.getInt(0));
+    final Comparator<InternalRow> comparator = Comparator.comparingInt(o -> o.getInt(0));
 
-    private static ExecutorService service;
+    static ExecutorService service;
 
     @BeforeAll
     public static void before() {
@@ -223,11 +223,11 @@ public class MergeTreeCompactManagerTest {
         return (numLevels, runs) -> Optional.of(CompactUnit.fromLevelRuns(numLevels - 1, runs));
     }
 
-    private static class TestRewriter extends AbstractCompactRewriter {
+    static class TestRewriter extends AbstractCompactRewriter {
 
         private final boolean expectedDropDelete;
 
-        private TestRewriter(boolean expectedDropDelete) {
+        TestRewriter(boolean expectedDropDelete) {
             this.expectedDropDelete = expectedDropDelete;
         }
 
@@ -262,25 +262,25 @@ public class MergeTreeCompactManagerTest {
         }
     }
 
-    private static class LevelMinMax {
+    static class LevelMinMax {
 
-        private final int level;
-        private final int min;
-        private final int max;
+        protected final int level;
+        protected final int min;
+        protected final int max;
 
-        private LevelMinMax(DataFileMeta file) {
+        LevelMinMax(DataFileMeta file) {
             this.level = file.level();
             this.min = file.minKey().getInt(0);
             this.max = file.maxKey().getInt(0);
         }
 
-        private LevelMinMax(int level, int min, int max) {
+        LevelMinMax(int level, int min, int max) {
             this.level = level;
             this.min = min;
             this.max = max;
         }
 
-        private DataFileMeta toFile(long maxSequence) {
+        DataFileMeta toFile(long maxSequence) {
             return newFile(level, min, max, maxSequence);
         }
 

--- a/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/KeyValueFileStoreWriteTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.operation;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.TestFileStore;
+import org.apache.paimon.TestKeyValueGenerator;
+import org.apache.paimon.compact.CompactManager;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.disk.IOManagerImpl;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.mergetree.MergeTreeWriter;
+import org.apache.paimon.mergetree.compact.DeduplicateMergeFunction;
+import org.apache.paimon.mergetree.compact.DelayedLookupCompactManager;
+import org.apache.paimon.partition.PartitionTimeExtractor;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.TableSchema;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link KeyValueFileStoreWrite}. */
+public class KeyValueFileStoreWriteTest {
+
+    private static final int NUM_BUCKETS = 10;
+
+    @TempDir java.nio.file.Path tempDir;
+
+    private IOManager ioManager;
+
+    @BeforeEach
+    public void before() throws IOException {
+        this.ioManager = new IOManagerImpl(tempDir.toString());
+    }
+
+    @Test
+    public void testDelayedLookupPartition() throws Exception {
+        SchemaManager schemaManager =
+                new SchemaManager(LocalFileIO.create(), new Path(tempDir.toUri()));
+        Map<String, String> options = new HashMap<>();
+        Duration lookupDelayPartitionThreshold = Duration.ofDays(1L);
+        options.put(CoreOptions.LOOKUP_DELAY_PARTITION_THRESHOLD.key(), "1 d");
+        options.put(CoreOptions.DELETION_VECTORS_ENABLED.key(), "true");
+        options.put(CoreOptions.PARTITION_TIMESTAMP_FORMATTER.key(), "yyyyMMdd H");
+        options.put(CoreOptions.PARTITION_TIMESTAMP_PATTERN.key(), "$dt $hr");
+
+        TableSchema schema =
+                schemaManager.createTable(
+                        new Schema(
+                                TestKeyValueGenerator.DEFAULT_ROW_TYPE.getFields(),
+                                TestKeyValueGenerator.DEFAULT_PART_TYPE.getFieldNames(),
+                                TestKeyValueGenerator.getPrimaryKeys(
+                                        TestKeyValueGenerator.GeneratorMode.MULTI_PARTITIONED),
+                                options,
+                                null));
+        TestFileStore store =
+                new TestFileStore.Builder(
+                                "avro",
+                                tempDir.toString(),
+                                NUM_BUCKETS,
+                                TestKeyValueGenerator.DEFAULT_PART_TYPE,
+                                TestKeyValueGenerator.KEY_TYPE,
+                                TestKeyValueGenerator.DEFAULT_ROW_TYPE,
+                                TestKeyValueGenerator.TestKeyValueFieldsExtractor.EXTRACTOR,
+                                DeduplicateMergeFunction.factory(),
+                                schema)
+                        .build();
+
+        KeyValueFileStoreWrite write = (KeyValueFileStoreWrite) store.newWrite();
+        write.withIOManager(ioManager);
+        TestKeyValueGenerator gen = new TestKeyValueGenerator();
+        PartitionTimeExtractor partitionTimeExtractor = new PartitionTimeExtractor(store.options());
+
+        for (int i = 0; i < 100; i++) {
+            KeyValue keyValue = gen.next();
+            BinaryRow partition = gen.getPartition(keyValue);
+            LocalDateTime partitionTime =
+                    partitionTimeExtractor.extract(
+                            partition, TestKeyValueGenerator.DEFAULT_PART_TYPE);
+            AbstractFileStoreWrite.WriterContainer<KeyValue> writerContainer =
+                    write.createWriterContainer(gen.getPartition(keyValue), 1, false);
+            MergeTreeWriter writer = (MergeTreeWriter) writerContainer.writer;
+
+            CompactManager compactManager = writer.compactManager();
+            assertThat(compactManager).isInstanceOf(DelayedLookupCompactManager.class);
+
+            DelayedLookupCompactManager delayedLookupCompactManager =
+                    (DelayedLookupCompactManager) compactManager;
+            assertThat(delayedLookupCompactManager.isDelayedCompactPartition())
+                    .isEqualTo(
+                            !partitionTime.isAfter(
+                                    LocalDateTime.now().minus(lookupDelayPartitionThreshold)));
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DelayedCompactStoreSinkWrite.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DelayedCompactStoreSinkWrite.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.memory.MemorySegmentPool;
+import org.apache.paimon.operation.AbstractFileStoreWrite;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.RecordWriter;
+
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** {@link StoreSinkWrite} for tables that need delayed compaction trigger. */
+public class DelayedCompactStoreSinkWrite extends StoreSinkWriteImpl {
+
+    private final String tableName;
+
+    private static final String HAS_DELAYED_COMPACT_BUCKETS_STATE_NAME =
+            "paimon_has_delayed_compact_buckets";
+
+    public DelayedCompactStoreSinkWrite(
+            FileStoreTable table,
+            String commitUser,
+            StoreSinkWriteState state,
+            IOManager ioManager,
+            boolean ignorePreviousFiles,
+            boolean waitCompaction,
+            boolean isStreaming,
+            @Nullable MemorySegmentPool memoryPool,
+            MetricGroup metricGroup) {
+        super(
+                table,
+                commitUser,
+                state,
+                ioManager,
+                ignorePreviousFiles,
+                waitCompaction,
+                isStreaming,
+                memoryPool,
+                metricGroup);
+
+        this.tableName = table.name();
+        List<StoreSinkWriteState.StateValue> lateCompactBucketsStateValues =
+                state.get(tableName, HAS_DELAYED_COMPACT_BUCKETS_STATE_NAME);
+        if (lateCompactBucketsStateValues != null) {
+            for (StoreSinkWriteState.StateValue stateValue : lateCompactBucketsStateValues) {
+                ((AbstractFileStoreWrite<?>) write.getWrite())
+                        .getWriterWrapper(stateValue.partition(), stateValue.bucket());
+                stateValue.bucket();
+            }
+        }
+    }
+
+    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void snapshotState() throws Exception {
+        super.snapshotState();
+
+        Map<BinaryRow, Map<Integer, AbstractFileStoreWrite.WriterContainer>> writerContainerMap =
+                ((AbstractFileStoreWrite) write.getWrite()).writers();
+        List<StoreSinkWriteState.StateValue> delayedCompactBucketList = new ArrayList<>();
+
+        for (Map.Entry<BinaryRow, Map<Integer, AbstractFileStoreWrite.WriterContainer>>
+                partitionEntry : writerContainerMap.entrySet()) {
+            for (Map.Entry<Integer, AbstractFileStoreWrite.WriterContainer> bucketEntry :
+                    partitionEntry.getValue().entrySet()) {
+                RecordWriter writer = bucketEntry.getValue().writer;
+                if (writer.hasDelayedCompact()) {
+                    delayedCompactBucketList.add(
+                            new StoreSinkWriteState.StateValue(
+                                    partitionEntry.getKey(), bucketEntry.getKey(), new byte[0]));
+                }
+            }
+        }
+
+        state.put(tableName, HAS_DELAYED_COMPACT_BUCKETS_STATE_NAME, delayedCompactBucketList);
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #4917 

Introduce DelayedLookupCompactManager to support delayed lookup compaction

### Tests
DelayedLookupCompactManagerTest#testDelayedLookupCompactionBeforeThreshold
DelayedLookupCompactManagerTest#testDelayedLookupCompactionAfterThreshold
KeyValueFileStoreWriteTest#testDelayedLookupPartition
WriterOperatorTest#testDelayedLookupWithFailure



### API and Format

Introduce hasDelayedCompact() in RecordWriter and CompactManager

### Documentation

<!-- Does this change introduce a new feature -->
