### PR TITLE
[hotfix] Fix earlierThanTimeMills return value

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/TimeTravelUtil.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/TimeTravelUtil.java
@@ -139,8 +139,8 @@ public class TimeTravelUtil {
     }
 
     /**
-     * Returns the latest snapshot earlier than the timestamp mills. A non-existent snapshot may be
-     * returned if all snapshots are equal to or later than the timestamp mills.
+     * Returns the latest snapshot earlier than the timestamp mills. A non-existent snapshot or null
+     * may be returned if all snapshots are equal to or later than the timestamp mills.
      */
     public static @Nullable Long earlierThanTimeMills(
             SnapshotManager snapshotManager,
@@ -155,7 +155,7 @@ public class TimeTravelUtil {
         Snapshot earliestSnapshot =
                 earliestSnapshot(snapshotManager, changelogManager, startFromChangelog, latest);
         if (earliestSnapshot == null) {
-            return latest - 1;
+            return null;
         }
 
         if (earliestSnapshot.timeMillis() >= timestampMills) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

This PR fixes the bug that TimeTravelUtil.earlierThanTimeMillis might accidentally return a existing snapshot id(latest - 1).

### Tests

SnapshotManagerTest.

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
