### PR TITLE
[core] Fix computed column and projection of BinlogTable

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/system/BinlogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/BinlogTable.java
@@ -90,6 +90,8 @@ public class BinlogTable extends AuditLogTable {
 
     private class BinlogRead extends AuditLogRead {
 
+        private RowType readType = wrapped.rowType();
+
         private BinlogRead(InnerTableRead dataRead) {
             super(dataRead);
         }
@@ -104,13 +106,14 @@ public class BinlogTable extends AuditLogTable {
                     fields.add(field.newType(((ArrayType) field.type()).getElementType()));
                 }
             }
-            return super.withReadType(readType.copy(fields));
+            this.readType = readType.copy(fields);
+            return super.withReadType(this.readType);
         }
 
         @Override
         public RecordReader<InternalRow> createReader(Split split) throws IOException {
             DataSplit dataSplit = (DataSplit) split;
-            InternalRow.FieldGetter[] fieldGetters = wrapped.rowType().fieldGetters();
+            InternalRow.FieldGetter[] fieldGetters = readType.fieldGetters();
 
             if (dataSplit.isStreaming()) {
                 return new PackChangelogReader(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -808,6 +808,8 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
     public void testBinlogTableWithProjection() {
         sql("CREATE TABLE test_table (a int, b string);");
         sql("INSERT INTO test_table VALUES (1, 'A')");
+        assertThat(sql("SELECT * FROM `test_table$binlog`"))
+                .containsExactly(Row.of("+I", new Integer[] {1}, new String[] {"A"}));
         assertThat(sql("SELECT b FROM `test_table$binlog`"))
                 .containsExactly(Row.of((Object) new String[] {"A"}));
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -812,5 +812,7 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
                 .containsExactly(Row.of("+I", new Integer[] {1}, new String[] {"A"}));
         assertThat(sql("SELECT b FROM `test_table$binlog`"))
                 .containsExactly(Row.of((Object) new String[] {"A"}));
+        assertThat(sql("SELECT rowkind, b FROM `test_table$binlog`"))
+                .containsExactly(Row.of("+I", new String[] {"A"}));
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -792,4 +792,23 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
         assertThat(sql("SELECT * FROM `test_table$audit_log`"))
                 .containsExactly(Row.of("+I", 1, 1, 2));
     }
+
+    @Test
+    public void testBinlogTableWithComputedColumn() {
+        sql("CREATE TABLE test_table (a int, b int, c AS a + b);");
+        String ddl = sql("SHOW CREATE TABLE `test_table$binlog`").get(0).getFieldAs(0);
+        assertThat(ddl).doesNotContain("`c` AS `a` + `b`");
+
+        sql("INSERT INTO test_table VALUES (1, 1)");
+        assertThat(sql("SELECT * FROM `test_table$binlog`"))
+                .containsExactly(Row.of("+I", new Integer[] {1}, new Integer[] {1}));
+    }
+
+    @Test
+    public void testBinlogTableWithProjection() {
+        sql("CREATE TABLE test_table (a int, b string);");
+        sql("INSERT INTO test_table VALUES (1, 'A')");
+        assertThat(sql("SELECT b FROM `test_table$binlog`"))
+                .containsExactly(Row.of((Object) new String[] {"A"}));
+    }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonSystemTableTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonSystemTableTest.scala
@@ -119,5 +119,10 @@ class PaimonSystemTableTest extends PaimonSparkTestBase {
       sql("SELECT b FROM `T$binlog`"),
       Seq(Row(Array(3)), Row(Array(2)))
     )
+
+    checkAnswer(
+      sql("SELECT rowkind, b FROM `T$binlog`"),
+      Seq(Row("+I", Array(3)), Row("+I", Array(2)))
+    )
   }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonSystemTableTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonSystemTableTest.scala
@@ -114,5 +114,10 @@ class PaimonSystemTableTest extends PaimonSparkTestBase {
       sql("SELECT * FROM `T$binlog`"),
       Seq(Row("+I", Array(1), Array(3)), Row("+I", Array(2), Array(2)))
     )
+
+    checkAnswer(
+      sql("SELECT b FROM `T$binlog`"),
+      Seq(Row(Array(3)), Row(Array(2)))
+    )
   }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This PR fixes two problems. 
1. Projection was not be handled.
2. Computed column is not supported.
For example, if you create a able like 
```
CREATE TABLE test_table (a int, b int, c AS a + b)
```
You will get an exception while querying binlog:
`Cannot apply '+' to arguments of type '<INTEGER ARRAY> + <INTEGER ARRAY>'.`. It is complicated to support it because we should handle flink computed column expressions in this occasion.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
