### PR TITLE
[core] RESTCatalog: update parse region from dlf uri

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalogOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalogOptions.java
@@ -50,6 +50,12 @@ public class RESTCatalogOptions {
                     .noDefaultValue()
                     .withDescription("REST Catalog auth token provider.");
 
+    public static final ConfigOption<String> DLF_REGION =
+            ConfigOptions.key("dlf.region")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("REST Catalog auth DLF region.");
+
     public static final ConfigOption<String> DLF_TOKEN_PATH =
             ConfigOptions.key("dlf.token-path")
                     .stringType()

--- a/paimon-core/src/test/java/org/apache/paimon/rest/auth/AuthSessionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/auth/AuthSessionTest.java
@@ -224,7 +224,7 @@ public class AuthSessionTest {
         String fileName = UUID.randomUUID().toString();
         Pair<File, String> tokenFile2Token = generateTokenAndWriteToFile(fileName);
         String tokenStr = tokenFile2Token.getRight();
-        String serverUrl = "https://dlf.cn-hangzhou.aliyuncs.com";
+        String serverUrl = "https://dlf-cn-hangzhou.aliyuncs.com";
         AuthProvider authProvider = generateDLFAuthProvider(Optional.empty(), fileName, serverUrl);
         DLFToken token = OBJECT_MAPPER_INSTANCE.readValue(tokenStr, DLFToken.class);
         Map<String, String> parameters = new HashMap<>();

--- a/paimon-core/src/test/java/org/apache/paimon/rest/auth/AuthSessionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/auth/AuthSessionTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static org.apache.paimon.rest.RESTCatalogOptions.DLF_ACCESS_KEY_ID;
 import static org.apache.paimon.rest.RESTCatalogOptions.DLF_ACCESS_KEY_SECRET;
+import static org.apache.paimon.rest.RESTCatalogOptions.DLF_REGION;
 import static org.apache.paimon.rest.RESTCatalogOptions.DLF_SECURITY_TOKEN;
 import static org.apache.paimon.rest.RESTCatalogOptions.DLF_TOKEN_PATH;
 import static org.apache.paimon.rest.RESTCatalogOptions.TOKEN;
@@ -171,6 +172,7 @@ public class AuthSessionTest {
         options.set(DLF_ACCESS_KEY_ID.key(), token.getAccessKeyId());
         options.set(DLF_ACCESS_KEY_SECRET.key(), token.getAccessKeySecret());
         options.set(DLF_SECURITY_TOKEN.key(), token.getSecurityToken());
+        options.set(DLF_REGION.key(), "cn-hangzhou");
         AuthProvider authProvider =
                 AuthProviderFactory.createAuthProvider(AuthProviderEnum.DLF.identifier(), options);
         AuthSession session = AuthSession.fromRefreshAuthProvider(null, authProvider);
@@ -187,6 +189,7 @@ public class AuthSessionTest {
         DLFToken token = new DLFToken(akId, akSecret, null, null);
         options.set(DLF_ACCESS_KEY_ID.key(), token.getAccessKeyId());
         options.set(DLF_ACCESS_KEY_SECRET.key(), token.getAccessKeySecret());
+        options.set(DLF_REGION.key(), "cn-hangzhou");
         AuthProvider authProvider =
                 AuthProviderFactory.createAuthProvider(AuthProviderEnum.DLF.identifier(), options);
         AuthSession session = AuthSession.fromRefreshAuthProvider(null, authProvider);
@@ -280,6 +283,7 @@ public class AuthSessionTest {
         Options options = new Options();
         options.set(DLF_TOKEN_PATH.key(), folder.getRoot().getPath() + "/" + fileName);
         options.set(RESTCatalogOptions.URI.key(), serverUrl);
+        options.set(DLF_REGION.key(), "cn-hangzhou");
         tokenRefreshInMillsOpt.ifPresent(
                 tokenRefreshInMills ->
                         options.set(TOKEN_REFRESH_TIME.key(), tokenRefreshInMills + "ms"));

--- a/paimon-core/src/test/java/org/apache/paimon/rest/auth/DLFAuthProviderFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/auth/DLFAuthProviderFactoryTest.java
@@ -20,7 +20,10 @@ package org.apache.paimon.rest.auth;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Test for {@link DLFAuthProviderFactory}. */
 class DLFAuthProviderFactoryTest {
@@ -28,14 +31,21 @@ class DLFAuthProviderFactoryTest {
     @Test
     void getRegion() {
         String region = "cn-hangzhou";
+        String ipPortUri = "http://127.0.0.1:8080";
+        assertEquals(region, DLFAuthProviderFactory.getRegion(Optional.of(region), ipPortUri));
         String url = "https://dlf-" + region + "-internal.aliyuncs.com";
-        assertEquals(region, DLFAuthProviderFactory.getRegion(url));
+        assertEquals(region, DLFAuthProviderFactory.getRegion(Optional.empty(), url));
         url = "https://dlf-" + region + ".aliyuncs.com";
-        assertEquals(region, DLFAuthProviderFactory.getRegion(url));
+        assertEquals(region, DLFAuthProviderFactory.getRegion(Optional.empty(), url));
+        url = "https://dlf-pre-" + region + ".aliyuncs.com";
+        assertEquals(region, DLFAuthProviderFactory.getRegion(Optional.empty(), url));
         region = "us-east-1";
         url = "https://dlf-" + region + ".aliyuncs.com";
-        assertEquals(region, DLFAuthProviderFactory.getRegion(url));
+        assertEquals(region, DLFAuthProviderFactory.getRegion(Optional.empty(), url));
         url = "https://dlf-" + region + "-internal.aliyuncs.com";
-        assertEquals(region, DLFAuthProviderFactory.getRegion(url));
+        assertEquals(region, DLFAuthProviderFactory.getRegion(Optional.empty(), url));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DLFAuthProviderFactory.getRegion(Optional.empty(), ipPortUri));
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/rest/auth/DLFAuthProviderFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/auth/DLFAuthProviderFactoryTest.java
@@ -20,7 +20,7 @@ package org.apache.paimon.rest.auth;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Test for {@link DLFAuthProviderFactory}. */
 class DLFAuthProviderFactoryTest {

--- a/paimon-core/src/test/java/org/apache/paimon/rest/auth/DLFAuthProviderFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/auth/DLFAuthProviderFactoryTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest.auth;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Test for {@link DLFAuthProviderFactory}. */
+class DLFAuthProviderFactoryTest {
+
+    @Test
+    void getRegion() {
+        String region = "cn-hangzhou";
+        String url = "https://dlf-" + region + "-internal.aliyuncs.com";
+        assertEquals(region, DLFAuthProviderFactory.getRegion(url));
+        url = "https://dlf-" + region + ".aliyuncs.com";
+        assertEquals(region, DLFAuthProviderFactory.getRegion(url));
+        region = "us-east-1";
+        url = "https://dlf-" + region + ".aliyuncs.com";
+        assertEquals(region, DLFAuthProviderFactory.getRegion(url));
+        url = "https://dlf-" + region + "-internal.aliyuncs.com";
+        assertEquals(region, DLFAuthProviderFactory.getRegion(url));
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
RESTCatalog: update parse region from DLF uri
Linked issue: #4540 

<!-- What is the purpose of the change -->

### Tests
DLFAuthProviderFactoryTest.getRegion

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
