### PR TITLE
[core] Incremental delta scan should be in stream mode, not mergeing

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/IncrementalDeltaStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/IncrementalDeltaStartingScanner.java
@@ -131,6 +131,7 @@ public class IncrementalDeltaStartingScanner extends AbstractStartingScanner {
                                             .collect(Collectors.toList()))) {
                 DataSplit.Builder dataSplitBuilder =
                         DataSplit.builder()
+                                .isStreaming(true)
                                 .withSnapshot(endingSnapshotId)
                                 .withPartition(partition)
                                 .withBucket(bucket)

--- a/paimon-core/src/test/java/org/apache/paimon/table/IncrementalTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/IncrementalTableTest.java
@@ -104,10 +104,13 @@ public class IncrementalTableTest extends TableTestBase {
         List<InternalRow> result = read(table, Pair.of(INCREMENTAL_BETWEEN, "2,5"));
         assertThat(result)
                 .containsExactlyInAnyOrder(
+                        GenericRow.of(1, 1, 3),
+                        GenericRow.of(1, 2, 3),
+                        GenericRow.of(2, 1, 3),
+                        GenericRow.of(2, 2, 1),
                         GenericRow.of(1, 1, 4),
                         GenericRow.of(1, 2, 4),
-                        GenericRow.of(2, 1, 4),
-                        GenericRow.of(2, 2, 1));
+                        GenericRow.of(2, 1, 4));
     }
 
     @Test
@@ -208,12 +211,14 @@ public class IncrementalTableTest extends TableTestBase {
         List<InternalRow> result = read(auditLog, Pair.of(INCREMENTAL_BETWEEN, "1,3"));
         assertThat(result)
                 .containsExactlyInAnyOrder(
-                        GenericRow.of(fromString("+I"), 2, 1, 3),
-                        GenericRow.of(fromString("+I"), 2, 2, 1),
-                        GenericRow.of(fromString("+I"), 1, 1, 2),
-                        GenericRow.of(fromString("+I"), 1, 4, 1),
+                        GenericRow.of(fromString("-D"), 1, 1, 1),
                         GenericRow.of(fromString("-D"), 1, 2, 1),
-                        GenericRow.of(fromString("-D"), 1, 3, 1));
+                        GenericRow.of(fromString("+I"), 1, 4, 1),
+                        GenericRow.of(fromString("+I"), 2, 1, 2),
+                        GenericRow.of(fromString("-D"), 1, 3, 1),
+                        GenericRow.of(fromString("+I"), 1, 1, 2),
+                        GenericRow.of(fromString("+I"), 2, 1, 3),
+                        GenericRow.of(fromString("+I"), 2, 2, 1));
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/IncrementalTimeStampTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/IncrementalTimeStampTableTest.java
@@ -147,9 +147,12 @@ public class IncrementalTimeStampTableTest extends TableTestBase {
                                         timestampEarliestString, timestampSnapshot2String)));
         assertThat(result2)
                 .containsExactlyInAnyOrder(
+                        GenericRow.of(1, 1, 1),
+                        GenericRow.of(1, 2, 1),
+                        GenericRow.of(1, 3, 1),
+                        GenericRow.of(2, 1, 1),
                         GenericRow.of(1, 1, 2),
                         GenericRow.of(1, 2, 2),
-                        GenericRow.of(1, 3, 1),
                         GenericRow.of(1, 4, 1),
                         GenericRow.of(2, 1, 2));
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/IncrementalTimeStampTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/IncrementalTimeStampTableTest.java
@@ -129,9 +129,12 @@ public class IncrementalTimeStampTableTest extends TableTestBase {
                                 String.format("%s,%s", timestampEarliest, timestampSnapshot2)));
         assertThat(result2)
                 .containsExactlyInAnyOrder(
+                        GenericRow.of(1, 1, 1),
+                        GenericRow.of(1, 2, 1),
+                        GenericRow.of(1, 3, 1),
+                        GenericRow.of(2, 1, 1),
                         GenericRow.of(1, 1, 2),
                         GenericRow.of(1, 2, 2),
-                        GenericRow.of(1, 3, 1),
                         GenericRow.of(1, 4, 1),
                         GenericRow.of(2, 1, 2));
         result2 =

--- a/paimon-core/src/test/java/org/apache/paimon/table/IncrementalTimeStampTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/IncrementalTimeStampTableTest.java
@@ -164,10 +164,13 @@ public class IncrementalTimeStampTableTest extends TableTestBase {
                                 String.format("%s,%s", timestampSnapshot2, timestampSnapshot4)));
         assertThat(result3)
                 .containsExactlyInAnyOrder(
+                        GenericRow.of(1, 1, 3),
+                        GenericRow.of(1, 2, 3),
+                        GenericRow.of(2, 1, 3),
+                        GenericRow.of(2, 2, 1),
                         GenericRow.of(1, 1, 4),
                         GenericRow.of(1, 2, 4),
-                        GenericRow.of(2, 1, 4),
-                        GenericRow.of(2, 2, 1));
+                        GenericRow.of(2, 1, 4));
         result3 =
                 read(
                         table,
@@ -178,10 +181,13 @@ public class IncrementalTimeStampTableTest extends TableTestBase {
                                         timestampSnapshot2String, timestampSnapshot4String)));
         assertThat(result3)
                 .containsExactlyInAnyOrder(
+                        GenericRow.of(1, 1, 3),
+                        GenericRow.of(1, 2, 3),
+                        GenericRow.of(2, 1, 3),
+                        GenericRow.of(2, 2, 1),
                         GenericRow.of(1, 1, 4),
                         GenericRow.of(1, 2, 4),
-                        GenericRow.of(2, 1, 4),
-                        GenericRow.of(2, 2, 1));
+                        GenericRow.of(2, 1, 4));
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/IncrementalDeltaStartingScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/IncrementalDeltaStartingScannerTest.java
@@ -74,7 +74,12 @@ public class IncrementalDeltaStartingScannerTest extends ScannerTestBase {
         List<Split> splits = table.copy(dynamicOptions).newScan().plan().splits();
         assertThat(getResult(table.newRead(), splits))
                 .hasSameElementsAs(
-                        Arrays.asList("+I 2|20|200", "+I 1|10|100", "+I 3|40|400", "+U 3|40|500"));
+                        Arrays.asList(
+                                "+I 2|20|200",
+                                "+I 1|10|100",
+                                "+I 3|40|400",
+                                "-U 3|40|400",
+                                "+U 3|40|500"));
 
         dynamicOptions.put(INCREMENTAL_BETWEEN_SCAN_MODE.key(), "delta");
         splits = table.copy(dynamicOptions).newScan().plan().splits();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -771,6 +771,8 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
                 sql(
                         "SELECT * FROM `test_scan_mode$audit_log` "
                                 + "/*+ OPTIONS('incremental-between'='1,8','incremental-between-scan-mode'='delta') */");
-        assertThat(result).containsExactlyInAnyOrder(Row.of("-D", 2, "B"), Row.of("+I", 3, "C"));
+        assertThat(result)
+                .containsExactlyInAnyOrder(
+                        Row.of("+I", 2, "B"), Row.of("-D", 2, "B"), Row.of("+I", 3, "C"));
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
When quering audit_log with scaning delta or changelog, we want to get each operation without merging. 

For example, one record was INSERT-ed then DELETE-ed, we need both operations. This is useful for multi micro-batch processing. 

Firstly, a new record is detected. If the record wast removed, we need detected the DELETE operation in the following batch query instead of nothing. This could cause users to mistakenly think nothing happened which actually did.
 

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
