### PR TITLE
[core] Throw exception when travel to timestamp before the earliest snapshot

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromSnapshotStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromSnapshotStartingScanner.java
@@ -52,12 +52,10 @@ public class StaticFromSnapshotStartingScanner extends ReadPlanStartingScanner {
         Long latestSnapshotId = snapshotManager.latestSnapshotId();
 
         if (earliestSnapshotId == null || latestSnapshotId == null) {
-            LOG.warn("There is currently no snapshot. Waiting for snapshot generation.");
-            return null;
+            throw new IllegalArgumentException("There is currently no snapshot.");
         }
 
-        // Checks earlier whether the specified scan snapshot id is valid and throws the correct
-        // exception.
+        // Checks earlier whether the specified scan snapshot id is valid.
         checkArgument(
                 startingSnapshotId >= earliestSnapshotId && startingSnapshotId <= latestSnapshotId,
                 "The specified scan snapshotId %s is out of available snapshotId range [%s, %s].",

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -264,7 +264,7 @@ public class SnapshotManager implements Serializable {
     }
 
     /**
-     * Returns a {@link Snapshot} whoes commit time is earlier than or equal to given timestamp
+     * Returns a {@link Snapshot} whose commit time is earlier than or equal to given timestamp
      * mills. If there is no such a snapshot, returns null.
      */
     public @Nullable Snapshot earlierOrEqualTimeMills(long timestampMills) {
@@ -275,7 +275,7 @@ public class SnapshotManager implements Serializable {
 
         Snapshot earliestSnapShot = earliestSnapshot(latest);
         if (earliestSnapShot == null || earliestSnapShot.timeMillis() > timestampMills) {
-            return earliestSnapShot;
+            return null;
         }
         long earliest = earliestSnapShot.id();
 

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -176,19 +176,17 @@ public class SnapshotManagerTest {
         }
 
         if (isRaceCondition) {
-            // The earliest snapshot has expired, so always return the second snapshot
-            assertThat(snapshotManager.earlierOrEqualTimeMills(millis - 1L).timeMillis())
-                    .isEqualTo(millis + 1000L);
-            assertThat(snapshotManager.earlierOrEqualTimeMills(millis + 999).timeMillis())
-                    .isEqualTo(millis + 1000L);
+            // The earliest snapshot has expired, so always return the second snapshot, smaller than
+            // the second snapshot return null
+            assertThat(snapshotManager.earlierOrEqualTimeMills(millis - 1L)).isEqualTo(null);
+            assertThat(snapshotManager.earlierOrEqualTimeMills(millis + 999)).isEqualTo(null);
             assertThat(snapshotManager.earlierOrEqualTimeMills(millis + 1000).timeMillis())
                     .isEqualTo(millis + 1000L);
             assertThat(snapshotManager.earlierOrEqualTimeMills(millis + 1001).timeMillis())
                     .isEqualTo(millis + 1000L);
         } else {
-            // there is no snapshot smaller than "millis - 1L" return the earliest snapshot
-            assertThat(snapshotManager.earlierOrEqualTimeMills(millis - 1L).timeMillis())
-                    .isEqualTo(millis);
+            // there is no snapshot smaller than "millis - 1L" return null
+            assertThat(snapshotManager.earlierOrEqualTimeMills(millis - 1L)).isEqualTo(null);
 
             // smaller than the second snapshot return the first snapshot
             assertThat(snapshotManager.earlierOrEqualTimeMills(millis + 999).timeMillis())

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkTimeTravelWithDataFrameITCase.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkTimeTravelWithDataFrameITCase.java
@@ -125,14 +125,19 @@ public class SparkTimeTravelWithDataFrameITCase extends SparkReadTestBase {
     }
 
     @Test
-    public void testTravelToNonExistedTimestamp() {
-        Dataset<Row> dataset =
-                spark.read()
-                        .format("paimon")
-                        .option("path", tablePath1.toString())
-                        .option(CoreOptions.SCAN_TIMESTAMP_MILLIS.key(), 0)
-                        .load();
-        assertThat(dataset.collectAsList().toString()).isEqualTo("[[1,2,1], [5,6,3]]");
+    public void testTravelToTimestampBeforeTheEarliestSnapshot() {
+        assertThatThrownBy(
+                        () ->
+                                spark.read()
+                                        .format("paimon")
+                                        .option("path", tablePath1.toString())
+                                        .option(CoreOptions.SCAN_TIMESTAMP_MILLIS.key(), 0)
+                                        .load()
+                                        .collectAsList())
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class,
+                                "There is currently no snapshot earlier than or equal to timestamp [0]"));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
