### PR TITLE
[core] Introduce 'cache.expire-after-write' to expire a max interval

### DIFF
--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -33,10 +33,16 @@ under the License.
             <td>Controls whether the catalog will cache databases, tables, manifests and partitions.</td>
         </tr>
         <tr>
-            <td><h5>cache.expiration-interval</h5></td>
+            <td><h5>cache.expire-after-access</h5></td>
             <td style="word-wrap: break-word;">10 min</td>
             <td>Duration</td>
-            <td>Controls the duration for which databases and tables in the catalog are cached.</td>
+            <td>Cache expiration policy: marks cache entries to expire after a specified duration has passed since their last access.</td>
+        </tr>
+        <tr>
+            <td><h5>cache.expire-after-write</h5></td>
+            <td style="word-wrap: break-word;">30 min</td>
+            <td>Duration</td>
+            <td>Cache expiration policy: marks cache entries to expire after a specified duration has passed since their last refresh.</td>
         </tr>
         <tr>
             <td><h5>cache.manifest.max-memory</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -89,12 +89,20 @@ public class CatalogOptions {
                     .withDescription(
                             "Controls whether the catalog will cache databases, tables, manifests and partitions.");
 
-    public static final ConfigOption<Duration> CACHE_EXPIRATION_INTERVAL_MS =
-            key("cache.expiration-interval")
+    public static final ConfigOption<Duration> CACHE_EXPIRE_AFTER_ACCESS =
+            key("cache.expire-after-access")
                     .durationType()
                     .defaultValue(Duration.ofMinutes(10))
+                    .withFallbackKeys("cache.expiration-interval")
                     .withDescription(
-                            "Controls the duration for which databases and tables in the catalog are cached.");
+                            "Cache expiration policy: marks cache entries to expire after a specified duration has passed since their last access.");
+
+    public static final ConfigOption<Duration> CACHE_EXPIRE_AFTER_WRITE =
+            key("cache.expire-after-write")
+                    .durationType()
+                    .defaultValue(Duration.ofMinutes(30))
+                    .withDescription(
+                            "Cache expiration policy: marks cache entries to expire after a specified duration has passed since their last refresh.");
 
     public static final ConfigOption<Long> CACHE_PARTITION_MAX_NUM =
             key("cache.partition.max-num")

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/TestableCachingCatalog.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/TestableCachingCatalog.java
@@ -29,7 +29,8 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
-import static org.apache.paimon.options.CatalogOptions.CACHE_EXPIRATION_INTERVAL_MS;
+import static org.apache.paimon.options.CatalogOptions.CACHE_EXPIRE_AFTER_ACCESS;
+import static org.apache.paimon.options.CatalogOptions.CACHE_EXPIRE_AFTER_WRITE;
 import static org.apache.paimon.options.CatalogOptions.CACHE_PARTITION_MAX_NUM;
 
 /**
@@ -41,14 +42,20 @@ public class TestableCachingCatalog extends CachingCatalog {
     private final Duration cacheExpirationInterval;
 
     public TestableCachingCatalog(Catalog catalog, Duration expirationInterval, Ticker ticker) {
-        super(catalog, createOptions(expirationInterval));
-        init(ticker);
-        this.cacheExpirationInterval = expirationInterval;
+        this(catalog, expirationInterval, Duration.ofDays(1), ticker);
     }
 
-    private static Options createOptions(Duration expirationInterval) {
+    public TestableCachingCatalog(
+            Catalog catalog, Duration expireAfterAccess, Duration expireAfterWrite, Ticker ticker) {
+        super(catalog, createOptions(expireAfterAccess, expireAfterWrite));
+        init(ticker);
+        this.cacheExpirationInterval = expireAfterAccess;
+    }
+
+    private static Options createOptions(Duration expireAfterAccess, Duration expireAfterWrite) {
         Options options = new Options();
-        options.set(CACHE_EXPIRATION_INTERVAL_MS, expirationInterval);
+        options.set(CACHE_EXPIRE_AFTER_ACCESS, expireAfterAccess);
+        options.set(CACHE_EXPIRE_AFTER_WRITE, expireAfterWrite);
         options.set(CACHE_PARTITION_MAX_NUM, 100L);
         return options;
     }


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

Our previous cache expiration never expired under frequent access, which can cause some problems, such as schema updates that prevent users from seeing the new schema of the table.

So in this PR:

1. Introduce 'cache.expire-after-write'.
2. Rename 'cache.expiration-interval' to 'cache.expire-after-access'.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
