### PR TITLE
[rest] Redoc page uses UTF-8 charset

### DIFF
--- a/docs/layouts/partials/docs/inject/head.html
+++ b/docs/layouts/partials/docs/inject/head.html
@@ -24,5 +24,6 @@ under the License.
 <script src="{{.Site.BaseURL}}/js/flink.js"></script>
 <!-- Only takes effect when the `redocPage` variable is true. -->
 {{ if .Params.redocPage }}
+    <meta charset="UTF-8">
     <script src="{{.Site.BaseURL}}/js/redoc.standalone.js"></script>
 {{ end }}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

There are charset issues in redoc page
![image](https://github.com/user-attachments/assets/78594271-c77c-402b-a21d-e553700dc965)



<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
