### PR TITLE
[core] do not overwrite options when merging options and token

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
@@ -153,7 +153,8 @@ public class RESTTokenFileIO implements FileIO {
 
             CatalogContext context = catalogLoader.context();
             Options options = context.options();
-            options = new Options(RESTUtil.merge(options.toMap(), token.token()));
+            // the original options are not overwritten
+            options = new Options(RESTUtil.merge(token.token(), options.toMap()));
             options.set(FILE_IO_ALLOW_CACHE, false);
             context = CatalogContext.create(options, context.preferIO(), context.fallbackIO());
             try {

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTUtil.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTUtil.java
@@ -52,9 +52,15 @@ public class RESTUtil {
     }
 
     public static Map<String, String> merge(
-            Map<String, String> target, Map<String, String> updates) {
+            Map<String, String> targets, Map<String, String> updates) {
+        if (targets == null) {
+            targets = Maps.newHashMap();
+        }
+        if (updates == null) {
+            updates = Maps.newHashMap();
+        }
         ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-        for (Map.Entry<String, String> entry : target.entrySet()) {
+        for (Map.Entry<String, String> entry : targets.entrySet()) {
             if (!updates.containsKey(entry.getKey())) {
                 builder.put(entry.getKey(), entry.getValue());
             }

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTUtilTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTUtilTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Test for {@link RESTUtil}. */
+public class RESTUtilTest {
+    @Test
+    public void testMerge() {
+        {
+            Map<String, String> targets = new HashMap<>();
+            targets.put("a", "1");
+            targets.put("b", "2");
+            Map<String, String> updates = new HashMap<>();
+            updates.put("b", "3");
+            Map<String, String> result = RESTUtil.merge(targets, updates);
+            assertEquals(result.get("a"), "1");
+            assertEquals(result.get("b"), "3");
+        }
+        {
+            Map<String, String> targets = new HashMap<>();
+            targets.put("a", "1");
+            targets.put("b", "2");
+            Map<String, String> updates = new HashMap<>();
+            targets.put("a", "1");
+            updates.put("b", "3");
+            Map<String, String> result = RESTUtil.merge(targets, updates);
+            assertEquals(result.get("a"), "1");
+            assertEquals(result.get("b"), "3");
+        }
+        {
+            Map<String, String> targets = new HashMap<>();
+            targets.put("a", "1");
+            targets.put("b", "2");
+            Map<String, String> updates = new HashMap<>();
+            Map<String, String> result = RESTUtil.merge(targets, updates);
+            assertEquals(result.get("a"), "1");
+            assertEquals(result.get("b"), "2");
+        }
+        {
+            Map<String, String> targets = new HashMap<>();
+            Map<String, String> updates = new HashMap<>();
+            updates.put("b", "3");
+            Map<String, String> result = RESTUtil.merge(targets, updates);
+            assertEquals(result.get("b"), "3");
+        }
+        {
+            Map<String, String> targets = new HashMap<>();
+            Map<String, String> updates = new HashMap<>();
+            Map<String, String> result = RESTUtil.merge(targets, updates);
+            assertEquals(result.size(), 0);
+        }
+        {
+            Map<String, String> targets = new HashMap<>();
+            Map<String, String> updates = null;
+            Map<String, String> result = RESTUtil.merge(targets, updates);
+            assertEquals(result.size(), 0);
+        }
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTUtilTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTUtilTest.java
@@ -31,40 +31,40 @@ public class RESTUtilTest {
     public void testMerge() {
         {
             Map<String, String> targets = new HashMap<>();
-            targets.put("a", "1");
-            targets.put("b", "2");
+            targets.put("key1", "default1");
+            targets.put("key2", "default2");
             Map<String, String> updates = new HashMap<>();
-            updates.put("b", "3");
+            updates.put("key2", "update2");
             Map<String, String> result = RESTUtil.merge(targets, updates);
-            assertEquals(result.get("a"), "1");
-            assertEquals(result.get("b"), "3");
+            assertEquals(result.get("key1"), "default1");
+            assertEquals(result.get("key2"), "update2");
         }
         {
             Map<String, String> targets = new HashMap<>();
-            targets.put("a", "1");
-            targets.put("b", "2");
+            targets.put("key1", "default1");
+            targets.put("key2", "default2");
             Map<String, String> updates = new HashMap<>();
-            targets.put("a", "1");
-            updates.put("b", "3");
+            updates.put("key1", "default1");
+            updates.put("key2", "update2");
             Map<String, String> result = RESTUtil.merge(targets, updates);
-            assertEquals(result.get("a"), "1");
-            assertEquals(result.get("b"), "3");
+            assertEquals(result.get("key1"), "default1");
+            assertEquals(result.get("key2"), "update2");
         }
         {
             Map<String, String> targets = new HashMap<>();
-            targets.put("a", "1");
-            targets.put("b", "2");
+            targets.put("key1", "default1");
+            targets.put("key2", "default2");
             Map<String, String> updates = new HashMap<>();
             Map<String, String> result = RESTUtil.merge(targets, updates);
-            assertEquals(result.get("a"), "1");
-            assertEquals(result.get("b"), "2");
+            assertEquals(result.get("key1"), "default1");
+            assertEquals(result.get("key2"), "default2");
         }
         {
             Map<String, String> targets = new HashMap<>();
             Map<String, String> updates = new HashMap<>();
-            updates.put("b", "3");
+            updates.put("key2", "update2");
             Map<String, String> result = RESTUtil.merge(targets, updates);
-            assertEquals(result.get("b"), "3");
+            assertEquals(result.get("key2"), "update2");
         }
         {
             Map<String, String> targets = new HashMap<>();
@@ -73,7 +73,7 @@ public class RESTUtilTest {
             assertEquals(result.size(), 0);
         }
         {
-            Map<String, String> targets = new HashMap<>();
+            Map<String, String> targets = null;
             Map<String, String> updates = null;
             Map<String, String> result = RESTUtil.merge(targets, updates);
             assertEquals(result.size(), 0);


### PR DESCRIPTION
### Purpose
When merging option and token in RESTTokenFileIO, the value in options should not be overwritten. DLF server will pass a default value, such as fs.oss.endpoint=oss-cn-hangzhou-internal.aliyuncs.com, which is not available in some client environment, and the value passed in options needs to be used.

### Tests
RESTUtilTest
