### PR TITLE
[CORE] Fix dynamic insert into table with partition columns contain primary key error

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/crosspartition/GlobalIndexAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/crosspartition/GlobalIndexAssigner.java
@@ -40,7 +40,7 @@ import org.apache.paimon.sort.BinaryExternalSortBuffer;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.PartitionKeyExtractor;
-import org.apache.paimon.table.sink.RowPartitionKeyExtractor;
+import org.apache.paimon.table.sink.RowPartitionAllPrimaryKeyExtractor;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
@@ -129,7 +129,7 @@ public class GlobalIndexAssigner implements Serializable, Closeable {
 
         CoreOptions coreOptions = table.coreOptions();
         this.targetBucketRowNumber = (int) coreOptions.dynamicBucketTargetRowNum();
-        this.extractor = new RowPartitionKeyExtractor(table.schema());
+        this.extractor = new RowPartitionAllPrimaryKeyExtractor(table.schema());
         this.keyPartExtractor = new KeyPartPartitionKeyExtractor(table.schema());
 
         // state
@@ -149,7 +149,7 @@ public class GlobalIndexAssigner implements Serializable, Closeable {
                         path.toString(),
                         rocksdbOptions,
                         coreOptions.crossPartitionUpsertIndexTtl());
-        RowType keyType = table.schema().logicalTrimmedPrimaryKeysType();
+        RowType keyType = table.schema().logicalPrimaryKeysType();
         this.keyIndex =
                 stateFactory.valueState(
                         INDEX_NAME,

--- a/paimon-core/src/test/java/org/apache/paimon/crosspartition/IndexBootstrapTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/crosspartition/IndexBootstrapTest.java
@@ -68,7 +68,7 @@ public class IndexBootstrapTest extends TableTestBase {
                 row(3, 6, 6, 7),
                 row(3, 7, 7, 8));
 
-        IndexBootstrap indexBootstrap = new IndexBootstrap(table);
+        IndexBootstrap indexBootstrap = new IndexBootstrap((FileStoreTable) table);
         List<GenericRow> result = new ArrayList<>();
         Consumer<InternalRow> consumer =
                 row -> result.add(GenericRow.of(row.getInt(0), row.getInt(1), row.getInt(2)));

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/InsertOverwriteTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/InsertOverwriteTableTestBase.scala
@@ -608,4 +608,27 @@ abstract class InsertOverwriteTableTestBase extends PaimonSparkTestBase {
       }
     }
   }
+
+  test("Paimon Insert: dynamic insert into table with partition columns contain primary key") {
+    withSQLConf("spark.sql.shuffle.partitions" -> "10") {
+      withTable("pk_pt") {
+        sql("""
+              |create table pk_pt (c1 int) partitioned by(p1 string, p2 string)
+              |tblproperties('primary-key'='c1, p1')
+              |""".stripMargin)
+
+        sql("insert into table pk_pt partition(p1, p2) values(1, 'a', 'b'), (1, 'b', 'b')")
+        checkAnswer(
+          sql("select * from pk_pt"),
+          Seq(Row(1, "a", "b"), Row(1, "b", "b"))
+        )
+
+        sql("insert into table pk_pt partition(p1, p2) values(1, 'a', 'b'), (1, 'c', 'c')")
+        checkAnswer(
+          sql("select * from pk_pt order by c1, p1, p2"),
+          Seq(Row(1, "a", "b"), Row(1, "b", "b"), Row(1, "c", "c"))
+        )
+      }
+    }
+  }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->

If the partition columns contain primary key, cross partition insertion would fail.

```sql
create table pk_pt (c1 int) partitioned by(p1 string, p2 string) tblproperties('primary-key'='c1, p1')

insert into table pk_pt partition(p1, p2) values(1, 'a', 'b'), (1, 'b', 'b')
```


```
RootCause:
org.apache.spark.SparkException: Job aborted due to stage failure: Task 1 in stage 1.0 (TID 701)failed with no retrying exception: Lost task 1.0 in stage 1.0 (TID 701) (33.212.14.188 executor ): java.lang.IllegalArgumentException: Field names must be unique. Found duplicates: [category]
Caused by: java.lang.IllegalArgumentException: Field names must be unique. Found duplicates: [category]
TraceStack:
org.apache.spark.SparkException: Job aborted due to stage failure: Task 1 in stage 1.0 (TID 701)failed with no retrying exception: Lost task 1.0 in stage 1.0 (TID 701) (33.212.14.188 executor ): java.lang.IllegalArgumentException: Field names must be unique. Found duplicates: [category]
	at org.apache.paimon.types.RowType.validateFields(RowType.java:192)
	at org.apache.paimon.types.RowType.<init>(RowType.java:66)
	at org.apache.paimon.types.RowType.<init>(RowType.java:70)
	at org.apache.paimon.schema.TableSchema.projectedLogicalRowType(TableSchema.java:283)
	at org.apache.paimon.crosspartition.KeyPartPartitionKeyExtractor.<init>(KeyPartPartitionKeyExtractor.java:43)
	at org.apache.paimon.crosspartition.GlobalIndexAssigner.open(GlobalIndexAssigner.java:133)
	at org.apache.paimon.spark.commands.GlobalIndexAssignerIterator.<init>(BucketProcessor.scala:176)
	at org.apache.paimon.spark.commands.GlobalDynamicBucketProcessor.processPartition(BucketProcessor.scala:148)
	at org.apache.paimon.spark.commands.PaimonSparkWriter.$anonfun$write$10(PaimonSparkWriter.scala:167)

```


### Tests

<!-- List UT and IT cases to verify this change -->
added test

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
