### PR TITLE
[hotfix] Catch NegativeArraySizeException when reserveBytes in HeapBytesVector

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/heap/HeapBytesVector.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/heap/HeapBytesVector.java
@@ -102,7 +102,16 @@ public class HeapBytesVector extends AbstractHeapVector implements WritableBytes
     private void reserveBytes(int newCapacity) {
         if (newCapacity > buffer.length) {
             int newBytesCapacity = newCapacity * 2;
-            buffer = Arrays.copyOf(buffer, newBytesCapacity);
+            try {
+                buffer = Arrays.copyOf(buffer, newBytesCapacity);
+            } catch (NegativeArraySizeException e) {
+                throw new RuntimeException(
+                        String.format(
+                                "The new claimed capacity %s is too large, will overflow the INTEGER.MAX after multiply by 2. "
+                                        + "Try reduce `read.batch-size` to avoid this exception.",
+                                newCapacity),
+                        e);
+            }
         }
     }
 

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/newreader/DeltaByteArrayEncodingTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/newreader/DeltaByteArrayEncodingTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /* This file is based on source code from the Spark Project (http://spark.apache.org/), licensed by the Apache
  * Software Foundation (ASF) under the Apache License, Version 2.0. See the NOTICE file distributed with this work for
@@ -91,6 +92,18 @@ public class DeltaByteArrayEncodingTest {
         assertEquals(10, writableColumnVector.getInt(0));
         assertEquals(0, writableColumnVector.getInt(1));
         assertEquals(7, writableColumnVector.getInt(2));
+    }
+
+    @Test
+    public void testNegativeSize() {
+        HeapBytesVector heapBytesVector = new HeapBytesVector(32);
+        assertThrows(
+                RuntimeException.class,
+                () -> heapBytesVector.putByteArray(1, null, 0, Integer.MAX_VALUE - 1),
+                String.format(
+                        "The new claimed capacity %s is too large, will overflow the INTEGER.MAX after multiply by 2. "
+                                + "Try reduce `read.batch-size` to avoid this exception.",
+                        Integer.MAX_VALUE - 1));
     }
 
     private void assertReadWrite(


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5271

<!-- What is the purpose of the change -->

### Tests

DeltaByteArrayEncodingTest#testNegativeSize

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
