### PR TITLE
[core] Unify timetravel processing to starting scanners

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -477,8 +477,12 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
 
     private Optional<TableSchema> tryTimeTravel(Options options) {
         CoreOptions coreOptions = new CoreOptions(options);
-        Snapshot snapshot =
-                TimeTravelUtil.resolveSnapshotFromOptions(coreOptions, snapshotManager());
+        Snapshot snapshot;
+        try {
+            snapshot = TimeTravelUtil.resolveSnapshotFromOptions(coreOptions, snapshotManager());
+        } catch (Exception e) {
+            return Optional.empty();
+        }
         if (snapshot == null) {
             return Optional.empty();
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -476,10 +476,11 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
     }
 
     private Optional<TableSchema> tryTimeTravel(Options options) {
-        CoreOptions coreOptions = new CoreOptions(options);
         Snapshot snapshot;
         try {
-            snapshot = TimeTravelUtil.resolveSnapshotFromOptions(coreOptions, snapshotManager());
+            snapshot =
+                    TimeTravelUtil.resolveSnapshotFromOptions(
+                            options, snapshotManager(), tagManager());
         } catch (Exception e) {
             return Optional.empty();
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -86,6 +86,8 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
 
     private static final long serialVersionUID = 1L;
 
+    private static final String WATERMARK_PREFIX = "watermark-";
+
     protected final FileIO fileIO;
     protected final Path path;
     protected final TableSchema tableSchema;
@@ -188,7 +190,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
 
     @Override
     public Optional<Statistics> statistics() {
-        Snapshot snapshot = TimeTravelUtil.resolveSnapshot(this);
+        Snapshot snapshot = TimeTravelUtil.tryTravelOrLatest(this);
         if (snapshot != null) {
             String file = snapshot.statistics();
             if (file == null) {
@@ -479,8 +481,8 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
         Snapshot snapshot;
         try {
             snapshot =
-                    TimeTravelUtil.resolveSnapshotFromOptions(
-                            options, snapshotManager(), tagManager());
+                    TimeTravelUtil.tryTravelToSnapshot(options, snapshotManager(), tagManager())
+                            .orElse(null);
         } catch (Exception e) {
             return Optional.empty();
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromTagStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromTagStartingScanner.java
@@ -34,6 +34,12 @@ public class StaticFromTagStartingScanner extends ReadPlanStartingScanner {
         this.tagName = tagName;
     }
 
+    public Snapshot getSnapshot() {
+        TagManager tagManager =
+                new TagManager(snapshotManager.fileIO(), snapshotManager.tablePath());
+        return tagManager.getOrThrow(tagName).trimToSnapshot();
+    }
+
     @Override
     public ScanMode startingScanMode() {
         return ScanMode.ALL;
@@ -41,9 +47,6 @@ public class StaticFromTagStartingScanner extends ReadPlanStartingScanner {
 
     @Override
     public SnapshotReader configure(SnapshotReader snapshotReader) {
-        TagManager tagManager =
-                new TagManager(snapshotManager.fileIO(), snapshotManager.tablePath());
-        Snapshot snapshot = tagManager.getOrThrow(tagName).trimToSnapshot();
-        return snapshotReader.withMode(ScanMode.ALL).withSnapshot(snapshot);
+        return snapshotReader.withMode(ScanMode.ALL).withSnapshot(getSnapshot());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromTimestampStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/StaticFromTimestampStartingScanner.java
@@ -23,9 +23,6 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.utils.SnapshotManager;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.annotation.Nullable;
 
 /**
@@ -34,15 +31,11 @@ import javax.annotation.Nullable;
  */
 public class StaticFromTimestampStartingScanner extends ReadPlanStartingScanner {
 
-    private static final Logger LOG =
-            LoggerFactory.getLogger(StaticFromTimestampStartingScanner.class);
-
-    private final long startupMillis;
+    private final Snapshot snapshot;
 
     public StaticFromTimestampStartingScanner(SnapshotManager snapshotManager, long startupMillis) {
         super(snapshotManager);
-        this.startupMillis = startupMillis;
-        Snapshot snapshot = timeTravelToTimestamp(snapshotManager, startupMillis);
+        this.snapshot = timeTravelToTimestamp(snapshotManager, startupMillis);
         if (snapshot == null) {
             Snapshot earliestSnapshot = snapshotManager.earliestSnapshot();
             throw new IllegalArgumentException(
@@ -56,9 +49,13 @@ public class StaticFromTimestampStartingScanner extends ReadPlanStartingScanner 
         this.startingSnapshotId = snapshot.id();
     }
 
+    public Snapshot getSnapshot() {
+        return snapshot;
+    }
+
     @Override
     public SnapshotReader configure(SnapshotReader snapshotReader) {
-        return snapshotReader.withMode(ScanMode.ALL).withSnapshot(startingSnapshotId);
+        return snapshotReader.withMode(ScanMode.ALL).withSnapshot(snapshot);
     }
 
     @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ManifestsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ManifestsTable.java
@@ -229,7 +229,7 @@ public class ManifestsTable implements ReadonlyTable {
 
     private static List<ManifestFileMeta> allManifests(FileStoreTable dataTable) {
         CoreOptions options = dataTable.coreOptions();
-        Snapshot snapshot = TimeTravelUtil.resolveSnapshot(dataTable);
+        Snapshot snapshot = TimeTravelUtil.tryTravelOrLatest(dataTable);
         if (snapshot == null) {
             LOG.warn("Check if your snapshot is empty.");
             return Collections.emptyList();

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/TableIndexesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/TableIndexesTable.java
@@ -230,7 +230,7 @@ public class TableIndexesTable implements ReadonlyTable {
 
     private static List<IndexManifestEntry> allIndexEntries(FileStoreTable dataTable) {
         IndexFileHandler indexFileHandler = dataTable.store().newIndexFileHandler();
-        Snapshot snapshot = TimeTravelUtil.resolveSnapshot(dataTable);
+        Snapshot snapshot = TimeTravelUtil.tryTravelOrLatest(dataTable);
         if (snapshot == null) {
             LOG.warn("Check if your snapshot is empty.");
             return Collections.emptyList();

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/TimeTravelUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/TimeTravelUtilsTest.java
@@ -56,21 +56,27 @@ public class TimeTravelUtilsTest extends ScannerTestBase {
         HashMap<String, String> optMap = new HashMap<>(4);
         optMap.put("scan.snapshot-id", "2");
         CoreOptions options = CoreOptions.fromMap(optMap);
-        Snapshot snapshot = TimeTravelUtil.resolveSnapshotFromOptions(options, snapshotManager);
+        Snapshot snapshot =
+                TimeTravelUtil.resolveSnapshotFromOptions(
+                        options.toConfiguration(), snapshotManager, null);
         assertNotNull(snapshot);
         assertTrue(snapshot.id() == 2);
 
         optMap.clear();
         optMap.put("scan.timestamp-millis", ts + "");
         options = CoreOptions.fromMap(optMap);
-        snapshot = TimeTravelUtil.resolveSnapshotFromOptions(options, snapshotManager);
+        snapshot =
+                TimeTravelUtil.resolveSnapshotFromOptions(
+                        options.toConfiguration(), snapshotManager, null);
         assertTrue(snapshot.id() == 1);
 
         table.createTag("tag3", 3);
         optMap.clear();
         optMap.put("scan.tag-name", "tag3");
         options = CoreOptions.fromMap(optMap);
-        snapshot = TimeTravelUtil.resolveSnapshotFromOptions(options, snapshotManager);
+        snapshot =
+                TimeTravelUtil.resolveSnapshotFromOptions(
+                        options.toConfiguration(), snapshotManager, null);
         assertTrue(snapshot.id() == 3);
 
         // if contain more scan.xxx config would throw out
@@ -78,7 +84,9 @@ public class TimeTravelUtilsTest extends ScannerTestBase {
         CoreOptions options1 = CoreOptions.fromMap(optMap);
         assertThrows(
                 IllegalArgumentException.class,
-                () -> TimeTravelUtil.resolveSnapshotFromOptions(options1, snapshotManager),
+                () ->
+                        TimeTravelUtil.resolveSnapshotFromOptions(
+                                options1.toConfiguration(), snapshotManager, null),
                 "scan.snapshot-id scan.tag-name scan.watermark and scan.timestamp-millis can contains only one");
 
         assertThat(

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/TimeTravelUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/snapshot/TimeTravelUtilsTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TimeTravelUtilsTest extends ScannerTestBase {
 
     @Test
-    public void testResolveSnapshotFromOptions() throws Exception {
+    public void testtryTravelToSnapshot() throws Exception {
         SnapshotManager snapshotManager = table.snapshotManager();
         StreamTableWrite write = table.newWrite(commitUser);
         StreamTableCommit commit = table.newCommit(commitUser);
@@ -57,8 +57,8 @@ public class TimeTravelUtilsTest extends ScannerTestBase {
         optMap.put("scan.snapshot-id", "2");
         CoreOptions options = CoreOptions.fromMap(optMap);
         Snapshot snapshot =
-                TimeTravelUtil.resolveSnapshotFromOptions(
-                        options.toConfiguration(), snapshotManager, null);
+                TimeTravelUtil.tryTravelToSnapshot(options.toConfiguration(), snapshotManager, null)
+                        .orElse(null);
         assertNotNull(snapshot);
         assertTrue(snapshot.id() == 2);
 
@@ -66,8 +66,8 @@ public class TimeTravelUtilsTest extends ScannerTestBase {
         optMap.put("scan.timestamp-millis", ts + "");
         options = CoreOptions.fromMap(optMap);
         snapshot =
-                TimeTravelUtil.resolveSnapshotFromOptions(
-                        options.toConfiguration(), snapshotManager, null);
+                TimeTravelUtil.tryTravelToSnapshot(options.toConfiguration(), snapshotManager, null)
+                        .orElse(null);
         assertTrue(snapshot.id() == 1);
 
         table.createTag("tag3", 3);
@@ -75,8 +75,8 @@ public class TimeTravelUtilsTest extends ScannerTestBase {
         optMap.put("scan.tag-name", "tag3");
         options = CoreOptions.fromMap(optMap);
         snapshot =
-                TimeTravelUtil.resolveSnapshotFromOptions(
-                        options.toConfiguration(), snapshotManager, null);
+                TimeTravelUtil.tryTravelToSnapshot(options.toConfiguration(), snapshotManager, null)
+                        .orElse(null);
         assertTrue(snapshot.id() == 3);
 
         // if contain more scan.xxx config would throw out
@@ -85,7 +85,7 @@ public class TimeTravelUtilsTest extends ScannerTestBase {
         assertThrows(
                 IllegalArgumentException.class,
                 () ->
-                        TimeTravelUtil.resolveSnapshotFromOptions(
+                        TimeTravelUtil.tryTravelToSnapshot(
                                 options1.toConfiguration(), snapshotManager, null),
                 "scan.snapshot-id scan.tag-name scan.watermark and scan.timestamp-millis can contains only one");
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
@@ -47,6 +47,7 @@ import java.util.List;
 import static org.apache.paimon.SnapshotTest.newSnapshotManager;
 import static org.apache.paimon.utils.FileStorePathFactoryTest.createNonPartFactory;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Unit tests for {@link ManifestsTable}. */
 public class ManifestsTableTest extends TableTestBase {
@@ -146,6 +147,18 @@ public class ManifestsTableTest extends TableTestBase {
                                         String.valueOf(System.currentTimeMillis())));
         List<InternalRow> result = read(manifestsTable);
         assertThat(result).containsExactlyElementsOf(expectedRow);
+    }
+
+    @Test
+    public void testReadManifestsFromNotExistSnapshot() {
+        manifestsTable =
+                (ManifestsTable)
+                        manifestsTable.copy(
+                                Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "3"));
+        assertThrows(
+                Exception.class,
+                () -> read(manifestsTable),
+                "Specified parameter scan.snapshot-id = 3 is not exist, you can set it in range from 1 to 2");
     }
 
     private List<InternalRow> getExpectedResult(long snapshotId) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
@@ -36,7 +36,6 @@ import org.apache.paimon.table.Table;
 import org.apache.paimon.table.TableTestBase;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.utils.SnapshotManager;
-import org.apache.paimon.utils.SnapshotNotExistException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,7 +47,6 @@ import java.util.List;
 import static org.apache.paimon.SnapshotTest.newSnapshotManager;
 import static org.apache.paimon.utils.FileStorePathFactoryTest.createNonPartFactory;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Unit tests for {@link ManifestsTable}. */
 public class ManifestsTableTest extends TableTestBase {
@@ -148,18 +146,6 @@ public class ManifestsTableTest extends TableTestBase {
                                         String.valueOf(System.currentTimeMillis())));
         List<InternalRow> result = read(manifestsTable);
         assertThat(result).containsExactlyElementsOf(expectedRow);
-    }
-
-    @Test
-    public void testReadManifestsFromNotExistSnapshot() {
-        manifestsTable =
-                (ManifestsTable)
-                        manifestsTable.copy(
-                                Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "3"));
-        assertThrows(
-                SnapshotNotExistException.class,
-                () -> read(manifestsTable),
-                "Specified parameter scan.snapshot-id = 3 is not exist, you can set it in range from 1 to 2");
     }
 
     private List<InternalRow> getExpectedResult(long snapshotId) {

--- a/paimon-flink/paimon-flink-1.15/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-1.15/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -80,7 +80,7 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
         assertThatThrownBy(() -> batchSql("SELECT * FROM T /*+ OPTIONS('scan.snapshot-id'='0') */"))
                 .satisfies(
                         anyCauseMatches(
-                                IllegalArgumentException.class,
+                                Exception.class,
                                 "The specified scan snapshotId 0 is out of available snapshotId range [1, 4]."));
 
         assertThatThrownBy(
@@ -89,7 +89,7 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
                                         "SELECT * FROM T /*+ OPTIONS('scan.mode'='from-snapshot-full','scan.snapshot-id'='0') */"))
                 .satisfies(
                         anyCauseMatches(
-                                IllegalArgumentException.class,
+                                Exception.class,
                                 "The specified scan snapshotId 0 is out of available snapshotId range [1, 4]."));
 
         assertThat(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -25,7 +25,6 @@ import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.snapshot.TimeTravelUtil;
 import org.apache.paimon.utils.BlockingIterator;
 import org.apache.paimon.utils.DateTimeUtils;
-import org.apache.paimon.utils.SnapshotNotExistException;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
 
@@ -120,8 +119,8 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
         assertThatThrownBy(() -> batchSql("SELECT * FROM T /*+ OPTIONS('scan.snapshot-id'='0') */"))
                 .satisfies(
                         anyCauseMatches(
-                                SnapshotNotExistException.class,
-                                "Specified parameter scan.snapshot-id = 0 is not exist, you can set it in range from 1 to 4."));
+                                Exception.class,
+                                "The specified scan snapshotId 0 is out of available snapshotId range [1, 4]."));
 
         assertThatThrownBy(
                         () ->
@@ -129,8 +128,8 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
                                         "SELECT * FROM T /*+ OPTIONS('scan.mode'='from-snapshot-full','scan.snapshot-id'='0') */"))
                 .satisfies(
                         anyCauseMatches(
-                                SnapshotNotExistException.class,
-                                "Specified parameter scan.snapshot-id = 0 is not exist, you can set it in range from 1 to 4."));
+                                Exception.class,
+                                "The specified scan snapshotId 0 is out of available snapshotId range [1, 4]."));
 
         assertThat(
                         batchSql(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Code refactor.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
