### PR TITLE
[core] fix: function need belong to database

### DIFF
--- a/docs/static/rest-catalog-open-api.yaml
+++ b/docs/static/rest-catalog-open-api.yaml
@@ -1184,7 +1184,7 @@ paths:
           $ref: '#/components/responses/ViewAlreadyExistErrorResponse'
         "500":
           $ref: '#/components/responses/ServerErrorResponse'
-  /v1/{prefix}/functions:
+  /v1/{prefix}/databases/{database}/functions:
     get:
       tags:
         - function
@@ -1192,6 +1192,11 @@ paths:
       operationId: listFunctions
       parameters:
         - name: prefix
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: database
           in: path
           required: true
           schema:
@@ -1227,6 +1232,11 @@ paths:
           required: true
           schema:
             type: string
+        - name: database
+          in: path
+          required: true
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1244,7 +1254,7 @@ paths:
         "500":
           $ref: '#/components/responses/ServerErrorResponse'
 
-  /v1/{prefix}/functions/{function}:
+  /v1/{prefix}/databases/{database}/functions/{function}:
     get:
       tags:
         - function
@@ -1252,6 +1262,11 @@ paths:
       operationId: getFunction
       parameters:
         - name: prefix
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: database
           in: path
           required: true
           schema:
@@ -1285,6 +1300,11 @@ paths:
           required: true
           schema:
             type: string
+        - name: database
+          in: path
+          required: true
+          schema:
+            type: string
         - name: function
           in: path
           required: true
@@ -1311,6 +1331,11 @@ paths:
       operationId: dropFunction
       parameters:
         - name: prefix
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: database
           in: path
           required: true
           schema:
@@ -2483,8 +2508,6 @@ components:
     GetFunctionResponse:
       type: object
       properties:
-        uuid:
-          type: string
         name:
           type: string
         inputParams:

--- a/docs/static/rest-catalog-open-api.yaml
+++ b/docs/static/rest-catalog-open-api.yaml
@@ -1219,6 +1219,8 @@ paths:
                 $ref: '#/components/schemas/ListFunctionsResponse'
         "401":
           $ref: '#/components/responses/UnauthorizedErrorResponse'
+        "404":
+          $ref: '#/components/responses/DatabaseNotExistErrorResponse'
         "500":
           $ref: '#/components/responses/ServerErrorResponse'
     post:
@@ -1249,6 +1251,8 @@ paths:
           $ref: '#/components/responses/BadRequestErrorResponse'
         "401":
           $ref: '#/components/responses/UnauthorizedErrorResponse'
+        "404":
+          $ref: '#/components/responses/DatabaseNotExistErrorResponse'
         "409":
           $ref: '#/components/responses/FunctionAlreadyExistErrorResponse'
         "500":
@@ -1286,7 +1290,7 @@ paths:
         "401":
           $ref: '#/components/responses/UnauthorizedErrorResponse'
         "404":
-          $ref: '#/components/responses/DatabaseNotExistErrorResponse'
+          $ref: '#/components/responses/FunctionNotExistErrorResponse'
         "500":
           $ref: '#/components/responses/ServerErrorResponse'
     post:

--- a/paimon-api/src/main/java/org/apache/paimon/function/Function.java
+++ b/paimon-api/src/main/java/org/apache/paimon/function/Function.java
@@ -22,17 +22,18 @@ import org.apache.paimon.types.DataField;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /** Interface for function. */
 public interface Function {
 
-    String uuid();
-
     String name();
 
-    List<DataField> inputParams();
+    String fullName();
 
-    List<DataField> returnParams();
+    Optional<List<DataField>> inputParams();
+
+    Optional<List<DataField>> returnParams();
 
     boolean isDeterministic();
 

--- a/paimon-api/src/main/java/org/apache/paimon/function/FunctionImpl.java
+++ b/paimon-api/src/main/java/org/apache/paimon/function/FunctionImpl.java
@@ -18,17 +18,17 @@
 
 package org.apache.paimon.function;
 
+import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.types.DataField;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /** Function implementation. */
 public class FunctionImpl implements Function {
 
-    private final String uuid;
-
-    private final String name;
+    private final Identifier identifier;
 
     private final List<DataField> inputParams;
 
@@ -43,16 +43,14 @@ public class FunctionImpl implements Function {
     private final Map<String, String> options;
 
     public FunctionImpl(
-            String uuid,
-            String functionName,
+            Identifier identifier,
             List<DataField> inputParams,
             List<DataField> returnParams,
             boolean deterministic,
             Map<String, FunctionDefinition> definitions,
             String comment,
             Map<String, String> options) {
-        this.uuid = uuid;
-        this.name = functionName;
+        this.identifier = identifier;
         this.inputParams = inputParams;
         this.returnParams = returnParams;
         this.deterministic = deterministic;
@@ -62,23 +60,23 @@ public class FunctionImpl implements Function {
     }
 
     @Override
-    public String uuid() {
-        return this.uuid;
-    }
-
-    @Override
     public String name() {
-        return this.name;
+        return identifier.getObjectName();
     }
 
     @Override
-    public List<DataField> inputParams() {
-        return inputParams;
+    public String fullName() {
+        return identifier.getFullName();
     }
 
     @Override
-    public List<DataField> returnParams() {
-        return returnParams;
+    public Optional<List<DataField>> inputParams() {
+        return Optional.ofNullable(inputParams);
+    }
+
+    @Override
+    public Optional<List<DataField>> returnParams() {
+        return Optional.ofNullable(returnParams);
     }
 
     @Override

--- a/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
@@ -396,33 +396,40 @@ public class RESTApi {
         return response.branches();
     }
 
-    public List<String> listFunctions() {
+    public List<String> listFunctions(String databaseName) {
         return listDataFromPageApi(
                 queryParams ->
                         client.get(
-                                resourcePaths.functions(),
+                                resourcePaths.functions(databaseName),
                                 queryParams,
                                 ListFunctionsResponse.class,
                                 restAuthFunction));
     }
 
-    public GetFunctionResponse getFunction(String functionName) {
+    public GetFunctionResponse getFunction(Identifier identifier) {
         return client.get(
-                resourcePaths.function(functionName), GetFunctionResponse.class, restAuthFunction);
+                resourcePaths.function(identifier.getDatabaseName(), identifier.getObjectName()),
+                GetFunctionResponse.class,
+                restAuthFunction);
     }
 
-    public void createFunction(String functionName, org.apache.paimon.function.Function function) {
+    public void createFunction(
+            Identifier identifier, org.apache.paimon.function.Function function) {
         client.post(
-                resourcePaths.functions(), new CreateFunctionRequest(function), restAuthFunction);
+                resourcePaths.functions(identifier.getDatabaseName()),
+                new CreateFunctionRequest(function),
+                restAuthFunction);
     }
 
-    public void dropFunction(String functionName) {
-        client.delete(resourcePaths.function(functionName), restAuthFunction);
+    public void dropFunction(Identifier identifier) {
+        client.delete(
+                resourcePaths.function(identifier.getDatabaseName(), identifier.getObjectName()),
+                restAuthFunction);
     }
 
-    public void alterFunction(String functionName, List<FunctionChange> changes) {
+    public void alterFunction(Identifier identifier, List<FunctionChange> changes) {
         client.post(
-                resourcePaths.function(functionName),
+                resourcePaths.function(identifier.getDatabaseName(), identifier.getObjectName()),
                 new AlterFunctionRequest(changes),
                 restAuthFunction);
     }

--- a/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
@@ -702,7 +702,12 @@ public class RESTApi {
         return response.branches();
     }
 
-    /** TODO. */
+    /**
+     * List functions for database.
+     *
+     * @param databaseName
+     * @return a list of function name
+     */
     public List<String> listFunctions(String databaseName) {
         return listDataFromPageApi(
                 queryParams ->
@@ -713,7 +718,14 @@ public class RESTApi {
                                 restAuthFunction));
     }
 
-    /** TODO. */
+    /**
+     * Get a function by identifier.
+     *
+     * @param identifier the identifier of the function to retrieve
+     * @return the function response object
+     * @throws NoSuchResourceException if the function does not exist
+     * @throws ForbiddenException if the user lacks permission to access the function
+     */
     public GetFunctionResponse getFunction(Identifier identifier) {
         return client.get(
                 resourcePaths.function(identifier.getDatabaseName(), identifier.getObjectName()),
@@ -721,7 +733,15 @@ public class RESTApi {
                 restAuthFunction);
     }
 
-    /** TODO. */
+    /**
+     * Create a function.
+     *
+     * @param identifier database name and function name.
+     * @param function the function to be created
+     * @throws AlreadyExistsException Exception thrown on HTTP 409 means a function already exists
+     * @throws ForbiddenException Exception thrown on HTTP 403 means don't have the permission for
+     *     creating function
+     */
     public void createFunction(
             Identifier identifier, org.apache.paimon.function.Function function) {
         client.post(
@@ -730,14 +750,28 @@ public class RESTApi {
                 restAuthFunction);
     }
 
-    /** TODO. */
+    /**
+     * Drop a function.
+     *
+     * @param identifier database name and function name.
+     * @throws NoSuchResourceException Exception thrown on HTTP 404 means the function not exists
+     * @throws ForbiddenException Exception thrown on HTTP 403 means don't have the permission for
+     *     this function
+     */
     public void dropFunction(Identifier identifier) {
         client.delete(
                 resourcePaths.function(identifier.getDatabaseName(), identifier.getObjectName()),
                 restAuthFunction);
     }
 
-    /** TODO. */
+    /**
+     * Alter a function.
+     *
+     * @param identifier database name and function name.
+     * @param changes list of function changes to apply
+     * @throws NoSuchResourceException if the function does not exist
+     * @throws ForbiddenException if the user lacks permission to modify the function
+     */
     public void alterFunction(Identifier identifier, List<FunctionChange> changes) {
         client.post(
                 resourcePaths.function(identifier.getDatabaseName(), identifier.getObjectName()),

--- a/paimon-api/src/main/java/org/apache/paimon/rest/ResourcePaths.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/ResourcePaths.java
@@ -215,11 +215,17 @@ public class ResourcePaths {
         return SLASH.join(V1, prefix, VIEWS, "rename");
     }
 
-    public String functions() {
-        return SLASH.join(V1, prefix, FUNCTIONS);
+    public String functions(String databaseName) {
+        return SLASH.join(V1, prefix, DATABASES, encodeString(databaseName), FUNCTIONS);
     }
 
-    public String function(String functionName) {
-        return SLASH.join(V1, prefix, FUNCTIONS, encodeString(functionName));
+    public String function(String databaseName, String functionName) {
+        return SLASH.join(
+                V1,
+                prefix,
+                DATABASES,
+                encodeString(databaseName),
+                FUNCTIONS,
+                encodeString(functionName));
     }
 }

--- a/paimon-api/src/main/java/org/apache/paimon/rest/requests/CreateFunctionRequest.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/requests/CreateFunctionRequest.java
@@ -84,8 +84,8 @@ public class CreateFunctionRequest implements RESTRequest {
 
     public CreateFunctionRequest(Function function) {
         this.functionName = function.name();
-        this.inputParams = function.inputParams();
-        this.returnParams = function.returnParams();
+        this.inputParams = function.inputParams().orElse(null);
+        this.returnParams = function.returnParams().orElse(null);
         this.deterministic = function.isDeterministic();
         this.definitions = function.definitions();
         this.comment = function.comment();

--- a/paimon-api/src/main/java/org/apache/paimon/rest/responses/GetFunctionResponse.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/responses/GetFunctionResponse.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.rest.responses;
 
+import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.function.Function;
 import org.apache.paimon.function.FunctionDefinition;
 import org.apache.paimon.function.FunctionImpl;
@@ -136,10 +137,9 @@ public class GetFunctionResponse extends AuditRESTResponse {
         return options;
     }
 
-    public Function toFunction() {
+    public Function toFunction(Identifier identifier) {
         return new FunctionImpl(
-                uuid,
-                functionName,
+                identifier,
                 inputParams,
                 returnParams,
                 deterministic,

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -523,30 +523,30 @@ public abstract class AbstractCatalog implements Catalog {
             throws TableNotExistException {}
 
     @Override
-    public List<String> listFunctions() {
+    public List<String> listFunctions(String databaseName) {
         return Collections.emptyList();
     }
 
     @Override
-    public Function getFunction(String functionName) throws FunctionNotExistException {
-        throw new FunctionNotExistException(functionName);
+    public Function getFunction(Identifier identifier) throws FunctionNotExistException {
+        throw new FunctionNotExistException(identifier);
     }
 
     @Override
-    public void createFunction(String functionName, Function function, boolean ignoreIfExists)
+    public void createFunction(Identifier identifier, Function function, boolean ignoreIfExists)
             throws FunctionAlreadyExistException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void dropFunction(String functionName, boolean ignoreIfNotExists)
+    public void dropFunction(Identifier identifier, boolean ignoreIfNotExists)
             throws FunctionNotExistException {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public void alterFunction(
-            String functionName, List<FunctionChange> changes, boolean ignoreIfNotExists)
+            Identifier identifier, List<FunctionChange> changes, boolean ignoreIfNotExists)
             throws FunctionNotExistException, DefinitionAlreadyExistException,
                     DefinitionNotExistException {
         throw new UnsupportedOperationException();

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -534,7 +534,7 @@ public abstract class AbstractCatalog implements Catalog {
 
     @Override
     public void createFunction(Identifier identifier, Function function, boolean ignoreIfExists)
-            throws FunctionAlreadyExistException {
+            throws FunctionAlreadyExistException, DatabaseNotExistException {
         throw new UnsupportedOperationException();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -669,46 +669,47 @@ public interface Catalog extends AutoCloseable {
             throws TableNotExistException;
 
     /** List all functions in catalog. */
-    List<String> listFunctions();
+    List<String> listFunctions(String databaseName);
 
     /**
      * Get function by name.
      *
-     * @param functionName
+     * @param identifier
      * @throws FunctionNotExistException
      */
-    Function getFunction(String functionName) throws FunctionNotExistException;
+    Function getFunction(Identifier identifier) throws FunctionNotExistException;
 
     /**
      * Create function.
      *
-     * @param functionName
+     * @param identifier
      * @param function
      * @param ignoreIfExists
      * @throws FunctionAlreadyExistException
      */
-    void createFunction(String functionName, Function function, boolean ignoreIfExists)
+    void createFunction(Identifier identifier, Function function, boolean ignoreIfExists)
             throws FunctionAlreadyExistException;
 
     /**
      * Drop function.
      *
-     * @param functionName
+     * @param identifier
      * @param ignoreIfNotExists
      * @throws FunctionNotExistException
      */
-    void dropFunction(String functionName, boolean ignoreIfNotExists)
+    void dropFunction(Identifier identifier, boolean ignoreIfNotExists)
             throws FunctionNotExistException;
 
     /**
      * Alter function.
      *
-     * @param functionName
+     * @param identifier
      * @param changes
      * @param ignoreIfNotExists
      * @throws FunctionNotExistException
      */
-    void alterFunction(String functionName, List<FunctionChange> changes, boolean ignoreIfNotExists)
+    void alterFunction(
+            Identifier identifier, List<FunctionChange> changes, boolean ignoreIfNotExists)
             throws FunctionNotExistException, DefinitionAlreadyExistException,
                     DefinitionNotExistException;
 
@@ -1148,19 +1149,19 @@ public interface Catalog extends AutoCloseable {
 
         private static final String MSG = "Function %s already exists.";
 
-        private final String functionName;
+        private final Identifier identifier;
 
-        public FunctionAlreadyExistException(String functionName) {
-            this(functionName, null);
+        public FunctionAlreadyExistException(Identifier identifier) {
+            this(identifier, null);
         }
 
-        public FunctionAlreadyExistException(String functionName, Throwable cause) {
-            super(String.format(MSG, functionName), cause);
-            this.functionName = functionName;
+        public FunctionAlreadyExistException(Identifier identifier, Throwable cause) {
+            super(String.format(MSG, identifier.getFullName()), cause);
+            this.identifier = identifier;
         }
 
-        public String functionName() {
-            return functionName;
+        public Identifier identifier() {
+            return identifier;
         }
     }
 
@@ -1169,19 +1170,19 @@ public interface Catalog extends AutoCloseable {
 
         private static final String MSG = "Function %s doesn't exist.";
 
-        private final String functionName;
+        private final Identifier identifier;
 
-        public FunctionNotExistException(String functionName) {
-            this(functionName, null);
+        public FunctionNotExistException(Identifier identifier) {
+            this(identifier, null);
         }
 
-        public FunctionNotExistException(String functionName, Throwable cause) {
-            super(String.format(MSG, functionName), cause);
-            this.functionName = functionName;
+        public FunctionNotExistException(Identifier identifier, Throwable cause) {
+            super(String.format(MSG, identifier), cause);
+            this.identifier = identifier;
         }
 
-        public String functionName() {
-            return functionName;
+        public Identifier identifier() {
+            return identifier;
         }
     }
 
@@ -1190,21 +1191,22 @@ public interface Catalog extends AutoCloseable {
 
         private static final String MSG = "Definition %s in function %s already exists.";
 
-        private final String functionName;
+        private final Identifier identifier;
         private final String name;
 
-        public DefinitionAlreadyExistException(String functionName, String name) {
-            this(functionName, name, null);
+        public DefinitionAlreadyExistException(Identifier identifier, String name) {
+            this(identifier, name, null);
         }
 
-        public DefinitionAlreadyExistException(String functionName, String name, Throwable cause) {
-            super(String.format(MSG, name, functionName), cause);
-            this.functionName = functionName;
+        public DefinitionAlreadyExistException(
+                Identifier identifier, String name, Throwable cause) {
+            super(String.format(MSG, name, identifier.getFullName()), cause);
+            this.identifier = identifier;
             this.name = name;
         }
 
-        public String functionName() {
-            return functionName;
+        public Identifier identifier() {
+            return identifier;
         }
 
         public String name() {
@@ -1217,21 +1219,21 @@ public interface Catalog extends AutoCloseable {
 
         private static final String MSG = "Definition %s in function %s doesn't exist.";
 
-        private final String functionName;
+        private final Identifier identifier;
         private final String name;
 
-        public DefinitionNotExistException(String functionName, String name) {
-            this(functionName, name, null);
+        public DefinitionNotExistException(Identifier identifier, String name) {
+            this(identifier, name, null);
         }
 
-        public DefinitionNotExistException(String functionName, String name, Throwable cause) {
-            super(String.format(MSG, name, functionName), cause);
-            this.functionName = functionName;
+        public DefinitionNotExistException(Identifier identifier, String name, Throwable cause) {
+            super(String.format(MSG, name, identifier.getFullName()), cause);
+            this.identifier = identifier;
             this.name = name;
         }
 
-        public String functionName() {
-            return functionName;
+        public Identifier identifier() {
+            return identifier;
         }
 
         public String name() {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -668,27 +668,38 @@ public interface Catalog extends AutoCloseable {
     void alterPartitions(Identifier identifier, List<PartitionStatistics> partitions)
             throws TableNotExistException;
 
-    /** List all functions in catalog. */
-    List<String> listFunctions(String databaseName);
+    /**
+     * Get the names of all functions in this catalog.
+     *
+     * @return a list of the names of all functions
+     * @throws DatabaseNotExistException if the database does not exist
+     */
+    List<String> listFunctions(String databaseName) throws DatabaseNotExistException;
 
     /**
      * Get function by name.
      *
-     * @param identifier
-     * @throws FunctionNotExistException
+     * @param identifier Path of the function to get
+     * @return The requested function
+     * @throws FunctionNotExistException if the function does not exist
      */
     Function getFunction(Identifier identifier) throws FunctionNotExistException;
 
     /**
-     * Create function.
+     * Create a new function.
      *
-     * @param identifier
-     * @param function
-     * @param ignoreIfExists
-     * @throws FunctionAlreadyExistException
+     * <p>NOTE: System functions can not be created.
+     *
+     * @param identifier path of the function to be created
+     * @param function the function definition
+     * @param ignoreIfExists flag to specify behavior when a function already exists at the given
+     *     path: if set to false, it throws a FunctionAlreadyExistException, if set to true, do
+     *     nothing.
+     * @throws FunctionAlreadyExistException if function already exists and ignoreIfExists is false
+     * @throws DatabaseNotExistException if the database in identifier doesn't exist
      */
     void createFunction(Identifier identifier, Function function, boolean ignoreIfExists)
-            throws FunctionAlreadyExistException;
+            throws FunctionAlreadyExistException, DatabaseNotExistException;
 
     /**
      * Drop function.

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -212,33 +212,33 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
-    public List<String> listFunctions() {
-        return wrapped.listFunctions();
+    public List<String> listFunctions(String databaseName) {
+        return wrapped.listFunctions(databaseName);
     }
 
     @Override
-    public Function getFunction(String functionName) throws FunctionNotExistException {
-        return wrapped.getFunction(functionName);
+    public Function getFunction(Identifier identifier) throws FunctionNotExistException {
+        return wrapped.getFunction(identifier);
     }
 
     @Override
-    public void createFunction(String functionName, Function function, boolean ignoreIfExists)
+    public void createFunction(Identifier identifier, Function function, boolean ignoreIfExists)
             throws FunctionAlreadyExistException {
-        wrapped.createFunction(functionName, function, ignoreIfExists);
+        wrapped.createFunction(identifier, function, ignoreIfExists);
     }
 
     @Override
-    public void dropFunction(String functionName, boolean ignoreIfNotExists)
+    public void dropFunction(Identifier identifier, boolean ignoreIfNotExists)
             throws FunctionNotExistException {
-        wrapped.dropFunction(functionName, ignoreIfNotExists);
+        wrapped.dropFunction(identifier, ignoreIfNotExists);
     }
 
     @Override
     public void alterFunction(
-            String functionName, List<FunctionChange> changes, boolean ignoreIfNotExists)
+            Identifier identifier, List<FunctionChange> changes, boolean ignoreIfNotExists)
             throws FunctionNotExistException, DefinitionAlreadyExistException,
                     DefinitionNotExistException {
-        wrapped.alterFunction(functionName, changes, ignoreIfNotExists);
+        wrapped.alterFunction(identifier, changes, ignoreIfNotExists);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -212,7 +212,7 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
-    public List<String> listFunctions(String databaseName) {
+    public List<String> listFunctions(String databaseName) throws DatabaseNotExistException {
         return wrapped.listFunctions(databaseName);
     }
 
@@ -223,7 +223,7 @@ public abstract class DelegateCatalog implements Catalog {
 
     @Override
     public void createFunction(Identifier identifier, Function function, boolean ignoreIfExists)
-            throws FunctionAlreadyExistException {
+            throws FunctionAlreadyExistException, DatabaseNotExistException {
         wrapped.createFunction(identifier, function, ignoreIfExists);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -612,8 +612,12 @@ public class RESTCatalog implements Catalog {
     }
 
     @Override
-    public List<String> listFunctions(String databaseName) {
-        return api.listFunctions(databaseName);
+    public List<String> listFunctions(String databaseName) throws DatabaseNotExistException {
+        try {
+            return api.listFunctions(databaseName);
+        } catch (NoSuchResourceException e) {
+            throw new DatabaseNotExistException(databaseName, e);
+        }
     }
 
     @Override
@@ -632,9 +636,11 @@ public class RESTCatalog implements Catalog {
             Identifier identifier,
             org.apache.paimon.function.Function function,
             boolean ignoreIfExists)
-            throws FunctionAlreadyExistException {
+            throws FunctionAlreadyExistException, DatabaseNotExistException {
         try {
             api.createFunction(identifier, function);
+        } catch (NoSuchResourceException e) {
+            throw new DatabaseNotExistException(identifier.getDatabaseName(), e);
         } catch (AlreadyExistsException e) {
             if (ignoreIfExists) {
                 return;

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -608,65 +608,65 @@ public class RESTCatalog implements Catalog {
     }
 
     @Override
-    public List<String> listFunctions() {
-        return api.listFunctions();
+    public List<String> listFunctions(String databaseName) {
+        return api.listFunctions(databaseName);
     }
 
     @Override
-    public org.apache.paimon.function.Function getFunction(String functionName)
+    public org.apache.paimon.function.Function getFunction(Identifier identifier)
             throws FunctionNotExistException {
         try {
-            GetFunctionResponse response = api.getFunction(functionName);
-            return response.toFunction();
+            GetFunctionResponse response = api.getFunction(identifier);
+            return response.toFunction(identifier);
         } catch (NoSuchResourceException e) {
-            throw new FunctionNotExistException(functionName, e);
+            throw new FunctionNotExistException(identifier, e);
         }
     }
 
     @Override
     public void createFunction(
-            String functionName,
+            Identifier identifier,
             org.apache.paimon.function.Function function,
             boolean ignoreIfExists)
             throws FunctionAlreadyExistException {
         try {
-            api.createFunction(functionName, function);
+            api.createFunction(identifier, function);
         } catch (AlreadyExistsException e) {
             if (ignoreIfExists) {
                 return;
             }
-            throw new FunctionAlreadyExistException(functionName, e);
+            throw new FunctionAlreadyExistException(identifier, e);
         }
     }
 
     @Override
-    public void dropFunction(String functionName, boolean ignoreIfNotExists)
+    public void dropFunction(Identifier identifier, boolean ignoreIfNotExists)
             throws FunctionNotExistException {
         try {
-            api.dropFunction(functionName);
+            api.dropFunction(identifier);
         } catch (NoSuchResourceException e) {
             if (ignoreIfNotExists) {
                 return;
             }
-            throw new FunctionNotExistException(functionName, e);
+            throw new FunctionNotExistException(identifier, e);
         }
     }
 
     @Override
     public void alterFunction(
-            String functionName, List<FunctionChange> changes, boolean ignoreIfNotExists)
+            Identifier identifier, List<FunctionChange> changes, boolean ignoreIfNotExists)
             throws FunctionNotExistException, DefinitionAlreadyExistException,
                     DefinitionNotExistException {
         try {
-            api.alterFunction(functionName, changes);
+            api.alterFunction(identifier, changes);
         } catch (AlreadyExistsException e) {
-            throw new DefinitionAlreadyExistException(functionName, e.resourceName());
+            throw new DefinitionAlreadyExistException(identifier, e.resourceName());
         } catch (NoSuchResourceException e) {
             if (StringUtils.equals(e.resourceType(), ErrorResponse.RESOURCE_TYPE_DEFINITION)) {
-                throw new DefinitionNotExistException(functionName, e.resourceName());
+                throw new DefinitionNotExistException(identifier, e.resourceName());
             }
             if (!ignoreIfNotExists) {
-                throw new FunctionNotExistException(functionName);
+                throw new FunctionNotExistException(identifier, e);
             }
         } catch (BadRequestException e) {
             throw new IllegalArgumentException(e.getMessage());

--- a/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTMessage.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTMessage.java
@@ -286,12 +286,12 @@ public class MockRESTMessage {
     }
 
     public static GetFunctionResponse getFunctionResponse() {
-        Function function = function("function");
+        Function function = function(Identifier.create(databaseName(), "function"));
         return new GetFunctionResponse(
-                function.uuid(),
+                UUID.randomUUID().toString(),
                 function.name(),
-                function.inputParams(),
-                function.returnParams(),
+                function.inputParams().orElse(null),
+                function.returnParams().orElse(null),
                 function.isDeterministic(),
                 function.definitions(),
                 function.comment(),
@@ -304,18 +304,18 @@ public class MockRESTMessage {
     }
 
     public static CreateFunctionRequest createFunctionRequest() {
-        Function function = function("function");
+        Function function = function(Identifier.create(databaseName(), "function"));
         return new CreateFunctionRequest(
                 function.name(),
-                function.inputParams(),
-                function.returnParams(),
+                function.inputParams().orElse(null),
+                function.returnParams().orElse(null),
                 function.isDeterministic(),
                 function.definitions(),
                 function.comment(),
                 function.options());
     }
 
-    public static Function function(String functionName) {
+    public static Function function(Identifier identifier) {
         List<DataField> inputParams =
                 Lists.newArrayList(
                         new DataField(0, "length", DataTypes.DOUBLE()),
@@ -334,8 +334,7 @@ public class MockRESTMessage {
         definitions.put("spark", sparkFunction);
         definitions.put("trino", trinoFunction);
         return new FunctionImpl(
-                UUID.randomUUID().toString(),
-                functionName,
+                identifier,
                 inputParams,
                 returnParams,
                 false,

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -1323,86 +1323,90 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
 
     @Test
     void testFunction() throws Exception {
-        Function function = MockRESTMessage.function("function");
+        Identifier identifier = new Identifier("rest_catalog_db", "function");
+        catalog.createDatabase(identifier.getDatabaseName(), false);
+        Function function = MockRESTMessage.function(identifier);
 
-        catalog.createFunction(function.name(), function, true);
+        catalog.createFunction(identifier, function, true);
         assertThrows(
                 Catalog.FunctionAlreadyExistException.class,
-                () -> catalog.createFunction(function.name(), function, false));
+                () -> catalog.createFunction(identifier, function, false));
 
-        assertThat(catalog.listFunctions().contains(function.name())).isTrue();
+        assertThat(catalog.listFunctions(identifier.getDatabaseName()).contains(function.name()))
+                .isTrue();
 
-        Function getFunction = catalog.getFunction(function.name());
+        Function getFunction = catalog.getFunction(identifier);
         assertThat(getFunction.name()).isEqualTo(function.name());
         for (String dialect : function.definitions().keySet()) {
             assertThat(getFunction.definition(dialect)).isEqualTo(function.definition(dialect));
         }
-        catalog.dropFunction(function.name(), true);
+        catalog.dropFunction(identifier, true);
 
-        assertThat(catalog.listFunctions().contains(function.name())).isFalse();
+        assertThat(catalog.listFunctions(identifier.getDatabaseName()).contains(function.name()))
+                .isFalse();
         assertThrows(
                 Catalog.FunctionNotExistException.class,
-                () -> catalog.dropFunction(function.name(), false));
+                () -> catalog.dropFunction(identifier, false));
         assertThrows(
-                Catalog.FunctionNotExistException.class,
-                () -> catalog.getFunction(function.name()));
+                Catalog.FunctionNotExistException.class, () -> catalog.getFunction(identifier));
     }
 
     @Test
     void testAlterFunction() throws Exception {
-        String functionName = "alter_function_name";
-        Function function = MockRESTMessage.function(functionName);
+        Identifier identifier = new Identifier("rest_catalog_db", "alter_function_name");
+        catalog.createDatabase(identifier.getDatabaseName(), false);
+        Function function = MockRESTMessage.function(identifier);
         FunctionDefinition definition = FunctionDefinition.sql("x * y + 1");
         FunctionChange.AddDefinition addDefinition =
                 (FunctionChange.AddDefinition) FunctionChange.addDefinition("flink_1", definition);
         assertDoesNotThrow(
-                () -> catalog.alterFunction(functionName, ImmutableList.of(addDefinition), true));
+                () -> catalog.alterFunction(identifier, ImmutableList.of(addDefinition), true));
         assertThrows(
                 Catalog.FunctionNotExistException.class,
-                () -> catalog.alterFunction(functionName, ImmutableList.of(addDefinition), false));
-        catalog.createFunction(function.name(), function, true);
+                () -> catalog.alterFunction(identifier, ImmutableList.of(addDefinition), false));
+        catalog.createFunction(identifier, function, true);
         // set options
         String key = UUID.randomUUID().toString();
         String value = UUID.randomUUID().toString();
         FunctionChange setOption = FunctionChange.setOption(key, value);
-        catalog.alterFunction(functionName, ImmutableList.of(setOption), false);
-        Function catalogFunction = catalog.getFunction(functionName);
+        catalog.alterFunction(identifier, ImmutableList.of(setOption), false);
+        Function catalogFunction = catalog.getFunction(identifier);
         assertThat(catalogFunction.options().get(key)).isEqualTo(value);
 
         // remove options
         catalog.alterFunction(
-                functionName, ImmutableList.of(FunctionChange.removeOption(key)), false);
-        catalogFunction = catalog.getFunction(functionName);
+                identifier, ImmutableList.of(FunctionChange.removeOption(key)), false);
+        catalogFunction = catalog.getFunction(identifier);
         assertThat(catalogFunction.options().containsKey(key)).isEqualTo(false);
 
         // update comment
         String newComment = "new comment";
         catalog.alterFunction(
-                functionName, ImmutableList.of(FunctionChange.updateComment(newComment)), false);
-        catalogFunction = catalog.getFunction(functionName);
+                identifier, ImmutableList.of(FunctionChange.updateComment(newComment)), false);
+        catalogFunction = catalog.getFunction(identifier);
         assertThat(catalogFunction.comment()).isEqualTo(newComment);
         // add definition
-        catalog.alterFunction(functionName, ImmutableList.of(addDefinition), false);
-        catalogFunction = catalog.getFunction(functionName);
+        catalog.alterFunction(identifier, ImmutableList.of(addDefinition), false);
+        catalogFunction = catalog.getFunction(identifier);
         assertThat(catalogFunction.definition(addDefinition.name()))
                 .isEqualTo(addDefinition.definition());
         assertThrows(
                 Catalog.DefinitionAlreadyExistException.class,
-                () -> catalog.alterFunction(functionName, ImmutableList.of(addDefinition), false));
+                () -> catalog.alterFunction(identifier, ImmutableList.of(addDefinition), false));
 
         // update definition
         FunctionChange.UpdateDefinition updateDefinition =
                 (FunctionChange.UpdateDefinition)
                         FunctionChange.updateDefinition("flink_1", definition);
-        catalog.alterFunction(functionName, ImmutableList.of(updateDefinition), false);
-        catalogFunction = catalog.getFunction(functionName);
+        catalog.alterFunction(identifier, ImmutableList.of(updateDefinition), false);
+        catalogFunction = catalog.getFunction(identifier);
         assertThat(catalogFunction.definition(updateDefinition.name()))
                 .isEqualTo(updateDefinition.definition());
         assertThrows(
                 Catalog.DefinitionNotExistException.class,
                 () ->
                         catalog.alterFunction(
-                                functionName,
+                                identifier,
                                 ImmutableList.of(
                                         FunctionChange.updateDefinition("no_exist", definition)),
                                 false));
@@ -1411,13 +1415,13 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         FunctionChange.DropDefinition dropDefinition =
                 (FunctionChange.DropDefinition)
                         FunctionChange.dropDefinition(updateDefinition.name());
-        catalog.alterFunction(functionName, ImmutableList.of(dropDefinition), false);
-        catalogFunction = catalog.getFunction(functionName);
+        catalog.alterFunction(identifier, ImmutableList.of(dropDefinition), false);
+        catalogFunction = catalog.getFunction(identifier);
         assertThat(catalogFunction.definition(updateDefinition.name())).isNull();
 
         assertThrows(
                 Catalog.DefinitionNotExistException.class,
-                () -> catalog.alterFunction(functionName, ImmutableList.of(dropDefinition), false));
+                () -> catalog.alterFunction(identifier, ImmutableList.of(dropDefinition), false));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #5420

<!-- What is the purpose of the change -->
update function api
- function belong to database
- inputParams and returnParams is optional

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
