### PR TITLE
[core] refine the dlf config key

### DIFF
--- a/docs/content/concepts/rest-catalog.md
+++ b/docs/content/concepts/rest-catalog.md
@@ -74,8 +74,8 @@ WITH (
     'metastore' = 'rest',
     'warehouse' = 'my_instance_name',
     'token.provider' = 'dlf',
-    'dlf.accessKeyId'='<accessKeyId>',
-    'dlf.accessKeySecret'='<accessKeySecret>',
+    'dlf.access-key-id'='<access-key-id>',
+    'dlf.access-key-secret'='<access-key-secret>',
 );
 ```
 
@@ -89,9 +89,9 @@ WITH (
     'metastore' = 'rest',
     'warehouse' = 'my_instance_name',
     'token.provider' = 'dlf',
-    'dlf.accessKeyId'='<accessKeyId>',
-    'dlf.accessKeySecret'='<accessKeySecret>',
-    'dlf.securityToken'='<securityToken>'
+    'dlf.access-key-id'='<access-key-id>',
+    'dlf.access-key-secret'='<access-key-secret>',
+    'dlf.security-token'='<security-token>'
 );
 ```
 

--- a/docs/content/spark/sql-ddl.md
+++ b/docs/content/spark/sql-ddl.md
@@ -141,8 +141,8 @@ spark-sql ... \
     --conf spark.sql.catalog.paimon.metastore=rest \
     --conf spark.sql.catalog.paimon.uri=<catalog server url> \
     --conf spark.sql.catalog.paimon.token.provider=dlf \
-    --conf spark.sql.catalog.paimon.dlf.accessKeyId=<accessKeyId> \
-    --conf spark.sql.catalog.paimon.dlf.accessKeySecret=<accessKeySecret>
+    --conf spark.sql.catalog.paimon.dlf.access-key-id=<access-key-id> \
+    --conf spark.sql.catalog.paimon.dlf.access-key-secret=<security-token>
     
 ```
 
@@ -153,9 +153,9 @@ spark-sql ... \
     --conf spark.sql.catalog.paimon.metastore=rest \
     --conf spark.sql.catalog.paimon.uri=<catalog server url> \
     --conf spark.sql.catalog.paimon.token.provider=dlf \
-    --conf spark.sql.catalog.paimon.dlf.accessKeyId=<accessKeyId> \
-    --conf spark.sql.catalog.paimon.dlf.accessKeySecret=<accessKeySecret> \
-    --conf spark.sql.catalog.paimon.dlf.securityToken=<securityToken> 
+    --conf spark.sql.catalog.paimon.dlf.access-key-id=<access-key-id> \
+    --conf spark.sql.catalog.paimon.dlf.access-key-secret=<access-key-secret> \
+    --conf spark.sql.catalog.paimon.dlf.security-token=<security-token>
     
     
 ```

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalogOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalogOptions.java
@@ -63,19 +63,19 @@ public class RESTCatalogOptions {
                     .withDescription("REST Catalog auth DLF token file path.");
 
     public static final ConfigOption<String> DLF_ACCESS_KEY_ID =
-            ConfigOptions.key("dlf.accessKeyId")
+            ConfigOptions.key("dlf.access-key-id")
                     .stringType()
                     .noDefaultValue()
                     .withDescription("REST Catalog auth DLF access key id");
 
     public static final ConfigOption<String> DLF_ACCESS_KEY_SECRET =
-            ConfigOptions.key("dlf.accessKeySecret")
+            ConfigOptions.key("dlf.access-key-secret")
                     .stringType()
                     .noDefaultValue()
                     .withDescription("REST Catalog auth DLF access key secret");
 
     public static final ConfigOption<String> DLF_SECURITY_TOKEN =
-            ConfigOptions.key("dlf.securityToken")
+            ConfigOptions.key("dlf.security-token")
                     .stringType()
                     .noDefaultValue()
                     .withDescription("REST Catalog auth DLF security token");


### PR DESCRIPTION
### Purpose
In Paimon's configuration items, it seems that lowercase letters and - are usually used to define configuration key names.
Another reason is that when options are passed from SparkCatalog, all keys are converted to lowercase.

### Tests

### API and Format

### Documentation
