### PR TITLE
[rest] ignore empty securityToken and expiration in DLFToken.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/rest/auth/DLFAuthProvider.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/auth/DLFAuthProvider.java
@@ -146,7 +146,7 @@ public class DLFAuthProvider implements AuthProvider {
             signHeaders.put(DLF_CONTENT_TYPE_KEY, MEDIA_TYPE.toString());
             signHeaders.put(DLF_CONTENT_MD5_HEADER_KEY, DLFAuthSignature.md5(data));
         }
-        if (securityToken != null) {
+        if (securityToken != null && !securityToken.isEmpty()) {
             signHeaders.put(DLF_SECURITY_TOKEN_HEADER_KEY, securityToken);
         }
         return signHeaders;

--- a/paimon-core/src/main/java/org/apache/paimon/rest/auth/DLFToken.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/auth/DLFToken.java
@@ -49,10 +49,11 @@ public class DLFToken {
     @JsonProperty(ACCESS_KEY_SECRET_FIELD_NAME)
     private final String accessKeySecret;
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty(SECURITY_TOKEN_FIELD_NAME)
     private final String securityToken;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty(EXPIRATION_FIELD_NAME)
     @Nullable
     private final String expiration;
@@ -69,7 +70,7 @@ public class DLFToken {
         this.accessKeySecret = accessKeySecret;
         this.securityToken = securityToken;
         this.expiration = expiration;
-        if (expiration == null) {
+        if (expiration == null || expiration.isEmpty()) {
             this.expirationAtMills = null;
         } else {
             LocalDateTime dateTime = LocalDateTime.parse(expiration, TOKEN_DATE_FORMATTER);

--- a/paimon-core/src/test/java/org/apache/paimon/rest/auth/AuthProviderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/auth/AuthProviderTest.java
@@ -376,6 +376,34 @@ public class AuthProviderTest {
                 header.get(DLFAuthProvider.DLF_CONTENT_SHA56_HEADER_KEY));
     }
 
+    @Test
+    public void testCreateDLFAuthProviderByEmptyParams() throws IOException {
+        Options options = new Options();
+        String akId = UUID.randomUUID().toString();
+        String akSecret = UUID.randomUUID().toString();
+        // security token is empty
+        DLFToken token = new DLFToken(akId, akSecret, "", null);
+        options.set(DLF_ACCESS_KEY_ID.key(), token.getAccessKeyId());
+        options.set(DLF_ACCESS_KEY_SECRET.key(), token.getAccessKeySecret());
+
+        options.set(DLF_REGION.key(), "cn-hangzhou");
+        options.set(TOKEN_PROVIDER, "dlf");
+        DLFAuthProvider authProvider =
+                (DLFAuthProvider) AuthProviderFactory.createAuthProvider(options);
+        String authToken = OBJECT_MAPPER_INSTANCE.writeValueAsString(authProvider.getFreshToken());
+        assertEquals(OBJECT_MAPPER_INSTANCE.writeValueAsString(token), authToken);
+
+        // add empty security token to options
+        options.set(DLF_SECURITY_TOKEN.key(), token.getSecurityToken());
+        authToken = OBJECT_MAPPER_INSTANCE.writeValueAsString(authProvider.getFreshToken());
+        assertEquals(OBJECT_MAPPER_INSTANCE.writeValueAsString(token), authToken);
+
+        // expiration is empty
+        token = new DLFToken(akId, akSecret, "", "");
+        authToken = OBJECT_MAPPER_INSTANCE.writeValueAsString(authProvider.getFreshToken());
+        assertEquals(OBJECT_MAPPER_INSTANCE.writeValueAsString(token), authToken);
+    }
+
     private Pair<File, String> generateTokenAndWriteToFile(String fileName) throws IOException {
         File tokenFile = folder.newFile(fileName);
         String expiration = ZonedDateTime.now(ZoneOffset.UTC).format(TOKEN_DATE_FORMATTER);

--- a/paimon-core/src/test/java/org/apache/paimon/rest/auth/AuthProviderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/auth/AuthProviderTest.java
@@ -31,6 +31,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
@@ -111,7 +112,7 @@ public class AuthProviderTest {
         tokenFile2Token = generateTokenAndWriteToFile(fileName);
         token = tokenFile2Token.getRight();
         tokenFile = tokenFile2Token.getLeft();
-        FileUtils.writeStringToFile(tokenFile, token);
+        FileUtils.writeStringToFile(tokenFile, token, StandardCharsets.UTF_8);
         authToken = OBJECT_MAPPER_INSTANCE.writeValueAsString(authProvider.getFreshToken());
         assertEquals(token, authToken);
     }
@@ -410,7 +411,7 @@ public class AuthProviderTest {
         String secret = UUID.randomUUID().toString();
         DLFToken token = new DLFToken("accessKeyId", secret, "securityToken", expiration);
         String tokenStr = OBJECT_MAPPER_INSTANCE.writeValueAsString(token);
-        FileUtils.writeStringToFile(tokenFile, tokenStr);
+        FileUtils.writeStringToFile(tokenFile, tokenStr, StandardCharsets.UTF_8);
         return Pair.of(tokenFile, tokenStr);
     }
 


### PR DESCRIPTION
### Purpose
ignore empty securityToken and expiration in DLFToken.

### Tests
AuthProviderTest#testCreateDLFAuthProviderByEmptyParams