### PR TITLE
[arrow] Fix bug: field writer contruct in ArrowFormatWriter should use nested field nullable to create sub writers

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatWriter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatWriter.java
@@ -22,6 +22,7 @@ import org.apache.paimon.arrow.ArrowUtils;
 import org.apache.paimon.arrow.writer.ArrowFieldWriter;
 import org.apache.paimon.arrow.writer.ArrowFieldWriterFactoryVisitor;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 
 import org.apache.arrow.memory.BufferAllocator;
@@ -57,12 +58,10 @@ public class ArrowFormatWriter implements AutoCloseable {
         fieldWriters = new ArrowFieldWriter[rowType.getFieldCount()];
 
         for (int i = 0; i < fieldWriters.length; i++) {
+            DataType type = rowType.getFields().get(i).type();
             fieldWriters[i] =
-                    rowType.getFields()
-                            .get(i)
-                            .type()
-                            .accept(ArrowFieldWriterFactoryVisitor.INSTANCE)
-                            .create(vectorSchemaRoot.getVector(i), rowType.isNullable());
+                    type.accept(ArrowFieldWriterFactoryVisitor.INSTANCE)
+                            .create(vectorSchemaRoot.getVector(i), type.isNullable());
         }
 
         this.batchSize = writeBatchSize;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
