### PR TITLE
[core] Reduce the file size per append table compaction task

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinator.java
@@ -330,7 +330,7 @@ public class UnawareAppendTableCompactionCoordinator {
             }
 
             public boolean binFull() {
-                return totalFileSize >= targetFileSize * 50 && fileNum >= minFileNum;
+                return totalFileSize >= targetFileSize * 2 && fileNum >= minFileNum;
             }
         }
     }

--- a/paimon-core/src/test/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/UnawareAppendTableCompactionCoordinatorTest.java
@@ -59,7 +59,7 @@ public class UnawareAppendTableCompactionCoordinatorTest {
     @Test
     public void testForCompactPlan() {
         List<DataFileMeta> files = generateNewFiles(200, 0);
-        assertTasks(files, 1);
+        assertTasks(files, 2);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class UnawareAppendTableCompactionCoordinatorTest {
         List<DataFileMeta> files =
                 generateNewFiles(
                         100, appendOnlyFileStoreTable.coreOptions().targetFileSize(false) / 3 + 1);
-        assertTasks(files, 1);
+        assertTasks(files, 17);
     }
 
     @Test
@@ -91,14 +91,14 @@ public class UnawareAppendTableCompactionCoordinatorTest {
                         1000, appendOnlyFileStoreTable.coreOptions().targetFileSize(false) / 10);
         compactionCoordinator.notifyNewFiles(partition, files);
 
-        assertThat(compactionCoordinator.compactPlan().size()).isEqualTo(3);
+        assertThat(compactionCoordinator.compactPlan().size()).isEqualTo(56);
         files.clear();
 
         files =
                 generateNewFiles(
                         1050, appendOnlyFileStoreTable.coreOptions().targetFileSize(false) / 5);
         compactionCoordinator.notifyNewFiles(partition, files);
-        assertThat(compactionCoordinator.compactPlan().size()).isEqualTo(5);
+        assertThat(compactionCoordinator.compactPlan().size()).isEqualTo(105);
     }
 
     @Test
@@ -107,7 +107,7 @@ public class UnawareAppendTableCompactionCoordinatorTest {
                 generateNewFiles(
                         1089, appendOnlyFileStoreTable.coreOptions().targetFileSize(false) / 5);
         compactionCoordinator.notifyNewFiles(partition, files);
-        assertThat(compactionCoordinator.compactPlan().size()).isEqualTo(5);
+        assertThat(compactionCoordinator.compactPlan().size()).isEqualTo(109);
     }
 
     @Test

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
@@ -767,12 +767,12 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
       spark.sql(
         "CALL sys.compact(table => 'T', options => 'source.split.open-file-cost=3200M, compaction.min.file-num=2')")
 
-      // sparkParallelism is 5, task groups is 1, use 1 as the read parallelism
+      // sparkParallelism is 5, task groups is 3, use 3 as the read parallelism
       spark.conf.set("spark.sql.shuffle.partitions", 5)
       spark.sql(
         "CALL sys.compact(table => 'T', options => 'source.split.open-file-cost=3200M, compaction.min.file-num=2')")
 
-      assertResult(Seq(2, 1))(taskBuffer)
+      assertResult(Seq(2, 3))(taskBuffer)
     } finally {
       spark.sparkContext.removeSparkListener(listener)
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
TargetFileSize * 50 is too greater for append only table compaction. If 1000 small files, open cost is 4M, then one task will contain 256 * 50 / 4 = 3200 files to compact. It is a great burden for compaction task.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
