### PR TITLE
[core] Not throw exception for fallback reading

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BranchSqlITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BranchSqlITCase.java
@@ -311,11 +311,11 @@ public class BranchSqlITCase extends CatalogITCaseBase {
     public void testCrossPartitionFallbackBranchBatchRead() throws Exception {
         sql(
                 "CREATE TABLE t ( pk INT PRIMARY KEY NOT ENFORCED, name STRING, dt STRING ) PARTITIONED BY (dt) WITH ( 'bucket' = '-1' )");
-        sql(
-                "INSERT INTO t VALUES (1, 'Jack', '20250227'), (1, 'Jackson', '20250227'), (2, 'Sam', '20250228')");
         sql("CALL sys.create_branch('default.t', 'stream')");
         sql("ALTER TABLE t SET ( 'scan.fallback-branch' = 'stream' )");
 
+        sql(
+                "INSERT INTO t VALUES (1, 'Jack', '20250227'), (1, 'Jackson', '20250227'), (2, 'Sam', '20250228')");
         sql(
                 "INSERT INTO `t$branch_stream` VALUES (1, 'John Stream', '20250228'), (3, 'Rick Stream', '20250301')");
         assertThat(collectResult("SELECT pk, name, dt FROM t order by dt"))


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
There is no need to force an exception if fallback-branch has no files to be readed.

<!-- What is the purpose of the change -->

### Tests
BranchSqlITCase#testCrossPartitionFallbackBranchBatchRead
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
