### PR TITLE
[common] Fix bug in BitmapIndexResult 'or' operation.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bitmap/BitmapIndexResult.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bitmap/BitmapIndexResult.java
@@ -51,6 +51,6 @@ public class BitmapIndexResult extends LazyField<RoaringBitmap32> implements Fil
             return new BitmapIndexResult(
                     () -> RoaringBitmap32.or(get(), ((BitmapIndexResult) fileIndexResult).get()));
         }
-        return FileIndexResult.super.and(fileIndexResult);
+        return FileIndexResult.super.or(fileIndexResult);
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/bitmapindex/BitmapFileIndexTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/bitmapindex/BitmapFileIndexTest.java
@@ -81,6 +81,29 @@ public class BitmapFileIndexTest {
     }
 
     @Test
+    public void testCompoundIndexResult() {
+
+        BitmapIndexResult bitmapIndexResult = new BitmapIndexResult(() -> RoaringBitmap32.bitmapOf(1, 3, 5));
+        BitmapIndexResult bitmapEmptyResult = new BitmapIndexResult(RoaringBitmap32::bitmapOf);
+
+        assert FileIndexResult.REMAIN.remain();
+        assert !FileIndexResult.SKIP.remain();
+
+        assert bitmapIndexResult.remain();
+        assert !bitmapEmptyResult.remain();
+
+        assert !bitmapIndexResult.and(FileIndexResult.SKIP).remain();
+        assert bitmapIndexResult.and(FileIndexResult.REMAIN).remain();
+        assert bitmapIndexResult.or(FileIndexResult.SKIP).remain();
+        assert bitmapIndexResult.or(FileIndexResult.REMAIN).remain();
+
+        assert !bitmapEmptyResult.and(FileIndexResult.SKIP).remain();
+        assert !bitmapEmptyResult.and(FileIndexResult.REMAIN).remain();
+        assert !bitmapEmptyResult.or(FileIndexResult.SKIP).remain();
+        assert bitmapEmptyResult.or(FileIndexResult.REMAIN).remain();
+    }
+
+    @Test
     public void testV1() throws Exception {
         testIntType(BitmapFileIndex.VERSION_1);
         testStringType(BitmapFileIndex.VERSION_1);
@@ -180,7 +203,7 @@ public class BitmapFileIndexTest {
         assert !reader.visitEqual(fieldRef, 2).remain();
     }
 
-    void testBooleanType(int version) throws Exception {
+    private void testBooleanType(int version) throws Exception {
         FieldRef fieldRef = new FieldRef(0, "", DataTypes.BOOLEAN());
         Object[] dataColumn = {Boolean.TRUE, Boolean.FALSE, Boolean.TRUE, Boolean.FALSE, null};
         FileIndexReader reader =

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/bitmapindex/BitmapFileIndexTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/bitmapindex/BitmapFileIndexTest.java
@@ -83,7 +83,8 @@ public class BitmapFileIndexTest {
     @Test
     public void testCompoundIndexResult() {
 
-        BitmapIndexResult bitmapIndexResult = new BitmapIndexResult(() -> RoaringBitmap32.bitmapOf(1, 3, 5));
+        BitmapIndexResult bitmapIndexResult =
+                new BitmapIndexResult(() -> RoaringBitmap32.bitmapOf(1, 3, 5));
         BitmapIndexResult bitmapEmptyResult = new BitmapIndexResult(RoaringBitmap32::bitmapOf);
 
         assert FileIndexResult.REMAIN.remain();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Fixed the incorrect logic of BitmapIndexResult and other IndexResult operations

<!-- What is the purpose of the change -->

### Tests
org.apache.paimon.fileindex.bitmapindex.BitmapFileIndexTest::testCompoundIndexResult
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
