### PR TITLE
[core] ensure that record-expire takes effect when full compaction

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/io/RecordLevelExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/RecordLevelExpire.java
@@ -22,6 +22,12 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.schema.KeyValueFieldsExtractor;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.stats.SimpleStatsEvolution;
+import org.apache.paimon.stats.SimpleStatsEvolutions;
+import org.apache.paimon.table.PrimaryKeyTableUtils;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeChecks;
@@ -34,6 +40,8 @@ import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 
 /** A factory to create {@link RecordReader} expires records by time. */
@@ -42,8 +50,14 @@ public class RecordLevelExpire {
     private final int expireTime;
     private final Function<InternalRow, Optional<Integer>> fieldGetter;
 
+    private final ConcurrentMap<Long, TableSchema> tableSchemas;
+    private final TableSchema schema;
+    private final SchemaManager schemaManager;
+    private final SimpleStatsEvolutions fieldValueStatsConverters;
+
     @Nullable
-    public static RecordLevelExpire create(CoreOptions options, RowType rowType) {
+    public static RecordLevelExpire create(
+            CoreOptions options, TableSchema schema, SchemaManager schemaManager) {
         Duration expireTime = options.recordLevelExpireTime();
         if (expireTime == null) {
             return null;
@@ -56,6 +70,7 @@ public class RecordLevelExpire {
         }
 
         // should no project here, record level expire only works in compaction
+        RowType rowType = schema.logicalRowType();
         int fieldIndex = rowType.getFieldIndex(timeFieldName);
         if (fieldIndex == -1) {
             throw new IllegalArgumentException(
@@ -66,19 +81,50 @@ public class RecordLevelExpire {
         DataType dataType = rowType.getField(timeFieldName).type();
         Function<InternalRow, Optional<Integer>> fieldGetter =
                 createFieldGetter(dataType, fieldIndex);
-        return new RecordLevelExpire((int) expireTime.getSeconds(), fieldGetter);
+        return new RecordLevelExpire(
+                (int) expireTime.getSeconds(), fieldGetter, schema, schemaManager);
     }
 
     private RecordLevelExpire(
-            int expireTime, Function<InternalRow, Optional<Integer>> fieldGetter) {
+            int expireTime,
+            Function<InternalRow, Optional<Integer>> fieldGetter,
+            TableSchema schema,
+            SchemaManager schemaManager) {
         this.expireTime = expireTime;
         this.fieldGetter = fieldGetter;
+
+        this.tableSchemas = new ConcurrentHashMap<>();
+        this.schema = schema;
+        this.schemaManager = schemaManager;
+
+        KeyValueFieldsExtractor extractor =
+                PrimaryKeyTableUtils.PrimaryKeyFieldsExtractor.EXTRACTOR;
+
+        fieldValueStatsConverters =
+                new SimpleStatsEvolutions(
+                        sid -> extractor.valueFields(scanTableSchema(sid)), schema.id());
     }
 
     public boolean isExpireFile(DataFileMeta file) {
+        InternalRow minValues = file.valueStats().minValues();
+
+        if (file.schemaId() != schema.id() || file.valueStatsCols() != null) {
+            // In the following cases, can not read minValues with field index directly
+            //
+            // 1. if the table had suffered schema evolution, read minValues with new field index
+            // may cause exception.
+            // 2. if metadata.stats-dense-store = true, minValues may not contain all data fields
+            // which may cause exception when reading with origin field index
+            SimpleStatsEvolution.Result result =
+                    fieldValueStatsConverters
+                            .getOrCreate(file.schemaId())
+                            .evolution(file.valueStats(), file.rowCount(), file.valueStatsCols());
+            minValues = result.minValues();
+        }
+
         int currentTime = (int) (System.currentTimeMillis() / 1000);
         return fieldGetter
-                .apply(file.valueStats().minValues())
+                .apply(minValues)
                 .map(minValue -> currentTime - expireTime > minValue)
                 .orElse(false);
     }
@@ -137,5 +183,10 @@ public class RecordLevelExpire {
         }
 
         return fieldGetter;
+    }
+
+    private TableSchema scanTableSchema(long id) {
+        return tableSchemas.computeIfAbsent(
+                id, key -> key == schema.id() ? schema : schemaManager.schema(id));
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/io/RecordLevelExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/RecordLevelExpire.java
@@ -75,6 +75,14 @@ public class RecordLevelExpire {
         this.fieldGetter = fieldGetter;
     }
 
+    public boolean isExpireFile(DataFileMeta file) {
+        int currentTime = (int) (System.currentTimeMillis() / 1000);
+        return fieldGetter
+                .apply(file.valueStats().minValues())
+                .map(minValue -> currentTime - expireTime > minValue)
+                .orElse(false);
+    }
+
     public FileReaderFactory<KeyValue> wrap(FileReaderFactory<KeyValue> readerFactory) {
         return file -> wrap(readerFactory.createRecordReader(file));
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -158,7 +158,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                         pathFactory,
                         extractor,
                         options);
-        this.recordLevelExpire = RecordLevelExpire.create(options, valueType);
+        this.recordLevelExpire = RecordLevelExpire.create(options, schema, schemaManager);
         this.writerFactoryBuilder =
                 KeyValueFileWriterFactory.builder(
                         fileIO,

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -281,7 +281,8 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                             : compactionMetrics.createReporter(partition, bucket),
                     dvMaintainer,
                     options.prepareCommitWaitCompaction(),
-                    options.needLookup());
+                    options.needLookup(),
+                    recordLevelExpire);
         }
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
@@ -541,7 +541,8 @@ public abstract class MergeTreeTestBase {
                 null,
                 null,
                 false,
-                options.needLookup());
+                options.needLookup(),
+                null);
     }
 
     static class MockFailResultCompactionManager extends MergeTreeCompactManager {
@@ -564,7 +565,8 @@ public abstract class MergeTreeTestBase {
                     null,
                     null,
                     false,
-                    false);
+                    false,
+                    null);
         }
 
         protected CompactResult obtainCompactResult()

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManagerTest.java
@@ -207,7 +207,8 @@ public class MergeTreeCompactManagerTest {
                         null,
                         null,
                         false,
-                        true);
+                        true,
+                        null);
 
         MergeTreeCompactManager defaultManager =
                 new MergeTreeCompactManager(
@@ -221,7 +222,8 @@ public class MergeTreeCompactManagerTest {
                         null,
                         null,
                         false,
-                        false);
+                        false,
+                        null);
 
         assertThat(lookupManager.compactNotCompleted()).isTrue();
         assertThat(defaultManager.compactNotCompleted()).isFalse();
@@ -256,7 +258,8 @@ public class MergeTreeCompactManagerTest {
                         null,
                         null,
                         false,
-                        false);
+                        false,
+                        null);
         manager.triggerCompaction(false);
         manager.getCompactionResult(true);
         List<LevelMinMax> outputs =


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
Record-Level expiration happens in compaction, but some specific data files will not be rewritten even in full compaction which may leading some expired records can't be expired for a long time. This pr aims to ensure that record-expire takes effect when full compaction. 

When full compaction, the files with the following kinds will not be rewritten:

- large file, file level is maxLevel and no overlap with other file: do nothing for the file
- large file, outputLevel is not maxLevel or has no deleted records: directly upgrade file level to outputLevel without rewriting

For these files,  rewrite them if they contain expired records.

And full compaction will pick no files for compaction in the following cases:

- lsm tree is empty
- only one maxLevel sorted run in lsm tree

For only one maxLevel sorted run in lsm tree, pick the files containing expired records to perform full compaction.

### Tests

<!-- List UT and IT cases to verify this change -->
RecordLevelExpireTest#testIsExpireFile
RecordLevelExpireTest#testTotallyExpire

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
