### PR TITLE
[core] Remove useless 'compaction.max.file-num'

### DIFF
--- a/docs/content/append-table/bucketed.md
+++ b/docs/content/append-table/bucketed.md
@@ -82,13 +82,7 @@ control the strategy of compaction:
             <td><h5>compaction.min.file-num</h5></td>
             <td style="word-wrap: break-word;">5</td>
             <td>Integer</td>
-            <td>For file set [f_0,...,f_N], the minimum file number which satisfies sum(size(f_i)) &gt;= targetFileSize to trigger a compaction for append table. This value avoids almost-full-file to be compacted, which is not cost-effective.</td>
-        </tr>
-        <tr>
-            <td><h5>compaction.max.file-num</h5></td>
-            <td style="word-wrap: break-word;">5</td>
-            <td>Integer</td>
-            <td>For file set [f_0,...,f_N], the maximum file number to trigger a compaction for append table, even if sum(size(f_i)) &lt; targetFileSize. This value avoids pending too much small files, which slows down the performance.</td>
+            <td>For file set [f_0,...,f_N], the minimum file number to trigger a compaction for append table.</td>
         </tr>
         <tr>
             <td><h5>full-compaction.delta-commits</h5></td>

--- a/docs/content/program-api/catalog-api.md
+++ b/docs/content/program-api/catalog-api.md
@@ -244,7 +244,6 @@ public class AlterTable {
 
         Map<String, String> options = new HashMap<>();
         options.put("bucket", "4");
-        options.put("compaction.max.file-num", "40");
 
         Catalog catalog = CreateCatalog.createFilesystemCatalog();
         catalog.createDatabase("my_db", false);
@@ -283,8 +282,6 @@ public class AlterTable {
 
         // add option
         SchemaChange addOption = SchemaChange.setOption("snapshot.time-retained", "2h");
-        // remove option
-        SchemaChange removeOption = SchemaChange.removeOption("compaction.max.file-num");
         // add column
         SchemaChange addColumn = SchemaChange.addColumn("col1_after", DataTypes.STRING());
         // add a column after col1

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -165,16 +165,10 @@ under the License.
             <td>The size amplification is defined as the amount (in percentage) of additional storage needed to store a single byte of data in the merge tree for changelog mode table.</td>
         </tr>
         <tr>
-            <td><h5>compaction.max.file-num</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Integer</td>
-            <td>For file set [f_0,...,f_N], the maximum file number to trigger a compaction for append-only table, even if sum(size(f_i)) &lt; targetFileSize. This value avoids pending too much small files.<ul><li>Default value of Bucketed Append Table is '5'.</li></ul></td>
-        </tr>
-        <tr>
             <td><h5>compaction.min.file-num</h5></td>
             <td style="word-wrap: break-word;">5</td>
             <td>Integer</td>
-            <td>For file set [f_0,...,f_N], the minimum file number which satisfies sum(size(f_i)) &gt;= targetFileSize to trigger a compaction for append-only table. This value avoids almost-full-file to be compacted, which is not cost-effective.</td>
+            <td>For file set [f_0,...,f_N], the minimum file number to trigger a compaction for append-only table.</td>
         </tr>
         <tr>
             <td><h5>compaction.optimization-interval</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -612,24 +612,8 @@ public class CoreOptions implements Serializable {
                     .intType()
                     .defaultValue(5)
                     .withDescription(
-                            "For file set [f_0,...,f_N], the minimum file number which satisfies "
-                                    + "sum(size(f_i)) >= targetFileSize to trigger a compaction for "
-                                    + "append-only table. This value avoids almost-full-file to be compacted, "
-                                    + "which is not cost-effective.");
-
-    public static final ConfigOption<Integer> COMPACTION_MAX_FILE_NUM =
-            key("compaction.max.file-num")
-                    .intType()
-                    .noDefaultValue()
-                    .withFallbackKeys("compaction.early-max.file-num")
-                    .withDescription(
-                            Description.builder()
-                                    .text(
-                                            "For file set [f_0,...,f_N], the maximum file number to trigger a compaction "
-                                                    + "for append-only table, even if sum(size(f_i)) < targetFileSize. This value "
-                                                    + "avoids pending too much small files.")
-                                    .list(text("Default value of Bucketed Append Table is '5'."))
-                                    .build());
+                            "For file set [f_0,...,f_N], the minimum file number to trigger a compaction for "
+                                    + "append-only table.");
 
     public static final ConfigOption<ChangelogProducer> CHANGELOG_PRODUCER =
             key("changelog-producer")
@@ -2172,10 +2156,6 @@ public class CoreOptions implements Serializable {
 
     public int compactionMinFileNum() {
         return options.get(COMPACTION_MIN_FILE_NUM);
-    }
-
-    public Optional<Integer> compactionMaxFileNum() {
-        return options.getOptional(COMPACTION_MAX_FILE_NUM);
     }
 
     public long dynamicBucketTargetRowNum() {

--- a/paimon-core/src/main/java/org/apache/paimon/append/BucketedAppendCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/BucketedAppendCompactManager.java
@@ -59,7 +59,6 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
     private final DeletionVectorsMaintainer dvMaintainer;
     private final PriorityQueue<DataFileMeta> toCompact;
     private final int minFileNum;
-    private final int maxFileNum;
     private final long targetFileSize;
     private final CompactRewriter rewriter;
 
@@ -72,7 +71,6 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
             List<DataFileMeta> restored,
             @Nullable DeletionVectorsMaintainer dvMaintainer,
             int minFileNum,
-            int maxFileNum,
             long targetFileSize,
             CompactRewriter rewriter,
             @Nullable CompactionMetrics.Reporter metricsReporter) {
@@ -81,7 +79,6 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
         this.toCompact = new PriorityQueue<>(fileComparator(false));
         this.toCompact.addAll(restored);
         this.minFileNum = minFileNum;
-        this.maxFileNum = maxFileNum;
         this.targetFileSize = targetFileSize;
         this.rewriter = rewriter;
         this.metricsReporter = metricsReporter;
@@ -201,8 +198,7 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
             candidates.add(file);
             totalFileSize += file.fileSize();
             fileNum++;
-            if ((totalFileSize >= targetFileSize && fileNum >= minFileNum)
-                    || fileNum >= maxFileNum) {
+            if (fileNum >= minFileNum) {
                 return Optional.of(candidates);
             } else if (totalFileSize >= targetFileSize) {
                 // let pointer shift one pos to right

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFixedBucketFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFixedBucketFileStoreWrite.java
@@ -90,7 +90,6 @@ public class AppendOnlyFixedBucketFileStoreWrite extends AppendOnlyFileStoreWrit
                     restoredFiles,
                     dvMaintainer,
                     options.compactionMinFileNum(),
-                    options.compactionMaxFileNum().orElse(5),
                     options.targetFileSize(false),
                     files -> compactRewrite(partition, bucket, dvFactory, files),
                     compactionMetrics == null

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyTableCompactionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyTableCompactionTest.java
@@ -183,7 +183,6 @@ public class AppendOnlyTableCompactionTest {
         schemaBuilder.column("f2", DataTypes.STRING());
         schemaBuilder.column("f3", DataTypes.STRING());
         schemaBuilder.option("compaction.min.file-num", "3");
-        schemaBuilder.option("compaction.max.file-num", "6");
         schemaBuilder.option("bucket", "-1");
         return schemaBuilder.build();
     }

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -93,7 +93,6 @@ public class AppendOnlyWriterTest {
     private static final String PART = "2022-05-01";
     private static final long SCHEMA_ID = 0L;
     private static final int MIN_FILE_NUM = 3;
-    private static final int MAX_FILE_NUM = 4;
 
     @BeforeEach
     public void before() {
@@ -162,8 +161,8 @@ public class AppendOnlyWriterTest {
 
             writer.sync();
             CommitIncrement inc = writer.prepareCommit(true);
-            if (txn > 0 && txn % 3 == 0) {
-                assertThat(inc.compactIncrement().compactBefore()).hasSize(4);
+            if (txn > 0 && txn % 2 == 0) {
+                assertThat(inc.compactIncrement().compactBefore()).hasSize(3);
                 assertThat(inc.compactIncrement().compactAfter()).hasSize(1);
                 DataFileMeta compactAfter = inc.compactIncrement().compactAfter().get(0);
                 assertThat(compactAfter.fileName()).startsWith("compact-");
@@ -269,7 +268,7 @@ public class AppendOnlyWriterTest {
         List<DataFileMeta> compactAfter = secInc.compactIncrement().compactAfter();
         assertThat(compactBefore)
                 .containsExactlyInAnyOrderElementsOf(
-                        firstInc.newFilesIncrement().newFiles().subList(0, 4));
+                        firstInc.newFilesIncrement().newFiles().subList(0, 3));
         assertThat(compactAfter).hasSize(1);
         assertThat(compactBefore.stream().mapToLong(DataFileMeta::fileSize).sum())
                 .isEqualTo(compactAfter.stream().mapToLong(DataFileMeta::fileSize).sum());
@@ -652,7 +651,6 @@ public class AppendOnlyWriterTest {
                         toCompact,
                         null,
                         MIN_FILE_NUM,
-                        MAX_FILE_NUM,
                         targetFileSize,
                         compactBefore -> {
                             latch.await();

--- a/paimon-core/src/test/java/org/apache/paimon/append/BucketedAppendCompactManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/BucketedAppendCompactManagerTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.append;
 
 import org.apache.paimon.io.DataFileMeta;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -124,6 +125,7 @@ public class BucketedAppendCompactManagerTest {
                 Arrays.asList(newFile(2001L, 2005L), newFile(2006L, 2010L)));
     }
 
+    @Disabled // TODO create new tests for min files only
     @Test
     public void testPick() {
         // fileNum is 13 (which > 12) and totalFileSize is 130 (which < 1024)
@@ -197,7 +199,6 @@ public class BucketedAppendCompactManagerTest {
             List<DataFileMeta> expectedCompactBefore,
             List<DataFileMeta> toCompactAfterPick) {
         int minFileNum = 4;
-        int maxFileNum = 12;
         long targetFileSize = 1024;
         BucketedAppendCompactManager manager =
                 new BucketedAppendCompactManager(
@@ -205,7 +206,6 @@ public class BucketedAppendCompactManagerTest {
                         toCompactBeforePick,
                         null,
                         minFileNum,
-                        maxFileNum,
                         targetFileSize,
                         null, // not used
                         null);

--- a/paimon-core/src/test/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinatorTest.java
@@ -185,7 +185,6 @@ public class UnawareAppendTableCompactionCoordinatorTest {
         schemaBuilder.column("f2", DataTypes.STRING());
         schemaBuilder.column("f3", DataTypes.STRING());
         schemaBuilder.option(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "3");
-        schemaBuilder.option(CoreOptions.COMPACTION_MAX_FILE_NUM.key(), "6");
         return schemaBuilder.build();
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
@@ -87,7 +87,7 @@ public class FileFormatSuffixTest extends KeyValueFileReadWriteTest {
                         SCHEMA,
                         0,
                         new BucketedAppendCompactManager(
-                                null, toCompact, null, 4, 10, 10, null, null), // not used
+                                null, toCompact, null, 4, 10, null, null), // not used
                         null,
                         false,
                         dataFilePathFactory,

--- a/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTMessage.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTMessage.java
@@ -153,8 +153,6 @@ public class MockRESTMessage {
     public static List<SchemaChange> getChanges() {
         // add option
         SchemaChange addOption = SchemaChange.setOption("snapshot.time-retained", "2h");
-        // remove option
-        SchemaChange removeOption = SchemaChange.removeOption("compaction.max.file-num");
         // update comment
         SchemaChange updateComment = SchemaChange.updateComment(null);
         // add column
@@ -204,7 +202,6 @@ public class MockRESTMessage {
 
         List<SchemaChange> schemaChanges = new ArrayList<>();
         schemaChanges.add(addOption);
-        schemaChanges.add(removeOption);
         schemaChanges.add(updateComment);
         schemaChanges.add(addColumn);
         schemaChanges.add(addColumnMap);

--- a/paimon-core/src/test/java/org/apache/paimon/table/SimpleTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SimpleTableTestBase.java
@@ -99,7 +99,6 @@ import static org.apache.paimon.CoreOptions.BUCKET;
 import static org.apache.paimon.CoreOptions.BUCKET_KEY;
 import static org.apache.paimon.CoreOptions.CHANGELOG_NUM_RETAINED_MAX;
 import static org.apache.paimon.CoreOptions.CHANGELOG_NUM_RETAINED_MIN;
-import static org.apache.paimon.CoreOptions.COMPACTION_MAX_FILE_NUM;
 import static org.apache.paimon.CoreOptions.CONSUMER_IGNORE_PROGRESS;
 import static org.apache.paimon.CoreOptions.DELETION_VECTORS_ENABLED;
 import static org.apache.paimon.CoreOptions.ExpireExecutionMode;
@@ -579,7 +578,6 @@ public abstract class SimpleTableTestBase {
                 createFileStoreTable(
                         conf -> {
                             conf.set(WRITE_ONLY, true);
-                            conf.set(COMPACTION_MAX_FILE_NUM, 5);
                             // 'write-only' options will also skip expiration
                             // these options shouldn't have any effect
                             conf.set(SNAPSHOT_NUM_RETAINED_MIN, 3);

--- a/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-1.18/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
@@ -39,8 +39,7 @@ public class UnawareBucketAppendOnlyTableITCase extends CatalogITCaseBase {
 
     @Test
     public void testCompactionInStreamingMode() throws Exception {
-        batchSql("ALTER TABLE append_table SET ('compaction.min.file-num' = '2')");
-        batchSql("ALTER TABLE append_table SET ('compaction.early-max.file-num' = '4')");
+        batchSql("ALTER TABLE append_table SET ('compaction.min.file-num' = '4')");
         batchSql("ALTER TABLE append_table SET ('continuous.discovery-interval' = '1 s')");
 
         sEnv.getConfig().getConfiguration().set(CHECKPOINTING_INTERVAL, Duration.ofMillis(500));

--- a/paimon-flink/paimon-flink-1.19/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-1.19/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
@@ -39,8 +39,7 @@ public class UnawareBucketAppendOnlyTableITCase extends CatalogITCaseBase {
 
     @Test
     public void testCompactionInStreamingMode() throws Exception {
-        batchSql("ALTER TABLE append_table SET ('compaction.min.file-num' = '2')");
-        batchSql("ALTER TABLE append_table SET ('compaction.early-max.file-num' = '4')");
+        batchSql("ALTER TABLE append_table SET ('compaction.min.file-num' = '4')");
         batchSql("ALTER TABLE append_table SET ('continuous.discovery-interval' = '1 s')");
 
         sEnv.getConfig().getConfiguration().set(CHECKPOINTING_INTERVAL, Duration.ofMillis(500));

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
@@ -342,8 +342,7 @@ public class AppendOnlyTableITCase extends CatalogITCaseBase {
 
     @Test
     public void testAutoCompaction() {
-        batchSql("ALTER TABLE append_table SET ('compaction.min.file-num' = '2')");
-        batchSql("ALTER TABLE append_table SET ('compaction.early-max.file-num' = '4')");
+        batchSql("ALTER TABLE append_table SET ('compaction.min.file-num' = '4')");
 
         assertAutoCompaction(
                 "INSERT INTO append_table VALUES (1, 'AAA'), (2, 'BBB')",

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/UnawareBucketAppendOnlyTableITCase.java
@@ -150,8 +150,7 @@ public class UnawareBucketAppendOnlyTableITCase extends CatalogITCaseBase {
 
     @Test
     public void testNoCompactionInBatchMode() {
-        batchSql("ALTER TABLE append_table SET ('compaction.min.file-num' = '2')");
-        batchSql("ALTER TABLE append_table SET ('compaction.early-max.file-num' = '4')");
+        batchSql("ALTER TABLE append_table SET ('compaction.min.file-num' = '4')");
 
         assertExecuteExpected(
                 "INSERT INTO append_table VALUES (1, 'AAA'), (2, 'BBB')",
@@ -212,8 +211,7 @@ public class UnawareBucketAppendOnlyTableITCase extends CatalogITCaseBase {
 
     @Test
     public void testCompactionInStreamingMode() throws Exception {
-        batchSql("ALTER TABLE append_table SET ('compaction.min.file-num' = '2')");
-        batchSql("ALTER TABLE append_table SET ('compaction.early-max.file-num' = '4')");
+        batchSql("ALTER TABLE append_table SET ('compaction.min.file-num' = '4')");
         batchSql("ALTER TABLE append_table SET ('continuous.discovery-interval' = '1 s')");
 
         sEnv.getConfig()
@@ -237,8 +235,7 @@ public class UnawareBucketAppendOnlyTableITCase extends CatalogITCaseBase {
 
     @Test
     public void testCompactionInStreamingModeWithMaxWatermark() throws Exception {
-        batchSql("ALTER TABLE append_table SET ('compaction.min.file-num' = '2')");
-        batchSql("ALTER TABLE append_table SET ('compaction.early-max.file-num' = '4')");
+        batchSql("ALTER TABLE append_table SET ('compaction.min.file-num' = '4')");
         batchSql("ALTER TABLE append_table SET ('continuous.discovery-interval' = '1 s')");
 
         sEnv.getConfig()

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactActionITCase.java
@@ -157,7 +157,7 @@ public class CompactActionITCase extends CompactActionITCaseBase {
                         snapshotManager.latestSnapshotId() - 2
                                 == snapshotManager.earliestSnapshotId(),
                 Duration.ofSeconds(60_000),
-                Duration.ofSeconds(100),
+                Duration.ofSeconds(10),
                 String.format("Cannot validate snapshot expiration in %s milliseconds.", 60_000));
     }
 
@@ -179,7 +179,6 @@ public class CompactActionITCase extends CompactActionITCaseBase {
             Map<String, String> tableOptions = new HashMap<>();
             tableOptions.put(CoreOptions.BUCKET.key(), "-1");
             tableOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
-            tableOptions.put(CoreOptions.COMPACTION_MAX_FILE_NUM.key(), "2");
 
             table =
                     prepareTable(
@@ -240,7 +239,6 @@ public class CompactActionITCase extends CompactActionITCaseBase {
         tableOptions.put(CoreOptions.CONTINUOUS_DISCOVERY_INTERVAL.key(), "1s");
         tableOptions.put(CoreOptions.BUCKET.key(), "-1");
         tableOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
-        tableOptions.put(CoreOptions.COMPACTION_MAX_FILE_NUM.key(), "2");
 
         FileStoreTable table =
                 prepareTable(
@@ -282,7 +280,6 @@ public class CompactActionITCase extends CompactActionITCaseBase {
         Map<String, String> tableOptions = new HashMap<>();
         tableOptions.put(CoreOptions.BUCKET.key(), "-1");
         tableOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
-        tableOptions.put(CoreOptions.COMPACTION_MAX_FILE_NUM.key(), "2");
 
         FileStoreTable table =
                 prepareTable(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactDatabaseActionITCase.java
@@ -118,7 +118,6 @@ public class CompactDatabaseActionITCase extends CompactActionITCaseBase {
                 if (tableName.endsWith("unaware_bucket")) {
                     option.put("bucket", "-1");
                     option.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
-                    option.put(CoreOptions.COMPACTION_MAX_FILE_NUM.key(), "2");
                     keys = Lists.newArrayList();
                     FileStoreTable table =
                             createTable(dbName, tableName, Arrays.asList("dt", "hh"), keys, option);
@@ -223,7 +222,6 @@ public class CompactDatabaseActionITCase extends CompactActionITCaseBase {
                 if (tableName.endsWith("unaware_bucket")) {
                     option.put("bucket", "-1");
                     option.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
-                    option.put(CoreOptions.COMPACTION_MAX_FILE_NUM.key(), "2");
                     keys = Lists.newArrayList();
                 } else {
                     option.put("bucket", "1");
@@ -566,7 +564,6 @@ public class CompactDatabaseActionITCase extends CompactActionITCaseBase {
                 if (tableName.endsWith("unaware_bucket")) {
                     option.put("bucket", "-1");
                     option.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
-                    option.put(CoreOptions.COMPACTION_MAX_FILE_NUM.key(), "2");
                     keys = Lists.newArrayList();
                 } else {
                     option.put("bucket", "1");
@@ -872,7 +869,6 @@ public class CompactDatabaseActionITCase extends CompactActionITCaseBase {
         // test that dedicated compact job will expire snapshots
         options.put(CoreOptions.BUCKET.key(), "-1");
         options.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
-        options.put(CoreOptions.COMPACTION_MAX_FILE_NUM.key(), "2");
 
         List<FileStoreTable> tables = new ArrayList<>();
         for (String tableName : TABLE_NAMES) {
@@ -946,7 +942,6 @@ public class CompactDatabaseActionITCase extends CompactActionITCaseBase {
         // test that dedicated compact job will expire snapshots
         options.put(CoreOptions.BUCKET.key(), "-1");
         options.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
-        options.put(CoreOptions.COMPACTION_MAX_FILE_NUM.key(), "2");
 
         List<FileStoreTable> tables = new ArrayList<>();
         for (String tableName : TABLE_NAMES) {
@@ -1013,7 +1008,6 @@ public class CompactDatabaseActionITCase extends CompactActionITCaseBase {
         } else {
             options.put(CoreOptions.BUCKET.key(), "-1");
             options.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
-            options.put(CoreOptions.COMPACTION_MAX_FILE_NUM.key(), "2");
             keys = Collections.emptyList();
         }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/UnawareBucketNewFilesCompactionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/UnawareBucketNewFilesCompactionITCase.java
@@ -67,7 +67,6 @@ public class UnawareBucketNewFilesCompactionITCase extends AbstractTestBase {
                         + ") PARTITIONED BY (pt) WITH (\n"
                         + "  'write-only' = 'true',\n"
                         + "  'compaction.min.file-num' = '3',\n"
-                        + "  'compaction.max.file-num' = '3',\n"
                         + "  'precommit-compact' = 'true',\n"
                         + "  'sink.parallelism' = '2'\n"
                         + ")");

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlySingleTableCompactionWorkerOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlySingleTableCompactionWorkerOperatorTest.java
@@ -52,7 +52,7 @@ import java.util.stream.Collectors;
 /** Tests for {@link AppendOnlySingleTableCompactionWorkerOperator}. */
 public class AppendOnlySingleTableCompactionWorkerOperatorTest extends TableTestBase {
 
-    @RepeatedTest(100)
+    @RepeatedTest(10)
     public void testAsyncCompactionWorks() throws Exception {
         createTableDefault();
         AppendOnlySingleTableCompactionWorkerOperator workerOperator =
@@ -209,7 +209,6 @@ public class AppendOnlySingleTableCompactionWorkerOperatorTest extends TableTest
         schemaBuilder.column("f1", DataTypes.BIGINT());
         schemaBuilder.column("f2", DataTypes.STRING());
         schemaBuilder.option(CoreOptions.BUCKET.key(), "-1");
-        schemaBuilder.option(CoreOptions.COMPACTION_MAX_FILE_NUM.key(), "5");
         return schemaBuilder.build();
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreMultiCommitterTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreMultiCommitterTest.java
@@ -71,7 +71,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
-import static org.apache.paimon.CoreOptions.COMPACTION_MAX_FILE_NUM;
 import static org.apache.paimon.SnapshotTest.newSnapshotManager;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -135,7 +134,6 @@ class StoreMultiCommitterTest {
         Options secondOptions = new Options();
         secondOptions.setString("bucket", "1");
         secondOptions.setString("bucket-key", "a");
-        secondOptions.set(COMPACTION_MAX_FILE_NUM, 50);
         Schema secondTableSchema =
                 new Schema(
                         rowType2.getFields(),
@@ -330,7 +328,7 @@ class StoreMultiCommitterTest {
         // should create 20 snapshots in total for first table
         assertThat(snapshotManager1.latestSnapshotId()).isEqualTo(20);
         // should create 10 snapshots for second table
-        assertThat(snapshotManager2.latestSnapshotId()).isEqualTo(10);
+        assertThat(snapshotManager2.latestSnapshotId()).isEqualTo(11);
         testHarness.close();
     }
 

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveWriteITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveWriteITCase.java
@@ -242,15 +242,14 @@ public class HiveWriteITCase extends HiveTestBase {
 
     @Test
     public void testWriteOnlyWithAppendOnlyTableOption() throws Exception {
-
         String innerName = "hive_test_table_output";
-        int maxCompact = 3;
+        int maxCompact = 5;
         String path = folder.newFolder().toURI().toString();
         String tablePath = String.format("%s/test_db.db/%s", path, innerName);
         Options conf = new Options();
         conf.set(CatalogOptions.WAREHOUSE, path);
         conf.set(CoreOptions.FILE_FORMAT, CoreOptions.FILE_FORMAT_AVRO);
-        conf.set(CoreOptions.COMPACTION_MAX_FILE_NUM, maxCompact);
+        conf.set(CoreOptions.COMPACTION_MIN_FILE_NUM, maxCompact);
         Identifier identifier = Identifier.create(DATABASE_NAME, innerName);
         Table table =
                 FileStoreTestUtils.createFileStoreTable(

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactManifestProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactManifestProcedureTest.scala
@@ -27,12 +27,11 @@ import org.assertj.core.api.Assertions
 class CompactManifestProcedureTest extends PaimonSparkTestBase with StreamTest {
 
   test("Paimon Procedure: compact manifest") {
-    spark.sql(
-      s"""
-         |CREATE TABLE T (id INT, value STRING, dt STRING, hh INT)
-         |TBLPROPERTIES ('bucket'='-1', 'write-only'='true', 'compaction.min.file-num'='2', 'compaction.max.file-num'='2')
-         |PARTITIONED BY (dt, hh)
-         |""".stripMargin)
+    spark.sql(s"""
+                 |CREATE TABLE T (id INT, value STRING, dt STRING, hh INT)
+                 |TBLPROPERTIES ('bucket'='-1', 'write-only'='true', 'compaction.min.file-num'='2')
+                 |PARTITIONED BY (dt, hh)
+                 |""".stripMargin)
 
     spark.sql(s"INSERT INTO T VALUES (5, '5', '2024-01-02', 0), (6, '6', '2024-01-02', 1)")
     spark.sql(s"INSERT OVERWRITE T VALUES (5, '5', '2024-01-02', 0), (6, '6', '2024-01-02', 1)")

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
@@ -456,12 +456,11 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
   }
 
   test("Paimon Procedure: compact unaware bucket append table") {
-    spark.sql(
-      s"""
-         |CREATE TABLE T (id INT, value STRING, pt STRING)
-         |TBLPROPERTIES ('bucket'='-1', 'write-only'='true', 'compaction.min.file-num'='2', 'compaction.max.file-num' = '3')
-         |PARTITIONED BY (pt)
-         |""".stripMargin)
+    spark.sql(s"""
+                 |CREATE TABLE T (id INT, value STRING, pt STRING)
+                 |TBLPROPERTIES ('bucket'='-1', 'write-only'='true', 'compaction.min.file-num'='2')
+                 |PARTITIONED BY (pt)
+                 |""".stripMargin)
 
     val table = loadTable("T")
 
@@ -490,12 +489,11 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
   }
 
   test("Paimon Procedure: compact unaware bucket append table with many small files") {
-    spark.sql(
-      s"""
-         |CREATE TABLE T (id INT, value STRING, pt STRING)
-         |TBLPROPERTIES ('bucket'='-1', 'write-only'='true', 'compaction.max.file-num' = '10')
-         |PARTITIONED BY (pt)
-         |""".stripMargin)
+    spark.sql(s"""
+                 |CREATE TABLE T (id INT, value STRING, pt STRING)
+                 |TBLPROPERTIES ('bucket'='-1', 'write-only'='true')
+                 |PARTITIONED BY (pt)
+                 |""".stripMargin)
 
     val table = loadTable("T")
 
@@ -543,7 +541,7 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
     spark.sql(
       s"""
          |CREATE TABLE T (id INT, value STRING, dt STRING, hh INT)
-         |TBLPROPERTIES ('bucket'='1', 'bucket-key'='id', 'write-only'='true', 'compaction.min.file-num'='1', 'compaction.max.file-num'='2')
+         |TBLPROPERTIES ('bucket'='1', 'bucket-key'='id', 'write-only'='true', 'compaction.min.file-num'='1')
          |PARTITIONED BY (dt, hh)
          |""".stripMargin)
 
@@ -599,12 +597,11 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
     spark.sql(s"INSERT INTO T VALUES (5, 'e', 'p1'), (6, 'f', 'p2')")
 
     spark.sql(
-      "CALL sys.compact(table => 'T', partitions => 'pt=\"p1\"', options => 'compaction.min.file-num=2,compaction.max.file-num = 3')")
+      "CALL sys.compact(table => 'T', partitions => 'pt=\"p1\"', options => 'compaction.min.file-num=2')")
     Assertions.assertThat(lastSnapshotCommand(table).equals(CommitKind.COMPACT)).isTrue
     Assertions.assertThat(lastSnapshotId(table)).isEqualTo(4)
 
-    spark.sql(
-      "CALL sys.compact(table => 'T', options => 'compaction.min.file-num=2,compaction.max.file-num = 3')")
+    spark.sql("CALL sys.compact(table => 'T', options => 'compaction.min.file-num=2')")
     Assertions.assertThat(lastSnapshotCommand(table).equals(CommitKind.COMPACT)).isTrue
     Assertions.assertThat(lastSnapshotId(table)).isEqualTo(5)
 
@@ -663,12 +660,11 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
   }
 
   test("Paimon Procedure: compact with partition_idle_time for unaware bucket append table") {
-    spark.sql(
-      s"""
-         |CREATE TABLE T (id INT, value STRING, dt STRING, hh INT)
-         |TBLPROPERTIES ('bucket'='-1', 'write-only'='true', 'compaction.min.file-num'='2', 'compaction.max.file-num'='2')
-         |PARTITIONED BY (dt, hh)
-         |""".stripMargin)
+    spark.sql(s"""
+                 |CREATE TABLE T (id INT, value STRING, dt STRING, hh INT)
+                 |TBLPROPERTIES ('bucket'='-1', 'write-only'='true', 'compaction.min.file-num'='2')
+                 |PARTITIONED BY (dt, hh)
+                 |""".stripMargin)
 
     val table = loadTable("T")
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DeletionVectorTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DeletionVectorTest.scala
@@ -160,7 +160,6 @@ class DeletionVectorTest extends PaimonSparkTestBase with AdaptiveSparkPlanHelpe
                        |CREATE TABLE T (id INT, name STRING)
                        |TBLPROPERTIES (
                        |  'deletion-vectors.enabled' = 'true',
-                       |  'compaction.max.file-num' = '50',
                        |  'bucket' = '$bucket' $bucketKey)
                        |""".stripMargin)
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The 'compaction.max.file-num' is uesless:
- For append bucketed table, this option is equal to `min.file-num`, it is useless.
- For append unaware table, this option has been removed in https://github.com/apache/incubator-paimon/pull/5442

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
