### PR TITLE
[core] Make with MetricRegistry public

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/metrics/MetricRegistry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metrics/MetricRegistry.java
@@ -18,21 +18,24 @@
 
 package org.apache.paimon.metrics;
 
+import org.apache.paimon.annotation.Public;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-/** Factory to create {@link MetricGroup}s. */
-public abstract class MetricRegistry {
+/**
+ * Factory to create {@link MetricGroup}s.
+ *
+ * @since 1.2.0
+ */
+@Public
+public interface MetricRegistry {
 
-    private static final String KEY_TABLE = "table";
-
-    public MetricGroup tableMetricGroup(String groupName, String tableName) {
+    default MetricGroup createTableMetricGroup(String groupName, String tableName) {
         Map<String, String> variables = new LinkedHashMap<>();
-        variables.put(KEY_TABLE, tableName);
-
+        variables.put("table", tableName);
         return createMetricGroup(groupName, variables);
     }
 
-    protected abstract MetricGroup createMetricGroup(
-            String groupName, Map<String, String> variables);
+    MetricGroup createMetricGroup(String groupName, Map<String, String> variables);
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/CommitMetrics.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/CommitMetrics.java
@@ -32,7 +32,7 @@ public class CommitMetrics {
     private final MetricGroup metricGroup;
 
     public CommitMetrics(MetricRegistry registry, String tableName) {
-        this.metricGroup = registry.tableMetricGroup(GROUP_NAME, tableName);
+        this.metricGroup = registry.createTableMetricGroup(GROUP_NAME, tableName);
         registerGenericCommitMetrics();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/CompactionMetrics.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/CompactionMetrics.java
@@ -62,7 +62,7 @@ public class CompactionMetrics {
     private Counter compactionsQueuedCounter;
 
     public CompactionMetrics(MetricRegistry registry, String tableName) {
-        this.metricGroup = registry.tableMetricGroup(GROUP_NAME, tableName);
+        this.metricGroup = registry.createTableMetricGroup(GROUP_NAME, tableName);
         this.reporters = new HashMap<>();
         this.compactTimers = new ConcurrentHashMap<>();
         this.compactionTimes = new ConcurrentLinkedQueue<>();

--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanMetrics.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanMetrics.java
@@ -43,7 +43,7 @@ public class ScanMetrics {
     private ScanStats latestScan;
 
     public ScanMetrics(MetricRegistry registry, String tableName) {
-        metricGroup = registry.tableMetricGroup(GROUP_NAME, tableName);
+        metricGroup = registry.createTableMetricGroup(GROUP_NAME, tableName);
         metricGroup.gauge(
                 LAST_SCAN_DURATION, () -> latestScan == null ? 0L : latestScan.getDuration());
         durationHistogram = metricGroup.histogram(SCAN_DURATION, HISTOGRAM_WINDOW_SIZE);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/WriterBufferMetric.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/WriterBufferMetric.java
@@ -42,7 +42,7 @@ public class WriterBufferMetric {
             Supplier<MemoryPoolFactory> memoryPoolFactorySupplier,
             MetricRegistry metricRegistry,
             String tableName) {
-        metricGroup = metricRegistry.tableMetricGroup(GROUP_NAME, tableName);
+        metricGroup = metricRegistry.createTableMetricGroup(GROUP_NAME, tableName);
         numWriters = new AtomicInteger(0);
         metricGroup.gauge(NUM_WRITERS, numWriters::get);
         metricGroup.gauge(

--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -108,7 +108,7 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
     @Override
     public InnerTableRead newRead() {
         RawFileSplitRead read = store().newRead();
-        return new AbstractDataTableRead<InternalRow>(schema()) {
+        return new AbstractDataTableRead(schema()) {
 
             @Override
             protected InnerTableRead innerWithFilter(Predicate predicate) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
@@ -296,9 +296,9 @@ public class FallbackReadFileStoreTable extends DelegatedFileStoreTable {
         }
 
         @Override
-        public Scan withMetricsRegistry(MetricRegistry metricRegistry) {
-            mainScan.withMetricsRegistry(metricRegistry);
-            fallbackScan.withMetricsRegistry(metricRegistry);
+        public Scan withMetricRegistry(MetricRegistry metricRegistry) {
+            mainScan.withMetricRegistry(metricRegistry);
+            fallbackScan.withMetricRegistry(metricRegistry);
             return this;
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/InnerTableCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/InnerTableCommit.java
@@ -44,5 +44,6 @@ public interface InnerTableCommit extends StreamTableCommit, BatchTableCommit {
      */
     InnerTableCommit ignoreEmptyCommit(boolean ignoreEmptyCommit);
 
+    @Override
     InnerTableCommit withMetricRegistry(MetricRegistry registry);
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommit.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.sink;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.table.Table;
 
 import java.util.List;
@@ -34,6 +35,9 @@ import java.util.List;
  */
 @Public
 public interface TableCommit extends AutoCloseable {
+
+    /** Set {@link MetricRegistry} to table commit. */
+    TableCommit withMetricRegistry(MetricRegistry registry);
 
     /** Abort an unsuccessful commit. The data files will be deleted. */
     void abort(List<CommitMessage> commitMessages);

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWrite.java
@@ -76,6 +76,6 @@ public interface TableWrite extends AutoCloseable {
      */
     void compact(BinaryRow partition, int bucket, boolean fullCompaction) throws Exception;
 
-    /** With metrics to measure compaction. */
+    /** Set {@link MetricRegistry} to table write. */
     TableWrite withMetricRegistry(MetricRegistry registry);
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.util.Optional;
 
 /** A {@link InnerTableRead} for data table. */
-public abstract class AbstractDataTableRead<T> implements InnerTableRead {
+public abstract class AbstractDataTableRead implements InnerTableRead {
 
     private final DefaultValueAssigner defaultValueAssigner;
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
@@ -113,7 +113,7 @@ abstract class AbstractDataTableScan implements DataTableScan {
         return this;
     }
 
-    public AbstractDataTableScan withMetricsRegistry(MetricRegistry metricsRegistry) {
+    public AbstractDataTableScan withMetricRegistry(MetricRegistry metricsRegistry) {
         snapshotReader.withMetricRegistry(metricsRegistry);
         return this;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableRead.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.table.source;
 
+import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.types.RowType;
@@ -55,6 +56,11 @@ public interface InnerTableRead extends TableRead {
 
     @Override
     default TableRead executeFilter() {
+        return this;
+    }
+
+    @Override
+    default InnerTableRead withMetricRegistry(MetricRegistry registry) {
         return this;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableScan.java
@@ -59,7 +59,8 @@ public interface InnerTableScan extends TableScan {
         return this;
     }
 
-    default InnerTableScan withMetricsRegistry(MetricRegistry metricRegistry) {
+    @Override
+    default InnerTableScan withMetricRegistry(MetricRegistry metricRegistry) {
         // do nothing, should implement this if need
         return this;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
@@ -46,7 +46,7 @@ import java.util.function.Supplier;
 /**
  * An abstraction layer above {@link MergeFileSplitRead} to provide reading of {@link InternalRow}.
  */
-public final class KeyValueTableRead extends AbstractDataTableRead<KeyValue> {
+public final class KeyValueTableRead extends AbstractDataTableRead {
 
     private final List<SplitReadProvider> readProviders;
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/TableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/TableRead.java
@@ -22,6 +22,7 @@ import org.apache.paimon.annotation.Public;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.mergetree.compact.ConcatRecordReader;
+import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.operation.SplitRead;
 import org.apache.paimon.reader.ReaderSupplier;
 import org.apache.paimon.reader.RecordReader;
@@ -37,6 +38,9 @@ import java.util.List;
  */
 @Public
 public interface TableRead {
+
+    /** Set {@link MetricRegistry} to table read. */
+    TableRead withMetricRegistry(MetricRegistry registry);
 
     TableRead executeFilter();
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/TableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/TableScan.java
@@ -21,6 +21,7 @@ package org.apache.paimon.table.source;
 import org.apache.paimon.annotation.Public;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.manifest.PartitionEntry;
+import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.table.Table;
 
 import java.util.List;
@@ -33,6 +34,9 @@ import java.util.stream.Collectors;
  */
 @Public
 public interface TableScan {
+
+    /** Set {@link MetricRegistry} to table scan. */
+    TableScan withMetricRegistry(MetricRegistry registry);
 
     /** Plan splits, throws {@link EndOfScanException} if the scan is ended. */
     Plan plan();

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
@@ -450,8 +450,8 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
         }
 
         @Override
-        public InnerTableScan withMetricsRegistry(MetricRegistry metricsRegistry) {
-            batchScan.withMetricsRegistry(metricsRegistry);
+        public InnerTableScan withMetricRegistry(MetricRegistry metricsRegistry) {
+            batchScan.withMetricRegistry(metricsRegistry);
             return this;
         }
 
@@ -565,8 +565,8 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
         }
 
         @Override
-        public StreamDataTableScan withMetricsRegistry(MetricRegistry metricsRegistry) {
-            streamScan.withMetricsRegistry(metricsRegistry);
+        public StreamDataTableScan withMetricRegistry(MetricRegistry metricsRegistry) {
+            streamScan.withMetricRegistry(metricsRegistry);
             return this;
         }
 

--- a/paimon-core/src/test/java/org/apache/paimon/metrics/MetricGroupTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/metrics/MetricGroupTest.java
@@ -30,7 +30,7 @@ public class MetricGroupTest {
     @Test
     public void testGroupRegisterMetrics() {
         TestMetricRegistry registry = new TestMetricRegistry();
-        MetricGroup group = registry.tableMetricGroup("commit", "myTable");
+        MetricGroup group = registry.createTableMetricGroup("commit", "myTable");
 
         // these will fail is the registration is propagated
         group.counter("testcounter");
@@ -51,7 +51,7 @@ public class MetricGroupTest {
     public void testTolerateMetricNameCollisions() {
         final String name = "abctestname";
         TestMetricRegistry registry = new TestMetricRegistry();
-        MetricGroup group = registry.tableMetricGroup("commit", "myTable");
+        MetricGroup group = registry.createTableMetricGroup("commit", "myTable");
 
         Counter counter = group.counter(name);
         // return the old one with the metric name collision

--- a/paimon-core/src/test/java/org/apache/paimon/metrics/TestMetricRegistry.java
+++ b/paimon-core/src/test/java/org/apache/paimon/metrics/TestMetricRegistry.java
@@ -21,10 +21,10 @@ package org.apache.paimon.metrics;
 import java.util.Map;
 
 /** Implementation of {@link MetricRegistry} for tests. */
-public class TestMetricRegistry extends MetricRegistry {
+public class TestMetricRegistry implements MetricRegistry {
 
     @Override
-    protected MetricGroup createMetricGroup(String groupName, Map<String, String> variables) {
+    public MetricGroup createMetricGroup(String groupName, Map<String, String> variables) {
         return new MetricGroupImpl(groupName, variables);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupCompactDiffRead.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupCompactDiffRead.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.flink.lookup;
 
-import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.operation.MergeFileSplitRead;
@@ -38,7 +37,7 @@ import java.io.IOException;
 import static org.apache.paimon.table.source.KeyValueTableRead.unwrap;
 
 /** An {@link InnerTableRead} that reads the data changed before and after compaction. */
-public class LookupCompactDiffRead extends AbstractDataTableRead<KeyValue> {
+public class LookupCompactDiffRead extends AbstractDataTableRead {
     private final SplitRead<InternalRow> fullPhaseMergeRead;
     private final SplitRead<InternalRow> incrementalDiffRead;
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/metrics/FlinkMetricRegistry.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/metrics/FlinkMetricRegistry.java
@@ -24,7 +24,7 @@ import org.apache.paimon.metrics.MetricRegistry;
 import java.util.Map;
 
 /** {@link MetricRegistry} to create {@link FlinkMetricGroup}. */
-public class FlinkMetricRegistry extends MetricRegistry {
+public class FlinkMetricRegistry implements MetricRegistry {
 
     private final org.apache.flink.metrics.MetricGroup group;
 
@@ -33,7 +33,7 @@ public class FlinkMetricRegistry extends MetricRegistry {
     }
 
     @Override
-    protected MetricGroup createMetricGroup(String groupName, Map<String, String> variables) {
+    public MetricGroup createMetricGroup(String groupName, Map<String, String> variables) {
         return new FlinkMetricGroup(group, groupName, variables);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileStoreSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileStoreSource.java
@@ -82,7 +82,7 @@ public class ContinuousFileStoreSource extends FlinkSource {
         StreamTableScan scan = readBuilder.newStreamScan();
         if (metricGroup(context) != null) {
             ((StreamDataTableScan) scan)
-                    .withMetricsRegistry(new FlinkMetricRegistry(context.metricGroup()));
+                    .withMetricRegistry(new FlinkMetricRegistry(context.metricGroup()));
         }
         scan.restore(nextSnapshotId);
         return buildEnumerator(context, splits, nextSnapshotId, scan);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/LogHybridSourceFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/LogHybridSourceFactory.java
@@ -132,7 +132,7 @@ public class LogHybridSourceFactory
                 // register scan metrics
                 if (context.metricGroup() != null) {
                     ((StreamDataTableScan) scan)
-                            .withMetricsRegistry(new FlinkMetricRegistry(context.metricGroup()));
+                            .withMetricRegistry(new FlinkMetricRegistry(context.metricGroup()));
                 }
                 splits = splitGenerator.createSplits(scan.plan());
                 Long nextSnapshotId = scan.checkpoint();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSource.java
@@ -93,7 +93,7 @@ public class StaticFileStoreSource extends FlinkSource {
         // register scan metrics
         if (context.metricGroup() != null) {
             ((InnerTableScan) scan)
-                    .withMetricsRegistry(new FlinkMetricRegistry(context.metricGroup()));
+                    .withMetricRegistry(new FlinkMetricRegistry(context.metricGroup()));
         }
         return splitGenerator.createSplits(scan.plan());
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumeratorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumeratorTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.source;
 
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.manifest.PartitionEntry;
+import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.source.DataFilePlan;
 import org.apache.paimon.table.source.DataSplit;
@@ -893,6 +894,11 @@ public class ContinuousFileSplitEnumeratorTest extends FileSplitEnumeratorTestBa
             this.results = results;
             this.nextSnapshotId = null;
             this.nextSnapshotIdForConsumer = null;
+        }
+
+        @Override
+        public TableScan withMetricRegistry(MetricRegistry registry) {
+            return this;
         }
 
         @Override

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -68,7 +68,7 @@ abstract class PaimonBaseScan(
     readBuilder
       .newScan()
       .asInstanceOf[InnerTableScan]
-      .withMetricsRegistry(paimonMetricsRegistry)
+      .withMetricRegistry(paimonMetricsRegistry)
       .plan()
       .splits()
       .asScala

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/metric/SparkMetricRegistry.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/metric/SparkMetricRegistry.scala
@@ -32,7 +32,7 @@ case class SparkMetricRegistry() extends MetricRegistry {
 
   private val metricGroups = mutable.Map.empty[String, MetricGroup]
 
-  override protected def createMetricGroup(
+  override def createMetricGroup(
       groupName: String,
       variables: util.Map[String, String]): MetricGroup = {
     val metricGroup = new MetricGroupImpl(groupName, variables)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Public `withMetricRegistry` in TableRead, TableScan, TableWrite and TableCommit.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
