### PR TITLE
[hotfix] fix the currentFetchEventTimeLag metric will not increase when datastream is completely blocked

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceReader.java
@@ -41,6 +41,7 @@ public class FileStoreSourceReader
                 RecordIterator<RowData>, RowData, FileStoreSourceSplit, FileStoreSourceSplitState> {
 
     private final IOManager ioManager;
+    private final FileStoreSourceReaderMetrics metrics;
 
     private long lastConsumeSnapshotId = Long.MIN_VALUE;
 
@@ -64,6 +65,7 @@ public class FileStoreSourceReader
                 readerContext.getConfiguration(),
                 readerContext);
         this.ioManager = ioManager;
+        this.metrics = metrics;
     }
 
     @Override
@@ -72,6 +74,7 @@ public class FileStoreSourceReader
         if (getNumberOfCurrentlyAssignedSplits() == 0) {
             context.sendSplitRequest();
         }
+        metrics.idlingStarted();
     }
 
     @Override


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #4244

<!-- What is the purpose of the change -->
fix the currentFetchEventTimeLag metric will not increase when datastream is completely blocked

### Tests

<!-- List UT and IT cases to verify this change -->
FileStoreSourceReaderMetricsTest#testFetchLagWhenIdling

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
