### PR TITLE
[test] Local tests exceptionally no write permission when creating Hive catalog

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/FlinkGenericCatalogITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/FlinkGenericCatalogITCase.java
@@ -44,7 +44,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,6 +56,7 @@ public class FlinkGenericCatalogITCase extends AbstractTestBaseJUnit4 {
 
     @Rule public TemporaryFolder folder = new TemporaryFolder();
 
+    protected String path;
     protected TableEnvironment tEnv;
 
     @HiveSQL(files = {})
@@ -70,6 +71,7 @@ public class FlinkGenericCatalogITCase extends AbstractTestBaseJUnit4 {
 
     @Before
     public void before() throws Exception {
+        path = folder.newFolder().toURI().toString();
         hiveShell.execute("CREATE DATABASE IF NOT EXISTS test_db");
         hiveShell.execute("USE test_db");
         hiveShell.execute("CREATE TABLE hive_table ( a INT, b STRING )");
@@ -81,7 +83,7 @@ public class FlinkGenericCatalogITCase extends AbstractTestBaseJUnit4 {
         FlinkGenericCatalog catalog =
                 FlinkGenericCatalogFactory.createCatalog(
                         this.getClass().getClassLoader(),
-                        new HashMap<>(),
+                        Collections.singletonMap("warehouse", path),
                         hiveCatalog.getName(),
                         hiveCatalog);
         catalog.open();


### PR DESCRIPTION
…te hive catalog exception: no wirte permissions for root directory /

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

"Improved local testing in flink generic catalog IT case class. Create hive catalog exception: no wirte permissions for root directory `/`.

exception:
```
java.io.UncheckedIOException: org.apache.hadoop.security.AccessControlException: Permission denied: user=zhuangchong, access=WRITE, inode="/":omm:supergroup:drwxr-xr-x
	at org.apache.hadoop.hdfs.server.namenode.FSPermissionChecker.check(FSPermissionChecker.java:410)
	at org.apache.hadoop.hdfs.server.namenode.FSPermissionChecker.checkPermission(FSPermissionChecker.java:258)
	...
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1761)
	at org.apache.hadoop.ipc.Server$Handler.run(Server.java:2911)


	at org.apache.paimon.hive.HiveCatalog.createHiveCatalog(HiveCatalog.java:1681)
	at org.apache.paimon.hive.HiveCatalogFactory.create(HiveCatalogFactory.java:37)
	at org.apache.paimon.catalog.CatalogFactory.createUnwrappedCatalog(CatalogFactory.java:84)
	at org.apache.paimon.catalog.CatalogFactory.createCatalog(CatalogFactory.java:71)
	at org.apache.paimon.flink.FlinkGenericCatalogFactory.createCatalog(FlinkGenericCatalogFactory.java:95)
	at org.apache.paimon.hive.FlinkGenericCatalogITCase.before(FlinkGenericCatalogITCase.java:85)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
```


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
