### PR TITLE
[core] Add metric "deletedRecordCount" for class Partition

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -652,6 +652,7 @@ public interface Catalog extends AutoCloseable {
     String NUM_FILES_PROP = "numFiles";
     String TOTAL_SIZE_PROP = "totalSize";
     String LAST_UPDATE_TIME_PROP = "lastUpdateTime";
+    String DELETED_RECORD_COUNT_PROP = "deletedRecordCount";
 
     // ======================= Exceptions ===============================
 

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/PartitionEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/PartitionEntry.java
@@ -43,18 +43,21 @@ public class PartitionEntry {
     private final long fileSizeInBytes;
     private final long fileCount;
     private final long lastFileCreationTime;
+    private final long deletedRecordCount;
 
     public PartitionEntry(
             BinaryRow partition,
             long recordCount,
             long fileSizeInBytes,
             long fileCount,
-            long lastFileCreationTime) {
+            long lastFileCreationTime,
+            long deletedRecordCount) {
         this.partition = partition;
         this.recordCount = recordCount;
         this.fileSizeInBytes = fileSizeInBytes;
         this.fileCount = fileCount;
         this.lastFileCreationTime = lastFileCreationTime;
+        this.deletedRecordCount = deletedRecordCount;
     }
 
     public BinaryRow partition() {
@@ -83,7 +86,8 @@ public class PartitionEntry {
                 recordCount + entry.recordCount,
                 fileSizeInBytes + entry.fileSizeInBytes,
                 fileCount + entry.fileCount,
-                Math.max(lastFileCreationTime, entry.lastFileCreationTime));
+                Math.max(lastFileCreationTime, entry.lastFileCreationTime),
+                deletedRecordCount + entry.deletedRecordCount);
     }
 
     public Partition toPartition(InternalRowPartitionComputer computer) {
@@ -93,6 +97,7 @@ public class PartitionEntry {
                 fileSizeInBytes,
                 fileCount,
                 lastFileCreationTime,
+                deletedRecordCount,
                 false);
     }
 
@@ -102,7 +107,8 @@ public class PartitionEntry {
                 recordCount,
                 fileSizeInBytes,
                 fileCount,
-                lastFileCreationTime);
+                lastFileCreationTime,
+                deletedRecordCount);
     }
 
     public static PartitionEntry fromManifestEntry(ManifestEntry entry) {
@@ -120,7 +126,12 @@ public class PartitionEntry {
             fileCount = -fileCount;
         }
         return new PartitionEntry(
-                partition, recordCount, fileSizeInBytes, fileCount, file.creationTimeEpochMillis());
+                partition,
+                recordCount,
+                fileSizeInBytes,
+                fileCount,
+                file.creationTimeEpochMillis(),
+                file.deleteRowCount().orElse(0L));
     }
 
     public static Collection<PartitionEntry> merge(Collection<ManifestEntry> fileEntries) {

--- a/paimon-core/src/main/java/org/apache/paimon/partition/Partition.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/Partition.java
@@ -47,8 +47,15 @@ public class Partition extends PartitionStatistics {
             @JsonProperty(FIELD_FILE_SIZE_IN_BYTES) long fileSizeInBytes,
             @JsonProperty(FIELD_FILE_COUNT) long fileCount,
             @JsonProperty(FIELD_LAST_FILE_CREATION_TIME) long lastFileCreationTime,
+            @JsonProperty(FIELD_DELETED_RECORD_COUNT) long deletedRecordCount,
             @JsonProperty(FIELD_DONE) boolean done) {
-        super(spec, recordCount, fileSizeInBytes, fileCount, lastFileCreationTime);
+        super(
+                spec,
+                recordCount,
+                fileSizeInBytes,
+                fileCount,
+                lastFileCreationTime,
+                deletedRecordCount);
         this.done = done;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionStatistics.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionStatistics.java
@@ -44,6 +44,7 @@ public class PartitionStatistics implements Serializable {
     public static final String FIELD_FILE_SIZE_IN_BYTES = "fileSizeInBytes";
     public static final String FIELD_FILE_COUNT = "fileCount";
     public static final String FIELD_LAST_FILE_CREATION_TIME = "lastFileCreationTime";
+    public static final String FIELD_DELETED_RECORD_COUNT = "deletedRecordCount";
 
     @JsonProperty(FIELD_SPEC)
     protected final Map<String, String> spec;
@@ -60,18 +61,23 @@ public class PartitionStatistics implements Serializable {
     @JsonProperty(FIELD_LAST_FILE_CREATION_TIME)
     protected final long lastFileCreationTime;
 
+    @JsonProperty(FIELD_DELETED_RECORD_COUNT)
+    private final long deletedRecordCount;
+
     @JsonCreator
     public PartitionStatistics(
             @JsonProperty(FIELD_SPEC) Map<String, String> spec,
             @JsonProperty(FIELD_RECORD_COUNT) long recordCount,
             @JsonProperty(FIELD_FILE_SIZE_IN_BYTES) long fileSizeInBytes,
             @JsonProperty(FIELD_FILE_COUNT) long fileCount,
-            @JsonProperty(FIELD_LAST_FILE_CREATION_TIME) long lastFileCreationTime) {
+            @JsonProperty(FIELD_LAST_FILE_CREATION_TIME) long lastFileCreationTime,
+            @JsonProperty(FIELD_DELETED_RECORD_COUNT) long deletedRecordCount) {
         this.spec = spec;
         this.recordCount = recordCount;
         this.fileSizeInBytes = fileSizeInBytes;
         this.fileCount = fileCount;
         this.lastFileCreationTime = lastFileCreationTime;
+        this.deletedRecordCount = deletedRecordCount;
     }
 
     @JsonGetter(FIELD_SPEC)
@@ -99,6 +105,11 @@ public class PartitionStatistics implements Serializable {
         return lastFileCreationTime;
     }
 
+    @JsonGetter(FIELD_DELETED_RECORD_COUNT)
+    public long deletedRecordCount() {
+        return deletedRecordCount;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -112,12 +123,19 @@ public class PartitionStatistics implements Serializable {
                 && fileSizeInBytes == that.fileSizeInBytes
                 && fileCount == that.fileCount
                 && lastFileCreationTime == that.lastFileCreationTime
+                && deletedRecordCount == that.deletedRecordCount
                 && Objects.equals(spec, that.spec);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(spec, recordCount, fileSizeInBytes, fileCount, lastFileCreationTime);
+        return Objects.hash(
+                spec,
+                recordCount,
+                fileSizeInBytes,
+                fileCount,
+                lastFileCreationTime,
+                deletedRecordCount);
     }
 
     @Override
@@ -133,6 +151,8 @@ public class PartitionStatistics implements Serializable {
                 + fileCount
                 + ", lastFileCreationTime="
                 + lastFileCreationTime
+                + ", deletedRecordCount="
+                + deletedRecordCount
                 + '}';
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java
@@ -139,6 +139,18 @@ public class DataSplit implements Split {
         return rowCount;
     }
 
+    public long deletedRecordCount() {
+        long deletedRecordCount = 0;
+        if (dataDeletionFiles != null) {
+            for (DeletionFile file : dataDeletionFiles) {
+                if (file != null) {
+                    deletedRecordCount += file.cardinality() == null ? 0 : file.cardinality();
+                }
+            }
+        }
+        return deletedRecordCount;
+    }
+
     /** Whether it is possible to calculate the merged row count. */
     public boolean mergedRowCountAvailable() {
         return rawConvertible

--- a/paimon-core/src/main/java/org/apache/paimon/utils/PartitionStatisticsReporter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/PartitionStatisticsReporter.java
@@ -73,10 +73,12 @@ public class PartitionStatisticsReporter implements Closeable {
             long rowCount = 0;
             long totalSize = 0;
             long fileCount = 0;
+            long deletedRecordCount = 0;
             for (DataSplit split : splits) {
                 List<DataFileMeta> fileMetas = split.dataFiles();
                 rowCount += split.rowCount();
                 fileCount += fileMetas.size();
+                deletedRecordCount += split.deletedRecordCount();
                 for (DataFileMeta fileMeta : fileMetas) {
                     totalSize += fileMeta.fileSize();
                 }
@@ -84,7 +86,12 @@ public class PartitionStatisticsReporter implements Closeable {
 
             PartitionStatistics partitionStats =
                     new PartitionStatistics(
-                            partitionSpec, fileCount, totalSize, rowCount, modifyTimeMillis);
+                            partitionSpec,
+                            fileCount,
+                            totalSize,
+                            rowCount,
+                            deletedRecordCount,
+                            modifyTimeMillis);
             LOG.info("alter partition {} with statistic {}.", partitionSpec, partitionStats);
             partitionHandler.alterPartitions(Collections.singletonList(partitionStats));
         }

--- a/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTMessage.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTMessage.java
@@ -146,7 +146,7 @@ public class MockRESTMessage {
     public static ListPartitionsResponse listPartitionsResponse() {
         Map<String, String> spec = new HashMap<>();
         spec.put("f0", "1");
-        Partition partition = new Partition(spec, 1, 1, 1, 1, false);
+        Partition partition = new Partition(spec, 1, 1, 1, 1, 0, false);
         return new ListPartitionsResponse(ImmutableList.of(partition));
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -1538,6 +1538,7 @@ public class RESTCatalogServer {
                                                             stats.fileSizeInBytes(),
                                                             stats.fileCount(),
                                                             stats.lastFileCreationTime(),
+                                                            stats.deletedRecordCount(),
                                                             false))
                                     .collect(Collectors.toList());
                     tablePartitionsStore.put(identifier.getFullName(), newPartitions);
@@ -1579,6 +1580,9 @@ public class RESTCatalogServer {
                                                                                 .lastFileCreationTime(),
                                                                         stats
                                                                                 .lastFileCreationTime()),
+                                                                oldPartition.deletedRecordCount()
+                                                                        + stats
+                                                                                .deletedRecordCount(),
                                                                 oldPartition.done());
                                                     })
                                             .collect(Collectors.toList());

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -555,6 +555,10 @@ public class HiveCatalog extends AbstractCatalog {
                                                     parameters.getOrDefault(
                                                             LAST_UPDATE_TIME_PROP,
                                                             System.currentTimeMillis() + ""));
+                                    long deletedRecordCount =
+                                            Long.parseLong(
+                                                    parameters.getOrDefault(
+                                                            DELETED_RECORD_COUNT_PROP, "0"));
                                     return new org.apache.paimon.partition.Partition(
                                             Collections.singletonMap(
                                                     tagToPartitionField, part.getValues().get(0)),
@@ -562,6 +566,7 @@ public class HiveCatalog extends AbstractCatalog {
                                             fileSizeInBytes,
                                             fileCount,
                                             lastFileCreationTime,
+                                            deletedRecordCount,
                                             false);
                                 })
                         .collect(Collectors.toList());

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -508,7 +508,7 @@ public class HiveCatalogTest extends CatalogTestBase {
         long fileCreationTime = System.currentTimeMillis();
         PartitionStatistics partition =
                 new PartitionStatistics(
-                        Collections.singletonMap("dt", "20250101"), 1, 2, 3, fileCreationTime);
+                        Collections.singletonMap("dt", "20250101"), 1, 2, 3, fileCreationTime, 0);
         catalog.alterPartitions(alterIdentifier, Collections.singletonList(partition));
         Partition partitionFromServer = catalog.listPartitions(alterIdentifier).get(0);
         checkPartition(
@@ -518,6 +518,7 @@ public class HiveCatalogTest extends CatalogTestBase {
                         2,
                         3,
                         fileCreationTime,
+                        0,
                         false),
                 partitionFromServer);
 

--- a/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
+++ b/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
@@ -587,7 +587,7 @@ public class RESTCatalogController {
         // paged list partitions in this table with provided maxResults and pageToken
         Map<String, String> spec = new HashMap<>();
         spec.put("f1", "1");
-        Partition partition = new Partition(spec, 1, 2, 3, 4, false);
+        Partition partition = new Partition(spec, 1, 2, 3, 4, 0, false);
         return new ListPartitionsResponse(ImmutableList.of(partition));
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Expose metric deletedRecordCount for partition, in case that compute engine need this.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
