### PR TITLE
[spark] Add bucket function and write benchmark

### DIFF
--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/benchmark/BucketFunctionBenchmark.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/benchmark/BucketFunctionBenchmark.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.benchmark
+
+import org.apache.spark.sql.paimon.PaimonBenchmark
+
+object BucketFunctionBenchmark extends PaimonSqlBasedBenchmark {
+
+  private val N = 20L * 1000 * 1000
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val benchmark = PaimonBenchmark(s"Bucket function", N, output = output)
+
+    benchmark.addCase("Single int column", 3) {
+      _ => spark.range(N).selectExpr("fixed_bucket(10, id)").noop()
+    }
+
+    benchmark.addCase("Single string column", 3) {
+      _ => spark.range(N).selectExpr("fixed_bucket(10, uuid())").noop()
+    }
+
+    benchmark.addCase("Multiple columns", 3) {
+      _ => spark.range(N).selectExpr("fixed_bucket(10, id, uuid(), uuid())").noop()
+    }
+
+    benchmark.run()
+  }
+}

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/benchmark/PaimonSqlBasedBenchmark.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/benchmark/PaimonSqlBasedBenchmark.scala
@@ -18,7 +18,7 @@
 
 package org.apache.paimon.spark.benchmark
 
-import org.apache.paimon.spark.SparkGenericCatalog
+import org.apache.paimon.spark.SparkCatalog
 import org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -40,15 +40,18 @@ trait PaimonSqlBasedBenchmark extends SqlBasedBenchmark {
       .appName(this.getClass.getCanonicalName)
       .config("spark.ui.enabled", value = false)
       .config("spark.sql.warehouse.dir", tempDBDir.getCanonicalPath)
-      .config("spark.sql.catalog.spark_catalog", classOf[SparkGenericCatalog].getName)
-      .config("spark.sql.catalog.spark_catalog.warehouse", tempDBDir.getCanonicalPath)
+      .config("spark.sql.catalog.paimon", classOf[SparkCatalog].getName)
+      .config("spark.sql.catalog.paimon.warehouse", tempDBDir.getCanonicalPath)
+      .config("spark.sql.defaultCatalog", "paimon")
       .config("spark.sql.extensions", classOf[PaimonSparkSessionExtensions].getName)
       .getOrCreate()
   }
 
   def withTempTable(tableNames: String*)(f: => Unit): Unit = {
     try f
-    finally tableNames.foreach(spark.catalog.dropTempView)
+    finally {
+      tableNames.foreach(spark.catalog.dropTempView)
+    }
   }
 
   def withTable(tableNames: String*)(f: => Unit): Unit = {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/benchmark/PaimonSqlBasedBenchmark.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/benchmark/PaimonSqlBasedBenchmark.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.benchmark
+
+import org.apache.paimon.spark.SparkGenericCatalog
+import org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions
+
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
+import org.apache.spark.sql.paimon.Utils
+
+import java.io.File
+
+trait PaimonSqlBasedBenchmark extends SqlBasedBenchmark {
+
+  protected lazy val tempDBDir: File = Utils.createTempDir
+
+  protected lazy val sql: String => DataFrame = spark.sql
+
+  override def getSparkSession: SparkSession = {
+    SparkSession
+      .builder()
+      .master("local[1]")
+      .appName(this.getClass.getCanonicalName)
+      .config("spark.ui.enabled", value = false)
+      .config("spark.sql.warehouse.dir", tempDBDir.getCanonicalPath)
+      .config("spark.sql.catalog.spark_catalog", classOf[SparkGenericCatalog].getName)
+      .config("spark.sql.catalog.spark_catalog.warehouse", tempDBDir.getCanonicalPath)
+      .config("spark.sql.extensions", classOf[PaimonSparkSessionExtensions].getName)
+      .getOrCreate()
+  }
+
+  def withTempTable(tableNames: String*)(f: => Unit): Unit = {
+    try f
+    finally tableNames.foreach(spark.catalog.dropTempView)
+  }
+
+  def withTable(tableNames: String*)(f: => Unit): Unit = {
+    try f
+    finally {
+      tableNames.foreach(name => sql(s"DROP TABLE IF EXISTS $name"))
+    }
+  }
+}

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/benchmark/WriteBenchmark.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/benchmark/WriteBenchmark.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.benchmark
+
+import org.apache.spark.sql.paimon.PaimonBenchmark
+
+object WriteBenchmark extends PaimonSqlBasedBenchmark {
+
+  private val N = 10L * 1000 * 1000
+  private val sourceTable = "source"
+
+  def writeNonPKTable(keys: String, i: Int, benchmark: PaimonBenchmark): Unit = {
+    writeTable(isPKTable = false, keys, i, benchmark)
+  }
+
+  def writeTable(
+      isPKTable: Boolean,
+      keys: String,
+      bucket: Int,
+      benchmark: PaimonBenchmark): Unit = {
+    benchmark.addCase(s"write table, isPKTable: $isPKTable, keys: $keys, bucket: $bucket", 3) {
+      _ =>
+        val tableName = "nonPKTable"
+        val keyProp = if (keys.isEmpty) {
+          ""
+        } else if (isPKTable) {
+          s"'primary-key' = '$keys',"
+        } else {
+          s"'bucket-key' = '$keys',"
+        }
+        withTable(tableName) {
+          sql(s"""
+                 |CREATE TABLE $tableName(id INT, s1 STRING, s2 STRING) USING paimon
+                 |TBLPROPERTIES (
+                 | $keyProp
+                 | 'bucket' = '$bucket'
+                 |)
+                 |""".stripMargin)
+          sql(s"INSERT INTO $tableName SELECT * FROM $sourceTable")
+        }
+    }
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val benchmark = PaimonBenchmark(s"Write paimon table", N, output = output)
+
+    withTempTable(sourceTable) {
+      spark
+        .range(N)
+        .selectExpr("id", "uuid() as s1", "uuid() as s2")
+        .createOrReplaceTempView(sourceTable)
+
+      // fixed bucket
+      writeNonPKTable("id", 10, benchmark)
+      writeNonPKTable("s1", 10, benchmark)
+      writeNonPKTable("id,s1", 10, benchmark)
+
+      // unaware bucket
+      writeNonPKTable("", -1, benchmark)
+
+      benchmark.run()
+    }
+  }
+}

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/benchmark/WriteBenchmark.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/benchmark/WriteBenchmark.scala
@@ -36,7 +36,7 @@ object WriteBenchmark extends PaimonSqlBasedBenchmark {
       benchmark: PaimonBenchmark): Unit = {
     benchmark.addCase(s"write table, isPKTable: $isPKTable, keys: $keys, bucket: $bucket", 3) {
       _ =>
-        val tableName = "nonPKTable"
+        val tableName = "targetTable"
         val keyProp = if (keys.isEmpty) {
           ""
         } else if (isPKTable) {
@@ -46,7 +46,7 @@ object WriteBenchmark extends PaimonSqlBasedBenchmark {
         }
         withTable(tableName) {
           sql(s"""
-                 |CREATE TABLE $tableName(id INT, s1 STRING, s2 STRING) USING paimon
+                 |CREATE TABLE $tableName (id INT, s1 STRING, s2 STRING) USING paimon
                  |TBLPROPERTIES (
                  | $keyProp
                  | 'bucket' = '$bucket'

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/spark/sql/paimon/PaimonBenchmark.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/spark/sql/paimon/PaimonBenchmark.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.paimon
+
+import org.apache.spark.benchmark.Benchmark
+
+import java.io.OutputStream
+
+import scala.concurrent.duration._
+
+case class PaimonBenchmark(
+    name: String,
+    valuesPerIteration: Long,
+    minNumIters: Int = 2,
+    warmupTime: FiniteDuration = 2.seconds,
+    minTime: FiniteDuration = 2.seconds,
+    outputPerIteration: Boolean = false,
+    output: Option[OutputStream] = None)
+  extends Benchmark(
+    name,
+    valuesPerIteration,
+    minNumIters,
+    warmupTime,
+    minTime,
+    outputPerIteration,
+    output)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

```
OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Mac OS X 14.4.1
Apple M1
Bucket function:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Single int column                                  1965           2718        1260         10.2          98.3       1.0X
Single string column                               8529           8654         108          2.3         426.4       0.2X
Multiple columns                                  13629          14425        1238          1.5         681.4       0.1X
```

```
OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Mac OS X 14.4.1
Apple M1
Write paimon table:                                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------------
write table, isPKTable: false, keys: id, bucket: 10             21347          21878         462          0.5        2134.7       1.0X
write table, isPKTable: false, keys: s1, bucket: 10             22006          22336         550          0.5        2200.6       1.0X
write table, isPKTable: false, keys: id,s1, bucket: 10          23409          23665         225          0.4        2340.9       0.9X
write table, isPKTable: false, keys: , bucket: -1               10759          10851          96          0.9        1075.9       2.0X
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
