### PR TITLE
[core] Remove useless branch arguement in FileStoreCommitImpl

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -329,7 +329,6 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                                 committable.logOffsets(),
                                 Snapshot.CommitKind.APPEND,
                                 noConflictCheck(),
-                                branchName,
                                 null);
                 generatedSnapshot += 1;
             }
@@ -364,7 +363,6 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                                 committable.logOffsets(),
                                 Snapshot.CommitKind.COMPACT,
                                 hasConflictChecked(safeLatestSnapshotId),
-                                branchName,
                                 null);
                 generatedSnapshot += 1;
             }
@@ -510,7 +508,6 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                                 committable.logOffsets(),
                                 Snapshot.CommitKind.COMPACT,
                                 mustConflictCheck(),
-                                branchName,
                                 null);
                 generatedSnapshot += 1;
             }
@@ -605,7 +602,6 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 Collections.emptyMap(),
                 Snapshot.CommitKind.ANALYZE,
                 noConflictCheck(),
-                branchName,
                 statsFileName);
     }
 
@@ -721,7 +717,6 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             Map<Integer, Long> logOffsets,
             Snapshot.CommitKind commitKind,
             ConflictCheck conflictCheck,
-            String branchName,
             @Nullable String statsFileName) {
         int retryCount = 0;
         RetryResult retryResult = null;
@@ -740,7 +735,6 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                             commitKind,
                             latestSnapshot,
                             conflictCheck,
-                            branchName,
                             statsFileName);
 
             if (result.isSuccess()) {
@@ -816,7 +810,6 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 logOffsets,
                 Snapshot.CommitKind.OVERWRITE,
                 mustConflictCheck(),
-                branchName,
                 null);
     }
 
@@ -832,7 +825,6 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             Snapshot.CommitKind commitKind,
             @Nullable Snapshot latestSnapshot,
             ConflictCheck conflictCheck,
-            String branchName,
             @Nullable String newStatsFileName) {
         long startMillis = System.currentTimeMillis();
         long newSnapshotId =

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
@@ -71,7 +71,6 @@ import static org.apache.paimon.operation.FileStoreTestUtils.assertPathExists;
 import static org.apache.paimon.operation.FileStoreTestUtils.assertPathNotExists;
 import static org.apache.paimon.operation.FileStoreTestUtils.commitData;
 import static org.apache.paimon.operation.FileStoreTestUtils.partitionedData;
-import static org.apache.paimon.utils.FileSystemBranchManager.DEFAULT_MAIN_BRANCH;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -802,7 +801,6 @@ public class FileDeletionTest {
                     Snapshot.CommitKind.APPEND,
                     store.snapshotManager().latestSnapshot(),
                     mustConflictCheck(),
-                    DEFAULT_MAIN_BRANCH,
                     null);
         }
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Minor refactor.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
