### PR TITLE
[core] Add withLevel method in SnapshotReader to optimize RO/compacted table scanning

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -83,6 +83,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
     private Filter<Integer> bucketFilter = null;
     private BiFilter<Integer, Integer> totalAwareBucketFilter = null;
     protected ScanMode scanMode = ScanMode.ALL;
+    private Integer specifiedLevel = null;
     private Filter<Integer> levelFilter = null;
     private Filter<ManifestEntry> manifestEntryFilter = null;
     private Filter<String> fileNameFilter = null;
@@ -188,6 +189,13 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
     @Override
     public FileStoreScan withKind(ScanMode scanMode) {
         this.scanMode = scanMode;
+        return this;
+    }
+
+    @Override
+    public FileStoreScan withLevel(int level) {
+        manifestsReader.withLevel(level);
+        this.specifiedLevel = level;
         return this;
     }
 
@@ -524,7 +532,12 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
                 return false;
             }
 
-            if (levelFilter != null && !levelFilter.test(levelGetter.apply(row))) {
+            int level = levelGetter.apply(row);
+            if (specifiedLevel != null && level != specifiedLevel) {
+                return false;
+            }
+
+            if (levelFilter != null && !levelFilter.test(level)) {
                 return false;
             }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
@@ -72,6 +72,8 @@ public interface FileStoreScan {
 
     FileStoreScan withKind(ScanMode scanMode);
 
+    FileStoreScan withLevel(int level);
+
     FileStoreScan withLevelFilter(Filter<Integer> levelFilter);
 
     FileStoreScan enableValueFilter();

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestsReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestsReader.java
@@ -50,6 +50,7 @@ public class ManifestsReader {
 
     private boolean onlyReadRealBuckets = false;
     @Nullable private Integer specifiedBucket = null;
+    @Nullable private Integer specifiedLevel = null;
     @Nullable private PartitionPredicate partitionFilter = null;
 
     public ManifestsReader(
@@ -70,6 +71,11 @@ public class ManifestsReader {
 
     public ManifestsReader withBucket(int bucket) {
         this.specifiedBucket = bucket;
+        return this;
+    }
+
+    public ManifestsReader withLevel(int level) {
+        this.specifiedLevel = level;
         return this;
     }
 
@@ -143,6 +149,15 @@ public class ManifestsReader {
             }
             if (specifiedBucket != null
                     && (specifiedBucket < minBucket || specifiedBucket > maxBucket)) {
+                return false;
+            }
+        }
+
+        Integer minLevel = manifest.minLevel();
+        Integer maxLevel = manifest.maxLevel();
+        if (minLevel != null && maxLevel != null) {
+            if (specifiedLevel != null
+                    && (specifiedLevel < minLevel || specifiedLevel > maxLevel)) {
                 return false;
             }
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
@@ -80,6 +80,8 @@ public interface SnapshotReader {
 
     SnapshotReader withMode(ScanMode scanMode);
 
+    SnapshotReader withLevel(int level);
+
     SnapshotReader withLevelFilter(Filter<Integer> levelFilter);
 
     SnapshotReader enableValueFilter();
@@ -131,6 +133,7 @@ public interface SnapshotReader {
         /** Result splits. */
         List<Split> splits();
 
+        @SuppressWarnings({"unchecked", "rawtypes"})
         default List<DataSplit> dataSplits() {
             return (List) splits();
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
@@ -246,6 +246,12 @@ public class SnapshotReaderImpl implements SnapshotReader {
     }
 
     @Override
+    public SnapshotReader withLevel(int level) {
+        scan.withLevel(level);
+        return this;
+    }
+
+    @Override
     public SnapshotReader withLevelFilter(Filter<Integer> levelFilter) {
         scan.withLevelFilter(levelFilter);
         return this;

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
@@ -336,6 +336,12 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
         }
 
         @Override
+        public SnapshotReader withLevel(int level) {
+            wrapped.withLevel(level);
+            return this;
+        }
+
+        @Override
         public SnapshotReader withLevelFilter(Filter<Integer> levelFilter) {
             wrapped.withLevelFilter(levelFilter);
             return this;

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ReadOptimizedTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ReadOptimizedTable.java
@@ -120,9 +120,9 @@ public class ReadOptimizedTable implements DataTable, ReadonlyTable {
 
     @Override
     public SnapshotReader newSnapshotReader() {
-        if (wrapped.schema().primaryKeys().size() > 0) {
+        if (!wrapped.schema().primaryKeys().isEmpty()) {
             return wrapped.newSnapshotReader()
-                    .withLevelFilter(level -> level == coreOptions().numLevels() - 1)
+                    .withLevel(coreOptions().numLevels() - 1)
                     .enableValueFilter();
         } else {
             return wrapped.newSnapshotReader();
@@ -132,7 +132,7 @@ public class ReadOptimizedTable implements DataTable, ReadonlyTable {
     @Override
     public DataTableBatchScan newScan() {
         return new DataTableBatchScan(
-                wrapped.schema().primaryKeys().size() > 0,
+                !wrapped.schema().primaryKeys().isEmpty(),
                 coreOptions(),
                 newSnapshotReader(),
                 DefaultValueAssigner.create(wrapped.schema()));
@@ -140,7 +140,7 @@ public class ReadOptimizedTable implements DataTable, ReadonlyTable {
 
     @Override
     public StreamDataTableScan newStreamScan() {
-        if (wrapped.schema().primaryKeys().size() > 0) {
+        if (!wrapped.schema().primaryKeys().isEmpty()) {
             throw new UnsupportedOperationException(
                     "Unsupported streaming scan for read optimized table");
         }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/CompactionChangelogFollowUpScannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/CompactionChangelogFollowUpScannerTest.java
@@ -67,7 +67,7 @@ public class CompactionChangelogFollowUpScannerTest extends ScannerTestBase {
 
         assertThat(snapshotManager.latestSnapshotId()).isEqualTo(5);
 
-        snapshotReader.withLevelFilter(level -> level == table.coreOptions().numLevels() - 1);
+        snapshotReader.withLevel(table.coreOptions().numLevels() - 1);
         TableRead read = table.newRead();
         ChangelogFollowUpScanner scanner = new ChangelogFollowUpScanner();
 


### PR DESCRIPTION
### Purpose

This PR adds `withLevel` method in `SnapshotReader` to optimize `$ro` system table scanning and `FULL_COMPACTION` scan mode. This method uses the newly added stats about levels in `ManifestFileMeta`.

### Tests

Existing tests should cover this change.

### API and Format

No format changes.

### Documentation

No new feature.
