### PR TITLE
[parquet] Fix timestamp type and decimal type, if the file schema is not correctly match the schema in metadata

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetSplitReaderUtil.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetSplitReaderUtil.java
@@ -60,7 +60,6 @@ import org.apache.parquet.io.PrimitiveColumnIO;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.InvalidSchemaException;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
-import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 
@@ -149,10 +148,6 @@ public class ParquetSplitReaderUtil {
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
                 int precision = DataTypeChecks.getPrecision(fieldType);
                 if (precision > 6) {
-                    checkArgument(
-                            typeName == PrimitiveType.PrimitiveTypeName.INT96,
-                            "Unexpected type: %s",
-                            typeName);
                     return new HeapTimestampVector(batchSize);
                 } else {
                     return new HeapLongVector(batchSize);
@@ -160,31 +155,10 @@ public class ParquetSplitReaderUtil {
             case DECIMAL:
                 DecimalType decimalType = (DecimalType) fieldType;
                 if (ParquetSchemaConverter.is32BitDecimal(decimalType.getPrecision())) {
-                    checkArgument(
-                            (typeName == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY
-                                            || typeName == PrimitiveType.PrimitiveTypeName.INT32)
-                                    && primitiveType.getLogicalTypeAnnotation()
-                                            instanceof DecimalLogicalTypeAnnotation,
-                            "Unexpected type: %s",
-                            typeName);
                     return new HeapIntVector(batchSize);
                 } else if (ParquetSchemaConverter.is64BitDecimal(decimalType.getPrecision())) {
-                    checkArgument(
-                            (typeName == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY
-                                            || typeName == PrimitiveType.PrimitiveTypeName.INT64)
-                                    && primitiveType.getLogicalTypeAnnotation()
-                                            instanceof DecimalLogicalTypeAnnotation,
-                            "Unexpected type: %s",
-                            typeName);
                     return new HeapLongVector(batchSize);
                 } else {
-                    checkArgument(
-                            (typeName == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY
-                                            || typeName == PrimitiveType.PrimitiveTypeName.BINARY)
-                                    && primitiveType.getLogicalTypeAnnotation()
-                                            instanceof DecimalLogicalTypeAnnotation,
-                            "Unexpected type: %s",
-                            typeName);
                     return new HeapBytesVector(batchSize);
                 }
             case ARRAY:

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetVectorUpdaterFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetVectorUpdaterFactory.java
@@ -700,9 +700,9 @@ public class ParquetVectorUpdaterFactory {
         protected void putDecimal(WritableColumnVector values, int offset, BigDecimal decimal) {
             int precision = paimonType.getPrecision();
             if (ParquetSchemaConverter.is32BitDecimal(precision)) {
-                ((HeapIntVector) values).setInt(offset, decimal.intValue());
+                ((HeapIntVector) values).setInt(offset, decimal.unscaledValue().intValue());
             } else if (ParquetSchemaConverter.is64BitDecimal(precision)) {
-                ((HeapLongVector) values).setLong(offset, decimal.longValue());
+                ((HeapLongVector) values).setLong(offset, decimal.unscaledValue().longValue());
             } else {
                 byte[] bytes = decimal.unscaledValue().toByteArray();
                 ((WritableBytesVector) values).putByteArray(offset, bytes, 0, bytes.length);

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedColumnReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedColumnReader.java
@@ -18,6 +18,13 @@
 
 package org.apache.paimon.format.parquet.reader;
 
+import org.apache.paimon.data.columnar.BooleanColumnVector;
+import org.apache.paimon.data.columnar.BytesColumnVector;
+import org.apache.paimon.data.columnar.ColumnVector;
+import org.apache.paimon.data.columnar.DoubleColumnVector;
+import org.apache.paimon.data.columnar.FloatColumnVector;
+import org.apache.paimon.data.columnar.IntColumnVector;
+import org.apache.paimon.data.columnar.LongColumnVector;
 import org.apache.paimon.data.columnar.writable.WritableColumnVector;
 import org.apache.paimon.data.columnar.writable.WritableIntVector;
 import org.apache.paimon.types.DataType;
@@ -42,6 +49,7 @@ import org.apache.parquet.schema.PrimitiveType;
 
 import java.io.IOException;
 
+import static org.apache.paimon.types.DataTypeRoot.FLOAT;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
 
 /** Decoder to return values from a single column. */
@@ -108,8 +116,28 @@ public class VectorizedColumnReader {
     }
 
     private boolean isLazyDecodingSupported(
-            PrimitiveType.PrimitiveTypeName typeName, DataType paimonType) {
-        return true;
+            PrimitiveType.PrimitiveTypeName typeName, ColumnVector columnVector) {
+        boolean isSupported = false;
+        switch (typeName) {
+            case INT32:
+                isSupported = columnVector instanceof IntColumnVector;
+                break;
+            case INT64:
+                isSupported = columnVector instanceof LongColumnVector;
+                break;
+            case FLOAT:
+                isSupported = columnVector instanceof FloatColumnVector;
+                break;
+            case DOUBLE:
+                isSupported = columnVector instanceof DoubleColumnVector;
+                break;
+            case BOOLEAN:
+                isSupported = columnVector instanceof BooleanColumnVector;
+                break;
+            case BINARY:
+                isSupported = columnVector instanceof BytesColumnVector;
+        }
+        return isSupported;
     }
 
     /** Reads `total` rows from this columnReader into column. */
@@ -176,7 +204,7 @@ public class VectorizedColumnReader {
                 // the values to add microseconds precision.
                 if (column.hasDictionary()
                         || (startRowId == pageFirstRowIndex
-                                && isLazyDecodingSupported(typeName, type))) {
+                                && isLazyDecodingSupported(typeName, column))) {
                     column.setDictionary(new ParquetDictionary(dictionary));
                 } else {
                     updater.decodeDictionaryIds(

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/FileTypeNotMatchReadTypeTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/FileTypeNotMatchReadTypeTest.java
@@ -56,6 +56,9 @@ public class FileTypeNotMatchReadTypeTest {
             int writePrecision = RANDOM.nextInt(10);
             int readPrecision = writePrecision == 0 ? 0 : RANDOM.nextInt(writePrecision);
 
+            // precision 0-3 and 3-6 are all long type (INT64) in file.
+            // but precision 0-3 is TIMESTAMP_MICROS and 3-6 is TIMESTAMP_MILLIS in file.
+            // so we need to set readPrecision to 4 if writePrecision is 4-6.
             if (readPrecision <= 3 && writePrecision > 3) {
                 readPrecision = 4;
             }

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/FileTypeNotMatchReadTypeTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/FileTypeNotMatchReadTypeTest.java
@@ -107,10 +107,9 @@ public class FileTypeNotMatchReadTypeTest {
                             new LocalOutputFile(new File(fileWholePath).toPath()), rowTypeWrite);
 
             ParquetWriter<InternalRow> parquetWriter = parquetRowDataBuilder.build();
-            Decimal decimal = Decimal.fromBigDecimal(
-                    new java.math.BigDecimal(1.0), writePrecision, 0);
-            parquetWriter.write(
-                    GenericRow.of(decimal));
+            Decimal decimal =
+                    Decimal.fromBigDecimal(new java.math.BigDecimal(1.0), writePrecision, 0);
+            parquetWriter.write(GenericRow.of(decimal));
             parquetWriter.write(
                     GenericRow.of(
                             Decimal.fromBigDecimal(

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/FileTypeNotMatchReadTypeTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/FileTypeNotMatchReadTypeTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.parquet.reader;
+
+import org.apache.paimon.data.Decimal;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.format.FormatReaderContext;
+import org.apache.paimon.format.parquet.ParquetReaderFactory;
+import org.apache.paimon.format.parquet.writer.ParquetRowDataBuilder;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.reader.FileRecordReader;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.io.LocalOutputFile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test field type not match correctly with read type. */
+public class FileTypeNotMatchReadTypeTest {
+
+    private static final Random RANDOM = new Random();
+    @TempDir private Path tempDir;
+
+    @Test
+    public void testTimestamp() throws Exception {
+        String fileName = "test.parquet";
+        String fileWholePath = tempDir + "/" + fileName;
+        for (int i = 0; i < 100; i++) {
+            int writePrecision = RANDOM.nextInt(10);
+            int readPrecision = writePrecision == 0 ? 0 : RANDOM.nextInt(writePrecision);
+
+            if (readPrecision <= 3 && writePrecision > 3) {
+                readPrecision = 4;
+            }
+
+            RowType rowTypeWrite = RowType.of(DataTypes.TIMESTAMP(writePrecision));
+            RowType rowTypeRead = RowType.of(DataTypes.TIMESTAMP(readPrecision));
+
+            ParquetRowDataBuilder parquetRowDataBuilder =
+                    new ParquetRowDataBuilder(
+                            new LocalOutputFile(new File(fileWholePath).toPath()), rowTypeWrite);
+
+            ParquetWriter<InternalRow> parquetWriter = parquetRowDataBuilder.build();
+            Timestamp timestamp = Timestamp.now();
+            parquetWriter.write(GenericRow.of(timestamp));
+            parquetWriter.write(GenericRow.of(Timestamp.now()));
+            parquetWriter.close();
+
+            ParquetReaderFactory parquetReaderFactory =
+                    new ParquetReaderFactory(new Options(), rowTypeRead, 100, null);
+
+            File file = new File(fileWholePath);
+            FileRecordReader<InternalRow> fileRecordReader =
+                    parquetReaderFactory.createReader(
+                            new FormatReaderContext(
+                                    LocalFileIO.create(),
+                                    new org.apache.paimon.fs.Path(tempDir.toString(), fileName),
+                                    file.length()));
+
+            InternalRow row = fileRecordReader.readBatch().next();
+            Timestamp getTimestamp = row.getTimestamp(0, readPrecision);
+            assertThat(timestamp.getMillisecond()).isEqualTo(getTimestamp.getMillisecond());
+            file.delete();
+        }
+    }
+
+    @Test
+    public void testDecimal() throws Exception {
+        String fileName = "test.parquet";
+        String fileWholePath = tempDir + "/" + fileName;
+        for (int i = 0; i < 100; i++) {
+            int writePrecision = 1 + RANDOM.nextInt(30);
+            int readPrecision = 1 + RANDOM.nextInt(writePrecision);
+
+            RowType rowTypeWrite = RowType.of(DataTypes.DECIMAL(writePrecision, 0));
+            RowType rowTypeRead = RowType.of(DataTypes.DECIMAL(readPrecision, 0));
+
+            ParquetRowDataBuilder parquetRowDataBuilder =
+                    new ParquetRowDataBuilder(
+                            new LocalOutputFile(new File(fileWholePath).toPath()), rowTypeWrite);
+
+            ParquetWriter<InternalRow> parquetWriter = parquetRowDataBuilder.build();
+            Decimal decimal = Decimal.fromBigDecimal(
+                    new java.math.BigDecimal(1.0), writePrecision, 0);
+            parquetWriter.write(
+                    GenericRow.of(decimal));
+            parquetWriter.write(
+                    GenericRow.of(
+                            Decimal.fromBigDecimal(
+                                    new java.math.BigDecimal(2.0), writePrecision, 0)));
+            parquetWriter.close();
+
+            ParquetReaderFactory parquetReaderFactory =
+                    new ParquetReaderFactory(new Options(), rowTypeRead, 100, null);
+
+            File file = new File(fileWholePath);
+            FileRecordReader<InternalRow> fileRecordReader =
+                    parquetReaderFactory.createReader(
+                            new FormatReaderContext(
+                                    LocalFileIO.create(),
+                                    new org.apache.paimon.fs.Path(tempDir.toString(), fileName),
+                                    file.length()));
+
+            InternalRow row = fileRecordReader.readBatch().next();
+            Decimal getDecimal = row.getDecimal(0, readPrecision, 0);
+            assertThat(decimal.toUnscaledLong()).isEqualTo(getDecimal.toUnscaledLong());
+            file.delete();
+        }
+    }
+}


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
If the timestamp field, in paimon, precision is 3. But in file, it is Binary. We will get an exception.

Fix this issue, do the converter for timestamp type and decimal type.
<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
