### PR TITLE
[test][hive] Upgrade hiverunner usage to support tests in jdk11

### DIFF
--- a/paimon-hive/paimon-hive-connector-2.3/pom.xml
+++ b/paimon-hive/paimon-hive-connector-2.3/pom.xml
@@ -156,7 +156,7 @@ under the License.
         </dependency>
 
         <dependency>
-            <groupId>com.klarna</groupId>
+            <groupId>io.github.hiverunner</groupId>
             <artifactId>hiverunner</artifactId>
             <version>${hiverunner.version}</version>
             <scope>test</scope>

--- a/paimon-hive/paimon-hive-connector-3.1/pom.xml
+++ b/paimon-hive/paimon-hive-connector-3.1/pom.xml
@@ -35,6 +35,7 @@ under the License.
 
     <properties>
         <hive.version>3.1.2</hive.version>
+        <hiverunner.version>6.1.0</hiverunner.version>
         <jackson.version>2.13.3</jackson.version>
     </properties>
 
@@ -170,7 +171,7 @@ under the License.
         </dependency>
 
         <dependency>
-            <groupId>com.klarna</groupId>
+            <groupId>io.github.hiverunner</groupId>
             <artifactId>hiverunner</artifactId>
             <version>${hiverunner.version}</version>
             <scope>test</scope>
@@ -226,6 +227,10 @@ under the License.
                 </exclusion>
                 <exclusion>
                     <artifactId>hadoop-mapreduce-client-core</artifactId>
+                    <groupId>org.apache.hadoop</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>hadoop-mapreduce-client-common</artifactId>
                     <groupId>org.apache.hadoop</groupId>
                 </exclusion>
                 <exclusion>

--- a/paimon-hive/paimon-hive-connector-common/pom.xml
+++ b/paimon-hive/paimon-hive-connector-common/pom.xml
@@ -165,7 +165,7 @@ under the License.
         </dependency>
 
         <dependency>
-            <groupId>com.klarna</groupId>
+            <groupId>io.github.hiverunner</groupId>
             <artifactId>hiverunner</artifactId>
             <version>${hiverunner.version}</version>
             <scope>test</scope>
@@ -254,6 +254,97 @@ under the License.
                 <exclusion>
                     <groupId>com.google.protobuf</groupId>
                     <artifactId>protobuf-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>tez-dag</artifactId>
+                    <groupId>org.apache.tez</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>tez-common</artifactId>
+                    <groupId>org.apache.tez</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>tez-mapreduce</artifactId>
+                    <groupId>org.apache.tez</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <artifactId>tez-dag</artifactId>
+            <groupId>org.apache.tez</groupId>
+            <version>${tez.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>hadoop-yarn-client</artifactId>
+                    <groupId>org.apache.hadoop</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>hadoop-yarn-server-common</artifactId>
+                    <groupId>org.apache.hadoop</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>hadoop-yarn-server-web-proxy</artifactId>
+                    <groupId>org.apache.hadoop</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>hadoop-yarn-common</artifactId>
+                    <groupId>org.apache.hadoop</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>slf4j-log4j12</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>protobuf-java</artifactId>
+                    <groupId>com.google.protobuf</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <artifactId>tez-common</artifactId>
+            <groupId>org.apache.tez</groupId>
+            <version>${tez.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>hadoop-yarn-common</artifactId>
+                    <groupId>org.apache.hadoop</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>slf4j-log4j12</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>protobuf-java</artifactId>
+                    <groupId>com.google.protobuf</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <artifactId>tez-mapreduce</artifactId>
+            <groupId>org.apache.tez</groupId>
+            <version>${tez.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>hadoop-mapreduce-client-common</artifactId>
+                    <groupId>org.apache.hadoop</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>hadoop-yarn-client</artifactId>
+                    <groupId>org.apache.hadoop</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>hadoop-yarn-common</artifactId>
+                    <groupId>org.apache.hadoop</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>protobuf-java</artifactId>
+                    <groupId>com.google.protobuf</groupId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveLocationTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveLocationTest.java
@@ -92,9 +92,7 @@ public class HiveLocationTest {
         options.set(CatalogOptions.METASTORE, "hive");
         options.set(CatalogOptions.URI, "");
         options.set(CatalogOptions.LOCK_ENABLED, false);
-        options.set(
-                HiveCatalogOptions.HIVE_CONF_DIR,
-                hiveShell.getBaseDir().getRoot().getPath() + HIVE_CONF);
+        options.set(HiveCatalogOptions.HIVE_CONF_DIR, hiveShell.getBaseDir() + HIVE_CONF);
         options.set(HiveCatalogOptions.LOCATION_IN_PROPERTIES, true);
 
         for (Map.Entry<String, String> stringStringEntry :
@@ -248,7 +246,7 @@ public class HiveLocationTest {
         String[][] params =
                 new String[][] {
                     {"table1", objectStorePath},
-                    {"table2", hiveShell.getBaseDir().getRoot().getAbsolutePath()},
+                    {"table2", hiveShell.getBaseDir().toAbsolutePath().toString()},
                 };
         for (String[] param : params) {
             String tableName = param[0];

--- a/paimon-hive/pom.xml
+++ b/paimon-hive/pom.xml
@@ -46,7 +46,8 @@ under the License.
 
     <properties>
         <hive.version>2.3.10</hive.version>
-        <hiverunner.version>4.0.0</hiverunner.version>
+        <tez.version>0.10.0</tez.version>
+        <hiverunner.version>5.5.0</hiverunner.version>
         <reflections.version>0.9.8</reflections.version>
         <aws.version>1.12.319</aws.version>
         <iceberg.flink.version>1.19</iceberg.flink.version>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Currently, hive tests on jdk11 always failed.
After digging into the problem, I found that old hiverunner usage was outdated and can be replaced as `io.github.hiverunner:hiverunner` refer to https://github.com/HiveRunner/HiveRunner/blob/main/README.md.
In addition, The dependency tez 0.9.1 in hiverunner has bugs for jdk0.9+ and have been fixed in 0.10.0 refer to https://issues.apache.org/jira/browse/TEZ-3860.

CI on jdk11: https://github.com/liyubin117/paimon/actions/runs/13676925840


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
