### PR TITLE
[spark] Eliminate the union stage when merging into without notMatche…

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonTable.scala
@@ -144,29 +144,38 @@ case class MergeIntoPaimonTable(
       }
     } else {
       val touchedFilePathsSet = mutable.Set.empty[String]
+      val intersectionFilePaths = mutable.Set.empty[String]
+
       def hasUpdate(actions: Seq[MergeAction]): Boolean = {
         actions.exists {
           case _: UpdateAction | _: DeleteAction => true
           case _ => false
         }
       }
-      if (hasUpdate(matchedActions) || notMatchedActions.nonEmpty) {
-        touchedFilePathsSet ++= findTouchedFiles(
-          targetDS.alias("_left").join(sourceDS, toColumn(mergeCondition), "inner"),
-          sparkSession,
-          "_left." + FILE_PATH_COLUMN
-        )
-      }
-      if (hasUpdate(notMatchedBySourceActions)) {
-        touchedFilePathsSet ++= findTouchedFiles(
-          targetDS.alias("_left").join(sourceDS, toColumn(mergeCondition), "left_anti"),
+
+      def findTouchedFiles0(joinType: String): Array[String] = {
+        findTouchedFiles(
+          targetDS.alias("_left").join(sourceDS, toColumn(mergeCondition), joinType),
           sparkSession,
           "_left." + FILE_PATH_COLUMN)
       }
 
-      val targetFilePaths: Array[String] = findTouchedFiles(targetDS, sparkSession)
+      if (hasUpdate(matchedActions)) {
+        touchedFilePathsSet ++= findTouchedFiles0("inner")
+      } else if (notMatchedActions.nonEmpty) {
+        intersectionFilePaths ++= findTouchedFiles0("inner")
+      }
+
+      if (hasUpdate(notMatchedBySourceActions)) {
+        touchedFilePathsSet ++= findTouchedFiles0("left_anti")
+      }
+
       val touchedFilePaths: Array[String] = touchedFilePathsSet.toArray
-      val unTouchedFilePaths = targetFilePaths.filterNot(touchedFilePaths.contains)
+      val unTouchedFilePaths = if (notMatchedActions.nonEmpty) {
+        intersectionFilePaths.diff(touchedFilePathsSet).toArray
+      } else {
+        Array[String]()
+      }
 
       val (touchedFiles, touchedFileRelation) =
         createNewRelation(touchedFilePaths, dataFilePathToMeta, relation)
@@ -177,13 +186,9 @@ case class MergeIntoPaimonTable(
       // modified and was from touched file, it should be kept too.
       val touchedDsWithFileTouchedCol = createDataset(sparkSession, touchedFileRelation)
         .withColumn(FILE_TOUCHED_COL, lit(true))
-      val targetDSWithFileTouchedCol = if (notMatchedBySourceActions.nonEmpty) {
-        touchedDsWithFileTouchedCol.union(
-          createDataset(sparkSession, unTouchedFileRelation)
-            .withColumn(FILE_TOUCHED_COL, lit(false)))
-      } else {
-        touchedDsWithFileTouchedCol
-      }
+      val targetDSWithFileTouchedCol = touchedDsWithFileTouchedCol.union(
+        createDataset(sparkSession, unTouchedFileRelation)
+          .withColumn(FILE_TOUCHED_COL, lit(false)))
 
       val toWriteDS =
         constructChangedRows(sparkSession, targetDSWithFileTouchedCol).drop(ROW_KIND_COL)


### PR DESCRIPTION
…dActions

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5136

1. Untouched files should participate in the join process only when the notMatchedActions is present
2. Only intersectionFilePaths should be part of the untouched files

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
