### PR TITLE
[test] refactor test in RESTCatalogTestBase#testListPartitionsWhenMetastorePartitionedIsTrue

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -960,7 +960,7 @@ public class RESTCatalogServer {
                 response =
                         new GetTableResponse(
                                 tableMetadata.uuid(),
-                                identifier.getTableName(),
+                                identifier.getObjectName(),
                                 path,
                                 tableMetadata.isExternal(),
                                 tableMetadata.schema().id(),
@@ -1020,8 +1020,8 @@ public class RESTCatalogServer {
             case "GET":
                 List<Partition> partitions = new ArrayList<>();
                 for (Map.Entry<String, List<Partition>> entry : tablePartitionsStore.entrySet()) {
-                    String tableName = Identifier.fromString(entry.getKey()).getTableName();
-                    if (tableName.equals(tableIdentifier.getTableName())) {
+                    String objectName = Identifier.fromString(entry.getKey()).getObjectName();
+                    if (objectName.equals(tableIdentifier.getObjectName())) {
                         partitions.addAll(entry.getValue());
                     }
                 }

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTestBase.java
@@ -627,7 +627,7 @@ public abstract class RESTCatalogTestBase extends CatalogTestBase {
             }
             commit.commit(write.prepareCommit());
         }
-        assertThat(catalog.listPartitions(identifier).stream().map(Partition::spec))
+        assertThat(catalog.listPartitions(branchIdentifier).stream().map(Partition::spec))
                 .containsExactlyInAnyOrder(partitionSpecs.get(0), partitionSpecs.get(1));
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

refactor testListPartitionsWhenMetastorePartitionedIsTrue due to changes of branch logic in #5325

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
