### PR TITLE
[hotfix] incremental-between-timestamp should return empty data instead of throwing exception

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/IncrementalTimeStampStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/IncrementalTimeStampStartingScanner.java
@@ -46,7 +46,11 @@ public class IncrementalTimeStampStartingScanner extends AbstractStartingScanner
 
     @Override
     public Result scan(SnapshotReader reader) {
-        Snapshot earliestSnapshot = snapshotManager.snapshot(snapshotManager.earliestSnapshotId());
+        Snapshot earliestSnapshot = snapshotManager.earliestSnapshot();
+        if (earliestSnapshot == null) {
+            return new NoSnapshot();
+        }
+
         Snapshot latestSnapshot = snapshotManager.latestSnapshot();
         if (startTimestamp > latestSnapshot.timeMillis()
                 || endTimestamp < earliestSnapshot.timeMillis()) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -729,4 +729,10 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
                 "SELECT Q.id, P.v FROM Q INNER JOIN P /*+ OPTIONS('scan.partitions' = 'pt=b;pt=c') */ ON Q.id = P.id ORDER BY Q.id, P.v";
         assertThat(sql(query)).containsExactly(Row.of(1, 11), Row.of(1, 12), Row.of(2, 22));
     }
+
+    @Test
+    public void testEmptyTableIncrementalBetweenTimestamp() {
+        assertThat(sql("SELECT * FROM t /*+ OPTIONS('incremental-between-timestamp'='0,1') */"))
+                .isEmpty();
+    }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -732,7 +732,7 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
 
     @Test
     public void testEmptyTableIncrementalBetweenTimestamp() {
-        assertThat(sql("SELECT * FROM t /*+ OPTIONS('incremental-between-timestamp'='0,1') */"))
+        assertThat(sql("SELECT * FROM T /*+ OPTIONS('incremental-between-timestamp'='0,1') */"))
                 .isEmpty();
     }
 }


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
