### PR TITLE
[core] Postpone bucket writing job should not expire snapshots

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -100,7 +100,7 @@ under the License.
         </tr>
         <tr>
             <td><h5>postpone.default-bucket-num</h5></td>
-            <td style="word-wrap: break-word;">4</td>
+            <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>
             <td>Bucket number for the partitions compacted for the first time in postpone bucket tables.</td>
         </tr>

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
@@ -39,6 +39,8 @@ import org.apache.paimon.table.source.MergeTreeSplitGenerator;
 import org.apache.paimon.table.source.SplitGenerator;
 import org.apache.paimon.types.RowType;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 import java.util.function.BiConsumer;
 
@@ -172,5 +174,15 @@ public class PrimaryKeyFileStoreTable extends AbstractFileStoreTable {
     @Override
     public LocalTableQuery newLocalTableQuery() {
         return new LocalTableQuery(this);
+    }
+
+    @Override
+    @Nullable
+    protected Runnable newExpireRunnable() {
+        if (coreOptions().bucket() == BucketMode.POSTPONE_BUCKET) {
+            return null;
+        } else {
+            return super.newExpireRunnable();
+        }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -461,7 +461,7 @@ public class FlinkConnectorOptions {
     public static final ConfigOption<Integer> POSTPONE_DEFAULT_BUCKET_NUM =
             key("postpone.default-bucket-num")
                     .intType()
-                    .defaultValue(4)
+                    .defaultValue(1)
                     .withDescription(
                             "Bucket number for the partitions compacted for the first time in postpone bucket tables.");
 


### PR DESCRIPTION
### Purpose

Postpone bucket writing job should not expire snapshots. Snapshot expiration should be done in the compaction job.

This PR fixes the issue.

### Tests

* `PostponeBucketTableITCase#testPostponeWriteNotExpireSnapshots`.

### API and Format

No format changes.

### Documentation

No new feature.
