### PR TITLE
[core] Support configurable Iceberg metadata path independent of storage type

### DIFF
--- a/docs/content/migration/iceberg-compatibility.md
+++ b/docs/content/migration/iceberg-compatibility.md
@@ -55,6 +55,18 @@ Set the following table options, so that Paimon tables can generate Iceberg comp
         </ul>
       </td>
     </tr>
+    <tr>
+      <td><h5>metadata.iceberg.storage-location</h5></td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Enum</td>
+      <td>
+        Specifies where to store Iceberg metadata files. If not set, the storage location will default based on the selected metadata.iceberg.storage type.
+        <ul>
+          <li><code>table-location</code>: Store Iceberg metadata in each table's directory. Useful for standalone Iceberg tables or Iceberg Java API access. Can also be used with Hive Catalog.</li>
+          <li><code>catalog-location</code>: Store Iceberg metadata in a separate directory. This is the default behavior when using Hive Catalog or Hadoop Catalog.</li>
+        </ul>
+      </td>
+    </tr>
     </tbody>
 </table>
 
@@ -63,7 +75,9 @@ or `'metadata.iceberg.storage' = 'hive-catalog'`,
 so that all tables can be visited as an Iceberg warehouse.
 For Iceberg Java API users, you might consider setting `'metadata.iceberg.storage' = 'table-location'`,
 so you can visit each table with its table path.
-
+When using `metadata.iceberg.storage = hadoop-catalog` or `hive-catalog`,
+you can optionally configure `metadata.iceberg.storage-location` to control where the metadata is stored. 
+If not set, the default behavior depends on the storage type.
 ## Append Tables
 
 Let's walk through a simple example, where we query Paimon tables with Iceberg connectors in Flink and Spark.

--- a/docs/layouts/shortcodes/generated/iceberg_configuration.html
+++ b/docs/layouts/shortcodes/generated/iceberg_configuration.html
@@ -99,6 +99,12 @@ under the License.
             <td>When set, produce Iceberg metadata after a snapshot is committed, so that Iceberg readers can read Paimon's raw data files.<br /><br />Possible values:<ul><li>"disabled": Disable Iceberg compatibility support.</li><li>"table-location": Store Iceberg metadata in each table's directory.</li><li>"hadoop-catalog": Store Iceberg metadata in a separate directory. This directory can be specified as the warehouse directory of an Iceberg Hadoop catalog.</li><li>"hive-catalog": Not only store Iceberg metadata like hadoop-catalog, but also create Iceberg external table in Hive.</li></ul></td>
         </tr>
         <tr>
+            <td><h5>metadata.iceberg.storage-location</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td><p>Enum</p></td>
+            <td>To store Iceberg metadata in a separate directory or under table location<br /><br />Possible values:<ul><li>"table-location": Store Iceberg metadata in each table's directory. Useful for standalone Iceberg tables or Java API access. Can also be used with Hive Catalog</li><li>"catalog-location": Store Iceberg metadata in a separate directory. Allows integration with Hive Catalog or Hadoop Catalog.</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>metadata.iceberg.table</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
@@ -37,6 +37,13 @@ public class IcebergOptions {
                             "When set, produce Iceberg metadata after a snapshot is committed, "
                                     + "so that Iceberg readers can read Paimon's raw data files.");
 
+    public static final ConfigOption<StorageLocation> METADATA_ICEBERG_STORAGE_LOCATION =
+            key("metadata.iceberg.storage-location")
+                    .enumType(StorageLocation.class)
+                    .noDefaultValue()
+                    .withDescription(
+                            "To store Iceberg metadata in a separate directory or under table location");
+
     public static final ConfigOption<Integer> COMPACT_MIN_FILE_NUM =
             ConfigOptions.key("metadata.iceberg.compaction.min.file-num")
                     .intType()
@@ -143,6 +150,36 @@ public class IcebergOptions {
         private final String description;
 
         StorageType(String value, String description) {
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return TextElement.text(description);
+        }
+    }
+
+    /** Where to store Iceberg metadata. */
+    public enum StorageLocation implements DescribedEnum {
+        TABLE_LOCATION(
+                "table-location",
+                "Store Iceberg metadata in each table's directory. Useful for standalone "
+                        + "Iceberg tables or Java API access. Can also be used with Hive Catalog"),
+        CATALOG_STORAGE(
+                "catalog-location",
+                "Store Iceberg metadata in a separate directory. "
+                        + "Allows integration with Hive Catalog or Hadoop Catalog.");
+
+        private final String value;
+        private final String description;
+
+        StorageLocation(String value, String description) {
             this.value = value;
             this.description = description;
         }

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCommitCallbackTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCommitCallbackTest.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.FileStoreTable;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Tests for {@link IcebergCommitCallback}. */
+public class IcebergCommitCallbackTest {
+
+    private FileStoreTable mockTable;
+    private CoreOptions mockCoreOptions;
+    private Options mockConfig;
+
+    @BeforeEach
+    void setUp() {
+        mockTable = mock(FileStoreTable.class);
+        when(mockTable.location()).thenReturn(new Path("file:/tmp/paimon/mydb.db/mytable"));
+
+        mockCoreOptions = mock(CoreOptions.class);
+        when(mockTable.coreOptions()).thenReturn(mockCoreOptions);
+
+        mockConfig = mock(Options.class);
+        when(mockCoreOptions.toConfiguration()).thenReturn(mockConfig);
+    }
+
+    @ParameterizedTest(name = "StorageType: {0}")
+    @MethodSource("provideMetadataPathsWithStorageType")
+    void testCatalogTableMetadataPathWithStorageType(
+            IcebergOptions.StorageType storageType, String expectedPath) {
+        when(mockConfig.get(IcebergOptions.METADATA_ICEBERG_STORAGE)).thenReturn(storageType);
+
+        Path result = IcebergCommitCallback.catalogTableMetadataPath(mockTable);
+
+        assertThat(result.toString()).isEqualTo(expectedPath);
+    }
+
+    @ParameterizedTest(name = "StorageType: {0}")
+    @MethodSource("provideDatabasePathsWithStorageType")
+    void testCatalogDatabasePathWithStorageType(
+            IcebergOptions.StorageType storageType, String expectedPath) {
+        when(mockConfig.get(IcebergOptions.METADATA_ICEBERG_STORAGE)).thenReturn(storageType);
+
+        Path result = IcebergCommitCallback.catalogDatabasePath(mockTable);
+
+        assertThat(result.toString()).isEqualTo(expectedPath);
+    }
+
+    @ParameterizedTest(name = "StorageType: {0}")
+    @MethodSource("provideMetadataPathsWithStorageLocation")
+    void testCatalogMetadataPathWithStorageLocation(
+            IcebergOptions.StorageType storageType,
+            IcebergOptions.StorageLocation storageLocation,
+            String expectedPath) {
+        when(mockConfig.get(IcebergOptions.METADATA_ICEBERG_STORAGE)).thenReturn(storageType);
+        if (storageLocation != null) {
+            when(mockConfig.getOptional(IcebergOptions.METADATA_ICEBERG_STORAGE_LOCATION))
+                    .thenReturn(java.util.Optional.of(storageLocation));
+        } else {
+            when(mockConfig.getOptional(IcebergOptions.METADATA_ICEBERG_STORAGE_LOCATION))
+                    .thenReturn(java.util.Optional.empty());
+        }
+
+        Path result = IcebergCommitCallback.catalogTableMetadataPath(mockTable);
+
+        assertThat(result.toString()).isEqualTo(expectedPath);
+    }
+
+    @ParameterizedTest(name = "StorageType: {0}")
+    @MethodSource("provideDatabasePathsWithStorageLocation")
+    void testCatalogDatabasePathWithStorageLocation(
+            IcebergOptions.StorageType storageType,
+            IcebergOptions.StorageLocation storageLocation,
+            String expectedPath) {
+        when(mockConfig.get(IcebergOptions.METADATA_ICEBERG_STORAGE)).thenReturn(storageType);
+        if (storageLocation != null) {
+            when(mockConfig.getOptional(IcebergOptions.METADATA_ICEBERG_STORAGE_LOCATION))
+                    .thenReturn(java.util.Optional.of(storageLocation));
+        } else {
+            when(mockConfig.getOptional(IcebergOptions.METADATA_ICEBERG_STORAGE_LOCATION))
+                    .thenReturn(java.util.Optional.empty());
+        }
+
+        Path result = IcebergCommitCallback.catalogDatabasePath(mockTable);
+
+        assertThat(result.toString()).isEqualTo(expectedPath);
+    }
+
+    private static Stream<Arguments> provideMetadataPathsWithStorageType() {
+        return Stream.of(
+                Arguments.of(
+                        IcebergOptions.StorageType.TABLE_LOCATION,
+                        "file:/tmp/paimon/mydb.db/mytable/metadata"),
+                Arguments.of(
+                        IcebergOptions.StorageType.HIVE_CATALOG,
+                        "file:/tmp/paimon/iceberg/mydb/mytable/metadata"),
+                Arguments.of(
+                        IcebergOptions.StorageType.HADOOP_CATALOG,
+                        "file:/tmp/paimon/iceberg/mydb/mytable/metadata"));
+    }
+
+    private static Stream<Arguments> provideMetadataPathsWithStorageLocation() {
+        return Stream.of(
+                // Explicitly set StorageLocation
+                Arguments.of(
+                        IcebergOptions.StorageType.TABLE_LOCATION,
+                        IcebergOptions.StorageLocation.TABLE_LOCATION,
+                        "file:/tmp/paimon/mydb.db/mytable/metadata"),
+                Arguments.of(
+                        IcebergOptions.StorageType.TABLE_LOCATION,
+                        IcebergOptions.StorageLocation.CATALOG_STORAGE,
+                        "file:/tmp/paimon/iceberg/mydb/mytable/metadata"),
+                Arguments.of(
+                        IcebergOptions.StorageType.HIVE_CATALOG,
+                        IcebergOptions.StorageLocation.TABLE_LOCATION,
+                        "file:/tmp/paimon/mydb.db/mytable/metadata"),
+                Arguments.of(
+                        IcebergOptions.StorageType.HIVE_CATALOG,
+                        IcebergOptions.StorageLocation.CATALOG_STORAGE,
+                        "file:/tmp/paimon/iceberg/mydb/mytable/metadata"),
+                Arguments.of(
+                        IcebergOptions.StorageType.HADOOP_CATALOG,
+                        IcebergOptions.StorageLocation.TABLE_LOCATION,
+                        "file:/tmp/paimon/mydb.db/mytable/metadata"),
+                Arguments.of(
+                        IcebergOptions.StorageType.HADOOP_CATALOG,
+                        IcebergOptions.StorageLocation.CATALOG_STORAGE,
+                        "file:/tmp/paimon/iceberg/mydb/mytable/metadata"),
+
+                // Backward compatibility: StorageLocation is not provided.
+                Arguments.of(
+                        IcebergOptions.StorageType.TABLE_LOCATION,
+                        null,
+                        "file:/tmp/paimon/mydb.db/mytable/metadata"), // Defaults to TABLE_LOCATION
+                Arguments.of(
+                        IcebergOptions.StorageType.HIVE_CATALOG,
+                        null,
+                        "file:/tmp/paimon/iceberg/mydb/mytable/metadata"), // Defaults to
+                // CATALOG_STORAGE
+                Arguments.of(
+                        IcebergOptions.StorageType.HADOOP_CATALOG,
+                        null,
+                        "file:/tmp/paimon/iceberg/mydb/mytable/metadata") // Defaults to
+                // CATALOG_STORAGE
+                );
+    }
+
+    private static Stream<Arguments> provideDatabasePathsWithStorageType() {
+        return Stream.of(
+                Arguments.of(IcebergOptions.StorageType.TABLE_LOCATION, "file:/tmp/paimon/mydb.db"),
+                Arguments.of(
+                        IcebergOptions.StorageType.HIVE_CATALOG, "file:/tmp/paimon/iceberg/mydb"),
+                Arguments.of(
+                        IcebergOptions.StorageType.HADOOP_CATALOG,
+                        "file:/tmp/paimon/iceberg/mydb"));
+    }
+
+    private static Stream<Arguments> provideDatabasePathsWithStorageLocation() {
+        return Stream.of(
+                Arguments.of(
+                        IcebergOptions.StorageType.TABLE_LOCATION,
+                        IcebergOptions.StorageLocation.TABLE_LOCATION,
+                        "file:/tmp/paimon/mydb.db"),
+                Arguments.of(
+                        IcebergOptions.StorageType.TABLE_LOCATION,
+                        IcebergOptions.StorageLocation.CATALOG_STORAGE,
+                        "file:/tmp/paimon/iceberg/mydb"),
+                Arguments.of(
+                        IcebergOptions.StorageType.HIVE_CATALOG,
+                        IcebergOptions.StorageLocation.TABLE_LOCATION,
+                        "file:/tmp/paimon/mydb.db"),
+                Arguments.of(
+                        IcebergOptions.StorageType.HIVE_CATALOG,
+                        IcebergOptions.StorageLocation.CATALOG_STORAGE,
+                        "file:/tmp/paimon/iceberg/mydb"),
+                Arguments.of(
+                        IcebergOptions.StorageType.HADOOP_CATALOG,
+                        IcebergOptions.StorageLocation.TABLE_LOCATION,
+                        "file:/tmp/paimon/mydb.db"),
+                Arguments.of(
+                        IcebergOptions.StorageType.HADOOP_CATALOG,
+                        IcebergOptions.StorageLocation.CATALOG_STORAGE,
+                        "file:/tmp/paimon/iceberg/mydb"),
+                // Backward compatibility: StorageLocation is not provided.
+                Arguments.of(
+                        IcebergOptions.StorageType.TABLE_LOCATION,
+                        null,
+                        "file:/tmp/paimon/mydb.db"), // Defaults to TABLE_LOCATION
+                Arguments.of(
+                        IcebergOptions.StorageType.HIVE_CATALOG,
+                        null,
+                        "file:/tmp/paimon/iceberg/mydb"), // Defaults to CATALOG_STORAGE
+                Arguments.of(
+                        IcebergOptions.StorageType.HADOOP_CATALOG,
+                        null,
+                        "file:/tmp/paimon/iceberg/mydb") // Defaults to CATALOG_STORAGE
+                );
+    }
+}


### PR DESCRIPTION
[core] Support configurable Iceberg metadata path independent of storage type

### Purpose

Linked issue [Feature]: close #5470

This PR introduces a new table option `metadata.iceberg.storage-location` to allow users to configure where Iceberg metadata is stored, independently of the selected metadata.iceberg.storage type.

By default, when using `metadata.iceberg.storage = table-location`, Paimon does not register the table or database in Hive or AWS Glue catalogs. This is expected behavior, but it limits integration with catalog-based systems such as Lake Formation or Iceberg readers that rely on Hive/Glue.

This feature adds support for catalog registration even when using table-location, by decoupling the metadata storage path from the catalog integration logic.

This enables users to:

- Store Iceberg metadata in the table directory
- Still register tables and databases in Hive or Glue
- Support hybrid deployments where metadata is colocated with table data but still discoverable via catalogs

### Tests

- Added unit tests in IcebergCommitCallbackTest
- Manually tested using Kafka to Paimon connector with Flink and AWS Glue

### API and Format

No changes to public API or storage format

### Documentation

Introduces a new table option: metadata.iceberg.storage-location
Updated iceberg-compatibility.md to document the new configuration and usage scenarios
