### PR TITLE
[core] Use LocalDate#parse to replace LocalDateTime#parse

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionTimeExtractor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionTimeExtractor.java
@@ -112,7 +112,8 @@ public class PartitionTimeExtractor {
         DateTimeFormatter dateTimeFormatter =
                 DateTimeFormatter.ofPattern(Objects.requireNonNull(formatterPattern), Locale.ROOT);
         try {
-            return LocalDateTime.parse(timestampString, Objects.requireNonNull(dateTimeFormatter));
+            return LocalDate.parse(timestampString, Objects.requireNonNull(dateTimeFormatter))
+                    .atStartOfDay();
         } catch (DateTimeParseException e) {
             return LocalDateTime.of(
                     LocalDate.parse(timestampString, Objects.requireNonNull(dateTimeFormatter)),


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

In our company, we found the expire_partition action runs very slow.
We try to jstack and found:
![image](https://github.com/user-attachments/assets/92071580-f408-4467-9280-2593e90c7533)
and the params of we call PartitionTimeExtractor#toLocalDateTime is "20250510" and "yyyyMMdd".
After ut, we found the exception is : "ava.time.format.DateTimeParseException: Text '20250510' could not be parsed: Unable to obtain LocalDateTime from TemporalAccessor: {},ISO resolved to 2025-05-10 of type java.time.format.Parsed".

So we want optimize this.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
