### PR TITLE
[flink] fix parallelismConfigured in cases when sink parallelism is set

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -70,7 +70,6 @@ import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_USE_MANAGED_MEM
 import static org.apache.paimon.flink.FlinkConnectorOptions.generateCustomUid;
 import static org.apache.paimon.flink.utils.ManagedMemoryUtils.declareManagedMemory;
 import static org.apache.paimon.flink.utils.ParallelismUtils.forwardParallelism;
-import static org.apache.paimon.flink.utils.ParallelismUtils.setParallelism;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Abstract sink of paimon. */
@@ -227,7 +226,7 @@ public abstract class FlinkSink<T> implements Serializable {
                                         hasSinkMaterializer(input)),
                                 commitUser));
         if (parallelism == null) {
-            setParallelism(written, input.getParallelism(), false);
+            forwardParallelism(written, input);
         } else {
             written.setParallelism(parallelism);
         }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

This PR fixes the bug that AdaptiveBatchScheduler can still adjust the parallelism of a writer operator when `sink.parallelism` is configured.

<!-- What is the purpose of the change -->

### Tests

ReadWriteTableITCase#testSinkParallelism

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
