### PR TITLE
[core][rest] Remove partition modification method in RESTCatalog

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -34,7 +34,6 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FormatTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.object.ObjectTable;
-import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.RowType;
 
@@ -161,26 +160,6 @@ public abstract class AbstractCatalog implements Catalog {
     }
 
     protected abstract Database getDatabaseImpl(String name) throws DatabaseNotExistException;
-
-    @Override
-    public void createPartitions(Identifier identifier, List<Map<String, String>> partitions)
-            throws TableNotExistException {}
-
-    @Override
-    public void dropPartitions(Identifier identifier, List<Map<String, String>> partitions)
-            throws TableNotExistException {
-        checkNotSystemTable(identifier, "dropPartition");
-        Table table = getTable(identifier);
-        try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
-            commit.truncatePartitions(partitions);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Override
-    public void alterPartitions(Identifier identifier, List<Partition> partitions)
-            throws TableNotExistException {}
 
     @Override
     public void markDonePartitions(Identifier identifier, List<Map<String, String>> partitions)

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
@@ -272,24 +272,6 @@ public class CachingCatalog extends DelegateCatalog {
     }
 
     @Override
-    public void dropPartitions(Identifier identifier, List<Map<String, String>> partitions)
-            throws TableNotExistException {
-        wrapped.dropPartitions(identifier, partitions);
-        if (partitionCache != null) {
-            partitionCache.invalidate(identifier);
-        }
-    }
-
-    @Override
-    public void alterPartitions(Identifier identifier, List<Partition> partitions)
-            throws TableNotExistException {
-        wrapped.alterPartitions(identifier, partitions);
-        if (partitionCache != null) {
-            partitionCache.invalidate(identifier);
-        }
-    }
-
-    @Override
     public void invalidateTable(Identifier identifier) {
         tableCache.invalidate(identifier);
         if (partitionCache != null) {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -283,37 +283,6 @@ public interface Catalog extends AutoCloseable {
     // ======================= partition methods ===============================
 
     /**
-     * Create partitions of the specify table. Ignore existing partitions.
-     *
-     * @param identifier path of the table to create partitions
-     * @param partitions partitions to be created
-     * @throws TableNotExistException if the table does not exist
-     */
-    void createPartitions(Identifier identifier, List<Map<String, String>> partitions)
-            throws TableNotExistException;
-
-    /**
-     * Drop partitions of the specify table. Ignore non-existent partitions.
-     *
-     * @param identifier path of the table to drop partitions
-     * @param partitions partitions to be deleted
-     * @throws TableNotExistException if the table does not exist
-     */
-    void dropPartitions(Identifier identifier, List<Map<String, String>> partitions)
-            throws TableNotExistException;
-
-    /**
-     * Alter partitions of the specify table. For non-existent partitions, partitions will be
-     * created directly.
-     *
-     * @param identifier path of the table to alter partitions
-     * @param partitions partitions to be altered
-     * @throws TableNotExistException if the table does not exist
-     */
-    void alterPartitions(Identifier identifier, List<Partition> partitions)
-            throws TableNotExistException;
-
-    /**
      * Mark partitions done of the specify table. For non-existent partitions, partitions will be
      * created directly.
      *

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogSnapshotCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogSnapshotCommit.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.catalog;
 
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.partition.Partition;
+import org.apache.paimon.partition.PartitionStatistics;
 import org.apache.paimon.utils.SnapshotManager;
 
 import java.util.List;
@@ -36,7 +36,7 @@ public class CatalogSnapshotCommit implements SnapshotCommit {
     }
 
     @Override
-    public boolean commit(Snapshot snapshot, String branch, List<Partition> statistics)
+    public boolean commit(Snapshot snapshot, String branch, List<PartitionStatistics> statistics)
             throws Exception {
         Identifier newIdentifier =
                 new Identifier(identifier.getDatabaseName(), identifier.getTableName(), branch);

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -129,24 +129,6 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
-    public void createPartitions(Identifier identifier, List<Map<String, String>> partitions)
-            throws TableNotExistException {
-        wrapped.createPartitions(identifier, partitions);
-    }
-
-    @Override
-    public void dropPartitions(Identifier identifier, List<Map<String, String>> partitions)
-            throws TableNotExistException {
-        wrapped.dropPartitions(identifier, partitions);
-    }
-
-    @Override
-    public void alterPartitions(Identifier identifier, List<Partition> partitions)
-            throws TableNotExistException {
-        wrapped.alterPartitions(identifier, partitions);
-    }
-
-    @Override
     public void markDonePartitions(Identifier identifier, List<Map<String, String>> partitions)
             throws TableNotExistException {
         wrapped.markDonePartitions(identifier, partitions);

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/RenamingSnapshotCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/RenamingSnapshotCommit.java
@@ -23,7 +23,7 @@ import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.operation.Lock;
-import org.apache.paimon.partition.Partition;
+import org.apache.paimon.partition.PartitionStatistics;
 import org.apache.paimon.utils.SnapshotManager;
 
 import javax.annotation.Nullable;
@@ -51,7 +51,7 @@ public class RenamingSnapshotCommit implements SnapshotCommit {
     }
 
     @Override
-    public boolean commit(Snapshot snapshot, String branch, List<Partition> statistics)
+    public boolean commit(Snapshot snapshot, String branch, List<PartitionStatistics> statistics)
             throws Exception {
         Path newSnapshotPath =
                 snapshotManager.branch().equals(branch)

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/SnapshotCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/SnapshotCommit.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.catalog;
 
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.partition.Partition;
+import org.apache.paimon.partition.PartitionStatistics;
 import org.apache.paimon.utils.SnapshotManager;
 
 import java.io.Serializable;
@@ -28,7 +28,8 @@ import java.util.List;
 /** Interface to commit snapshot atomically. */
 public interface SnapshotCommit extends AutoCloseable {
 
-    boolean commit(Snapshot snapshot, String branch, List<Partition> statistics) throws Exception;
+    boolean commit(Snapshot snapshot, String branch, List<PartitionStatistics> statistics)
+            throws Exception;
 
     /** Factory to create {@link SnapshotCommit}. */
     interface Factory extends Serializable {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/SupportsPartitionModification.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/SupportsPartitionModification.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.catalog;
+
+import org.apache.paimon.partition.PartitionStatistics;
+
+import java.util.List;
+import java.util.Map;
+
+/** A {@link Catalog} supports modifying table partitions. */
+public interface SupportsPartitionModification extends Catalog {
+
+    /**
+     * Create partitions of the specify table. Ignore existing partitions.
+     *
+     * @param identifier path of the table to create partitions
+     * @param partitions partitions to be created
+     * @throws TableNotExistException if the table does not exist
+     */
+    void createPartitions(Identifier identifier, List<Map<String, String>> partitions)
+            throws TableNotExistException;
+
+    /**
+     * Drop partitions of the specify table. Ignore non-existent partitions.
+     *
+     * @param identifier path of the table to drop partitions
+     * @param partitions partitions to be deleted
+     * @throws TableNotExistException if the table does not exist
+     */
+    void dropPartitions(Identifier identifier, List<Map<String, String>> partitions)
+            throws TableNotExistException;
+
+    /**
+     * Alter partitions of the specify table. For non-existent partitions, partitions will be
+     * created directly.
+     *
+     * @param identifier path of the table to alter partitions
+     * @param partitions partitions to be altered
+     * @throws TableNotExistException if the table does not exist
+     */
+    void alterPartitions(Identifier identifier, List<PartitionStatistics> partitions)
+            throws TableNotExistException;
+}

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/SupportsSnapshots.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/SupportsSnapshots.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.catalog;
 
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.partition.Partition;
+import org.apache.paimon.partition.PartitionStatistics;
 import org.apache.paimon.table.TableSnapshot;
 
 import java.util.List;
@@ -37,7 +37,8 @@ public interface SupportsSnapshots extends Catalog {
      * @return Success or not
      * @throws Catalog.TableNotExistException if the target does not exist
      */
-    boolean commitSnapshot(Identifier identifier, Snapshot snapshot, List<Partition> statistics)
+    boolean commitSnapshot(
+            Identifier identifier, Snapshot snapshot, List<PartitionStatistics> statistics)
             throws Catalog.TableNotExistException;
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/PartitionEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/PartitionEntry.java
@@ -22,6 +22,7 @@ import org.apache.paimon.annotation.Public;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.partition.Partition;
+import org.apache.paimon.partition.PartitionStatistics;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.utils.InternalRowPartitionComputer;
 
@@ -87,6 +88,16 @@ public class PartitionEntry {
 
     public Partition toPartition(InternalRowPartitionComputer computer) {
         return new Partition(
+                computer.generatePartValues(partition),
+                recordCount,
+                fileSizeInBytes,
+                fileCount,
+                lastFileCreationTime,
+                false);
+    }
+
+    public PartitionStatistics toPartitionStatistics(InternalRowPartitionComputer computer) {
+        return new PartitionStatistics(
                 computer.generatePartValues(partition),
                 recordCount,
                 fileSizeInBytes,

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -41,8 +41,8 @@ import org.apache.paimon.manifest.SimpleFileEntry;
 import org.apache.paimon.operation.metrics.CommitMetrics;
 import org.apache.paimon.operation.metrics.CommitStats;
 import org.apache.paimon.options.MemorySize;
-import org.apache.paimon.partition.Partition;
 import org.apache.paimon.partition.PartitionPredicate;
+import org.apache.paimon.partition.PartitionStatistics;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.schema.SchemaManager;
@@ -1149,9 +1149,9 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
     private boolean commitSnapshotImpl(Snapshot newSnapshot, List<PartitionEntry> deltaStatistics) {
         try {
-            List<Partition> statistics = new ArrayList<>(deltaStatistics.size());
+            List<PartitionStatistics> statistics = new ArrayList<>(deltaStatistics.size());
             for (PartitionEntry entry : deltaStatistics) {
-                statistics.add(entry.toPartition(partitionComputer));
+                statistics.add(entry.toPartitionStatistics(partitionComputer));
             }
             return snapshotCommit.commit(newSnapshot, branchName, statistics);
         } catch (Throwable e) {

--- a/paimon-core/src/main/java/org/apache/paimon/partition/Partition.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/Partition.java
@@ -25,40 +25,20 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGet
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.io.Serializable;
 import java.util.Map;
 import java.util.Objects;
 
-/**
- * Statistics of a partition, fields inside may be negative, indicating that some data has been
- * removed.
- */
+/** Represent a partition, including statistics and done flag. */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Public
-public class Partition implements Serializable {
+public class Partition extends PartitionStatistics {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
-    public static final String FIELD_SPEC = "spec";
-    public static final String FIELD_RECORD_COUNT = "recordCount";
-    public static final String FIELD_FILE_SIZE_IN_BYTES = "fileSizeInBytes";
-    public static final String FIELD_FILE_COUNT = "fileCount";
-    public static final String FIELD_LAST_FILE_CREATION_TIME = "lastFileCreationTime";
+    public static final String FIELD_DONE = "done";
 
-    @JsonProperty(FIELD_SPEC)
-    private final Map<String, String> spec;
-
-    @JsonProperty(FIELD_RECORD_COUNT)
-    private final long recordCount;
-
-    @JsonProperty(FIELD_FILE_SIZE_IN_BYTES)
-    private final long fileSizeInBytes;
-
-    @JsonProperty(FIELD_FILE_COUNT)
-    private final long fileCount;
-
-    @JsonProperty(FIELD_LAST_FILE_CREATION_TIME)
-    private final long lastFileCreationTime;
+    @JsonProperty(FIELD_DONE)
+    private final boolean done;
 
     @JsonCreator
     public Partition(
@@ -66,58 +46,32 @@ public class Partition implements Serializable {
             @JsonProperty(FIELD_RECORD_COUNT) long recordCount,
             @JsonProperty(FIELD_FILE_SIZE_IN_BYTES) long fileSizeInBytes,
             @JsonProperty(FIELD_FILE_COUNT) long fileCount,
-            @JsonProperty(FIELD_LAST_FILE_CREATION_TIME) long lastFileCreationTime) {
-        this.spec = spec;
-        this.recordCount = recordCount;
-        this.fileSizeInBytes = fileSizeInBytes;
-        this.fileCount = fileCount;
-        this.lastFileCreationTime = lastFileCreationTime;
+            @JsonProperty(FIELD_LAST_FILE_CREATION_TIME) long lastFileCreationTime,
+            @JsonProperty(FIELD_DONE) boolean done) {
+        super(spec, recordCount, fileSizeInBytes, fileCount, lastFileCreationTime);
+        this.done = done;
     }
 
-    @JsonGetter(FIELD_SPEC)
-    public Map<String, String> spec() {
-        return spec;
-    }
-
-    @JsonGetter(FIELD_RECORD_COUNT)
-    public long recordCount() {
-        return recordCount;
-    }
-
-    @JsonGetter(FIELD_FILE_SIZE_IN_BYTES)
-    public long fileSizeInBytes() {
-        return fileSizeInBytes;
-    }
-
-    @JsonGetter(FIELD_FILE_COUNT)
-    public long fileCount() {
-        return fileCount;
-    }
-
-    @JsonGetter(FIELD_LAST_FILE_CREATION_TIME)
-    public long lastFileCreationTime() {
-        return lastFileCreationTime;
+    @JsonGetter(FIELD_DONE)
+    public boolean done() {
+        return done;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        Partition that = (Partition) o;
-        return recordCount == that.recordCount
-                && fileSizeInBytes == that.fileSizeInBytes
-                && fileCount == that.fileCount
-                && lastFileCreationTime == that.lastFileCreationTime
-                && Objects.equals(spec, that.spec);
+        if (!super.equals(o)) {
+            return false;
+        }
+        Partition partition = (Partition) o;
+        return done == partition.done;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(spec, recordCount, fileSizeInBytes, fileCount, lastFileCreationTime);
+        return Objects.hash(super.hashCode(), done);
     }
 
     @Override
@@ -133,6 +87,8 @@ public class Partition implements Serializable {
                 + fileCount
                 + ", lastFileCreationTime="
                 + lastFileCreationTime
+                + ", done="
+                + done
                 + '}';
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionStatistics.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionStatistics.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.partition;
+
+import org.apache.paimon.annotation.Public;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Statistics of a partition, fields inside may be negative, indicating that some data has been
+ * removed.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Public
+public class PartitionStatistics implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String FIELD_SPEC = "spec";
+    public static final String FIELD_RECORD_COUNT = "recordCount";
+    public static final String FIELD_FILE_SIZE_IN_BYTES = "fileSizeInBytes";
+    public static final String FIELD_FILE_COUNT = "fileCount";
+    public static final String FIELD_LAST_FILE_CREATION_TIME = "lastFileCreationTime";
+
+    @JsonProperty(FIELD_SPEC)
+    protected final Map<String, String> spec;
+
+    @JsonProperty(FIELD_RECORD_COUNT)
+    protected final long recordCount;
+
+    @JsonProperty(FIELD_FILE_SIZE_IN_BYTES)
+    protected final long fileSizeInBytes;
+
+    @JsonProperty(FIELD_FILE_COUNT)
+    protected final long fileCount;
+
+    @JsonProperty(FIELD_LAST_FILE_CREATION_TIME)
+    protected final long lastFileCreationTime;
+
+    @JsonCreator
+    public PartitionStatistics(
+            @JsonProperty(FIELD_SPEC) Map<String, String> spec,
+            @JsonProperty(FIELD_RECORD_COUNT) long recordCount,
+            @JsonProperty(FIELD_FILE_SIZE_IN_BYTES) long fileSizeInBytes,
+            @JsonProperty(FIELD_FILE_COUNT) long fileCount,
+            @JsonProperty(FIELD_LAST_FILE_CREATION_TIME) long lastFileCreationTime) {
+        this.spec = spec;
+        this.recordCount = recordCount;
+        this.fileSizeInBytes = fileSizeInBytes;
+        this.fileCount = fileCount;
+        this.lastFileCreationTime = lastFileCreationTime;
+    }
+
+    @JsonGetter(FIELD_SPEC)
+    public Map<String, String> spec() {
+        return spec;
+    }
+
+    @JsonGetter(FIELD_RECORD_COUNT)
+    public long recordCount() {
+        return recordCount;
+    }
+
+    @JsonGetter(FIELD_FILE_SIZE_IN_BYTES)
+    public long fileSizeInBytes() {
+        return fileSizeInBytes;
+    }
+
+    @JsonGetter(FIELD_FILE_COUNT)
+    public long fileCount() {
+        return fileCount;
+    }
+
+    @JsonGetter(FIELD_LAST_FILE_CREATION_TIME)
+    public long lastFileCreationTime() {
+        return lastFileCreationTime;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PartitionStatistics that = (PartitionStatistics) o;
+        return recordCount == that.recordCount
+                && fileSizeInBytes == that.fileSizeInBytes
+                && fileCount == that.fileCount
+                && lastFileCreationTime == that.lastFileCreationTime
+                && Objects.equals(spec, that.spec);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(spec, recordCount, fileSizeInBytes, fileCount, lastFileCreationTime);
+    }
+
+    @Override
+    public String toString() {
+        return "{"
+                + "spec="
+                + spec
+                + ", recordCount="
+                + recordCount
+                + ", fileSizeInBytes="
+                + fileSizeInBytes
+                + ", fileCount="
+                + fileCount
+                + ", lastFileCreationTime="
+                + lastFileCreationTime
+                + '}';
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedCatalog.java
@@ -27,7 +27,6 @@ import org.apache.paimon.catalog.PropertyChange;
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
 import org.apache.paimon.options.Options;
-import org.apache.paimon.partition.Partition;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.FileStoreTable;
@@ -157,27 +156,6 @@ public class PrivilegedCatalog extends DelegateCatalog {
         } else {
             return table;
         }
-    }
-
-    @Override
-    public void createPartitions(Identifier identifier, List<Map<String, String>> partitions)
-            throws TableNotExistException {
-        privilegeManager.getPrivilegeChecker().assertCanInsert(identifier);
-        wrapped.createPartitions(identifier, partitions);
-    }
-
-    @Override
-    public void dropPartitions(Identifier identifier, List<Map<String, String>> partitions)
-            throws TableNotExistException {
-        privilegeManager.getPrivilegeChecker().assertCanInsert(identifier);
-        wrapped.dropPartitions(identifier, partitions);
-    }
-
-    @Override
-    public void alterPartitions(Identifier identifier, List<Partition> partitions)
-            throws TableNotExistException {
-        privilegeManager.getPrivilegeChecker().assertCanInsert(identifier);
-        wrapped.alterPartitions(identifier, partitions);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -34,6 +34,7 @@ import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
+import org.apache.paimon.partition.PartitionStatistics;
 import org.apache.paimon.rest.auth.AuthSession;
 import org.apache.paimon.rest.auth.RESTAuthFunction;
 import org.apache.paimon.rest.auth.RESTAuthParameter;
@@ -44,15 +45,12 @@ import org.apache.paimon.rest.exceptions.NoSuchResourceException;
 import org.apache.paimon.rest.exceptions.NotImplementedException;
 import org.apache.paimon.rest.exceptions.ServiceFailureException;
 import org.apache.paimon.rest.requests.AlterDatabaseRequest;
-import org.apache.paimon.rest.requests.AlterPartitionsRequest;
 import org.apache.paimon.rest.requests.AlterTableRequest;
 import org.apache.paimon.rest.requests.CommitTableRequest;
 import org.apache.paimon.rest.requests.CreateBranchRequest;
 import org.apache.paimon.rest.requests.CreateDatabaseRequest;
-import org.apache.paimon.rest.requests.CreatePartitionsRequest;
 import org.apache.paimon.rest.requests.CreateTableRequest;
 import org.apache.paimon.rest.requests.CreateViewRequest;
-import org.apache.paimon.rest.requests.DropPartitionsRequest;
 import org.apache.paimon.rest.requests.ForwardBranchRequest;
 import org.apache.paimon.rest.requests.MarkDonePartitionsRequest;
 import org.apache.paimon.rest.requests.RenameTableRequest;
@@ -79,7 +77,6 @@ import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.TableSnapshot;
-import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.view.View;
 import org.apache.paimon.view.ViewImpl;
@@ -89,8 +86,6 @@ import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.shade.guava30.com.google.common.collect.Maps;
 
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -122,8 +117,6 @@ import static org.apache.paimon.utils.ThreadPoolUtils.createScheduledThreadPool;
 
 /** A catalog implementation for REST. */
 public class RESTCatalog implements Catalog, SupportsSnapshots, SupportsBranches {
-
-    private static final Logger LOG = LoggerFactory.getLogger(RESTCatalog.class);
 
     public static final String HEADER_PREFIX = "header.";
     public static final String MAX_RESULTS = "maxResults";
@@ -388,7 +381,7 @@ public class RESTCatalog implements Catalog, SupportsSnapshots, SupportsBranches
 
     @Override
     public boolean commitSnapshot(
-            Identifier identifier, Snapshot snapshot, List<Partition> statistics)
+            Identifier identifier, Snapshot snapshot, List<PartitionStatistics> statistics)
             throws TableNotExistException {
         CommitTableRequest request = new CommitTableRequest(snapshot, statistics);
         CommitTableResponse response;
@@ -557,63 +550,6 @@ public class RESTCatalog implements Catalog, SupportsSnapshots, SupportsBranches
     }
 
     @Override
-    public void createPartitions(Identifier identifier, List<Map<String, String>> partitions)
-            throws TableNotExistException {
-        try {
-            CreatePartitionsRequest request = new CreatePartitionsRequest(partitions);
-            client.post(
-                    resourcePaths.partitions(
-                            identifier.getDatabaseName(), identifier.getObjectName()),
-                    request,
-                    restAuthFunction);
-        } catch (NoSuchResourceException e) {
-            throw new TableNotExistException(identifier);
-        } catch (NotImplementedException ignored) {
-            // not a metastore partitioned table
-        }
-    }
-
-    @Override
-    public void dropPartitions(Identifier identifier, List<Map<String, String>> partitions)
-            throws TableNotExistException {
-        try {
-            DropPartitionsRequest request = new DropPartitionsRequest(partitions);
-            client.post(
-                    resourcePaths.dropPartitions(
-                            identifier.getDatabaseName(), identifier.getObjectName()),
-                    request,
-                    restAuthFunction);
-        } catch (NoSuchResourceException e) {
-            throw new TableNotExistException(identifier);
-        } catch (NotImplementedException ignored) {
-            // not a metastore partitioned table
-        }
-
-        try (BatchTableCommit commit = getTable(identifier).newBatchWriteBuilder().newCommit()) {
-            commit.truncatePartitions(partitions);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Override
-    public void alterPartitions(Identifier identifier, List<Partition> partitions)
-            throws TableNotExistException {
-        try {
-            AlterPartitionsRequest request = new AlterPartitionsRequest(partitions);
-            client.post(
-                    resourcePaths.alterPartitions(
-                            identifier.getDatabaseName(), identifier.getObjectName()),
-                    request,
-                    restAuthFunction);
-        } catch (NoSuchResourceException e) {
-            throw new TableNotExistException(identifier);
-        } catch (NotImplementedException ignored) {
-            // not a metastore partitioned table
-        }
-    }
-
-    @Override
     public void markDonePartitions(Identifier identifier, List<Map<String, String>> partitions)
             throws TableNotExistException {
         try {
@@ -634,14 +570,14 @@ public class RESTCatalog implements Catalog, SupportsSnapshots, SupportsBranches
     public List<Partition> listPartitions(Identifier identifier) throws TableNotExistException {
         try {
             return listDataFromPageApi(
-                    queryParams -> {
-                        return client.get(
-                                resourcePaths.partitions(
-                                        identifier.getDatabaseName(), identifier.getObjectName()),
-                                queryParams,
-                                ListPartitionsResponse.class,
-                                restAuthFunction);
-                    });
+                    queryParams ->
+                            client.get(
+                                    resourcePaths.partitions(
+                                            identifier.getDatabaseName(),
+                                            identifier.getObjectName()),
+                                    queryParams,
+                                    ListPartitionsResponse.class,
+                                    restAuthFunction));
         } catch (NoSuchResourceException e) {
             throw new TableNotExistException(identifier);
         } catch (ForbiddenException e) {
@@ -649,6 +585,33 @@ public class RESTCatalog implements Catalog, SupportsSnapshots, SupportsBranches
         } catch (NotImplementedException e) {
             // not a metastore partitioned table
             return listPartitionsFromFileSystem(getTable(identifier));
+        }
+    }
+
+    @Override
+    public PagedList<Partition> listPartitionsPaged(
+            Identifier identifier, @Nullable Integer maxResults, @Nullable String pageToken)
+            throws TableNotExistException {
+        try {
+            ListPartitionsResponse response =
+                    client.get(
+                            resourcePaths.partitions(
+                                    identifier.getDatabaseName(), identifier.getObjectName()),
+                            buildPagedQueryParams(maxResults, pageToken),
+                            ListPartitionsResponse.class,
+                            restAuthFunction);
+            List<Partition> partitions = response.getPartitions();
+            if (partitions == null) {
+                return new PagedList<>(emptyList(), null);
+            }
+            return new PagedList<>(partitions, response.getNextPageToken());
+        } catch (NoSuchResourceException e) {
+            throw new TableNotExistException(identifier);
+        } catch (ForbiddenException e) {
+            throw new TableNoPermissionException(identifier, e);
+        } catch (NotImplementedException e) {
+            // not a metastore partitioned table
+            return new PagedList<>(listPartitionsFromFileSystem(getTable(identifier)), null);
         }
     }
 
@@ -724,33 +687,6 @@ public class RESTCatalog implements Catalog, SupportsSnapshots, SupportsBranches
             throw new TableNotExistException(identifier);
         } catch (ForbiddenException e) {
             throw new TableNoPermissionException(identifier, e);
-        }
-    }
-
-    @Override
-    public PagedList<Partition> listPartitionsPaged(
-            Identifier identifier, @Nullable Integer maxResults, @Nullable String pageToken)
-            throws TableNotExistException {
-        try {
-            ListPartitionsResponse response =
-                    client.get(
-                            resourcePaths.partitions(
-                                    identifier.getDatabaseName(), identifier.getObjectName()),
-                            buildPagedQueryParams(maxResults, pageToken),
-                            ListPartitionsResponse.class,
-                            restAuthFunction);
-            List<Partition> partitions = response.getPartitions();
-            if (partitions == null) {
-                return new PagedList<>(emptyList(), null);
-            }
-            return new PagedList<>(partitions, response.getNextPageToken());
-        } catch (NoSuchResourceException e) {
-            throw new TableNotExistException(identifier);
-        } catch (ForbiddenException e) {
-            throw new TableNoPermissionException(identifier, e);
-        } catch (NotImplementedException e) {
-            // not a metastore partitioned table
-            return new PagedList<>(listPartitionsFromFileSystem(getTable(identifier)), null);
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/rest/ResourcePaths.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/ResourcePaths.java
@@ -129,30 +129,6 @@ public class ResourcePaths {
                 PARTITIONS);
     }
 
-    public String dropPartitions(String databaseName, String objectName) {
-        return SLASH.join(
-                V1,
-                prefix,
-                DATABASES,
-                encodeString(databaseName),
-                TABLES,
-                encodeString(objectName),
-                PARTITIONS,
-                "drop");
-    }
-
-    public String alterPartitions(String databaseName, String objectName) {
-        return SLASH.join(
-                V1,
-                prefix,
-                DATABASES,
-                encodeString(databaseName),
-                TABLES,
-                encodeString(objectName),
-                PARTITIONS,
-                "alter");
-    }
-
     public String markDonePartitions(String databaseName, String objectName) {
         return SLASH.join(
                 V1,

--- a/paimon-core/src/main/java/org/apache/paimon/rest/requests/CommitTableRequest.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/requests/CommitTableRequest.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.rest.requests;
 
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.partition.Partition;
+import org.apache.paimon.partition.PartitionStatistics;
 import org.apache.paimon.rest.RESTRequest;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
@@ -40,12 +40,12 @@ public class CommitTableRequest implements RESTRequest {
     private final Snapshot snapshot;
 
     @JsonProperty(FIELD_STATISTICS)
-    private final List<Partition> statistics;
+    private final List<PartitionStatistics> statistics;
 
     @JsonCreator
     public CommitTableRequest(
             @JsonProperty(FIELD_SNAPSHOT) Snapshot snapshot,
-            @JsonProperty(FIELD_STATISTICS) List<Partition> statistics) {
+            @JsonProperty(FIELD_STATISTICS) List<PartitionStatistics> statistics) {
         this.snapshot = snapshot;
         this.statistics = statistics;
     }
@@ -56,7 +56,7 @@ public class CommitTableRequest implements RESTRequest {
     }
 
     @JsonGetter(FIELD_STATISTICS)
-    public List<Partition> getStatistics() {
+    public List<PartitionStatistics> getStatistics() {
         return statistics;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/rest/requests/GetPartitionsRequest.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/requests/GetPartitionsRequest.java
@@ -25,12 +25,12 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonPro
 import java.util.List;
 import java.util.Map;
 
-/** Request for dropping partition. */
+/** Request for getting partitions. */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class DropPartitionsRequest extends BasePartitionsRequest {
+public class GetPartitionsRequest extends BasePartitionsRequest {
 
     @JsonCreator
-    public DropPartitionsRequest(
+    public GetPartitionsRequest(
             @JsonProperty(FIELD_PARTITION_SPECS) List<Map<String, String>> partitionSpecs) {
         super(partitionSpecs);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/PartitionStatisticsReporter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/PartitionStatisticsReporter.java
@@ -21,7 +21,7 @@ package org.apache.paimon.utils;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.io.DataFileMeta;
-import org.apache.paimon.partition.Partition;
+import org.apache.paimon.partition.PartitionStatistics;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.PartitionHandler;
 import org.apache.paimon.table.source.DataSplit;
@@ -82,8 +82,9 @@ public class PartitionStatisticsReporter implements Closeable {
                 }
             }
 
-            Partition partitionStats =
-                    new Partition(partitionSpec, fileCount, totalSize, rowCount, modifyTimeMillis);
+            PartitionStatistics partitionStats =
+                    new PartitionStatistics(
+                            partitionSpec, fileCount, totalSize, rowCount, modifyTimeMillis);
             LOG.info("alter partition {} with statistic {}.", partitionSpec, partitionStats);
             partitionHandler.alterPartitions(Collections.singletonList(partitionStats));
         }

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
@@ -233,8 +233,7 @@ public class IcebergCompatibilityTest {
                 Map<String, String> partition = new HashMap<>();
                 partition.put("pt1", "20250304");
                 partition.put("pt2", "16");
-                paimonCatalog.dropPartitions(
-                        paimonIdentifier, Collections.singletonList(partition));
+                commit.truncatePartitions(Collections.singletonList(partition));
 
                 assertThat(getIcebergResult())
                         .containsExactlyInAnyOrder(
@@ -243,8 +242,7 @@ public class IcebergCompatibilityTest {
                 // delete the first-level partition
                 Map<String, String> partition = new HashMap<>();
                 partition.put("pt1", "20250304");
-                paimonCatalog.dropPartitions(
-                        paimonIdentifier, Collections.singletonList(partition));
+                commit.truncatePartitions(Collections.singletonList(partition));
 
                 assertThat(getIcebergResult())
                         .containsExactlyInAnyOrder("Record(20250305, 15, 1, 1)");

--- a/paimon-core/src/test/java/org/apache/paimon/operation/PartitionExpireTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/PartitionExpireTest.java
@@ -29,7 +29,7 @@ import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataIncrement;
 import org.apache.paimon.options.Options;
-import org.apache.paimon.partition.Partition;
+import org.apache.paimon.partition.PartitionStatistics;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
@@ -122,7 +122,7 @@ public class PartitionExpireTest {
                     }
 
                     @Override
-                    public void alterPartitions(List<Partition> partitions)
+                    public void alterPartitions(List<PartitionStatistics> partitions)
                             throws Catalog.TableNotExistException {}
 
                     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTMessage.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTMessage.java
@@ -27,7 +27,7 @@ import org.apache.paimon.rest.requests.CreateDatabaseRequest;
 import org.apache.paimon.rest.requests.CreatePartitionsRequest;
 import org.apache.paimon.rest.requests.CreateTableRequest;
 import org.apache.paimon.rest.requests.CreateViewRequest;
-import org.apache.paimon.rest.requests.DropPartitionsRequest;
+import org.apache.paimon.rest.requests.GetPartitionsRequest;
 import org.apache.paimon.rest.requests.RenameTableRequest;
 import org.apache.paimon.rest.responses.AlterDatabaseResponse;
 import org.apache.paimon.rest.responses.CreateDatabaseResponse;
@@ -144,14 +144,14 @@ public class MockRESTMessage {
         return new CreatePartitionsRequest(ImmutableList.of(Collections.singletonMap("pt", "1")));
     }
 
-    public static DropPartitionsRequest dropPartitionsRequest() {
-        return new DropPartitionsRequest(ImmutableList.of(Collections.singletonMap("pt", "1")));
+    public static GetPartitionsRequest dropPartitionsRequest() {
+        return new GetPartitionsRequest(ImmutableList.of(Collections.singletonMap("pt", "1")));
     }
 
     public static ListPartitionsResponse listPartitionsResponse() {
         Map<String, String> spec = new HashMap<>();
         spec.put("f0", "1");
-        Partition partition = new Partition(spec, 1, 1, 1, 1);
+        Partition partition = new Partition(spec, 1, 1, 1, 1, false);
         return new ListPartitionsResponse(ImmutableList.of(partition));
     }
 
@@ -269,7 +269,7 @@ public class MockRESTMessage {
     }
 
     private static Partition partition() {
-        return new Partition(Collections.singletonMap("pt", "1"), 1, 1, 1, 1);
+        return new Partition(Collections.singletonMap("pt", "1"), 1, 1, 1, 1, false);
     }
 
     private static Schema schema(Map<String, String> options) {

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -50,7 +50,7 @@ import org.apache.paimon.rest.requests.CreateDatabaseRequest;
 import org.apache.paimon.rest.requests.CreatePartitionsRequest;
 import org.apache.paimon.rest.requests.CreateTableRequest;
 import org.apache.paimon.rest.requests.CreateViewRequest;
-import org.apache.paimon.rest.requests.DropPartitionsRequest;
+import org.apache.paimon.rest.requests.GetPartitionsRequest;
 import org.apache.paimon.rest.requests.MarkDonePartitionsRequest;
 import org.apache.paimon.rest.requests.RenameTableRequest;
 import org.apache.paimon.rest.responses.AlterDatabaseResponse;
@@ -115,6 +115,7 @@ import static org.apache.paimon.rest.RESTObjectMapper.OBJECT_MAPPER;
 
 /** Mock REST server for testing. */
 public class RESTCatalogServer {
+
     private static final Logger LOG = LoggerFactory.getLogger(RESTCatalogServer.class);
 
     public static final int DEFAULT_MAX_RESULTS = 100;
@@ -1343,9 +1344,9 @@ public class RESTCatalogServer {
 
     private MockResponse dropPartitionsHandle(Identifier identifier, String data)
             throws Catalog.TableNotExistException, JsonProcessingException {
-        DropPartitionsRequest dropPartitionsRequest =
-                OBJECT_MAPPER.readValue(data, DropPartitionsRequest.class);
-        List<Map<String, String>> partitionSpecs = dropPartitionsRequest.getPartitionSpecs();
+        GetPartitionsRequest getPartitionsRequest =
+                OBJECT_MAPPER.readValue(data, GetPartitionsRequest.class);
+        List<Map<String, String>> partitionSpecs = getPartitionsRequest.getPartitionSpecs();
         if (tableMetadataStore.containsKey(identifier.getFullName())) {
             List<Partition> existPartitions = tablePartitionsStore.get(identifier.getFullName());
             partitionSpecs.forEach(
@@ -1439,7 +1440,7 @@ public class RESTCatalogServer {
 
     private Partition spec2Partition(Map<String, String> spec) {
         // todo: need update
-        return new Partition(spec, 123, 456, 789, 123);
+        return new Partition(spec, 123, 456, 789, 123, false);
     }
 
     private FileStoreTable getFileTable(Identifier identifier)

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTestBase.java
@@ -29,6 +29,7 @@ import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
+import org.apache.paimon.partition.PartitionStatistics;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.rest.auth.DLFToken;
 import org.apache.paimon.rest.responses.ConfigResponse;
@@ -64,15 +65,12 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.apache.paimon.CoreOptions.METASTORE_PARTITIONED_TABLE;
-import static org.apache.paimon.CoreOptions.METASTORE_TAG_TO_PARTITION;
 import static org.apache.paimon.catalog.Catalog.SYSTEM_DATABASE_NAME;
 import static org.apache.paimon.rest.RESTCatalog.PAGE_TOKEN;
 import static org.apache.paimon.rest.auth.DLFAuthProvider.TOKEN_DATE_FORMATTER;
@@ -262,7 +260,7 @@ public abstract class RESTCatalogTestBase extends CatalogTestBase {
                         restCatalog.commitSnapshot(
                                 identifier,
                                 createSnapshotWithMillis(1L, System.currentTimeMillis()),
-                                new ArrayList<Partition>()));
+                                new ArrayList<PartitionStatistics>()));
     }
 
     @Test
@@ -585,29 +583,30 @@ public abstract class RESTCatalogTestBase extends CatalogTestBase {
                                         "non_existing_db", finalMaxResults, pageToken));
     }
 
-    @Test
-    void testListPartitionsWhenMetastorePartitionedIsTrue() throws Exception {
-        String branchName = "test_branch";
-        Identifier identifier = Identifier.create("test_db", "test_table");
-        Identifier branchIdentifier = new Identifier("test_db", "test_table", branchName);
-        assertThrows(
-                Catalog.TableNotExistException.class, () -> restCatalog.listPartitions(identifier));
-
-        createTable(
-                identifier,
-                ImmutableMap.of(METASTORE_PARTITIONED_TABLE.key(), "" + true),
-                Lists.newArrayList("col1"));
-        List<Partition> result = catalog.listPartitions(identifier);
-        assertEquals(0, result.size());
-        List<Map<String, String>> partitionSpecs =
-                Arrays.asList(
-                        Collections.singletonMap("dt", "20250101"),
-                        Collections.singletonMap("dt", "20250102"));
-        restCatalog.createBranch(identifier, branchName, null);
-        restCatalog.createPartitions(branchIdentifier, Lists.newArrayList(partitionSpecs));
-        assertThat(catalog.listPartitions(identifier).stream().map(Partition::spec))
-                .containsExactlyInAnyOrder(partitionSpecs.get(0), partitionSpecs.get(1));
-    }
+    //    @Test
+    //    void testListPartitionsWhenMetastorePartitionedIsTrue() throws Exception {
+    //        String branchName = "test_branch";
+    //        Identifier identifier = Identifier.create("test_db", "test_table");
+    //        Identifier branchIdentifier = new Identifier("test_db", "test_table", branchName);
+    //        assertThrows(
+    //                Catalog.TableNotExistException.class, () ->
+    // restCatalog.listPartitions(identifier));
+    //
+    //        createTable(
+    //                identifier,
+    //                ImmutableMap.of(METASTORE_PARTITIONED_TABLE.key(), "" + true),
+    //                Lists.newArrayList("col1"));
+    //        List<Partition> result = catalog.listPartitions(identifier);
+    //        assertEquals(0, result.size());
+    //        List<Map<String, String>> partitionSpecs =
+    //                Arrays.asList(
+    //                        Collections.singletonMap("dt", "20250101"),
+    //                        Collections.singletonMap("dt", "20250102"));
+    //        restCatalog.createBranch(identifier, branchName, null);
+    //        restCatalog.createPartitions(branchIdentifier, Lists.newArrayList(partitionSpecs));
+    //        assertThat(catalog.listPartitions(identifier).stream().map(Partition::spec))
+    //                .containsExactlyInAnyOrder(partitionSpecs.get(0), partitionSpecs.get(1));
+    //    }
 
     @Test
     void testListPartitionsFromFile() throws Exception {
@@ -617,121 +616,122 @@ public abstract class RESTCatalogTestBase extends CatalogTestBase {
         assertEquals(0, result.size());
     }
 
-    @Test
-    void testListPartitions() throws Exception {
-        List<Map<String, String>> partitionSpecs =
-                Arrays.asList(
-                        Collections.singletonMap("dt", "20250101"),
-                        Collections.singletonMap("dt", "20250102"),
-                        Collections.singletonMap("dt", "20240102"),
-                        Collections.singletonMap("dt", "20260101"),
-                        Collections.singletonMap("dt", "20250104"),
-                        Collections.singletonMap("dt", "20250103"));
-        Map[] sortedSpecs =
-                partitionSpecs.stream()
-                        .sorted(Comparator.comparing(i -> i.get("dt")))
-                        .toArray(Map[]::new);
+    //    @Test
+    //    void testListPartitions() throws Exception {
+    //        List<Map<String, String>> partitionSpecs =
+    //                Arrays.asList(
+    //                        Collections.singletonMap("dt", "20250101"),
+    //                        Collections.singletonMap("dt", "20250102"),
+    //                        Collections.singletonMap("dt", "20240102"),
+    //                        Collections.singletonMap("dt", "20260101"),
+    //                        Collections.singletonMap("dt", "20250104"),
+    //                        Collections.singletonMap("dt", "20250103"));
+    //        Map[] sortedSpecs =
+    //                partitionSpecs.stream()
+    //                        .sorted(Comparator.comparing(i -> i.get("dt")))
+    //                        .toArray(Map[]::new);
+    //
+    //        String databaseName = "partitions_db";
+    //        Identifier identifier = Identifier.create(databaseName, "table");
+    //        Schema schema =
+    //                Schema.newBuilder()
+    //                        .option(METASTORE_PARTITIONED_TABLE.key(), "true")
+    //                        .option(METASTORE_TAG_TO_PARTITION.key(), "dt")
+    //                        .column("col", DataTypes.INT())
+    //                        .column("dt", DataTypes.STRING())
+    //                        .partitionKeys("dt")
+    //                        .build();
+    //
+    //        restCatalog.createDatabase(databaseName, true);
+    //        restCatalog.createTable(identifier, schema, true);
+    //        restCatalog.createPartitions(identifier, partitionSpecs);
+    //
+    //        List<Partition> restPartitions = restCatalog.listPartitions(identifier);
+    //        assertThat(restPartitions.stream().map(Partition::spec)).containsExactly(sortedSpecs);
+    //    }
 
-        String databaseName = "partitions_db";
-        Identifier identifier = Identifier.create(databaseName, "table");
-        Schema schema =
-                Schema.newBuilder()
-                        .option(METASTORE_PARTITIONED_TABLE.key(), "true")
-                        .option(METASTORE_TAG_TO_PARTITION.key(), "dt")
-                        .column("col", DataTypes.INT())
-                        .column("dt", DataTypes.STRING())
-                        .partitionKeys("dt")
-                        .build();
-
-        restCatalog.createDatabase(databaseName, true);
-        restCatalog.createTable(identifier, schema, true);
-        restCatalog.createPartitions(identifier, partitionSpecs);
-
-        List<Partition> restPartitions = restCatalog.listPartitions(identifier);
-        assertThat(restPartitions.stream().map(Partition::spec)).containsExactly(sortedSpecs);
-    }
-
-    @Test
-    public void testListPartitionsPaged() throws Exception {
-        String databaseName = "partitions_paged_db";
-        List<Map<String, String>> partitionSpecs =
-                Arrays.asList(
-                        Collections.singletonMap("dt", "20250101"),
-                        Collections.singletonMap("dt", "20250102"),
-                        Collections.singletonMap("dt", "20240102"),
-                        Collections.singletonMap("dt", "20260101"),
-                        Collections.singletonMap("dt", "20250104"),
-                        Collections.singletonMap("dt", "20250103"));
-        catalog.dropDatabase(databaseName, true, true);
-        catalog.createDatabase(databaseName, true);
-        Identifier identifier = Identifier.create(databaseName, "table");
-
-        assertThrows(
-                Catalog.TableNotExistException.class,
-                () -> catalog.listPartitionsPaged(identifier, 10, "dt=20250101"));
-
-        catalog.createTable(
-                identifier,
-                Schema.newBuilder()
-                        .option(METASTORE_PARTITIONED_TABLE.key(), "true")
-                        .option(METASTORE_TAG_TO_PARTITION.key(), "dt")
-                        .column("col", DataTypes.INT())
-                        .column("dt", DataTypes.STRING())
-                        .partitionKeys("dt")
-                        .build(),
-                true);
-
-        catalog.createPartitions(identifier, partitionSpecs);
-        PagedList<Partition> pagedPartitions = catalog.listPartitionsPaged(identifier, null, null);
-        Map[] sortedSpecs =
-                partitionSpecs.stream()
-                        .sorted(Comparator.comparing(i -> i.get("dt")))
-                        .toArray(Map[]::new);
-        assertPagedPartitions(pagedPartitions, partitionSpecs.size(), sortedSpecs);
-
-        int maxResults = 2;
-        pagedPartitions = catalog.listPartitionsPaged(identifier, maxResults, null);
-        assertPagedPartitions(
-                pagedPartitions, maxResults, partitionSpecs.get(2), partitionSpecs.get(0));
-        assertEquals("dt=20250101", pagedPartitions.getNextPageToken());
-
-        pagedPartitions =
-                catalog.listPartitionsPaged(
-                        identifier, maxResults, pagedPartitions.getNextPageToken());
-        assertPagedPartitions(
-                pagedPartitions, maxResults, partitionSpecs.get(1), partitionSpecs.get(5));
-        assertEquals("dt=20250103", pagedPartitions.getNextPageToken());
-
-        pagedPartitions =
-                catalog.listPartitionsPaged(
-                        identifier, maxResults, pagedPartitions.getNextPageToken());
-        assertPagedPartitions(
-                pagedPartitions, maxResults, partitionSpecs.get(4), partitionSpecs.get(3));
-        assertEquals("dt=20260101", pagedPartitions.getNextPageToken());
-
-        pagedPartitions =
-                catalog.listPartitionsPaged(
-                        identifier, maxResults, pagedPartitions.getNextPageToken());
-        assertThat(pagedPartitions.getElements()).isEmpty();
-        assertNull(pagedPartitions.getNextPageToken());
-
-        maxResults = 8;
-        pagedPartitions = catalog.listPartitionsPaged(identifier, maxResults, null);
-
-        assertPagedPartitions(
-                pagedPartitions, Math.min(maxResults, partitionSpecs.size()), sortedSpecs);
-        assertNull(pagedPartitions.getNextPageToken());
-
-        pagedPartitions = catalog.listPartitionsPaged(identifier, maxResults, "dt=20250101");
-        assertPagedPartitions(
-                pagedPartitions,
-                4,
-                partitionSpecs.get(1),
-                partitionSpecs.get(5),
-                partitionSpecs.get(4),
-                partitionSpecs.get(3));
-        assertNull(pagedPartitions.getNextPageToken());
-    }
+    //    @Test
+    //    public void testListPartitionsPaged() throws Exception {
+    //        String databaseName = "partitions_paged_db";
+    //        List<Map<String, String>> partitionSpecs =
+    //                Arrays.asList(
+    //                        Collections.singletonMap("dt", "20250101"),
+    //                        Collections.singletonMap("dt", "20250102"),
+    //                        Collections.singletonMap("dt", "20240102"),
+    //                        Collections.singletonMap("dt", "20260101"),
+    //                        Collections.singletonMap("dt", "20250104"),
+    //                        Collections.singletonMap("dt", "20250103"));
+    //        catalog.dropDatabase(databaseName, true, true);
+    //        catalog.createDatabase(databaseName, true);
+    //        Identifier identifier = Identifier.create(databaseName, "table");
+    //
+    //        assertThrows(
+    //                Catalog.TableNotExistException.class,
+    //                () -> catalog.listPartitionsPaged(identifier, 10, "dt=20250101"));
+    //
+    //        catalog.createTable(
+    //                identifier,
+    //                Schema.newBuilder()
+    //                        .option(METASTORE_PARTITIONED_TABLE.key(), "true")
+    //                        .option(METASTORE_TAG_TO_PARTITION.key(), "dt")
+    //                        .column("col", DataTypes.INT())
+    //                        .column("dt", DataTypes.STRING())
+    //                        .partitionKeys("dt")
+    //                        .build(),
+    //                true);
+    //
+    //        catalog.createPartitions(identifier, partitionSpecs);
+    //        PagedList<Partition> pagedPartitions = catalog.listPartitionsPaged(identifier, null,
+    // null);
+    //        Map[] sortedSpecs =
+    //                partitionSpecs.stream()
+    //                        .sorted(Comparator.comparing(i -> i.get("dt")))
+    //                        .toArray(Map[]::new);
+    //        assertPagedPartitions(pagedPartitions, partitionSpecs.size(), sortedSpecs);
+    //
+    //        int maxResults = 2;
+    //        pagedPartitions = catalog.listPartitionsPaged(identifier, maxResults, null);
+    //        assertPagedPartitions(
+    //                pagedPartitions, maxResults, partitionSpecs.get(2), partitionSpecs.get(0));
+    //        assertEquals("dt=20250101", pagedPartitions.getNextPageToken());
+    //
+    //        pagedPartitions =
+    //                catalog.listPartitionsPaged(
+    //                        identifier, maxResults, pagedPartitions.getNextPageToken());
+    //        assertPagedPartitions(
+    //                pagedPartitions, maxResults, partitionSpecs.get(1), partitionSpecs.get(5));
+    //        assertEquals("dt=20250103", pagedPartitions.getNextPageToken());
+    //
+    //        pagedPartitions =
+    //                catalog.listPartitionsPaged(
+    //                        identifier, maxResults, pagedPartitions.getNextPageToken());
+    //        assertPagedPartitions(
+    //                pagedPartitions, maxResults, partitionSpecs.get(4), partitionSpecs.get(3));
+    //        assertEquals("dt=20260101", pagedPartitions.getNextPageToken());
+    //
+    //        pagedPartitions =
+    //                catalog.listPartitionsPaged(
+    //                        identifier, maxResults, pagedPartitions.getNextPageToken());
+    //        assertThat(pagedPartitions.getElements()).isEmpty();
+    //        assertNull(pagedPartitions.getNextPageToken());
+    //
+    //        maxResults = 8;
+    //        pagedPartitions = catalog.listPartitionsPaged(identifier, maxResults, null);
+    //
+    //        assertPagedPartitions(
+    //                pagedPartitions, Math.min(maxResults, partitionSpecs.size()), sortedSpecs);
+    //        assertNull(pagedPartitions.getNextPageToken());
+    //
+    //        pagedPartitions = catalog.listPartitionsPaged(identifier, maxResults, "dt=20250101");
+    //        assertPagedPartitions(
+    //                pagedPartitions,
+    //                4,
+    //                partitionSpecs.get(1),
+    //                partitionSpecs.get(5),
+    //                partitionSpecs.get(4),
+    //                partitionSpecs.get(3));
+    //        assertNull(pagedPartitions.getNextPageToken());
+    //    }
 
     @Test
     void testRefreshFileIO() throws Exception {
@@ -793,7 +793,7 @@ public abstract class RESTCatalogTestBase extends CatalogTestBase {
                         restCatalog.commitSnapshot(
                                 hasSnapshotTableIdentifier,
                                 createSnapshotWithMillis(1L, System.currentTimeMillis()),
-                                new ArrayList<Partition>()));
+                                new ArrayList<PartitionStatistics>()));
 
         createTable(hasSnapshotTableIdentifier, Maps.newHashMap(), Lists.newArrayList("col1"));
         long id = 10086;
@@ -971,7 +971,8 @@ public abstract class RESTCatalogTestBase extends CatalogTestBase {
 
     @Override
     protected boolean supportPartitions() {
-        return true;
+        // TODO support this
+        return false;
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTObjectMapperTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTObjectMapperTest.java
@@ -25,7 +25,7 @@ import org.apache.paimon.rest.requests.CreateDatabaseRequest;
 import org.apache.paimon.rest.requests.CreatePartitionsRequest;
 import org.apache.paimon.rest.requests.CreateTableRequest;
 import org.apache.paimon.rest.requests.CreateViewRequest;
-import org.apache.paimon.rest.requests.DropPartitionsRequest;
+import org.apache.paimon.rest.requests.GetPartitionsRequest;
 import org.apache.paimon.rest.requests.RenameTableRequest;
 import org.apache.paimon.rest.responses.AlterDatabaseResponse;
 import org.apache.paimon.rest.responses.ConfigResponse;
@@ -219,10 +219,10 @@ public class RESTObjectMapperTest {
 
     @Test
     public void dropPartitionRequestParseTest() throws JsonProcessingException {
-        DropPartitionsRequest request = MockRESTMessage.dropPartitionsRequest();
+        GetPartitionsRequest request = MockRESTMessage.dropPartitionsRequest();
         String requestStr = OBJECT_MAPPER.writeValueAsString(request);
-        DropPartitionsRequest parseData =
-                OBJECT_MAPPER.readValue(requestStr, DropPartitionsRequest.class);
+        GetPartitionsRequest parseData =
+                OBJECT_MAPPER.readValue(requestStr, GetPartitionsRequest.class);
         assertEquals(parseData.getPartitionSpecs().size(), parseData.getPartitionSpecs().size());
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/utils/PartitionStatisticsReporterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/PartitionStatisticsReporterTest.java
@@ -22,7 +22,7 @@ import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
-import org.apache.paimon.partition.Partition;
+import org.apache.paimon.partition.PartitionStatistics;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.FileStoreTable;
@@ -83,7 +83,7 @@ public class PartitionStatisticsReporterTest {
         BatchTableCommit committer = table.newBatchWriteBuilder().newCommit();
         committer.commit(messages);
         AtomicBoolean closed = new AtomicBoolean(false);
-        Map<String, Partition> partitionParams = Maps.newHashMap();
+        Map<String, PartitionStatistics> partitionParams = Maps.newHashMap();
 
         PartitionHandler partitionHandler =
                 new PartitionHandler() {
@@ -104,7 +104,7 @@ public class PartitionStatisticsReporterTest {
                     }
 
                     @Override
-                    public void alterPartitions(List<Partition> partitions) {
+                    public void alterPartitions(List<PartitionStatistics> partitions) {
                         partitions.forEach(
                                 partition -> {
                                     partitionParams.put(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -26,6 +26,7 @@ import org.apache.paimon.catalog.CatalogUtils;
 import org.apache.paimon.catalog.Database;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.catalog.PropertyChange;
+import org.apache.paimon.catalog.SupportsPartitionModification;
 import org.apache.paimon.flink.procedure.ProcedureUtil;
 import org.apache.paimon.flink.utils.FlinkCatalogPropertiesUtil;
 import org.apache.paimon.flink.utils.FlinkDescriptorProperties;
@@ -1418,8 +1419,12 @@ public class FlinkCatalog extends AbstractCatalog {
 
         try {
             Identifier identifier = toIdentifier(tablePath);
-            catalog.createPartitions(
-                    identifier, Collections.singletonList(partitionSpec.getPartitionSpec()));
+            if (catalog instanceof SupportsPartitionModification) {
+                ((SupportsPartitionModification) catalog)
+                        .createPartitions(
+                                identifier,
+                                Collections.singletonList(partitionSpec.getPartitionSpec()));
+            }
         } catch (Catalog.TableNotExistException e) {
             throw new CatalogException(e);
         }
@@ -1438,8 +1443,18 @@ public class FlinkCatalog extends AbstractCatalog {
 
         try {
             Identifier identifier = toIdentifier(tablePath);
-            catalog.dropPartitions(
-                    identifier, Collections.singletonList(partitionSpec.getPartitionSpec()));
+            List<Map<String, String>> partitions =
+                    Collections.singletonList(partitionSpec.getPartitionSpec());
+            if (catalog instanceof SupportsPartitionModification) {
+                ((SupportsPartitionModification) catalog).dropPartitions(identifier, partitions);
+            } else {
+                Table table = catalog.getTable(identifier);
+                try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
+                    commit.truncatePartitions(partitions);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
         } catch (Catalog.TableNotExistException e) {
             throw new CatalogException(e);
         }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/AddDonePartitionActionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/AddDonePartitionActionTest.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.flink.sink.partition;
 
 import org.apache.paimon.catalog.Catalog;
-import org.apache.paimon.partition.Partition;
+import org.apache.paimon.partition.PartitionStatistics;
 import org.apache.paimon.partition.actions.AddDonePartitionAction;
 import org.apache.paimon.table.PartitionHandler;
 
@@ -64,7 +64,7 @@ class AddDonePartitionActionTest {
                             throws Catalog.TableNotExistException {}
 
                     @Override
-                    public void alterPartitions(List<Partition> partitions)
+                    public void alterPartitions(List<PartitionStatistics> partitions)
                             throws Catalog.TableNotExistException {}
 
                     @Override

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -26,6 +26,7 @@ import org.apache.paimon.client.ClientPool;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
+import org.apache.paimon.partition.PartitionStatistics;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.types.DataField;
@@ -56,10 +57,12 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORECONNECTURLKEY;
+import static org.apache.paimon.CoreOptions.METASTORE_PARTITIONED_TABLE;
 import static org.apache.paimon.CoreOptions.METASTORE_TAG_TO_PARTITION;
 import static org.apache.paimon.hive.HiveCatalog.PAIMON_TABLE_IDENTIFIER;
 import static org.apache.paimon.hive.HiveCatalog.TABLE_TYPE_PROP;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -468,15 +471,70 @@ public class HiveCatalogTest extends CatalogTestBase {
                         .build(),
                 true);
 
-        catalog.createPartitions(
-                identifier,
-                Arrays.asList(
-                        Collections.singletonMap("dt", "20250101"),
-                        Collections.singletonMap("dt", "20250102")));
+        ((HiveCatalog) catalog)
+                .createPartitions(
+                        identifier,
+                        Arrays.asList(
+                                Collections.singletonMap("dt", "20250101"),
+                                Collections.singletonMap("dt", "20250102")));
         assertThat(catalog.listPartitions(identifier).stream().map(Partition::spec))
                 .containsExactlyInAnyOrder(
                         Collections.singletonMap("dt", "20250102"),
                         Collections.singletonMap("dt", "20250101"));
+    }
+
+    @Test
+    public void testAlterPartitions() throws Exception {
+        if (!supportPartitions()) {
+            return;
+        }
+        String databaseName = "testAlterPartitionTable";
+        catalog.dropDatabase(databaseName, true, true);
+        catalog.createDatabase(databaseName, true);
+        Identifier alterIdentifier = Identifier.create(databaseName, "alert_partitions");
+        catalog.createTable(
+                alterIdentifier,
+                Schema.newBuilder()
+                        .option(METASTORE_PARTITIONED_TABLE.key(), "true")
+                        .option(METASTORE_TAG_TO_PARTITION.key(), "dt")
+                        .column("col", DataTypes.INT())
+                        .column("dt", DataTypes.STRING())
+                        .partitionKeys("dt")
+                        .build(),
+                true);
+        ((HiveCatalog) catalog)
+                .createPartitions(
+                        alterIdentifier, Arrays.asList(Collections.singletonMap("dt", "20250101")));
+        assertThat(catalog.listPartitions(alterIdentifier).stream().map(Partition::spec))
+                .containsExactlyInAnyOrder(Collections.singletonMap("dt", "20250101"));
+        PartitionStatistics partition =
+                new PartitionStatistics(
+                        Collections.singletonMap("dt", "20250101"),
+                        1,
+                        2,
+                        3,
+                        System.currentTimeMillis());
+        ((HiveCatalog) catalog).alterPartitions(alterIdentifier, Arrays.asList(partition));
+        Partition partitionFromServer = catalog.listPartitions(alterIdentifier).get(0);
+        checkPartition(
+                new Partition(
+                        Collections.singletonMap("dt", "20250101"),
+                        1,
+                        2,
+                        3,
+                        System.currentTimeMillis(),
+                        false),
+                partitionFromServer);
+
+        // Test when table does not exist
+        assertThatExceptionOfType(Catalog.TableNotExistException.class)
+                .isThrownBy(
+                        () ->
+                                ((HiveCatalog) catalog)
+                                        .alterPartitions(
+                                                Identifier.create(
+                                                        databaseName, "non_existing_table"),
+                                                Arrays.asList(partition)));
     }
 
     @Override

--- a/paimon-open-api/rest-catalog-open-api.yaml
+++ b/paimon-open-api/rest-catalog-open-api.yaml
@@ -630,119 +630,6 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         "500":
           description: Internal Server Error
-    post:
-      tags:
-        - partition
-      summary: Create partitions, ignore existing partitions
-      operationId: createPartitions
-      parameters:
-        - name: prefix
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: database
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: table
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreatePartitionsRequest'
-      responses:
-        "200":
-          description: Success, no content
-        "404":
-          description: Resource not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        "500":
-          description: Internal Server Error
-  /v1/{prefix}/databases/{database}/tables/{table}/partitions/drop:
-    post:
-      tags:
-        - partition
-      summary: Drop partitions, ignore non-existent partitions
-      operationId: dropPartitions
-      parameters:
-        - name: prefix
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: database
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: table
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DropPartitionsRequest'
-      responses:
-        "200":
-          description: Success, no content
-        "404":
-          description: Resource not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        "500":
-          description: Internal Server Error
-  /v1/{prefix}/databases/{database}/tables/{table}/partitions/alter:
-    post:
-      tags:
-        - partition
-      summary: Alter partitions, for non-existent partitions, partitions will be created directly
-      operationId: alterPartitions
-      parameters:
-        - name: prefix
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: database
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: table
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AlterPartitionsRequest'
-      responses:
-        "200":
-          description: Success, no content
-        "404":
-          description: Resource not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        "500":
-          description: Internal Server Error
   /v1/{prefix}/databases/{database}/tables/{table}/partitions/mark:
     post:
       tags:
@@ -1480,7 +1367,7 @@ components:
         statistics:
           type: array
           items:
-            $ref: '#/components/schemas/Partition'
+            $ref: '#/components/schemas/PartitionStatistics'
     Snapshot:
       type: object
       properties:
@@ -1727,6 +1614,25 @@ components:
           additionalProperties:
             type: string
     Partition:
+      type: object
+      properties:
+        spec:
+          type: object
+        recordCount:
+          type: integer
+          format: int64
+        fileSizeInBytes:
+          type: integer
+          format: int64
+        fileCount:
+          type: integer
+          format: int64
+        lastFileCreationTime:
+          type: integer
+          format: int64
+        done:
+          type: boolean
+    PartitionStatistics:
       type: object
       properties:
         spec:

--- a/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
+++ b/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
@@ -20,15 +20,12 @@ package org.apache.paimon.open.api;
 
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.rest.requests.AlterDatabaseRequest;
-import org.apache.paimon.rest.requests.AlterPartitionsRequest;
 import org.apache.paimon.rest.requests.AlterTableRequest;
 import org.apache.paimon.rest.requests.CommitTableRequest;
 import org.apache.paimon.rest.requests.CreateBranchRequest;
 import org.apache.paimon.rest.requests.CreateDatabaseRequest;
-import org.apache.paimon.rest.requests.CreatePartitionsRequest;
 import org.apache.paimon.rest.requests.CreateTableRequest;
 import org.apache.paimon.rest.requests.CreateViewRequest;
-import org.apache.paimon.rest.requests.DropPartitionsRequest;
 import org.apache.paimon.rest.requests.ForwardBranchRequest;
 import org.apache.paimon.rest.requests.MarkDonePartitionsRequest;
 import org.apache.paimon.rest.requests.RenameTableRequest;
@@ -483,69 +480,9 @@ public class RESTCatalogController {
         // paged list partitions in this table with provided maxResults and pageToken
         Map<String, String> spec = new HashMap<>();
         spec.put("f1", "1");
-        Partition partition = new Partition(spec, 1, 2, 3, 4);
+        Partition partition = new Partition(spec, 1, 2, 3, 4, false);
         return new ListPartitionsResponse(ImmutableList.of(partition));
     }
-
-    @Operation(
-            summary = "Create partition",
-            tags = {"partition"})
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Success, no content"),
-        @ApiResponse(
-                responseCode = "404",
-                description = "Resource not found",
-                content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
-        @ApiResponse(
-                responseCode = "500",
-                content = {@Content(schema = @Schema())})
-    })
-    @PostMapping("/v1/{prefix}/databases/{database}/tables/{table}/partitions")
-    public void createPartitions(
-            @PathVariable String prefix,
-            @PathVariable String database,
-            @PathVariable String table,
-            @RequestBody CreatePartitionsRequest request) {}
-
-    @Operation(
-            summary = "Drop partitions",
-            tags = {"partition"})
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Success, no content"),
-        @ApiResponse(
-                responseCode = "404",
-                description = "Resource not found",
-                content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
-        @ApiResponse(
-                responseCode = "500",
-                content = {@Content(schema = @Schema())})
-    })
-    @PostMapping("/v1/{prefix}/databases/{database}/tables/{table}/partitions/drop")
-    public void dropPartitions(
-            @PathVariable String prefix,
-            @PathVariable String database,
-            @PathVariable String table,
-            @RequestBody DropPartitionsRequest request) {}
-
-    @Operation(
-            summary = "Alter partitions",
-            tags = {"partition"})
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Success, no content"),
-        @ApiResponse(
-                responseCode = "404",
-                description = "Resource not found",
-                content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
-        @ApiResponse(
-                responseCode = "500",
-                content = {@Content(schema = @Schema())})
-    })
-    @PostMapping("/v1/{prefix}/databases/{database}/tables/{table}/partitions/alter")
-    public void alterPartitions(
-            @PathVariable String prefix,
-            @PathVariable String database,
-            @PathVariable String table,
-            @RequestBody AlterPartitionsRequest request) {}
 
     @Operation(
             summary = "MarkDone partitions",


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Partition information can be calculated in commit snapshot interface, so partition does not need to be calculated by catalog interface.

RESTCatalog only provide list partitions and mark done partitions for partition metadata only.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
