### PR TITLE
[hotfix] html <h1> tag cannot be referenced by directories

### DIFF
--- a/docs/content/project/contributing.md
+++ b/docs/content/project/contributing.md
@@ -31,8 +31,8 @@ the community and contribute to Apache Paimon. There are several ways to interac
 to Paimon including asking questions, filing bug reports, proposing new features, joining discussions on the mailing
 lists, contributing code or documentation, improving website, testing release candidates and writing corresponding blog etc.
 
-<h1>What do you want to do?</h1>
-<p>Contributing to Apache Paimon goes beyond writing code for the project. Below, we list different opportunities to help the project:</p>
+## What do you want to do?
+Contributing to Apache Paimon goes beyond writing code for the project. Below, we list different opportunities to help the project:
 
 <table class="table table-bordered">
   <thead>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Fix `Contributing.md` format.
<img width="1471" alt="image" src="https://github.com/user-attachments/assets/2b3db968-62e7-470b-9fdb-2a4ea4aaeea5" />

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
