### PR TITLE
[fileio] Introduce FileIO.overwriteHintFile

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
@@ -349,6 +349,15 @@ public interface FileIO extends Serializable, Closeable {
     }
 
     /**
+     * Overwrite hint file by content atomically, the characteristic of Hint file is that it can not
+     * exist for a period of time, which allows some file systems to perform overwrite writing by
+     * deleting and renaming.
+     */
+    default void overwriteHintFile(Path path, String content) throws IOException {
+        overwriteFileUtf8(path, content);
+    }
+
+    /**
      * Copy content of one file into another.
      *
      * @throws IOException Thrown, if the stream could not be opened because of an I/O, or because

--- a/paimon-core/src/main/java/org/apache/paimon/utils/HintFileUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/HintFileUtils.java
@@ -109,7 +109,7 @@ public class HintFileUtils {
         int loopTime = 3;
         while (loopTime-- > 0) {
             try {
-                fileIO.overwriteFileUtf8(hintFile, String.valueOf(id));
+                fileIO.overwriteHintFile(hintFile, String.valueOf(id));
                 return;
             } catch (IOException e) {
                 try {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
```
    /**
     * Overwrite hint file by content atomically, the characteristic of Hint file is that it can not
     * exist for a period of time, which allows some file systems to perform overwrite writing by
     * deleting and renaming.
     */
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
