### PR TITLE
[refactor] Move #earlierThanTimeMills to TimeTravelUtil

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScanner.java
@@ -19,19 +19,11 @@
 package org.apache.paimon.table.source.snapshot;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.Snapshot;
 import org.apache.paimon.utils.ChangelogManager;
-import org.apache.paimon.utils.FunctionWithException;
 import org.apache.paimon.utils.SnapshotManager;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nullable;
-
-import java.io.FileNotFoundException;
-
-import static org.apache.paimon.utils.SnapshotManager.EARLIEST_SNAPSHOT_DEFAULT_RETRY_NUM;
 
 /**
  * {@link StartingScanner} for the {@link CoreOptions.StartupMode#FROM_TIMESTAMP} startup mode of a
@@ -56,7 +48,7 @@ public class ContinuousFromTimestampStartingScanner extends AbstractStartingScan
         this.startupMillis = startupMillis;
         this.startFromChangelog = changelogDecoupled;
         this.startingSnapshotId =
-                earlierThanTimeMills(
+                TimeTravelUtil.earlierThanTimeMills(
                         snapshotManager, changelogManager, startupMillis, startFromChangelog);
     }
 
@@ -71,113 +63,15 @@ public class ContinuousFromTimestampStartingScanner extends AbstractStartingScan
 
     @Override
     public Result scan(SnapshotReader snapshotReader) {
-        Long startingSnapshotId =
-                earlierThanTimeMills(
-                        snapshotManager, changelogManager, startupMillis, startFromChangelog);
+        if (startingSnapshotId == null) {
+            startingSnapshotId =
+                    TimeTravelUtil.earlierThanTimeMills(
+                            snapshotManager, changelogManager, startupMillis, startFromChangelog);
+        }
         if (startingSnapshotId == null) {
             LOG.debug("There is currently no snapshot. Waiting for snapshot generation.");
             return new NoSnapshot();
         }
         return new NextSnapshot(startingSnapshotId + 1);
-    }
-
-    /**
-     * Returns the latest snapshot earlier than the timestamp mills. A non-existent snapshot may be
-     * returned if all snapshots are equal to or later than the timestamp mills.
-     */
-    public static @Nullable Long earlierThanTimeMills(
-            SnapshotManager snapshotManager,
-            ChangelogManager changelogManager,
-            long timestampMills,
-            boolean startFromChangelog) {
-        Long latest = snapshotManager.latestSnapshotId();
-        if (latest == null) {
-            return null;
-        }
-
-        Snapshot earliestSnapshot =
-                earliestSnapshot(snapshotManager, changelogManager, startFromChangelog, latest);
-        if (earliestSnapshot == null) {
-            return latest - 1;
-        }
-
-        if (earliestSnapshot.timeMillis() >= timestampMills) {
-            return earliestSnapshot.id() - 1;
-        }
-
-        long earliest = earliestSnapshot.id();
-        while (earliest < latest) {
-            long mid = (earliest + latest + 1) / 2;
-            Snapshot snapshot =
-                    startFromChangelog
-                            ? changelogOrSnapshot(snapshotManager, changelogManager, mid)
-                            : snapshotManager.snapshot(mid);
-            if (snapshot.timeMillis() < timestampMills) {
-                earliest = mid;
-            } else {
-                latest = mid - 1;
-            }
-        }
-        return earliest;
-    }
-
-    private static @Nullable Snapshot earliestSnapshot(
-            SnapshotManager snapshotManager,
-            ChangelogManager changelogManager,
-            boolean includeChangelog,
-            @Nullable Long stopSnapshotId) {
-        Long snapshotId = null;
-        if (includeChangelog) {
-            snapshotId = changelogManager.earliestLongLivedChangelogId();
-        }
-        if (snapshotId == null) {
-            snapshotId = snapshotManager.earliestSnapshotId();
-        }
-        if (snapshotId == null) {
-            return null;
-        }
-
-        if (stopSnapshotId == null) {
-            stopSnapshotId = snapshotId + EARLIEST_SNAPSHOT_DEFAULT_RETRY_NUM;
-        }
-
-        FunctionWithException<Long, Snapshot, FileNotFoundException> snapshotFunction =
-                includeChangelog
-                        ? s -> tryGetChangelogOrSnapshot(snapshotManager, changelogManager, s)
-                        : snapshotManager::tryGetSnapshot;
-
-        do {
-            try {
-                return snapshotFunction.apply(snapshotId);
-            } catch (FileNotFoundException e) {
-                snapshotId++;
-                if (snapshotId > stopSnapshotId) {
-                    return null;
-                }
-                LOG.warn(
-                        "The earliest snapshot or changelog was once identified but disappeared. "
-                                + "It might have been expired by other jobs operating on this table. "
-                                + "Searching for the second earliest snapshot or changelog instead. ");
-            }
-        } while (true);
-    }
-
-    private static Snapshot tryGetChangelogOrSnapshot(
-            SnapshotManager snapshotManager, ChangelogManager changelogManager, long snapshotId)
-            throws FileNotFoundException {
-        if (changelogManager.longLivedChangelogExists(snapshotId)) {
-            return changelogManager.tryGetChangelog(snapshotId);
-        } else {
-            return snapshotManager.tryGetSnapshot(snapshotId);
-        }
-    }
-
-    private static Snapshot changelogOrSnapshot(
-            SnapshotManager snapshotManager, ChangelogManager changelogManager, long snapshotId) {
-        if (changelogManager.longLivedChangelogExists(snapshotId)) {
-            return changelogManager.changelog(snapshotId);
-        } else {
-            return snapshotManager.snapshot(snapshotId);
-        }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -23,7 +23,7 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
-import org.apache.paimon.table.source.snapshot.ContinuousFromTimestampStartingScanner;
+import org.apache.paimon.table.source.snapshot.TimeTravelUtil;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -129,9 +129,7 @@ public class SnapshotManagerTest {
                 // pick a random time equal to one of the snapshots
                 time = millis.get(random.nextInt(numSnapshots));
             }
-            Long actual =
-                    ContinuousFromTimestampStartingScanner.earlierThanTimeMills(
-                            snapshotManager, null, time, false);
+            Long actual = TimeTravelUtil.earlierThanTimeMills(snapshotManager, null, time, false);
 
             if (millis.get(numSnapshots - 1) < time) {
                 if (isRaceCondition && millis.size() == 1) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
earlierThanTimeMills might be used by other class, so it's better to put it in a util class 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
