### PR TITLE
[hive][clone] Output the table name if the format is unsupported.

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveMigrator.java
@@ -301,7 +301,7 @@ public class HiveMigrator implements Migrator {
 
         for (Partition partition : partitions) {
             List<String> partitionValues = partition.getValues();
-            String format = parseFormat(partition.getSd().getSerdeInfo().toString());
+            String format = parseFormat(partition);
             String location = partition.getSd().getLocation();
             BinaryRow partitionRow =
                     FileMetaUtils.writePartitionValue(
@@ -323,7 +323,7 @@ public class HiveMigrator implements Migrator {
             Table sourceTable,
             FileStoreTable paimonTable,
             Map<Path, Path> rollback) {
-        String format = parseFormat(sourceTable.getSd().getSerdeInfo().toString());
+        String format = parseFormat(sourceTable);
         String location = sourceTable.getSd().getLocation();
         Path path = paimonTable.store().pathFactory().bucketPath(BinaryRow.EMPTY_ROW, 0);
         return new MigrateTask(


### PR DESCRIPTION
### Purpose

CloneHiveTable would fail when hive table format is unsupported, better to print the table name if the format is unsupported.

### Tests

N/A

### API and Format

N/A

### Documentation

N/A
