### PR TITLE
[spark] Support scan mode when query with incremental_between

### DIFF
--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
@@ -91,6 +91,11 @@ class TableValuedFunctionsTest extends PaimonHiveTestBase {
                     spark.sql(
                       "SELECT * FROM paimon_incremental_query('t', '1', '3') ORDER BY a, b"),
                     Row(1, 3, "3") :: Row(1, 5, "5") :: Row(1, 7, "7") :: Row(2, 4, "4") :: Nil)
+                  checkAnswer(
+                    spark.sql(
+                      "SELECT * FROM paimon_incremental_query('t', '1', '3', 'incremental-between-scan-mode=diff') ORDER BY a, b"),
+                    Row(1, 3, "3") :: Row(1, 5, "5") :: Row(1, 7, "7") :: Row(2, 4, "4") :: Nil
+                  )
                 }
             }
           }
@@ -138,6 +143,11 @@ class TableValuedFunctionsTest extends PaimonHiveTestBase {
               sql(
                 s"SELECT * FROM paimon_incremental_between_timestamp('$catalogName.$dbName.t', '$t1String', '$t3String') ORDER BY id"),
               Seq(Row(2), Row(3), Row(4)))
+            checkAnswer(
+              sql(
+                s"SELECT * FROM paimon_incremental_between_timestamp('$catalogName.$dbName.t', '$t1String', '$t3String','incremental-between-scan-mode=diff') ORDER BY id"),
+              Seq(Row(2), Row(3), Row(4))
+            )
           }
         }
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

When querying with paimon_incremental_between_timestamp, we want to switch among different scan modes.
* delta or changelog, if every single change is needed. 
* diff, if merge is needed.

In our micro/small batch operation, executed in hourly, we need to know when a record INSERTEd, and also when it's DELETEd. This needs deleta or changelog mode. If with diff mode, the +I and -D operation could be merged, then we won't get the -D operation. 

But when quering the main table, not the audit_log table, the merged result is expected, to just get the INSERTEd and UPDATEd records. So we also need the diff mode.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
