### PR TITLE
[flink] make tableConf valid for database compaction job

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactDatabaseAction.java
@@ -215,6 +215,7 @@ public class CompactDatabaseAction extends ActionBase {
                                         .get(CoreOptions.CONTINUOUS_DISCOVERY_INTERVAL)
                                         .toMillis())
                         .withPartitionIdleTime(partitionIdleTime);
+        sourceBuilder.withTableOptions(tableOptions.toMap());
 
         Integer parallelism =
                 tableOptions.get(FlinkConnectorOptions.SINK_PARALLELISM) == null

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/MultiAwareBucketTableScan.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/MultiAwareBucketTableScan.java
@@ -51,8 +51,15 @@ public class MultiAwareBucketTableScan extends MultiTableScanBase<Tuple2<Split, 
             Pattern includingPattern,
             Pattern excludingPattern,
             Pattern databasePattern,
-            boolean isStreaming) {
-        super(catalogLoader, includingPattern, excludingPattern, databasePattern, isStreaming);
+            boolean isStreaming,
+            Map<String, String> tableOptions) {
+        super(
+                catalogLoader,
+                includingPattern,
+                excludingPattern,
+                databasePattern,
+                isStreaming,
+                tableOptions);
         tablesMap = new HashMap<>();
         scansMap = new HashMap<>();
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/MultiTableScanBase.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/MultiTableScanBase.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.apache.paimon.flink.utils.MultiTablesCompactorUtil.shouldCompactTable;
@@ -59,18 +60,22 @@ public abstract class MultiTableScanBase<T> implements AutoCloseable {
 
     protected boolean isStreaming;
 
+    protected final Map<String, String> tableOptions;
+
     public MultiTableScanBase(
             CatalogLoader catalogLoader,
             Pattern includingPattern,
             Pattern excludingPattern,
             Pattern databasePattern,
-            boolean isStreaming) {
+            boolean isStreaming,
+            Map<String, String> tableOptions) {
         catalog = catalogLoader.load();
 
         this.includingPattern = includingPattern;
         this.excludingPattern = excludingPattern;
         this.databasePattern = databasePattern;
         this.isStreaming = isStreaming;
+        this.tableOptions = tableOptions;
     }
 
     protected void updateTableMap()
@@ -93,7 +98,7 @@ public abstract class MultiTableScanBase<T> implements AutoCloseable {
                             continue;
                         }
 
-                        FileStoreTable fileStoreTable = (FileStoreTable) table;
+                        FileStoreTable fileStoreTable = ((FileStoreTable) table).copy(tableOptions);
                         addScanTable(fileStoreTable, identifier);
                     }
                 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/MultiUnawareBucketTableScan.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/MultiUnawareBucketTableScan.java
@@ -45,8 +45,15 @@ public class MultiUnawareBucketTableScan
             Pattern includingPattern,
             Pattern excludingPattern,
             Pattern databasePattern,
-            boolean isStreaming) {
-        super(catalogLoader, includingPattern, excludingPattern, databasePattern, isStreaming);
+            boolean isStreaming,
+            Map<String, String> tableOptions) {
+        super(
+                catalogLoader,
+                includingPattern,
+                excludingPattern,
+                databasePattern,
+                isStreaming,
+                tableOptions);
         tablesMap = new HashMap<>();
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendOnlyMultiTableCompactionWorkerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendOnlyMultiTableCompactionWorkerOperator.java
@@ -118,7 +118,7 @@ public class AppendOnlyMultiTableCompactionWorkerOperator
     private UnawareBucketCompactor compactor(Identifier tableId) {
         try {
             return new UnawareBucketCompactor(
-                    (FileStoreTable) catalog.getTable(tableId),
+                    (FileStoreTable) catalog.getTable(tableId).copy(options.toMap()),
                     commitUser,
                     this::workerExecutor,
                     getMetricGroup());

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
@@ -226,6 +226,7 @@ public class MultiTablesStoreCompactOperator
             while (true) {
                 try {
                     table = (FileStoreTable) catalog.getTable(tableId);
+                    table = table.copy(options.toMap());
                     HashMap<String, String> dynamicOptions =
                             new HashMap<String, String>() {
                                 {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/PrepareCommitOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/PrepareCommitOperator.java
@@ -53,7 +53,7 @@ public abstract class PrepareCommitOperator<IN, OUT> extends AbstractStreamOpera
 
     @Nullable protected transient MemorySegmentPool memoryPool;
     @Nullable private transient MemorySegmentAllocator memoryAllocator;
-    private final Options options;
+    protected final Options options;
     private boolean endOfInput = false;
 
     public PrepareCommitOperator(StreamOperatorParameters<OUT> parameters, Options options) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CombinedTableCompactorSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CombinedTableCompactorSourceBuilder.java
@@ -37,6 +37,8 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import javax.annotation.Nullable;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
@@ -54,6 +56,7 @@ public class CombinedTableCompactorSourceBuilder {
     private boolean isContinuous = false;
     private StreamExecutionEnvironment env;
     @Nullable private Duration partitionIdleTime = null;
+    private Map<String, String> tableOptions = new HashMap<>();
 
     public CombinedTableCompactorSourceBuilder(
             CatalogLoader catalogLoader,
@@ -84,6 +87,11 @@ public class CombinedTableCompactorSourceBuilder {
         return this;
     }
 
+    public CombinedTableCompactorSourceBuilder withTableOptions(Map<String, String> tableOptions) {
+        this.tableOptions = tableOptions;
+        return this;
+    }
+
     public DataStream<RowData> buildAwareBucketTableSource() {
         Preconditions.checkArgument(env != null, "StreamExecutionEnvironment should not be null.");
         RowType produceType = CompactBucketsTable.getRowType();
@@ -96,6 +104,7 @@ public class CombinedTableCompactorSourceBuilder {
                     includingPattern,
                     excludingPattern,
                     databasePattern,
+                    tableOptions,
                     monitorInterval);
         } else {
             return CombinedAwareBatchSource.buildSource(
@@ -106,6 +115,7 @@ public class CombinedTableCompactorSourceBuilder {
                     includingPattern,
                     excludingPattern,
                     databasePattern,
+                    tableOptions,
                     partitionIdleTime);
         }
     }
@@ -120,6 +130,7 @@ public class CombinedTableCompactorSourceBuilder {
                     includingPattern,
                     excludingPattern,
                     databasePattern,
+                    tableOptions,
                     monitorInterval);
         } else {
             return CombinedUnawareBatchSource.buildSource(
@@ -129,6 +140,7 @@ public class CombinedTableCompactorSourceBuilder {
                     includingPattern,
                     excludingPattern,
                     databasePattern,
+                    tableOptions,
                     partitionIdleTime);
         }
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedAwareBatchSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedAwareBatchSource.java
@@ -43,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.apache.paimon.flink.compact.MultiTableScanBase.ScanResult.FINISHED;
@@ -52,13 +53,16 @@ import static org.apache.paimon.flink.compact.MultiTableScanBase.ScanResult.IS_E
 public class CombinedAwareBatchSource extends CombinedCompactorSource<Tuple2<Split, String>> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CombinedAwareBatchSource.class);
+    private final Map<String, String> tableOptions;
 
     public CombinedAwareBatchSource(
             CatalogLoader catalogLoader,
             Pattern includingPattern,
             Pattern excludingPattern,
-            Pattern databasePattern) {
+            Pattern databasePattern,
+            Map<String, String> tableOptions) {
         super(catalogLoader, includingPattern, excludingPattern, databasePattern, false);
+        this.tableOptions = tableOptions;
     }
 
     @Override
@@ -79,7 +83,8 @@ public class CombinedAwareBatchSource extends CombinedCompactorSource<Tuple2<Spl
                             includingPattern,
                             excludingPattern,
                             databasePattern,
-                            isStreaming);
+                            isStreaming,
+                            tableOptions);
         }
 
         @Override
@@ -116,10 +121,15 @@ public class CombinedAwareBatchSource extends CombinedCompactorSource<Tuple2<Spl
             Pattern includingPattern,
             Pattern excludingPattern,
             Pattern databasePattern,
+            Map<String, String> tableOptions,
             Duration partitionIdleTime) {
         CombinedAwareBatchSource source =
                 new CombinedAwareBatchSource(
-                        catalogLoader, includingPattern, excludingPattern, databasePattern);
+                        catalogLoader,
+                        includingPattern,
+                        excludingPattern,
+                        databasePattern,
+                        tableOptions);
         TupleTypeInfo<Tuple2<Split, String>> tupleTypeInfo =
                 new TupleTypeInfo<>(
                         new JavaTypeInfo<>(Split.class), BasicTypeInfo.STRING_TYPE_INFO);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedAwareStreamingSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedAwareStreamingSource.java
@@ -40,6 +40,7 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.data.RowData;
 
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.apache.paimon.flink.compact.MultiTableScanBase.ScanResult.FINISHED;
@@ -49,14 +50,17 @@ import static org.apache.paimon.flink.compact.MultiTableScanBase.ScanResult.IS_E
 public class CombinedAwareStreamingSource extends CombinedCompactorSource<Tuple2<Split, String>> {
 
     private final long monitorInterval;
+    private final Map<String, String> tableOptions;
 
     public CombinedAwareStreamingSource(
             CatalogLoader catalogLoader,
             Pattern includingPattern,
             Pattern excludingPattern,
             Pattern databasePattern,
+            Map<String, String> tableOptions,
             long monitorInterval) {
         super(catalogLoader, includingPattern, excludingPattern, databasePattern, true);
+        this.tableOptions = tableOptions;
         this.monitorInterval = monitorInterval;
     }
 
@@ -78,7 +82,8 @@ public class CombinedAwareStreamingSource extends CombinedCompactorSource<Tuple2
                             includingPattern,
                             excludingPattern,
                             databasePattern,
-                            isStreaming);
+                            isStreaming,
+                            tableOptions);
         }
 
         @Override
@@ -111,6 +116,7 @@ public class CombinedAwareStreamingSource extends CombinedCompactorSource<Tuple2
             Pattern includingPattern,
             Pattern excludingPattern,
             Pattern databasePattern,
+            Map<String, String> tableOptions,
             long monitorInterval) {
 
         CombinedAwareStreamingSource source =
@@ -119,6 +125,7 @@ public class CombinedAwareStreamingSource extends CombinedCompactorSource<Tuple2
                         includingPattern,
                         excludingPattern,
                         databasePattern,
+                        tableOptions,
                         monitorInterval);
         TupleTypeInfo<Tuple2<Split, String>> tupleTypeInfo =
                 new TupleTypeInfo<>(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedUnawareBatchSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedUnawareBatchSource.java
@@ -62,13 +62,16 @@ public class CombinedUnawareBatchSource
         extends CombinedCompactorSource<MultiTableUnawareAppendCompactionTask> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CombinedUnawareBatchSource.class);
+    private final Map<String, String> tableOptions;
 
     public CombinedUnawareBatchSource(
             CatalogLoader catalogLoader,
             Pattern includingPattern,
             Pattern excludingPattern,
-            Pattern databasePattern) {
+            Pattern databasePattern,
+            Map<String, String> tableOptions) {
         super(catalogLoader, includingPattern, excludingPattern, databasePattern, false);
+        this.tableOptions = tableOptions;
     }
 
     @Override
@@ -90,7 +93,8 @@ public class CombinedUnawareBatchSource
                             includingPattern,
                             excludingPattern,
                             databasePattern,
-                            isStreaming);
+                            isStreaming,
+                            tableOptions);
         }
 
         @Override
@@ -126,10 +130,15 @@ public class CombinedUnawareBatchSource
             Pattern includingPattern,
             Pattern excludingPattern,
             Pattern databasePattern,
+            Map<String, String> tableOptions,
             @Nullable Duration partitionIdleTime) {
         CombinedUnawareBatchSource combinedUnawareBatchSource =
                 new CombinedUnawareBatchSource(
-                        catalogLoader, includingPattern, excludingPattern, databasePattern);
+                        catalogLoader,
+                        includingPattern,
+                        excludingPattern,
+                        databasePattern,
+                        tableOptions);
         MultiTableCompactionTaskTypeInfo compactionTaskTypeInfo =
                 new MultiTableCompactionTaskTypeInfo();
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedUnawareStreamingSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/CombinedUnawareStreamingSource.java
@@ -34,6 +34,7 @@ import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.apache.paimon.flink.compact.MultiTableScanBase.ScanResult.FINISHED;
@@ -46,14 +47,17 @@ public class CombinedUnawareStreamingSource
         extends CombinedCompactorSource<MultiTableUnawareAppendCompactionTask> {
 
     private final long monitorInterval;
+    private final Map<String, String> tableOptions;
 
     public CombinedUnawareStreamingSource(
             CatalogLoader catalogLoader,
             Pattern includingPattern,
             Pattern excludingPattern,
             Pattern databasePattern,
+            Map<String, String> tableOptions,
             long monitorInterval) {
         super(catalogLoader, includingPattern, excludingPattern, databasePattern, true);
+        this.tableOptions = tableOptions;
         this.monitorInterval = monitorInterval;
     }
 
@@ -76,7 +80,8 @@ public class CombinedUnawareStreamingSource
                             includingPattern,
                             excludingPattern,
                             databasePattern,
-                            isStreaming);
+                            isStreaming,
+                            tableOptions);
         }
 
         @Override
@@ -108,6 +113,7 @@ public class CombinedUnawareStreamingSource
             Pattern includingPattern,
             Pattern excludingPattern,
             Pattern databasePattern,
+            Map<String, String> tableOptions,
             long monitorInterval) {
 
         CombinedUnawareStreamingSource source =
@@ -116,6 +122,7 @@ public class CombinedUnawareStreamingSource
                         includingPattern,
                         excludingPattern,
                         databasePattern,
+                        tableOptions,
                         monitorInterval);
         MultiTableCompactionTaskTypeInfo compactionTaskTypeInfo =
                 new MultiTableCompactionTaskTypeInfo();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
Currently, tables are dynamically loaded when performing dedicated database compaction, and table conf set by user will not be passed to these tables in some stages, e.g., source stage and write stage will not pass the user table conf. This pr aims to fix it.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
