### PR TITLE
[flink] Fix lookup failed to join keys when using max_pt() and lookup table is updated by insert overwrite

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/DynamicPartitionLoader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/DynamicPartitionLoader.java
@@ -56,8 +56,10 @@ public class DynamicPartitionLoader extends PartitionLoader {
     @Override
     public void open() {
         super.open();
+
         RowType partitionType = table.rowType().project(table.partitionKeys());
         this.comparator = CodeGenUtils.newRecordComparator(partitionType.getFieldTypes());
+        this.lastRefresh = null;
     }
 
     @Override


### PR DESCRIPTION
### Purpose

If Flink lookup source table is updated by `INSERT OVERWRITE` and `max_pt()` is used to specify partition, lookup join operator might fail to join keys. This PR fixes the issue.

### Tests

* `LookupJoinITCase`

### API and Format

No format changes.

### Documentation

No new feature.
