### PR TITLE
[hotfix] Fix reduce scan.manifest.parallelism not take effect

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/ManifestReadThreadPool.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ManifestReadThreadPool.java
@@ -36,7 +36,7 @@ public class ManifestReadThreadPool {
             createCachedThreadPool(Runtime.getRuntime().availableProcessors(), THREAD_NAME);
 
     public static synchronized ThreadPoolExecutor getExecutorService(@Nullable Integer threadNum) {
-        if (threadNum == null || threadNum <= executorService.getMaximumPoolSize()) {
+        if (threadNum == null || threadNum >= executorService.getMaximumPoolSize()) {
             return executorService;
         }
         // we don't need to close previous pool


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

When reduce `scan.manifest.parallelism` parameter, it does not take effect.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
