### PR TITLE
[core] Introduce Catalog.authTableQuery to auth query select and filter

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -774,6 +774,12 @@ This config option does not affect the default filesystem metastore.</td>
             <td>Define primary key by table options, cannot define primary key on DDL and table options at the same time.</td>
         </tr>
         <tr>
+            <td><h5>query-auth.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Enable query auth to give Catalog the opportunity to perform column level and row level permission validation on queries.</td>
+        </tr>
+        <tr>
             <td><h5>read.batch-size</h5></td>
             <td style="word-wrap: break-word;">1024</td>
             <td>Integer</td>

--- a/docs/static/rest-catalog-open-api.yaml
+++ b/docs/static/rest-catalog-open-api.yaml
@@ -590,6 +590,51 @@ paths:
           $ref: '#/components/responses/TableNotExistErrorResponse'
         "500":
           $ref: '#/components/responses/ServerErrorResponse'
+  /v1/{prefix}/databases/{database}/tables/{table}/auth:
+    post:
+      tags:
+        - table
+      summary: Auth table query
+      operationId: authTableQuery
+      parameters:
+        - name: prefix
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: database
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: table
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthTableQueryRequest'
+      responses:
+        "200":
+          description: Success, no content
+        "401":
+          $ref: '#/components/responses/UnauthorizedErrorResponse'
+        404:
+          description:
+            Not Found
+            - TableNotExistException, table does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/ResourceNotExistErrorResponse'
+              examples:
+                TableNotExist:
+                  $ref: '#/components/examples/TableNotExistError'
+        "500":
+          $ref: '#/components/responses/ServerErrorResponse'
   /v1/{prefix}/databases/{database}/tables/{table}/snapshot:
     get:
       tags:
@@ -1791,7 +1836,6 @@ components:
       anyOf:
         - $ref: '#/components/schemas/SnapshotInstant'
         - $ref: '#/components/schemas/TagInstant'
-
     BaseInstant:
       discriminator:
         propertyName: action
@@ -1911,6 +1955,17 @@ components:
       properties:
         snapshot:
           $ref: '#/components/schemas/TableSnapshot'
+    AuthTableQueryRequest:
+      type: object
+      properties:
+        select:
+          type: array
+          items:
+            type: string
+        filter:
+          type: array
+          items:
+            type: string
     AlterDatabaseRequest:
       type: object
       properties:

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1652,6 +1652,9 @@ public class CoreOptions implements Serializable {
                             "Set a time duration when a partition has no new data after this time duration, "
                                     + "start to report the partition statistics to hms.");
 
+    public static final ConfigOption<Boolean> QUERY_AUTH_ENABLED =
+            key("query-auth.enabled").booleanType().defaultValue(false).withDescription(".");
+
     @ExcludeFromDocumentation("Only used internally to support materialized table")
     public static final ConfigOption<String> MATERIALIZED_TABLE_DEFINITION_QUERY =
             key("materialized-table.definition-query")
@@ -2036,6 +2039,10 @@ public class CoreOptions implements Serializable {
 
     public MergeEngine mergeEngine() {
         return options.get(MERGE_ENGINE);
+    }
+
+    public boolean queryAuthEnabled() {
+        return options.get(QUERY_AUTH_ENABLED);
     }
 
     public boolean ignoreDelete() {

--- a/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1653,7 +1653,12 @@ public class CoreOptions implements Serializable {
                                     + "start to report the partition statistics to hms.");
 
     public static final ConfigOption<Boolean> QUERY_AUTH_ENABLED =
-            key("query-auth.enabled").booleanType().defaultValue(false).withDescription(".");
+            key("query-auth.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Enable query auth to give Catalog the opportunity to perform "
+                                    + "column level and row level permission validation on queries.");
 
     @ExcludeFromDocumentation("Only used internally to support materialized table")
     public static final ConfigOption<String> MATERIALIZED_TABLE_DEFINITION_QUERY =

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -498,6 +498,9 @@ public abstract class AbstractCatalog implements Catalog {
     }
 
     @Override
+    public void authTableQuery(Identifier identifier, List<String> select, List<String> filter) {}
+
+    @Override
     public void createPartitions(Identifier identifier, List<Map<String, String>> partitions)
             throws TableNotExistException {}
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -666,6 +666,19 @@ public interface Catalog extends AutoCloseable {
     void alterPartitions(Identifier identifier, List<PartitionStatistics> partitions)
             throws TableNotExistException;
 
+    // ==================== Table Auth ==========================
+
+    /**
+     * Auth table query select and filter.
+     *
+     * @param identifier path of the table to alter partitions
+     * @param select projection fields
+     * @param filter query filter
+     * @throws TableNotExistException if the table does not exist
+     */
+    void authTableQuery(Identifier identifier, List<String> select, List<String> filter)
+            throws TableNotExistException;
+
     // ==================== Catalog Information ==========================
 
     /** Catalog options for re-creating this catalog. */

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -672,8 +672,8 @@ public interface Catalog extends AutoCloseable {
      * Auth table query select and filter.
      *
      * @param identifier path of the table to alter partitions
-     * @param select projection fields
-     * @param filter query filter
+     * @param select selected fields
+     * @param filter query filters
      * @throws TableNotExistException if the table does not exist
      */
     void authTableQuery(Identifier identifier, List<String> select, List<String> filter)

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -284,6 +284,12 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
+    public void authTableQuery(Identifier identifier, List<String> select, List<String> filter)
+            throws TableNotExistException {
+        wrapped.authTableQuery(identifier, select, filter);
+    }
+
+    @Override
     public void repairCatalog() {
         wrapped.repairCatalog();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -45,6 +45,7 @@ import org.apache.paimon.rest.exceptions.ServiceFailureException;
 import org.apache.paimon.rest.requests.AlterDatabaseRequest;
 import org.apache.paimon.rest.requests.AlterTableRequest;
 import org.apache.paimon.rest.requests.AlterViewRequest;
+import org.apache.paimon.rest.requests.AuthTableQueryRequest;
 import org.apache.paimon.rest.requests.CommitTableRequest;
 import org.apache.paimon.rest.requests.CreateBranchRequest;
 import org.apache.paimon.rest.requests.CreateDatabaseRequest;
@@ -594,6 +595,30 @@ public class RESTCatalog implements Catalog {
             }
         } catch (AlreadyExistsException e) {
             throw new ColumnAlreadyExistException(identifier, e.resourceName());
+        } catch (ForbiddenException e) {
+            throw new TableNoPermissionException(identifier, e);
+        } catch (ServiceFailureException e) {
+            throw new IllegalStateException(e.getMessage());
+        } catch (NotImplementedException e) {
+            throw new UnsupportedOperationException(e.getMessage());
+        } catch (BadRequestException e) {
+            throw new RuntimeException(new IllegalArgumentException(e.getMessage()));
+        }
+    }
+
+    @Override
+    public void authTableQuery(Identifier identifier, List<String> select, List<String> filter)
+            throws TableNotExistException {
+        checkNotSystemTable(identifier, "authTable");
+        try {
+            AuthTableQueryRequest request = new AuthTableQueryRequest(select, filter);
+            client.post(
+                    resourcePaths.authTable(
+                            identifier.getDatabaseName(), identifier.getObjectName()),
+                    request,
+                    restAuthFunction);
+        } catch (NoSuchResourceException e) {
+            throw new TableNotExistException(identifier);
         } catch (ForbiddenException e) {
             throw new TableNoPermissionException(identifier, e);
         } catch (ServiceFailureException e) {

--- a/paimon-core/src/main/java/org/apache/paimon/rest/ResourcePaths.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/ResourcePaths.java
@@ -127,6 +127,17 @@ public class ResourcePaths {
                 "snapshot");
     }
 
+    public String authTable(String databaseName, String objectName) {
+        return SLASH.join(
+                V1,
+                prefix,
+                DATABASES,
+                encodeString(databaseName),
+                TABLES,
+                encodeString(objectName),
+                "auth");
+    }
+
     public String partitions(String databaseName, String objectName) {
         return SLASH.join(
                 V1,

--- a/paimon-core/src/main/java/org/apache/paimon/rest/requests/AuthTableQueryRequest.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/requests/AuthTableQueryRequest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest.requests;
+
+import org.apache.paimon.rest.RESTRequest;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/** Request for auth table query. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AuthTableQueryRequest implements RESTRequest {
+
+    private static final String FIELD_SELECT = "select";
+    private static final String FIELD_FILTER = "filter";
+
+    @JsonProperty(FIELD_SELECT)
+    private final List<String> select;
+
+    @JsonProperty(FIELD_FILTER)
+    private final List<String> filter;
+
+    @JsonCreator
+    public AuthTableQueryRequest(
+            @JsonProperty(FIELD_SELECT) List<String> select,
+            @JsonProperty(FIELD_FILTER) List<String> filter) {
+        this.select = select;
+        this.filter = filter;
+    }
+
+    @JsonGetter(FIELD_SELECT)
+    public List<String> select() {
+        return select;
+    }
+
+    @JsonGetter(FIELD_FILTER)
+    public List<String> filter() {
+        return filter;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -262,21 +262,22 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
     @Override
     public DataTableBatchScan newScan() {
         return new DataTableBatchScan(
-                tableSchema.primaryKeys().size() > 0,
+                tableSchema,
                 coreOptions(),
                 newSnapshotReader(),
-                DefaultValueAssigner.create(tableSchema));
+                catalogEnvironment.tableQueryAuth(coreOptions()));
     }
 
     @Override
     public StreamDataTableScan newStreamScan() {
         return new DataTableStreamScan(
+                tableSchema,
                 coreOptions(),
                 newSnapshotReader(),
                 snapshotManager(),
                 changelogManager(),
                 supportStreamingReadOverwrite(),
-                DefaultValueAssigner.create(tableSchema));
+                catalogEnvironment.tableQueryAuth(coreOptions()));
     }
 
     protected abstract SplitGenerator splitGenerator();

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
@@ -27,6 +27,9 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.predicate.LeafPredicate;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.source.snapshot.CompactedStartingScanner;
 import org.apache.paimon.table.source.snapshot.ContinuousCompactorStartingScanner;
 import org.apache.paimon.table.source.snapshot.ContinuousFromSnapshotFullStartingScanner;
@@ -46,6 +49,7 @@ import org.apache.paimon.table.source.snapshot.StaticFromTagStartingScanner;
 import org.apache.paimon.table.source.snapshot.StaticFromTimestampStartingScanner;
 import org.apache.paimon.table.source.snapshot.StaticFromWatermarkStartingScanner;
 import org.apache.paimon.tag.Tag;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.ChangelogManager;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.Pair;
@@ -55,12 +59,16 @@ import org.apache.paimon.utils.TagManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.paimon.CoreOptions.FULL_COMPACTION_DELTA_COMMITS;
 import static org.apache.paimon.CoreOptions.IncrementalBetweenScanMode.DIFF;
+import static org.apache.paimon.predicate.PredicateBuilder.splitAnd;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
@@ -69,12 +77,29 @@ abstract class AbstractDataTableScan implements DataTableScan {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractDataTableScan.class);
 
+    private final TableSchema schema;
     private final CoreOptions options;
     protected final SnapshotReader snapshotReader;
+    private final TableQueryAuth queryAuth;
 
-    protected AbstractDataTableScan(CoreOptions options, SnapshotReader snapshotReader) {
+    @Nullable private RowType readType;
+    @Nullable private Predicate predicate;
+
+    protected AbstractDataTableScan(
+            TableSchema schema,
+            CoreOptions options,
+            SnapshotReader snapshotReader,
+            TableQueryAuth queryAuth) {
+        this.schema = schema;
         this.options = options;
         this.snapshotReader = snapshotReader;
+        this.queryAuth = queryAuth;
+    }
+
+    @Override
+    public InnerTableScan withFilter(Predicate predicate) {
+        this.predicate = predicate;
+        return this;
     }
 
     @Override
@@ -86,6 +111,12 @@ abstract class AbstractDataTableScan implements DataTableScan {
     @Override
     public AbstractDataTableScan withBucketFilter(Filter<Integer> bucketFilter) {
         snapshotReader.withBucketFilter(bucketFilter);
+        return this;
+    }
+
+    @Override
+    public InnerTableScan withReadType(@Nullable RowType readType) {
+        this.readType = readType;
         return this;
     }
 
@@ -116,6 +147,24 @@ abstract class AbstractDataTableScan implements DataTableScan {
     public AbstractDataTableScan withMetricsRegistry(MetricRegistry metricsRegistry) {
         snapshotReader.withMetricRegistry(metricsRegistry);
         return this;
+    }
+
+    protected void authQuery() {
+        if (!options.queryAuthEnabled()) {
+            return;
+        }
+
+        List<String> projection = readType == null ? schema.fieldNames() : readType.getFieldNames();
+        List<String> filter = new ArrayList<>();
+        if (predicate != null) {
+            List<Predicate> predicates = splitAnd(predicate);
+            for (Predicate predicate : predicates) {
+                if (predicate instanceof LeafPredicate) {
+                    filter.add(predicate.toString());
+                }
+            }
+        }
+        queryAuth.auth(projection, filter);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
@@ -26,6 +26,7 @@ import org.apache.paimon.lookup.LookupStrategy;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.operation.DefaultValueAssigner;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.source.snapshot.AllDeltaFollowUpScanner;
 import org.apache.paimon.table.source.snapshot.BoundedChecker;
 import org.apache.paimon.table.source.snapshot.ChangelogFollowUpScanner;
@@ -75,18 +76,19 @@ public class DataTableStreamScan extends AbstractDataTableScan implements Stream
     @Nullable private Long scanDelayMillis;
 
     public DataTableStreamScan(
+            TableSchema schema,
             CoreOptions options,
             SnapshotReader snapshotReader,
             SnapshotManager snapshotManager,
             ChangelogManager changelogManager,
             boolean supportStreamingReadOverwrite,
-            DefaultValueAssigner defaultValueAssigner) {
-        super(options, snapshotReader);
+            TableQueryAuth queryAuth) {
+        super(schema, options, snapshotReader, queryAuth);
         this.options = options;
         this.scanMode = options.toConfiguration().get(CoreOptions.STREAM_SCAN_MODE);
         this.snapshotManager = snapshotManager;
         this.supportStreamingReadOverwrite = supportStreamingReadOverwrite;
-        this.defaultValueAssigner = defaultValueAssigner;
+        this.defaultValueAssigner = DefaultValueAssigner.create(schema);
         this.nextSnapshotProvider =
                 new NextSnapshotFetcher(
                         snapshotManager, changelogManager, options.changelogLifecycleDecoupled());
@@ -94,6 +96,7 @@ public class DataTableStreamScan extends AbstractDataTableScan implements Stream
 
     @Override
     public DataTableStreamScan withFilter(Predicate predicate) {
+        super.withFilter(predicate);
         snapshotReader.withFilter(defaultValueAssigner.handlePredicate(predicate));
         return this;
     }
@@ -108,6 +111,8 @@ public class DataTableStreamScan extends AbstractDataTableScan implements Stream
 
     @Override
     public Plan plan() {
+        authQuery();
+
         if (!initialized) {
             initScanner();
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableScan.java
@@ -21,7 +21,10 @@ package org.apache.paimon.table.source;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
+
+import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Map;
@@ -30,6 +33,10 @@ import java.util.Map;
 public interface InnerTableScan extends TableScan {
 
     InnerTableScan withFilter(Predicate predicate);
+
+    default InnerTableScan withReadType(@Nullable RowType readType) {
+        return this;
+    }
 
     default InnerTableScan withLimit(int limit) {
         return this;

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -154,7 +154,7 @@ public class ReadBuilderImpl implements ReadBuilder {
     }
 
     private InnerTableScan configureScan(InnerTableScan scan) {
-        scan.withFilter(filter).withPartitionFilter(partitionSpec);
+        scan.withFilter(filter).withReadType(readType).withPartitionFilter(partitionSpec);
         checkState(
                 bucketFilter == null || shardIndexOfThisSubtask == null,
                 "Bucket filter and shard configuration cannot be used together. "

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/TableQueryAuth.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/TableQueryAuth.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source;
+
+import java.util.List;
+
+/** Table query auth. */
+public interface TableQueryAuth {
+
+    void auth(List<String> select, List<String> filter);
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ReadOptimizedTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ReadOptimizedTable.java
@@ -26,7 +26,6 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFileMeta;
-import org.apache.paimon.operation.DefaultValueAssigner;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.DataTable;
 import org.apache.paimon.table.FileStoreTable;
@@ -133,10 +132,10 @@ public class ReadOptimizedTable implements DataTable, ReadonlyTable {
     @Override
     public DataTableBatchScan newScan() {
         return new DataTableBatchScan(
-                !wrapped.schema().primaryKeys().isEmpty(),
+                wrapped.schema(),
                 coreOptions(),
                 newSnapshotReader(),
-                DefaultValueAssigner.create(wrapped.schema()));
+                wrapped.catalogEnvironment().tableQueryAuth(coreOptions()));
     }
 
     @Override
@@ -146,12 +145,13 @@ public class ReadOptimizedTable implements DataTable, ReadonlyTable {
                     "Unsupported streaming scan for read optimized table");
         }
         return new DataTableStreamScan(
+                wrapped.schema(),
                 coreOptions(),
                 newSnapshotReader(),
                 snapshotManager(),
                 changelogManager(),
                 wrapped.supportStreamingReadOverwrite(),
-                DefaultValueAssigner.create(wrapped.schema()));
+                wrapped.catalogEnvironment().tableQueryAuth(coreOptions()));
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTCatalogTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -172,6 +173,11 @@ class MockRESTCatalogTest extends RESTCatalogTest {
     @Override
     protected void revokeTablePermission(Identifier identifier) {
         restCatalogServer.addNoPermissionTable(identifier);
+    }
+
+    @Override
+    protected void authTableColumns(Identifier identifier, List<String> columns) {
+        restCatalogServer.addTableColumnAuth(identifier, columns);
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -43,6 +43,7 @@ import org.apache.paimon.rest.auth.RESTAuthParameter;
 import org.apache.paimon.rest.requests.AlterDatabaseRequest;
 import org.apache.paimon.rest.requests.AlterTableRequest;
 import org.apache.paimon.rest.requests.AlterViewRequest;
+import org.apache.paimon.rest.requests.AuthTableQueryRequest;
 import org.apache.paimon.rest.requests.CommitTableRequest;
 import org.apache.paimon.rest.requests.CreateBranchRequest;
 import org.apache.paimon.rest.requests.CreateDatabaseRequest;
@@ -126,11 +127,9 @@ public class RESTCatalogServer {
     public static final int DEFAULT_MAX_RESULTS = 100;
     public static final String AUTHORIZATION_HEADER_KEY = "Authorization";
 
-    private final String prefix;
     private final String databaseUri;
 
     private final FileSystemCatalog catalog;
-    private final Dispatcher dispatcher;
     private final MockWebServer server;
 
     private final Map<String, Database> databaseStore = new HashMap<>();
@@ -141,6 +140,7 @@ public class RESTCatalogServer {
     private final Map<String, TableSnapshot> tableWithSnapshotId2SnapshotStore = new HashMap<>();
     private final List<String> noPermissionDatabases = new ArrayList<>();
     private final List<String> noPermissionTables = new ArrayList<>();
+    private final Map<String, List<String>> columnAuthHandler = new HashMap<>();
     public final ConfigResponse configResponse;
     public final String warehouse;
 
@@ -150,7 +150,7 @@ public class RESTCatalogServer {
             String dataPath, AuthProvider authProvider, ConfigResponse config, String warehouse) {
         this.warehouse = warehouse;
         this.configResponse = config;
-        this.prefix =
+        String prefix =
                 this.configResponse.getDefaults().get(RESTCatalogInternalOptions.PREFIX.key());
         this.resourcePaths = new ResourcePaths(prefix);
         this.databaseUri = resourcePaths.databases();
@@ -167,7 +167,7 @@ public class RESTCatalogServer {
             throw new UncheckedIOException(e);
         }
         this.catalog = new FileSystemCatalog(fileIO, warehousePath, context.options());
-        this.dispatcher = initDispatcher(authProvider);
+        Dispatcher dispatcher = initDispatcher(authProvider);
         MockWebServer mockWebServer = new MockWebServer();
         mockWebServer.setDispatcher(dispatcher);
         server = mockWebServer;
@@ -214,6 +214,10 @@ public class RESTCatalogServer {
 
     public void addNoPermissionTable(Identifier identifier) {
         noPermissionTables.add(identifier.getFullName());
+    }
+
+    public void addTableColumnAuth(Identifier identifier, List<String> select) {
+        columnAuthHandler.put(identifier.getFullName(), select);
     }
 
     public RESTToken getDataToken(Identifier identifier) {
@@ -301,6 +305,10 @@ public class RESTCatalogServer {
                                 resources.length == 4
                                         && ResourcePaths.TABLES.equals(resources[1])
                                         && "snapshot".equals(resources[3]);
+                        boolean isTableAuth =
+                                resources.length == 4
+                                        && ResourcePaths.TABLES.equals(resources[1])
+                                        && "auth".equals(resources[3]);
                         boolean isCommitSnapshot =
                                 resources.length == 4
                                         && ResourcePaths.TABLES.equals(resources[1])
@@ -369,6 +377,8 @@ public class RESTCatalogServer {
                             return getDataTokenHandle(identifier);
                         } else if (isTableSnapshot) {
                             return snapshotHandle(identifier);
+                        } else if (isTableAuth) {
+                            return authTable(identifier, restAuthParameter.data());
                         } else if (isCommitSnapshot) {
                             return commitTableHandle(identifier, restAuthParameter.data());
                         } else if (isRollbackTable) {
@@ -604,6 +614,29 @@ public class RESTCatalogServer {
         return Optional.of(
                 mockResponse(
                         new ErrorResponse(ErrorResponse.RESOURCE_TYPE_TABLE, null, "", 404), 404));
+    }
+
+    private MockResponse authTable(Identifier identifier, String data) throws Exception {
+        AuthTableQueryRequest requestBody =
+                OBJECT_MAPPER.readValue(data, AuthTableQueryRequest.class);
+        if (noPermissionTables.contains(identifier.getFullName())) {
+            throw new Catalog.TableNoPermissionException(identifier);
+        }
+        if (!tableMetadataStore.containsKey(identifier.getFullName())) {
+            throw new Catalog.TableNotExistException(identifier);
+        }
+        List<String> columnAuth = columnAuthHandler.get(identifier.getFullName());
+        if (columnAuth != null) {
+            requestBody
+                    .select()
+                    .forEach(
+                            column -> {
+                                if (!columnAuth.contains(column)) {
+                                    throw new Catalog.TableNoPermissionException(identifier);
+                                }
+                            });
+        }
+        return new MockResponse().setResponseCode(200);
     }
 
     private MockResponse commitTableHandle(Identifier identifier, String data) throws Exception {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupDataTableScan.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupDataTableScan.java
@@ -20,8 +20,9 @@ package org.apache.paimon.flink.lookup;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.operation.DefaultValueAssigner;
+import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.source.DataTableStreamScan;
+import org.apache.paimon.table.source.TableQueryAuth;
 import org.apache.paimon.table.source.snapshot.AllDeltaFollowUpScanner;
 import org.apache.paimon.table.source.snapshot.BoundedChecker;
 import org.apache.paimon.table.source.snapshot.FollowUpScanner;
@@ -51,20 +52,22 @@ public class LookupDataTableScan extends DataTableStreamScan {
     private final LookupStreamScanMode lookupScanMode;
 
     public LookupDataTableScan(
+            TableSchema schema,
             CoreOptions options,
             SnapshotReader snapshotReader,
             SnapshotManager snapshotManager,
             ChangelogManager changelogManager,
             boolean supportStreamingReadOverwrite,
-            DefaultValueAssigner defaultValueAssigner,
-            LookupStreamScanMode lookupScanMode) {
+            LookupStreamScanMode lookupScanMode,
+            TableQueryAuth queryAuth) {
         super(
+                schema,
                 options,
                 snapshotReader,
                 snapshotManager,
                 changelogManager,
                 supportStreamingReadOverwrite,
-                defaultValueAssigner);
+                queryAuth);
         this.startupMode = options.startupMode();
         this.lookupScanMode = lookupScanMode;
         dropStats();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupFileStoreTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupFileStoreTable.java
@@ -22,7 +22,6 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.KeyValueFileStore;
 import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.utils.TableScanUtils;
-import org.apache.paimon.operation.DefaultValueAssigner;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.options.description.DescribedEnum;
 import org.apache.paimon.options.description.InlineElement;
@@ -75,13 +74,14 @@ public class LookupFileStoreTable extends DelegatedFileStoreTable {
     @Override
     public StreamDataTableScan newStreamScan() {
         return new LookupDataTableScan(
+                wrapped.schema(),
                 wrapped.coreOptions(),
                 wrapped.newSnapshotReader(),
                 wrapped.snapshotManager(),
                 wrapped.changelogManager(),
                 wrapped.supportStreamingReadOverwrite(),
-                DefaultValueAssigner.create(wrapped.schema()),
-                lookupScanMode);
+                lookupScanMode,
+                wrapped.catalogEnvironment().tableQueryAuth(wrapped.coreOptions()));
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
@@ -373,6 +373,7 @@ public abstract class BaseDataTableSource extends FlinkTableSource
         List<Split> splits =
                 table.newReadBuilder()
                         .dropStats()
+                        .withProjection(new int[0])
                         .withFilter(getPredicateWithScanPartitions())
                         .newScan()
                         .plan()

--- a/paimon-open-api/rest-catalog-open-api.yaml
+++ b/paimon-open-api/rest-catalog-open-api.yaml
@@ -590,6 +590,51 @@ paths:
           $ref: '#/components/responses/TableNotExistErrorResponse'
         "500":
           $ref: '#/components/responses/ServerErrorResponse'
+  /v1/{prefix}/databases/{database}/tables/{table}/auth:
+    post:
+      tags:
+        - table
+      summary: Auth table query
+      operationId: authTableQuery
+      parameters:
+        - name: prefix
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: database
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: table
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthTableQueryRequest'
+      responses:
+        "200":
+          description: Success, no content
+        "401":
+          $ref: '#/components/responses/UnauthorizedErrorResponse'
+        404:
+          description:
+            Not Found
+            - TableNotExistException, table does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/ResourceNotExistErrorResponse'
+              examples:
+                TableNotExist:
+                  $ref: '#/components/examples/TableNotExistError'
+        "500":
+          $ref: '#/components/responses/ServerErrorResponse'
   /v1/{prefix}/databases/{database}/tables/{table}/snapshot:
     get:
       tags:
@@ -1791,7 +1836,6 @@ components:
       anyOf:
         - $ref: '#/components/schemas/SnapshotInstant'
         - $ref: '#/components/schemas/TagInstant'
-
     BaseInstant:
       discriminator:
         propertyName: action
@@ -1911,6 +1955,17 @@ components:
       properties:
         snapshot:
           $ref: '#/components/schemas/TableSnapshot'
+    AuthTableQueryRequest:
+      type: object
+      properties:
+        select:
+          type: array
+          items:
+            type: string
+        filter:
+          type: array
+          items:
+            type: string
     AlterDatabaseRequest:
       type: object
       properties:

--- a/paimon-open-api/rest-catalog-open-api.yaml
+++ b/paimon-open-api/rest-catalog-open-api.yaml
@@ -622,6 +622,8 @@ paths:
           description: Success, no content
         "401":
           $ref: '#/components/responses/UnauthorizedErrorResponse'
+        "403":
+          $ref: '#/components/responses/ForbiddenErrorResponse'
         404:
           description:
             Not Found
@@ -1208,6 +1210,17 @@ components:
           example: {
             "message": "No auth for this resource",
             "code": 401
+          }
+    ForbiddenErrorResponse:
+      description:
+        Used for 403 errors.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example: {
+            "message": "Table has no permission",
+            "code": 403
           }
     ResourceNotExistErrorResponse:
       description:

--- a/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
+++ b/paimon-open-api/src/main/java/org/apache/paimon/open/api/RESTCatalogController.java
@@ -22,6 +22,7 @@ import org.apache.paimon.partition.Partition;
 import org.apache.paimon.rest.requests.AlterDatabaseRequest;
 import org.apache.paimon.rest.requests.AlterTableRequest;
 import org.apache.paimon.rest.requests.AlterViewRequest;
+import org.apache.paimon.rest.requests.AuthTableQueryRequest;
 import org.apache.paimon.rest.requests.CommitTableRequest;
 import org.apache.paimon.rest.requests.CreateBranchRequest;
 import org.apache.paimon.rest.requests.CreateDatabaseRequest;
@@ -498,6 +499,30 @@ public class RESTCatalogController {
             @PathVariable String database,
             @PathVariable String table,
             @RequestBody RollbackTableRequest request) {}
+
+    @Operation(
+            summary = "Auth table query",
+            tags = {"table"})
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Success, no content"),
+        @ApiResponse(
+                responseCode = "401",
+                description = "Unauthorized",
+                content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
+        @ApiResponse(
+                responseCode = "404",
+                description = "Resource not found",
+                content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
+        @ApiResponse(
+                responseCode = "500",
+                content = {@Content(schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @PostMapping("/v1/{prefix}/databases/{database}/tables/{table}/auth")
+    public void authTableQuery(
+            @PathVariable String prefix,
+            @PathVariable String database,
+            @PathVariable String table,
+            @RequestBody AuthTableQueryRequest request) {}
 
     @Operation(
             summary = "Get table token",


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This PR introduces an interface to give Catalog the opportunity to perform column level and row level permission validation on queries.

Introduce Catalog method:
```
    /**
     * Auth table query select and filter.
     *
     * @param identifier path of the table to alter partitions
     * @param select projection fields
     * @param filter query filter
     * @throws TableNotExistException if the table does not exist
     */
    void authTableQuery(Identifier identifier, List<String> select, List<String> filter)
            throws TableNotExistException;
```

Introduce rest api:
```
  /v1/{prefix}/databases/{database}/tables/{table}/auth:
    post:
      tags:
        - table
      summary: Auth table query
      operationId: authTableQuery
      parameters:
        - name: prefix
          in: path
          required: true
          schema:
            type: string
        - name: database
          in: path
          required: true
          schema:
            type: string
        - name: table
          in: path
          required: true
          schema:
            type: string
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/AuthTableQueryRequest'
      responses:
        "200":
          description: Success, no content
        "401":
          $ref: '#/components/responses/UnauthorizedErrorResponse'
        404:
          description:
            Not Found
            - TableNotExistException, table does not exist
          content:
            application/json:
              schema:
                $ref: '#/components/responses/ResourceNotExistErrorResponse'
              examples:
                TableNotExist:
                  $ref: '#/components/examples/TableNotExistError'
        "500":
          $ref: '#/components/responses/ServerErrorResponse'
```

NOTE: This PR does not cover all cases, and many scans may need to adjust the code to set the required projection, otherwise it will result in verification permission failure.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
