### PR TITLE
[flink] Support dry_run in purge_files procedure

### DIFF
--- a/docs/content/flink/procedures.md
+++ b/docs/content/flink/procedures.md
@@ -496,6 +496,7 @@ All available procedures are listed below.
       <td>
          To clear table with purge files directly. Argument:
             <li>table: the target table identifier. Cannot be empty.</li>
+            <li>dry_run(optional): only check what files will be purged, but not really remove them. Default is false.</li>
       </td>
       <td>
          -- for Flink 1.18<br/>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5337

<!-- What is the purpose of the change -->
This PR adds support for dryRun in Flink purge_files procedure.

### Tests

<!-- List UT and IT cases to verify this change -->
PurgeFilesProcedureITCase.

### API and Format

<!-- Does this change affect API or storage format -->
This PR adds a new dry_run parameter to Flink purge_files procedure.

### Documentation

<!-- Does this change introduce a new feature -->
The new parameter dry_run has been added to the document.
