### PR TITLE
[flink] Set IOManager to TableRead in Flink source

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.source;
 
 import org.apache.paimon.KeyValue;
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.operation.MergeFileSplitRead;
@@ -141,5 +142,10 @@ public final class KeyValueTableRead extends AbstractDataTableRead<KeyValue> {
                 reader.close();
             }
         };
+    }
+
+    @VisibleForTesting
+    public IOManager ioManager() {
+        return ioManager;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceReader.java
@@ -55,7 +55,9 @@ public class FileStoreSourceReader
         super(
                 () ->
                         new FileStoreSourceSplitReader(
-                                tableRead, RecordLimiter.create(limit), metrics),
+                                tableRead.withIOManager(ioManager),
+                                RecordLimiter.create(limit),
+                                metrics),
                 (element, output, state) ->
                         FlinkRecordsWithSplitIds.emitRecord(
                                 readerContext, element, output, state, metrics, rowData),

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
@@ -41,7 +41,6 @@ import org.apache.paimon.schema.KeyValueFieldsExtractor;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.source.KeyValueTableRead;
-import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.IntType;
@@ -117,7 +116,7 @@ public class TestChangelogDataReadWrite {
         this.commitUser = UUID.randomUUID().toString();
     }
 
-    public TableRead createReadWithKey() {
+    public KeyValueTableRead createReadWithKey() {
         SchemaManager schemaManager = new SchemaManager(LocalFileIO.create(), tablePath);
         CoreOptions options = new CoreOptions(new HashMap<>());
         TableSchema schema = schemaManager.schema(0);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/align/AlignedSourceReaderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/align/AlignedSourceReaderTest.java
@@ -25,7 +25,6 @@ import org.apache.paimon.flink.source.FileStoreSourceReader;
 import org.apache.paimon.flink.source.FileStoreSourceReaderTest;
 import org.apache.paimon.flink.source.FileStoreSourceSplit;
 import org.apache.paimon.flink.source.FileStoreSourceSplitGenerator;
-import org.apache.paimon.flink.source.TestChangelogDataReadWrite;
 import org.apache.paimon.flink.source.metrics.FileStoreSourceReaderMetrics;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
@@ -37,6 +36,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
+import org.apache.paimon.table.source.TableRead;
 
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
@@ -220,10 +220,11 @@ public class AlignedSourceReaderTest extends FileStoreSourceReaderTest {
     }
 
     @Override
-    protected FileStoreSourceReader createReader(TestingReaderContext context) {
+    protected FileStoreSourceReader createReader(
+            TestingReaderContext context, TableRead tableRead) {
         return new AlignedSourceReader(
                 context,
-                new TestChangelogDataReadWrite(tempDir.toString()).createReadWithKey(),
+                tableRead,
                 new FileStoreSourceReaderMetrics(new DummyMetricGroup()),
                 IOManager.create(tempDir.toString()),
                 null,


### PR DESCRIPTION
### Purpose

Currently `sort-spill-threshold` does not affect Paimon Flink sources, because `IOManager` is not set to `TableRead` in Flink sources. This PR fixes the issue.

### Tests

* `FileStoreSourceReaderTest`

### API and Format

No format changes.

### Documentation

No new feature.
