### PR TITLE
[iceberg] support migrating iceberg table with nested types

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergDataTypeDeserializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergDataTypeDeserializer.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg.metadata;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonParser;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.ObjectCodec;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.JsonDeserializer;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+
+/** JsonDeserializer for iceberg data types. */
+public class IcebergDataTypeDeserializer extends JsonDeserializer<Object> {
+    @Override
+    public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        ObjectCodec mapper = p.getCodec();
+        JsonNode node = mapper.readTree(p);
+
+        if (node.isTextual()) {
+            return node.asText();
+        } else if (node.isObject()) {
+            if (!node.has("type")) {
+                throw new IOException(
+                        "Exception occurs when deserialize iceberg data field. Missing 'type' field: "
+                                + node);
+            }
+
+            String type = node.get("type").asText();
+            switch (type) {
+                case "map":
+                    return mapper.treeToValue(node, IcebergMapType.class);
+                case "list":
+                    return mapper.treeToValue(node, IcebergListType.class);
+                case "struct":
+                    return mapper.treeToValue(node, IcebergStructType.class);
+                default:
+                    throw new IOException(
+                            "Exception occurs when deserialize iceberg data field. Unknown iceberg field type: "
+                                    + type);
+            }
+        } else {
+            throw new IOException("Unexpected json node. node type: " + node.getNodeType());
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergListType.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergListType.java
@@ -22,6 +22,7 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCre
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import java.util.Objects;
 
@@ -48,6 +49,7 @@ public class IcebergListType {
     private final boolean elementRequired;
 
     @JsonProperty(FIELD_ELEMENT)
+    @JsonDeserialize(using = IcebergDataTypeDeserializer.class)
     private final Object element;
 
     public IcebergListType(int elementId, boolean elementRequired, Object element) {

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergMapType.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergMapType.java
@@ -22,6 +22,7 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCre
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import java.util.Objects;
 
@@ -47,6 +48,7 @@ public class IcebergMapType {
     private final int keyId;
 
     @JsonProperty(FIELD_KEY)
+    @JsonDeserialize(using = IcebergDataTypeDeserializer.class)
     private final Object key;
 
     @JsonProperty(FIELD_VALUE_ID)
@@ -56,6 +58,7 @@ public class IcebergMapType {
     private final boolean valueRequired;
 
     @JsonProperty(FIELD_VALUE)
+    @JsonDeserialize(using = IcebergDataTypeDeserializer.class)
     private final Object value;
 
     public IcebergMapType(int keyId, Object key, int valueId, boolean valueRequired, Object value) {

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/migrate/IcebergMigrateTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/migrate/IcebergMigrateTest.java
@@ -716,6 +716,83 @@ public class IcebergMigrateTest {
         assertThat(paiResults.size()).isEqualTo(1);
     }
 
+    @Test
+    public void testNestedDataTypes() throws Exception {
+        Schema innerType1 =
+                new Schema(
+                        Types.NestedField.required(11, "c31", Types.IntegerType.get()),
+                        Types.NestedField.required(12, "c32", Types.StringType.get()));
+        Schema innerType2 =
+                new Schema(
+                        Types.NestedField.required(13, "c41", Types.IntegerType.get()),
+                        Types.NestedField.required(14, "c42", Types.StringType.get()));
+        Schema iceNestedTypesSchema =
+                new Schema(
+                        Types.NestedField.required(
+                                1, "c1", Types.ListType.ofRequired(15, Types.StringType.get())),
+                        Types.NestedField.required(
+                                2,
+                                "c2",
+                                Types.MapType.ofRequired(
+                                        16, 17, Types.StringType.get(), Types.IntegerType.get())),
+                        Types.NestedField.required(3, "c3", innerType1.asStruct()),
+                        Types.NestedField.required(
+                                4,
+                                "c4",
+                                Types.MapType.ofRequired(
+                                        18,
+                                        19,
+                                        Types.IntegerType.get(),
+                                        Types.ListType.ofRequired(20, innerType2.asStruct()))));
+        Table icebergTable = createIcebergTable(false, iceNestedTypesSchema);
+        String format = "parquet";
+        GenericRecord record =
+                toIcebergRecord(
+                        iceNestedTypesSchema,
+                        Arrays.asList("hello", "hi"),
+                        new HashMap<String, Integer>() {
+                            {
+                                put("k1", 1);
+                                put("k2", 2);
+                            }
+                        },
+                        toIcebergRecord(innerType1, 1, "test"),
+                        new HashMap<Integer, List<GenericRecord>>() {
+                            {
+                                put(
+                                        1,
+                                        Collections.singletonList(
+                                                toIcebergRecord(innerType2, 11, "test-11")));
+                                put(
+                                        2,
+                                        Arrays.asList(
+                                                toIcebergRecord(innerType2, 12, "test-12"),
+                                                toIcebergRecord(innerType2, 13, "test-13")));
+                            }
+                        });
+
+        writeRecordsToIceberg(icebergTable, format, Collections.singletonList(record));
+
+        IcebergMigrator icebergMigrator =
+                new IcebergMigrator(
+                        paiCatalog,
+                        paiDatabase,
+                        paiTable,
+                        iceDatabase,
+                        iceTable,
+                        new Options(icebergProperties),
+                        1);
+        icebergMigrator.executeMigrate();
+
+        FileStoreTable paimonTable =
+                (FileStoreTable) paiCatalog.getTable(Identifier.create(paiDatabase, paiTable));
+        List<String> paiResults = getPaimonResult(paimonTable);
+        assertThat(paiResults.stream().map(row -> String.format("(%s)", row)))
+                .hasSameElementsAs(
+                        Collections.singletonList(
+                                record.toString().replaceAll("\\bRecord\\b", "")));
+    }
+
     private org.apache.iceberg.catalog.Catalog createIcebergCatalog() {
         Map<String, String> icebergCatalogOptions = new HashMap<>();
         icebergCatalogOptions.put("type", "hadoop");
@@ -899,7 +976,7 @@ public class IcebergMigrateTest {
             recordReader.forEachRemaining(
                     row ->
                             result.add(
-                                    DataFormatTestUtil.toStringNoRowKind(
+                                    DataFormatTestUtil.toStringWithRowKind(
                                             row, paimonTable.rowType())));
             return result;
         }

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/migrate/IcebergMigrateTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/migrate/IcebergMigrateTest.java
@@ -718,6 +718,13 @@ public class IcebergMigrateTest {
 
     @Test
     public void testNestedDataTypes() throws Exception {
+        // iceberg nested schema
+        // table {
+        //  1: c1: required list<string>
+        //  2: c2: required map<string, int>
+        //  3: c3: required struct<11: c31: required int, 12: c32: required string>
+        //  4: c4: required map<int, list<struct<13: c41: required int, 14: c42: required string>>>
+        // }
         Schema innerType1 =
                 new Schema(
                         Types.NestedField.required(11, "c31", Types.IntegerType.get()),
@@ -781,7 +788,8 @@ public class IcebergMigrateTest {
                         iceDatabase,
                         iceTable,
                         new Options(icebergProperties),
-                        1);
+                        1,
+                        Collections.emptyMap());
         icebergMigrator.executeMigrate();
 
         FileStoreTable paimonTable =


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
This pr supports migrating an iceberg table with nested type to paimon. The nested types are list, map and struct. 

### Tests

<!-- List UT and IT cases to verify this change -->
IcebergMigrateTest#testNestedDataTypes
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
