### PR TITLE
[core] Remove the checker in bucket function

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/KeyAndBucketExtractor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/KeyAndBucketExtractor.java
@@ -50,6 +50,7 @@ public interface KeyAndBucketExtractor<T> {
     }
 
     static int bucket(int hashcode, int numBuckets) {
+        assert numBuckets > 0;
         return Math.abs(hashcode % numBuckets);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/KeyAndBucketExtractor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/KeyAndBucketExtractor.java
@@ -24,8 +24,6 @@ import org.apache.paimon.types.RowKind;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.paimon.utils.Preconditions.checkArgument;
-
 /**
  * Utility interface to extract partition keys, bucket id, primary keys for file store ({@code
  * trimmedPrimaryKey}) and primary keys for external log system ({@code logPrimaryKey}) from the

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/KeyAndBucketExtractor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/KeyAndBucketExtractor.java
@@ -52,7 +52,6 @@ public interface KeyAndBucketExtractor<T> {
     }
 
     static int bucket(int hashcode, int numBuckets) {
-        checkArgument(numBuckets > 0, "Num bucket is illegal: " + numBuckets);
         return Math.abs(hashcode % numBuckets);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/sink/FixedBucketRowKeyExtractorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/sink/FixedBucketRowKeyExtractorTest.java
@@ -67,8 +67,7 @@ public class FixedBucketRowKeyExtractorTest {
     @Test
     public void testIllegalBucket() {
         GenericRow row = GenericRow.of(5, 6, 7);
-        assertThatThrownBy(() -> bucket(extractor("", "", "a", -1), row))
-                .hasMessageContaining("Num bucket is illegal");
+        assertThatThrownBy(() -> bucket(extractor("", "", "a", -1), row));
     }
 
     private int bucket(FixedBucketRowKeyExtractor extractor, InternalRow row) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

`static int bucket(int hashcode, int numBuckets)` will be called at the row level, remove the checker in it

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
