### PR TITLE
[Bug] Fix the bug of expire tags procedure LocalDateTime using utc timezone

### DIFF
--- a/paimon-common/src/test/java/org/apache/paimon/utils/DateTimeUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/DateTimeUtilsTest.java
@@ -67,6 +67,10 @@ public class DateTimeUtilsTest {
         ts = DateTimeUtils.parseTimestampData(dt, 3);
         assertThat(dt)
                 .isEqualTo(ts.toLocalDateTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+
+        dt = "2025-04-22 17:49:21";
+        LocalDateTime ld = DateTimeUtils.toLocalDateTime(dt, 3);
+        assertThat(dt).isEqualTo(ld.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ExpireTagsProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ExpireTagsProcedure.java
@@ -55,9 +55,7 @@ public class ExpireTagsProcedure extends ProcedureBase {
         TagTimeExpire tagTimeExpire =
                 fileStoreTable.store().newTagCreationManager().getTagTimeExpire();
         if (olderThanStr != null) {
-            LocalDateTime olderThanTime =
-                    DateTimeUtils.parseTimestampData(olderThanStr, 3, TimeZone.getDefault())
-                            .toLocalDateTime();
+            LocalDateTime olderThanTime = DateTimeUtils.toLocalDateTime(olderThanStr, 3);
             tagTimeExpire.withOlderThanTime(olderThanTime);
         }
         List<String> expired = tagTimeExpire.expire();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx
```sql
CALL sys.expire_tags(
    table => 'db_name.table_name',
    older_than => '2025-04-22 17:49:21'
)
```
When executing the above statement, ExpireTagsProcedure will incorrectly convert the date string '2025-04-22 17:49:21' to the UTC LocalDateTime 2025-04-22 09:49:21

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
org.apache.paimon.utils.DateTimeUtilsTest#testParseTimestampData

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
