### PR TITLE
[core] Fix that snapshot expire might delete files used by tag mistakenly

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -371,7 +371,7 @@ public abstract class FileDeletionBase<T extends Snapshot> {
     protected void addMergedDataFiles(
             Map<BinaryRow, Map<Integer, Set<String>>> dataFiles, Snapshot snapshot)
             throws IOException {
-        for (ExpireFileEntry entry : readMergedDataFiles(snapshot)) {
+        for (ExpireFileEntry entry : readMergedDataFiles(manifestList.readAllManifests(snapshot))) {
             dataFiles
                     .computeIfAbsent(entry.partition(), p -> new HashMap<>())
                     .computeIfAbsent(entry.bucket(), b -> new HashSet<>())
@@ -379,14 +379,8 @@ public abstract class FileDeletionBase<T extends Snapshot> {
         }
     }
 
-    protected Collection<ExpireFileEntry> readMergedDataFiles(Snapshot snapshot)
+    protected Collection<ExpireFileEntry> readMergedDataFiles(List<ManifestFileMeta> manifests)
             throws IOException {
-        // read data manifests
-
-        List<ManifestFileMeta> manifests = tryReadManifestList(snapshot.baseManifestList());
-        manifests.addAll(tryReadManifestList(snapshot.deltaManifestList()));
-
-        // read and merge manifest entries
         Map<Identifier, ExpireFileEntry> map = new HashMap<>();
         for (ManifestFileMeta manifest : manifests) {
             List<ExpireFileEntry> entries =

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -340,9 +340,11 @@ public abstract class FileDeletionBase<T extends Snapshot> {
         if (index >= 0) {
             Snapshot previousTag = taggedSnapshots.get(index);
             if (previousTag.id() != cachedTag) {
-                cachedTag = previousTag.id();
+                cachedTag = 0;
                 cachedTagDataFiles.clear();
                 addMergedDataFiles(cachedTagDataFiles, previousTag);
+                // update cachedTag after read tag successfully
+                cachedTag = previousTag.id();
             }
             return entry -> containsDataFile(cachedTagDataFiles, entry);
         }
@@ -359,7 +361,7 @@ public abstract class FileDeletionBase<T extends Snapshot> {
         try {
             return manifestList.read(manifestListName);
         } catch (Exception e) {
-            LOG.warn("Failed to read manifest list file " + manifestListName, e);
+            LOG.warn("Failed to read manifest list file {}", manifestListName, e);
             return Collections.emptyList();
         }
     }
@@ -371,7 +373,8 @@ public abstract class FileDeletionBase<T extends Snapshot> {
     protected void addMergedDataFiles(
             Map<BinaryRow, Map<Integer, Set<String>>> dataFiles, Snapshot snapshot)
             throws IOException {
-        for (ExpireFileEntry entry : readMergedDataFiles(manifestList.readAllManifests(snapshot))) {
+        for (ExpireFileEntry entry :
+                readMergedDataFiles(manifestList.readDataManifests(snapshot))) {
             dataFiles
                     .computeIfAbsent(entry.partition(), p -> new HashMap<>())
                     .computeIfAbsent(entry.bucket(), b -> new HashSet<>())

--- a/paimon-core/src/main/java/org/apache/paimon/operation/TagDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/TagDeletion.java
@@ -26,6 +26,7 @@ import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.io.DataFilePathFactory;
 import org.apache.paimon.manifest.ExpireFileEntry;
 import org.apache.paimon.manifest.ManifestFile;
+import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.manifest.ManifestList;
 import org.apache.paimon.stats.StatsFileHandler;
 import org.apache.paimon.utils.DataFilePathFactories;
@@ -73,7 +74,10 @@ public class TagDeletion extends FileDeletionBase<Snapshot> {
     public void cleanUnusedDataFiles(Snapshot taggedSnapshot, Predicate<ExpireFileEntry> skipper) {
         Collection<ExpireFileEntry> manifestEntries;
         try {
-            manifestEntries = readMergedDataFiles(taggedSnapshot);
+            List<ManifestFileMeta> manifests =
+                    tryReadManifestList(taggedSnapshot.baseManifestList());
+            manifests.addAll(tryReadManifestList(taggedSnapshot.deltaManifestList()));
+            manifestEntries = readMergedDataFiles(manifests);
         } catch (IOException e) {
             LOG.info("Skip data file clean for the tag of id {}.", taggedSnapshot.id(), e);
             return;


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Another solution for #5229

This PR tries to maintain the original logic of Tag deleting files as much as possible to avoid residual files.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
