### PR TITLE
[core] support format table for json

### DIFF
--- a/docs/content/concepts/table-types.md
+++ b/docs/content/concepts/table-types.md
@@ -145,7 +145,7 @@ directory structure.
 
 Format Table is enabled by default, you can disable it by configuring Catalog option: `'format-table.enabled'`.
 
-Currently only support `CSV`, `Parquet`, `ORC` formats.
+Currently only support `CSV`, `Parquet`, `ORC`, `JSON` formats.
 
 {{< tabs "format-table" >}}
 {{< tab "Flink-CSV" >}}
@@ -193,6 +193,30 @@ CREATE TABLE my_parquet_table (
     a INT,
     b STRING
 ) USING parquet
+```
+
+{{< /tab >}}
+
+{{< tab "Flink-JSON" >}}
+
+```sql
+CREATE TABLE my_json_table (
+    a INT,
+    b STRING
+) WITH (
+    'type'='format-table',
+    'file.format'='json'
+)
+```
+{{< /tab >}}
+
+{{< tab "Spark-JSON" >}}
+
+```sql
+CREATE TABLE my_json_table (
+    a INT,
+    b STRING
+) USING json
 ```
 
 {{< /tab >}}

--- a/paimon-core/src/main/java/org/apache/paimon/table/FormatTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FormatTable.java
@@ -68,7 +68,8 @@ public interface FormatTable extends Table {
     enum Format {
         ORC,
         PARQUET,
-        CSV
+        CSV,
+        JSON
     }
 
     /** Parses a file format string to a corresponding {@link Format} enum constant. */

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -1404,6 +1404,8 @@ public class HiveCatalog extends AbstractCatalog {
                 return "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe";
             case ORC:
                 return "org.apache.hadoop.hive.ql.io.orc.OrcSerde";
+            case JSON:
+                return "org.apache.hive.hcatalog.data.JsonSerDe";
         }
         return SERDE_CLASS_NAME;
     }
@@ -1414,6 +1416,7 @@ public class HiveCatalog extends AbstractCatalog {
         }
         switch (provider) {
             case CSV:
+            case JSON:
                 return "org.apache.hadoop.mapred.TextInputFormat";
             case PARQUET:
                 return "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat";
@@ -1429,6 +1432,7 @@ public class HiveCatalog extends AbstractCatalog {
         }
         switch (provider) {
             case CSV:
+            case JSON:
                 return "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat";
             case PARQUET:
                 return "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat";

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveTableUtils.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveTableUtils.java
@@ -72,10 +72,15 @@ class HiveTableUtils {
         } else if (serLib.contains("orc")) {
             format = Format.ORC;
         } else if (inputFormat.contains("Text")) {
-            format = Format.CSV;
-            // hive default field delimiter is '\u0001'
-            options.set(
-                    FIELD_DELIMITER, serdeInfo.getParameters().getOrDefault(FIELD_DELIM, "\u0001"));
+            if (serLib.contains("json")) {
+                format = Format.JSON;
+            } else {
+                format = Format.CSV;
+                // hive default field delimiter is '\u0001'
+                options.set(
+                        FIELD_DELIMITER,
+                        serdeInfo.getParameters().getOrDefault(FIELD_DELIM, "\u0001"));
+            }
         } else {
             throw new UnsupportedOperationException("Unsupported table: " + hiveTable);
         }

--- a/paimon-hive/paimon-hive-connector-2.3/pom.xml
+++ b/paimon-hive/paimon-hive-connector-2.3/pom.xml
@@ -115,6 +115,13 @@ under the License.
 
         <dependency>
             <groupId>org.apache.flink</groupId>
+            <artifactId>flink-json</artifactId>
+            <version>${test.flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-test-utils</artifactId>
             <version>${test.flink.version}</version>
             <scope>test</scope>

--- a/paimon-hive/paimon-hive-connector-3.1/pom.xml
+++ b/paimon-hive/paimon-hive-connector-3.1/pom.xml
@@ -110,6 +110,13 @@ under the License.
 
         <dependency>
             <groupId>org.apache.flink</groupId>
+            <artifactId>flink-json</artifactId>
+            <version>${test.flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
             <artifactId>flink-orc</artifactId>
             <version>${test.flink.version}</version>
             <scope>test</scope>

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -46,10 +46,12 @@ import org.apache.spark.sql.connector.expressions.IdentityTransform;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.execution.datasources.csv.CSVFileFormat;
+import org.apache.spark.sql.execution.datasources.json.JsonFileFormat;
 import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat;
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat;
 import org.apache.spark.sql.execution.datasources.v2.FileTable;
 import org.apache.spark.sql.execution.datasources.v2.csv.CSVTable;
+import org.apache.spark.sql.execution.datasources.v2.json.JsonTable;
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcTable;
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetTable;
 import org.apache.spark.sql.types.StructField;
@@ -489,6 +491,14 @@ public class SparkCatalog extends SparkBaseCatalog implements SupportFunction, S
                     scala.collection.JavaConverters.asScalaBuffer(pathList).toSeq(),
                     scala.Option.apply(schema),
                     ParquetFileFormat.class);
+        } else if (formatTable.format() == FormatTable.Format.JSON) {
+            return new JsonTable(
+                    ident.name(),
+                    SparkSession.active(),
+                    dsOptions,
+                    scala.collection.JavaConverters.asScalaBuffer(pathList).toSeq(),
+                    scala.Option.apply(schema),
+                    JsonFileFormat.class);
         } else {
             throw new UnsupportedOperationException(
                     "Unsupported format table "

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkSource.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkSource.scala
@@ -118,7 +118,7 @@ object SparkSource {
 
   val NAME = "paimon"
 
-  val FORMAT_NAMES: Seq[String] = Seq("csv", "orc", "parquet")
+  val FORMAT_NAMES: Seq[String] = Seq("csv", "orc", "parquet", "json")
 
   def toBaseRelation(table: FileStoreTable, _sqlContext: SQLContext): BaseRelation = {
     new BaseRelation {

--- a/paimon-spark/paimon-spark-ut/pom.xml
+++ b/paimon-spark/paimon-spark-ut/pom.xml
@@ -33,7 +33,7 @@ under the License.
 
     <properties>
         <spark.version>${paimon-spark-common.spark.version}</spark.version>
-        <jackson.version>${paimon.shade.jackson.version}</jackson.version>
+        <jackson.version>2.15.2</jackson.version>
     </properties>
 
     <dependencies>

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithHiveTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithHiveTest.java
@@ -114,6 +114,16 @@ public class SparkCatalogWithHiveTest {
                                 .collect(Collectors.toList()))
                 .containsExactlyInAnyOrder("[1,1,1]", "[2,2,2]");
 
+        // test json table
+
+        spark.sql("CREATE TABLE IF NOT EXISTS table_json (a INT, bb INT, c STRING) USING json");
+        spark.sql("INSERT INTO table_json VALUES(1, 1, '1'), (2, 2, '2')");
+        assertThat(
+                        spark.sql("SELECT * FROM table_json").collectAsList().stream()
+                                .map(Row::toString)
+                                .collect(Collectors.toList()))
+                .containsExactlyInAnyOrder("[1,1,1]", "[2,2,2]");
+
         spark.close();
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
Currently paimon format table only support CSV, Parquet, ORC formats, this pr adds support for json format.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
