### PR TITLE
[parquet] Fix that ColumnIndexFilter return empty mistakenly when projection doesn't contain filter fields

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
@@ -61,7 +61,11 @@ public class ParquetFileFormat extends FileFormat {
     public FormatReaderFactory createReaderFactory(
             RowType projectedRowType, List<Predicate> filters) {
         return new ParquetReaderFactory(
-                options, projectedRowType, readBatchSize, ParquetFilters.convert(filters));
+                options,
+                projectedRowType,
+                readBatchSize,
+                ParquetFilters.convert(filters),
+                ParquetFilters.getFilterFields(filters));
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
@@ -97,11 +97,25 @@ public class ParquetReaderFactory implements FormatReaderFactory {
     private final Set<Integer> unknownFieldsIndices = new HashSet<>();
 
     public ParquetReaderFactory(
-            Options conf, RowType readType, int batchSize, FilterCompat.Filter filter) {
+            Options conf,
+            RowType readType,
+            int batchSize,
+            FilterCompat.Filter filter,
+            List<DataField> filterFields) {
         this.conf = conf;
-        this.readFields = readType.getFields().toArray(new DataField[0]);
+        this.readFields = getReadFields(readType, filterFields);
         this.batchSize = batchSize;
         this.filter = filter;
+    }
+
+    private DataField[] getReadFields(RowType readType, List<DataField> filterFields) {
+        List<DataField> readFields = new ArrayList<>(readType.getFields());
+        for (DataField field : filterFields) {
+            if (readFields.stream().noneMatch(f -> f.name().equals(field.name()))) {
+                readFields.add(field);
+            }
+        }
+        return readFields.toArray(new DataField[0]);
     }
 
     // TODO: remove this when new reader is stable

--- a/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
+++ b/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
@@ -49,6 +49,8 @@ import org.apache.paimon.types.VariantType;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.io.api.Binary;
 
+import javax.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -79,10 +81,12 @@ public class ParquetFilters {
         return result != null ? FilterCompat.get(result) : FilterCompat.NOOP;
     }
 
-    public static List<DataField> getFilterFields(List<Predicate> predicates) {
-        return predicates.stream()
-                .flatMap(p -> p.visit(FilterFieldsVisitor.INSTANCE).stream())
-                .collect(Collectors.toList());
+    public static List<DataField> getFilterFields(@Nullable List<Predicate> predicates) {
+        return predicates == null
+                ? Collections.emptyList()
+                : predicates.stream()
+                        .flatMap(p -> p.visit(FilterFieldsVisitor.INSTANCE).stream())
+                        .collect(Collectors.toList());
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
+++ b/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
@@ -27,6 +27,7 @@ import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.BinaryType;
 import org.apache.paimon.types.BooleanType;
 import org.apache.paimon.types.CharType;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypeVisitor;
 import org.apache.paimon.types.DateType;
 import org.apache.paimon.types.DecimalType;
@@ -48,7 +49,9 @@ import org.apache.paimon.types.VariantType;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.io.api.Binary;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /** Convert {@link Predicate} to {@link FilterCompat.Filter}. */
 public class ParquetFilters {
@@ -74,6 +77,12 @@ public class ParquetFilters {
         }
 
         return result != null ? FilterCompat.get(result) : FilterCompat.NOOP;
+    }
+
+    public static List<DataField> getFilterFields(List<Predicate> predicates) {
+        return predicates.stream()
+                .flatMap(p -> p.visit(FilterFieldsVisitor.INSTANCE).stream())
+                .collect(Collectors.toList());
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -307,6 +316,87 @@ public class ParquetFilters {
         @Override
         public Operators.Column<?> visit(RowType rowType) {
             throw new UnsupportedOperationException();
+        }
+    }
+
+    /** To get fields in filter. */
+    private static class FilterFieldsVisitor implements FunctionVisitor<List<DataField>> {
+
+        public static final FilterFieldsVisitor INSTANCE = new FilterFieldsVisitor();
+
+        @Override
+        public List<DataField> visitIsNotNull(FieldRef fieldRef) {
+            return Collections.singletonList(new DataField(-1, fieldRef.name(), fieldRef.type()));
+        }
+
+        @Override
+        public List<DataField> visitIsNull(FieldRef fieldRef) {
+            return Collections.singletonList(new DataField(-1, fieldRef.name(), fieldRef.type()));
+        }
+
+        @Override
+        public List<DataField> visitStartsWith(FieldRef fieldRef, Object literal) {
+            return Collections.singletonList(new DataField(-1, fieldRef.name(), fieldRef.type()));
+        }
+
+        @Override
+        public List<DataField> visitEndsWith(FieldRef fieldRef, Object literal) {
+            return Collections.singletonList(new DataField(-1, fieldRef.name(), fieldRef.type()));
+        }
+
+        @Override
+        public List<DataField> visitContains(FieldRef fieldRef, Object literal) {
+            return Collections.singletonList(new DataField(-1, fieldRef.name(), fieldRef.type()));
+        }
+
+        @Override
+        public List<DataField> visitLessThan(FieldRef fieldRef, Object literal) {
+            return Collections.singletonList(new DataField(-1, fieldRef.name(), fieldRef.type()));
+        }
+
+        @Override
+        public List<DataField> visitGreaterOrEqual(FieldRef fieldRef, Object literal) {
+            return Collections.singletonList(new DataField(-1, fieldRef.name(), fieldRef.type()));
+        }
+
+        @Override
+        public List<DataField> visitNotEqual(FieldRef fieldRef, Object literal) {
+            return Collections.singletonList(new DataField(-1, fieldRef.name(), fieldRef.type()));
+        }
+
+        @Override
+        public List<DataField> visitLessOrEqual(FieldRef fieldRef, Object literal) {
+            return Collections.singletonList(new DataField(-1, fieldRef.name(), fieldRef.type()));
+        }
+
+        @Override
+        public List<DataField> visitEqual(FieldRef fieldRef, Object literal) {
+            return Collections.singletonList(new DataField(-1, fieldRef.name(), fieldRef.type()));
+        }
+
+        @Override
+        public List<DataField> visitGreaterThan(FieldRef fieldRef, Object literal) {
+            return Collections.singletonList(new DataField(-1, fieldRef.name(), fieldRef.type()));
+        }
+
+        @Override
+        public List<DataField> visitIn(FieldRef fieldRef, List<Object> literals) {
+            return Collections.singletonList(new DataField(-1, fieldRef.name(), fieldRef.type()));
+        }
+
+        @Override
+        public List<DataField> visitNotIn(FieldRef fieldRef, List<Object> literals) {
+            return Collections.singletonList(new DataField(-1, fieldRef.name(), fieldRef.type()));
+        }
+
+        @Override
+        public List<DataField> visitAnd(List<List<DataField>> children) {
+            return children.stream().flatMap(List::stream).collect(Collectors.toList());
+        }
+
+        @Override
+        public List<DataField> visitOr(List<List<DataField>> children) {
+            return children.stream().flatMap(List::stream).collect(Collectors.toList());
         }
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetColumnVectorTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetColumnVectorTest.java
@@ -47,6 +47,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -593,7 +594,8 @@ public class ParquetColumnVectorTest {
         writer.close();
 
         ParquetReaderFactory readerFactory =
-                new ParquetReaderFactory(new Options(), rowType, 1024, FilterCompat.NOOP);
+                new ParquetReaderFactory(
+                        new Options(), rowType, 1024, FilterCompat.NOOP, Collections.emptyList());
 
         RecordReader<InternalRow> reader =
                 readerFactory.createReader(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Fix bug of #4780 
Why the bug occurs:
ColumnIndexFilter#applyPredicate: 
```
if (!columns.contains(columnPath)) {
    return rangesForMissingColumns;
}
```
It returns empty range, then VectorizedParquetRecordReader:
```
this.totalRowCount = reader.getFilteredRecordCount(); // always 0
```
Finally, VectorizedParquetRecordReader#nextBatch:
```
if (rowsReturned >= totalRowCount) { // 0 >= 0
    return false;
}
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
