### PR TITLE
[core] remove additional signed headers

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -35,7 +35,6 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
@@ -83,7 +82,7 @@ public class HttpClient implements RESTClient {
     @Override
     public <T extends RESTResponse> T get(
             String path, Class<T> responseType, RESTAuthFunction restAuthFunction) {
-        Map<String, String> authHeaders = getHeaders(uri, path, "GET", "", restAuthFunction);
+        Map<String, String> authHeaders = getHeaders(path, "GET", "", restAuthFunction);
         Request request =
                 new Request.Builder()
                         .url(getRequestUrl(uri, path, null))
@@ -100,7 +99,7 @@ public class HttpClient implements RESTClient {
             Class<T> responseType,
             RESTAuthFunction restAuthFunction) {
         Map<String, String> authHeaders =
-                getHeaders(uri, path, queryParams, "GET", "", restAuthFunction);
+                getHeaders(path, queryParams, "GET", "", restAuthFunction);
         Request request =
                 new Request.Builder()
                         .url(getRequestUrl(uri, path, queryParams))
@@ -124,8 +123,7 @@ public class HttpClient implements RESTClient {
             RESTAuthFunction restAuthFunction) {
         try {
             String bodyStr = OBJECT_MAPPER.writeValueAsString(body);
-            Map<String, String> authHeaders =
-                    getHeaders(uri, path, "POST", bodyStr, restAuthFunction);
+            Map<String, String> authHeaders = getHeaders(path, "POST", bodyStr, restAuthFunction);
             RequestBody requestBody = buildRequestBody(bodyStr);
             Request request =
                     new Request.Builder()
@@ -141,7 +139,7 @@ public class HttpClient implements RESTClient {
 
     @Override
     public <T extends RESTResponse> T delete(String path, RESTAuthFunction restAuthFunction) {
-        Map<String, String> authHeaders = getHeaders(uri, path, "DELETE", "", restAuthFunction);
+        Map<String, String> authHeaders = getHeaders(path, "DELETE", "", restAuthFunction);
         Request request =
                 new Request.Builder()
                         .url(getRequestUrl(uri, path, null))
@@ -156,8 +154,7 @@ public class HttpClient implements RESTClient {
             String path, RESTRequest body, RESTAuthFunction restAuthFunction) {
         try {
             String bodyStr = OBJECT_MAPPER.writeValueAsString(body);
-            Map<String, String> authHeaders =
-                    getHeaders(uri, path, "DELETE", bodyStr, restAuthFunction);
+            Map<String, String> authHeaders = getHeaders(path, "DELETE", bodyStr, restAuthFunction);
             RequestBody requestBody = buildRequestBody(bodyStr);
             Request request =
                     new Request.Builder()
@@ -222,24 +219,22 @@ public class HttpClient implements RESTClient {
     }
 
     private static Map<String, String> getHeaders(
-            String uri,
             String path,
             String method,
             String data,
             Function<RESTAuthParameter, Map<String, String>> headerFunction) {
 
-        return getHeaders(uri, path, Collections.emptyMap(), method, data, headerFunction);
+        return getHeaders(path, Collections.emptyMap(), method, data, headerFunction);
     }
 
     private static Map<String, String> getHeaders(
-            String uri,
             String path,
             Map<String, String> queryParams,
             String method,
             String data,
             Function<RESTAuthParameter, Map<String, String>> headerFunction) {
         RESTAuthParameter restAuthParameter =
-                new RESTAuthParameter(URI.create(uri).getHost(), path, queryParams, method, data);
+                new RESTAuthParameter(path, queryParams, method, data);
         return headerFunction.apply(restAuthParameter);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/rest/auth/DLFAuthProvider.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/auth/DLFAuthProvider.java
@@ -39,7 +39,6 @@ import static org.apache.paimon.rest.RESTObjectMapper.OBJECT_MAPPER;
 /** Auth provider for <b>Ali CLoud</b> DLF. */
 public class DLFAuthProvider implements AuthProvider {
 
-    public static final String DLF_HOST_HEADER_KEY = "Host";
     public static final String DLF_AUTHORIZATION_HEADER_KEY = "Authorization";
     public static final String DLF_CONTENT_MD5_HEADER_KEY = "Content-MD5";
     public static final String DLF_CONTENT_TYPE_KEY = "Content-Type";
@@ -104,10 +103,7 @@ public class DLFAuthProvider implements AuthProvider {
             String dateTime = now.format(AUTH_DATE_TIME_FORMATTER);
             Map<String, String> signHeaders =
                     generateSignHeaders(
-                            restAuthParameter.host(),
-                            restAuthParameter.data(),
-                            dateTime,
-                            token.getSecurityToken());
+                            restAuthParameter.data(), dateTime, token.getSecurityToken());
             String authorization =
                     DLFAuthSignature.getAuthorization(
                             restAuthParameter, token, region, signHeaders, dateTime, date);
@@ -121,10 +117,9 @@ public class DLFAuthProvider implements AuthProvider {
     }
 
     public static Map<String, String> generateSignHeaders(
-            String host, String data, String dateTime, String securityToken) throws Exception {
+            String data, String dateTime, String securityToken) throws Exception {
         Map<String, String> signHeaders = new HashMap<>();
         signHeaders.put(DLF_DATE_HEADER_KEY, dateTime);
-        signHeaders.put(DLF_HOST_HEADER_KEY, host);
         signHeaders.put(DLF_CONTENT_SHA56_HEADER_KEY, DLF_CONTENT_SHA56_VALUE);
         signHeaders.put(DLF_AUTH_VERSION_HEADER_KEY, DLFAuthSignature.VERSION);
         if (data != null && !data.isEmpty()) {

--- a/paimon-core/src/main/java/org/apache/paimon/rest/auth/RESTAuthParameter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/auth/RESTAuthParameter.java
@@ -26,19 +26,13 @@ import static org.apache.paimon.rest.RESTUtil.encodeString;
 /** RestAuthParameter for building rest auth header. */
 public class RESTAuthParameter {
 
-    private final String host;
     private final String resourcePath;
     private final Map<String, String> parameters;
     private final String method;
     private final String data;
 
     public RESTAuthParameter(
-            String host,
-            String resourcePath,
-            Map<String, String> parameters,
-            String method,
-            String data) {
-        this.host = host;
+            String resourcePath, Map<String, String> parameters, String method, String data) {
         this.resourcePath = resourcePath;
         this.parameters = new HashMap<>();
         for (Map.Entry<String, String> entry : parameters.entrySet()) {
@@ -46,10 +40,6 @@ public class RESTAuthParameter {
         }
         this.method = method;
         this.data = data;
-    }
-
-    public String host() {
-        return host;
     }
 
     public String resourcePath() {

--- a/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
@@ -183,7 +183,6 @@ public class HttpClientTest {
         String queryKey = "pageToken";
         RESTAuthParameter restAuthParameter =
                 new RESTAuthParameter(
-                        "http://a.b.c:8080",
                         "/api/v1/tables/my_table$schemas",
                         ImmutableMap.of(queryKey, "dt=20230101"),
                         "GET",

--- a/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTCatalogTest.java
@@ -51,9 +51,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class MockRESTCatalogTest extends RESTCatalogTestBase {
 
     private RESTCatalogServer restCatalogServer;
-    private String initToken = "init_token";
-    private String serverDefineHeaderName = "test-header";
-    private String serverDefineHeaderValue = "test-value";
+    private final String initToken = "init_token";
+    private final String serverDefineHeaderName = "test-header";
+    private final String serverDefineHeaderValue = "test-value";
     private String dataPath;
     private AuthProvider authProvider;
 
@@ -152,7 +152,7 @@ class MockRESTCatalogTest extends RESTCatalogTestBase {
         parameters.put("k1", "v1");
         parameters.put("k2", "v2");
         RESTAuthParameter restAuthParameter =
-                new RESTAuthParameter("host", "/path", parameters, "method", "data");
+                new RESTAuthParameter("/path", parameters, "method", "data");
         Map<String, String> headers = restCatalog.headers(restAuthParameter);
         assertEquals(
                 headers.get(BearTokenAuthProvider.AUTHORIZATION_HEADER_KEY), "Bearer init_token");

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -237,11 +237,7 @@ public class RESTCatalogServer {
                     String data = request.getBody().readUtf8();
                     RESTAuthParameter restAuthParameter =
                             new RESTAuthParameter(
-                                    request.getHeader("Host"),
-                                    resourcePath,
-                                    parameters,
-                                    request.getMethod(),
-                                    data);
+                                    resourcePath, parameters, request.getMethod(), data);
                     String authToken =
                             authProvider
                                     .header(headers, restAuthParameter)

--- a/paimon-core/src/test/java/org/apache/paimon/rest/auth/AuthSessionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/auth/AuthSessionTest.java
@@ -241,7 +241,7 @@ public class AuthSessionTest {
         parameters.put("k2", "v2");
         String data = "data";
         RESTAuthParameter restAuthParameter =
-                new RESTAuthParameter(serverUrl, "/path", parameters, "method", "data");
+                new RESTAuthParameter("/path", parameters, "method", "data");
         Map<String, String> header = authProvider.header(new HashMap<>(), restAuthParameter);
         String authorization = header.get(DLF_AUTHORIZATION_HEADER_KEY);
         String[] credentials = authorization.split(",")[0].split(" ")[1].split("/");
@@ -249,14 +249,13 @@ public class AuthSessionTest {
         String date = credentials[1];
         String newAuthorization =
                 DLFAuthSignature.getAuthorization(
-                        new RESTAuthParameter(serverUrl, "/path", parameters, "method", "data"),
+                        new RESTAuthParameter("/path", parameters, "method", "data"),
                         token,
                         "cn-hangzhou",
                         header,
                         dateTime,
                         date);
         assertEquals(newAuthorization, authorization);
-        assertEquals(restAuthParameter.host(), header.get(DLFAuthProvider.DLF_HOST_HEADER_KEY));
         assertEquals(
                 token.getSecurityToken(),
                 header.get(DLFAuthProvider.DLF_SECURITY_TOKEN_HEADER_KEY));

--- a/paimon-core/src/test/java/org/apache/paimon/rest/auth/DLFAuthSignatureTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/auth/DLFAuthSignatureTest.java
@@ -32,7 +32,6 @@ public class DLFAuthSignatureTest {
 
     @Test
     public void testGetAuthorization() throws Exception {
-        String endpoint = "dlf.cn-hangzhou.aliyuncs.com";
         String region = "cn-hangzhou";
         String dateTime = "20231203T121212Z";
         String date = "20231203";
@@ -43,19 +42,16 @@ public class DLFAuthSignatureTest {
                 RESTObjectMapper.OBJECT_MAPPER.writeValueAsString(
                         MockRESTMessage.createDatabaseRequest("database"));
         RESTAuthParameter restAuthParameter =
-                new RESTAuthParameter(endpoint, "/v1/paimon/databases", parameters, "POST", data);
+                new RESTAuthParameter("/v1/paimon/databases", parameters, "POST", data);
         DLFToken token = new DLFToken("access-key-id", "access-key-secret", "securityToken", null);
         Map<String, String> signHeaders =
                 DLFAuthProvider.generateSignHeaders(
-                        restAuthParameter.host(),
-                        restAuthParameter.data(),
-                        dateTime,
-                        "securityToken");
+                        restAuthParameter.data(), dateTime, "securityToken");
         String authorization =
                 DLFAuthSignature.getAuthorization(
                         restAuthParameter, token, region, signHeaders, dateTime, date);
         Assertions.assertEquals(
-                "DLF4-HMAC-SHA256 Credential=access-key-id/20231203/cn-hangzhou/DlfNext/aliyun_v4_request,AdditionalHeaders=host,Signature=5afbdad67b52f17c47e202da2222bff9f5cf2f86c3ed973bb919a8216d086fb7",
+                "DLF4-HMAC-SHA256 Credential=access-key-id/20231203/cn-hangzhou/DlfNext/aliyun_v4_request,Signature=c72caf1d40b55b1905d891ee3e3de48a2f8bebefa7e39e4f277acc93c269c5e3",
                 authorization);
     }
 }


### PR DESCRIPTION
### Purpose
Because the host header is easily overwritten after several forwarding, so remove it from add additional signed headers.
### Tests
DLFAuthSignatureTest
