### PR TITLE
[core] RESTCatalog:  encode resource name and query value in url

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -41,7 +41,6 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
 
 import static okhttp3.ConnectionSpec.CLEARTEXT;
@@ -169,16 +168,15 @@ public class HttpClient implements RESTClient {
         }
     }
 
+    @VisibleForTesting
     protected static String getRequestUrl(
             String uri, String path, Map<String, String> queryParams) {
         String fullPath = StringUtils.isNullOrWhitespaceOnly(path) ? uri : uri + path;
         if (queryParams != null && !queryParams.isEmpty()) {
             HttpUrl httpUrl = HttpUrl.parse(fullPath);
-            if (Objects.nonNull(httpUrl)) {
-                HttpUrl.Builder builder = httpUrl.newBuilder();
-                queryParams.forEach(builder::addQueryParameter);
-                fullPath = builder.build().toString();
-            }
+            HttpUrl.Builder builder = httpUrl.newBuilder();
+            queryParams.forEach(builder::addQueryParameter);
+            fullPath = builder.build().toString();
         }
         return fullPath;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -23,7 +23,6 @@ import org.apache.paimon.rest.auth.RESTAuthFunction;
 import org.apache.paimon.rest.auth.RESTAuthParameter;
 import org.apache.paimon.rest.exceptions.RESTException;
 import org.apache.paimon.rest.responses.ErrorResponse;
-import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.StringUtils;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
@@ -44,7 +43,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static okhttp3.ConnectionSpec.CLEARTEXT;
 import static okhttp3.ConnectionSpec.COMPATIBLE_TLS;
@@ -86,7 +84,7 @@ public class HttpClient implements RESTClient {
     @Override
     public <T extends RESTResponse> T get(
             String path, Class<T> responseType, RESTAuthFunction restAuthFunction) {
-        Map<String, String> authHeaders = getHeaders(path, "GET", "", restAuthFunction);
+        Map<String, String> authHeaders = getHeaders(uri, path, "GET", "", restAuthFunction);
         Request request =
                 new Request.Builder()
                         .url(getRequestUrl(path))
@@ -102,13 +100,11 @@ public class HttpClient implements RESTClient {
             Map<String, String> queryParams,
             Class<T> responseType,
             RESTAuthFunction restAuthFunction) {
-        Map<String, String> authHeaders = getHeaders(path, "GET", "", restAuthFunction);
+        String url = getRequestUrl(uri, path, queryParams);
+        Map<String, String> authHeaders =
+                getHeaders(uri, path, queryParams, "GET", "", restAuthFunction);
         Request request =
-                new Request.Builder()
-                        .url(getRequestUrl(path, queryParams))
-                        .get()
-                        .headers(Headers.of(authHeaders))
-                        .build();
+                new Request.Builder().url(url).get().headers(Headers.of(authHeaders)).build();
         return exec(request, responseType);
     }
 
@@ -126,7 +122,8 @@ public class HttpClient implements RESTClient {
             RESTAuthFunction restAuthFunction) {
         try {
             String bodyStr = OBJECT_MAPPER.writeValueAsString(body);
-            Map<String, String> authHeaders = getHeaders(path, "POST", bodyStr, restAuthFunction);
+            Map<String, String> authHeaders =
+                    getHeaders(uri, path, "POST", bodyStr, restAuthFunction);
             RequestBody requestBody = buildRequestBody(bodyStr);
             Request request =
                     new Request.Builder()
@@ -142,7 +139,7 @@ public class HttpClient implements RESTClient {
 
     @Override
     public <T extends RESTResponse> T delete(String path, RESTAuthFunction restAuthFunction) {
-        Map<String, String> authHeaders = getHeaders(path, "DELETE", "", restAuthFunction);
+        Map<String, String> authHeaders = getHeaders(uri, path, "DELETE", "", restAuthFunction);
         Request request =
                 new Request.Builder()
                         .url(getRequestUrl(path))
@@ -157,7 +154,8 @@ public class HttpClient implements RESTClient {
             String path, RESTRequest body, RESTAuthFunction restAuthFunction) {
         try {
             String bodyStr = OBJECT_MAPPER.writeValueAsString(body);
-            Map<String, String> authHeaders = getHeaders(path, "DELETE", bodyStr, restAuthFunction);
+            Map<String, String> authHeaders =
+                    getHeaders(uri, path, "DELETE", bodyStr, restAuthFunction);
             RequestBody requestBody = buildRequestBody(bodyStr);
             Request request =
                     new Request.Builder()
@@ -169,6 +167,20 @@ public class HttpClient implements RESTClient {
         } catch (JsonProcessingException e) {
             throw new RESTException(e, "build request failed.");
         }
+    }
+
+    protected static String getRequestUrl(
+            String uri, String path, Map<String, String> queryParams) {
+        String fullPath = StringUtils.isNullOrWhitespaceOnly(path) ? uri : uri + path;
+        if (queryParams != null && !queryParams.isEmpty()) {
+            HttpUrl httpUrl = HttpUrl.parse(fullPath);
+            if (Objects.nonNull(httpUrl)) {
+                HttpUrl.Builder builder = httpUrl.newBuilder();
+                queryParams.forEach(builder::addQueryParameter);
+                fullPath = builder.build().toString();
+            }
+        }
+        return fullPath;
     }
 
     private <T extends RESTResponse> T exec(Request request, Class<T> responseType) {
@@ -209,59 +221,29 @@ public class HttpClient implements RESTClient {
     }
 
     private String getRequestUrl(String path) {
-        return getRequestUrl(path, null);
+        return getRequestUrl(uri, path, null);
     }
 
-    private String getRequestUrl(String path, Map<String, String> queryParams) {
-        String fullPath = StringUtils.isNullOrWhitespaceOnly(path) ? uri : uri + path;
-        if (queryParams != null && !queryParams.isEmpty()) {
-            HttpUrl httpUrl = HttpUrl.parse(fullPath);
-            if (Objects.nonNull(httpUrl)) {
-                HttpUrl.Builder builder = httpUrl.newBuilder();
-                queryParams.forEach(builder::addQueryParameter);
-                return builder.build().toString();
-            } else {
-                return fullPath;
-            }
-        } else {
-            return fullPath;
-        }
-    }
-
-    private Map<String, String> getHeaders(
+    private static Map<String, String> getHeaders(
+            String uri,
             String path,
             String method,
             String data,
             Function<RESTAuthParameter, Map<String, String>> headerFunction) {
-        Pair<String, Map<String, String>> resourcePath2Parameters = parsePath(path);
-        RESTAuthParameter restAuthParameter =
-                new RESTAuthParameter(
-                        URI.create(uri).getHost(),
-                        resourcePath2Parameters.getLeft(),
-                        resourcePath2Parameters.getValue(),
-                        method,
-                        data);
-        return headerFunction.apply(restAuthParameter);
+
+        return getHeaders(uri, path, Collections.emptyMap(), method, data, headerFunction);
     }
 
-    @VisibleForTesting
-    protected static Pair<String, Map<String, String>> parsePath(String path) {
-        String[] paths = path.split("\\?");
-        String resourcePath = paths[0];
-        if (paths.length == 1) {
-            return Pair.of(resourcePath, Collections.emptyMap());
-        }
-        String query = paths[1];
-        Map<String, String> parameters =
-                Arrays.stream(query.split("&"))
-                        .map(pair -> pair.split("=", 2))
-                        .collect(
-                                Collectors.toMap(
-                                        pair -> pair[0].trim(), // key
-                                        pair -> pair[1].trim(), // value
-                                        (existing, replacement) -> existing // handle duplicates
-                                        ));
-        return Pair.of(resourcePath, parameters);
+    private static Map<String, String> getHeaders(
+            String uri,
+            String path,
+            Map<String, String> queryParams,
+            String method,
+            String data,
+            Function<RESTAuthParameter, Map<String, String>> headerFunction) {
+        RESTAuthParameter restAuthParameter =
+                new RESTAuthParameter(URI.create(uri).getHost(), path, queryParams, method, data);
+        return headerFunction.apply(restAuthParameter);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -86,7 +86,7 @@ public class HttpClient implements RESTClient {
         Map<String, String> authHeaders = getHeaders(uri, path, "GET", "", restAuthFunction);
         Request request =
                 new Request.Builder()
-                        .url(getRequestUrl(path))
+                        .url(getRequestUrl(uri, path, null))
                         .get()
                         .headers(Headers.of(authHeaders))
                         .build();
@@ -99,11 +99,14 @@ public class HttpClient implements RESTClient {
             Map<String, String> queryParams,
             Class<T> responseType,
             RESTAuthFunction restAuthFunction) {
-        String url = getRequestUrl(uri, path, queryParams);
         Map<String, String> authHeaders =
                 getHeaders(uri, path, queryParams, "GET", "", restAuthFunction);
         Request request =
-                new Request.Builder().url(url).get().headers(Headers.of(authHeaders)).build();
+                new Request.Builder()
+                        .url(getRequestUrl(uri, path, queryParams))
+                        .get()
+                        .headers(Headers.of(authHeaders))
+                        .build();
         return exec(request, responseType);
     }
 
@@ -126,7 +129,7 @@ public class HttpClient implements RESTClient {
             RequestBody requestBody = buildRequestBody(bodyStr);
             Request request =
                     new Request.Builder()
-                            .url(getRequestUrl(path))
+                            .url(getRequestUrl(uri, path, null))
                             .post(requestBody)
                             .headers(Headers.of(authHeaders))
                             .build();
@@ -141,7 +144,7 @@ public class HttpClient implements RESTClient {
         Map<String, String> authHeaders = getHeaders(uri, path, "DELETE", "", restAuthFunction);
         Request request =
                 new Request.Builder()
-                        .url(getRequestUrl(path))
+                        .url(getRequestUrl(uri, path, null))
                         .delete()
                         .headers(Headers.of(authHeaders))
                         .build();
@@ -158,7 +161,7 @@ public class HttpClient implements RESTClient {
             RequestBody requestBody = buildRequestBody(bodyStr);
             Request request =
                     new Request.Builder()
-                            .url(getRequestUrl(path))
+                            .url(getRequestUrl(uri, path, null))
                             .delete(requestBody)
                             .headers(Headers.of(authHeaders))
                             .build();
@@ -216,10 +219,6 @@ public class HttpClient implements RESTClient {
 
     private static RequestBody buildRequestBody(String body) throws JsonProcessingException {
         return RequestBody.create(body.getBytes(StandardCharsets.UTF_8), MEDIA_TYPE);
-    }
-
-    private String getRequestUrl(String path) {
-        return getRequestUrl(uri, path, null);
     }
 
     private static Map<String, String> getHeaders(

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -84,6 +84,7 @@ import org.apache.paimon.view.ViewImpl;
 import org.apache.paimon.view.ViewSchema;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.shade.guava30.com.google.common.collect.Maps;
 
 import org.apache.commons.lang3.StringUtils;
@@ -125,6 +126,7 @@ public class RESTCatalog implements Catalog, SupportsSnapshots, SupportsBranches
     public static final String HEADER_PREFIX = "header.";
     public static final String MAX_RESULTS = "maxResults";
     public static final String PAGE_TOKEN = "pageToken";
+    public static final String QUERY_PARAMETER_WAREHOUSE_KEY = "warehouse";
 
     private final RESTClient client;
     private final ResourcePaths resourcePaths;
@@ -145,11 +147,16 @@ public class RESTCatalog implements Catalog, SupportsSnapshots, SupportsBranches
         Map<String, String> baseHeaders = Collections.emptyMap();
         if (configRequired) {
             String warehouse = options.get(WAREHOUSE);
+            Map<String, String> queryParams =
+                    StringUtils.isNotEmpty(warehouse)
+                            ? ImmutableMap.of(QUERY_PARAMETER_WAREHOUSE_KEY, warehouse)
+                            : ImmutableMap.of();
             baseHeaders = extractPrefixMap(context.options(), HEADER_PREFIX);
             options =
                     new Options(
                             client.get(
-                                            ResourcePaths.config(warehouse),
+                                            ResourcePaths.config(),
+                                            queryParams,
                                             ConfigResponse.class,
                                             new RESTAuthFunction(
                                                     Collections.emptyMap(), catalogAuth))

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -423,10 +423,20 @@ public class RESTCatalog implements Catalog, SupportsSnapshots, SupportsBranches
     private TableMetadata loadTableMetadata(Identifier identifier) throws TableNotExistException {
         GetTableResponse response;
         try {
+            // if the table is system table, we need to load table metadata from the system table's
+            // data table
+            Identifier loadTableIdentifier =
+                    identifier.isSystemTable()
+                            ? new Identifier(
+                                    identifier.getDatabaseName(),
+                                    identifier.getTableName(),
+                                    identifier.getBranchName())
+                            : identifier;
             response =
                     client.get(
                             resourcePaths.table(
-                                    identifier.getDatabaseName(), identifier.getObjectName()),
+                                    loadTableIdentifier.getDatabaseName(),
+                                    loadTableIdentifier.getObjectName()),
                             GetTableResponse.class,
                             restAuthFunction);
         } catch (NoSuchResourceException e) {

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTUtil.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTUtil.java
@@ -24,6 +24,11 @@ import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.shade.guava30.com.google.common.collect.Maps;
 
+import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /** Util for REST. */
@@ -57,5 +62,30 @@ public class RESTUtil {
         updates.forEach(builder::put);
 
         return builder.build();
+    }
+
+    public static String encodeString(String toEncode) {
+        Preconditions.checkArgument(toEncode != null, "Invalid string to encode: null");
+        try {
+            return URLEncoder.encode(toEncode, StandardCharsets.UTF_8.name())
+                    .replaceAll("\\+", "%20");
+        } catch (UnsupportedEncodingException e) {
+            throw new UncheckedIOException(
+                    String.format(
+                            "Failed to URL encode '%s': UTF-8 encoding is not supported", toEncode),
+                    e);
+        }
+    }
+
+    public static String decodeString(String encoded) {
+        Preconditions.checkArgument(encoded != null, "Invalid string to decode: null");
+        try {
+            return URLDecoder.decode(encoded, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new UncheckedIOException(
+                    String.format(
+                            "Failed to URL decode '%s': UTF-8 encoding is not supported", encoded),
+                    e);
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTUtil.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTUtil.java
@@ -67,8 +67,7 @@ public class RESTUtil {
     public static String encodeString(String toEncode) {
         Preconditions.checkArgument(toEncode != null, "Invalid string to encode: null");
         try {
-            return URLEncoder.encode(toEncode, StandardCharsets.UTF_8.name())
-                    .replaceAll("\\+", "%20");
+            return URLEncoder.encode(toEncode, StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             throw new UncheckedIOException(
                     String.format(

--- a/paimon-core/src/main/java/org/apache/paimon/rest/ResourcePaths.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/ResourcePaths.java
@@ -54,87 +54,166 @@ public class ResourcePaths {
     }
 
     public String database(String databaseName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName);
+        return SLASH.join(V1, prefix, DATABASES, RESTUtil.encodeString(databaseName));
     }
 
     public String databaseProperties(String databaseName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, "properties");
+        return SLASH.join(V1, prefix, DATABASES, RESTUtil.encodeString(databaseName), "properties");
     }
 
     public String tables(String databaseName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES);
+        return SLASH.join(V1, prefix, DATABASES, RESTUtil.encodeString(databaseName), TABLES);
     }
 
     public String tableDetails(String databaseName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLE_DETAILS);
+        return SLASH.join(
+                V1, prefix, DATABASES, RESTUtil.encodeString(databaseName), TABLE_DETAILS);
     }
 
     public String table(String databaseName, String objectName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, objectName);
+        return SLASH.join(
+                V1,
+                prefix,
+                DATABASES,
+                RESTUtil.encodeString(databaseName),
+                TABLES,
+                RESTUtil.encodeString(objectName));
     }
 
     public String renameTable(String databaseName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, "rename");
+        return SLASH.join(
+                V1, prefix, DATABASES, RESTUtil.encodeString(databaseName), TABLES, "rename");
     }
 
     public String commitTable(String databaseName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, "commit");
+        return SLASH.join(
+                V1, prefix, DATABASES, RESTUtil.encodeString(databaseName), TABLES, "commit");
     }
 
     public String tableToken(String databaseName, String objectName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, objectName, "token");
+        return SLASH.join(
+                V1,
+                prefix,
+                DATABASES,
+                RESTUtil.encodeString(databaseName),
+                TABLES,
+                RESTUtil.encodeString(objectName),
+                "token");
     }
 
     public String tableSnapshot(String databaseName, String objectName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, objectName, "snapshot");
+        return SLASH.join(
+                V1,
+                prefix,
+                DATABASES,
+                RESTUtil.encodeString(databaseName),
+                TABLES,
+                RESTUtil.encodeString(objectName),
+                "snapshot");
     }
 
     public String partitions(String databaseName, String objectName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, objectName, PARTITIONS);
+        return SLASH.join(
+                V1,
+                prefix,
+                DATABASES,
+                RESTUtil.encodeString(databaseName),
+                TABLES,
+                RESTUtil.encodeString(objectName),
+                PARTITIONS);
     }
 
     public String dropPartitions(String databaseName, String objectName) {
         return SLASH.join(
-                V1, prefix, DATABASES, databaseName, TABLES, objectName, PARTITIONS, "drop");
+                V1,
+                prefix,
+                DATABASES,
+                RESTUtil.encodeString(databaseName),
+                TABLES,
+                RESTUtil.encodeString(objectName),
+                PARTITIONS,
+                "drop");
     }
 
     public String alterPartitions(String databaseName, String objectName) {
         return SLASH.join(
-                V1, prefix, DATABASES, databaseName, TABLES, objectName, PARTITIONS, "alter");
+                V1,
+                prefix,
+                DATABASES,
+                RESTUtil.encodeString(databaseName),
+                TABLES,
+                RESTUtil.encodeString(objectName),
+                PARTITIONS,
+                "alter");
     }
 
     public String markDonePartitions(String databaseName, String objectName) {
         return SLASH.join(
-                V1, prefix, DATABASES, databaseName, TABLES, objectName, PARTITIONS, "mark");
+                V1,
+                prefix,
+                DATABASES,
+                RESTUtil.encodeString(databaseName),
+                TABLES,
+                RESTUtil.encodeString(objectName),
+                PARTITIONS,
+                "mark");
     }
 
     public String branches(String databaseName, String objectName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, objectName, BRANCHES);
+        return SLASH.join(
+                V1,
+                prefix,
+                DATABASES,
+                RESTUtil.encodeString(databaseName),
+                TABLES,
+                RESTUtil.encodeString(objectName),
+                BRANCHES);
     }
 
     public String branch(String databaseName, String objectName, String branchName) {
         return SLASH.join(
-                V1, prefix, DATABASES, databaseName, TABLES, objectName, BRANCHES, branchName);
+                V1,
+                prefix,
+                DATABASES,
+                RESTUtil.encodeString(databaseName),
+                TABLES,
+                RESTUtil.encodeString(objectName),
+                BRANCHES,
+                RESTUtil.encodeString(branchName));
     }
 
     public String forwardBranch(String databaseName, String objectName) {
         return SLASH.join(
-                V1, prefix, DATABASES, databaseName, TABLES, objectName, BRANCHES, "forward");
+                V1,
+                prefix,
+                DATABASES,
+                RESTUtil.encodeString(databaseName),
+                TABLES,
+                RESTUtil.encodeString(objectName),
+                BRANCHES,
+                "forward");
     }
 
     public String views(String databaseName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, VIEWS);
+        return SLASH.join(V1, prefix, DATABASES, RESTUtil.encodeString(databaseName), VIEWS);
     }
 
     public String viewDetails(String databaseName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, VIEW_DETAILS);
+        return SLASH.join(V1, prefix, DATABASES, RESTUtil.encodeString(databaseName), VIEW_DETAILS);
     }
 
     public String view(String databaseName, String viewName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, VIEWS, viewName);
+        return SLASH.join(
+                V1,
+                prefix,
+                DATABASES,
+                RESTUtil.encodeString(databaseName),
+                VIEWS,
+                RESTUtil.encodeString(viewName));
     }
 
     public String renameView(String databaseName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, VIEWS, "rename");
+        return SLASH.join(
+                V1, prefix, DATABASES, RESTUtil.encodeString(databaseName), VIEWS, "rename");
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/rest/ResourcePaths.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/ResourcePaths.java
@@ -34,10 +34,9 @@ public class ResourcePaths {
     private static final String VIEWS = "views";
     private static final String TABLE_DETAILS = "table-details";
     private static final String VIEW_DETAILS = "view-details";
-    public static final String QUERY_PARAMETER_WAREHOUSE_KEY = "warehouse";
 
-    public static String config(String warehouse) {
-        return String.format("%s/config?%s=%s", V1, QUERY_PARAMETER_WAREHOUSE_KEY, warehouse);
+    public static String config() {
+        return String.format("%s/config", V1);
     }
 
     public static ResourcePaths forCatalogProperties(Options options) {
@@ -70,8 +69,8 @@ public class ResourcePaths {
         return SLASH.join(V1, prefix, DATABASES, databaseName, TABLE_DETAILS);
     }
 
-    public String table(String databaseName, String tableName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, tableName);
+    public String table(String databaseName, String objectName) {
+        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, objectName);
     }
 
     public String renameTable(String databaseName) {
@@ -82,45 +81,45 @@ public class ResourcePaths {
         return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, "commit");
     }
 
-    public String tableToken(String databaseName, String tableName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, tableName, "token");
+    public String tableToken(String databaseName, String objectName) {
+        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, objectName, "token");
     }
 
-    public String tableSnapshot(String databaseName, String tableName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, tableName, "snapshot");
+    public String tableSnapshot(String databaseName, String objectName) {
+        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, objectName, "snapshot");
     }
 
-    public String partitions(String databaseName, String tableName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, tableName, PARTITIONS);
+    public String partitions(String databaseName, String objectName) {
+        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, objectName, PARTITIONS);
     }
 
-    public String dropPartitions(String databaseName, String tableName) {
+    public String dropPartitions(String databaseName, String objectName) {
         return SLASH.join(
-                V1, prefix, DATABASES, databaseName, TABLES, tableName, PARTITIONS, "drop");
+                V1, prefix, DATABASES, databaseName, TABLES, objectName, PARTITIONS, "drop");
     }
 
-    public String alterPartitions(String databaseName, String tableName) {
+    public String alterPartitions(String databaseName, String objectName) {
         return SLASH.join(
-                V1, prefix, DATABASES, databaseName, TABLES, tableName, PARTITIONS, "alter");
+                V1, prefix, DATABASES, databaseName, TABLES, objectName, PARTITIONS, "alter");
     }
 
-    public String markDonePartitions(String databaseName, String tableName) {
+    public String markDonePartitions(String databaseName, String objectName) {
         return SLASH.join(
-                V1, prefix, DATABASES, databaseName, TABLES, tableName, PARTITIONS, "mark");
+                V1, prefix, DATABASES, databaseName, TABLES, objectName, PARTITIONS, "mark");
     }
 
-    public String branches(String databaseName, String tableName) {
-        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, tableName, BRANCHES);
+    public String branches(String databaseName, String objectName) {
+        return SLASH.join(V1, prefix, DATABASES, databaseName, TABLES, objectName, BRANCHES);
     }
 
-    public String branch(String databaseName, String tableName, String branchName) {
+    public String branch(String databaseName, String objectName, String branchName) {
         return SLASH.join(
-                V1, prefix, DATABASES, databaseName, TABLES, tableName, BRANCHES, branchName);
+                V1, prefix, DATABASES, databaseName, TABLES, objectName, BRANCHES, branchName);
     }
 
-    public String forwardBranch(String databaseName, String tableName) {
+    public String forwardBranch(String databaseName, String objectName) {
         return SLASH.join(
-                V1, prefix, DATABASES, databaseName, TABLES, tableName, BRANCHES, "forward");
+                V1, prefix, DATABASES, databaseName, TABLES, objectName, BRANCHES, "forward");
     }
 
     public String views(String databaseName) {

--- a/paimon-core/src/main/java/org/apache/paimon/rest/auth/RESTAuthParameter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/auth/RESTAuthParameter.java
@@ -18,6 +18,9 @@
 
 package org.apache.paimon.rest.auth;
 
+import org.apache.paimon.rest.RESTUtil;
+
+import java.util.HashMap;
 import java.util.Map;
 
 /** RestAuthParameter for building rest auth header. */
@@ -37,7 +40,10 @@ public class RESTAuthParameter {
             String data) {
         this.host = host;
         this.resourcePath = resourcePath;
-        this.parameters = parameters;
+        this.parameters = new HashMap<>();
+        for (Map.Entry<String, String> entry : parameters.entrySet()) {
+            this.parameters.put(entry.getKey(), RESTUtil.encodeString(entry.getValue()));
+        }
         this.method = method;
         this.data = data;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/rest/responses/ErrorResponse.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/responses/ErrorResponse.java
@@ -25,12 +25,6 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGet
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 /** Response for error. */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ErrorResponse implements RESTResponse {
@@ -39,7 +33,6 @@ public class ErrorResponse implements RESTResponse {
     private static final String FIELD_RESOURCE_TYPE = "resourceType";
     private static final String FIELD_RESOURCE_NAME = "resourceName";
     private static final String FIELD_CODE = "code";
-    private static final String FIELD_STACK = "stack";
 
     @JsonProperty(FIELD_RESOURCE_TYPE)
     private final ErrorResponseResourceType resourceType;
@@ -53,9 +46,6 @@ public class ErrorResponse implements RESTResponse {
     @JsonProperty(FIELD_CODE)
     private final Integer code;
 
-    @JsonProperty(FIELD_STACK)
-    private final List<String> stack;
-
     public ErrorResponse(
             ErrorResponseResourceType resourceType,
             String resourceName,
@@ -65,7 +55,6 @@ public class ErrorResponse implements RESTResponse {
         this.resourceName = resourceName;
         this.code = code;
         this.message = message;
-        this.stack = new ArrayList<String>();
     }
 
     @JsonCreator
@@ -73,13 +62,11 @@ public class ErrorResponse implements RESTResponse {
             @JsonProperty(FIELD_RESOURCE_TYPE) ErrorResponseResourceType resourceType,
             @JsonProperty(FIELD_RESOURCE_NAME) String resourceName,
             @JsonProperty(FIELD_MESSAGE) String message,
-            @JsonProperty(FIELD_CODE) int code,
-            @JsonProperty(FIELD_STACK) List<String> stack) {
+            @JsonProperty(FIELD_CODE) int code) {
         this.resourceType = resourceType;
         this.resourceName = resourceName;
         this.message = message;
         this.code = code;
-        this.stack = stack;
     }
 
     @JsonGetter(FIELD_MESSAGE)
@@ -100,22 +87,5 @@ public class ErrorResponse implements RESTResponse {
     @JsonGetter(FIELD_CODE)
     public Integer getCode() {
         return code;
-    }
-
-    @JsonGetter(FIELD_STACK)
-    public List<String> getStack() {
-        return stack;
-    }
-
-    private List<String> getStackFromThrowable(Throwable throwable) {
-        if (throwable == null) {
-            return new ArrayList<String>();
-        }
-        StringWriter sw = new StringWriter();
-        try (PrintWriter pw = new PrintWriter(sw)) {
-            throwable.printStackTrace(pw);
-        }
-
-        return Arrays.asList(sw.toString().split("\n"));
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -489,6 +489,9 @@ public abstract class CatalogTestBase {
         catalog.createTable(identifier, DEFAULT_TABLE_SCHEMA, false);
         Table systemTable = catalog.getTable(Identifier.create("test_db", "test_table$snapshots"));
         assertThat(systemTable).isNotNull();
+        Table systemTableCheckWithBranch =
+                catalog.getTable(new Identifier("test_db", "test_table", "main", "snapshots"));
+        assertThat(systemTableCheckWithBranch).isNotNull();
         Table dataTable = catalog.getTable(identifier);
         assertThat(dataTable).isNotNull();
 

--- a/paimon-core/src/test/java/org/apache/paimon/rest/DefaultErrorHandlerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/DefaultErrorHandlerTest.java
@@ -33,7 +33,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
 
 import static org.junit.Assert.assertThrows;
 
@@ -81,6 +80,6 @@ public class DefaultErrorHandlerTest {
     }
 
     private ErrorResponse generateErrorResponse(int code) {
-        return new ErrorResponse(null, null, "message", code, new ArrayList<String>());
+        return new ErrorResponse(null, null, "message", code);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
@@ -92,7 +92,8 @@ public class HttpClientTest {
     @Test
     public void testGetSuccessWithQueryParams() {
         server.enqueueResponse(mockResponseDataStr, 200);
-        Map<String, String> queryParams = ImmutableMap.of("maxResults", "10", "pageToken", "abc");
+        Map<String, String> queryParams =
+                ImmutableMap.of("maxResults", "10", "pageToken", "abc=123");
         MockRESTData response =
                 httpClient.get(MOCK_PATH, queryParams, MockRESTData.class, restAuthFunction);
         assertEquals(mockResponseData.data(), response.data());
@@ -153,6 +154,20 @@ public class HttpClientTest {
         server.enqueueResponse(errorResponseStr, 400);
         assertThrows(
                 BadRequestException.class, () -> httpClient.delete(MOCK_PATH, restAuthFunction));
+    }
+
+    @Test
+    public void testDeleteWithDataSuccess() {
+        server.enqueueResponse(mockResponseDataStr, 200);
+        assertDoesNotThrow(() -> httpClient.delete(MOCK_PATH, mockResponseData, restAuthFunction));
+    }
+
+    @Test
+    public void testDeleteWithDataFail() {
+        server.enqueueResponse(errorResponseStr, 400);
+        assertThrows(
+                BadRequestException.class,
+                () -> httpClient.delete(MOCK_PATH, mockResponseData, restAuthFunction));
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -226,7 +226,7 @@ public class RESTCatalogServer {
                                 request.getPath()
                                         .substring((databaseUri + "/").length())
                                         .split("/");
-                        String databaseName = resources[0];
+                        String databaseName = RESTUtil.decodeString(resources[0]);
                         if (noPermissionDatabases.contains(databaseName)) {
                             throw new Catalog.DatabaseNoPermissionException(databaseName);
                         }
@@ -298,7 +298,8 @@ public class RESTCatalogServer {
                                 resources.length >= 3
                                                 && !"rename".equals(resources[2])
                                                 && !"commit".equals(resources[2])
-                                        ? Identifier.create(databaseName, resources[2])
+                                        ? Identifier.create(
+                                                databaseName, RESTUtil.decodeString(resources[2]))
                                         : null;
                         if (identifier != null && "tables".equals(resources[1])) {
                             if (!identifier.isSystemTable()
@@ -314,7 +315,7 @@ public class RESTCatalogServer {
                                 || isDropPartitions
                                 || isAlterPartitions
                                 || isMarkDonePartitions) {
-                            String tableName = resources[2];
+                            String tableName = RESTUtil.decodeString(resources[2]);
                             Optional<MockResponse> error =
                                     checkTablePartitioned(
                                             Identifier.create(databaseName, tableName));
@@ -957,7 +958,7 @@ public class RESTCatalogServer {
         try {
             switch (request.getMethod()) {
                 case "DELETE":
-                    branch = resources[4];
+                    branch = RESTUtil.decodeString(resources[4]);
                     branchIdentifier =
                             new Identifier(
                                     identifier.getDatabaseName(),

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -214,7 +214,10 @@ public class RESTCatalogServer {
                     if (!("Bearer " + authToken).equals(token)) {
                         return new MockResponse().setResponseCode(401);
                     }
-                    if (request.getPath().equals(resourcePaths.config(warehouse))) {
+                    if (request.getPath().startsWith(resourcePaths.config())
+                            && request.getRequestUrl()
+                                    .queryParameter(RESTCatalog.QUERY_PARAMETER_WAREHOUSE_KEY)
+                                    .equals(warehouse)) {
                         return mockResponse(configResponse, 200);
                     } else if (databaseUri.equals(request.getPath())) {
                         return databasesApiHandler(request);

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTObjectMapperTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTObjectMapperTest.java
@@ -47,7 +47,6 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonProcessin
 
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -72,8 +71,7 @@ public class RESTObjectMapperTest {
     public void errorResponseParseTest() throws Exception {
         String message = "message";
         Integer code = 400;
-        ErrorResponse response =
-                new ErrorResponse(null, null, message, code, new ArrayList<String>());
+        ErrorResponse response = new ErrorResponse(null, null, message, code);
         String responseStr = OBJECT_MAPPER.writeValueAsString(response);
         ErrorResponse parseData = OBJECT_MAPPER.readValue(responseStr, ErrorResponse.class);
         assertEquals(message, parseData.getMessage());

--- a/paimon-core/src/test/java/org/apache/paimon/rest/ResourcePathsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/ResourcePathsTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest;
+
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Test for {@link ResourcePaths}. */
+public class ResourcePathsTest {
+
+    @Test
+    public void testUrlEncode() {
+        String database = "test_db";
+        String objectName = "test_table$snapshot";
+        ResourcePaths resourcePaths = new ResourcePaths("paimon");
+        assertEquals(
+                "/v1/paimon/databases/test_db/tables/test_table%24snapshot",
+                resourcePaths.table(database, objectName));
+    }
+}

--- a/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
+++ b/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
@@ -78,7 +78,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.apache.paimon.rest.ResourcePaths.QUERY_PARAMETER_WAREHOUSE_KEY;
+import static org.apache.paimon.rest.RESTCatalog.QUERY_PARAMETER_WAREHOUSE_KEY;
 
 /** RESTCatalog management APIs. */
 @CrossOrigin(origins = "http://localhost:8081")


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
RESTCatalog:  encode resource name in URL
<!-- Linking this pull request to the issue -->
Linked issue: https://github.com/apache/paimon/issues/4540

<!-- What is the purpose of the change -->

### Tests
- HttpClientTest. testUrl
- ResourcePathsTest. testUrlEncode
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
