### PR TITLE
[hotfix] ArrowFormatWriter should reset ArrowFieldWriters after flushing

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatCWriter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatCWriter.java
@@ -54,6 +54,10 @@ public class ArrowFormatCWriter implements AutoCloseable {
         return ArrowUtils.serializeToCStruct(vectorSchemaRoot, array, schema);
     }
 
+    public void reset() {
+        realWriter.reset();
+    }
+
     public boolean empty() {
         return realWriter.empty();
     }

--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatWriter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatWriter.java
@@ -64,7 +64,6 @@ public class ArrowFormatWriter implements AutoCloseable {
 
     public void flush() {
         vectorSchemaRoot.setRowCount(rowId);
-        rowId = 0;
     }
 
     public boolean write(InternalRow currentRow) {
@@ -87,6 +86,13 @@ public class ArrowFormatWriter implements AutoCloseable {
 
     public boolean empty() {
         return rowId == 0;
+    }
+
+    public void reset() {
+        for (ArrowFieldWriter fieldWriter : fieldWriters) {
+            fieldWriter.reset();
+        }
+        rowId = 0;
     }
 
     @Override


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The`ArrayWriter` and `MapWriter` need to be reset before writing again, so the `ArrowFormatWriter` should expose the reset method.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
