### PR TITLE
[flink] Fix deletion vector support for postpone bucket tables

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactAction.java
@@ -277,41 +277,31 @@ public class CompactAction extends TableActionBase {
 
             bucketOptions = new HashMap<>(table.options());
             bucketOptions.put(CoreOptions.BUCKET.key(), String.valueOf(bucketNum));
-            // bucket-postpone files won't be read if deletion vectors are set
-            bucketOptions.put(CoreOptions.DELETION_VECTORS_ENABLED.key(), "false");
-            FileStoreTable tableForRead = table.copy(table.schema().copy(bucketOptions));
+            FileStoreTable realTable = table.copy(table.schema().copy(bucketOptions));
 
             LinkedHashMap<String, String> partitionSpec =
                     partitionComputer.generatePartValues(partition);
             Pair<DataStream<RowData>, DataStream<Committable>> sourcePair =
                     PostponeBucketCompactSplitSource.buildSource(
                             env,
-                            tableForRead.fullName() + partitionSpec,
-                            tableForRead.rowType(),
-                            tableForRead
-                                    .newReadBuilder()
-                                    .withPartitionFilter(partitionSpec)
-                                    .withBucket(BucketMode.POSTPONE_BUCKET),
+                            realTable,
+                            partitionSpec,
                             options.get(FlinkConnectorOptions.SCAN_PARALLELISM));
-
-            bucketOptions = new HashMap<>(table.options());
-            bucketOptions.put(CoreOptions.BUCKET.key(), String.valueOf(bucketNum));
-            FileStoreTable tableForWrite = table.copy(table.schema().copy(bucketOptions));
 
             DataStream<InternalRow> partitioned =
                     FlinkStreamPartitioner.partition(
                             FlinkSinkBuilder.mapToInternalRow(
-                                    sourcePair.getLeft(), tableForWrite.rowType()),
-                            new RowDataChannelComputer(tableForWrite.schema(), false),
+                                    sourcePair.getLeft(), realTable.rowType()),
+                            new RowDataChannelComputer(realTable.schema(), false),
                             null);
-            FixedBucketSink sink = new FixedBucketSink(tableForWrite, null, null);
+            FixedBucketSink sink = new FixedBucketSink(realTable, null, null);
             DataStream<Committable> written =
                     sink.doWrite(partitioned, commitUser, partitioned.getParallelism())
                             .forward()
                             .transform(
                                     "Rewrite compact committable",
                                     new CommittableTypeInfo(),
-                                    new RewritePostponeBucketCommittableOperator(tableForWrite));
+                                    new RewritePostponeBucketCommittableOperator(realTable));
             dataStreams.add(written);
             dataStreams.add(sourcePair.getRight());
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/postpone/PostponeBucketCompactSplitSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/postpone/PostponeBucketCompactSplitSource.java
@@ -28,13 +28,11 @@ import org.apache.paimon.flink.source.SimpleSourceSplit;
 import org.apache.paimon.flink.source.operator.ReadOperator;
 import org.apache.paimon.flink.utils.JavaTypeInfo;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.table.BucketMode;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.ChannelComputer;
 import org.apache.paimon.table.source.DataSplit;
-import org.apache.paimon.table.source.EndOfScanException;
-import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
-import org.apache.paimon.table.source.TableScan;
-import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Preconditions;
 
@@ -58,6 +56,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -71,10 +70,13 @@ public class PostponeBucketCompactSplitSource extends AbstractNonCoordinatedSour
     private static final Logger LOG =
             LoggerFactory.getLogger(PostponeBucketCompactSplitSource.class);
 
-    private final ReadBuilder readBuilder;
+    private final FileStoreTable table;
+    private final Map<String, String> partitionSpec;
 
-    public PostponeBucketCompactSplitSource(ReadBuilder readBuilder) {
-        this.readBuilder = readBuilder;
+    public PostponeBucketCompactSplitSource(
+            FileStoreTable table, Map<String, String> partitionSpec) {
+        this.table = table;
+        this.partitionSpec = partitionSpec;
     }
 
     @Override
@@ -90,50 +92,50 @@ public class PostponeBucketCompactSplitSource extends AbstractNonCoordinatedSour
 
     private class Reader extends AbstractNonCoordinatedSourceReader<Split> {
 
-        private final TableScan scan = readBuilder.newScan();
-
         @Override
         public InputStatus pollNext(ReaderOutput<Split> output) throws Exception {
-            try {
-                List<Split> splits = scan.plan().splits();
+            List<Split> splits =
+                    table.newSnapshotReader()
+                            .withPartitionFilter(partitionSpec)
+                            .withBucket(BucketMode.POSTPONE_BUCKET)
+                            .read()
+                            .splits();
 
-                for (Split split : splits) {
-                    DataSplit dataSplit = (DataSplit) split;
-                    List<DataFileMeta> files = new ArrayList<>(dataSplit.dataFiles());
-                    // we must replay the written records in exact order
-                    files.sort(Comparator.comparing(DataFileMeta::creationTime));
-                    for (DataFileMeta meta : files) {
-                        DataSplit s =
-                                DataSplit.builder()
-                                        .withPartition(dataSplit.partition())
-                                        .withBucket(dataSplit.bucket())
-                                        .withBucketPath(dataSplit.bucketPath())
-                                        .withTotalBuckets(dataSplit.totalBuckets())
-                                        .withDataFiles(Collections.singletonList(meta))
-                                        .isStreaming(false)
-                                        .build();
-                        output.collect(s);
-                    }
+            for (Split split : splits) {
+                DataSplit dataSplit = (DataSplit) split;
+                List<DataFileMeta> files = new ArrayList<>(dataSplit.dataFiles());
+                // we must replay the written records in exact order
+                files.sort(Comparator.comparing(DataFileMeta::creationTime));
+                for (DataFileMeta meta : files) {
+                    DataSplit s =
+                            DataSplit.builder()
+                                    .withPartition(dataSplit.partition())
+                                    .withBucket(dataSplit.bucket())
+                                    .withBucketPath(dataSplit.bucketPath())
+                                    .withTotalBuckets(dataSplit.totalBuckets())
+                                    .withDataFiles(Collections.singletonList(meta))
+                                    .isStreaming(false)
+                                    .build();
+                    output.collect(s);
                 }
-            } catch (EndOfScanException esf) {
-                LOG.info("Catching EndOfStreamException, the stream is finished.");
-                return InputStatus.END_OF_INPUT;
             }
-            return InputStatus.MORE_AVAILABLE;
+
+            return InputStatus.END_OF_INPUT;
         }
     }
 
     public static Pair<DataStream<RowData>, DataStream<Committable>> buildSource(
             StreamExecutionEnvironment env,
-            String name,
-            RowType rowType,
-            ReadBuilder readBuilder,
+            FileStoreTable table,
+            Map<String, String> partitionSpec,
             @Nullable Integer parallelism) {
         DataStream<Split> source =
                 env.fromSource(
-                                new PostponeBucketCompactSplitSource(readBuilder),
+                                new PostponeBucketCompactSplitSource(table, partitionSpec),
                                 WatermarkStrategy.noWatermarks(),
-                                "Compact split generator: " + name,
+                                String.format(
+                                        "Compact split generator: %s - %s",
+                                        table.fullName(), partitionSpec),
                                 new JavaTypeInfo<>(Split.class))
                         .forceNonParallel();
 
@@ -148,9 +150,12 @@ public class PostponeBucketCompactSplitSource extends AbstractNonCoordinatedSour
         return Pair.of(
                 new DataStream<>(source.getExecutionEnvironment(), partitioned)
                         .transform(
-                                "Compact split reader: " + name,
-                                InternalTypeInfo.of(LogicalTypeConversion.toLogicalType(rowType)),
-                                new ReadOperator(readBuilder, null)),
+                                String.format(
+                                        "Compact split reader: %s - %s",
+                                        table.fullName(), partitionSpec),
+                                InternalTypeInfo.of(
+                                        LogicalTypeConversion.toLogicalType(table.rowType())),
+                                new ReadOperator(table::newRead, null)),
                 source.forward()
                         .transform(
                                 "Remove new files",

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/postpone/RewritePostponeBucketCommittableOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/postpone/RewritePostponeBucketCommittableOperator.java
@@ -23,10 +23,12 @@ import org.apache.paimon.flink.sink.Committable;
 import org.apache.paimon.flink.utils.BoundedOneInputOperator;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFilePathFactory;
 import org.apache.paimon.io.DataIncrement;
+import org.apache.paimon.io.IndexIncrement;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.utils.FileStorePathFactory;
@@ -96,16 +98,13 @@ public class RewritePostponeBucketCommittableOperator
             for (Map.Entry<Integer, BucketFiles> bucketEntry :
                     partitionEntry.getValue().entrySet()) {
                 BucketFiles bucketFiles = bucketEntry.getValue();
-                CommitMessageImpl message =
-                        new CommitMessageImpl(
-                                partitionEntry.getKey(),
-                                bucketEntry.getKey(),
-                                bucketFiles.totalBuckets,
-                                DataIncrement.emptyIncrement(),
-                                bucketFiles.makeIncrement());
                 output.collect(
                         new StreamRecord<>(
-                                new Committable(checkpointId, Committable.Kind.FILE, message)));
+                                new Committable(
+                                        checkpointId,
+                                        Committable.Kind.FILE,
+                                        bucketFiles.makeMessage(
+                                                partitionEntry.getKey(), bucketEntry.getKey()))));
             }
         }
         bucketFiles.clear();
@@ -121,6 +120,8 @@ public class RewritePostponeBucketCommittableOperator
         private final List<DataFileMeta> compactBefore;
         private final List<DataFileMeta> compactAfter;
         private final List<DataFileMeta> changelogFiles;
+        private final List<IndexFileMeta> newIndexFiles;
+        private final List<IndexFileMeta> deletedIndexFiles;
 
         private BucketFiles(DataFilePathFactory pathFactory, FileIO fileIO) {
             this.pathFactory = pathFactory;
@@ -130,6 +131,8 @@ public class RewritePostponeBucketCommittableOperator
             this.compactBefore = new ArrayList<>();
             this.compactAfter = new ArrayList<>();
             this.changelogFiles = new ArrayList<>();
+            this.newIndexFiles = new ArrayList<>();
+            this.deletedIndexFiles = new ArrayList<>();
         }
 
         private void update(CommitMessageImpl message) {
@@ -157,13 +160,22 @@ public class RewritePostponeBucketCommittableOperator
             changelogFiles.addAll(message.newFilesIncrement().changelogFiles());
             changelogFiles.addAll(message.compactIncrement().changelogFiles());
 
+            newIndexFiles.addAll(message.indexIncrement().newIndexFiles());
+            deletedIndexFiles.addAll(message.indexIncrement().deletedIndexFiles());
+
             toDelete.forEach((fileName, path) -> fileIO.deleteQuietly(path));
         }
 
-        private CompactIncrement makeIncrement() {
+        private CommitMessageImpl makeMessage(BinaryRow partition, int bucket) {
             List<DataFileMeta> realCompactAfter = new ArrayList<>(newFiles.values());
             realCompactAfter.addAll(compactAfter);
-            return new CompactIncrement(compactBefore, realCompactAfter, changelogFiles);
+            return new CommitMessageImpl(
+                    partition,
+                    bucket,
+                    totalBuckets,
+                    DataIncrement.emptyIncrement(),
+                    new CompactIncrement(compactBefore, realCompactAfter, changelogFiles),
+                    new IndexIncrement(newIndexFiles, deletedIndexFiles));
         }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/MonitorSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/MonitorSource.java
@@ -229,7 +229,9 @@ public class MonitorSource extends AbstractNonCoordinatedSource<Split> {
                                 singleOutputStreamOperator, shuffleBucketWithPartition);
 
         return sourceDataStream.transform(
-                name + "-Reader", typeInfo, new ReadOperator(readBuilder, nestedProjectedRowData));
+                name + "-Reader",
+                typeInfo,
+                new ReadOperator(readBuilder::newRead, nestedProjectedRowData));
     }
 
     private static DataStream<Split> shuffleUnwareBucket(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PostponeBucketTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PostponeBucketTableITCase.java
@@ -550,6 +550,45 @@ public class PostponeBucketTableITCase extends AbstractTestBase {
         it.close();
     }
 
+    @Test
+    public void testDeletionVector() throws Exception {
+        String warehouse = getTempDirPath();
+        TableEnvironment tEnv =
+                tableEnvironmentBuilder()
+                        .batchMode()
+                        .setConf(TableConfigOptions.TABLE_DML_SYNC, true)
+                        .build();
+
+        tEnv.executeSql(
+                "CREATE CATALOG mycat WITH (\n"
+                        + "  'type' = 'paimon',\n"
+                        + "  'warehouse' = '"
+                        + warehouse
+                        + "'\n"
+                        + ")");
+        tEnv.executeSql("USE CATALOG mycat");
+        tEnv.executeSql(
+                "CREATE TABLE T (\n"
+                        + "  k INT,\n"
+                        + "  v INT,\n"
+                        + "  PRIMARY KEY (k) NOT ENFORCED\n"
+                        + ") WITH (\n"
+                        + "  'bucket' = '-2',\n"
+                        + "  'deletion-vectors.enabled' = 'true'\n"
+                        + ")");
+
+        tEnv.executeSql("INSERT INTO T VALUES (1, 10), (2, 20), (3, 30), (4, 40)").await();
+        tEnv.executeSql("CALL sys.compact(`table` => 'default.T')").await();
+        assertThat(collect(tEnv.executeSql("SELECT * FROM T")))
+                .containsExactlyInAnyOrder("+I[1, 10]", "+I[2, 20]", "+I[3, 30]", "+I[4, 40]");
+
+        tEnv.executeSql("INSERT INTO T VALUES (1, 11), (5, 51)").await();
+        tEnv.executeSql("CALL sys.compact(`table` => 'default.T')").await();
+        assertThat(collect(tEnv.executeSql("SELECT * FROM T")))
+                .containsExactlyInAnyOrder(
+                        "+I[1, 11]", "+I[2, 20]", "+I[3, 30]", "+I[4, 40]", "+I[5, 51]");
+    }
+
     private List<String> collect(TableResult result) throws Exception {
         List<String> ret = new ArrayList<>();
         try (CloseableIterator<Row> it = result.collect()) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PostponeBucketTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PostponeBucketTableITCase.java
@@ -587,6 +587,12 @@ public class PostponeBucketTableITCase extends AbstractTestBase {
         assertThat(collect(tEnv.executeSql("SELECT * FROM T")))
                 .containsExactlyInAnyOrder(
                         "+I[1, 11]", "+I[2, 20]", "+I[3, 30]", "+I[4, 40]", "+I[5, 51]");
+
+        tEnv.executeSql("INSERT INTO T VALUES (2, 52), (3, 32)").await();
+        tEnv.executeSql("CALL sys.compact(`table` => 'default.T')").await();
+        assertThat(collect(tEnv.executeSql("SELECT * FROM T")))
+                .containsExactlyInAnyOrder(
+                        "+I[1, 11]", "+I[2, 52]", "+I[3, 32]", "+I[4, 40]", "+I[5, 51]");
     }
 
     private List<String> collect(TableResult result) throws Exception {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
@@ -184,7 +184,7 @@ public class OperatorSourceTest {
 
     @Test
     public void testReadOperator() throws Exception {
-        ReadOperator readOperator = new ReadOperator(table.newReadBuilder(), null);
+        ReadOperator readOperator = new ReadOperator(() -> table.newReadBuilder().newRead(), null);
         OneInputStreamOperatorTestHarness<Split, RowData> harness =
                 new OneInputStreamOperatorTestHarness<>(readOperator);
         harness.setup(
@@ -206,7 +206,7 @@ public class OperatorSourceTest {
 
     @Test
     public void testReadOperatorMetricsRegisterAndUpdate() throws Exception {
-        ReadOperator readOperator = new ReadOperator(table.newReadBuilder(), null);
+        ReadOperator readOperator = new ReadOperator(() -> table.newReadBuilder().newRead(), null);
         OneInputStreamOperatorTestHarness<Split, RowData> harness =
                 new OneInputStreamOperatorTestHarness<>(readOperator);
         harness.setup(


### PR DESCRIPTION
### Purpose

Currently, deletion vectors are not working in postpone bucket tables, because compaction job does not handle index files correctly. This PR fixes the problem.

### Tests

* `PostponeBucketTableITCase#testDeletionVector`

### API and Format

No format changes.

### Documentation

No new feature.
