### PR TITLE
[core] fix refresh token to earlier refresh and log refresh

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
@@ -210,6 +210,10 @@ public class RESTTokenFileIO implements FileIO {
                 throw new RuntimeException(e);
             }
         }
+        LOG.info(
+                "end refresh token for identifier [{}] expiresAtMillis [{}]",
+                identifier,
+                response.getExpiresAtMillis());
 
         token = new RESTToken(response.getToken(), response.getExpiresAtMillis());
     }

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -548,7 +548,7 @@ public class RESTCatalogServer {
     private MockResponse getDataTokenHandle(Identifier tableIdentifier) throws Exception {
         RESTToken dataToken = getDataToken(tableIdentifier);
         if (dataToken == null) {
-            long currentTimeMillis = System.currentTimeMillis() + 60_000;
+            long currentTimeMillis = System.currentTimeMillis() + 4000_000L;
             dataToken =
                     new RESTToken(
                             ImmutableMap.of(

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -817,7 +817,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         RESTToken newDataToken =
                 new RESTToken(
                         ImmutableMap.of("akId", "akId", "akSecret", UUID.randomUUID().toString()),
-                        System.currentTimeMillis() + 100_000);
+                        System.currentTimeMillis());
         setDataTokenToRestServerForMock(identifier, newDataToken);
         RESTToken nextFileDataToken = fileIO.validToken();
         assertEquals(newDataToken, nextFileDataToken);

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -807,7 +807,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         RESTToken expiredDataToken =
                 new RESTToken(
                         ImmutableMap.of("akId", "akId", "akSecret", UUID.randomUUID().toString()),
-                        System.currentTimeMillis());
+                        System.currentTimeMillis() + 3600_000L);
         setDataTokenToRestServerForMock(identifier, expiredDataToken);
         createTable(identifier, Maps.newHashMap(), Lists.newArrayList("col1"));
         FileStoreTable fileStoreTable = (FileStoreTable) catalog.getTable(identifier);
@@ -817,7 +817,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         RESTToken newDataToken =
                 new RESTToken(
                         ImmutableMap.of("akId", "akId", "akSecret", UUID.randomUUID().toString()),
-                        System.currentTimeMillis());
+                        System.currentTimeMillis() + 4000_000L);
         setDataTokenToRestServerForMock(identifier, newDataToken);
         RESTToken nextFileDataToken = fileIO.validToken();
         assertEquals(newDataToken, nextFileDataToken);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
fix refresh token: add log and expire token when in 1 hour.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
