### PR TITLE
[test] Fixed incorrect use of FileIO in CloneActionITCase

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CloneActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CloneActionITCase.java
@@ -723,7 +723,7 @@ public class CloneActionITCase extends ActionITCaseBase {
                 }
             }
 
-            Pair<Path, Boolean> result = pathExist(targetTable.fileIO(), paths);
+            Pair<Path, Boolean> result = pathExist(sourceTable.fileIO(), paths);
             assertThat(result.getRight()).isTrue();
             assertThat(targetTable.fileIO().getFileSize(filesPathInfo.getLeft()))
                     .isEqualTo(sourceTable.fileIO().getFileSize(result.getLeft()));


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Fixes the bug that targetFileIO is used to read sourceTable's content in CloneActionITCase.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
