### PR TITLE
[flink] by default, use paimon catalog to create views in flink generic catalog.

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkGenericCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkGenericCatalog.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.CatalogPartition;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.TableChange;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
@@ -179,6 +180,15 @@ public class FlinkGenericCatalog extends AbstractCatalog {
     @Override
     public void createTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists)
             throws TableAlreadyExistException, DatabaseNotExistException, CatalogException {
+        // create view
+        // TODO: By default, use the Paimon catalog to create the view. Create views with options is
+        // not supported.
+        if (table instanceof CatalogView) {
+            paimon.createTable(tablePath, table, ignoreIfExists);
+            return;
+        }
+
+        // create table
         String connector = table.getOptions().get(CONNECTOR.key());
         if (connector == null) {
             throw new RuntimeException(

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/FlinkGenericCatalogITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/FlinkGenericCatalogITCase.java
@@ -217,4 +217,15 @@ public class FlinkGenericCatalogITCase extends AbstractTestBaseJUnit4 {
         List<Row> result = sql("SELECT tag_name FROM paimon_t$tags");
         assertThat(result).contains(Row.of("tag_1"));
     }
+
+    @Test
+    public void testCreateView() {
+        sql("CREATE TABLE paimon_t ( " + "f0 INT, " + "f1 INT " + ") WITH ('connector'='paimon')");
+        sql("INSERT INTO paimon_t VALUES (1, 1), (2, 2)");
+        assertThat(sql("SELECT * FROM paimon_t"))
+                .containsExactlyInAnyOrder(Row.of(1, 1), Row.of(2, 2));
+        sql("CREATE VIEW paimon_t_view AS SELECT * FROM paimon_t WHERE f0=1");
+
+        assertThat(sql("SELECT * FROM paimon_t_view")).containsExactlyInAnyOrder(Row.of(1, 1));
+    }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5489

By default, use the Paimon catalog to create the view. Create views with options is not supported.


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
