### PR TITLE
[improve] As for `TimeTravel`, if the expected timestamp is earlier than the earliest snapshot, add one parameter to decide to return null or not

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/ContinuousFromTimestampStartingScanner.java
@@ -49,7 +49,11 @@ public class ContinuousFromTimestampStartingScanner extends AbstractStartingScan
         this.startFromChangelog = changelogDecoupled;
         this.startingSnapshotId =
                 TimeTravelUtil.earlierThanTimeMills(
-                        snapshotManager, changelogManager, startupMillis, startFromChangelog);
+                        snapshotManager,
+                        changelogManager,
+                        startupMillis,
+                        startFromChangelog,
+                        false);
     }
 
     @Override
@@ -66,7 +70,11 @@ public class ContinuousFromTimestampStartingScanner extends AbstractStartingScan
         if (startingSnapshotId == null) {
             startingSnapshotId =
                     TimeTravelUtil.earlierThanTimeMills(
-                            snapshotManager, changelogManager, startupMillis, startFromChangelog);
+                            snapshotManager,
+                            changelogManager,
+                            startupMillis,
+                            startFromChangelog,
+                            false);
         }
         if (startingSnapshotId == null) {
             LOG.debug("There is currently no snapshot. Waiting for snapshot generation.");

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/TimeTravelUtil.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/TimeTravelUtil.java
@@ -159,7 +159,8 @@ public class TimeTravelUtil {
         }
 
         if (earliestSnapshot.timeMillis() >= timestampMills) {
-            return earliestSnapshot.id() - 1;
+            // Please return null if the earliest snapshot is later than the timestamp.
+            return null;
         }
 
         long earliest = earliestSnapshot.id();

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/TimeTravelUtil.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/TimeTravelUtil.java
@@ -147,7 +147,7 @@ public class TimeTravelUtil {
             ChangelogManager changelogManager,
             long timestampMills,
             boolean startFromChangelog,
-            boolean returnNullIfTooLealy) {
+            boolean returnNullIfTooEarly) {
         Long latest = snapshotManager.latestSnapshotId();
         if (latest == null) {
             return null;
@@ -160,7 +160,7 @@ public class TimeTravelUtil {
         }
 
         if (earliestSnapshot.timeMillis() >= timestampMills) {
-            return returnNullIfTooLealy ? null : earliestSnapshot.id() - 1;
+            return returnNullIfTooEarly ? null : earliestSnapshot.id() - 1;
         }
 
         long earliest = earliestSnapshot.id();

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/TimeTravelUtil.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/TimeTravelUtil.java
@@ -146,7 +146,8 @@ public class TimeTravelUtil {
             SnapshotManager snapshotManager,
             ChangelogManager changelogManager,
             long timestampMills,
-            boolean startFromChangelog) {
+            boolean startFromChangelog,
+            boolean returnNullIfTooLealy) {
         Long latest = snapshotManager.latestSnapshotId();
         if (latest == null) {
             return null;
@@ -159,8 +160,7 @@ public class TimeTravelUtil {
         }
 
         if (earliestSnapshot.timeMillis() >= timestampMills) {
-            // Please return null if the earliest snapshot is later than the timestamp.
-            return null;
+            return returnNullIfTooLealy ? null : earliestSnapshot.id() - 1;
         }
 
         long earliest = earliestSnapshot.id();

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/TimeTravelUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/TimeTravelUtilsTest.java
@@ -83,8 +83,13 @@ public class TimeTravelUtilsTest extends ScannerTestBase {
 
         assertThat(
                         TimeTravelUtil.earlierThanTimeMills(
-                                snapshotManager, table.changelogManager(), 1L, true))
+                                snapshotManager, table.changelogManager(), 1L, true, true))
                 .isNull();
+
+        assertThat(
+                        TimeTravelUtil.earlierThanTimeMills(
+                                snapshotManager, table.changelogManager(), 1L, true, false))
+                .isEqualTo(0);
 
         write.close();
         commit.close();

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/TimeTravelUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/TimeTravelUtilsTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -79,6 +80,12 @@ public class TimeTravelUtilsTest extends ScannerTestBase {
                 IllegalArgumentException.class,
                 () -> TimeTravelUtil.resolveSnapshotFromOptions(options1, snapshotManager),
                 "scan.snapshot-id scan.tag-name scan.watermark and scan.timestamp-millis can contains only one");
+
+        assertThat(
+                        TimeTravelUtil.earlierThanTimeMills(
+                                snapshotManager, table.changelogManager(), 1L, true))
+                .isNull();
+
         write.close();
         commit.close();
     }

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -129,7 +129,8 @@ public class SnapshotManagerTest {
                 // pick a random time equal to one of the snapshots
                 time = millis.get(random.nextInt(numSnapshots));
             }
-            Long actual = TimeTravelUtil.earlierThanTimeMills(snapshotManager, null, time, false);
+            Long actual =
+                    TimeTravelUtil.earlierThanTimeMills(snapshotManager, null, time, false, false);
 
             if (millis.get(numSnapshots - 1) < time) {
                 if (isRaceCondition && millis.size() == 1) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Return null if time travel meet earlier timestamp than the earliest snapshot timestamp when set flag.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
