### PR TITLE
display the external full path when external path is not null

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta.java
@@ -278,6 +278,9 @@ public class DataFileMeta {
     }
 
     public String fileName() {
+        if (externalPath != null) {
+            return externalPath;
+        }
         return fileName;
     }
 


### PR DESCRIPTION
I think it would be better to display the external full path when the external path is not null.

eg:
`SELECT * FROM my_table$files;`

The display is as follows:

![image](https://github.com/user-attachments/assets/5ef7d83f-c18b-484f-b5a1-e73692c1680b)



