### PR TITLE
[rest] Add commit statistics when commit to REST Server

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
@@ -147,13 +147,7 @@ public class CatalogUtils {
                 table.newReadBuilder().newScan().listPartitionEntries();
         List<Partition> partitions = new ArrayList<>(partitionEntries.size());
         for (PartitionEntry entry : partitionEntries) {
-            partitions.add(
-                    new Partition(
-                            computer.generatePartValues(entry.partition()),
-                            entry.recordCount(),
-                            entry.fileSizeInBytes(),
-                            entry.fileCount(),
-                            entry.lastFileCreationTime()));
+            partitions.add(entry.toPartition(computer));
         }
         return partitions;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/RenamingSnapshotCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/RenamingSnapshotCommit.java
@@ -23,10 +23,12 @@ import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.operation.Lock;
+import org.apache.paimon.partition.Partition;
 import org.apache.paimon.utils.SnapshotManager;
 
 import javax.annotation.Nullable;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 
@@ -49,7 +51,8 @@ public class RenamingSnapshotCommit implements SnapshotCommit {
     }
 
     @Override
-    public boolean commit(Snapshot snapshot, String branch) throws Exception {
+    public boolean commit(Snapshot snapshot, String branch, List<Partition> statistics)
+            throws Exception {
         Path newSnapshotPath =
                 snapshotManager.branch().equals(branch)
                         ? snapshotManager.snapshotPath(snapshot.id())

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/SnapshotCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/SnapshotCommit.java
@@ -19,14 +19,16 @@
 package org.apache.paimon.catalog;
 
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.partition.Partition;
 import org.apache.paimon.utils.SnapshotManager;
 
 import java.io.Serializable;
+import java.util.List;
 
 /** Interface to commit snapshot atomically. */
 public interface SnapshotCommit extends AutoCloseable {
 
-    boolean commit(Snapshot snapshot, String branch) throws Exception;
+    boolean commit(Snapshot snapshot, String branch, List<Partition> statistics) throws Exception;
 
     /** Factory to create {@link SnapshotCommit}. */
     interface Factory extends Serializable {

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/PartitionEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/PartitionEntry.java
@@ -21,7 +21,9 @@ package org.apache.paimon.manifest;
 import org.apache.paimon.annotation.Public;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.partition.Partition;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.utils.InternalRowPartitionComputer;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -81,6 +83,15 @@ public class PartitionEntry {
                 fileSizeInBytes + entry.fileSizeInBytes,
                 fileCount + entry.fileCount,
                 Math.max(lastFileCreationTime, entry.lastFileCreationTime));
+    }
+
+    public Partition toPartition(InternalRowPartitionComputer computer) {
+        return new Partition(
+                computer.generatePartValues(partition),
+                recordCount,
+                fileSizeInBytes,
+                fileCount,
+                lastFileCreationTime);
     }
 
     public static PartitionEntry fromManifestEntry(ManifestEntry entry) {

--- a/paimon-core/src/main/java/org/apache/paimon/partition/Partition.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/Partition.java
@@ -29,7 +29,10 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.Objects;
 
-/** Entry representing a partition. */
+/**
+ * Statistics of a partition, fields inside may be negative, indicating that some data has been
+ * removed.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Public
 public class Partition implements Serializable {

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -340,8 +340,9 @@ public class RESTCatalog implements Catalog, SupportsSnapshots {
         return Optional.of(response.getSnapshot());
     }
 
-    public boolean commitSnapshot(Identifier identifier, Snapshot snapshot) {
-        CommitTableRequest request = new CommitTableRequest(identifier, snapshot);
+    public boolean commitSnapshot(
+            Identifier identifier, Snapshot snapshot, List<Partition> statistics) {
+        CommitTableRequest request = new CommitTableRequest(identifier, snapshot, statistics);
         CommitTableResponse response =
                 client.post(
                         resourcePaths.commitTable(identifier.getDatabaseName()),

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTSnapshotCommitFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTSnapshotCommitFactory.java
@@ -21,7 +21,10 @@ package org.apache.paimon.rest;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.catalog.SnapshotCommit;
+import org.apache.paimon.partition.Partition;
 import org.apache.paimon.utils.SnapshotManager;
+
+import java.util.List;
 
 /** Factory to create {@link SnapshotCommit} for REST Catalog. */
 public class RESTSnapshotCommitFactory implements SnapshotCommit.Factory {
@@ -39,11 +42,11 @@ public class RESTSnapshotCommitFactory implements SnapshotCommit.Factory {
         RESTCatalog catalog = loader.load();
         return new SnapshotCommit() {
             @Override
-            public boolean commit(Snapshot snapshot, String branch) {
+            public boolean commit(Snapshot snapshot, String branch, List<Partition> statistics) {
                 Identifier newIdentifier =
                         new Identifier(
                                 identifier.getDatabaseName(), identifier.getTableName(), branch);
-                return catalog.commitSnapshot(newIdentifier, snapshot);
+                return catalog.commitSnapshot(newIdentifier, snapshot, statistics);
             }
 
             @Override

--- a/paimon-core/src/main/java/org/apache/paimon/rest/requests/CommitTableRequest.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/requests/CommitTableRequest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.rest.requests;
 
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.partition.Partition;
 import org.apache.paimon.rest.RESTRequest;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
@@ -27,12 +28,15 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGet
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 /** Request for committing snapshot to table. */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CommitTableRequest implements RESTRequest {
 
     private static final String FIELD_IDENTIFIER = "identifier";
     private static final String FIELD_SNAPSHOT = "snapshot";
+    private static final String FIELD_STATISTICS = "statistics";
 
     @JsonProperty(FIELD_IDENTIFIER)
     private final Identifier identifier;
@@ -40,12 +44,17 @@ public class CommitTableRequest implements RESTRequest {
     @JsonProperty(FIELD_SNAPSHOT)
     private final Snapshot snapshot;
 
+    @JsonProperty(FIELD_STATISTICS)
+    private final List<Partition> statistics;
+
     @JsonCreator
     public CommitTableRequest(
             @JsonProperty(FIELD_IDENTIFIER) Identifier identifier,
-            @JsonProperty(FIELD_SNAPSHOT) Snapshot snapshot) {
+            @JsonProperty(FIELD_SNAPSHOT) Snapshot snapshot,
+            @JsonProperty(FIELD_STATISTICS) List<Partition> statistics) {
         this.identifier = identifier;
         this.snapshot = snapshot;
+        this.statistics = statistics;
     }
 
     @JsonGetter(FIELD_IDENTIFIER)
@@ -56,5 +65,10 @@ public class CommitTableRequest implements RESTRequest {
     @JsonGetter(FIELD_SNAPSHOT)
     public Snapshot getSnapshot() {
         return snapshot;
+    }
+
+    @JsonGetter(FIELD_STATISTICS)
+    public List<Partition> getStatistics() {
+        return statistics;
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -70,6 +70,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -406,7 +407,8 @@ public class RESTCatalogServer {
         if (branchName == null) {
             branchName = "main";
         }
-        boolean success = commit.commit(requestBody.getSnapshot(), branchName);
+        boolean success =
+                commit.commit(requestBody.getSnapshot(), branchName, Collections.emptyList());
         CommitTableResponse response = new CommitTableResponse(success);
         return mockResponse(response, 200);
     }

--- a/paimon-open-api/rest-catalog-open-api.yaml
+++ b/paimon-open-api/rest-catalog-open-api.yaml
@@ -1186,6 +1186,10 @@ components:
           $ref: '#/components/schemas/Identifier'
         snapshot:
           $ref: '#/components/schemas/Snapshot'
+        statistics:
+          type: array
+          items:
+            $ref: '#/components/schemas/Partition'
     Snapshot:
       type: object
       properties:


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
When we commit a table, we can obtain the statistical information of this change. We can aggregate this statistical information by partition and provide it to the REST service. This way, the server can maintain tables and partitions based on this information to provide better services.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
