### PR TITLE
[hive][clone] support clone file format including options

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/ListCloneFilesFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/ListCloneFilesFunction.java
@@ -146,6 +146,20 @@ public class ListCloneFilesFunction
                         existedTable.coreOptions().formatType()),
                 "source table format is not compatible with existed paimon table format.");
 
+        Map<String, String> sourceFormatOptions =
+                HiveCloneUtils.getIdentifierPrefixOptions(
+                        sourceSchema.options().get(FILE_FORMAT.key()), sourceSchema.options());
+        Map<String, String> existedFormatOptions =
+                HiveCloneUtils.getIdentifierPrefixOptions(
+                        existedTable.coreOptions().formatType(), existedTable.schema().options());
+        for (String key : sourceFormatOptions.keySet()) {
+            checkState(
+                    existedFormatOptions.containsKey(key)
+                            && Objects.equals(
+                                    sourceFormatOptions.get(key), existedFormatOptions.get(key)),
+                    "source table format options is not compatible with existed paimon table format options.");
+        }
+
         // check compression
         checkState(
                 Objects.equals(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/ListCloneFilesFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/ListCloneFilesFunction.java
@@ -43,7 +43,10 @@ import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
+import static org.apache.paimon.CoreOptions.FILE_COMPRESSION;
+import static org.apache.paimon.CoreOptions.FILE_FORMAT;
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
 import static org.apache.paimon.utils.Preconditions.checkState;
 
@@ -135,6 +138,20 @@ public class ListCloneFilesFunction
                 existedTable.coreOptions().bucket() == -1,
                 "Can not clone data to existed paimon table which bucket is not -1. Existed paimon table is "
                         + existedTable.name());
+
+        // check format
+        checkState(
+                Objects.equals(
+                        sourceSchema.options().get(FILE_FORMAT.key()),
+                        existedTable.coreOptions().formatType()),
+                "source table format is not compatible with existed paimon table format.");
+
+        // check compression
+        checkState(
+                Objects.equals(
+                        sourceSchema.options().get(FILE_COMPRESSION.key()),
+                        existedTable.coreOptions().fileCompression()),
+                "source table compression is not compatible with existed paimon table compression.");
 
         // check partition keys
         List<String> sourcePartitionFields = sourceSchema.partitionKeys();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/ListCloneFilesFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/ListCloneFilesFunction.java
@@ -45,7 +45,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.apache.paimon.CoreOptions.FILE_COMPRESSION;
 import static org.apache.paimon.CoreOptions.FILE_FORMAT;
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
 import static org.apache.paimon.utils.Preconditions.checkState;
@@ -145,27 +144,6 @@ public class ListCloneFilesFunction
                         sourceSchema.options().get(FILE_FORMAT.key()),
                         existedTable.coreOptions().formatType()),
                 "source table format is not compatible with existed paimon table format.");
-
-        Map<String, String> sourceFormatOptions =
-                HiveCloneUtils.getIdentifierPrefixOptions(
-                        sourceSchema.options().get(FILE_FORMAT.key()), sourceSchema.options());
-        Map<String, String> existedFormatOptions =
-                HiveCloneUtils.getIdentifierPrefixOptions(
-                        existedTable.coreOptions().formatType(), existedTable.schema().options());
-        for (String key : sourceFormatOptions.keySet()) {
-            checkState(
-                    existedFormatOptions.containsKey(key)
-                            && Objects.equals(
-                                    sourceFormatOptions.get(key), existedFormatOptions.get(key)),
-                    "source table format options is not compatible with existed paimon table format options.");
-        }
-
-        // check compression
-        checkState(
-                Objects.equals(
-                        sourceSchema.options().get(FILE_COMPRESSION.key()),
-                        existedTable.coreOptions().fileCompression()),
-                "source table compression is not compatible with existed paimon table compression.");
 
         // check partition keys
         List<String> sourcePartitionFields = sourceSchema.partitionKeys();

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveCloneUtils.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/migrate/HiveCloneUtils.java
@@ -265,7 +265,7 @@ public class HiveCloneUtils {
         return compression;
     }
 
-    private static Map<String, String> getIdentifierPrefixOptions(
+    public static Map<String, String> getIdentifierPrefixOptions(
             String formatIdentifier, Map<String, String> options) {
         Map<String, String> result = new HashMap<>();
         String prefix = formatIdentifier.toLowerCase() + ".";

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/CloneActionITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/CloneActionITCase.java
@@ -384,7 +384,7 @@ public class CloneActionITCase extends ActionITCaseBase {
 
     @Test
     public void testCloneWithExistedTable() throws Exception {
-        String format = "avro";
+        String format = randomFormat();
 
         TableEnvironment tEnv = tableEnvironmentBuilder().batchMode().build();
         tEnv.executeSql("CREATE CATALOG HIVE WITH ('type'='hive')");

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/CloneActionITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/CloneActionITCase.java
@@ -506,34 +506,34 @@ public class CloneActionITCase extends ActionITCaseBase {
                 "CREATE TABLE test.test_table (id string, id2 int, id3 int, PRIMARY KEY (id, id2, id3) NOT ENFORCED) "
                         + "PARTITIONED BY (id2, id3) with ('bucket' = '-1', 'file.format' = '"
                         + format
-                        + "','file.compression' = 'none');";
+                        + ");";
         // has different partition keys
         String ddl1 =
                 "CREATE TABLE test.test_table (id string, id2 int, id3 int) "
                         + "PARTITIONED BY (id, id3) with ('bucket' = '-1', 'file.format' = '"
                         + format
-                        + "','file.compression' = 'none');";
+                        + "');";
         // size of fields is different
         String ddl2 =
                 "CREATE TABLE test.test_table (id2 int, id3 int) "
                         + "PARTITIONED BY (id2, id3) with ('bucket' = '-1', 'file.format' = '"
                         + format
-                        + "','file.compression' = 'none');";
+                        + "');";
 
         // different format
         String ddl3 =
                 "CREATE TABLE test.test_table (id2 int, id3 int) "
                         + "PARTITIONED BY (id2, id3) with ('bucket' = '-1', 'file.format' = '"
                         + randomFormat(format)
-                        + "','file.compression' = 'none');";
+                        + "');";
 
         // normal
         String ddl4 =
                 "CREATE TABLE test.test_table (id string, id2 int, id3 int) "
                         + "PARTITIONED BY (id2, id3) with ('bucket' = '-1', 'file.format' = '"
                         + format
-                        + "','file.compression' = 'none');";
-        return new String[] {ddl0, ddl1, ddl2, ddl3};
+                        + "');";
+        return new String[] {ddl0, ddl1, ddl2, ddl3, ddl4};
     }
 
     private String[] exceptionMsg() {

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/CloneActionITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/CloneActionITCase.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -383,7 +384,7 @@ public class CloneActionITCase extends ActionITCaseBase {
 
     @Test
     public void testCloneWithExistedTable() throws Exception {
-        String format = randomFormat();
+        String format = "avro";
 
         TableEnvironment tEnv = tableEnvironmentBuilder().batchMode().build();
         tEnv.executeSql("CREATE CATALOG HIVE WITH ('type'='hive')");
@@ -407,7 +408,7 @@ public class CloneActionITCase extends ActionITCaseBase {
         tEnv.executeSql("CREATE DATABASE test");
         // create a paimon table with the same name
         int ddlIndex = ThreadLocalRandom.current().nextInt(0, 4);
-        tEnv.executeSql(ddls()[ddlIndex]);
+        tEnv.executeSql(ddls(format)[ddlIndex]);
 
         List<String> args =
                 new ArrayList<>(
@@ -428,7 +429,7 @@ public class CloneActionITCase extends ActionITCaseBase {
                                 "--target_catalog_conf",
                                 "warehouse=" + warehouse));
 
-        if (ddlIndex < 3) {
+        if (ddlIndex < 4) {
             assertThatThrownBy(() -> createAction(CloneAction.class, args).run())
                     .rootCause()
                     .hasMessageContaining(exceptionMsg()[ddlIndex]);
@@ -499,23 +500,39 @@ public class CloneActionITCase extends ActionITCaseBase {
         Assertions.assertThatList(r1).containsExactlyInAnyOrderElementsOf(r2);
     }
 
-    private String[] ddls() {
+    private String[] ddls(String format) {
         // has primary key
         String ddl0 =
                 "CREATE TABLE test.test_table (id string, id2 int, id3 int, PRIMARY KEY (id, id2, id3) NOT ENFORCED) "
-                        + "PARTITIONED BY (id2, id3) with ('bucket' = '-1');";
+                        + "PARTITIONED BY (id2, id3) with ('bucket' = '-1', 'file.format' = '"
+                        + format
+                        + "','file.compression' = 'none');";
         // has different partition keys
         String ddl1 =
                 "CREATE TABLE test.test_table (id string, id2 int, id3 int) "
-                        + "PARTITIONED BY (id, id3) with ('bucket' = '-1');";
+                        + "PARTITIONED BY (id, id3) with ('bucket' = '-1', 'file.format' = '"
+                        + format
+                        + "','file.compression' = 'none');";
         // size of fields is different
         String ddl2 =
                 "CREATE TABLE test.test_table (id2 int, id3 int) "
-                        + "PARTITIONED BY (id2, id3) with ('bucket' = '-1');";
-        // normal
+                        + "PARTITIONED BY (id2, id3) with ('bucket' = '-1', 'file.format' = '"
+                        + format
+                        + "','file.compression' = 'none');";
+
+        // different format
         String ddl3 =
+                "CREATE TABLE test.test_table (id2 int, id3 int) "
+                        + "PARTITIONED BY (id2, id3) with ('bucket' = '-1', 'file.format' = '"
+                        + randomFormat(format)
+                        + "','file.compression' = 'none');";
+
+        // normal
+        String ddl4 =
                 "CREATE TABLE test.test_table (id string, id2 int, id3 int) "
-                        + "PARTITIONED BY (id2, id3) with ('bucket' = '-1');";
+                        + "PARTITIONED BY (id2, id3) with ('bucket' = '-1', 'file.format' = '"
+                        + format
+                        + "','file.compression' = 'none');";
         return new String[] {ddl0, ddl1, ddl2, ddl3};
     }
 
@@ -523,7 +540,8 @@ public class CloneActionITCase extends ActionITCaseBase {
         return new String[] {
             "Can not clone data to existed paimon table which has primary keys",
             "source table partition keys is not compatible with existed paimon table partition keys.",
-            "source table partition keys is not compatible with existed paimon table partition keys."
+            "source table partition keys is not compatible with existed paimon table partition keys.",
+            "source table format is not compatible with existed paimon table format."
         };
     }
 
@@ -549,13 +567,18 @@ public class CloneActionITCase extends ActionITCaseBase {
     private String randomFormat() {
         ThreadLocalRandom random = ThreadLocalRandom.current();
         int i = random.nextInt(3);
-        if (i == 0) {
-            return "orc";
-        } else if (i == 1) {
-            return "parquet";
-        } else {
-            return "avro";
+        String[] formats = new String[] {"orc", "parquet", "avro"};
+        return formats[i];
+    }
+
+    private String randomFormat(String excludedFormat) {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        int i = random.nextInt(3);
+        String[] formats = new String[] {"orc", "parquet", "avro"};
+        if (Objects.equals(excludedFormat, formats[i])) {
+            return formats[(i + 1) % 3];
         }
+        return formats[i];
     }
 
     protected FileStoreTable paimonTable(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
support clone file format including options

Currently, the file format and related configurations of the source hive table are not cloned. The cloned target paimon table uses the default option 'file.format' =  'parquet', which will affect the subsequent writing of the paimon table. For example, after a hive table using orc is cloned to the paimon table and written again, the new file will be in parquet format, which is unexpected. This PR is to fix this problem.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->


### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
