### PR TITLE
[doc] not recommended to use asynchronous expiration in batch mode

### DIFF
--- a/docs/content/maintenance/manage-snapshots.md
+++ b/docs/content/maintenance/manage-snapshots.md
@@ -224,7 +224,9 @@ Please note that too short retain time or too small retain number may result in:
 By default, paimon will delete expired snapshots synchronously. When there are too 
 many files that need to be deleted, they may not be deleted quickly and back-pressured 
 to the upstream operator. To avoid this situation, users can use asynchronous expiration 
-mode by setting `snapshot.expire.execution-mode` to `async`.
+mode by setting `snapshot.expire.execution-mode` to `async`. However, if your job runs in 
+batch mode, it is not recommended to use asynchronous expiration mode, as the expire task 
+may fail to complete successfully.
 
 ## Rollback to Snapshot
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
