### PR TITLE
[spark] Avoid using bucket function for timestamp with spark unsupported precision

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalog/functions/PaimonFunctions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalog/functions/PaimonFunctions.scala
@@ -115,7 +115,7 @@ object BucketFunction {
   }
 
   /**
-   * The reason of this is that Spark's timestamp precision is limited to 6, and in
+   * The reason of this is that Spark's timestamp precision is fixed to 6, and in
    * [[BucketFunction.bind]], we use `InternalRowSerializer(bucketKeyRowType)` to convert paimon
    * rows, but the `bucketKeyRowType` is derived from Spark's StructType which will lose the true
    * precision of timestamp, leading to anomalies in bucket calculations.

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalog/functions/PaimonFunctions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalog/functions/PaimonFunctions.scala
@@ -23,7 +23,9 @@ import org.apache.paimon.shade.guava30.com.google.common.collect.{ImmutableList,
 import org.apache.paimon.spark.SparkInternalRowWrapper
 import org.apache.paimon.spark.SparkTypeUtils.toPaimonRowType
 import org.apache.paimon.spark.catalog.functions.PaimonFunctions._
+import org.apache.paimon.table.{BucketMode, FileStoreTable}
 import org.apache.paimon.table.sink.KeyAndBucketExtractor.{bucket, bucketKeyHashCode}
+import org.apache.paimon.types.{ArrayType, DataType => PaimonDataType, LocalZonedTimestampType, MapType, RowType, TimestampType}
 import org.apache.paimon.utils.ProjectedRow
 
 import org.apache.spark.sql.catalyst.InternalRow
@@ -32,6 +34,8 @@ import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.types.DataTypes.{IntegerType, StringType}
 
 import javax.annotation.Nullable
+
+import scala.collection.JavaConverters._
 
 object PaimonFunctions {
 
@@ -96,6 +100,41 @@ class BucketFunction extends UnboundFunction {
   override def description: String = name
 
   override def name: String = BUCKET
+}
+
+object BucketFunction {
+
+  private val SPARK_TIMESTAMP_PRECISION = 6
+
+  def supportsTable(table: FileStoreTable): Boolean = {
+    table.bucketMode match {
+      case BucketMode.HASH_FIXED =>
+        table.schema().logicalBucketKeyType().getFieldTypes.asScala.forall(supportsType)
+      case _ => false
+    }
+  }
+
+  /**
+   * The reason of this is that Spark's timestamp precision is limited to 6, and in
+   * [[BucketFunction.bind]], we use `InternalRowSerializer(bucketKeyRowType)` to convert paimon
+   * rows, but the `bucketKeyRowType` is derived from Spark's StructType which will lose the true
+   * precision of timestamp, leading to anomalies in bucket calculations.
+   *
+   * todo: find a way get the correct paimon type in BucketFunction, then remove this checker
+   */
+  private def supportsType(t: PaimonDataType): Boolean = t match {
+    case arrayType: ArrayType =>
+      supportsType(arrayType.getElementType)
+    case mapType: MapType =>
+      supportsType(mapType.getKeyType) && supportsType(mapType.getValueType)
+    case rowType: RowType =>
+      rowType.getFieldTypes.asScala.forall(supportsType)
+    case timestamp: TimestampType =>
+      timestamp.getPrecision == SPARK_TIMESTAMP_PRECISION
+    case localZonedTimestamp: LocalZonedTimestampType =>
+      localZonedTimestamp.getPrecision == SPARK_TIMESTAMP_PRECISION
+    case _ => true
+  }
 }
 
 /**

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
@@ -19,6 +19,7 @@
 package org.apache.paimon.spark
 
 import org.apache.paimon.catalog.{Catalog, Identifier}
+import org.apache.paimon.data.GenericRow
 import org.apache.paimon.fs.FileIO
 import org.apache.paimon.fs.local.LocalFileIO
 import org.apache.paimon.spark.catalog.WithPaimonCatalog
@@ -189,5 +190,16 @@ class PaimonSparkTestBase
       .get
       .scan
       .asInstanceOf[PaimonScan]
+  }
+
+  object GenericRow {
+    def of(values: Any*): GenericRow = {
+      val row = new GenericRow(values.length)
+      values.zipWithIndex.foreach {
+        case (value, index) =>
+          row.setField(index, value)
+      }
+      row
+    }
   }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/SparkWriteITCase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/SparkWriteITCase.scala
@@ -277,7 +277,7 @@ class SparkWriteITCase extends PaimonSparkTestBase {
 
       // insert using table api
       val table = loadTable("t")
-      val writeBuilder = table.newBatchWriteBuilder.withOverwrite
+      val writeBuilder = table.newBatchWriteBuilder
       val write = writeBuilder.newWrite
       write.write(
         GenericRow.of(

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/SparkWriteITCase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/SparkWriteITCase.scala
@@ -18,9 +18,10 @@
 
 package org.apache.paimon.spark.sql
 
-import org.apache.paimon.Snapshot
-import org.apache.paimon.io.DataFileMeta
+import org.apache.paimon.catalog.Identifier
+import org.apache.paimon.schema.Schema
 import org.apache.paimon.spark.PaimonSparkTestBase
+import org.apache.paimon.types.DataTypes
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.Row
@@ -259,6 +260,43 @@ class SparkWriteITCase extends PaimonSparkTestBase {
         ) :: Nil
       )
 
+    }
+  }
+
+  test("Paimon write: write table with timestamp3 bucket key") {
+    withTable("t") {
+      // create timestamp3 table using table api
+      val schema = Schema.newBuilder
+        .column("id", DataTypes.INT)
+        .column("ts3", DataTypes.TIMESTAMP(3))
+        .option("bucket-key", "ts3")
+        .option("bucket", "1024")
+        .option("file.format", "avro")
+        .build
+      paimonCatalog.createTable(Identifier.create(dbName0, "t"), schema, false)
+
+      // insert using table api
+      val table = loadTable("t")
+      val writeBuilder = table.newBatchWriteBuilder.withOverwrite
+      val write = writeBuilder.newWrite
+      write.write(
+        GenericRow.of(
+          1,
+          org.apache.paimon.data.Timestamp
+            .fromSQLTimestamp(java.sql.Timestamp.valueOf("2024-01-01 00:00:00"))))
+      val commit = writeBuilder.newCommit
+      commit.commit(write.prepareCommit())
+      commit.close()
+      write.close()
+
+      // write using spark sql
+      sql("INSERT INTO t VALUES (2, TIMESTAMP '2024-01-01 00:00:00')")
+
+      // check bucket id
+      checkAnswer(
+        sql("SELECT ts3, __paimon_bucket FROM t WHERE id = 1"),
+        sql("SELECT ts3, __paimon_bucket FROM t WHERE id = 2")
+      )
     }
   }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
@@ -367,15 +367,4 @@ class TableValuedFunctionsTest extends PaimonHiveTestBase {
 
   private def utcMills(timestamp: String) =
     Timestamp.fromLocalDateTime(LocalDateTime.parse(timestamp)).getMillisecond
-
-  object GenericRow {
-    def of(values: Any*): GenericRow = {
-      val row = new GenericRow(values.length)
-      values.zipWithIndex.foreach {
-        case (value, index) =>
-          row.setField(index, value)
-      }
-      row
-    }
-  }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

The reason of this is that Spark's timestamp precision is fixed to 6, and in [[BucketFunction.bind]], we use `InternalRowSerializer(bucketKeyRowType)` to convert paimon rows, but the `bucketKeyRowType` is derived from Spark's StructType which will lose the true precision of timestamp, leading to anomalies in bucket calculations.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
