### PR TITLE
[flink] Add default parallelism for source and sink in rescale procedure, also make them configurable

### DIFF
--- a/docs/content/flink/procedures.md
+++ b/docs/content/flink/procedures.md
@@ -776,15 +776,15 @@ All available procedures are listed below.
    <tr>
       <td>rescale</td>
       <td>
-         CALL [catalog.]sys.rescale(`table` => 'identifier', `bucket_num` => bucket_num, `partition` => 'partition', `source_parallelism` => 'source_parallelism', `sink_parallelism` => 'sink_parallelism')
+         CALL [catalog.]sys.rescale(`table` => 'identifier', `bucket_num` => bucket_num, `partition` => 'partition', `source.parallelism` => 'source.parallelism', `sink.parallelism` => 'sink.parallelism')
       </td>
       <td>
          Rescale one partition of a table. Arguments:
          <li>identifier: The target table identifier. Cannot be empty.</li>
          <li>bucket_num: Resulting bucket number after rescale. The default value of argument bucket_num is the current bucket number of the table. Cannot be empty for postpone bucket tables.</li>
          <li>partition: What partition to rescale. For partitioned table this argument cannot be empty.</li>
-         <li>source_parallelism: Parallelism of source operator. The default value is the current bucket number of the partition.</li>
-         <li>sink_parallelism: Parallelism of sink operator. The default value is equal to bucket_num.</li>
+         <li>source.parallelism: Parallelism of source operator. The default value is the current bucket number of the partition.</li>
+         <li>sink.parallelism: Parallelism of sink operator. The default value is equal to bucket_num.</li>
       </td>
       <td>
          CALL sys.rescale(`table` => 'default.T', `bucket_num` => 16, `partition` => 'dt=20250217,hh=08')

--- a/docs/content/flink/procedures.md
+++ b/docs/content/flink/procedures.md
@@ -776,13 +776,15 @@ All available procedures are listed below.
    <tr>
       <td>rescale</td>
       <td>
-         CALL [catalog.]sys.rescale(`table` => 'identifier', `bucket_num` => bucket_num, `partition` => 'partition')
+         CALL [catalog.]sys.rescale(`table` => 'identifier', `bucket_num` => bucket_num, `partition` => 'partition', `source_parallelism` => 'source_parallelism', `sink_parallelism` => 'sink_parallelism')
       </td>
       <td>
          Rescale one partition of a table. Arguments:
          <li>identifier: The target table identifier. Cannot be empty.</li>
          <li>bucket_num: Resulting bucket number after rescale. The default value of argument bucket_num is the current bucket number of the table. Cannot be empty for postpone bucket tables.</li>
          <li>partition: What partition to rescale. For partitioned table this argument cannot be empty.</li>
+         <li>source_parallelism: Parallelism of source operator. The default value is the current bucket number of the partition.</li>
+         <li>partition: Parallelism of sink operator. The default value is equal to bucket_num.</li>
       </td>
       <td>
          CALL sys.rescale(`table` => 'default.T', `bucket_num` => 16, `partition` => 'dt=20250217,hh=08')

--- a/docs/content/flink/procedures.md
+++ b/docs/content/flink/procedures.md
@@ -784,7 +784,7 @@ All available procedures are listed below.
          <li>bucket_num: Resulting bucket number after rescale. The default value of argument bucket_num is the current bucket number of the table. Cannot be empty for postpone bucket tables.</li>
          <li>partition: What partition to rescale. For partitioned table this argument cannot be empty.</li>
          <li>source_parallelism: Parallelism of source operator. The default value is the current bucket number of the partition.</li>
-         <li>partition: Parallelism of sink operator. The default value is equal to bucket_num.</li>
+         <li>sink_parallelism: Parallelism of sink operator. The default value is equal to bucket_num.</li>
       </td>
       <td>
          CALL sys.rescale(`table` => 'default.T', `bucket_num` => 16, `partition` => 'dt=20250217,hh=08')

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RescaleActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RescaleActionFactory.java
@@ -26,6 +26,8 @@ public class RescaleActionFactory implements ActionFactory {
     public static final String IDENTIFIER = "rescale";
     private static final String BUCKET_NUM = "bucket_num";
     private static final String PARTITION = "partition";
+    private static final String SOURCE_PARALLELISM = "source_parallelism";
+    private static final String SINK_PARALLELISM = "sink_parallelism";
 
     @Override
     public String identifier() {
@@ -43,9 +45,14 @@ public class RescaleActionFactory implements ActionFactory {
         if (params.has(BUCKET_NUM)) {
             action.withBucketNum(Integer.parseInt(params.get(BUCKET_NUM)));
         }
-
         if (params.has(PARTITION)) {
             action.withPartition(getPartitions(params).get(0));
+        }
+        if (params.has(SOURCE_PARALLELISM)) {
+            action.withSourceParallelism(Integer.parseInt(params.get(SOURCE_PARALLELISM)));
+        }
+        if (params.has(SINK_PARALLELISM)) {
+            action.withSinkParallelism(Integer.parseInt(params.get(SINK_PARALLELISM)));
         }
 
         return Optional.of(action);
@@ -60,11 +67,16 @@ public class RescaleActionFactory implements ActionFactory {
         System.out.println(
                 "  rescale --warehouse <warehouse_path> --database <database_name> "
                         + "--table <table_name> [--bucket_num <bucket_num>] "
-                        + "[--partition <partition>]");
+                        + "[--partition <partition>] "
+                        + "[--source_parallelism <source_parallelism>] [--sink_parallelism <sink_parallelism>]");
         System.out.println(
-                "The default value of argument bucket_num is the current bucket number of the table. "
+                "The default value of argument bucket_num is the value of 'bucket' option of the table. "
                         + "For postpone bucket tables, this argument must be specified.");
         System.out.println(
                 "Argument partition must be specified if the table is a partitioned table.");
+        System.out.println(
+                "The default value of argument source_parallelism is the current bucket number of the partition.");
+        System.out.println(
+                "The default value of argument sink_parallelism is equal to bucket_num.");
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RescaleActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RescaleActionFactory.java
@@ -26,8 +26,8 @@ public class RescaleActionFactory implements ActionFactory {
     public static final String IDENTIFIER = "rescale";
     private static final String BUCKET_NUM = "bucket_num";
     private static final String PARTITION = "partition";
-    private static final String SOURCE_PARALLELISM = "source_parallelism";
-    private static final String SINK_PARALLELISM = "sink_parallelism";
+    private static final String SOURCE_PARALLELISM = "source.parallelism";
+    private static final String SINK_PARALLELISM = "sink.parallelism";
 
     @Override
     public String identifier() {
@@ -68,15 +68,15 @@ public class RescaleActionFactory implements ActionFactory {
                 "  rescale --warehouse <warehouse_path> --database <database_name> "
                         + "--table <table_name> [--bucket_num <bucket_num>] "
                         + "[--partition <partition>] "
-                        + "[--source_parallelism <source_parallelism>] [--sink_parallelism <sink_parallelism>]");
+                        + "[--source.parallelism <source.parallelism>] [--sink.parallelism <sink.parallelism>]");
         System.out.println(
                 "The default value of argument bucket_num is the value of 'bucket' option of the table. "
                         + "For postpone bucket tables, this argument must be specified.");
         System.out.println(
                 "Argument partition must be specified if the table is a partitioned table.");
         System.out.println(
-                "The default value of argument source_parallelism is the current bucket number of the partition.");
+                "The default value of argument source.parallelism is the current bucket number of the partition.");
         System.out.println(
-                "The default value of argument sink_parallelism is equal to bucket_num.");
+                "The default value of argument sink.parallelism is equal to bucket_num.");
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RescaleProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RescaleProcedure.java
@@ -38,13 +38,26 @@ public class RescaleProcedure extends ProcedureBase {
             argument = {
                 @ArgumentHint(name = "table", type = @DataTypeHint("STRING")),
                 @ArgumentHint(name = "bucket_num", type = @DataTypeHint("INT"), isOptional = true),
-                @ArgumentHint(name = "partition", type = @DataTypeHint("STRING"), isOptional = true)
+                @ArgumentHint(
+                        name = "partition",
+                        type = @DataTypeHint("STRING"),
+                        isOptional = true),
+                @ArgumentHint(
+                        name = "source_parallelism",
+                        type = @DataTypeHint("INT"),
+                        isOptional = true),
+                @ArgumentHint(
+                        name = "sink_parallelism",
+                        type = @DataTypeHint("INT"),
+                        isOptional = true)
             })
     public String[] call(
             ProcedureContext procedureContext,
             String tableId,
             @Nullable Integer bucketNum,
-            @Nullable String partition)
+            @Nullable String partition,
+            @Nullable Integer sourceParallelism,
+            @Nullable Integer sinkParallelism)
             throws Exception {
         Identifier identifier = Identifier.fromString(tableId);
         String databaseName = identifier.getDatabaseName();
@@ -56,6 +69,12 @@ public class RescaleProcedure extends ProcedureBase {
         }
         if (partition != null) {
             action.withPartition(ParameterUtils.getPartitions(partition).get(0));
+        }
+        if (sourceParallelism != null) {
+            action.withSourceParallelism(sourceParallelism);
+        }
+        if (sinkParallelism != null) {
+            action.withSinkParallelism(sinkParallelism);
         }
 
         return execute(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RescaleProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RescaleProcedure.java
@@ -43,11 +43,11 @@ public class RescaleProcedure extends ProcedureBase {
                         type = @DataTypeHint("STRING"),
                         isOptional = true),
                 @ArgumentHint(
-                        name = "source_parallelism",
+                        name = "source.parallelism",
                         type = @DataTypeHint("INT"),
                         isOptional = true),
                 @ArgumentHint(
-                        name = "sink_parallelism",
+                        name = "sink.parallelism",
                         type = @DataTypeHint("INT"),
                         isOptional = true)
             })


### PR DESCRIPTION
### Purpose

Currently user has no way to configure source and sink parallelism in rescale procedure. This PR adds default parallelism and make it configurable.

### Tests

Existing tests should cover this change.

### API and Format

No format changes.

### Documentation

Document is also added.
