### PR TITLE
[rest] add requestId into errorMsg

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/rest/DefaultErrorHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/DefaultErrorHandler.java
@@ -29,6 +29,8 @@ import org.apache.paimon.rest.exceptions.ServiceFailureException;
 import org.apache.paimon.rest.exceptions.ServiceUnavailableException;
 import org.apache.paimon.rest.responses.ErrorResponse;
 
+import static org.apache.paimon.rest.LoggingInterceptor.DEFAULT_REQUEST_ID;
+
 /** Default error handler. */
 public class DefaultErrorHandler extends ErrorHandler {
 
@@ -39,9 +41,15 @@ public class DefaultErrorHandler extends ErrorHandler {
     }
 
     @Override
-    public void accept(ErrorResponse error) {
+    public void accept(ErrorResponse error, String requestId) {
         int code = error.getCode();
-        String message = error.getMessage();
+        String message;
+        if (DEFAULT_REQUEST_ID.equals(requestId)) {
+            message = error.getMessage();
+        } else {
+            // if we have a requestId, append it to the message
+            message = String.format("%s requestId:%s", error.getMessage(), requestId);
+        }
         switch (code) {
             case 400:
                 throw new BadRequestException(String.format("%s", message));

--- a/paimon-core/src/main/java/org/apache/paimon/rest/ErrorHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/ErrorHandler.java
@@ -20,7 +20,7 @@ package org.apache.paimon.rest;
 
 import org.apache.paimon.rest.responses.ErrorResponse;
 
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 /** Error handler for REST client. */
-public abstract class ErrorHandler implements Consumer<ErrorResponse> {}
+public abstract class ErrorHandler implements BiConsumer<ErrorResponse, String> {}

--- a/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -45,6 +45,8 @@ import java.util.function.Function;
 import static okhttp3.ConnectionSpec.CLEARTEXT;
 import static okhttp3.ConnectionSpec.COMPATIBLE_TLS;
 import static okhttp3.ConnectionSpec.MODERN_TLS;
+import static org.apache.paimon.rest.LoggingInterceptor.DEFAULT_REQUEST_ID;
+import static org.apache.paimon.rest.LoggingInterceptor.REQUEST_ID_KEY;
 import static org.apache.paimon.rest.RESTObjectMapper.OBJECT_MAPPER;
 
 /** HTTP client for REST catalog. */
@@ -199,7 +201,8 @@ public class HttpClient implements RESTClient {
                                             : "response body is null",
                                     response.code());
                 }
-                errorHandler.accept(error);
+                String requestId = response.header(REQUEST_ID_KEY, DEFAULT_REQUEST_ID);
+                errorHandler.accept(error, requestId);
             }
             if (responseType != null && responseBodyStr != null) {
                 return OBJECT_MAPPER.readValue(responseBodyStr, responseType);

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -1222,7 +1222,7 @@ public abstract class CatalogTestBase {
         // alter table
         SchemaChange schemaChange = SchemaChange.addColumn("new_col", DataTypes.STRING());
         assertThatThrownBy(() -> catalog.alterTable(identifier, schemaChange, false))
-                .hasMessage("Only data table support alter table.");
+                .hasMessageContaining("Only data table support alter table.");
 
         // drop table
         catalog.dropTable(identifier, false);

--- a/paimon-core/src/test/java/org/apache/paimon/rest/DefaultErrorHandlerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/DefaultErrorHandlerTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.apache.paimon.rest.LoggingInterceptor.DEFAULT_REQUEST_ID;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Test for {@link DefaultErrorHandler}. */
@@ -49,34 +50,37 @@ public class DefaultErrorHandlerTest {
     public void testHandleErrorResponse() {
         assertThrows(
                 BadRequestException.class,
-                () -> defaultErrorHandler.accept(generateErrorResponse(400)));
+                () -> defaultErrorHandler.accept(generateErrorResponse(400), DEFAULT_REQUEST_ID));
         assertThrows(
                 NotAuthorizedException.class,
-                () -> defaultErrorHandler.accept(generateErrorResponse(401)));
+                () -> defaultErrorHandler.accept(generateErrorResponse(401), DEFAULT_REQUEST_ID));
         assertThrows(
                 ForbiddenException.class,
-                () -> defaultErrorHandler.accept(generateErrorResponse(403)));
+                () -> defaultErrorHandler.accept(generateErrorResponse(403), DEFAULT_REQUEST_ID));
         assertThrows(
                 NoSuchResourceException.class,
-                () -> defaultErrorHandler.accept(generateErrorResponse(404)));
+                () -> defaultErrorHandler.accept(generateErrorResponse(404), DEFAULT_REQUEST_ID));
         assertThrows(
-                RESTException.class, () -> defaultErrorHandler.accept(generateErrorResponse(405)));
+                RESTException.class,
+                () -> defaultErrorHandler.accept(generateErrorResponse(405), DEFAULT_REQUEST_ID));
         assertThrows(
-                RESTException.class, () -> defaultErrorHandler.accept(generateErrorResponse(406)));
+                RESTException.class,
+                () -> defaultErrorHandler.accept(generateErrorResponse(406), DEFAULT_REQUEST_ID));
         assertThrows(
                 AlreadyExistsException.class,
-                () -> defaultErrorHandler.accept(generateErrorResponse(409)));
+                () -> defaultErrorHandler.accept(generateErrorResponse(409), DEFAULT_REQUEST_ID));
         assertThrows(
                 ServiceFailureException.class,
-                () -> defaultErrorHandler.accept(generateErrorResponse(500)));
+                () -> defaultErrorHandler.accept(generateErrorResponse(500), DEFAULT_REQUEST_ID));
         assertThrows(
                 NotImplementedException.class,
-                () -> defaultErrorHandler.accept(generateErrorResponse(501)));
+                () -> defaultErrorHandler.accept(generateErrorResponse(501), DEFAULT_REQUEST_ID));
         assertThrows(
-                RESTException.class, () -> defaultErrorHandler.accept(generateErrorResponse(502)));
+                RESTException.class,
+                () -> defaultErrorHandler.accept(generateErrorResponse(502), DEFAULT_REQUEST_ID));
         assertThrows(
                 ServiceUnavailableException.class,
-                () -> defaultErrorHandler.accept(generateErrorResponse(503)));
+                () -> defaultErrorHandler.accept(generateErrorResponse(503), DEFAULT_REQUEST_ID));
     }
 
     private ErrorResponse generateErrorResponse(int code) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In the restCatalog, we need to include the requestId in the client's error message to better troubleshoot issues, especially when logs are absent.

Additionally, if the server does not provide a requestId (unknown), the error message should remain unchanged.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
