### PR TITLE
[core] Add supportsListObjectsPaged to Catalog

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -481,6 +481,11 @@ public abstract class AbstractCatalog implements Catalog {
     }
 
     @Override
+    public boolean supportsListObjectsPaged() {
+        return false;
+    }
+
+    @Override
     public boolean supportsVersionManagement() {
         return false;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -137,6 +137,11 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
+    public boolean supportsListObjectsPaged() {
+        return wrapped.supportsListObjectsPaged();
+    }
+
+    @Override
     public boolean supportsVersionManagement() {
         return wrapped.supportsVersionManagement();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -392,6 +392,11 @@ public class RESTCatalog implements Catalog {
     }
 
     @Override
+    public boolean supportsListObjectsPaged() {
+        return true;
+    }
+
+    @Override
     public boolean supportsVersionManagement() {
         return true;
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

In Catalog.listXXXPaged methods' Javadocs, there is a description as follows.

> NOTE: Currently only RestCatalog will return pagedList data, other catalog will return all
> databases names like listDatabases.

So In order to get the correct paged results, invokers have to identify whether a catalog is a RESTCatalog, which breaks the isolation between the Catalog interface and its implementations. This PR proposes to add a supportsListObjectsPaged method to solve this problem. A similar design could be referenced from Catalog#supportsVersionManagement.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->
This PR adds a public Catalog#supportsListObjectsPaged method.

### Documentation

<!-- Does this change introduce a new feature -->
