### PR TITLE
[hotfix] Fix dedicated compaction

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
@@ -86,18 +86,18 @@ public class CompactorSourceBuilder {
     }
 
     private Source<RowData, ?, ?> buildSource(CompactBucketsTable compactBucketsTable) {
+        compactBucketsTable =
+                compactBucketsTable.copy(
+                        isContinuous ? streamingCompactOptions() : batchCompactOptions());
         ReadBuilder readBuilder =
                 compactBucketsTable.newReadBuilder().withFilter(partitionPredicate);
-        if (compactBucketsTable.coreOptions().manifestDeleteFileDropStats()) {
+        if (CoreOptions.fromMap(table.options()).manifestDeleteFileDropStats()) {
             readBuilder = readBuilder.dropStats();
         }
         if (isContinuous) {
-            compactBucketsTable = compactBucketsTable.copy(streamingCompactOptions());
             return new ContinuousFileStoreSource(readBuilder, compactBucketsTable.options(), null);
         } else {
-            compactBucketsTable = compactBucketsTable.copy(batchCompactOptions());
             Options options = compactBucketsTable.coreOptions().toConfiguration();
-
             return new StaticFileStoreSource(
                     readBuilder,
                     null,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
There are some failures related to delicated compaction
```
1. FlinkActionsWithKafkaE2eTest
Result is still unexpected after 60 retries.
Expected: {20221206, 1, 100=1, 20221205, 1, 100=1}
Actual: {}
	at org.apache.paimon.tests.E2eTestBase.checkResult(E2eTestBase.java:333)
	at org.apache.paimon.tests.FlinkActionsWithKafkaE2eTest.testCompact(FlinkActionsWithKafkaE2eTest.java:112)

2. CompactProcedureITCase
java.util.concurrent.TimeoutException: Cannot collect 2 records in 3 MINUTES
	at org.apache.paimon.utils.BlockingIterator.collect(BlockingIterator.java:84)
	at org.apache.paimon.utils.BlockingIterator.collect(BlockingIterator.java:72)
	at org.apache.paimon.flink.procedure.CompactProcedureITCase.testStreamingCompact(CompactProcedureITCase.java:138)
``` 
<!-- What is the purpose of the change -->

### Tests
FlinkActionsWithKafkaE2eTest
CompactProcedureITCase

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
