### PR TITLE
[core] make rowType not null for KeyValue and AppendOnlyFileStore

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/KeyValue.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValue.java
@@ -111,7 +111,7 @@ public class KeyValue {
     }
 
     public static RowType schema(RowType keyType, RowType valueType) {
-        return new RowType(createKeyValueFields(keyType.getFields(), valueType.getFields()));
+        return new RowType(false, createKeyValueFields(keyType.getFields(), valueType.getFields()));
     }
 
     public static RowType schemaWithLevel(RowType keyType, RowType valueType) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -76,7 +76,7 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
                             new CoreOptions(tableSchema.options()),
                             tableSchema.logicalPartitionType(),
                             tableSchema.logicalBucketKeyType(),
-                            tableSchema.logicalRowType(),
+                            tableSchema.logicalRowType().notNull(),
                             name(),
                             catalogEnvironment);
         }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
rowType in KeyValue and AppendOnlyFileStore is used for read and write, make it not null.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
