### PR TITLE
[spark][test] Fix spark parquet dependency conflict when executing tests locally.

### DIFF
--- a/paimon-spark/paimon-spark-3.2/pom.xml
+++ b/paimon-spark/paimon-spark-3.2/pom.xml
@@ -76,6 +76,13 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-format</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
@@ -105,6 +112,7 @@ under the License.
             <version>${spark.version}</version>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
     <build>

--- a/paimon-spark/paimon-spark-3.3/pom.xml
+++ b/paimon-spark/paimon-spark-3.3/pom.xml
@@ -76,6 +76,13 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-format</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>

--- a/paimon-spark/paimon-spark-3.4/pom.xml
+++ b/paimon-spark/paimon-spark-3.4/pom.xml
@@ -76,6 +76,13 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-format</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

When I execute a spark 3.4- UT in idea, such as `DDLTest`, get `NoClassDefFoundError`

```
Caused by: java.lang.NoClassDefFoundError: org/apache/parquet/hadoop/ParquetEmptyBlockException
	at org.apache.paimon.format.parquet.ParquetUtil.getParquetReader(ParquetUtil.java:81)
	at org.apache.paimon.format.parquet.ParquetUtil.extractColumnStats(ParquetUtil.java:51)
	at org.apache.paimon.format.parquet.ParquetSimpleStatsExtractor.extractWithFileInfo(ParquetSimpleStatsExtractor.java:78)
	at org.apache.paimon.format.parquet.ParquetSimpleStatsExtractor.extract(ParquetSimpleStatsExtractor.java:71)
	at org.apache.paimon.io.StatsCollectingSingleFileWriter.fieldStats(StatsCollectingSingleFileWriter.java:105)
	at org.apache.paimon.io.RowDataFileWriter.result(RowDataFileWriter.java:112)
```

There is a parquet dependency conflict in spark 3.4-, spark 3.5 does not have this problem because its parquet version does not conflict.

<img width="876" alt="截屏2025-03-02 11 57 47" src="https://github.com/user-attachments/assets/d70be6c1-bd27-43a2-88c6-5080c7830039" />

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
