### PR TITLE
[core] Postpone bucket should introduce a new BucketMode

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/table/BucketMode.java
+++ b/paimon-common/src/main/java/org/apache/paimon/table/BucketMode.java
@@ -57,7 +57,15 @@ public enum BucketMode {
      * Ignoring bucket concept, although all data is written to bucket-0, the parallelism of reads
      * and writes is unrestricted. This mode only works for append-only table.
      */
-    BUCKET_UNAWARE;
+    BUCKET_UNAWARE,
+
+    /**
+     * Configured by 'bucket' = '-2' (postpone bucket) for primary key table. This mode aims to
+     * solve the difficulty to determine a fixed number of buckets and support different buckets for
+     * different partitions. The bucket will be adaptively adjusted to the appropriate value in the
+     * background.
+     */
+    POSTPONE_MODE;
 
     public static final int UNAWARE_BUCKET = 0;
 

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -210,9 +210,11 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
 
     @Override
     protected KeyValueFileStoreScan newScan(ScanType scanType) {
+        BucketMode bucketMode = bucketMode();
         BucketSelectConverter bucketSelectConverter =
                 keyFilter -> {
-                    if (bucketMode() != BucketMode.HASH_FIXED) {
+                    if (bucketMode != BucketMode.HASH_FIXED
+                            && bucketMode != BucketMode.POSTPONE_MODE) {
                         return Optional.empty();
                     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -99,11 +99,15 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
 
     @Override
     public BucketMode bucketMode() {
-        if (options.bucket() == -1) {
-            return crossPartitionUpdate ? BucketMode.CROSS_PARTITION : BucketMode.HASH_DYNAMIC;
-        } else {
-            checkArgument(!crossPartitionUpdate);
-            return BucketMode.HASH_FIXED;
+        int bucket = options.bucket();
+        switch (bucket) {
+            case -2:
+                return BucketMode.POSTPONE_MODE;
+            case -1:
+                return crossPartitionUpdate ? BucketMode.CROSS_PARTITION : BucketMode.HASH_DYNAMIC;
+            default:
+                checkArgument(!crossPartitionUpdate);
+                return BucketMode.HASH_FIXED;
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -40,6 +40,7 @@ import org.apache.paimon.table.sink.AppendTableRowKeyExtractor;
 import org.apache.paimon.table.sink.DynamicBucketRowKeyExtractor;
 import org.apache.paimon.table.sink.FixedBucketRowKeyExtractor;
 import org.apache.paimon.table.sink.FixedBucketWriteSelector;
+import org.apache.paimon.table.sink.PostponeBucketRowKeyExtractor;
 import org.apache.paimon.table.sink.RowKeyExtractor;
 import org.apache.paimon.table.sink.RowKindGenerator;
 import org.apache.paimon.table.sink.TableCommitImpl;
@@ -217,6 +218,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
             case HASH_FIXED:
                 return Optional.of(new FixedBucketWriteSelector(schema()));
             case BUCKET_UNAWARE:
+            case POSTPONE_MODE:
                 return Optional.empty();
             default:
                 throw new UnsupportedOperationException(
@@ -238,6 +240,8 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
                 return new DynamicBucketRowKeyExtractor(schema());
             case BUCKET_UNAWARE:
                 return new AppendTableRowKeyExtractor(schema());
+            case POSTPONE_MODE:
+                return new PostponeBucketRowKeyExtractor(schema());
             default:
                 throw new UnsupportedOperationException("Unsupported mode: " + bucketMode());
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
@@ -33,8 +33,6 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.schema.KeyValueFieldsExtractor;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.query.LocalTableQuery;
-import org.apache.paimon.table.sink.PostponeBucketRowKeyExtractor;
-import org.apache.paimon.table.sink.RowKeyExtractor;
 import org.apache.paimon.table.sink.TableWriteImpl;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.KeyValueTableRead;
@@ -187,15 +185,6 @@ public class PrimaryKeyFileStoreTable extends AbstractFileStoreTable {
             return null;
         } else {
             return super.newExpireRunnable();
-        }
-    }
-
-    @Override
-    public RowKeyExtractor createRowKeyExtractor() {
-        if (coreOptions().bucket() == BucketMode.POSTPONE_BUCKET) {
-            return new PostponeBucketRowKeyExtractor(schema());
-        } else {
-            return super.createRowKeyExtractor();
         }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyPartialLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyPartialLookupTable.java
@@ -72,9 +72,10 @@ public class PrimaryKeyPartialLookupTable implements LookupTable {
     private PrimaryKeyPartialLookupTable(
             QueryExecutorFactory executorFactory, FileStoreTable table, List<String> joinKey) {
         this.executorFactory = executorFactory;
-        if (table.bucketMode() != BucketMode.HASH_FIXED) {
+        BucketMode bucketMode = table.bucketMode();
+        if (bucketMode != BucketMode.HASH_FIXED && bucketMode != BucketMode.POSTPONE_MODE) {
             throw new UnsupportedOperationException(
-                    "Unsupported mode for partial lookup: " + table.bucketMode());
+                    "Unsupported mode for partial lookup: " + bucketMode);
         }
 
         TableSchema schema = table.schema();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSinkBuilder.java
@@ -55,7 +55,6 @@ public class CompactorSinkBuilder {
             case HASH_FIXED:
             case HASH_DYNAMIC:
                 return buildForBucketAware();
-            case BUCKET_UNAWARE:
             default:
                 throw new UnsupportedOperationException("Unsupported bucket mode: " + bucketMode);
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
@@ -235,12 +235,10 @@ public class FlinkSinkBuilder {
 
         BucketMode bucketMode = table.bucketMode();
         switch (bucketMode) {
+            case POSTPONE_MODE:
+                return buildPostponeBucketSink(input);
             case HASH_FIXED:
-                if (table.coreOptions().bucket() == BucketMode.POSTPONE_BUCKET) {
-                    return buildPostponeBucketSink(input);
-                } else {
-                    return buildForFixedBucket(input);
-                }
+                return buildForFixedBucket(input);
             case HASH_DYNAMIC:
                 return buildDynamicBucketSink(input, false);
             case CROSS_PARTITION:

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
@@ -87,7 +87,6 @@ import static org.apache.paimon.flink.FlinkConnectorOptions.SCAN_WATERMARK_ALIGN
 import static org.apache.paimon.flink.FlinkConnectorOptions.SCAN_WATERMARK_ALIGNMENT_UPDATE_INTERVAL;
 import static org.apache.paimon.flink.FlinkConnectorOptions.SCAN_WATERMARK_EMIT_STRATEGY;
 import static org.apache.paimon.flink.FlinkConnectorOptions.SCAN_WATERMARK_IDLE_TIMEOUT;
-import static org.apache.paimon.table.BucketMode.POSTPONE_BUCKET;
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
 /**
@@ -414,7 +413,6 @@ public abstract class BaseDataTableSource extends FlinkTableSource
             List<String> joinKeyFieldNames, List<String> bucketKeyFieldNames) {
         BucketSpec bucketSpec = ((FileStoreTable) table).bucketSpec();
         return bucketSpec.getBucketMode() == BucketMode.HASH_FIXED
-                && bucketSpec.getNumBuckets() != POSTPONE_BUCKET
                 && new HashSet<>(joinKeyFieldNames).containsAll(bucketKeyFieldNames);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkJobRecoveryITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkJobRecoveryITCase.java
@@ -89,6 +89,9 @@ public class FlinkJobRecoveryITCase extends CatalogITCaseBase {
     @EnumSource(BucketMode.class)
     @Timeout(300)
     public void testRestoreFromSavepointWithJobGraphChange(BucketMode bucketMode) throws Exception {
+        if (bucketMode == BucketMode.POSTPONE_MODE) {
+            return;
+        }
         createTargetTable("target_table", bucketMode);
         String beforeRecoverSql =
                 "INSERT INTO `target_table` /*+ OPTIONS('sink.operator-uid.suffix'='test-uid') */ SELECT * FROM source_table1 /*+ OPTIONS('source.operator-uid.suffix'='test-uid') */";

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkTable.scala
@@ -25,6 +25,7 @@ import org.apache.paimon.spark.schema.PaimonMetadataColumn
 import org.apache.paimon.spark.util.OptionUtils
 import org.apache.paimon.spark.write.{PaimonV2WriteBuilder, PaimonWriteBuilder}
 import org.apache.paimon.table.{BucketMode, DataTable, FileStoreTable, KnownSplitsTable, Table}
+import org.apache.paimon.table.BucketMode.{BUCKET_UNAWARE, HASH_FIXED, POSTPONE_MODE}
 import org.apache.paimon.utils.StringUtils
 
 import org.apache.spark.sql.connector.catalog.{MetadataColumn, SupportsMetadataColumns, SupportsRead, SupportsWrite, TableCapability, TableCatalog}
@@ -55,8 +56,8 @@ case class SparkTable(table: Table)
     table match {
       case storeTable: FileStoreTable =>
         storeTable.bucketMode() match {
-          case BucketMode.HASH_FIXED => BucketFunction.supportsTable(storeTable)
-          case BucketMode.BUCKET_UNAWARE => true
+          case HASH_FIXED => BucketFunction.supportsTable(storeTable)
+          case BUCKET_UNAWARE | POSTPONE_MODE => true
           case _ => false
         }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -236,14 +236,11 @@ case class PaimonSparkWriter(table: FileStoreTable) {
           )
         }
 
-      case BUCKET_UNAWARE =>
-        // Topology: input ->
+      case BUCKET_UNAWARE | POSTPONE_MODE =>
         writeWithoutBucket(data)
 
       case HASH_FIXED =>
-        if (table.bucketSpec().getNumBuckets == POSTPONE_BUCKET) {
-          writeWithoutBucket(data)
-        } else if (paimonExtensionEnabled && BucketFunction.supportsTable(table)) {
+        if (paimonExtensionEnabled && BucketFunction.supportsTable(table)) {
           // Topology: input -> shuffle by partition & bucket
           val bucketNumber = table.coreOptions().bucket()
           val bucketKeyCol = tableSchema

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/PaimonWriteRequirement.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/PaimonWriteRequirement.scala
@@ -39,15 +39,11 @@ object PaimonWriteRequirement {
     val bucketSpec = table.bucketSpec()
     val bucketTransforms = bucketSpec.getBucketMode match {
       case HASH_FIXED =>
-        if (bucketSpec.getNumBuckets == POSTPONE_BUCKET) {
-          Seq.empty
-        } else {
-          Seq(
-            Expressions.bucket(
-              bucketSpec.getNumBuckets,
-              bucketSpec.getBucketKeys.asScala.map(quote).toArray: _*))
-        }
-      case BUCKET_UNAWARE =>
+        Seq(
+          Expressions.bucket(
+            bucketSpec.getNumBuckets,
+            bucketSpec.getBucketKeys.asScala.map(quote).toArray: _*))
+      case BUCKET_UNAWARE | POSTPONE_MODE =>
         Seq.empty
       case _ =>
         throw new UnsupportedOperationException(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The previous `HASH_FIXED` pattern already assumed that the `bucket` was a positive value, which is already assumed in many engines. We need to introduce a new mode to Postpone Bucket to avoid bugs.

For example, Spark bucketed Join.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
We should add tests for Spark postpone bucket reading, but currently, we lack the Table API for compact postpone bucket table. We should add these table api later.

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
