### PR TITLE
[core] Make Iceberg partition a required field

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergDataFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergDataFileMeta.java
@@ -218,7 +218,7 @@ public class IcebergDataFileMeta {
         fields.add(new DataField(134, "content", DataTypes.INT().notNull()));
         fields.add(new DataField(100, "file_path", DataTypes.STRING().notNull()));
         fields.add(new DataField(101, "file_format", DataTypes.STRING().notNull()));
-        fields.add(new DataField(102, "partition", partitionType));
+        fields.add(new DataField(102, "partition", partitionType.notNull()));
         fields.add(new DataField(103, "record_count", DataTypes.BIGINT().notNull()));
         fields.add(new DataField(104, "file_size_in_bytes", DataTypes.BIGINT().notNull()));
         fields.add(

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/manifest/IcebergDataFileMetaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/manifest/IcebergDataFileMetaTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg.manifest;
+
+import org.apache.paimon.TestKeyValueGenerator;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IcebergDataFileMetaTest {
+
+    @Test
+    @DisplayName("Test partition is a required field")
+    void testPartitionIsNotNull() {
+        RowType partitionType = TestKeyValueGenerator.SINGLE_PARTITIONED_PART_TYPE;
+        RowType schema = IcebergDataFileMeta.schema(partitionType);
+        List<DataField> fields = schema.getFields();
+
+        Optional<DataField> partitionField = fields.stream().filter(f -> f.id() == 102).findFirst();
+
+        assertThat(partitionField).isPresent();
+        assertThat(partitionField.get().name()).isEqualTo("partition");
+        assertThat(partitionField.get().type()).isEqualTo(partitionType.notNull());
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5384

<!-- What is the purpose of the change -->

Make sure generated avro file is valid according to the [Iceberg spec](https://iceberg.apache.org/spec/#manifests:~:text=%2C%20or%20puffin-,required,spec%20output%20using%20partition%20field%20ids%20for%20the%20struct%20field%20ids,-required).

### Tests

<!-- List UT and IT cases to verify this change -->

A test is added.

### API and Format

<!-- Does this change affect API or storage format -->

API is not affected.

### Documentation

<!-- Does this change introduce a new feature -->

No new features were added.