### PR TITLE
[core] Support cross-partition for fallback branch feature

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/crosspartition/IndexBootstrap.java
+++ b/paimon-core/src/main/java/org/apache/paimon/crosspartition/IndexBootstrap.java
@@ -27,8 +27,8 @@ import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.Table;
-import org.apache.paimon.table.source.AbstractDataTableScan;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.DataTableScan;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.types.DataField;
@@ -84,7 +84,7 @@ public class IndexBootstrap implements Serializable {
                         .newReadBuilder()
                         .withProjection(keyProjection);
 
-        AbstractDataTableScan tableScan = (AbstractDataTableScan) readBuilder.newScan();
+        DataTableScan tableScan = (DataTableScan) readBuilder.newScan();
         List<Split> splits =
                 tableScan
                         .withBucketFilter(bucket -> bucket % numAssigners == assignId)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Support cross-partition for fallback branch feature.
Currently, once writing into a cross-partition table which fallback branch feature enabled, 
```
Flink SQL> create table part1(id int primary key not enforced, name string, dt string) partitioned by (dt);
Flink SQL> call sys.create_branch('branch.part1', 'stream');
Flink SQL> alter table part1 set ('scan.fallback-branch'='stream');
Flink SQL> insert into part1 values (1,'anew','20250301'),(20, 'from stream', '20250303');
```
throws exception as follow, it is caused by FallbackReadFileStoreTable#newScan return a DataTableScan instance, we should use `DataTableScan` instead of `AbstractDataTableScan` in IndexBootstrap#bootstrap.
```
Caused by: java.lang.ClassCastException: org.apache.paimon.table.FallbackReadFileStoreTable$Scan cannot be cast to org.apache.paimon.table.source.AbstractDataTableScan
	at org.apache.paimon.crosspartition.IndexBootstrap.bootstrap(IndexBootstrap.java:87)
	at org.apache.paimon.crosspartition.IndexBootstrap.bootstrap(IndexBootstrap.java:69)
	at org.apache.paimon.flink.sink.index.IndexBootstrapOperator.initializeState(IndexBootstrapOperator.java:60)
	at org.apache.flink.streaming.api.operators.StreamOperatorStateHandler.initializeOperatorState(StreamOperatorStateHandler.java:147)
	at org.apache.flink.streaming.api.operators.AbstractStreamOperator.initializeState(AbstractStreamOperator.java:294)
```

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
