### PR TITLE
[core] Aggregate merge function should not return empty row with non-null column type exist

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeFunction.java
@@ -36,7 +36,10 @@ import org.apache.paimon.KeyValue;
  */
 public interface MergeFunction<T> {
 
-    /** Reset the merge function to its default state. */
+    /**
+     * Reset the merge function to its default state, call this before calling {@link
+     * #add(KeyValue)} for the fist time or after {@link #getResult}.
+     */
     void reset();
 
     /** Add the given {@link KeyValue} to the merge function. */

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeFunction.java
@@ -38,7 +38,7 @@ public interface MergeFunction<T> {
 
     /**
      * Reset the merge function to its default state, call this before calling {@link
-     * #add(KeyValue)} for the fist time or after {@link #getResult}.
+     * #add(KeyValue)} for the first time or after {@link #getResult}.
      */
     void reset();
 

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
@@ -286,7 +286,9 @@ public class LookupChangelogMergeFunctionWrapperTest {
                                                 new FieldAggregator[] {
                                                     new FieldSumAggFactory()
                                                             .create(DataTypes.INT(), null, null)
-                                                })),
+                                                },
+                                                false,
+                                                null)),
                         key -> null,
                         changelogRowDeduplicate ? EQUALISER : null,
                         LookupStrategy.from(false, true, false, false),
@@ -373,7 +375,9 @@ public class LookupChangelogMergeFunctionWrapperTest {
                                                 new FieldAggregator[] {
                                                     new FieldLastValueAggFactory()
                                                             .create(DataTypes.INT(), null, null)
-                                                })),
+                                                },
+                                                false,
+                                                null)),
                         highLevel::get,
                         null,
                         LookupStrategy.from(false, true, false, false),


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

like #5077, aggregate merge function should not return empty row with non-null column type exist

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
