### PR TITLE
[core] Remove redundant reset by HeapRowVector

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/heap/HeapRowVector.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/heap/HeapRowVector.java
@@ -48,16 +48,6 @@ public class HeapRowVector extends AbstractStructVector
     }
 
     @Override
-    public void reset() {
-        super.reset();
-        for (ColumnVector field : children) {
-            if (field instanceof WritableColumnVector) {
-                ((WritableColumnVector) field).reset();
-            }
-        }
-    }
-
-    @Override
     void reserveForHeapVector(int newCapacity) {
         // Nothing to store.
     }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/newreader/VectorizedParquetRecordReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/newreader/VectorizedParquetRecordReader.java
@@ -58,6 +58,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static java.lang.String.format;
+
 /* This file is based on source code from the Spark Project (http://spark.apache.org/), licensed by the Apache
  * Software Foundation (ASF) under the Apache License, Version 2.0. See the NOTICE file distributed with this work for
  * additional information regarding copyright ownership. */
@@ -258,36 +260,44 @@ public class VectorizedParquetRecordReader implements FileRecordReader<InternalR
     }
 
     public boolean nextBatch() throws IOException {
-        // Primary key table will use the last record, so we can't reset first
-        // TODO: remove usage of the last record by primary key table after batch reset
-        if (rowsReturned >= totalRowCount) {
-            return false;
-        }
-        for (ParquetColumnVector vector : columnVectors) {
-            vector.reset();
-        }
-        columnarBatch.setNumRows(0);
-        checkEndOfRowGroup();
-
-        int num = (int) Math.min(batchSize, totalCountLoadedSoFar - rowsReturned);
-        for (ParquetColumnVector cv : columnVectors) {
-            for (ParquetColumnVector leafCv : cv.getLeaves()) {
-                VectorizedColumnReader columnReader = leafCv.getColumnReader();
-                if (columnReader != null) {
-                    columnReader.readBatch(
-                            num,
-                            leafCv.getColumn().getType(),
-                            leafCv.getValueVector(),
-                            leafCv.getRepetitionLevelVector(),
-                            leafCv.getDefinitionLevelVector());
-                }
+        try {
+            // Primary key table will use the last record, so we can't reset first
+            // TODO: remove usage of the last record by primary key table after batch reset
+            if (rowsReturned >= totalRowCount) {
+                return false;
             }
-            cv.assemble();
+            for (ParquetColumnVector vector : columnVectors) {
+                vector.reset();
+            }
+            columnarBatch.setNumRows(0);
+            checkEndOfRowGroup();
+
+            int num = (int) Math.min(batchSize, totalCountLoadedSoFar - rowsReturned);
+            for (ParquetColumnVector cv : columnVectors) {
+                for (ParquetColumnVector leafCv : cv.getLeaves()) {
+                    VectorizedColumnReader columnReader = leafCv.getColumnReader();
+                    if (columnReader != null) {
+                        columnReader.readBatch(
+                                num,
+                                leafCv.getColumn().getType(),
+                                leafCv.getValueVector(),
+                                leafCv.getRepetitionLevelVector(),
+                                leafCv.getDefinitionLevelVector());
+                    }
+                }
+                cv.assemble();
+            }
+            rowsReturned += num;
+            columnarBatch.setNumRows(num);
+            rowIndexGenerator.populateRowIndex(columnarBatch);
+            return true;
+        } catch (IOException e) {
+            throw new IOException(
+                    format(
+                            "Exception in nextBatch, filePath: %s fileSchema: %s",
+                            filePath, fileSchema),
+                    e);
         }
-        rowsReturned += num;
-        columnarBatch.setNumRows(num);
-        rowIndexGenerator.populateRowIndex(columnarBatch);
-        return true;
     }
 
     private void checkEndOfRowGroup() throws IOException {

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/newreader/VectorizedParquetRecordReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/newreader/VectorizedParquetRecordReader.java
@@ -297,6 +297,12 @@ public class VectorizedParquetRecordReader implements FileRecordReader<InternalR
                             "Exception in nextBatch, filePath: %s fileSchema: %s",
                             filePath, fileSchema),
                     e);
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    format(
+                            "Exception in nextBatch, filePath: %s fileSchema: %s",
+                            filePath, fileSchema),
+                    e);
         }
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
** Remove redundant reset in `HeapRowVector`
** Throws file location if next batch errors

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
