### PR TITLE
[core]Support enums without spaces in TagPeriodFormatter

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -1012,7 +1012,7 @@ If the data size allocated for the sorting task is uneven,which may lead to perf
             <td><h5>tag.period-formatter</h5></td>
             <td style="word-wrap: break-word;">with_dashes</td>
             <td><p>Enum</p></td>
-            <td>The date format for tag periods.<br /><br />Possible values:<ul><li>"with_dashes": Dates and hours with dashes, e.g., 'yyyy-MM-dd HH'</li><li>"without_dashes": Dates and hours without dashes, e.g., 'yyyyMMdd HH'</li></ul></td>
+            <td>The date format for tag periods.<br /><br />Possible values:<ul><li>"with_dashes": Dates and hours with dashes, e.g., 'yyyy-MM-dd HH'</li><li>"without_dashes": Dates and hours without dashes, e.g., 'yyyyMMdd HH'</li><li>"with_dashes_without_spaces": Dates and hours with dashes without spaces, e.g., 'yyyy-MM-ddHH'</li><li>"without_dashes_and_spaces": Dates and hours without dashes and spaces, e.g., 'yyyyMMddHH'</li></ul></td>
         </tr>
         <tr>
             <td><h5>target-file-size</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -1012,7 +1012,7 @@ If the data size allocated for the sorting task is uneven,which may lead to perf
             <td><h5>tag.period-formatter</h5></td>
             <td style="word-wrap: break-word;">with_dashes</td>
             <td><p>Enum</p></td>
-            <td>The date format for tag periods.<br /><br />Possible values:<ul><li>"with_dashes": Dates and hours with dashes, e.g., 'yyyy-MM-dd HH'</li><li>"without_dashes": Dates and hours without dashes, e.g., 'yyyyMMdd HH'</li><li>"with_dashes_without_spaces": Dates and hours with dashes without spaces, e.g., 'yyyy-MM-ddHH'</li><li>"without_dashes_and_spaces": Dates and hours without dashes and spaces, e.g., 'yyyyMMddHH'</li></ul></td>
+            <td>The date format for tag periods.<br /><br />Possible values:<ul><li>"with_dashes": Dates and hours with dashes, e.g., 'yyyy-MM-dd HH'</li><li>"without_dashes": Dates and hours without dashes, e.g., 'yyyyMMdd HH'</li><li>"without_dashes_and_spaces": Dates and hours without dashes and spaces, e.g., 'yyyyMMddHH'</li></ul></td>
         </tr>
         <tr>
             <td><h5>target-file-size</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -3001,7 +3001,8 @@ public class CoreOptions implements Serializable {
         WITH_DASHES("with_dashes", "Dates and hours with dashes, e.g., 'yyyy-MM-dd HH'"),
         WITHOUT_DASHES("without_dashes", "Dates and hours without dashes, e.g., 'yyyyMMdd HH'"),
         WITHOUT_DASHES_AND_SPACES(
-                "without_dashes_and_spaces", "Dates and hours without dashes, e.g., 'yyyyMMddHH'");
+                "without_dashes_and_spaces",
+                "Dates and hours without dashes and spaces, e.g., 'yyyyMMddHH'");
 
         private final String value;
         private final String description;

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -3000,8 +3000,6 @@ public class CoreOptions implements Serializable {
     public enum TagPeriodFormatter implements DescribedEnum {
         WITH_DASHES("with_dashes", "Dates and hours with dashes, e.g., 'yyyy-MM-dd HH'"),
         WITHOUT_DASHES("without_dashes", "Dates and hours without dashes, e.g., 'yyyyMMdd HH'"),
-        WITH_DASHES_WITHOUT_SPACES(
-                "with_dashes_without_spaces", "Dates and hours with dashes, e.g., 'yyyy-MM-ddHH'"),
         WITHOUT_DASHES_AND_SPACES(
                 "without_dashes_and_spaces", "Dates and hours without dashes, e.g., 'yyyyMMddHH'");
 

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2999,7 +2999,11 @@ public class CoreOptions implements Serializable {
     /** The period format options for tag creation. */
     public enum TagPeriodFormatter implements DescribedEnum {
         WITH_DASHES("with_dashes", "Dates and hours with dashes, e.g., 'yyyy-MM-dd HH'"),
-        WITHOUT_DASHES("without_dashes", "Dates and hours without dashes, e.g., 'yyyyMMdd HH'");
+        WITHOUT_DASHES("without_dashes", "Dates and hours without dashes, e.g., 'yyyyMMdd HH'"),
+        WITH_DASHES_WITHOUT_SPACES(
+                "with_dashes_without_spaces", "Dates and hours with dashes, e.g., 'yyyy-MM-ddHH'"),
+        WITHOUT_DASHES_AND_SPACES(
+                "without_dashes_and_spaces", "Dates and hours without dashes, e.g., 'yyyyMMddHH'");
 
         private final String value;
         private final String description;

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagPeriodHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagPeriodHandler.java
@@ -61,6 +61,26 @@ public interface TagPeriodHandler {
                     .toFormatter()
                     .withResolverStyle(ResolverStyle.LENIENT);
 
+    DateTimeFormatter HOUR_FORMATTER_WITHOUT_SPACES =
+            new DateTimeFormatterBuilder()
+                    .appendValue(YEAR, 1, 10, SignStyle.NORMAL)
+                    .appendLiteral('-')
+                    .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NORMAL)
+                    .appendLiteral('-')
+                    .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NORMAL)
+                    .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NORMAL)
+                    .toFormatter()
+                    .withResolverStyle(ResolverStyle.LENIENT);
+
+    DateTimeFormatter HOUR_FORMATTER_WITHOUT_DASHES_AND_SPACES =
+            new DateTimeFormatterBuilder()
+                    .appendValue(YEAR, 1, 10, SignStyle.NORMAL)
+                    .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NORMAL)
+                    .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NORMAL)
+                    .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NORMAL)
+                    .toFormatter()
+                    .withResolverStyle(ResolverStyle.LENIENT);
+
     DateTimeFormatter MINUTE_FORMATTER =
             new DateTimeFormatterBuilder()
                     .appendValue(YEAR, 1, 10, SignStyle.NORMAL)
@@ -179,6 +199,10 @@ public interface TagPeriodHandler {
                     return HOUR_FORMATTER;
                 case WITHOUT_DASHES:
                     return HOUR_FORMATTER_WITHOUT_DASHES;
+                case WITH_DASHES_WITHOUT_SPACES:
+                    return HOUR_FORMATTER_WITHOUT_SPACES;
+                case WITHOUT_DASHES_AND_SPACES:
+                    return HOUR_FORMATTER_WITHOUT_DASHES_AND_SPACES;
                 default:
                     throw new IllegalArgumentException("Unsupported date format type");
             }
@@ -205,8 +229,10 @@ public interface TagPeriodHandler {
         protected DateTimeFormatter formatter() {
             switch (formatter) {
                 case WITH_DASHES:
+                case WITH_DASHES_WITHOUT_SPACES:
                     return DAY_FORMATTER;
                 case WITHOUT_DASHES:
+                case WITHOUT_DASHES_AND_SPACES:
                     return DAY_FORMATTER_WITHOUT_DASHES;
                 default:
                     throw new IllegalArgumentException("Unsupported date format type");

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagPeriodHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagPeriodHandler.java
@@ -61,17 +61,6 @@ public interface TagPeriodHandler {
                     .toFormatter()
                     .withResolverStyle(ResolverStyle.LENIENT);
 
-    DateTimeFormatter HOUR_FORMATTER_WITHOUT_SPACES =
-            new DateTimeFormatterBuilder()
-                    .appendValue(YEAR, 1, 10, SignStyle.NORMAL)
-                    .appendLiteral('-')
-                    .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NORMAL)
-                    .appendLiteral('-')
-                    .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NORMAL)
-                    .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NORMAL)
-                    .toFormatter()
-                    .withResolverStyle(ResolverStyle.LENIENT);
-
     DateTimeFormatter HOUR_FORMATTER_WITHOUT_DASHES_AND_SPACES =
             new DateTimeFormatterBuilder()
                     .appendValue(YEAR, 1, 10, SignStyle.NORMAL)
@@ -199,8 +188,6 @@ public interface TagPeriodHandler {
                     return HOUR_FORMATTER;
                 case WITHOUT_DASHES:
                     return HOUR_FORMATTER_WITHOUT_DASHES;
-                case WITH_DASHES_WITHOUT_SPACES:
-                    return HOUR_FORMATTER_WITHOUT_SPACES;
                 case WITHOUT_DASHES_AND_SPACES:
                     return HOUR_FORMATTER_WITHOUT_DASHES_AND_SPACES;
                 default:
@@ -229,7 +216,6 @@ public interface TagPeriodHandler {
         protected DateTimeFormatter formatter() {
             switch (formatter) {
                 case WITH_DASHES:
-                case WITH_DASHES_WITHOUT_SPACES:
                     return DAY_FORMATTER;
                 case WITHOUT_DASHES:
                 case WITHOUT_DASHES_AND_SPACES:

--- a/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoManagerTest.java
@@ -292,6 +292,23 @@ public class TagAutoManagerTest extends PrimaryKeyTableTestBase {
     }
 
     @Test
+    public void testTagHourlyPeriodFormatterWithoutDashesAndSpaces() {
+        Options options = new Options();
+        options.set(TAG_AUTOMATIC_CREATION, TagCreationMode.WATERMARK);
+        options.set(TAG_CREATION_PERIOD, TagCreationPeriod.HOURLY);
+        options.set(TAG_PERIOD_FORMATTER, TagPeriodFormatter.WITHOUT_DASHES_AND_SPACES);
+        FileStoreTable table = this.table.copy(options.toMap());
+        TableCommitImpl commit = table.newCommit(commitUser).ignoreEmptyCommit(false);
+        TagManager tagManager = table.store().newTagManager();
+
+        commit.commit(new ManifestCommittable(0, utcMills("2023-07-18T12:12:00")));
+        assertThat(tagManager.allTagNames()).containsOnly("2023071811");
+
+        commit.commit(new ManifestCommittable(1, utcMills("2023-07-18T13:13:00")));
+        assertThat(tagManager.allTagNames()).contains("2023071811", "2023071812");
+    }
+
+    @Test
     public void testOnlyExpireAutoCreatedTag() {
         Options options = new Options();
         options.set(TAG_AUTOMATIC_CREATION, TagCreationMode.WATERMARK);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Hourly tag format only supports yyyy-MM-dd HH and yyyyMMdd HH now, user also need format without space.
<!-- Linking this pull request to the issue -->
Linked issue: close #5161

<!-- What is the purpose of the change -->
Support enums without spaces in TagPeriodFormatter.
### Tests

<!-- List UT and IT cases to verify this change -->
Add testTagHourlyPeriodFormatterWithoutDashesAndSpaces in TagAutoManagerTest.java
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
