### PR TITLE
[hive][clone] check compatibility if paimon table already exists

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/hive/CopyProcessFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/hive/CopyProcessFunction.java
@@ -28,6 +28,8 @@ import org.apache.paimon.table.Table;
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,6 +39,8 @@ import static org.apache.paimon.flink.clone.hive.CloneHiveUtils.getRootHiveCatal
 
 /** Abstract function for copying tables. */
 public abstract class CopyProcessFunction<I, O> extends ProcessFunction<I, O> {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(CopyProcessFunction.class);
 
     protected final Map<String, String> sourceCatalogConfig;
     protected final Map<String, String> targetCatalogConfig;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/hive/ListHiveFilesFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/hive/ListHiveFilesFunction.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.clone.hive;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.predicate.SimpleSqlPredicateConvertor;
 import org.apache.paimon.hive.migrate.HiveCloneUtils;
@@ -28,7 +29,10 @@ import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -37,10 +41,13 @@ import org.apache.flink.util.Collector;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
+import static org.apache.paimon.utils.Preconditions.checkState;
 
 /** List files for table. */
 public class ListHiveFilesFunction
@@ -78,7 +85,23 @@ public class ListHiveFilesFunction
                         schema.primaryKeys(),
                         options,
                         schema.comment());
-        targetCatalog.createTable(tuple.f1, schema, false);
+        try {
+            Table existedTable = targetCatalog.getTable(tuple.f1);
+
+            checkState(
+                    existedTable instanceof FileStoreTable,
+                    String.format(
+                            "existed paimon table '%s' is not a FileStoreTable, but a %s",
+                            tuple.f1, existedTable.getClass().getName()));
+            checkCompatible(schema, (FileStoreTable) existedTable);
+
+            LOG.info("paimon table '{}' already exists, use it as target table.", tuple.f1);
+        } catch (Catalog.TableNotExistException e) {
+            LOG.info("create target paimon table '{}'.", tuple.f1);
+
+            targetCatalog.createTable(tuple.f1, schema, false);
+        }
+
         FileStoreTable table = (FileStoreTable) targetCatalog.getTable(tuple.f1);
         PartitionPredicate predicate =
                 getPartitionPredicate(whereSql, table.schema().logicalPartitionType(), tuple.f0);
@@ -92,6 +115,71 @@ public class ListHiveFilesFunction
                         predicate);
         for (HivePartitionFiles partitionFiles : allPartitions) {
             CloneFileInfo.fromHive(tuple.f1, partitionFiles).forEach(collector::collect);
+        }
+    }
+
+    private void checkCompatible(Schema sourceSchema, FileStoreTable existedTable) {
+        Schema existedSchema = existedTable.schema().toSchema();
+
+        // check primary keys
+        if (!existedSchema.primaryKeys().isEmpty()) {
+            throw new IllegalStateException(
+                    "Can not clone data to existed paimon table which has primary keys. Existed paimon table is "
+                            + existedTable.name());
+        }
+
+        // check bucket
+        if (existedTable.coreOptions().bucket() != -1) {
+            throw new IllegalStateException(
+                    "Can not clone data to existed paimon table which bucket is not -1. Existed paimon table is "
+                            + existedTable.name());
+        }
+
+        // check partition keys
+        List<DataField> sourcePartitionFields =
+                new ArrayList<>(
+                        TableSchema.create(0, sourceSchema)
+                                .projectedLogicalRowType(sourceSchema.partitionKeys())
+                                .getFields());
+
+        List<DataField> existedPartitionFields =
+                new ArrayList<>(
+                        existedTable
+                                .schema()
+                                .projectedLogicalRowType(existedTable.partitionKeys())
+                                .getFields());
+
+        if (sourcePartitionFields.size() != existedPartitionFields.size()) {
+            throw new IllegalStateException(
+                    "size of source table partition keys not equal existed paimon table partition keys.");
+        }
+        checkCompatible(sourcePartitionFields, existedPartitionFields);
+
+        // check all fields
+        List<DataField> sourceFields = new ArrayList<>(sourceSchema.fields());
+        List<DataField> existedFields = new ArrayList<>(existedSchema.fields());
+
+        if (sourceFields.size() != existedFields.size()) {
+            throw new IllegalStateException(
+                    "size of source table fields not equal existed paimon table fields.");
+        }
+        checkCompatible(sourceFields, existedFields);
+    }
+
+    private void checkCompatible(List<DataField> sourceFields, List<DataField> existedFields) {
+
+        sourceFields.sort(Comparator.comparing(DataField::name));
+        existedFields.sort(Comparator.comparing(DataField::name));
+
+        for (int i = 0; i < sourceFields.size(); i++) {
+            DataField s = sourceFields.get(i);
+            DataField e = existedFields.get(i);
+
+            if (!s.name().equals(e.name())
+                    || !s.type().asSQLString().equalsIgnoreCase(e.type().asSQLString())) {
+                throw new RuntimeException(
+                        "Source table fields not match existed table fields, please checkCompatible.");
+            }
         }
     }
 

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/CloneHiveActionITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/CloneHiveActionITCase.java
@@ -369,7 +369,8 @@ public class CloneHiveActionITCase extends ActionITCaseBase {
         tEnv.useCatalog("PAIMON");
         tEnv.executeSql("CREATE DATABASE test");
         // create a paimon table with the same name
-        int ddlIndex = ThreadLocalRandom.current().nextInt(0, 4);
+        //        int ddlIndex = ThreadLocalRandom.current().nextInt(0, 4);
+        int ddlIndex = 3;
         tEnv.executeSql(ddls()[ddlIndex]);
 
         List<String> args =
@@ -433,8 +434,8 @@ public class CloneHiveActionITCase extends ActionITCaseBase {
     private String[] exceptionMsg() {
         return new String[] {
             "Can not clone data to existed paimon table which has primary keys",
-            "Source table fields not match existed table fields",
-            "size of source table fields not equal existed paimon table fields."
+            "source table partition keys is not compatible with existed paimon table partition keys.",
+            "source table partition keys is not compatible with existed paimon table partition keys."
         };
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

When clone hive table to paimon, if target paimon table already exists, check its compatibility with hive table.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
