### PR TITLE
[hotfix] fix markdown heading level

### DIFF
--- a/docs/content/concepts/spec/datafile.md
+++ b/docs/content/concepts/spec/datafile.md
@@ -83,7 +83,7 @@ relationship between various table types and buckets in Paimon:
 The name of data file is `data-${uuid}-${id}.${format}`. For the append table, the file stores the data of the table
 without adding any new columns. But for the primary key table, each row of data stores additional system columns:
 
-## Table with Primary key Data File
+### Table with Primary key Data File
 
 1. Primary key columns, `_KEY_` prefix to key columns, this is to avoid conflicts with columns of the table. It's optional,
    Paimon version 1.0 and above will retrieve the primary key fields from value_columns.
@@ -107,7 +107,7 @@ Its file has 6 columns: `_KEY_a`, `_VALUE_KIND`, `_SEQUENCE_NUMBER`, `a`, `b`, `
 
 When `data-file.thin-mode` enabled, its file has 5 columns: `_VALUE_KIND`, `_SEQUENCE_NUMBER`, `a`, `b`, `c`.
 
-## Table w/o Primary key Data File
+### Table w/o Primary key Data File
 
 - Value columns. All columns declared in the table.
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Fix  `datafile.md` file format, maybe `Table with Primary key Data File` and `Table w/o Primary key Data File` are H3 level, which is easier to understand.

 <img width="1200" alt="image" src="https://github.com/user-attachments/assets/5d45060c-af82-40db-b412-fc65021e47a7" />


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
