### PR TITLE
[core] Reduce useless getFileStatus for Parquet Reader

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/format/SimpleStatsExtractor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/SimpleStatsExtractor.java
@@ -27,9 +27,9 @@ import java.io.IOException;
 /** Extracts statistics directly from file. */
 public interface SimpleStatsExtractor {
 
-    SimpleColStats[] extract(FileIO fileIO, Path path) throws IOException;
+    SimpleColStats[] extract(FileIO fileIO, Path path, long length) throws IOException;
 
-    Pair<SimpleColStats[], FileInfo> extractWithFileInfo(FileIO fileIO, Path path)
+    Pair<SimpleColStats[], FileInfo> extractWithFileInfo(FileIO fileIO, Path path, long length)
             throws IOException;
 
     /** File info fetched from physical file. */

--- a/paimon-common/src/main/java/org/apache/paimon/fs/local/LocalFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/local/LocalFileIO.java
@@ -26,6 +26,9 @@ import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.fs.SeekableInputStream;
 import org.apache.paimon.fs.VectoredReadable;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -49,6 +52,8 @@ import static org.apache.paimon.utils.Preconditions.checkState;
 /** {@link FileIO} for local file. */
 public class LocalFileIO implements FileIO {
 
+    private static final Logger LOG = LoggerFactory.getLogger(LocalFileIO.class);
+
     private static final long serialVersionUID = 1L;
 
     // the lock to ensure atomic renaming
@@ -68,11 +73,13 @@ public class LocalFileIO implements FileIO {
 
     @Override
     public SeekableInputStream newInputStream(Path path) throws IOException {
+        LOG.debug("Invoking newInputStream for {}", path);
         return new LocalSeekableInputStream(toFile(path));
     }
 
     @Override
     public PositionOutputStream newOutputStream(Path path, boolean overwrite) throws IOException {
+        LOG.debug("Invoking newOutputStream for {}", path);
         if (exists(path) && !overwrite) {
             throw new FileAlreadyExistsException("File already exists: " + path);
         }
@@ -87,6 +94,7 @@ public class LocalFileIO implements FileIO {
 
     @Override
     public FileStatus getFileStatus(Path path) throws IOException {
+        LOG.debug("Invoking getFileStatus for {}", path);
         final File file = toFile(path);
         if (file.exists()) {
             return new LocalFileStatus(file, SCHEME);
@@ -103,6 +111,7 @@ public class LocalFileIO implements FileIO {
 
     @Override
     public FileStatus[] listStatus(Path path) throws IOException {
+        LOG.debug("Invoking listStatus for {}", path);
         final File file = toFile(path);
         FileStatus[] results = new FileStatus[0];
 
@@ -133,11 +142,13 @@ public class LocalFileIO implements FileIO {
 
     @Override
     public boolean exists(Path path) throws IOException {
+        LOG.debug("Invoking exists for {}", path);
         return toFile(path).exists();
     }
 
     @Override
     public boolean delete(Path path, boolean recursive) throws IOException {
+        LOG.debug("Invoking delete for {}", path);
         File file = toFile(path);
         if (file.isFile()) {
             return file.delete();
@@ -175,6 +186,7 @@ public class LocalFileIO implements FileIO {
 
     @Override
     public boolean mkdirs(Path path) throws IOException {
+        LOG.debug("Invoking mkdirs for {}", path);
         return mkdirsInternal(toFile(path));
     }
 
@@ -196,6 +208,7 @@ public class LocalFileIO implements FileIO {
 
     @Override
     public boolean rename(Path src, Path dst) throws IOException {
+        LOG.debug("Invoking rename for {} to {}", src, dst);
         File srcFile = toFile(src);
         File dstFile = toFile(dst);
         File dstParent = dstFile.getParentFile();
@@ -219,6 +232,7 @@ public class LocalFileIO implements FileIO {
 
     @Override
     public void copyFile(Path sourcePath, Path targetPath, boolean overwrite) throws IOException {
+        LOG.debug("Invoking copyFile for {} to {}", sourcePath, targetPath);
         if (!overwrite && exists(targetPath)) {
             return;
         }

--- a/paimon-common/src/test/java/org/apache/paimon/format/SimpleColStatsExtractorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/format/SimpleColStatsExtractorTest.java
@@ -99,7 +99,7 @@ public abstract class SimpleColStatsExtractorTest {
 
         SimpleStatsExtractor extractor = format.createStatsExtractor(rowType, stats).get();
         assertThat(extractor).isNotNull();
-        SimpleColStats[] actual = extractor.extract(fileIO, path);
+        SimpleColStats[] actual = extractor.extract(fileIO, path, fileIO.getFileSize(path));
         for (int i = 0; i < expected.length; i++) {
             expected[i] = regenerate(expected[i], rowType.getTypeAt(i));
         }

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileWriter.java
@@ -169,7 +169,9 @@ public abstract class KeyValueDataFileWriter
             return null;
         }
 
-        Pair<SimpleColStats[], SimpleColStats[]> keyValueStats = fetchKeyValueStats(fieldStats());
+        long fileSize = fileIO.getFileSize(path);
+        Pair<SimpleColStats[], SimpleColStats[]> keyValueStats =
+                fetchKeyValueStats(fieldStats(fileSize));
 
         SimpleStats keyStats = keyStatsConverter.toBinaryAllMode(keyValueStats.getKey());
         Pair<List<String>, SimpleStats> valueStatsPair =
@@ -183,7 +185,7 @@ public abstract class KeyValueDataFileWriter
         String externalPath = isExternalPath ? path.toString() : null;
         return new DataFileMeta(
                 path.getName(),
-                fileIO.getFileSize(path),
+                fileSize,
                 recordCount(),
                 minKey,
                 keySerializer.toBinaryRow(maxKey).copy(),

--- a/paimon-core/src/main/java/org/apache/paimon/io/RowDataFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/RowDataFileWriter.java
@@ -109,7 +109,9 @@ public class RowDataFileWriter extends StatsCollectingSingleFileWriter<InternalR
 
     @Override
     public DataFileMeta result() throws IOException {
-        Pair<List<String>, SimpleStats> statsPair = statsArraySerializer.toBinary(fieldStats());
+        long fileSize = fileIO.getFileSize(path);
+        Pair<List<String>, SimpleStats> statsPair =
+                statsArraySerializer.toBinary(fieldStats(fileSize));
         DataFileIndexWriter.FileIndexResult indexResult =
                 dataFileIndexWriter == null
                         ? DataFileIndexWriter.EMPTY_RESULT
@@ -117,7 +119,7 @@ public class RowDataFileWriter extends StatsCollectingSingleFileWriter<InternalR
         String externalPath = isExternalPath ? path.toString() : null;
         return DataFileMeta.forAppend(
                 path.getName(),
-                fileIO.getFileSize(path),
+                fileSize,
                 recordCount(),
                 statsPair.getRight(),
                 seqNumCounter.getValue() - super.recordCount(),

--- a/paimon-core/src/main/java/org/apache/paimon/io/StatsCollectingSingleFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/StatsCollectingSingleFileWriter.java
@@ -96,13 +96,13 @@ public abstract class StatsCollectingSingleFileWriter<T, R> extends SingleFileWr
         super.writeBundle(bundle);
     }
 
-    public SimpleColStats[] fieldStats() throws IOException {
+    public SimpleColStats[] fieldStats(long fileSize) throws IOException {
         Preconditions.checkState(closed, "Cannot access metric unless the writer is closed.");
         if (simpleStatsExtractor != null) {
             if (isStatsDisabled) {
                 return noneStats;
             } else {
-                return simpleStatsExtractor.extract(fileIO, path);
+                return simpleStatsExtractor.extract(fileIO, path, fileSize);
             }
         } else {
             return simpleStatsCollector.extract();

--- a/paimon-core/src/main/java/org/apache/paimon/migrate/FileMetaUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/migrate/FileMetaUtils.java
@@ -218,7 +218,7 @@ public class FileMetaUtils {
         SimpleStatsConverter statsArraySerializer = new SimpleStatsConverter(rowTypeWithSchemaId);
 
         Pair<SimpleColStats[], SimpleStatsExtractor.FileInfo> fileInfo =
-                simpleStatsExtractor.extractWithFileInfo(fileIO, path);
+                simpleStatsExtractor.extractWithFileInfo(fileIO, path, fileSize);
         SimpleStats stats = statsArraySerializer.toBinaryAllMode(fileInfo.getLeft());
 
         return DataFileMeta.forAppend(

--- a/paimon-core/src/test/java/org/apache/paimon/SnapshotTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/SnapshotTest.java
@@ -26,6 +26,7 @@ import org.apache.paimon.utils.SnapshotManager;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.paimon.utils.FileSystemBranchManager.DEFAULT_MAIN_BRANCH;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for snapshots. */
 public class SnapshotTest {
@@ -48,6 +49,30 @@ public class SnapshotTest {
                         + "  \"deltaRecordCount\" : null,\n"
                         + "  \"unknownKey\" : 22222\n"
                         + "}");
+    }
+
+    @Test
+    public void testSnapshotWithSizes() {
+        String json =
+                "{\n"
+                        + "  \"version\" : 3,\n"
+                        + "  \"id\" : 5,\n"
+                        + "  \"schemaId\" : 0,\n"
+                        + "  \"baseManifestList\" : null,\n"
+                        + "  \"baseManifestListSize\" : 6,\n"
+                        + "  \"deltaManifestList\" : null,\n"
+                        + "  \"deltaManifestListSize\" : 8,\n"
+                        + "  \"changelogManifestListSize\" : 10,\n"
+                        + "  \"commitUser\" : null,\n"
+                        + "  \"commitIdentifier\" : 0,\n"
+                        + "  \"commitKind\" : \"APPEND\",\n"
+                        + "  \"timeMillis\" : 1234,\n"
+                        + "  \"totalRecordCount\" : null,\n"
+                        + "  \"deltaRecordCount\" : null,\n"
+                        + "  \"unknownKey\" : 22222\n"
+                        + "}";
+        Snapshot snapshot = Snapshot.fromJson(json);
+        assertThat(Snapshot.fromJson(snapshot.toJson())).isEqualTo(snapshot);
     }
 
     public static SnapshotManager newSnapshotManager(FileIO fileIO, Path tablePath) {

--- a/paimon-core/src/test/java/org/apache/paimon/stats/TestSimpleStatsExtractor.java
+++ b/paimon-core/src/test/java/org/apache/paimon/stats/TestSimpleStatsExtractor.java
@@ -59,13 +59,13 @@ public class TestSimpleStatsExtractor implements SimpleStatsExtractor {
     }
 
     @Override
-    public SimpleColStats[] extract(FileIO fileIO, Path path) throws IOException {
-        return extractWithFileInfo(fileIO, path).getLeft();
+    public SimpleColStats[] extract(FileIO fileIO, Path path, long length) throws IOException {
+        return extractWithFileInfo(fileIO, path, length).getLeft();
     }
 
     @Override
-    public Pair<SimpleColStats[], FileInfo> extractWithFileInfo(FileIO fileIO, Path path)
-            throws IOException {
+    public Pair<SimpleColStats[], FileInfo> extractWithFileInfo(
+            FileIO fileIO, Path path, long length) throws IOException {
         IdentityObjectSerializer serializer = new IdentityObjectSerializer(rowType);
         FormatReaderFactory readerFactory = format.createReaderFactory(rowType);
         List<InternalRow> records = readListFromFile(fileIO, path, serializer, readerFactory);

--- a/paimon-format/src/main/java/org/apache/paimon/format/avro/AvroSimpleStatsExtractor.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/avro/AvroSimpleStatsExtractor.java
@@ -39,25 +39,23 @@ import java.util.stream.IntStream;
 public class AvroSimpleStatsExtractor implements SimpleStatsExtractor {
 
     private final RowType rowType;
-    private final SimpleColStatsCollector.Factory[] statsCollectors;
 
     public AvroSimpleStatsExtractor(
             RowType rowType, SimpleColStatsCollector.Factory[] statsCollectors) {
         this.rowType = rowType;
-        this.statsCollectors = statsCollectors;
         Preconditions.checkArgument(
                 rowType.getFieldCount() == statsCollectors.length,
                 "The stats collector is not aligned to write schema.");
     }
 
     @Override
-    public SimpleColStats[] extract(FileIO fileIO, Path path) throws IOException {
-        return extractWithFileInfo(fileIO, path).getLeft();
+    public SimpleColStats[] extract(FileIO fileIO, Path path, long length) throws IOException {
+        return extractWithFileInfo(fileIO, path, length).getLeft();
     }
 
     @Override
-    public Pair<SimpleColStats[], FileInfo> extractWithFileInfo(FileIO fileIO, Path path)
-            throws IOException {
+    public Pair<SimpleColStats[], FileInfo> extractWithFileInfo(
+            FileIO fileIO, Path path, long length) throws IOException {
 
         SeekableInputStream fileInputStream = fileIO.newInputStream(path);
         long rowCount = getRowCount(fileInputStream);

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/filter/OrcSimpleStatsExtractor.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/filter/OrcSimpleStatsExtractor.java
@@ -71,13 +71,13 @@ public class OrcSimpleStatsExtractor implements SimpleStatsExtractor {
     }
 
     @Override
-    public SimpleColStats[] extract(FileIO fileIO, Path path) throws IOException {
-        return extractWithFileInfo(fileIO, path).getLeft();
+    public SimpleColStats[] extract(FileIO fileIO, Path path, long length) throws IOException {
+        return extractWithFileInfo(fileIO, path, length).getLeft();
     }
 
     @Override
-    public Pair<SimpleColStats[], FileInfo> extractWithFileInfo(FileIO fileIO, Path path)
-            throws IOException {
+    public Pair<SimpleColStats[], FileInfo> extractWithFileInfo(
+            FileIO fileIO, Path path, long length) throws IOException {
         try (Reader reader =
                 OrcReaderFactory.createReader(new Configuration(false), fileIO, path, null)) {
             long rowCount = reader.getNumberOfRows();

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetInputFile.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetInputFile.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.format.parquet;
 
 import org.apache.paimon.fs.FileIO;
-import org.apache.paimon.fs.FileStatus;
 import org.apache.paimon.fs.Path;
 
 import org.apache.parquet.io.InputFile;
@@ -30,33 +29,36 @@ import java.io.IOException;
 public class ParquetInputFile implements InputFile {
 
     private final FileIO fileIO;
-    private final FileStatus stat;
+    private final Path path;
+    private final long length;
 
-    public static ParquetInputFile fromPath(FileIO fileIO, Path path) throws IOException {
-        return new ParquetInputFile(fileIO, fileIO.getFileStatus(path));
+    public static ParquetInputFile fromPath(FileIO fileIO, Path path, long length)
+            throws IOException {
+        return new ParquetInputFile(fileIO, path, length);
     }
 
-    private ParquetInputFile(FileIO fileIO, FileStatus stat) {
+    private ParquetInputFile(FileIO fileIO, Path path, long length) {
         this.fileIO = fileIO;
-        this.stat = stat;
+        this.path = path;
+        this.length = length;
     }
 
     public Path getPath() {
-        return stat.getPath();
+        return path;
     }
 
     @Override
     public long getLength() {
-        return stat.getLen();
+        return length;
     }
 
     @Override
     public ParquetInputStream newStream() throws IOException {
-        return new ParquetInputStream(fileIO.newInputStream(stat.getPath()));
+        return new ParquetInputStream(fileIO.newInputStream(path));
     }
 
     @Override
     public String toString() {
-        return stat.getPath().toString();
+        return path.toString();
     }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
@@ -113,7 +113,8 @@ public class ParquetReaderFactory implements FormatReaderFactory {
 
         ParquetFileReader reader =
                 new ParquetFileReader(
-                        ParquetInputFile.fromPath(context.fileIO(), context.filePath()),
+                        ParquetInputFile.fromPath(
+                                context.fileIO(), context.filePath(), context.fileSize()),
                         builder.build(),
                         context.selection());
         MessageType fileSchema = reader.getFileMetaData().getSchema();
@@ -145,7 +146,8 @@ public class ParquetReaderFactory implements FormatReaderFactory {
 
         ParquetFileReader reader =
                 new ParquetFileReader(
-                        ParquetInputFile.fromPath(context.fileIO(), context.filePath()),
+                        ParquetInputFile.fromPath(
+                                context.fileIO(), context.filePath(), context.fileSize()),
                         builder.build(),
                         context.selection());
         MessageType fileSchema = reader.getFileMetaData().getSchema();

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetSimpleStatsExtractor.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetSimpleStatsExtractor.java
@@ -67,15 +67,15 @@ public class ParquetSimpleStatsExtractor implements SimpleStatsExtractor {
     }
 
     @Override
-    public SimpleColStats[] extract(FileIO fileIO, Path path) throws IOException {
-        return extractWithFileInfo(fileIO, path).getLeft();
+    public SimpleColStats[] extract(FileIO fileIO, Path path, long length) throws IOException {
+        return extractWithFileInfo(fileIO, path, length).getLeft();
     }
 
     @Override
-    public Pair<SimpleColStats[], FileInfo> extractWithFileInfo(FileIO fileIO, Path path)
-            throws IOException {
+    public Pair<SimpleColStats[], FileInfo> extractWithFileInfo(
+            FileIO fileIO, Path path, long length) throws IOException {
         Pair<Map<String, Statistics<?>>, FileInfo> statsPair =
-                ParquetUtil.extractColumnStats(fileIO, path);
+                ParquetUtil.extractColumnStats(fileIO, path, length);
         SimpleColStatsCollector[] collectors = SimpleColStatsCollector.create(statsCollectors);
         return Pair.of(
                 IntStream.range(0, rowType.getFieldCount())

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetUtil.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetUtil.java
@@ -40,15 +40,16 @@ import java.util.Map;
 public class ParquetUtil {
 
     /**
-     * Extract stats from specified Parquet files path.
+     * Extract stats from specified Parquet file path.
      *
-     * @param path the path of parquet files to be read
+     * @param path the path of parquet file to be read
+     * @param length the length of parquet file to be read
      * @return result sets as map, key is column name, value is statistics (for example, null count,
      *     minimum value, maximum value)
      */
     public static Pair<Map<String, Statistics<?>>, SimpleStatsExtractor.FileInfo>
-            extractColumnStats(FileIO fileIO, Path path) throws IOException {
-        try (ParquetFileReader reader = getParquetReader(fileIO, path)) {
+            extractColumnStats(FileIO fileIO, Path path, long length) throws IOException {
+        try (ParquetFileReader reader = getParquetReader(fileIO, path, length)) {
             ParquetMetadata parquetMetadata = reader.getFooter();
             List<BlockMetaData> blockMetaDataList = parquetMetadata.getBlocks();
             Map<String, Statistics<?>> resultStats = new HashMap<>();
@@ -72,14 +73,16 @@ public class ParquetUtil {
     }
 
     /**
-     * Generate {@link ParquetFileReader} instance to read the Parquet files at the given path.
+     * Generate {@link ParquetFileReader} instance to read the Parquet file at the given path.
      *
-     * @param path the path of parquet files to be read
+     * @param path the path of parquet file to be read
+     * @param length the length of parquet file to be read
      * @return parquet reader, used for reading footer, status, etc.
      */
-    public static ParquetFileReader getParquetReader(FileIO fileIO, Path path) throws IOException {
+    public static ParquetFileReader getParquetReader(FileIO fileIO, Path path, long length)
+            throws IOException {
         return new ParquetFileReader(
-                ParquetInputFile.fromPath(fileIO, path),
+                ParquetInputFile.fromPath(fileIO, path, length),
                 ParquetReadOptions.builder().build(),
                 null);
     }

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
@@ -64,7 +64,7 @@ public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
         RowType rowType = DataTypes.ROW(DataTypes.INT().notNull(), DataTypes.BIGINT());
 
         if (ThreadLocalRandom.current().nextBoolean()) {
-            rowType = (RowType) rowType.notNull();
+            rowType = rowType.notNull();
         }
 
         PositionOutputStream out = fileIO.newOutputStream(file, false);
@@ -75,7 +75,8 @@ public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
         writer.close();
         out.close();
 
-        try (ParquetFileReader reader = ParquetUtil.getParquetReader(fileIO, file)) {
+        try (ParquetFileReader reader =
+                ParquetUtil.getParquetReader(fileIO, file, fileIO.getFileSize(file))) {
             ParquetMetadata parquetMetadata = reader.getFooter();
             List<BlockMetaData> blockMetaDataList = parquetMetadata.getBlocks();
             for (BlockMetaData blockMetaData : blockMetaDataList) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Minor optimization for parquet reader.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
