### PR TITLE
[core] Improve performance of PartialUpdateMergeFunction with sequence group

### DIFF
--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/compact/PartialUpdateMergeFunctionBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/compact/PartialUpdateMergeFunctionBenchmark.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.benchmark.compact;
+
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.benchmark.Benchmark;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.mergetree.compact.MergeFunction;
+import org.apache.paimon.mergetree.compact.MergeFunctionFactory;
+import org.apache.paimon.mergetree.compact.PartialUpdateMergeFunction;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
+
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
+
+import org.junit.jupiter.api.Test;
+
+/** Benchmark for measure the performance for {@link PartialUpdateMergeFunction}. */
+public class PartialUpdateMergeFunctionBenchmark {
+
+    private final int rowCount = 40000000;
+
+    @Test
+    public void testUpdateWithSequenceGroup() {
+        Options options = new Options();
+        options.set("fields.f1.sequence-group", "f2,f3,f4,f5");
+
+        MergeFunctionFactory<KeyValue> factory =
+                PartialUpdateMergeFunction.factory(options, getRowType(6), ImmutableList.of("f0"));
+
+        MergeFunction<KeyValue> func = factory.create();
+
+        Benchmark benchmark =
+                new Benchmark("partial-update-benchmark", rowCount)
+                        .setNumWarmupIters(1)
+                        .setOutputPerIteration(true);
+
+        benchmark.addCase(
+                "updateWithSequenceGroup",
+                5,
+                () -> {
+                    func.reset();
+                    for (int i = 0; i < rowCount; i++) {
+                        add(func, i, RowKind.INSERT, 1, i, 1, 1, 1, 1);
+                    }
+                });
+
+        benchmark.run();
+    }
+
+    @Test
+    public void testRetractWithSequenceGroup() {
+        Options options = new Options();
+        options.set("fields.f1.sequence-group", "f2,f3,f4,f5");
+
+        MergeFunctionFactory<KeyValue> factory =
+                PartialUpdateMergeFunction.factory(options, getRowType(6), ImmutableList.of("f0"));
+
+        MergeFunction<KeyValue> func = factory.create();
+
+        Benchmark benchmark =
+                new Benchmark("partial-update-benchmark", rowCount)
+                        .setNumWarmupIters(1)
+                        .setOutputPerIteration(true);
+
+        benchmark.addCase(
+                "retractWithSequenceGroup",
+                5,
+                () -> {
+                    func.reset();
+                    for (int i = 0; i < rowCount; i++) {
+                        add(func, i, RowKind.DELETE, 1, i, 1, 1, 1, 1);
+                    }
+                });
+
+        benchmark.run();
+    }
+
+    @Test
+    public void testUpdateWithEmptySequenceGroup() {
+        Options options = new Options();
+        options.set("fields.f1.sequence-group", "f2");
+        options.set("fields.f3.sequence-group", "f4");
+        options.set("fields.f5.sequence-group", "f6,f7,f8");
+
+        MergeFunctionFactory<KeyValue> factory =
+                PartialUpdateMergeFunction.factory(options, getRowType(9), ImmutableList.of("f0"));
+
+        MergeFunction<KeyValue> func = factory.create();
+
+        Benchmark benchmark =
+                new Benchmark("partial-update-benchmark", rowCount)
+                        .setNumWarmupIters(1)
+                        .setOutputPerIteration(true);
+
+        benchmark.addCase(
+                "updateWithEmptySequenceGroup",
+                5,
+                () -> {
+                    func.reset();
+                    for (int i = 0; i < rowCount; i++) {
+                        add(func, i, RowKind.INSERT, 1, i, 1, null, null, null, null, null, null);
+                    }
+                });
+
+        benchmark.run();
+    }
+
+    private RowType getRowType(int numFields) {
+        DataField[] fields = new DataField[numFields];
+        fields[0] = new DataField(0, "k", DataTypes.INT());
+
+        for (int i = 1; i < numFields; i++) {
+            fields[i] = new DataField(i, "f" + i, DataTypes.INT());
+        }
+        return RowType.of(fields);
+    }
+
+    private void add(
+            MergeFunction<KeyValue> function, int sequence, RowKind rowKind, Integer... f) {
+        function.add(new KeyValue().replace(GenericRow.of(1), sequence, rowKind, GenericRow.of(f)));
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Improve the performance of PartialUpdateMergeFunction with sequence group.  

We made the following changes:

* Use a List, instead of a Map, to store the `FieldsComparator` and `FieldAggregator` to improve the performance for accessing the `FieldsComparator` and `FieldAggregator`.
* Get the field from the value row when it is needed to avoid the unnecessary heavy call of `FieldGetter#getFieldOrNull`.
* Use an array of booleans to record if the sequence group is empty to avoid duplicate checks for the same sequence group.

The optimization gives about 51% performance boost by the benchmark `PartialUpdateMergeFunctionBenchmark` with empty sequence groups, and 28% without empty sequence groups. According to our experience, the `PartialUpdateMergeFunction#updateWithSequenceGroup` method is about 60% workload of the end-to-end compaction with partial update merge engine and sequence group, so we can expect about 30% overall performance of such compaction.

The following benchmark results were run on

```
OpenJDK 64-Bit Server VM 1.8.0_412-b08 on Mac OS X 15.4
Apple M3 Pro
```

Before optimization
```
partial-update-benchmark:                                                                            Best/Avg Time(ms)    Row Rate(K/s)      Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
OPERATORTEST_partial-update-benchmark_updateWithSequenceGroup                                           12079 / 12883           3311.4            302.0       1.0X
OPERATORTEST_partial-update-benchmark_retractWithSequenceGroup                                          10976 / 11129           3644.3            274.4       1.0X
OPERATORTEST_partial-update-benchmark_updateWithEmptySequenceGroup                                      11636 / 11727           3437.6            290.9       1.0X
```


After optimization
```
partial-update-benchmark:                                                                            Best/Avg Time(ms)    Row Rate(K/s)      Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
OPERATORTEST_partial-update-benchmark_updateWithSequenceGroup                                            9995 / 10029           4002.0            249.9       1.0X
OPERATORTEST_partial-update-benchmark_retractWithSequenceGroup                                            9311 / 9330           4295.9            232.8       1.0X
OPERATORTEST_partial-update-benchmark_updateWithEmptySequenceGroup                                        7701 / 7747           5194.2            192.5       1.0X
```

### Tests

Already covered by the existing tests, such as `PartialUpdateMergeFunctionTest`

