### PR TITLE
[flink] NoopStoreSinkWriteState should do nothing instead of throwing UnsupportedOperationException

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/NoopStoreSinkWriteState.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/NoopStoreSinkWriteState.java
@@ -41,13 +41,11 @@ public class NoopStoreSinkWriteState implements StoreSinkWriteState {
 
     @Override
     public @Nullable List<StateValue> get(String tableName, String key) {
-        throw new UnsupportedOperationException();
+        return null;
     }
 
     @Override
-    public void put(String tableName, String key, List<StateValue> stateValues) {
-        throw new UnsupportedOperationException();
-    }
+    public void put(String tableName, String key, List<StateValue> stateValues) {}
 
     @Override
     public void snapshotState() throws Exception {}


### PR DESCRIPTION
### Purpose

As the class name suggests, `NoopStoreSinkWriteState` should do nothing when `get` and `put` is called, instead of throwing `UnsupportedOperationException`.

### Tests

This is a simple change without tests.

### API and Format

No format changes.

### Documentation

No new feature.
