### PR TITLE
[hive][clone] Fix unstable CloneActionITCase#testCloneWithExistedTable

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/CloneActionITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/CloneActionITCase.java
@@ -506,7 +506,7 @@ public class CloneActionITCase extends ActionITCaseBase {
                 "CREATE TABLE test.test_table (id string, id2 int, id3 int, PRIMARY KEY (id, id2, id3) NOT ENFORCED) "
                         + "PARTITIONED BY (id2, id3) with ('bucket' = '-1', 'file.format' = '"
                         + format
-                        + ");";
+                        + "');";
         // has different partition keys
         String ddl1 =
                 "CREATE TABLE test.test_table (id string, id2 int, id3 int) "


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
random tested ddl sql lacks the close quotation mark
https://github.com/apache/paimon/actions/runs/14924626967/job/41926595406
```
Error:  org.apache.paimon.hive.procedure.CloneActionITCase.testCloneWithExistedTable  Time elapsed: 20.755 s  <<< ERROR!
org.apache.flink.table.api.SqlParserException: 
SQL parse failed. Encountered "\'" at line 1, column 166.
Was expecting one of:
    <BINARY_STRING_LITERAL> ...
    <QUOTED_STRING> ...
    <PREFIXED_STRING_LITERAL> ...
    <UNICODE_STRING_LITERAL> ...
    <BIG_QUERY_DOUBLE_QUOTED_STRING> ...
    <BIG_QUERY_QUOTED_STRING> ...
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
