### PR TITLE
[format] Bump parquet from 1.13.1 to 1.15.1

### DIFF
--- a/paimon-format/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/paimon-format/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -20,14 +20,17 @@ package org.apache.parquet.hadoop;
 
 import org.apache.paimon.format.parquet.ParquetInputFile;
 import org.apache.paimon.format.parquet.ParquetInputStream;
-import org.apache.paimon.fs.FileRange;
 import org.apache.paimon.fs.VectoredReadable;
 import org.apache.paimon.utils.RoaringBitmap32;
 
+import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.ParquetReadOptions;
+import org.apache.parquet.Preconditions;
 import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.bytes.ByteBufferReleaser;
 import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.bytes.ReusingByteBufferAllocator;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.DataPage;
 import org.apache.parquet.column.page.DataPageV1;
@@ -63,6 +66,7 @@ import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.hadoop.metadata.FileMetaData;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.hadoop.util.counters.BenchmarkCounter;
+import org.apache.parquet.hadoop.util.wrapped.io.FutureIO;
 import org.apache.parquet.internal.column.columnindex.ColumnIndex;
 import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 import org.apache.parquet.internal.filter2.columnindex.ColumnIndexFilter;
@@ -71,10 +75,10 @@ import org.apache.parquet.internal.filter2.columnindex.RowRanges;
 import org.apache.parquet.internal.hadoop.metadata.IndexReference;
 import org.apache.parquet.io.InputFile;
 import org.apache.parquet.io.ParquetDecodingException;
+import org.apache.parquet.io.ParquetFileRange;
 import org.apache.parquet.io.SeekableInputStream;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
-import org.apache.yetus.audience.InterfaceAudience.Private;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,11 +98,11 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.zip.CRC32;
 
-import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.parquet.bytes.BytesUtils.readIntLittleEndian;
 import static org.apache.parquet.filter2.compat.RowGroupFilter.FilterLevel.BLOOMFILTER;
 import static org.apache.parquet.filter2.compat.RowGroupFilter.FilterLevel.DICTIONARY;
@@ -118,11 +122,20 @@ public class ParquetFileReader implements Closeable {
 
     private static final Logger LOG = LoggerFactory.getLogger(ParquetFileReader.class);
 
+    public static final long HADOOP_VECTORED_READ_TIMEOUT_SECONDS = 300;
+
     private final ParquetMetadataConverter converter;
 
     private final CRC32 crc;
+    private final ReusingByteBufferAllocator crcAllocator;
 
-    private static ParquetMetadata readFooter(
+    public static final ParquetMetadata readFooter(
+            InputFile file, ParquetReadOptions options, SeekableInputStream f) throws IOException {
+        ParquetMetadataConverter converter = new ParquetMetadataConverter(options);
+        return readFooter(file, options, f, converter);
+    }
+
+    private static final ParquetMetadata readFooter(
             InputFile file,
             ParquetReadOptions options,
             SeekableInputStream f,
@@ -180,35 +193,39 @@ public class ParquetFileReader implements Closeable {
 
         // Read all the footer bytes in one time to avoid multiple read operations,
         // since it can be pretty time consuming for a single read operation in HDFS.
-        ByteBuffer footerBytesBuffer = ByteBuffer.allocate(fileMetadataLength);
-        f.readFully(footerBytesBuffer);
-        LOG.debug("Finished to read all footer bytes.");
-        footerBytesBuffer.flip();
-        InputStream footerBytesStream = ByteBufferInputStream.wrap(footerBytesBuffer);
+        ByteBuffer footerBytesBuffer = options.getAllocator().allocate(fileMetadataLength);
+        try {
+            f.readFully(footerBytesBuffer);
+            LOG.debug("Finished to read all footer bytes.");
+            footerBytesBuffer.flip();
+            InputStream footerBytesStream = ByteBufferInputStream.wrap(footerBytesBuffer);
 
-        // Regular file, or encrypted file with plaintext footer
-        if (!encryptedFooterMode) {
+            // Regular file, or encrypted file with plaintext footer
+            if (!encryptedFooterMode) {
+                return converter.readParquetMetadata(
+                        footerBytesStream,
+                        options.getMetadataFilter(),
+                        fileDecryptor,
+                        false,
+                        fileMetadataLength);
+            }
+
+            // Encrypted file with encrypted footer
+            if (null == fileDecryptor) {
+                throw new ParquetCryptoRuntimeException(
+                        "Trying to read file with encrypted footer. No keys available");
+            }
+            FileCryptoMetaData fileCryptoMetaData = readFileCryptoMetaData(footerBytesStream);
+            fileDecryptor.setFileCryptoMetaData(
+                    fileCryptoMetaData.getEncryption_algorithm(),
+                    true,
+                    fileCryptoMetaData.getKey_metadata());
+            // footer length is required only for signed plaintext footers
             return converter.readParquetMetadata(
-                    footerBytesStream,
-                    options.getMetadataFilter(),
-                    fileDecryptor,
-                    false,
-                    fileMetadataLength);
+                    footerBytesStream, options.getMetadataFilter(), fileDecryptor, true, 0);
+        } finally {
+            options.getAllocator().release(footerBytesBuffer);
         }
-
-        // Encrypted file with encrypted footer
-        if (null == fileDecryptor) {
-            throw new ParquetCryptoRuntimeException(
-                    "Trying to read file with encrypted footer. No keys available");
-        }
-        FileCryptoMetaData fileCryptoMetaData = readFileCryptoMetaData(footerBytesStream);
-        fileDecryptor.setFileCryptoMetaData(
-                fileCryptoMetaData.getEncryption_algorithm(),
-                true,
-                fileCryptoMetaData.getKey_metadata());
-        // footer length is required only for signed plaintext footers
-        return converter.readParquetMetadata(
-                footerBytesStream, options.getMetadataFilter(), fileDecryptor, true, 0);
     }
 
     protected final ParquetInputStream f;
@@ -268,7 +285,13 @@ public class ParquetFileReader implements Closeable {
         for (ColumnDescriptor col : footer.getFileMetaData().getSchema().getColumns()) {
             paths.put(ColumnPath.get(col.getPath()), col);
         }
-        this.crc = options.usePageChecksumVerification() ? new CRC32() : null;
+        if (options.usePageChecksumVerification()) {
+            this.crc = new CRC32();
+            this.crcAllocator = ReusingByteBufferAllocator.strict(options.getAllocator());
+        } else {
+            this.crc = null;
+            this.crcAllocator = null;
+        }
     }
 
     private static <T> List<T> listWithNulls(int size) {
@@ -446,7 +469,7 @@ public class ParquetFileReader implements Closeable {
         ColumnChunkPageReadStore rowGroup =
                 new ColumnChunkPageReadStore(block.getRowCount(), block.getRowIndexOffset());
         // prepare the list of consecutive parts to read them in one scan
-        List<ConsecutivePartList> allParts = new ArrayList<ConsecutivePartList>();
+        List<ConsecutivePartList> allParts = new ArrayList<>();
         ConsecutivePartList currentParts = null;
         for (ColumnChunkMetaData mc : block.getColumns()) {
             ColumnPath pathKey = mc.getPath();
@@ -466,6 +489,7 @@ public class ParquetFileReader implements Closeable {
         // actually read all the chunks
         ChunkListBuilder builder = new ChunkListBuilder(block.getRowCount());
         readAllPartsVectoredOrNormal(allParts, builder);
+        rowGroup.setReleaser(builder.releaser);
         for (Chunk chunk : builder.build()) {
             readChunkPages(chunk, block, rowGroup);
         }
@@ -600,24 +624,25 @@ public class ParquetFileReader implements Closeable {
     @SuppressWarnings("checkstyle:JavadocParagraph")
     private void readVectored(List<ConsecutivePartList> allParts, ChunkListBuilder builder)
             throws IOException {
-        List<FileRange> ranges = new ArrayList<>(allParts.size());
+
+        List<ParquetFileRange> ranges = new ArrayList<>(allParts.size());
         long totalSize = 0;
         for (ConsecutivePartList consecutiveChunks : allParts) {
             final long len = consecutiveChunks.length;
-            checkArgument(
+            Preconditions.checkArgument(
                     len < Integer.MAX_VALUE,
                     "Invalid length %s for vectored read operation. It must be less than max integer value.",
                     len);
-            ranges.add(FileRange.createFileRange(consecutiveChunks.offset, (int) len));
+            ranges.add(new ParquetFileRange(consecutiveChunks.offset, (int) len));
             totalSize += len;
         }
         LOG.debug(
                 "Reading {} bytes of data with vectored IO in {} ranges", totalSize, ranges.size());
         // Request a vectored read;
-        ((VectoredReadable) f.in()).readVectored(ranges);
+        f.readVectored(ranges, options.getAllocator());
         int k = 0;
         for (ConsecutivePartList consecutivePart : allParts) {
-            FileRange currRange = ranges.get(k++);
+            ParquetFileRange currRange = ranges.get(k++);
             consecutivePart.readFromVectoredRange(currRange, builder);
         }
     }
@@ -707,6 +732,7 @@ public class ParquetFileReader implements Closeable {
         }
         // actually read all the chunks
         readAllPartsVectoredOrNormal(allParts, builder);
+        rowGroup.setReleaser(builder.releaser);
         for (Chunk chunk : builder.build()) {
             readChunkPages(chunk, block, rowGroup);
         }
@@ -798,11 +824,11 @@ public class ParquetFileReader implements Closeable {
         if (blockIndex < 0 || blockIndex >= blocks.size()) {
             return null;
         }
-        return new DictionaryPageReader(this, blocks.get(blockIndex));
+        return new DictionaryPageReader(this, blocks.get(blockIndex), options.getAllocator());
     }
 
     public DictionaryPageReader getDictionaryReader(BlockMetaData block) {
-        return new DictionaryPageReader(this, block);
+        return new DictionaryPageReader(this, block, options.getAllocator());
     }
 
     /**
@@ -888,10 +914,7 @@ public class ParquetFileReader implements Closeable {
         int uncompressedPageSize = pageHeader.getUncompressed_page_size();
         int compressedPageSize = pageHeader.getCompressed_page_size();
 
-        byte[] dictPageBytes = new byte[compressedPageSize];
-        fin.readFully(dictPageBytes);
-
-        BytesInput bin = BytesInput.from(dictPageBytes);
+        BytesInput bin = BytesInput.from(fin, compressedPageSize);
 
         if (null != pageDecryptor) {
             bin = BytesInput.from(pageDecryptor.decrypt(bin.toByteArray(), dictionaryPageAAD));
@@ -1090,6 +1113,7 @@ public class ParquetFileReader implements Closeable {
         private ChunkDescriptor lastDescriptor;
         private final long rowCount;
         private SeekableInputStream f;
+        private final ByteBufferReleaser releaser = new ByteBufferReleaser(options.getAllocator());
 
         public ChunkListBuilder(long rowCount) {
             this.rowCount = rowCount;
@@ -1099,6 +1123,10 @@ public class ParquetFileReader implements Closeable {
             map.computeIfAbsent(descriptor, d -> new ChunkData()).buffers.addAll(buffers);
             lastDescriptor = descriptor;
             this.f = f;
+        }
+
+        void addBuffersToRelease(List<ByteBuffer> toRelease) {
+            toRelease.forEach(releaser::releaseLater);
         }
 
         void setOffsetIndex(ChunkDescriptor descriptor, OffsetIndex offsetIndex) {
@@ -1161,16 +1189,18 @@ public class ParquetFileReader implements Closeable {
          * Calculate checksum of input bytes, throw decoding exception if it does not match the
          * provided reference crc.
          */
-        private void verifyCrc(int referenceCrc, byte[] bytes, String exceptionMsg) {
+        private void verifyCrc(int referenceCrc, BytesInput bytes, String exceptionMsg) {
             crc.reset();
-            crc.update(bytes);
+            try (ByteBufferReleaser releaser = crcAllocator.getReleaser()) {
+                crc.update(bytes.toByteBuffer(releaser));
+            }
             if (crc.getValue() != ((long) referenceCrc & 0xffffffffL)) {
                 throw new ParquetDecodingException(exceptionMsg);
             }
         }
 
         /**
-         * Read all of the pages in a given column chunk.
+         * Read all the pages in a given column chunk.
          *
          * @return the list of pages
          */
@@ -1237,7 +1267,7 @@ public class ParquetFileReader implements Closeable {
                         if (options.usePageChecksumVerification() && pageHeader.isSetCrc()) {
                             verifyCrc(
                                     pageHeader.getCrc(),
-                                    pageBytes.toByteArray(),
+                                    pageBytes,
                                     "could not verify dictionary page integrity, CRC checksum verification failed");
                         }
                         DictionaryPageHeader dicHeader = pageHeader.getDictionary_page_header();
@@ -1258,7 +1288,7 @@ public class ParquetFileReader implements Closeable {
                         if (options.usePageChecksumVerification() && pageHeader.isSetCrc()) {
                             verifyCrc(
                                     pageHeader.getCrc(),
-                                    pageBytes.toByteArray(),
+                                    pageBytes,
                                     "could not verify page integrity, CRC checksum verification failed");
                         }
                         DataPageV1 dataPageV1 =
@@ -1289,23 +1319,41 @@ public class ParquetFileReader implements Closeable {
                                 compressedPageSize
                                         - dataHeaderV2.getRepetition_levels_byte_length()
                                         - dataHeaderV2.getDefinition_levels_byte_length();
-                        pagesInChunk.add(
+                        final BytesInput repetitionLevels =
+                                this.readAsBytesInput(
+                                        dataHeaderV2.getRepetition_levels_byte_length());
+                        final BytesInput definitionLevels =
+                                this.readAsBytesInput(
+                                        dataHeaderV2.getDefinition_levels_byte_length());
+                        final BytesInput values = this.readAsBytesInput(dataSize);
+                        if (options.usePageChecksumVerification() && pageHeader.isSetCrc()) {
+                            pageBytes =
+                                    BytesInput.concat(repetitionLevels, definitionLevels, values);
+                            verifyCrc(
+                                    pageHeader.getCrc(),
+                                    pageBytes,
+                                    "could not verify page integrity, CRC checksum verification failed");
+                        }
+                        DataPageV2 dataPageV2 =
                                 new DataPageV2(
                                         dataHeaderV2.getNum_rows(),
                                         dataHeaderV2.getNum_nulls(),
                                         dataHeaderV2.getNum_values(),
-                                        this.readAsBytesInput(
-                                                dataHeaderV2.getRepetition_levels_byte_length()),
-                                        this.readAsBytesInput(
-                                                dataHeaderV2.getDefinition_levels_byte_length()),
+                                        repetitionLevels,
+                                        definitionLevels,
                                         converter.getEncoding(dataHeaderV2.getEncoding()),
-                                        this.readAsBytesInput(dataSize),
+                                        values,
                                         uncompressedPageSize,
                                         converter.fromParquetStatistics(
                                                 getFileMetaData().getCreatedBy(),
                                                 dataHeaderV2.getStatistics(),
                                                 type),
-                                        dataHeaderV2.isIs_compressed()));
+                                        dataHeaderV2.isIs_compressed());
+                        // Copy crc to new page, used for testing
+                        if (pageHeader.isSetCrc()) {
+                            dataPageV2.setCrc(pageHeader.getCrc());
+                        }
+                        pagesInChunk.add(dataPageV2);
                         valuesCountReadSoFar += dataHeaderV2.getNum_values();
                         ++dataPageCountReadSoFar;
                         break;
@@ -1346,7 +1394,8 @@ public class ParquetFileReader implements Closeable {
                     pageBlockDecryptor,
                     aadPrefix,
                     rowGroupOrdinal,
-                    columnOrdinal);
+                    columnOrdinal,
+                    options);
         }
 
         private boolean hasMorePages(long valuesCountReadSoFar, int dataPageCountReadSoFar) {
@@ -1528,11 +1577,14 @@ public class ParquetFileReader implements Closeable {
             if (lastAllocationSize > 0) {
                 buffers.add(options.getAllocator().allocate(lastAllocationSize));
             }
+            builder.addBuffersToRelease(buffers);
 
+            long readStart = System.nanoTime();
             for (ByteBuffer buffer : buffers) {
                 f.readFully(buffer);
                 buffer.flip();
             }
+            setReadMetrics(readStart, length);
 
             // report in a counter the data we just scanned
             BenchmarkCounter.incrementBytesRead(length);
@@ -1542,24 +1594,60 @@ public class ParquetFileReader implements Closeable {
             }
         }
 
+        private void setReadMetrics(long startNs, long len) {
+            ParquetMetricsCallback metricsCallback = options.getMetricsCallback();
+            if (metricsCallback != null) {
+                long totalFileReadTimeNs = Math.max(System.nanoTime() - startNs, 0);
+                double sizeInMb = ((double) len) / (1024 * 1024);
+                double timeInSec = ((double) totalFileReadTimeNs) / 1000_0000_0000L;
+                double throughput = sizeInMb / timeInSec;
+                LOG.debug(
+                        "Parquet: File Read stats:  Length: {} MB, Time: {} secs, throughput: {} MB/sec ",
+                        sizeInMb,
+                        timeInSec,
+                        throughput);
+                metricsCallback.setDuration(
+                        ParquetFileReaderMetrics.ReadTime.name(), totalFileReadTimeNs);
+                metricsCallback.setValueLong(ParquetFileReaderMetrics.ReadSize.name(), length);
+                metricsCallback.setValueDouble(
+                        ParquetFileReaderMetrics.ReadThroughput.name(), throughput);
+            }
+        }
+
         /**
-         * Populate data in a parquet file range from a vectored range.
+         * Populate data in a parquet file range from a vectored range; will block for up to {@link
+         * #HADOOP_VECTORED_READ_TIMEOUT_SECONDS} seconds.
          *
          * @param currRange range to populated.
          * @param builder used to build chunk list to read the pages for the different columns.
          * @throws IOException if there is an error while reading from the stream, including a
          *     timeout.
          */
-        public void readFromVectoredRange(FileRange currRange, ChunkListBuilder builder)
+        public void readFromVectoredRange(ParquetFileRange currRange, ChunkListBuilder builder)
                 throws IOException {
-            byte[] buffer;
+            ByteBuffer buffer;
+            final long timeoutSeconds = HADOOP_VECTORED_READ_TIMEOUT_SECONDS;
+            long readStart = System.nanoTime();
             try {
-                buffer = currRange.getData().get();
-            } catch (InterruptedException | ExecutionException e) {
-                throw new RuntimeException(e);
+                LOG.debug(
+                        "Waiting for vectored read to finish for range {} with timeout {} seconds",
+                        currRange,
+                        timeoutSeconds);
+                buffer =
+                        FutureIO.awaitFuture(
+                                currRange.getDataReadFuture(), timeoutSeconds, TimeUnit.SECONDS);
+                setReadMetrics(readStart, currRange.getLength());
+                // report in a counter the data we just scanned
+                BenchmarkCounter.incrementBytesRead(currRange.getLength());
+            } catch (TimeoutException e) {
+                String error =
+                        String.format(
+                                "Timeout while fetching result for %s with time limit %d seconds",
+                                currRange, timeoutSeconds);
+                LOG.error(error, e);
+                throw new IOException(error, e);
             }
-
-            ByteBufferInputStream stream = ByteBufferInputStream.wrap(ByteBuffer.wrap(buffer));
+            ByteBufferInputStream stream = ByteBufferInputStream.wrap(buffer);
             for (ChunkDescriptor descriptor : chunks) {
                 builder.add(descriptor, stream.sliceBuffers(descriptor.size), f);
             }

--- a/paimon-format/src/main/resources/META-INF/NOTICE
+++ b/paimon-format/src/main/resources/META-INF/NOTICE
@@ -19,12 +19,12 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-annotations:2.14.2
 - org.apache.commons:commons-compress:1.22
 
-- org.apache.parquet:parquet-hadoop:1.13.1
-- org.apache.parquet:parquet-column:1.13.1
-- org.apache.parquet:parquet-common:1.13.1
-- org.apache.parquet:parquet-encoding:1.13.1
-- org.apache.parquet:parquet-format-structures:1.13.1
-- org.apache.parquet:parquet-jackson:1.13.1
+- org.apache.parquet:parquet-hadoop:1.15.1
+- org.apache.parquet:parquet-column:1.15.1
+- org.apache.parquet:parquet-common:1.15.1
+- org.apache.parquet:parquet-encoding:1.15.1
+- org.apache.parquet:parquet-format-structures:1.15.1
+- org.apache.parquet:parquet-jackson:1.15.1
 - commons-pool:commons-pool:1.6
 
 This project bundles the following dependencies under the BSD license.

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@ under the License.
         <flink.reuseForks>true</flink.reuseForks>
         <testcontainers.version>1.19.1</testcontainers.version>
         <iceberg.version>1.6.1</iceberg.version>
-        <parquet.version>1.13.1</parquet.version>
+        <parquet.version>1.15.1</parquet.version>
         <orc.version>1.9.2</orc.version>
         <protobuf-java.version>3.19.6</protobuf-java.version>
         <roaringbitmap.version>1.2.1</roaringbitmap.version>
@@ -932,7 +932,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.5.3</version>
                 </plugin>
 
                 <!-- configure scala style -->


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- What is the purpose of the change -->
Bump parquet from 1.13.1 to 1.15.1 to resolve [CVE-2025-30065](https://www.cve.org/CVERecord?id=CVE-2025-30065).

Copied some code from the parquet-java 1.15.1 [ParquetFileReader.java](https://github.com/apache/parquet-java/blob/apache-parquet-1.15.1/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java) file.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
