### PR TITLE
[spark] Add sys prefix for build-in function

### DIFF
--- a/docs/content/spark/sql-functions.md
+++ b/docs/content/spark/sql-functions.md
@@ -31,7 +31,7 @@ This section introduce all available Paimon Spark functions.
 
 ## max_pt
 
-`max_pt($table_name)`
+`sys.max_pt($table_name)`
 
 It accepts a string type literal to specify the table name and return a max-valid-toplevel partition value.
 - **valid**: the partition which contains data files
@@ -45,10 +45,10 @@ It would throw exception when:
 **Example**
 
 ```shell
-> SELECT max_pt('t');
+> SELECT sys.max_pt('t');
  20250101
  
-> SELECT * FROM t where pt = max_pt('t');
+> SELECT * FROM t where pt = sys.max_pt('t');
  a, 20250101
 ```
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonFunctionTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonFunctionTest.scala
@@ -71,7 +71,7 @@ class PaimonFunctionTest extends PaimonHiveTestBase {
     Seq("paimon", paimonHiveCatalogName).foreach {
       catalogName =>
         sql(s"use $catalogName")
-        val functions = sql("show user functions").collect()
+        val functions = sql("show user functions in sys").collect()
         assert(functions.exists(_.getString(0).contains("max_pt")), catalogName)
     }
   }
@@ -117,15 +117,12 @@ class PaimonFunctionTest extends PaimonHiveTestBase {
   }
 
   test("Add max_pt function") {
-    Seq("paimon", sparkCatalogName, paimonHiveCatalogName).foreach {
+    // spark_catalog does not currently support loading v2 function, see https://github.com/apache/spark/pull/50495
+    Seq("paimon", paimonHiveCatalogName).foreach {
       catalogName =>
         {
           sql(s"use $catalogName")
-          val maxPt = if (catalogName == sparkCatalogName) {
-            "paimon.max_pt"
-          } else {
-            "max_pt"
-          }
+          val maxPt = "sys.max_pt"
 
           intercept[Exception] {
             sql(s"SELECT $maxPt(1)").collect()


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Users may create their own functions with the same name as built-in functions, so we need to add the sys prefix to distinguish them, just like sys.procedure

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
