### PR TITLE
Jahangir yelp/fix iceberg database location

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
@@ -533,13 +533,13 @@ public class IcebergCommitCallback implements CommitCallback {
     }
 
     private Pair<List<IcebergManifestFileMeta>, IcebergSnapshotSummary>
-    createWithDeleteManifestFileMetas(
-            Map<String, BinaryRow> removedFiles,
-            Map<String, Pair<BinaryRow, DataFileMeta>> addedFiles,
-            List<BinaryRow> modifiedPartitions,
-            List<IcebergManifestFileMeta> baseManifestFileMetas,
-            long currentSnapshotId)
-            throws IOException {
+            createWithDeleteManifestFileMetas(
+                    Map<String, BinaryRow> removedFiles,
+                    Map<String, Pair<BinaryRow, DataFileMeta>> addedFiles,
+                    List<BinaryRow> modifiedPartitions,
+                    List<IcebergManifestFileMeta> baseManifestFileMetas,
+                    long currentSnapshotId)
+                    throws IOException {
         IcebergSnapshotSummary snapshotSummary = IcebergSnapshotSummary.APPEND;
         List<IcebergManifestFileMeta> newManifestFileMetas = new ArrayList<>();
 
@@ -567,10 +567,10 @@ public class IcebergCommitCallback implements CommitCallback {
 
             if (predicate == null
                     || predicate.test(
-                    fileMeta.liveRowsCount(),
-                    minValues,
-                    maxValues,
-                    new GenericArray(nullCounts))) {
+                            fileMeta.liveRowsCount(),
+                            minValues,
+                            maxValues,
+                            new GenericArray(nullCounts))) {
                 // check if any IcebergManifestEntry in this manifest file meta is removed
                 List<IcebergManifestEntry> entries =
                         manifestFile.read(new Path(fileMeta.manifestPath()).getName());
@@ -710,7 +710,7 @@ public class IcebergCommitCallback implements CommitCallback {
         }
         return snapshot.timestampMs()
                 < System.currentTimeMillis()
-                - options.get(CoreOptions.SNAPSHOT_TIME_RETAINED).toMillis();
+                        - options.get(CoreOptions.SNAPSHOT_TIME_RETAINED).toMillis();
     }
 
     private void expireManifestList(String toExpire, String next) {

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCommitCallbackTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCommitCallbackTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.FileStoreTable;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Tests for {@link IcebergCommitCallback}. */
+public class IcebergCommitCallbackTest {
+
+    private FileStoreTable mockTable;
+    private CoreOptions mockCoreOptions;
+    private Options mockConfig;
+
+    @BeforeEach
+    void setUp() {
+        mockTable = mock(FileStoreTable.class);
+        when(mockTable.location()).thenReturn(new Path("file:/tmp/paimon/mydb.db/mytable"));
+
+        mockCoreOptions = mock(CoreOptions.class);
+        when(mockTable.coreOptions()).thenReturn(mockCoreOptions);
+
+        mockConfig = mock(Options.class);
+        when(mockCoreOptions.toConfiguration()).thenReturn(mockConfig);
+    }
+
+    @ParameterizedTest(name = "StorageType: {0}")
+    @MethodSource("provideMetadataPaths")
+    void testCatalogTableMetadataPath(IcebergOptions.StorageType storageType, String expectedPath) {
+        when(mockConfig.get(IcebergOptions.METADATA_ICEBERG_STORAGE)).thenReturn(storageType);
+
+        Path result = IcebergCommitCallback.catalogTableMetadataPath(mockTable);
+
+        assertThat(result.toString()).isEqualTo(expectedPath);
+    }
+
+    @ParameterizedTest(name = "StorageType: {0}")
+    @MethodSource("provideDatabasePaths")
+    void testCatalogDatabasePath(IcebergOptions.StorageType storageType, String expectedPath) {
+        when(mockConfig.get(IcebergOptions.METADATA_ICEBERG_STORAGE)).thenReturn(storageType);
+
+        Path result = IcebergCommitCallback.catalogDatabasePath(mockTable);
+
+        assertThat(result.toString()).isEqualTo(expectedPath);
+    }
+
+    private static Stream<Arguments> provideMetadataPaths() {
+        return Stream.of(
+                Arguments.of(
+                        IcebergOptions.StorageType.TABLE_LOCATION,
+                        "file:/tmp/paimon/mydb.db/mytable/metadata"),
+                Arguments.of(
+                        IcebergOptions.StorageType.HIVE_CATALOG,
+                        "file:/tmp/paimon/iceberg/mydb/mytable/metadata"),
+                Arguments.of(
+                        IcebergOptions.StorageType.HADOOP_CATALOG,
+                        "file:/tmp/paimon/iceberg/mydb/mytable/metadata"));
+    }
+
+    private static Stream<Arguments> provideDatabasePaths() {
+        return Stream.of(
+                Arguments.of(IcebergOptions.StorageType.TABLE_LOCATION, "file:/tmp/paimon/mydb.db"),
+                Arguments.of(
+                        IcebergOptions.StorageType.HIVE_CATALOG, "file:/tmp/paimon/iceberg/mydb"),
+                Arguments.of(
+                        IcebergOptions.StorageType.HADOOP_CATALOG,
+                        "file:/tmp/paimon/iceberg/mydb"));
+    }
+}


### PR DESCRIPTION
### Purpose

Linked issue: close [#5259](https://github.com/apache/paimon/issues/5259)



This PR fixes an issue where Paimon registers an incorrect database location in Glue (or another catalog) when using IcebergOptions.StorageType.TABLE_LOCATION.

Issue Details:
When creating a Paimon table with Iceberg compatibility and setting:
'metadata.iceberg.storage' = 'table-location'
Paimon automatically creates the database and table in Glue if they do not already exist.
However, the registered database location does not match the actual table location, causing unexpected behavior.
This issue affects Iceberg readers and AWS Lake Formation, which rely on the correct database location for access control.

### Tests

The following unit tests (UT) were added:
IcebergCommitCallbackTest#testCatalogDatabasePath (Parameterized test for different storage types)
IcebergCommitCallbackTest#testCatalogTableMetadataPath (Ensures correct metadata path resolution)


### API and Format
No change

### Documentation
No new feature introduced
