### PR TITLE
[wip][security] Upgrade avro version to avoid CVE-2024-47561

### DIFF
--- a/paimon-format/src/main/resources/META-INF/NOTICE
+++ b/paimon-format/src/main/resources/META-INF/NOTICE
@@ -13,7 +13,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-lang:commons-lang:2.6
 - org.apache.commons:commons-lang3:3.12.0
 
-- org.apache.avro:avro:1.11.3
+- org.apache.avro:avro:1.11.4
 - com.fasterxml.jackson.core:jackson-core:2.14.2
 - com.fasterxml.jackson.core:jackson-databind:2.14.2
 - com.fasterxml.jackson.core:jackson-annotations:2.14.2

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@ under the License.
         <jaxb.api.version>2.3.1</jaxb.api.version>
         <findbugs.version>1.3.9</findbugs.version>
         <json-smart.version>2.4.9</json-smart.version>
-        <avro.version>1.11.3</avro.version>
+        <avro.version>1.11.4</avro.version>
         <kafka.version>3.2.3</kafka.version>
         <scala-maven-plugin.version>3.2.2</scala-maven-plugin.version>
         <scalatest-maven-plugin.version>2.1.0</scalatest-maven-plugin.version>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Seen https://avd.aquasec.com/nvd/2024/cve-2024-47561/

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
