### PR TITLE
[parquet] Support the nonstandard list and map parquet message type for hive migration

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
@@ -32,6 +32,7 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Pair;
+import org.apache.paimon.utils.Preconditions;
 
 import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.filter2.compat.FilterCompat;
@@ -42,6 +43,7 @@ import org.apache.parquet.io.MessageColumnIO;
 import org.apache.parquet.schema.ConversionPatterns;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
 import org.slf4j.Logger;
@@ -51,7 +53,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.paimon.format.parquet.ParquetSchemaConverter.MAP_REPEATED_NAME;
 import static org.apache.paimon.format.parquet.ParquetSchemaConverter.PAIMON_SCHEMA;
 import static org.apache.paimon.format.parquet.ParquetSchemaConverter.parquetListElementType;
 import static org.apache.paimon.format.parquet.ParquetSchemaConverter.parquetMapKeyValueType;
@@ -177,21 +178,38 @@ public class ParquetReaderFactory implements FormatReaderFactory {
             case MAP:
                 MapType mapType = (MapType) readType;
                 GroupType mapGroup = (GroupType) parquetType;
+                int mapSubFields = mapGroup.getFieldCount();
+                Preconditions.checkArgument(
+                        mapSubFields == 1,
+                        "Parquet map group type should only have one middle level REPEATED field.");
                 Pair<Type, Type> keyValueType = parquetMapKeyValueType(mapGroup);
                 return ConversionPatterns.mapType(
                         mapGroup.getRepetition(),
                         mapGroup.getName(),
-                        MAP_REPEATED_NAME,
+                        mapGroup.getType(0).getName(),
                         clipParquetType(mapType.getKeyType(), keyValueType.getLeft()),
                         clipParquetType(mapType.getValueType(), keyValueType.getRight()));
             case ARRAY:
                 ArrayType arrayType = (ArrayType) readType;
                 GroupType arrayGroup = (GroupType) parquetType;
-                return ConversionPatterns.listOfElements(
+                int listSubFields = arrayGroup.getFieldCount();
+                Preconditions.checkArgument(
+                        listSubFields == 1,
+                        "Parquet list group type should only have one middle level REPEATED field.");
+                Type elementType =
+                        clipParquetType(
+                                arrayType.getElementType(), parquetListElementType(arrayGroup));
+                // In case that the name in middle level is not "list".
+                Type groupMiddle =
+                        new GroupType(
+                                Type.Repetition.REPEATED,
+                                arrayGroup.getType(0).getName(),
+                                elementType);
+                return new GroupType(
                         arrayGroup.getRepetition(),
                         arrayGroup.getName(),
-                        clipParquetType(
-                                arrayType.getElementType(), parquetListElementType(arrayGroup)));
+                        OriginalType.LIST,
+                        groupMiddle);
             default:
                 return parquetType;
         }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetSchemaConverter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetSchemaConverter.java
@@ -51,20 +51,19 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 /** Schema converter converts Parquet schema to and from Paimon internal types. */
 public class ParquetSchemaConverter {
 
-    static final String PAIMON_SCHEMA = "paimon_schema";
+    public static final String PAIMON_SCHEMA = "paimon_schema";
 
-    static final String MAP_REPEATED_NAME = "key_value";
-    static final String MAP_KEY_NAME = "key";
-    static final String MAP_VALUE_NAME = "value";
-    static final String LIST_REPEATED_NAME = "list";
-    static final String LIST_ELEMENT_NAME = "element";
+    public static final String MAP_REPEATED_NAME = "key_value";
+    public static final String MAP_KEY_NAME = "key";
+    public static final String MAP_VALUE_NAME = "value";
+    public static final String LIST_ELEMENT_NAME = "element";
 
     /** Convert paimon {@link RowType} to parquet {@link MessageType}. */
     public static MessageType convertToParquetMessageType(RowType rowType) {
         return new MessageType(PAIMON_SCHEMA, convertToParquetTypes(rowType));
     }
 
-    private static Type[] convertToParquetTypes(RowType rowType) {
+    public static Type[] convertToParquetTypes(RowType rowType) {
         return rowType.getFields().stream()
                 .map(ParquetSchemaConverter::convertToParquetType)
                 .toArray(Type[]::new);
@@ -75,7 +74,7 @@ public class ParquetSchemaConverter {
         return convertToParquetType(field.name(), field.type(), field.id(), 0);
     }
 
-    private static Type convertToParquetType(String name, DataType type, int fieldId, int depth) {
+    public static Type convertToParquetType(String name, DataType type, int fieldId, int depth) {
         Type.Repetition repetition =
                 type.isNullable() ? Type.Repetition.OPTIONAL : Type.Repetition.REQUIRED;
         switch (type.getTypeRoot()) {
@@ -234,7 +233,7 @@ public class ParquetSchemaConverter {
         }
     }
 
-    private static Type createTimestampWithLogicalType(
+    public static Type createTimestampWithLogicalType(
             String name, int precision, Type.Repetition repetition, boolean isAdjustToUTC) {
         if (precision <= 3) {
             return Types.primitive(INT64, repetition)
@@ -402,11 +401,13 @@ public class ParquetSchemaConverter {
     }
 
     public static Type parquetListElementType(GroupType listType) {
-        return listType.getType(LIST_REPEATED_NAME).asGroupType().getType(LIST_ELEMENT_NAME);
+        // List type should only have one middle group type, which is repeated, and one element
+        // type, which is optional.
+        return listType.getType(0).asGroupType().getType(0);
     }
 
     public static Pair<Type, Type> parquetMapKeyValueType(GroupType mapType) {
-        GroupType keyValue = mapType.getType(MAP_REPEATED_NAME).asGroupType();
+        GroupType keyValue = mapType.getType(0).asGroupType();
         return Pair.of(keyValue.getType(MAP_KEY_NAME), keyValue.getType(MAP_VALUE_NAME));
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/ParquetRowDataBuilderForTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/ParquetRowDataBuilderForTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.parquet.reader;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.format.parquet.writer.ParquetRowDataWriter;
+import org.apache.paimon.types.RowType;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.api.WriteSupport;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.api.RecordConsumer;
+import org.apache.parquet.schema.MessageType;
+
+import java.util.HashMap;
+
+/** Parquet write build for testing user-defined schema. */
+public class ParquetRowDataBuilderForTest
+        extends ParquetWriter.Builder<InternalRow, ParquetRowDataBuilderForTest> {
+
+    private final RowType rowType;
+    private final MessageType schema;
+
+    public ParquetRowDataBuilderForTest(OutputFile path, RowType rowType, MessageType schema) {
+        super(path);
+        this.rowType = rowType;
+        this.schema = schema;
+    }
+
+    @Override
+    protected ParquetRowDataBuilderForTest self() {
+        return this;
+    }
+
+    @Override
+    protected WriteSupport<InternalRow> getWriteSupport(Configuration conf) {
+        return new ParquetWriteSupport();
+    }
+
+    private class ParquetWriteSupport extends WriteSupport<InternalRow> {
+
+        private ParquetRowDataWriter writer;
+
+        @Override
+        public WriteContext init(Configuration configuration) {
+            return new WriteContext(schema, new HashMap<>());
+        }
+
+        @Override
+        public void prepareForWrite(RecordConsumer recordConsumer) {
+            this.writer = new ParquetRowDataWriter(recordConsumer, rowType, schema);
+        }
+
+        @Override
+        public void write(InternalRow record) {
+            try {
+                this.writer.write(record);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The map and list type migrated from hive, may be non-standard. So the middle message type:
repeated group <name> may not be "list" (which for list type) and "key_value" (which for map type).

Support this situation for reading data from hive migration.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
