### PR TITLE
[log] Add detailed failure log and test for query metadata columns

### DIFF
--- a/docs/content/spark/sql-query.md
+++ b/docs/content/spark/sql-query.md
@@ -49,6 +49,10 @@ Paimon also supports reading some hidden metadata columns, currently supporting 
 SELECT *, __paimon_file_path, __paimon_partition, __paimon_bucket, __paimon_row_index FROM t;
 ```
 
+{{< hint info >}}
+Note: only append table or deletion vector table support querying metadata columns.
+{{< /hint >}}
+
 ### Batch Time Travel
 
 Paimon batch reads with time travel can specify a snapshot or a tag and read the corresponding data.

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonRecordReaderIterator.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonRecordReaderIterator.scala
@@ -50,7 +50,8 @@ case class PaimonRecordReaderIterator(
     if (needMetadata) {
       if (!isFileRecordIterator || !split.isInstanceOf[DataSplit]) {
         throw new RuntimeException(
-          "There need be FileRecordIterator when metadata columns are required.")
+          "There need be FileRecordIterator when metadata columns are required. " +
+            "Only append table or deletion vector table support querying metadata columns.")
       }
     }
   }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
https://github.com/apache/paimon/issues/5467, pk table not support querying metadata columns.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
