### PR TITLE
[common] Set SYNC_ALL_PROPERTIES default to true, be kind to user.

### DIFF
--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -136,7 +136,7 @@ under the License.
         </tr>
         <tr>
             <td><h5>sync-all-properties</h5></td>
-            <td style="word-wrap: break-word;">false</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Sync all table properties to hive metastore</td>
         </tr>

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -138,7 +138,9 @@ public class CatalogOptions {
     public static final ConfigOption<Boolean> SYNC_ALL_PROPERTIES =
             ConfigOptions.key("sync-all-properties")
                     .booleanType()
-                    .defaultValue(false)
+                    // We should set default value to true in case of hive metastore losing table
+                    // properties.
+                    .defaultValue(true)
                     .withDescription("Sync all table properties to hive metastore");
 
     public static final ConfigOption<Boolean> FORMAT_TABLE_ENABLED =

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -270,8 +270,8 @@ public class HiveCatalogTest extends CatalogTestBase {
             Table table = clients.run(client -> client.getTable(databaseName, tableName));
             Map<String, String> tableProperties = table.getParameters();
 
-            assertThat(tableProperties).containsEntry("table.owner", "Hms");
-            assertThat(tableProperties).containsEntry("table.create_time", "2024-01-22");
+            assertThat(tableProperties).containsEntry("hive.table.owner", "Hms");
+            assertThat(tableProperties).containsEntry("hive.table.create_time", "2024-01-22");
         } catch (Exception e) {
             fail("Test failed due to exception: " + e.getMessage());
         }

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -214,8 +214,8 @@ public class HiveCatalogTest extends CatalogTestBase {
             Map<String, String> tableProperties = table.getParameters();
 
             // Verify the transformed parameters
-            assertThat(tableProperties).containsEntry("table.owner", "Jon");
-            assertThat(tableProperties).containsEntry("storage.format", "ORC");
+            assertThat(tableProperties).containsEntry("hive.table.owner", "Jon");
+            assertThat(tableProperties).containsEntry("hive.storage.format", "ORC");
             assertThat(tableProperties).containsEntry("comment", "this is a hive table");
             assertThat(tableProperties)
                     .containsEntry(

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -77,7 +77,10 @@ public class HiveCatalogTest extends CatalogTestBase {
         String jdoConnectionURL = "jdbc:derby:memory:" + UUID.randomUUID();
         hiveConf.setVar(METASTORECONNECTURLKEY, jdoConnectionURL + ";create=true");
         String metastoreClientClass = "org.apache.hadoop.hive.metastore.HiveMetaStoreClient";
-        catalog = new HiveCatalog(fileIO, hiveConf, metastoreClientClass, warehouse);
+        Options catalogOptions = new Options();
+        catalogOptions.set(CatalogOptions.SYNC_ALL_PROPERTIES.key(), "false");
+        catalog =
+                new HiveCatalog(fileIO, hiveConf, metastoreClientClass, catalogOptions, warehouse);
     }
 
     @Test
@@ -214,8 +217,8 @@ public class HiveCatalogTest extends CatalogTestBase {
             Map<String, String> tableProperties = table.getParameters();
 
             // Verify the transformed parameters
-            assertThat(tableProperties).containsEntry("hive.table.owner", "Jon");
-            assertThat(tableProperties).containsEntry("hive.storage.format", "ORC");
+            assertThat(tableProperties).containsEntry("table.owner", "Jon");
+            assertThat(tableProperties).containsEntry("storage.format", "ORC");
             assertThat(tableProperties).containsEntry("comment", "this is a hive table");
             assertThat(tableProperties)
                     .containsEntry(
@@ -270,8 +273,8 @@ public class HiveCatalogTest extends CatalogTestBase {
             Table table = clients.run(client -> client.getTable(databaseName, tableName));
             Map<String, String> tableProperties = table.getParameters();
 
-            assertThat(tableProperties).containsEntry("hive.table.owner", "Hms");
-            assertThat(tableProperties).containsEntry("hive.table.create_time", "2024-01-22");
+            assertThat(tableProperties).containsEntry("table.owner", "Hms");
+            assertThat(tableProperties).containsEntry("table.create_time", "2024-01-22");
         } catch (Exception e) {
             fail("Test failed due to exception: " + e.getMessage());
         }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogITCaseBase.java
@@ -1825,7 +1825,8 @@ public abstract class HiveCatalogITCaseBase {
                                 + "    PRIMARY KEY (dt, hh, user_id) NOT ENFORCED\n"
                                 + ") PARTITIONED BY (dt, hh)"
                                 + " WITH (\n"
-                                + "'metastore.partitioned-table' = 'true'\n"
+                                + "'metastore.partitioned-table' = 'true',\n"
+                                + "'sync-all-properties' = 'false'\n"
                                 + ");")
                 .await();
         tEnv.executeSql("INSERT INTO t_repair_hive VALUES(1, 'login', '2020-01-02', '09')").await();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Set SYNC_ALL_PROPERTIES default to true, this change has been approved in paimon dev email.
<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
