### PR TITLE
[core] not allowed to delete fallback branch directly

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -62,6 +62,7 @@ import org.apache.paimon.utils.SegmentsCache;
 import org.apache.paimon.utils.SimpleFileReader;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.SnapshotNotExistException;
+import org.apache.paimon.utils.StringUtils;
 import org.apache.paimon.utils.TagManager;
 
 import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
@@ -647,6 +648,18 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
 
     @Override
     public void deleteBranch(String branchName) {
+        String fallbackBranch =
+                coreOptions().toConfiguration().get(CoreOptions.SCAN_FALLBACK_BRANCH);
+        if (!StringUtils.isNullOrWhitespaceOnly(fallbackBranch)
+                && branchName.equals(fallbackBranch)) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "can not delete the fallback branch. "
+                                    + "branchName to be deleted is %s. you have set 'scan.fallback-branch' = '%s'. "
+                                    + "you should reset 'scan.fallback-branch' before deleting this branch.",
+                            branchName, fallbackBranch));
+        }
+
         branchManager().dropBranch(branchName);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FileStoreTableTestBase.java
@@ -1269,6 +1269,22 @@ public abstract class FileStoreTableTestBase {
                         anyCauseMatches(
                                 IllegalArgumentException.class,
                                 "Branch name 'branch1' doesn't exist."));
+
+        // test delete fallback branch
+        table.createBranch("fallback");
+
+        Map<String, String> dynamicOptions = new HashMap<>();
+        dynamicOptions.put("scan.fallback-branch", "fallback");
+        FileStoreTable table1 = table.copy(dynamicOptions);
+        assertThatThrownBy(() -> table1.deleteBranch("fallback"))
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class,
+                                "can not delete the fallback branch. "
+                                        + "branchName to be deleted is fallback. you have set 'scan.fallback-branch' = 'fallback'. "
+                                        + "you should reset 'scan.fallback-branch' before deleting this branch."));
+
+        table.deleteBranch("fallback");
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
Currently if the fallback branch for table was deleted, AbstractCatalog.getTable will throw exception.

Therefore, user should reset 'scan.fallback-branch' before deleting this branch.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
