### PR TITLE
[Bug] Fix NumberFoematException of Dedicated Compaction

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
@@ -140,8 +140,9 @@ public class FallbackReadFileStoreTable extends DelegatedFileStoreTable {
         // so we need to convert main branch snapshot id to millisecond,
         // then convert millisecond to fallback branch snapshot id
         String scanSnapshotIdOptionKey = CoreOptions.SCAN_SNAPSHOT_ID.key();
-        if (options.containsKey(scanSnapshotIdOptionKey)) {
-            long id = Long.parseLong(options.get(scanSnapshotIdOptionKey));
+        String scanSnapshotId = options.get(scanSnapshotIdOptionKey);
+        if (scanSnapshotId != null) {
+            long id = Long.parseLong(scanSnapshotId);
             long millis = wrapped.snapshotManager().snapshot(id).timeMillis();
             Snapshot fallbackSnapshot = fallback.snapshotManager().earlierOrEqualTimeMills(millis);
             long fallbackId;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

In my company, the batch dedicated compaction throw a exception.
After read the code, we found in CompactorSourceBuilder#batchCompactOptions we will do `put(CoreOptions.SCAN_SNAPSHOT_ID.key(), null);`, so the exception throw.
Now fix it.

![image](https://github.com/user-attachments/assets/f7c74457-e415-4e79-bb45-92963179bbf4)


<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
