### PR TITLE
[rest] Introduce `redocPage` variable to support customizable parameters on pages using `Redoc`

### DIFF
--- a/docs/content/concepts/rest/rest-api.md
+++ b/docs/content/concepts/rest/rest-api.md
@@ -2,6 +2,7 @@
 title: "REST API"
 layout: "custom-page"
 bookToc: false
+redocPage: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/layouts/partials/docs/inject/head.html
+++ b/docs/layouts/partials/docs/inject/head.html
@@ -22,4 +22,8 @@ under the License.
 <link rel="stylesheet" type="text/css" href="{{.Site.BaseURL}}/font-awesome/css/font-awesome.min.css">
 <script src="{{.Site.BaseURL}}/js/anchor.min.js"></script>
 <script src="{{.Site.BaseURL}}/js/flink.js"></script>
-<script src="{{.Site.BaseURL}}/js/redoc.standalone.js"></script>
+<!-- Only takes effect when the `redocPage` variable is true. -->
+{{ if .Params.redocPage }}
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline' 'unsafe-eval'; default-src 'self' data: blob: 'unsafe-inline' https://raw.githubusercontent.com/apache/paimon/master/paimon-open-api/;">
+    <script src="{{.Site.BaseURL}}/js/redoc.standalone.js"></script>
+{{ end }}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

For pages using `Redoc`
1. Custom content-security-policy to allow visit `https://raw.githubusercontent.com/apache/paimon/master/paimon-open-api/`
2. use `redoc.standalone.js`, others not, speed up pages loading.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
