### PR TITLE
[cdc] Do not check referenced field if no physical fields provided when computing columns

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/Expression.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/Expression.java
@@ -23,6 +23,7 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeFamily;
 import org.apache.paimon.types.DataTypeJsonParser;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.VariantType;
 import org.apache.paimon.utils.DateTimeUtils;
 import org.apache.paimon.utils.SerializableSupplier;
 import org.apache.paimon.utils.StringUtils;
@@ -193,11 +194,13 @@ public interface Expression extends Serializable {
                     StringUtils.toLowerCaseIfNeed(referencedField, caseSensitive);
 
             DataType fieldType =
-                    checkNotNull(
-                            typeMapping.get(referencedFieldCheckForm),
-                            String.format(
-                                    "Referenced field '%s' is not in given fields: %s.",
-                                    referencedFieldCheckForm, typeMapping.keySet()));
+                    typeMapping.isEmpty()
+                            ? new VariantType()
+                            : checkNotNull(
+                                    typeMapping.get(referencedFieldCheckForm),
+                                    String.format(
+                                            "Referenced field '%s' is not in given fields: %s.",
+                                            referencedFieldCheckForm, typeMapping.keySet()));
             return new ReferencedField(referencedField, fieldType, literals);
         }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
This PR is for computing columns when using kafka_sync_database. There would be multiple different tables to sync, so it's hard to list the exact data fields. No data fields provided would stop the buidling of computing column expressions.

This PR ignores the check when building expressions for kafka_sync_database, since it provides empty_list as the data fields. And it postpones the check to evaluation, which returns null if the referenced field doesn't exist.
### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
