### PR TITLE
[core] File of Postpone bucket could be avro and no stats

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.apache.paimon.predicate.PredicateBuilder.and;
@@ -178,7 +179,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                     partitionType,
                     keyType,
                     valueType,
-                    format2PathFactory(),
+                    this::pathFactory,
                     snapshotManager(),
                     newScan(ScanType.FOR_WRITE).withManifestCacheFilter(manifestFilter),
                     options,
@@ -197,7 +198,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                     logDedupEqualSupplier,
                     mfFactory,
                     pathFactory(),
-                    format2PathFactory(),
+                    format2PathFactory(options, this::pathFactory),
                     snapshotManager(),
                     newScan(ScanType.FOR_WRITE).withManifestCacheFilter(manifestFilter),
                     indexFactory,
@@ -208,11 +209,12 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
         }
     }
 
-    private Map<String, FileStorePathFactory> format2PathFactory() {
+    public static Map<String, FileStorePathFactory> format2PathFactory(
+            CoreOptions options, Function<String, FileStorePathFactory> pathFactory) {
         Map<String, FileStorePathFactory> pathFactoryMap = new HashMap<>();
         Set<String> formats = new HashSet<>(options.fileFormatPerLevel().values());
         formats.add(options.fileFormatString());
-        formats.forEach(format -> pathFactoryMap.put(format, pathFactory(format)));
+        formats.forEach(format -> pathFactoryMap.put(format, pathFactory.apply(format)));
         return pathFactoryMap;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/postpone/PostponeBucketFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/postpone/PostponeBucketFileStoreWrite.java
@@ -39,9 +39,10 @@ import org.apache.paimon.utils.SnapshotManager;
 import javax.annotation.Nullable;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
+
+import static org.apache.paimon.KeyValueFileStore.format2PathFactory;
 
 /** {@link FileStoreWrite} for {@code bucket = -2} tables. */
 public class PostponeBucketFileStoreWrite extends AbstractFileStoreWrite<KeyValue> {
@@ -55,7 +56,7 @@ public class PostponeBucketFileStoreWrite extends AbstractFileStoreWrite<KeyValu
             RowType partitionType,
             RowType keyType,
             RowType valueType,
-            Map<String, FileStorePathFactory> format2PathFactory,
+            Function<String, FileStorePathFactory> pathFactory,
             SnapshotManager snapshotManager,
             FileStoreScan scan,
             CoreOptions options,
@@ -72,15 +73,21 @@ public class PostponeBucketFileStoreWrite extends AbstractFileStoreWrite<KeyValu
                 options.writeMaxWritersToSpill(),
                 options.legacyPartitionName());
 
-        this.options = options;
+        // copy options for postpone bucket
+        this.options = new CoreOptions(options.toConfiguration().toMap());
+
+        // use avro for postpone bucket
+        this.options.toConfiguration().set(CoreOptions.FILE_FORMAT, "avro");
+        this.options.toConfiguration().set(CoreOptions.METADATA_STATS_MODE, "none");
+
         this.writerFactoryBuilder =
                 KeyValueFileWriterFactory.builder(
                         fileIO,
                         schema.id(),
                         keyType,
                         valueType,
-                        options.fileFormat(),
-                        format2PathFactory,
+                        this.options.fileFormat(),
+                        format2PathFactory(this.options, pathFactory),
                         options.targetFileSize(true));
 
         // Ignoring previous files saves scanning time.


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Files in Postpone bucket are temporary files, should be avro and no stats for better performance.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
