### PR TITLE
[core] Support partition strategy for unaware bucket partitioned Appe…

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -708,6 +708,12 @@ This config option does not affect the default filesystem metastore.</td>
             <td>Mark done action will reports the partition to the remote http server, this can only be used by http-report partition mark done action.</td>
         </tr>
         <tr>
+            <td><h5>partition.strategy.for-unaware-append</h5></td>
+            <td style="word-wrap: break-word;">NONE</td>
+            <td><p>Enum</p></td>
+            <td>This is only for partitioned unaware-buckets append table, and the purpose is to reduce small files and improve write performance. Through this repartitioning strategy to reduce the number of partitions written by each task to as few as possible.<ul><li>none: Rebalanced or Forward partitioning, this is the default behavior, this strategy is suitable for the number of partitions you write in a batch is much smaller than write parallelism.</li><li>hash: Hash the partitions value, this strategy is suitable for the number of partitions you write in a batch is greater equals than write parallelism.</li></ul><br /><br />Possible values:<ul><li>"NONE"</li><li>"HASH"</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>partition.timestamp-formatter</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -459,6 +459,25 @@ public class CoreOptions implements Serializable {
                             "Open file cost of a source file. It is used to avoid reading"
                                     + " too many files with a source split, which can be very slow.");
 
+    public static final ConfigOption<UnawareAppendPartitionStrategy>
+            PARTITION_STRATEGY_FOR_UNAWARE_APPEND =
+                    key("partition.strategy.for-unaware-append")
+                            .enumType(UnawareAppendPartitionStrategy.class)
+                            .defaultValue(UnawareAppendPartitionStrategy.NONE)
+                            .withDescription(
+                                    Description.builder()
+                                            .text(
+                                                    "This is only for partitioned unaware-buckets append table, and the purpose is to reduce small files and improve write performance."
+                                                            + " Through this repartitioning strategy to reduce the number of partitions written by each task to as few as possible.")
+                                            .list(
+                                                    text(
+                                                            "none: Rebalanced or Forward partitioning, this is the default behavior,"
+                                                                    + " this strategy is suitable for the number of partitions you write in a batch is much smaller than write parallelism."),
+                                                    text(
+                                                            "hash: Hash the partitions value,"
+                                                                    + " this strategy is suitable for the number of partitions you write in a batch is greater equals than write parallelism."))
+                                            .build());
+
     public static final ConfigOption<MemorySize> WRITE_BUFFER_SIZE =
             key("write-buffer-size")
                     .memoryType()
@@ -1990,6 +2009,10 @@ public class CoreOptions implements Serializable {
         return options.get(WRITE_BUFFER_FOR_APPEND);
     }
 
+    public UnawareAppendPartitionStrategy partitionStrategyForUnawareAppend() {
+        return options.get(PARTITION_STRATEGY_FOR_UNAWARE_APPEND);
+    }
+
     public int writeMaxWritersToSpill() {
         return options.get(WRITE_MAX_WRITERS_TO_SPILL);
     }
@@ -3331,5 +3354,12 @@ public class CoreOptions implements Serializable {
 
         /** Lookup compaction will use UniversalCompaction strategy to gently compact new files. */
         GENTLE
+    }
+
+    /** Partition strategy for unaware bucket partitioned append only table. */
+    public enum UnawareAppendPartitionStrategy {
+        NONE,
+        HASH
+        // TODO : Supports range-partition strategy.
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataHashPartitionChannelComputer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataHashPartitionChannelComputer.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.sink.ChannelComputer;
+import org.apache.paimon.table.sink.KeyAndBucketExtractor;
+import org.apache.paimon.table.sink.UnawareBucketRowKeyExtractor;
+
+/** This is only for partitioned unaware-buckets Append only table. */
+public class RowDataHashPartitionChannelComputer implements ChannelComputer<InternalRow> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final TableSchema schema;
+
+    private transient int numChannels;
+    private transient KeyAndBucketExtractor<InternalRow> extractor;
+
+    public RowDataHashPartitionChannelComputer(TableSchema schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public void setup(int numChannels) {
+        this.numChannels = numChannels;
+        this.extractor = new UnawareBucketRowKeyExtractor(schema);
+    }
+
+    @Override
+    public int channel(InternalRow record) {
+        extractor.setRecord(record);
+        return ChannelComputer.select(extractor.partition(), 0, numChannels);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataHashPartitionChannelComputer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataHashPartitionChannelComputer.java
@@ -49,4 +49,9 @@ public class RowDataHashPartitionChannelComputer implements ChannelComputer<Inte
         extractor.setRecord(record);
         return ChannelComputer.select(extractor.partition(), 0, numChannels);
     }
+
+    @Override
+    public String toString() {
+        return "shuffle by partition";
+    }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
@@ -18,13 +18,16 @@
 
 package org.apache.paimon.flink;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.source.AbstractNonCoordinatedSource;
 import org.apache.paimon.flink.source.AbstractNonCoordinatedSourceReader;
 import org.apache.paimon.flink.source.SimpleSourceSplit;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.reader.RecordReaderIterator;
 import org.apache.paimon.table.FileStoreTable;
@@ -47,6 +50,8 @@ import org.apache.flink.types.RowKind;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.File;
 import java.time.Duration;
@@ -58,6 +63,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
+import static org.apache.paimon.CoreOptions.PARTITION_STRATEGY_FOR_UNAWARE_APPEND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -402,6 +408,77 @@ public class UnawareBucketAppendOnlyTableITCase extends CatalogITCaseBase {
         tEnv.executeSql("INSERT INTO append_table SELECT id, 'test' FROM S").await();
         assertThat(batchSql("SELECT * FROM append_table"))
                 .containsExactlyInAnyOrder(Row.of(1, "test"), Row.of(2, "test"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(CoreOptions.UnawareAppendPartitionStrategy.class)
+    public void testPartitionStrategyForPartitionedTable(
+            CoreOptions.UnawareAppendPartitionStrategy strategy)
+            throws Catalog.TableNotExistException {
+
+        int partitionNums = 5;
+        int largerSinkParallelism = 7;
+        int lessSinkParallelism = 3;
+        int hashStrategyResultFileCount = 1;
+        // sink parallelism is greater than the number of partitions write in a batch, there are 2
+        // task will be no data.
+        batchSql(
+                "CREATE TABLE IF NOT EXISTS partition_strategy_table_larger ("
+                        + "id INT, data STRING, dt STRING) PARTITIONED BY (dt)"
+                        + " WITH ("
+                        + "'bucket' = '-1',"
+                        + "'%s' = '%s',"
+                        + "'sink.parallelism' = '7')",
+                PARTITION_STRATEGY_FOR_UNAWARE_APPEND.key(), strategy);
+
+        // sink parallelism is less than the number of partitions write in a batch, there are 2 task
+        // will write data to 2 partition.
+        batchSql(
+                "CREATE TABLE IF NOT EXISTS partition_strategy_table_less ("
+                        + "id INT, data STRING, dt STRING) PARTITIONED BY (dt)"
+                        + " WITH ("
+                        + "'bucket' = '-1',"
+                        + "'%s' = '%s',"
+                        + "'sink.parallelism' = '3')",
+                PARTITION_STRATEGY_FOR_UNAWARE_APPEND.key(), strategy);
+
+        StringBuilder values = new StringBuilder();
+        // 5 partition in a batch write.
+        for (int i = 1; i <= 30; i++) {
+            for (int j = 1; j <= partitionNums; j++) {
+                values.append(String.format("(%s, 'HXH', '2025030%s'),", j, j));
+            }
+        }
+
+        batchSql(
+                "INSERT INTO partition_strategy_table_larger VALUES "
+                        + values.substring(0, values.length() - 1));
+        batchSql(
+                "INSERT INTO partition_strategy_table_less VALUES "
+                        + values.substring(0, values.length() - 1));
+
+        assertThat(batchSql("SELECT * FROM partition_strategy_table_larger").size()).isEqualTo(150);
+        assertThat(batchSql("SELECT * FROM partition_strategy_table_less").size()).isEqualTo(150);
+
+        FileStoreTable fileStoreTableLarger = paimonTable("partition_strategy_table_larger");
+        List<PartitionEntry> partitionEntriesLarger =
+                fileStoreTableLarger.newReadBuilder().newScan().listPartitionEntries();
+        assertThat(partitionEntriesLarger.size()).isEqualTo(partitionNums);
+        int fileCountLarger =
+                strategy == CoreOptions.UnawareAppendPartitionStrategy.HASH
+                        ? hashStrategyResultFileCount
+                        : largerSinkParallelism;
+        partitionEntriesLarger.forEach(x -> assertThat(x.fileCount()).isEqualTo(fileCountLarger));
+
+        FileStoreTable fileStoreTableLess = paimonTable("partition_strategy_table_less");
+        List<PartitionEntry> partitionEntriesLess =
+                fileStoreTableLess.newReadBuilder().newScan().listPartitionEntries();
+        assertThat(partitionEntriesLess.size()).isEqualTo(partitionNums);
+        int fileCountLess =
+                strategy == CoreOptions.UnawareAppendPartitionStrategy.HASH
+                        ? hashStrategyResultFileCount
+                        : lessSinkParallelism;
+        partitionEntriesLess.forEach(x -> assertThat(x.fileCount()).isEqualTo(fileCountLess));
     }
 
     private static class TestStatelessWriterSource extends AbstractNonCoordinatedSource<Integer> {


### PR DESCRIPTION
…nd only table.

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

In my company , we has an order table, we use the order create-time dt as the partition and extract MySQL data regularly according to the order update-time, each incremental data will contain order data of 600+ partitions (dt,hm). when we put it into the paimon unaware bucket append table, we find that there are many small files.
Flink streaming write:  set sink.parallelism = 40, one batch of data will be written to (600*40) files and 40 files per partition.

### Purpose

The purpose of this PR is to reduce the problem of small files when writing unaware bucket partitioned append tables. 

Currently, The unaware bucket partitioned append table will repartition the data when writing, this causes each task will receive all partitions data. So, each batch of data written will generate `(sink.parallelism)` files under each partition.
 `(partitionNums * parallelism)` files will be written at once.

Example : We write data to 5 partitions, and set `sink.parallelism = 5`. 

```
CREATE  TABLE xx ( 
..
) PARTITIONED BY (dt) WITH ( 
'bucket' = '-1' 
,'sink.parallelism' = '5' 
)

Step 2 : Write data across 5 partitions...

Step 3 : Watch manifest-list file:  (partitionNums * parallelism) 25 files were written at once. 

```
![1741005227497](https://github.com/user-attachments/assets/33b02ac1-37fd-4e97-9bbb-ff27f32fb539)

We can optimize this part by supporting the hash strategy to reduce the number of partitions each task receives.
Making the data of the same partition fall into the same task to reduce the number of files under the partition.

Apply this pr later : There is only one file per partition, while reducing the number of files, it also improves the file compression ratio and reduces storage space.

![1741005122917](https://github.com/user-attachments/assets/264ad71c-012c-43ce-9795-1baaab12dc19)



<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

UnawareBucketAppendOnlyTableITCase#testPartitionStrategyForPartitionedTable


<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
