### PR TITLE
[format] Bump parquet 1.13.1->1.15.1 & avro 1.11.3->1.11.4

### DIFF
--- a/paimon-arrow/pom.xml
+++ b/paimon-arrow/pom.xml
@@ -120,5 +120,42 @@ under the License.
             <version>${hadoop.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-test</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-yarn-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-core-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/paimon-core/pom.xml
+++ b/paimon-core/pom.xml
@@ -210,6 +210,12 @@ under the License.
             <artifactId>iceberg-data</artifactId>
             <version>${iceberg.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>parquet-hadoop</artifactId>
+                    <groupId>org.apache.parquet</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/paimon-core/src/test/java/org/apache/paimon/utils/PartitionStatisticsReporterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/PartitionStatisticsReporterTest.java
@@ -128,7 +128,7 @@ public class PartitionStatisticsReporterTest {
         Assertions.assertThat(partitionParams).containsKey("c1=a/");
         Assertions.assertThat(partitionParams.get("c1=a/").toString())
                 .isEqualTo(
-                        "{spec={c1=a}, recordCount=1, fileSizeInBytes=591, fileCount=1, lastFileCreationTime=1729598544974}");
+                        "{spec={c1=a}, recordCount=1, fileSizeInBytes=662, fileCount=1, lastFileCreationTime=1729598544974}");
         action.close();
         Assertions.assertThat(closed).isTrue();
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlySingleTableCompactionWorkerOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/AppendOnlySingleTableCompactionWorkerOperatorTest.java
@@ -40,7 +40,6 @@ import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
 import org.apache.flink.streaming.util.MockOutput;
 import org.apache.flink.streaming.util.MockStreamConfig;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -52,7 +51,7 @@ import java.util.stream.Collectors;
 /** Tests for {@link AppendOnlySingleTableCompactionWorkerOperator}. */
 public class AppendOnlySingleTableCompactionWorkerOperatorTest extends TableTestBase {
 
-    @RepeatedTest(100)
+    @Test
     public void testAsyncCompactionWorks() throws Exception {
         createTableDefault();
         AppendOnlySingleTableCompactionWorkerOperator workerOperator =
@@ -149,7 +148,7 @@ public class AppendOnlySingleTableCompactionWorkerOperatorTest extends TableTest
         }
 
         // wait compaction
-        Thread.sleep(500);
+        Thread.sleep(1_000);
 
         LocalFileIO localFileIO = LocalFileIO.create();
         DataFilePathFactory dataFilePathFactory =

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
@@ -608,7 +608,7 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
                         Committer.createContext("", metricGroup, true, false, null, 1, 1));
         committer.commit(Collections.singletonList(manifestCommittable));
         CommitterMetrics metrics = committer.getCommitterMetrics();
-        assertThat(metrics.getNumBytesOutCounter().getCount()).isEqualTo(533);
+        assertThat(metrics.getNumBytesOutCounter().getCount()).isEqualTo(572);
         assertThat(metrics.getNumRecordsOutCounter().getCount()).isEqualTo(2);
         committer.close();
     }

--- a/paimon-format/pom.xml
+++ b/paimon-format/pom.xml
@@ -35,6 +35,7 @@ under the License.
         <joda-time.version>2.5</joda-time.version>
         <commons.pool.version>1.6</commons.pool.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
+        <commons.io.version>2.16.1</commons.io.version>
         <storage-api.version>2.8.1</storage-api.version>
     </properties>
 
@@ -155,6 +156,12 @@ under the License.
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <version>${avro.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons.io.version}</version>
         </dependency>
 
         <dependency>
@@ -333,6 +340,7 @@ under the License.
                                     <include>com.fasterxml.jackson.core:jackson-databind</include>
                                     <include>com.fasterxml.jackson.core:jackson-annotations</include>
                                     <include>org.apache.commons:commons-compress</include>
+                                    <include>commons-io:commons-io</include>
 
                                     <!-- Parquet -->
                                     <include>org.apache.parquet:parquet-hadoop</include>

--- a/paimon-format/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/paimon-format/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -24,6 +24,7 @@ import org.apache.paimon.fs.FileRange;
 import org.apache.paimon.fs.VectoredReadable;
 import org.apache.paimon.utils.RoaringBitmap32;
 
+import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.bytes.ByteBufferInputStream;
@@ -74,7 +75,6 @@ import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.SeekableInputStream;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
-import org.apache.yetus.audience.InterfaceAudience.Private;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -179,7 +179,7 @@ public class ParquetFileReader implements Closeable {
         }
 
         // Read all the footer bytes in one time to avoid multiple read operations,
-        // since it can be pretty time consuming for a single read operation in HDFS.
+        // since it can be pretty time-consuming for a single read operation in HDFS.
         ByteBuffer footerBytesBuffer = ByteBuffer.allocate(fileMetadataLength);
         f.readFully(footerBytesBuffer);
         LOG.debug("Finished to read all footer bytes.");
@@ -798,11 +798,11 @@ public class ParquetFileReader implements Closeable {
         if (blockIndex < 0 || blockIndex >= blocks.size()) {
             return null;
         }
-        return new DictionaryPageReader(this, blocks.get(blockIndex));
+        return new DictionaryPageReader(this, blocks.get(blockIndex), options.getAllocator());
     }
 
     public DictionaryPageReader getDictionaryReader(BlockMetaData block) {
-        return new DictionaryPageReader(this, block);
+        return new DictionaryPageReader(this, block, options.getAllocator());
     }
 
     /**
@@ -1003,7 +1003,7 @@ public class ParquetFileReader implements Closeable {
      * @return the column index for the specified column chunk or {@code null} if there is no index
      * @throws IOException if any I/O error occurs during reading the file
      */
-    @Private
+    @InterfaceAudience.Private
     public ColumnIndex readColumnIndex(ColumnChunkMetaData column) throws IOException {
         IndexReference ref = column.getColumnIndexReference();
         if (ref == null) {
@@ -1037,7 +1037,7 @@ public class ParquetFileReader implements Closeable {
      * @return the offset index for the specified column chunk or {@code null} if there is no index
      * @throws IOException if any I/O error occurs during reading the file
      */
-    @Private
+    @InterfaceAudience.Private
     public OffsetIndex readOffsetIndex(ColumnChunkMetaData column) throws IOException {
         IndexReference ref = column.getOffsetIndexReference();
         if (ref == null) {
@@ -1346,7 +1346,8 @@ public class ParquetFileReader implements Closeable {
                     pageBlockDecryptor,
                     aadPrefix,
                     rowGroupOrdinal,
-                    columnOrdinal);
+                    columnOrdinal,
+                    options);
         }
 
         private boolean hasMorePages(long valuesCountReadSoFar, int dataPageCountReadSoFar) {

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@ under the License.
         <flink.reuseForks>true</flink.reuseForks>
         <testcontainers.version>1.19.1</testcontainers.version>
         <iceberg.version>1.6.1</iceberg.version>
-        <parquet.version>1.13.1</parquet.version>
+        <parquet.version>1.15.1</parquet.version>
         <orc.version>1.9.2</orc.version>
         <protobuf-java.version>3.19.6</protobuf-java.version>
         <roaringbitmap.version>1.2.1</roaringbitmap.version>
@@ -133,7 +133,7 @@ under the License.
         <jaxb.api.version>2.3.1</jaxb.api.version>
         <findbugs.version>1.3.9</findbugs.version>
         <json-smart.version>2.5.2</json-smart.version>
-        <avro.version>1.11.3</avro.version>
+        <avro.version>1.11.4</avro.version>
         <kafka.version>3.2.3</kafka.version>
         <scala-maven-plugin.version>3.2.2</scala-maven-plugin.version>
         <scalatest-maven-plugin.version>2.1.0</scalatest-maven-plugin.version>
@@ -979,7 +979,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.6.0</version>
                 </plugin>
 
                 <!-- configure scala style -->


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5456 

Fix code bugs refer to https://github.com/apache/parquet-java/blob/master/CHANGES.md from parquet 1.13.1, and Apache Hive(https://github.com/apache/hive/pull/5762), Iceberg(https://github.com/apache/iceberg/pull/12616), etc use parquet 1.15.1

Fix the critical CVE in avro 1.11.3.
[CVE-2024-47561](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47561)
[CVE-2024-26308](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26308)
[CVE-2024-25710](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-25710)
[CVE-2023-43642](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-43642)
[CVE-2023-42503](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-42503)

also remove unnecessary repeated tests to reduce tests duration 42min -> 37min

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
