### PR TITLE
[spark] support spark procedure for removing table exists in metastor…

### DIFF
--- a/paimon-spark/paimon-spark-common/pom.xml
+++ b/paimon-spark/paimon-spark-common/pom.xml
@@ -60,6 +60,13 @@ under the License.
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-bundle</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkProcedures.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkProcedures.java
@@ -38,6 +38,7 @@ import org.apache.paimon.spark.procedure.Procedure;
 import org.apache.paimon.spark.procedure.ProcedureBuilder;
 import org.apache.paimon.spark.procedure.PurgeFilesProcedure;
 import org.apache.paimon.spark.procedure.RefreshObjectTableProcedure;
+import org.apache.paimon.spark.procedure.RemoveNonExistingTableProcedure;
 import org.apache.paimon.spark.procedure.RemoveOrphanFilesProcedure;
 import org.apache.paimon.spark.procedure.RemoveUnexistingFilesProcedure;
 import org.apache.paimon.spark.procedure.RenameTagProcedure;
@@ -102,6 +103,8 @@ public class SparkProcedures {
         procedureBuilders.put("compact_manifest", CompactManifestProcedure::builder);
         procedureBuilders.put("refresh_object_table", RefreshObjectTableProcedure::builder);
         procedureBuilders.put("clear_consumers", ClearConsumersProcedure::builder);
+        procedureBuilders.put(
+                "remove_non_existing_table", RemoveNonExistingTableProcedure::builder);
         return procedureBuilders.build();
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RemoveNonExistingTableProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RemoveNonExistingTableProcedure.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.procedure;
+
+import org.apache.paimon.catalog.CachingCatalog;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.hive.HiveCatalog;
+import org.apache.paimon.spark.catalog.WithPaimonCatalog;
+import org.apache.paimon.utils.Preconditions;
+
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Procedure to remove table in metastore but does not exist in file system. */
+public class RemoveNonExistingTableProcedure extends BaseProcedure {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(RemoveNonExistingTableProcedure.class);
+
+    private static final ProcedureParameter[] PARAMETERS =
+            new ProcedureParameter[] {ProcedureParameter.required("table", DataTypes.StringType)};
+
+    private static final StructType OUTPUT_TYPE =
+            new StructType(
+                    new StructField[] {
+                        new StructField("result", DataTypes.BooleanType, true, Metadata.empty())
+                    });
+
+    private RemoveNonExistingTableProcedure(TableCatalog tableCatalog) {
+        super(tableCatalog);
+    }
+
+    @Override
+    public ProcedureParameter[] parameters() {
+        return PARAMETERS;
+    }
+
+    @Override
+    public StructType outputType() {
+        return OUTPUT_TYPE;
+    }
+
+    @Override
+    public InternalRow[] call(InternalRow args) {
+        String tableName = args.getString(0);
+        Preconditions.checkArgument(
+                tableName != null && !tableName.isEmpty(),
+                "Cannot drop table in metastore with empty tableName for argument %s",
+                tableName);
+        org.apache.paimon.catalog.Identifier identifier =
+                org.apache.paimon.catalog.Identifier.fromString(
+                        toIdentifier(args.getString(0), PARAMETERS[0].name()).toString());
+        LOG.info("identifier in RemoveNonExistingTableProcedure is {}.", identifier);
+
+        Catalog paimonCatalog = ((WithPaimonCatalog) tableCatalog()).paimonCatalog();
+        Catalog wrappedCatalog;
+        if (paimonCatalog instanceof CachingCatalog) {
+            wrappedCatalog = ((CachingCatalog) paimonCatalog).wrapped();
+        } else {
+            wrappedCatalog = paimonCatalog;
+        }
+        if (!(wrappedCatalog instanceof HiveCatalog)) {
+            throw new IllegalArgumentException(
+                    "Only support Hive Catalog in RemoveNonExistingTableProcedure");
+        }
+
+        try {
+            wrappedCatalog.getTable(identifier);
+            LOG.info(
+                    "table {}.{} exists in file system too, so will not drop it in metastore",
+                    identifier.getDatabaseName(),
+                    identifier.getTableName());
+            return new InternalRow[] {newInternalRow(false)};
+        } catch (Catalog.TableNotExistException e) {
+            // drop table in metastore
+            try {
+                ((HiveCatalog) wrappedCatalog)
+                        .getHmsClient()
+                        .dropTable(
+                                identifier.getDatabaseName(),
+                                identifier.getTableName(),
+                                false,
+                                false);
+
+                if (paimonCatalog instanceof CachingCatalog) {
+                    LOG.info(
+                            "dropped table {}.{} in metastore, so invalidateTable in CachingCatalog",
+                            identifier.getDatabaseName(),
+                            identifier.getTableName());
+                    paimonCatalog.invalidateTable(identifier);
+                }
+            } catch (NoSuchObjectException ex) {
+                LOG.error(
+                        "table {}.{} does not exist in metastore, so will not drop it",
+                        identifier.getDatabaseName(),
+                        identifier.getTableName());
+                throw new RuntimeException(
+                        String.format(
+                                "table %s.%s not found in metastore",
+                                identifier.getDatabaseName(), identifier.getTableName()),
+                        ex);
+            } catch (TException ex) {
+                throw new RuntimeException(
+                        String.format(
+                                "drop table %s.%s in metastore failed: ",
+                                identifier.getDatabaseName(), identifier.getTableName()),
+                        e);
+            }
+            return new InternalRow[] {newInternalRow(true)};
+        } catch (Exception e) {
+            LOG.info(
+                    "exception happen when try to get table {}.{}, so will not drop it in metastore",
+                    identifier.getDatabaseName(),
+                    identifier.getTableName(),
+                    e);
+            return new InternalRow[] {newInternalRow(false)};
+        }
+    }
+
+    public static ProcedureBuilder builder() {
+        return new Builder<RemoveNonExistingTableProcedure>() {
+            @Override
+            public RemoveNonExistingTableProcedure doBuild() {
+                return new RemoveNonExistingTableProcedure(tableCatalog());
+            }
+        };
+    }
+
+    @Override
+    public String description() {
+        return "RemoveNonExistingTableProcedure";
+    }
+}

--- a/paimon-spark/paimon-spark-ut/pom.xml
+++ b/paimon-spark/paimon-spark-ut/pom.xml
@@ -52,6 +52,13 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-hive-connector-common</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RemoveNonExistingTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RemoveNonExistingTableProcedureTest.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.procedure
+
+import org.apache.paimon.spark.{PaimonHiveTestBase, SparkCatalog}
+import org.apache.paimon.spark.PaimonHiveTestBase.hiveUri
+
+import org.apache.spark.SparkConf
+
+class RemoveNonExistingTableProcedureTest extends PaimonHiveTestBase {
+
+  protected val paimonHiveNoCacheCatalogName: String = "paimon_hive_no_cache"
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set(s"spark.sql.catalog.$paimonHiveNoCacheCatalogName.cache-enabled", "false")
+      .set(s"spark.sql.catalog.$paimonHiveNoCacheCatalogName", classOf[SparkCatalog].getName)
+      .set(s"spark.sql.catalog.$paimonHiveNoCacheCatalogName.metastore", "hive")
+      .set(
+        s"spark.sql.catalog.$paimonHiveNoCacheCatalogName.warehouse",
+        tempHiveDBDir.getCanonicalPath)
+      .set(s"spark.sql.catalog.$paimonHiveNoCacheCatalogName.uri", hiveUri)
+  }
+
+  test("Paimon DDL with hive catalog: drop table which location has been deleted") {
+    Seq(sparkCatalogName, paimonHiveCatalogName, paimonHiveNoCacheCatalogName).foreach {
+      catalogName =>
+        spark.sql(s"USE $catalogName")
+        withDatabase("paimon_db") {
+          spark.sql(s"CREATE DATABASE paimon_db")
+          spark.sql(s"USE paimon_db")
+          spark.sql("CREATE TABLE t USING paimon")
+          val table = loadTable("paimon_db", "t")
+
+          // the procedure will not drop table in metastore which exists in file system
+          spark
+            .sql(s"CALL sys.remove_non_existing_table(table => 'paimon_db.t')")
+          assert(spark.sql("SHOW TABLES").count() == 1)
+
+          // test drop table which location has been deleted in spark sql
+          table.fileIO().delete(table.location(), true)
+          spark.sql("DROP TABLE IF EXISTS t")
+          if (catalogName.equals(sparkCatalogName)) {
+            // tableExists in spark catalog will return true with catalog cache, then spark will drop it when drop table
+            // even the table does not exist in file system, spark session catalog spark_catalog will still drop it.
+            // but other catalog will not drop table, because Paimon HiveCatalog will getTable before dropTable
+            assert(spark.sql("SHOW TABLES").count() == 0)
+          } else {
+            // tableExists in spark catalog will return false without catalog cache, then spark will not drop it when drop table
+            assert(spark.sql("SHOW TABLES").count() == 1)
+          }
+
+          // test drop table in metastore but not in file system
+          if (!catalogName.equals(sparkCatalogName)) {
+            spark
+              .sql(s"CALL sys.remove_non_existing_table(table => 'paimon_db.t')")
+          }
+          assert(spark.sql("SHOW TABLES").count() == 0)
+
+          // test drop table not exists in metastore
+          assertThrows[RuntimeException] {
+            spark.sql(s"CALL sys.remove_non_existing_table(table => 'paimon_db.t')")
+          }
+        }
+    }
+  }
+}


### PR DESCRIPTION
Support spark procedure for removing table exists in metastore but does not exist in fs

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: workaround for  #4853

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
