### PR TITLE
[spark] In Spark 3.2 and 3.3, change paimon-spark-common to provided.

### DIFF
--- a/paimon-spark/paimon-spark-3.2/pom.xml
+++ b/paimon-spark/paimon-spark-3.2/pom.xml
@@ -46,6 +46,7 @@ under the License.
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-spark-common_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/paimon-spark/paimon-spark-3.3/pom.xml
+++ b/paimon-spark/paimon-spark-3.3/pom.xml
@@ -46,6 +46,7 @@ under the License.
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-spark-common_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Change paimon-spark-common to provided in paimon-spark-3.2 and paimon-spark-3.3.

### Tests

### API and Format


### Documentation
In the current pom.xml files for paimon-spark-3.2 and paimon-spark-3.3, the dependency on paimon-spark-common is included in a way that introduces a problem: these modules contain classes with the same names. For example, paimon-spark-3.2 includes a class named org.apache.paimon.spark.PaimonScan, and paimon-spark-common has a class with the same name. 
When packaging with the mvn command, the maven-shade-plugin resolves the conflict. However, when an external project includes the paimon-spark-3.2 dependency, the classpath will contain two org.apache.paimon.spark.PaimonScan classes, leading to a conflict if the external project code references PaimonScan, causing an exception. I believe changing the scope to provided is a good solution for paimon-spark-3.2, and the same applies to paimon-spark-3.3.
