### PR TITLE
[flink] Use RuntimeContextUtils to keep compatible

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
@@ -129,10 +129,10 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
         commitUser =
                 StateUtils.getSingleValueFromState(
                         context, "commit_user_state", String.class, initialCommitUser);
-        // parallelism of commit operator is always 1, so commitUser will never be null
-        int parallelism = getRuntimeContext().getNumberOfParallelSubtasks();
-        int index = getRuntimeContext().getIndexOfThisSubtask();
+        int parallelism = RuntimeContextUtils.getNumberOfParallelSubtasks(getRuntimeContext());
+        int index = RuntimeContextUtils.getIndexOfThisSubtask(getRuntimeContext());
 
+        // parallelism of commit operator is always 1, so commitUser will never be null
         committer =
                 committerFactory.create(
                         Committer.createContext(


### PR DESCRIPTION
getNumberOfParallelSubtasks From getRuntimeContext() may be not found in separated flink version. SO replace it by RuntimeContextUtils.