### PR TITLE
[core][tag][expire] Fix that snapshot expire might delete files used by tag mistakenly

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/TagDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/TagDeletion.java
@@ -34,7 +34,6 @@ import org.apache.paimon.utils.FileStorePathFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -74,7 +73,7 @@ public class TagDeletion extends FileDeletionBase<Snapshot> {
         Collection<ExpireFileEntry> manifestEntries;
         try {
             manifestEntries = readMergedDataFiles(taggedSnapshot);
-        } catch (IOException e) {
+        } catch (Exception e) {
             LOG.info("Skip data file clean for the tag of id {}.", taggedSnapshot.id(), e);
             return;
         }


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
When reading tag to collect file skipper, if exception occurs, the file skipper is empty. 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
