### PR TITLE
[core] Fix listFilesIterative bug and avoid using Files.walk in SimpleTableTestBase

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
@@ -154,22 +154,18 @@ public interface FileIO extends Serializable, Closeable {
             }
 
             private void maybeUnpackDirectory() throws IOException {
-                if (!files.isEmpty()) {
-                    return;
-                }
-                if (directories.isEmpty()) {
-                    return;
-                }
-                FileStatus[] statuses = listStatus(directories.remove());
-                for (FileStatus f : statuses) {
-                    if (!f.isDir()) {
-                        files.add(f);
-                        continue;
+                while (files.isEmpty() && !directories.isEmpty()) {
+                    FileStatus[] statuses = listStatus(directories.remove());
+                    for (FileStatus f : statuses) {
+                        if (!f.isDir()) {
+                            files.add(f);
+                            continue;
+                        }
+                        if (!recursive) {
+                            continue;
+                        }
+                        directories.add(f.getPath());
                     }
-                    if (!recursive) {
-                        continue;
-                    }
-                    directories.add(f.getPath());
                 }
             }
 

--- a/paimon-common/src/main/java/org/apache/paimon/fs/local/LocalFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/local/LocalFileIO.java
@@ -381,5 +381,10 @@ public class LocalFileIO implements FileIO {
         public long getModificationTime() {
             return file.lastModified();
         }
+
+        @Override
+        public String toString() {
+            return "{" + "file=" + file + ", length=" + length + ", scheme='" + scheme + '\'' + '}';
+        }
     }
 }


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
See title.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
