### PR TITLE
[core][test] Test that snapshot deletion stops when throwing exception for skipping set

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -152,6 +152,10 @@ public class TestFileStore extends KeyValueFileStore {
         return new SchemaManager(FileIOFinder.find(new Path(root)), options.path());
     }
 
+    public FileIO fileIO() {
+        return fileIO;
+    }
+
     public AbstractFileStoreWrite<KeyValue> newWrite() {
         return super.newWrite(commitUser);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreTestUtils.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreTestUtils.java
@@ -62,6 +62,10 @@ public class FileStoreTestUtils {
         assertThat(fileIO.exists(path)).isFalse();
     }
 
+    public static void assertNFilesExists(FileIO fileIO, Path path, int num) throws IOException {
+        assertThat(fileIO.listStatus(path)).hasSize(num);
+    }
+
     // --------------------------------------------------------------------------------
     // writeData & commitData are copied from TestFileStore#commitDataImpl and modified
     // --------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
