### PR TITLE
[core] Unaware bucket table compaction generates too many tasks

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -168,7 +168,7 @@ under the License.
             <td><h5>compaction.max.file-num</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
-            <td>For file set [f_0,...,f_N], the maximum file number to trigger a compaction for append-only table, even if sum(size(f_i)) &lt; targetFileSize. This value avoids pending too much small files.<ul><li>Default value of Append Table is '50'.</li><li>Default value of Bucketed Append Table is '5'.</li></ul></td>
+            <td>For file set [f_0,...,f_N], the maximum file number to trigger a compaction for append-only table, even if sum(size(f_i)) &lt; targetFileSize. This value avoids pending too much small files.<ul><li>Default value of Bucketed Append Table is '5'.</li></ul></td>
         </tr>
         <tr>
             <td><h5>compaction.min.file-num</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -628,9 +628,7 @@ public class CoreOptions implements Serializable {
                                             "For file set [f_0,...,f_N], the maximum file number to trigger a compaction "
                                                     + "for append-only table, even if sum(size(f_i)) < targetFileSize. This value "
                                                     + "avoids pending too much small files.")
-                                    .list(
-                                            text("Default value of Append Table is '50'."),
-                                            text("Default value of Bucketed Append Table is '5'."))
+                                    .list(text("Default value of Bucketed Append Table is '5'."))
                                     .build());
 
     public static final ConfigOption<ChangelogProducer> CHANGELOG_PRODUCER =

--- a/paimon-core/src/main/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinator.java
@@ -283,6 +283,7 @@ public class UnawareAppendTableCompactionCoordinator {
             }
             if (!fileBin.bin.isEmpty()) {
                 result.add(new ArrayList<>(fileBin.bin));
+                fileBin.reset();
             }
             return result;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinator.java
@@ -280,7 +280,7 @@ public class UnawareAppendTableCompactionCoordinator {
                     fileBin.reset();
                 }
             }
-            if (fileBin.fileNum > minFileNum) {
+            if (fileBin.fileNum >= minFileNum) {
                 result.add(new ArrayList<>(fileBin.bin));
                 fileBin.reset();
             }

--- a/paimon-core/src/main/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinator.java
@@ -242,14 +242,13 @@ public class UnawareAppendTableCompactionCoordinator {
         private List<List<DataFileMeta>> agePack() {
             List<List<DataFileMeta>> packed;
             if (dvMaintainerCache == null) {
-                packed = pack(toCompact);
+                packed =
+                        pack(toCompact).stream()
+                                .filter(meta -> meta.size() >= minFileNum)
+                                .collect(Collectors.toList());
             } else {
                 packed = packInDeletionVectorVMode(toCompact);
             }
-            packed =
-                    packed.stream()
-                            .filter(meta -> meta.size() > minFileNum)
-                            .collect(Collectors.toList());
             if (packed.isEmpty()) {
                 // non-packed, we need to grow up age, and check whether to compact once
                 if (++age > COMPACT_AGE && toCompact.size() > 1) {

--- a/paimon-core/src/test/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinatorTest.java
@@ -91,14 +91,14 @@ public class UnawareAppendTableCompactionCoordinatorTest {
                         1000, appendOnlyFileStoreTable.coreOptions().targetFileSize(false) / 10);
         compactionCoordinator.notifyNewFiles(partition, files);
 
-        assertThat(compactionCoordinator.compactPlan().size()).isEqualTo(2);
+        assertThat(compactionCoordinator.compactPlan().size()).isEqualTo(3);
         files.clear();
 
         files =
                 generateNewFiles(
                         1050, appendOnlyFileStoreTable.coreOptions().targetFileSize(false) / 5);
         compactionCoordinator.notifyNewFiles(partition, files);
-        assertThat(compactionCoordinator.compactPlan().size()).isEqualTo(6);
+        assertThat(compactionCoordinator.compactPlan().size()).isEqualTo(5);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinatorTest.java
@@ -59,7 +59,7 @@ public class UnawareAppendTableCompactionCoordinatorTest {
     @Test
     public void testForCompactPlan() {
         List<DataFileMeta> files = generateNewFiles(200, 0);
-        assertTasks(files, 200 / 6);
+        assertTasks(files, 1);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class UnawareAppendTableCompactionCoordinatorTest {
         List<DataFileMeta> files =
                 generateNewFiles(
                         100, appendOnlyFileStoreTable.coreOptions().targetFileSize(false) / 3 + 1);
-        assertTasks(files, 100 / 3);
+        assertTasks(files, 1);
     }
 
     @Test
@@ -82,6 +82,32 @@ public class UnawareAppendTableCompactionCoordinatorTest {
                 generateNewFiles(
                         100, appendOnlyFileStoreTable.coreOptions().targetFileSize(false) / 10 * 8);
         assertTasks(files, 0);
+    }
+
+    @Test
+    public void testCompactGroupSplit() {
+        List<DataFileMeta> files =
+                generateNewFiles(
+                        1000, appendOnlyFileStoreTable.coreOptions().targetFileSize(false) / 10);
+        compactionCoordinator.notifyNewFiles(partition, files);
+
+        assertThat(compactionCoordinator.compactPlan().size()).isEqualTo(2);
+        files.clear();
+
+        files =
+                generateNewFiles(
+                        1050, appendOnlyFileStoreTable.coreOptions().targetFileSize(false) / 5);
+        compactionCoordinator.notifyNewFiles(partition, files);
+        assertThat(compactionCoordinator.compactPlan().size()).isEqualTo(6);
+    }
+
+    @Test
+    public void testCompactGroupSplit2() {
+        List<DataFileMeta> files =
+                generateNewFiles(
+                        1089, appendOnlyFileStoreTable.coreOptions().targetFileSize(false) / 5);
+        compactionCoordinator.notifyNewFiles(partition, files);
+        assertThat(compactionCoordinator.compactPlan().size()).isEqualTo(5);
     }
 
     @Test

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
@@ -768,13 +768,15 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
       // spark.default.parallelism cannot be change in spark session
       // sparkParallelism is 2, task groups is 6, use 2 as the read parallelism
       spark.conf.set("spark.sql.shuffle.partitions", 2)
-      spark.sql("CALL sys.compact(table => 'T', options => 'compaction.max.file-num=2')")
+      spark.sql(
+        "CALL sys.compact(table => 'T', options => 'source.split.open-file-cost=3200M, compaction.min.file-num=2')")
 
-      // sparkParallelism is 5, task groups is 3, use 3 as the read parallelism
+      // sparkParallelism is 5, task groups is 1, use 1 as the read parallelism
       spark.conf.set("spark.sql.shuffle.partitions", 5)
-      spark.sql("CALL sys.compact(table => 'T', options => 'compaction.max.file-num=2')")
+      spark.sql(
+        "CALL sys.compact(table => 'T', options => 'source.split.open-file-cost=3200M, compaction.min.file-num=2')")
 
-      assertResult(Seq(2, 3))(taskBuffer)
+      assertResult(Seq(2, 1))(taskBuffer)
     } finally {
       spark.sparkContext.removeSparkListener(listener)
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Unaware bucket table compaction generates too many tasks. 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
