### PR TITLE
[hotfix] avoid to use `false` as default value of legacyTimestampLtzType in orc format

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/AbstractOrcColumnVector.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/AbstractOrcColumnVector.java
@@ -61,11 +61,6 @@ public abstract class AbstractOrcColumnVector
     }
 
     public static org.apache.paimon.data.columnar.ColumnVector createPaimonVector(
-            ColumnVector vector, VectorizedRowBatch orcBatch, DataType dataType) {
-        return createPaimonVector(vector, orcBatch, dataType, false);
-    }
-
-    public static org.apache.paimon.data.columnar.ColumnVector createPaimonVector(
             ColumnVector vector,
             VectorizedRowBatch orcBatch,
             DataType dataType,
@@ -86,12 +81,19 @@ public abstract class AbstractOrcColumnVector
             return new OrcTimestampColumnVector(vector, orcBatch, dataType, legacyTimestampLtzType);
         } else if (vector instanceof ListColumnVector) {
             return new OrcArrayColumnVector(
-                    (ListColumnVector) vector, orcBatch, (ArrayType) dataType);
+                    (ListColumnVector) vector,
+                    orcBatch,
+                    (ArrayType) dataType,
+                    legacyTimestampLtzType);
         } else if (vector instanceof StructColumnVector) {
             return new OrcRowColumnVector(
-                    (StructColumnVector) vector, orcBatch, (RowType) dataType);
+                    (StructColumnVector) vector,
+                    orcBatch,
+                    (RowType) dataType,
+                    legacyTimestampLtzType);
         } else if (vector instanceof MapColumnVector) {
-            return new OrcMapColumnVector((MapColumnVector) vector, orcBatch, (MapType) dataType);
+            return new OrcMapColumnVector(
+                    (MapColumnVector) vector, orcBatch, (MapType) dataType, legacyTimestampLtzType);
         } else {
             throw new UnsupportedOperationException(
                     "Unsupported vector: " + vector.getClass().getName());

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/OrcArrayColumnVector.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/OrcArrayColumnVector.java
@@ -34,10 +34,15 @@ public class OrcArrayColumnVector extends AbstractOrcColumnVector
     private final ColumnVector paimonVector;
 
     public OrcArrayColumnVector(
-            ListColumnVector hiveVector, VectorizedRowBatch orcBatch, ArrayType type) {
+            ListColumnVector hiveVector,
+            VectorizedRowBatch orcBatch,
+            ArrayType type,
+            boolean legacyTimestampLtzType) {
         super(hiveVector, orcBatch);
         this.hiveVector = hiveVector;
-        this.paimonVector = createPaimonVector(hiveVector.child, orcBatch, type.getElementType());
+        this.paimonVector =
+                createPaimonVector(
+                        hiveVector.child, orcBatch, type.getElementType(), legacyTimestampLtzType);
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/OrcMapColumnVector.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/OrcMapColumnVector.java
@@ -35,12 +35,18 @@ public class OrcMapColumnVector extends AbstractOrcColumnVector
     private final ColumnVector valuePaimonVector;
 
     public OrcMapColumnVector(
-            MapColumnVector hiveVector, VectorizedRowBatch orcBatch, MapType type) {
+            MapColumnVector hiveVector,
+            VectorizedRowBatch orcBatch,
+            MapType type,
+            boolean legacyTimestampLtzType) {
         super(hiveVector, orcBatch);
         this.hiveVector = hiveVector;
-        this.keyPaimonVector = createPaimonVector(hiveVector.keys, orcBatch, type.getKeyType());
+        this.keyPaimonVector =
+                createPaimonVector(
+                        hiveVector.keys, orcBatch, type.getKeyType(), legacyTimestampLtzType);
         this.valuePaimonVector =
-                createPaimonVector(hiveVector.values, orcBatch, type.getValueType());
+                createPaimonVector(
+                        hiveVector.values, orcBatch, type.getValueType(), legacyTimestampLtzType);
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/OrcRowColumnVector.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/reader/OrcRowColumnVector.java
@@ -33,13 +33,20 @@ public class OrcRowColumnVector extends AbstractOrcColumnVector
     private final VectorizedColumnBatch batch;
 
     public OrcRowColumnVector(
-            StructColumnVector hiveVector, VectorizedRowBatch orcBatch, RowType type) {
+            StructColumnVector hiveVector,
+            VectorizedRowBatch orcBatch,
+            RowType type,
+            boolean legacyTimestampLtzType) {
         super(hiveVector, orcBatch);
         int len = hiveVector.fields.length;
         ColumnVector[] paimonVectors = new ColumnVector[len];
         for (int i = 0; i < len; i++) {
             paimonVectors[i] =
-                    createPaimonVector(hiveVector.fields[i], orcBatch, type.getTypeAt(i));
+                    createPaimonVector(
+                            hiveVector.fields[i],
+                            orcBatch,
+                            type.getTypeAt(i),
+                            legacyTimestampLtzType);
         }
         this.batch = new VectorizedColumnBatch(paimonVectors);
     }


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

avoid to use `false` as default value of legacyTimestampLtzType in orc format

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
