### PR TITLE
[rest] Introduce `Redoc` to visualize Rest API

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ From this directory:
 	hugo -b "" serve
 	```
 
-The site can be viewed at http://localhost:1313/
+The site can be viewed at http://localhost:1313/docs/master/
 
 # Contribute
 

--- a/docs/content/concepts/rest/overview.md
+++ b/docs/content/concepts/rest/overview.md
@@ -62,3 +62,7 @@ RESTCatalog supports multiple access authentication methods, including the follo
 
 1. [Bear Token]({{< ref "concepts/rest/bear" >}}).
 2. [DLF Token]({{< ref "concepts/rest/dlf" >}}).
+
+## API
+
+{{< generated/rest_catalog >}}

--- a/docs/layouts/shortcodes/generated/rest_catalog.html
+++ b/docs/layouts/shortcodes/generated/rest_catalog.html
@@ -1,0 +1,22 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}
+<body>
+    <redoc spec-url="https://raw.githubusercontent.com/apache/paimon/master/paimon-open-api/rest-catalog-open-api.yaml"></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+</body>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Currently, it is difficult to understand the RestCatalog API in text form (https://raw.githubusercontent.com/apache/paimon/master/paimon-open-api/rest-catalog-open-api.yaml).
We can introduce Redoc (refer to https://nordicapis.com/using-redoc-to-auto-generate-openapi-documentation/) to visualize how the API can be used as shown below. And it will automatically change with the changes of the YAML definition, without additional maintenance.
![image](https://github.com/user-attachments/assets/83820a0f-a360-408a-8a57-2e9da71f6a28)

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
