### PR TITLE
[core] incremental-between-timestamp supports timestamp string

### DIFF
--- a/docs/content/flink/sql-query.md
+++ b/docs/content/flink/sql-query.md
@@ -93,6 +93,7 @@ SELECT * FROM t /*+ OPTIONS('incremental-between' = '12,20') */;
 
 -- incremental between snapshot time mills
 SELECT * FROM t /*+ OPTIONS('incremental-between-timestamp' = '1692169000000,1692169900000') */;
+SELECT * FROM t /*+ OPTIONS('incremental-between-timestamp' = '2025-03-12 00:00:00,2025-03-12 00:08:00') */;
 ```
 
 By default, will scan changelog files for the table which produces changelog files. Otherwise, scan newly changed files.

--- a/docs/content/spark/sql-query.md
+++ b/docs/content/spark/sql-query.md
@@ -100,6 +100,7 @@ SELECT * FROM paimon_incremental_query('tableName', 12, 20);
 
 -- read the incremental data between ts 1692169900000 and ts 1692169900000.
 SELECT * FROM paimon_incremental_between_timestamp('tableName', '1692169000000', '1692169900000');
+SELECT * FROM paimon_incremental_between_timestamp('tableName', '2025-03-12 00:00:00', '2025-03-12 00:08:00');
 
 -- read the incremental data to tag '2024-12-04'.
 -- Paimon will find an earlier tag and return changes between them.

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2241,21 +2241,42 @@ public class CoreOptions implements Serializable {
 
     public Pair<String, String> incrementalBetween() {
         String str = options.get(INCREMENTAL_BETWEEN);
-        if (str == null) {
-            str = options.get(INCREMENTAL_BETWEEN_TIMESTAMP);
-            if (str == null) {
-                return null;
-            }
-        }
-
         String[] split = str.split(",");
         if (split.length != 2) {
             throw new IllegalArgumentException(
-                    "The incremental-between or incremental-between-timestamp  must specific start(exclusive) and end snapshot or timestamp,"
+                    "The incremental-between must specific start(exclusive) and end snapshot,"
                             + " for example, 'incremental-between'='5,10' means changes between snapshot 5 and snapshot 10. But is: "
                             + str);
         }
         return Pair.of(split[0], split[1]);
+    }
+
+    public Pair<Long, Long> incrementalBetweenTimestamp() {
+        String str = options.get(INCREMENTAL_BETWEEN_TIMESTAMP);
+        String[] split = str.split(",");
+        if (split.length != 2) {
+            throw new IllegalArgumentException(
+                    "The incremental-between-timestamp must specific start(exclusive) and end timestamp. But is: "
+                            + str);
+        }
+
+        try {
+            return Pair.of(Long.parseLong(split[0]), Long.parseLong(split[1]));
+        } catch (NumberFormatException nfe) {
+            try {
+                long startTimestamp =
+                        DateTimeUtils.parseTimestampData(split[0], 3, TimeZone.getDefault())
+                                .getMillisecond();
+                long endTimestamp =
+                        DateTimeUtils.parseTimestampData(split[1], 3, TimeZone.getDefault())
+                                .getMillisecond();
+                return Pair.of(startTimestamp, endTimestamp);
+            } catch (Exception e) {
+                throw new IllegalArgumentException(
+                        "The incremental-between-timestamp must specific start(exclusive) and end timestamp. But is: "
+                                + str);
+            }
+        }
     }
 
     public IncrementalBetweenScanMode incrementalBetweenScanMode() {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
@@ -293,11 +293,11 @@ abstract class AbstractDataTableScan implements DataTableScan {
                 return new IncrementalStartingScanner(snapshotManager, startId, endId, scanMode);
             }
         } else if (conf.contains(CoreOptions.INCREMENTAL_BETWEEN_TIMESTAMP)) {
-            Pair<String, String> incrementalBetween = options.incrementalBetween();
+            Pair<Long, Long> incrementalBetween = options.incrementalBetweenTimestamp();
             return new IncrementalTimeStampStartingScanner(
                     snapshotManager,
-                    Long.parseLong(incrementalBetween.getLeft()),
-                    Long.parseLong(incrementalBetween.getRight()),
+                    incrementalBetween.getLeft(),
+                    incrementalBetween.getRight(),
                     scanMode);
         } else if (conf.contains(CoreOptions.INCREMENTAL_TO_AUTO_TAG)) {
             String endTag = options.incrementalToAutoTag();

--- a/paimon-core/src/test/java/org/apache/paimon/table/IncrementalTimeStampTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/IncrementalTimeStampTableTest.java
@@ -32,11 +32,14 @@ import org.apache.paimon.utils.SnapshotManager;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.apache.paimon.CoreOptions.INCREMENTAL_BETWEEN_TIMESTAMP;
 import static org.apache.paimon.SnapshotTest.newSnapshotManager;
 import static org.apache.paimon.io.DataFileTestUtils.row;
+import static org.apache.paimon.utils.DateTimeUtils.formatLocalDateTime;
+import static org.apache.paimon.utils.DateTimeUtils.toLocalDateTime;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link CoreOptions#INCREMENTAL_BETWEEN_TIMESTAMP}. */
@@ -59,7 +62,9 @@ public class IncrementalTimeStampTableTest extends TableTestBase {
         Path tablePath = new Path(String.format("%s/%s.db/%s", warehouse, database, "T"));
         SnapshotManager snapshotManager = newSnapshotManager(LocalFileIO.create(), tablePath);
 
+        String timestampEarliest0 = formatLocalDateTime(LocalDateTime.now().minusSeconds(1), 3);
         Long timestampEarliest = System.currentTimeMillis();
+        String timestampEarliestString = formatLocalDateTime(toLocalDateTime(timestampEarliest), 3);
         // snapshot 1: append
         write(
                 table,
@@ -76,6 +81,8 @@ public class IncrementalTimeStampTableTest extends TableTestBase {
                 GenericRow.of(1, 4, 1),
                 GenericRow.of(2, 1, 2));
         Long timestampSnapshot2 = snapshotManager.snapshot(2).timeMillis();
+        String timestampSnapshot2String =
+                formatLocalDateTime(toLocalDateTime(timestampSnapshot2), 3);
 
         // snapshot 3: compact
         compact(table, row(1), 0);
@@ -91,6 +98,8 @@ public class IncrementalTimeStampTableTest extends TableTestBase {
         // snapshot 5: append
         write(table, GenericRow.of(1, 1, 4), GenericRow.of(1, 2, 4), GenericRow.of(2, 1, 4));
         Long timestampSnapshot4 = snapshotManager.snapshot(5).timeMillis();
+        String timestampSnapshot4String =
+                formatLocalDateTime(toLocalDateTime(timestampSnapshot4), 3);
 
         // snapshot 6: append
         write(table, GenericRow.of(1, 1, 5), GenericRow.of(1, 2, 5), GenericRow.of(2, 1, 5));
@@ -101,6 +110,15 @@ public class IncrementalTimeStampTableTest extends TableTestBase {
                         Pair.of(
                                 INCREMENTAL_BETWEEN_TIMESTAMP,
                                 String.format("%s,%s", timestampEarliest - 1, timestampEarliest)));
+
+        assertThat(result1).isEmpty();
+        result1 =
+                read(
+                        table,
+                        Pair.of(
+                                INCREMENTAL_BETWEEN_TIMESTAMP,
+                                String.format(
+                                        "%s,%s", timestampEarliest0, timestampEarliestString)));
         assertThat(result1).isEmpty();
 
         List<InternalRow> result2 =
@@ -116,6 +134,21 @@ public class IncrementalTimeStampTableTest extends TableTestBase {
                         GenericRow.of(1, 3, 1),
                         GenericRow.of(1, 4, 1),
                         GenericRow.of(2, 1, 2));
+        result2 =
+                read(
+                        table,
+                        Pair.of(
+                                INCREMENTAL_BETWEEN_TIMESTAMP,
+                                String.format(
+                                        "%s,%s",
+                                        timestampEarliestString, timestampSnapshot2String)));
+        assertThat(result2)
+                .containsExactlyInAnyOrder(
+                        GenericRow.of(1, 1, 2),
+                        GenericRow.of(1, 2, 2),
+                        GenericRow.of(1, 3, 1),
+                        GenericRow.of(1, 4, 1),
+                        GenericRow.of(2, 1, 2));
 
         List<InternalRow> result3 =
                 read(
@@ -123,6 +156,20 @@ public class IncrementalTimeStampTableTest extends TableTestBase {
                         Pair.of(
                                 INCREMENTAL_BETWEEN_TIMESTAMP,
                                 String.format("%s,%s", timestampSnapshot2, timestampSnapshot4)));
+        assertThat(result3)
+                .containsExactlyInAnyOrder(
+                        GenericRow.of(1, 1, 4),
+                        GenericRow.of(1, 2, 4),
+                        GenericRow.of(2, 1, 4),
+                        GenericRow.of(2, 2, 1));
+        result3 =
+                read(
+                        table,
+                        Pair.of(
+                                INCREMENTAL_BETWEEN_TIMESTAMP,
+                                String.format(
+                                        "%s,%s",
+                                        timestampSnapshot2String, timestampSnapshot4String)));
         assertThat(result3)
                 .containsExactlyInAnyOrder(
                         GenericRow.of(1, 1, 4),

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
@@ -21,6 +21,7 @@ package org.apache.paimon.spark.sql
 import org.apache.paimon.data.{BinaryString, GenericRow, Timestamp}
 import org.apache.paimon.manifest.ManifestCommittable
 import org.apache.paimon.spark.PaimonHiveTestBase
+import org.apache.paimon.utils.DateTimeUtils
 
 import org.apache.spark.sql.{DataFrame, Row}
 
@@ -130,6 +131,12 @@ class TableValuedFunctionsTest extends PaimonHiveTestBase {
             checkAnswer(
               sql(
                 s"SELECT * FROM paimon_incremental_between_timestamp('$catalogName.$dbName.t', '$t1', '$t3') ORDER BY id"),
+              Seq(Row(2), Row(3), Row(4)))
+            val t1String = DateTimeUtils.formatLocalDateTime(DateTimeUtils.toLocalDateTime(t1), 3)
+            val t3String = DateTimeUtils.formatLocalDateTime(DateTimeUtils.toLocalDateTime(t3), 3)
+            checkAnswer(
+              sql(
+                s"SELECT * FROM paimon_incremental_between_timestamp('$catalogName.$dbName.t', '$t1String', '$t3String') ORDER BY id"),
               Seq(Row(2), Row(3), Row(4)))
           }
         }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
