### PR TITLE
[core] Should not close channelManager in BinaryExternalSortBuffer

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/sort/BinaryExternalSortBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/BinaryExternalSortBuffer.java
@@ -50,7 +50,7 @@ public class BinaryExternalSortBuffer implements SortBuffer {
     private final BinaryRowSerializer serializer;
     private final BinaryInMemorySortBuffer inMemorySortBuffer;
     private final IOManager ioManager;
-    private SpillChannelManager channelManager;
+    private final SpillChannelManager channelManager;
     private final int maxNumFileHandles;
     private final BlockCompressionFactory compressionCodecFactory;
     private final int compressionBlockSize;
@@ -154,8 +154,7 @@ public class BinaryExternalSortBuffer implements SortBuffer {
         inMemorySortBuffer.clear();
         spillChannelIDs.clear();
         // delete files
-        channelManager.close();
-        channelManager = new SpillChannelManager();
+        channelManager.reset();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/sort/SpillChannelManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/SpillChannelManager.java
@@ -61,15 +61,7 @@ public class SpillChannelManager implements Closeable {
         channels.remove(id);
     }
 
-    @Override
-    public synchronized void close() {
-
-        if (this.closed) {
-            return;
-        }
-
-        this.closed = true;
-
+    public synchronized void reset() {
         for (Iterator<FileIOChannel> channels = this.openChannels.iterator();
                 channels.hasNext(); ) {
             final FileIOChannel channel = channels.next();
@@ -91,5 +83,14 @@ public class SpillChannelManager implements Closeable {
             } catch (Throwable ignored) {
             }
         }
+    }
+
+    @Override
+    public synchronized void close() {
+        if (this.closed) {
+            return;
+        }
+        this.closed = true;
+        reset();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/sort/SpillChannelManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/SpillChannelManager.java
@@ -20,21 +20,16 @@ package org.apache.paimon.sort;
 
 import org.apache.paimon.disk.FileIOChannel;
 
-import java.io.Closeable;
 import java.io.File;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.apache.paimon.utils.Preconditions.checkArgument;
-
 /** Channel manager to manage the life cycle of spill channels. */
-public class SpillChannelManager implements Closeable {
+public class SpillChannelManager {
 
     private final HashSet<FileIOChannel.ID> channels;
     private final HashSet<FileIOChannel> openChannels;
-
-    private volatile boolean closed;
 
     public SpillChannelManager() {
         this.channels = new HashSet<>(64);
@@ -43,13 +38,11 @@ public class SpillChannelManager implements Closeable {
 
     /** Add a new File channel. */
     public synchronized void addChannel(FileIOChannel.ID id) {
-        checkArgument(!closed);
         channels.add(id);
     }
 
     /** Open File channels. */
     public synchronized void addOpenChannels(List<FileIOChannel> toOpen) {
-        checkArgument(!closed);
         for (FileIOChannel channel : toOpen) {
             openChannels.add(channel);
             channels.remove(channel.getChannelID());
@@ -57,7 +50,6 @@ public class SpillChannelManager implements Closeable {
     }
 
     public synchronized void removeChannel(FileIOChannel.ID id) {
-        checkArgument(!closed);
         channels.remove(id);
     }
 
@@ -83,14 +75,5 @@ public class SpillChannelManager implements Closeable {
             } catch (Throwable ignored) {
             }
         }
-    }
-
-    @Override
-    public synchronized void close() {
-        if (this.closed) {
-            return;
-        }
-        this.closed = true;
-        reset();
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/sort/BinaryExternalSortBufferTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/sort/BinaryExternalSortBufferTest.java
@@ -188,8 +188,15 @@ public class BinaryExternalSortBufferTest {
         innerTestSpilling(createBuffer());
     }
 
+    @Test
+    public void testSpillingAndClearWithMaxFanIn() throws Exception {
+        BinaryExternalSortBuffer buffer = createBuffer(2);
+        innerTestSpilling(buffer);
+        innerTestSpilling(buffer);
+    }
+
     private void innerTestSpilling(BinaryExternalSortBuffer sorter) throws Exception {
-        int size = 1000_000;
+        int size = 2000_000;
 
         MockBinaryRowReader reader = new MockBinaryRowReader(size);
         sorter.write(reader);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In `BinaryExternalSortBuffer`, should not close `channelManager`, because `channelManager` will be used in `BinaryExternalMerger`.

This bug can be produced in the scenario when spill files exceed `maxNumFileHandles`, this kind of scenario is very rare.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
`BinaryExternalSortBufferTest.testSpillingAndClearWithMaxFanIn`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
