### PR TITLE
[rest] Fix RESTCatalogController ambiguous mapping between listViewDetails and listViews method

### DIFF
--- a/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
+++ b/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
@@ -757,7 +757,7 @@ public class RESTCatalogController {
                 responseCode = "500",
                 content = {@Content(schema = @Schema())})
     })
-    @GetMapping("/v1/{prefix}/databases/{database}/views")
+    @GetMapping("/v1/{prefix}/databases/{database}/view-details")
     public ListViewDetailsResponse listViewDetails(
             @PathVariable String prefix,
             @PathVariable String database,


### PR DESCRIPTION
Caused by: java.lang.IllegalStateException: Ambiguous mapping. Cannot map 'RESTCatalogController' method 
org.apache.paimon.open.api.RESTCatalogController#listViewDetails(String, String, Integer, String)
to {GET [/v1/{prefix}/databases/{database}/views]}: There is already 'RESTCatalogController' bean method
org.apache.paimon.open.api.RESTCatalogController#listViews(String, String, Integer, String) mapped.

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
just as rest-catalog-open-api.yaml described,listViewDetails method should be mappinged into '/v1/{prefix}/databases/{database}/view-details' 

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
