### PR TITLE
[core] Fix Identifier should parse backquote.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Identifier.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Identifier.java
@@ -80,7 +80,10 @@ public class Identifier implements Serializable {
             @JsonProperty(FIELD_DATABASE_NAME) String database,
             @JsonProperty(FIELD_OBJECT_NAME) String object) {
         this.database = database;
-        this.object = object;
+        this.object =
+                object.startsWith("`") && object.endsWith("`")
+                        ? object.substring(1, object.length() - 1)
+                        : object;
     }
 
     public Identifier(String database, String table, @Nullable String branch) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

When using flink procedure,  table name can not parsed correctly when use `` quote. 

But Spark request  use `` for SYSTEM_TABLE_SPLITTER ($) .  So this is incompatible with Spark.

e.g :
```
Flink is OK But Spark is ERR  :  CALL sys.create_branch('default.T$branch_branch1', ......)

Flink is ERR But Spark is OK :  CALL sys.create_branch('default.`T$branch_branch1`', ......)

Flink will parse `T$branch_branch1` to table is `T  and branch is branch_branch1`.
```
![image](https://github.com/user-attachments/assets/f8e8b159-9479-40cd-b49f-55c76b4aed4e)

Why :

Flink use `org.apache.paimon.catalog.Identifier` to parse the `tableName` and miss processing backquote,
 spark use `spark.sessionState().sqlParser().parseMultipartIdentifier` to parse.


### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
