### PR TITLE
[test] RestCatalog: fix unit case annotation typo

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTSimpleTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTSimpleTableTest.java
@@ -30,6 +30,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.SimpleTableTestBase;
 import org.apache.paimon.types.RowType;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
@@ -58,7 +59,7 @@ public abstract class RESTSimpleTableTest extends SimpleTableTestBase {
 
     protected abstract RESTCatalog createRESTCatalog() throws IOException;
 
-    @BeforeEach
+    @AfterEach
     public void after() throws Exception {
         super.after();
         restCatalog.dropTable(identifier, true);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
[test] RestCatalog: fix unit case annotation typo

<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
