### PR TITLE
[Bug] throw Hive DDL and paimon schema mismatched excetion when show the table's schema with the timestamp type

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
@@ -255,6 +255,16 @@ public class HiveSchema {
         for (int i = 0; i < hiveFieldNames.size(); i++) {
             if (!hiveFieldNames.get(i).equalsIgnoreCase(schemaFieldNames.get(i))
                     || !Objects.equals(hiveFieldTypeInfos.get(i), schemaFieldTypeInfos.get(i))) {
+                if (schemaFieldTypeInfos
+                        .get(i)
+                        .getTypeName()
+                        .equals("timestamp with local time zone")) {
+                    // Hive timestamp is compatible with paimon timestamp
+                    // with local time zone
+                    LOG.info(
+                            "Hive DDL and paimon schema mismatched, but Hive timestamp is compatible with paimon timestamp with local time zone");
+                    continue;
+                }
                 String ddlField =
                         hiveFieldNames.get(i) + " " + hiveFieldTypeInfos.get(i).getTypeName();
                 String schemaField =

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
@@ -255,13 +255,14 @@ public class HiveSchema {
         for (int i = 0; i < hiveFieldNames.size(); i++) {
             if (!hiveFieldNames.get(i).equalsIgnoreCase(schemaFieldNames.get(i))
                     || !Objects.equals(hiveFieldTypeInfos.get(i), schemaFieldTypeInfos.get(i))) {
-                if (schemaFieldTypeInfos
+                if (hiveFieldNames.get(i).equalsIgnoreCase(schemaFieldNames.get(i))
+                        && hiveFieldTypeInfos.get(i).getTypeName().equals("timestamp")
+                        && schemaFieldTypeInfos
                         .get(i)
                         .getTypeName()
                         .equals("timestamp with local time zone")) {
-                    // Hive timestamp is compatible with paimon timestamp
-                    // with local time zone
-                    LOG.info(
+                    // Hive timestamp is compatible with paimon timestamp with local time zone
+                    LOG.warn(
                             "Hive DDL and paimon schema mismatched, but Hive timestamp is compatible with paimon timestamp with local time zone");
                     continue;
                 }

--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
@@ -258,9 +258,9 @@ public class HiveSchema {
                 if (hiveFieldNames.get(i).equalsIgnoreCase(schemaFieldNames.get(i))
                         && hiveFieldTypeInfos.get(i).getTypeName().equals("timestamp")
                         && schemaFieldTypeInfos
-                        .get(i)
-                        .getTypeName()
-                        .equals("timestamp with local time zone")) {
+                                .get(i)
+                                .getTypeName()
+                                .equals("timestamp with local time zone")) {
                     // Hive timestamp is compatible with paimon timestamp with local time zone
                     LOG.warn(
                             "Hive DDL and paimon schema mismatched, but Hive timestamp is compatible with paimon timestamp with local time zone");


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
To fix issue #5450

This PR addresses three issues related to Hive3 compatibility with Paimon tables:

1. Type Validation Failure for Timestamp LTZ
Hive3 stores the timestamp with local time zone type as timestamp in its metastore, while Paimon explicitly uses the type name timestamp with local time zone during type conversion. Although Hive3 natively supports this type, the metastore's type name mismatch causes validation failures. We resolve this by allowing type compatibility validation to bypass the naming inconsistency.

2. -8-Hour Timezone Offset in Query Results
After fixing the first issue, Hive3 successfully executes DDL operations but returns timestamp values with an incorrect -8-hour offset for the Beijing timezone. The root cause lies in the PaimonTimestampLocalTZObjectInspector.getPrimitiveJavaObject method (in the paimon-hive-connector-3.1 module), which fails to apply the session timezone during deserialization. According to the Parquet specification, timestamp with local time zone fields store UTC timestamps and require conversion to the local timezone during processing. We fix this by ensuring proper UTC-to-session-timezone conversion in the deserialization logic.

3. +8-Hour Offset in SparkSQL Queries After INSERT
When inserting Beijing local time into a Hive3-created table with a timestamp with local time zone field, querying via SparkSQL reveals an 8-hour offset. This is caused by Hive incorrectly treating timestamp data as local time during serialization, violating the timestamp with local time zone semantics. Specifically, the PaimonTimestampLocalTZObjectInspector.convert method erroneously converts Hive time data to a local Timestamp type instead of adhering to UTC. The fix involves converting the Hive time data to a UTC timestamp before storing it in Paimon’s timestamp type, ensuring alignment with the expected UTC-based storage semantics.

References: 
https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#instant-semantics-timestamps-normalized-to-utc
https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/timezone/#timestamp_ltz-type
https://spark.apache.org/docs/latest/sql-ref-datatypes.html#TimestampType
https://hive.apache.org/docs/latest/different-timestamp-types_103091503/

<!-- Linking this pull request to the issue -->
Linked issue: open #5450

<!-- What is the purpose of the change -->

### Tests
```sql
-- issue 1: show the schema of the table created by spark is ok
-- show create table is ok
hive> show create table test.data_type_table_ts;
OK
CREATE TABLE `test.data_type_table_ts`(
  `id` int COMMENT 'from deserializer', 
  `ts` timestamp with local time zone COMMENT 'from deserializer')
ROW FORMAT SERDE 
  'org.apache.paimon.hive.PaimonSerDe' 
STORED BY 
  'org.apache.paimon.hive.PaimonStorageHandler' 

LOCATION
  'hdfs://nameservice1/user/hive/warehouse/test.db/data_type_table_ts'
TBLPROPERTIES (
  'table_type'='PAIMON')

-- issue 2: select rows inserted by spark in hive is ok.
-- select is ok
hive> select * from test.data_type_table_ts;
OK
1       2025-04-13 16:00:00.0 PRC
2       2025-04-13 17:05:38.11 PRC
3       2025-04-15 13:46:30.0 PRC

-- select with functions is ok
hive> select id,from_unixtime(unix_timestamp(ts), 'yyyy-MM-dd HH:mm:ss') from test.data_type_table_ts;
OK
1       2025-04-13 16:00:00
2       2025-04-13 17:05:38
3       2025-04-15 13:46:30

-- issue 3: insert rows in hive and then select rows in hive and spark is ok.
-- create table using hive3 and insert into rows
hive> show create table test.hive_test_table;
OK
CREATE TABLE `test.hive_test_table`(
  `a` int COMMENT 'The a field', 
  `ts` timestamp with local time zone COMMENT 'The ts field')
ROW FORMAT SERDE 
  'org.apache.paimon.hive.PaimonSerDe' 
STORED BY 
  'org.apache.paimon.hive.PaimonStorageHandler' 
WITH SERDEPROPERTIES ( 
  'serialization.format'='1')
LOCATION
  'hdfs://nameservice1/user/hive/warehouse/test.db/hive_test_table'
TBLPROPERTIES (
  'bucketing_version'='2', 
  'last_modified_by'='hive', 
  'last_modified_time'='1745292917', 
  'transient_lastDdlTime'='1745292917')

hive> insert into test.hive_test_table values (9, '2023-01-12 20:00:01.12345');


-- query with spark and hive
spark-sql (default)> select * from test.hive_test_table where a = 9;
9       2023-01-12 20:00:01.12345

hive> select * from test.hive_test_table where a = 9;
OK
9       2023-01-12 20:00:01.12345 PRC

```

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
no
