### PR TITLE
[cdc] Improve cdc record conversion to row Failure logs add field name

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordUtils.java
@@ -91,7 +91,7 @@ public class CdcRecordUtils {
 
             int idx = fieldNames.indexOf(key);
             if (idx < 0) {
-                LOG.info("Field " + key + " not found. Waiting for schema update.");
+                LOG.info("Field '{}' not found. Waiting for schema update.", key);
                 return Optional.empty();
             }
 
@@ -106,11 +106,10 @@ public class CdcRecordUtils {
                 genericRow.setField(idx, TypeUtils.castFromCdcValueString(value, type));
             } catch (Exception e) {
                 LOG.info(
-                        "Failed to convert value "
-                                + (logCorruptRecord ? value : "<redacted>")
-                                + " to type "
-                                + type
-                                + ". Waiting for schema update.",
+                        "Failed to convert field '{}' value {} to type {}. Waiting for schema update.",
+                        key,
+                        logCorruptRecord ? value : "<redacted>",
+                        type,
                         e);
                 return Optional.empty();
             }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

When a cdc record conversion exception occurs, the user does not know which field it is.

<img width="1010" alt="image" src="https://github.com/user-attachments/assets/87297e62-64b3-42ad-afd9-de1fddb25d9e" />


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
