### PR TITLE
[test] Enhance inheritance and visibility for ITCase support

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogITCaseBase.java
@@ -109,7 +109,7 @@ public abstract class CatalogITCaseBase extends AbstractTestBase {
         return false;
     }
 
-    private void prepareEnv() {
+    protected void prepareEnv() {
         Parser parser = ((TableEnvironmentImpl) tEnv).getParser();
         for (String ddl : ddl()) {
             tEnv.executeSql(ddl);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PartialUpdateITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PartialUpdateITCase.java
@@ -139,7 +139,7 @@ public class PartialUpdateITCase extends CatalogITCaseBase {
         iter.close();
     }
 
-    private List<List<Object>> rowsToList(List<Row> rows) {
+    protected List<List<Object>> rowsToList(List<Row> rows) {
         return rows.stream().map(this::toList).collect(Collectors.toList());
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/BranchActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/BranchActionITCase.java
@@ -42,7 +42,7 @@ import static org.apache.paimon.flink.util.ReadWriteTableTestUtil.init;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** IT cases for branch management actions. */
-class BranchActionITCase extends ActionITCaseBase {
+public class BranchActionITCase extends ActionITCaseBase {
 
     @Test
     void testCreateAndDeleteBranch() throws Exception {
@@ -355,7 +355,7 @@ class BranchActionITCase extends ActionITCaseBase {
         Assert.assertEquals(expected, sortedActual);
     }
 
-    List<String> readTableData(FileStoreTable table) throws Exception {
+    protected List<String> readTableData(FileStoreTable table) throws Exception {
         RowType rowType =
                 RowType.of(
                         new DataType[] {DataTypes.BIGINT(), DataTypes.STRING()},

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CloneActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CloneActionITCase.java
@@ -642,7 +642,7 @@ public class CloneActionITCase extends ActionITCaseBase {
         compareCloneFiles(sourceWarehouse, "default", "t", targetWarehouse, "default", "t");
     }
 
-    private void compareCloneFiles(
+    protected void compareCloneFiles(
             String sourceWarehouse,
             String sourceDb,
             String sourceTableName,
@@ -730,7 +730,7 @@ public class CloneActionITCase extends ActionITCaseBase {
         }
     }
 
-    private Pair<Path, Boolean> pathExist(FileIO fileIO, List<Path> paths) throws IOException {
+    protected Pair<Path, Boolean> pathExist(FileIO fileIO, List<Path> paths) throws IOException {
         for (Path path : paths) {
             if (fileIO.exists(path)) {
                 return Pair.of(path, true);
@@ -739,7 +739,7 @@ public class CloneActionITCase extends ActionITCaseBase {
         return Pair.of(null, false);
     }
 
-    private Path getPathExcludeTableRoot(Path absolutePath, Path sourceTableRoot) {
+    protected Path getPathExcludeTableRoot(Path absolutePath, Path sourceTableRoot) {
         String fileAbsolutePath = absolutePath.toUri().toString();
         String sourceTableRootPath = sourceTableRoot.toString();
 
@@ -993,7 +993,7 @@ public class CloneActionITCase extends ActionITCaseBase {
         return tEnv.executeSql(procedureStatement).collect();
     }
 
-    private List<String> collect(TableEnvironment tEnv, String sql) throws Exception {
+    protected List<String> collect(TableEnvironment tEnv, String sql) throws Exception {
         List<String> actual = new ArrayList<>();
         try (CloseableIterator<Row> it = tEnv.executeSql(sql).collect()) {
             while (it.hasNext()) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactDatabaseActionITCase.java
@@ -87,7 +87,7 @@ public class CompactDatabaseActionITCase extends CompactActionITCaseBase {
                 Arguments.of("divided", "procedure_named"));
     }
 
-    private FileStoreTable createTable(
+    protected FileStoreTable createTable(
             String databaseName,
             String tableName,
             List<String> partitionKeys,

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionForUnawareBucketITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/SortCompactActionForUnawareBucketITCase.java
@@ -400,7 +400,7 @@ public class SortCompactActionForUnawareBucketITCase extends ActionITCaseBase {
         }
     }
 
-    private void createTable() throws Exception {
+    protected void createTable() throws Exception {
         catalog.createDatabase(database, true);
         catalog.createTable(identifier(), schema(), true);
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpirePartitionsProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpirePartitionsProcedureITCase.java
@@ -459,7 +459,7 @@ public class ExpirePartitionsProcedureITCase extends CatalogITCaseBase {
                 .collect(Collectors.toList());
     }
 
-    private List<String> read(
+    protected List<String> read(
             FileStoreTable table, Function<InternalRow, String> consumerReadResult)
             throws IOException {
         List<String> ret = new ArrayList<>();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpireSnapshotsProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpireSnapshotsProcedureITCase.java
@@ -162,7 +162,7 @@ public class ExpireSnapshotsProcedureITCase extends CatalogITCaseBase {
         checkSnapshots(snapshotManager, 6, 6);
     }
 
-    private void checkSnapshots(SnapshotManager sm, int earliest, int latest) throws IOException {
+    protected void checkSnapshots(SnapshotManager sm, int earliest, int latest) throws IOException {
         assertThat(sm.snapshotCount()).isEqualTo(latest - earliest + 1);
         assertThat(sm.earliestSnapshotId()).isEqualTo(earliest);
         assertThat(sm.latestSnapshotId()).isEqualTo(latest);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

- Changed the access modifiers of certain methods in Action and Procedure from private to protected:
    - This change enables subclasses to inherit and reuse logic for ITCase scenarios.
    - It also supports future extensibility and customization.

-  Updated the following classes to public access:
    - BranchActionITCase
    - This change allows the classes to be accessed across different packages, improving code reusability and modularity.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
