### PR TITLE
chore: bump Scala version to 2.13.16 & 2.12.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@ under the License.
         <paimon-flinkx-common>paimon-flink1-common</paimon-flinkx-common>
         <paimon-flink-common.flink.version>1.20.1</paimon-flink-common.flink.version>
         <flink.scala.binary.version>2.12</flink.scala.binary.version>
-        <scala212.version>2.12.20</scala212.version>
+        <scala212.version>2.12.18</scala212.version>
         <scala213.version>2.13.16</scala213.version>
         <scala.version>${scala212.version}</scala.version>
         <codegen.scala.version>${scala212.version}</codegen.scala.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@ under the License.
         <paimon-flinkx-common>paimon-flink1-common</paimon-flinkx-common>
         <paimon-flink-common.flink.version>1.20.1</paimon-flink-common.flink.version>
         <flink.scala.binary.version>2.12</flink.scala.binary.version>
-        <scala212.version>2.12.15</scala212.version>
-        <scala213.version>2.13.14</scala213.version>
+        <scala212.version>2.12.20</scala212.version>
+        <scala213.version>2.13.16</scala213.version>
         <scala.version>${scala212.version}</scala.version>
         <codegen.scala.version>${scala212.version}</codegen.scala.version>
         <snappy.version>1.1.8.4</snappy.version>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Bump the Scala version to the latest one

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
