### PR TITLE
[Bug] Fix bug of redundant mark partition done

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
@@ -53,11 +53,15 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
      * Filter out all {@link GlobalCommitT} which have committed, and commit the remaining {@link
      * GlobalCommitT}.
      */
-    int filterAndCommit(List<GlobalCommitT> globalCommittables, boolean checkAppendFiles)
+    int filterAndCommit(
+            List<GlobalCommitT> globalCommittables,
+            boolean checkAppendFiles,
+            boolean recoveryFromState)
             throws IOException;
 
-    default int filterAndCommit(List<GlobalCommitT> globalCommittables) throws IOException {
-        return filterAndCommit(globalCommittables, true);
+    default int filterAndCommitFromState(List<GlobalCommitT> globalCommittables)
+            throws IOException {
+        return filterAndCommit(globalCommittables, true, true);
     }
 
     Map<Long, List<CommitT>> groupByCheckpoint(Collection<CommitT> committables);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
@@ -210,7 +210,7 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
             // So when `endInput` is called, we must check if the corresponding snapshot exists.
             // However, if the snapshot does not exist, then append files must be new files. So
             // there is no need to check for duplicated append files.
-            committer.filterAndCommit(committables, false);
+            committer.filterAndCommit(committables, false, false);
         } else {
             committer.commit(committables);
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RestoreAndFailCommittableStateManager.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RestoreAndFailCommittableStateManager.java
@@ -79,7 +79,7 @@ public class RestoreAndFailCommittableStateManager<GlobalCommitT>
 
     private void recover(List<GlobalCommitT> committables, Committer<?, GlobalCommitT> committer)
             throws Exception {
-        int numCommitted = committer.filterAndCommit(committables);
+        int numCommitted = committer.filterAndCommitFromState(committables);
         if (numCommitted > 0) {
             throw new RuntimeException(
                     "This exception is intentionally thrown "

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
@@ -115,9 +115,12 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
 
     @Override
     public int filterAndCommit(
-            List<ManifestCommittable> globalCommittables, boolean checkAppendFiles) {
+            List<ManifestCommittable> globalCommittables,
+            boolean checkAppendFiles,
+            boolean recoveryFromState) {
         int committed = commit.filterAndCommitMultiple(globalCommittables, checkAppendFiles);
-        partitionListeners.notifyCommittable(globalCommittables);
+        partitionListeners.notifyCommittable(globalCommittables, recoveryFromState);
+
         return committed;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
@@ -178,14 +178,15 @@ public class StoreMultiCommitter
 
     @Override
     public int filterAndCommit(
-            List<WrappedManifestCommittable> globalCommittables, boolean checkAppendFiles)
-            throws IOException {
+            List<WrappedManifestCommittable> globalCommittables,
+            boolean checkAppendFiles,
+            boolean recoveryFromState) {
         int result = 0;
         for (Map.Entry<Identifier, List<ManifestCommittable>> entry :
                 groupByTable(globalCommittables).entrySet()) {
             result +=
                     getStoreCommitter(entry.getKey())
-                            .filterAndCommit(entry.getValue(), checkAppendFiles);
+                            .filterAndCommit(entry.getValue(), checkAppendFiles, recoveryFromState);
         }
         return result;
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionListener.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionListener.java
@@ -26,7 +26,7 @@ import java.util.List;
 /** The partition listener. */
 public interface PartitionListener extends Closeable {
 
-    void notifyCommittable(List<ManifestCommittable> committables);
+    void notifyCommittable(List<ManifestCommittable> committables, boolean recoverFromState);
 
     void snapshotState() throws Exception;
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionListeners.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionListeners.java
@@ -39,7 +39,14 @@ public class PartitionListeners implements Closeable {
 
     public void notifyCommittable(List<ManifestCommittable> committables) {
         for (PartitionListener trigger : listeners) {
-            trigger.notifyCommittable(committables);
+            trigger.notifyCommittable(committables, false);
+        }
+    }
+
+    public void notifyCommittable(
+            List<ManifestCommittable> committables, boolean recoveryFromState) {
+        for (PartitionListener trigger : listeners) {
+            trigger.notifyCommittable(committables, recoveryFromState);
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionMarkDone.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionMarkDone.java
@@ -133,7 +133,11 @@ public class PartitionMarkDone implements PartitionListener {
     }
 
     @Override
-    public void notifyCommittable(List<ManifestCommittable> committables) {
+    public void notifyCommittable(
+            List<ManifestCommittable> committables, boolean recoverFromState) {
+        if (recoverFromState) {
+            return;
+        }
         if (partitionMarkDoneActionMode == PartitionMarkDoneActionMode.WATERMARK) {
             markDoneByWatermark(committables);
         } else {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/ReportPartStatsListener.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/ReportPartStatsListener.java
@@ -85,7 +85,8 @@ public class ReportPartStatsListener implements PartitionListener {
         this.idleTime = idleTime;
     }
 
-    public void notifyCommittable(List<ManifestCommittable> committables) {
+    public void notifyCommittable(
+            List<ManifestCommittable> committables, boolean recoverFromCheckpoint) {
         Set<String> partition = new HashSet<>();
         boolean endInput = false;
         for (ManifestCommittable committable : committables) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

In our production environment, we use Flink bounded stream job write data to Paimon table. We use the 'partition mark done' feature to make downstream knows that our Flink bounded stream job has finished. But we found multi partition mark down will be trigger when :
1、Some writer task has finished.
2、Enable checkpoint.
3、Failover.
![image](https://github.com/user-attachments/assets/5be9b792-f4ff-41b1-9b6b-cb62384b634b)
![image](https://github.com/user-attachments/assets/4ea969b6-3065-477b-90e8-b2cc865ff138)
![image](https://github.com/user-attachments/assets/061e0fd3-825b-4662-b5d4-da3076c28e5c)
![image](https://github.com/user-attachments/assets/08ee8cf8-f76d-4c36-a16a-49356265c83a)
![image](https://github.com/user-attachments/assets/a93ac4df-89df-4f0c-b3fb-ecf3b9db7543)

After troubleshooting, we found the reason is when some wirte task finish, follow code will be called:
![image](https://github.com/user-attachments/assets/f89f7db0-6e4d-42c7-9ff3-d23fa7baec85)

Then when failover, the committer operator will mark partition done:
![image](https://github.com/user-attachments/assets/0425bdc7-1709-4c35-b572-c84151268031)

Finally, Our downstream started consuming before the Flink bounded stream job was completely finished, resulting in data loss online.

So, after discuss offline, we think when failover, no need to call PartitionListeners#notifyCommittable.


<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
