### PR TITLE
[build] Speed up tests execution

### DIFF
--- a/.github/workflows/e2e-tests-flink-2.x-jdk11.yml
+++ b/.github/workflows/e2e-tests-flink-2.x-jdk11.yml
@@ -49,8 +49,7 @@ jobs:
 
       - name: Build Flink
         run:  |
-          mvn -T 1C -B clean install -DskipTests -Pflink1,spark3 -pl paimon-e2e-tests -am -Pflink-${{ matrix.flink_version }},java11
-          mvn -T 1C -B clean install -DskipTests -Pflink2,spark3 -pl paimon-e2e-tests -am -Pflink-${{ matrix.flink_version }},java11
+          mvn -T 2C -B clean install -DskipTests -Pflink2,spark3 -pl paimon-e2e-tests -am -Pflink-${{ matrix.flink_version }},java11
 
       - name: Test Flink
         run: |

--- a/.github/workflows/utitcase-flink-1.x-jdk11.yml
+++ b/.github/workflows/utitcase-flink-1.x-jdk11.yml
@@ -57,6 +57,6 @@ jobs:
           test_modules+="org.apache.paimon:paimon-flink-${suffix},"
           done
           test_modules="${test_modules%,}"
-          mvn -T 1C -B clean install -Pflink1,spark3 -pl "${test_modules}" -Duser.timezone=$jvm_timezone
+          mvn -T 1C -B test verify -Pflink1,spark3 -pl "${test_modules}" -Duser.timezone=$jvm_timezone
         env:
           MAVEN_OPTS: -Xmx4096m

--- a/.github/workflows/utitcase-flink-2.x-jdk11.yml
+++ b/.github/workflows/utitcase-flink-2.x-jdk11.yml
@@ -31,6 +31,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -40,10 +41,11 @@ jobs:
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: 'temurin'
+
       - name: Build Flink
         run:  |
-          mvn -T 1C -B clean install -DskipTests -Pflink1,spark3
-          mvn -T 1C -B clean install -DskipTests -Pflink2,spark3
+          mvn -T 2C -B clean install -DskipTests -Pflink2,spark3
+
       - name: Test Flink
         run: |
           # run tests with random timezone to find out timezone related bugs
@@ -55,6 +57,6 @@ jobs:
           test_modules+="org.apache.paimon:paimon-flink-${suffix},"
           done
           test_modules="${test_modules%,}"
-          mvn -T 1C -B clean install -Pflink2,spark3 -pl "${test_modules}" -Duser.timezone=$jvm_timezone
+          mvn -T 2C -B test verify -Pflink2,spark3 -pl "${test_modules}" -Duser.timezone=$jvm_timezone
         env:
           MAVEN_OPTS: -Xmx4096m


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

1. End to End Tests Flink 2.x on JDK 11: 13min -> 9min https://github.com/liyubin117/paimon/actions/runs/14464290242
- should not compile for `-Pflink1,spark3`
2. UTCase and ITCase Flink 2.x on JDK 11: 46min -> 40min https://github.com/liyubin117/paimon/actions/runs/14464290191
- should not compile for `-Pflink1,spark3`
- should use `timeout-minutes`, https://github.com/apache/paimon/actions/runs/14462435680/job/40557390576 takes 360min and waste a lot of resources.
- test phase only be responsible to `test verify` instead of `install` again


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
