### PR TITLE
[core]: RESTCatalog: use object mapper from JsonSerdeUtil in RESTObjectMapper

### DIFF
--- a/docs/content/flink/procedures.md
+++ b/docs/content/flink/procedures.md
@@ -809,7 +809,7 @@ All available procedures are listed below.
          CALL [catalog.]sys.alter_view_dialect('view_identifier', 'update', 'flink', 'query')<br/>
          CALL [catalog.]sys.alter_view_dialect(`view` => 'view_identifier', `action` => 'update', `query` => 'query')<br/><br/>
          -- drop dialect in the view<br/>
-         CALL [catalog.]sys.alter_view_dialect('view_identifier', 'drop', 'flink')<br/><br/>
+         CALL [catalog.]sys.alter_view_dialect('view_identifier', 'drop', 'flink')<br/>
          CALL [catalog.]sys.alter_view_dialect(`view` => 'view_identifier', `action` => 'drop')<br/><br/>
       </td>
       <td>

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTObjectMapper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTObjectMapper.java
@@ -18,42 +18,12 @@
 
 package org.apache.paimon.rest;
 
-import org.apache.paimon.types.DataField;
-import org.apache.paimon.types.DataType;
-import org.apache.paimon.types.DataTypeJsonParser;
+import org.apache.paimon.utils.JsonSerdeUtil;
 
-import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.DeserializationFeature;
-import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.Module;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.SerializationFeature;
-import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.module.SimpleModule;
-import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-
-import static org.apache.paimon.utils.JsonSerdeUtil.registerJsonObjects;
 
 /** Object mapper for REST request and response. */
 public class RESTObjectMapper {
 
-    public static final ObjectMapper OBJECT_MAPPER = RESTObjectMapper.create();
-
-    private static ObjectMapper create() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
-        mapper.registerModule(createPaimonRestJacksonModule());
-        mapper.registerModule(new JavaTimeModule());
-        return mapper;
-    }
-
-    private static Module createPaimonRestJacksonModule() {
-        SimpleModule module = new SimpleModule("Paimon_REST");
-        registerJsonObjects(
-                module,
-                DataField.class,
-                DataField::serializeJson,
-                DataTypeJsonParser::parseDataField);
-        registerJsonObjects(
-                module, DataType.class, DataType::serializeJson, DataTypeJsonParser::parseDataType);
-        return module;
-    }
+    public static final ObjectMapper OBJECT_MAPPER = JsonSerdeUtil.OBJECT_MAPPER_INSTANCE;
 }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/JsonSerdeUtil.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/JsonSerdeUtil.java
@@ -29,9 +29,11 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonParser;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.DeserializationFeature;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.Module;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.SerializationFeature;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.SerializerProvider;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.module.SimpleModule;
@@ -53,10 +55,12 @@ public class JsonSerdeUtil {
      * Object mapper shared instance to serialize and deserialize the plan. Note that creating and
      * copying of object mappers is expensive and should be avoided.
      */
-    private static final ObjectMapper OBJECT_MAPPER_INSTANCE;
+    public static final ObjectMapper OBJECT_MAPPER_INSTANCE;
 
     static {
         OBJECT_MAPPER_INSTANCE = new ObjectMapper();
+        OBJECT_MAPPER_INSTANCE.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        OBJECT_MAPPER_INSTANCE.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         OBJECT_MAPPER_INSTANCE.registerModule(createPaimonJacksonModule());
         OBJECT_MAPPER_INSTANCE.registerModule(new JavaTimeModule());
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
RESTCatalog: use object mapper from JsonSerdeUtil  in RESTObjectMapper
<!-- Linking this pull request to the issue -->
Linked issue:  #4540

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
