### PR TITLE
[arrow] support ArrowFormatWriter to use an external BufferAllocator to provide finer-grained memory control and monitor allocation events.

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatCWriter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatCWriter.java
@@ -24,7 +24,7 @@ import org.apache.paimon.types.RowType;
 
 import org.apache.arrow.c.ArrowArray;
 import org.apache.arrow.c.ArrowSchema;
-import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 
 /**
@@ -38,8 +38,17 @@ public class ArrowFormatCWriter implements AutoCloseable {
     private final ArrowFormatWriter realWriter;
 
     public ArrowFormatCWriter(RowType rowType, int writeBatchSize, boolean caseSensitive) {
-        this.realWriter = new ArrowFormatWriter(rowType, writeBatchSize, caseSensitive);
-        RootAllocator allocator = realWriter.getAllocator();
+        this(new ArrowFormatWriter(rowType, writeBatchSize, caseSensitive));
+    }
+
+    public ArrowFormatCWriter(
+            RowType rowType, int writeBatchSize, boolean caseSensitive, BufferAllocator allocator) {
+        this(new ArrowFormatWriter(rowType, writeBatchSize, caseSensitive, allocator));
+    }
+
+    private ArrowFormatCWriter(ArrowFormatWriter arrowFormatWriter) {
+        this.realWriter = arrowFormatWriter;
+        BufferAllocator allocator = realWriter.getAllocator();
         array = ArrowArray.allocateNew(allocator);
         schema = ArrowSchema.allocateNew(allocator);
     }
@@ -79,7 +88,7 @@ public class ArrowFormatCWriter implements AutoCloseable {
         return realWriter.getVectorSchemaRoot();
     }
 
-    public RootAllocator getAllocator() {
+    public BufferAllocator getAllocator() {
         return realWriter.getAllocator();
     }
 }

--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatWriter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatWriter.java
@@ -24,6 +24,7 @@ import org.apache.paimon.arrow.writer.ArrowFieldWriterFactoryVisitor;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.types.RowType;
 
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.util.OversizedAllocationException;
@@ -40,11 +41,16 @@ public class ArrowFormatWriter implements AutoCloseable {
 
     private final int batchSize;
 
-    private final RootAllocator allocator;
+    private final BufferAllocator allocator;
     private int rowId;
 
     public ArrowFormatWriter(RowType rowType, int writeBatchSize, boolean caseSensitive) {
-        allocator = new RootAllocator();
+        this(rowType, writeBatchSize, caseSensitive, new RootAllocator());
+    }
+
+    public ArrowFormatWriter(
+            RowType rowType, int writeBatchSize, boolean caseSensitive, BufferAllocator allocator) {
+        this.allocator = allocator;
 
         vectorSchemaRoot = ArrowUtils.createVectorSchemaRoot(rowType, allocator, caseSensitive);
 
@@ -105,7 +111,7 @@ public class ArrowFormatWriter implements AutoCloseable {
         return vectorSchemaRoot;
     }
 
-    public RootAllocator getAllocator() {
+    public BufferAllocator getAllocator() {
         return allocator;
     }
 }


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5278 

<!-- What is the purpose of the change -->

[arrow] support ArrowFormatWriter to use an external BufferAllocator to provide finer-grained memory control and monitor allocation events.

### Tests

<!-- List UT and IT cases to verify this change -->

- org.apache.paimon.arrow.vector.ArrowFormatWriterTest#testWriteWithExternalAllocator

### API and Format

<!-- Does this change affect API or storage format -->
No.
### Documentation

<!-- Does this change introduce a new feature -->
No.