### PR TITLE
[core] Add option to always select level 0 files when compacting

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -153,6 +153,12 @@ under the License.
             <td>Specifies the commit user prefix.</td>
         </tr>
         <tr>
+            <td><h5>compaction.force-up-level-0</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>If set to true, compaction strategy will always include all level 0 files in candidates.</td>
+        </tr>
+        <tr>
             <td><h5>compaction.max-size-amplification-percent</h5></td>
             <td style="word-wrap: break-word;">200</td>
             <td>Integer</td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -583,6 +583,13 @@ public class CoreOptions implements Serializable {
                             "The size amplification is defined as the amount (in percentage) of additional storage "
                                     + "needed to store a single byte of data in the merge tree for changelog mode table.");
 
+    public static final ConfigOption<Boolean> COMPACTION_FORCE_UP_LEVEL_0 =
+            key("compaction.force-up-level-0")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "If set to true, compaction strategy will always include all level 0 files in candidates.");
+
     public static final ConfigOption<Integer> COMPACTION_SIZE_RATIO =
             key("compaction.size-ratio")
                     .intType()
@@ -2155,6 +2162,10 @@ public class CoreOptions implements Serializable {
 
     public int maxSizeAmplificationPercent() {
         return options.get(COMPACTION_MAX_SIZE_AMPLIFICATION_PERCENT);
+    }
+
+    public boolean compactionForceUpLevel0() {
+        return options.get(COMPACTION_FORCE_UP_LEVEL_0);
     }
 
     public int sortedRunSizeRatio() {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -241,11 +241,17 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
             }
         }
 
-        return new UniversalCompaction(
-                options.maxSizeAmplificationPercent(),
-                options.sortedRunSizeRatio(),
-                options.numSortedRunCompactionTrigger(),
-                options.optimizedCompactionInterval());
+        UniversalCompaction universal =
+                new UniversalCompaction(
+                        options.maxSizeAmplificationPercent(),
+                        options.sortedRunSizeRatio(),
+                        options.numSortedRunCompactionTrigger(),
+                        options.optimizedCompactionInterval());
+        if (options.compactionForceUpLevel0()) {
+            return new ForceUpLevel0Compaction(universal);
+        } else {
+            return universal;
+        }
     }
 
     private CompactManager createCompactManager(


### PR DESCRIPTION
### Purpose

When using async compaction, users may want to monitor the process of compaction by checking the number of level 0 files. This PR adds an option to always select level 0 files when compacting, so user can make sure that, if no level 0 file exists, the compaction has finished.

### Tests

* `KeyValueFileStoreWriteTest`

### API and Format

No format changes.

### Documentation

Document is also updated.
