### PR TITLE
[core] (work in progress) Iceberg REST

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
@@ -174,6 +174,7 @@ public class IcebergCommitCallback implements CommitCallback {
                 return IcebergOptions.StorageLocation.TABLE_LOCATION;
             case HIVE_CATALOG:
             case HADOOP_CATALOG:
+            case REST_CATALOG:
                 return IcebergOptions.StorageLocation.CATALOG_STORAGE;
             default:
                 throw new UnsupportedOperationException(

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
@@ -77,7 +77,13 @@ public class IcebergOptions {
             key("metadata.iceberg.uri")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("Hive metastore uri for Iceberg Hive catalog.");
+                    .withDescription("Uri for Hive metastore or REST catalog.");
+
+    public static final ConfigOption<String> REST_WAREHOUSE =
+            key("metadata.iceberg.rest-warehouse")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("REST catalog warehouse.");
 
     public static final ConfigOption<String> HIVE_CONF_DIR =
             key("metadata.iceberg.hive-conf-dir")
@@ -144,7 +150,11 @@ public class IcebergOptions {
         HIVE_CATALOG(
                 "hive-catalog",
                 "Not only store Iceberg metadata like hadoop-catalog, "
-                        + "but also create Iceberg external table in Hive.");
+                        + "but also create Iceberg external table in Hive."),
+        REST_CATALOG(
+                "rest-catalog",
+                "Store Iceberg metadata in a REST catalog. "
+                        + "This allows integration with Iceberg REST catalog services.");
 
         private final String value;
         private final String description;

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergRESTMetadataCommitter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergRESTMetadataCommitter.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg;
+
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.CatalogOptions;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.rest.RESTCatalog;
+import org.apache.paimon.rest.RESTCatalogFactory;
+import org.apache.paimon.rest.RESTCatalogOptions;
+import org.apache.paimon.rest.RESTTokenFileIO;
+import org.apache.paimon.rest.auth.AuthProviderEnum;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.paimon.iceberg.IcebergCommitCallback.catalogDatabasePath;
+
+public class IcebergRESTMetadataCommitter implements IcebergMetadataCommitter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IcebergRESTMetadataCommitter.class);
+
+    private final RESTCatalog restCatalog;
+    private final FileStoreTable table;
+    private final Identifier identifier;
+    private final String icebergDatabase;
+    private final String icebergTable;
+
+    public IcebergRESTMetadataCommitter(FileStoreTable table) {
+        this.table = table;
+        this.identifier =
+                Preconditions.checkNotNull(
+                        table.catalogEnvironment().identifier(),
+                        "If you want to sync Paimon Iceberg compatible metadata to REST catalog, "
+                                + "you must use a Paimon table created from a Paimon catalog, "
+                                + "instead of a temporary table.");
+        Preconditions.checkArgument(
+                identifier.getBranchName() == null,
+                "Paimon Iceberg compatibility currently does not support branches.");
+
+        // TODO this is hardcoded for an IT test but should not be
+        String initToken = "init_token";
+
+        Options tableOptions = new Options(table.options());
+
+        Options catalogOptions = new Options();
+        catalogOptions.set("metastore", "rest");
+        catalogOptions.set(CatalogOptions.WAREHOUSE.key(), tableOptions.get(IcebergOptions.REST_WAREHOUSE));
+        catalogOptions.set(RESTCatalogOptions.URI.key(), tableOptions.get(IcebergOptions.URI));
+        catalogOptions.set(RESTCatalogOptions.TOKEN.key(), initToken);
+        catalogOptions.set(
+                RESTCatalogOptions.TOKEN_PROVIDER.key(), AuthProviderEnum.BEAR.identifier());
+        catalogOptions.set(RESTTokenFileIO.DATA_TOKEN_ENABLED.key(), "true");
+        /*
+        catalogOptions.put(
+                RESTTestFileIO.DATA_PATH_CONF_KEY,
+                dataPath.replaceFirst("file", RESTFileIOTestLoader.SCHEME));
+         */
+
+        this.restCatalog = new RESTCatalog(CatalogContext.create(catalogOptions));
+
+        String icebergDatabase = tableOptions.get(IcebergOptions.METASTORE_DATABASE);
+        String icebergTable = tableOptions.get(IcebergOptions.METASTORE_TABLE);
+        this.icebergDatabase =
+                icebergDatabase != null && !icebergDatabase.isEmpty()
+                        ? icebergDatabase
+                        : this.identifier.getDatabaseName();
+        this.icebergTable =
+                icebergTable != null && !icebergTable.isEmpty()
+                        ? icebergTable
+                        : this.identifier.getTableName();
+    }
+
+    @Override
+    public void commitMetadata(Path newMetadataPath, @Nullable Path baseMetadataPath) {
+        try {
+            commitMetadataImpl(newMetadataPath, baseMetadataPath);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void commitMetadataImpl(Path newMetadataPath, @Nullable Path baseMetadataPath)
+            throws Exception {
+        boolean ignoreIfAlreadyExists = true;
+
+        // Create database
+        Map<String, String> databaseProperties = new HashMap<>();
+        databaseProperties.put("LocationUri", catalogDatabasePath(table).toString());
+        restCatalog.createDatabase(icebergDatabase, ignoreIfAlreadyExists, databaseProperties);
+
+        // TODO change table name to icebergTable
+        restCatalog.createTable(identifier, table.schema().toSchema(), ignoreIfAlreadyExists);
+
+        /*
+          TODO set Iceberg table parameters metadata_location and previous_metadata_location and options
+        */
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergRESTMetadataCommitterFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergRESTMetadataCommitterFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg;
+
+import org.apache.paimon.table.FileStoreTable;
+
+/** Factory to create {@link IcebergRESTMetadataCommitter}. */
+public class IcebergRESTMetadataCommitterFactory implements IcebergMetadataCommitterFactory {
+    @Override
+    public String identifier() {
+        return IcebergOptions.StorageType.REST_CATALOG.toString();
+    }
+
+    @Override
+    public IcebergMetadataCommitter create(FileStoreTable table) {
+        return new IcebergRESTMetadataCommitter(table);
+    }
+}

--- a/paimon-core/src/main/resources/META-INF/services/org.apache.paimon.factories.Factory
+++ b/paimon-core/src/main/resources/META-INF/services/org.apache.paimon.factories.Factory
@@ -38,6 +38,7 @@ org.apache.paimon.mergetree.compact.aggregate.factory.FieldSumAggFactory
 org.apache.paimon.mergetree.compact.aggregate.factory.FieldThetaSketchAggFactory
 org.apache.paimon.rest.RESTCatalogFactory
 org.apache.paimon.iceberg.migrate.IcebergMigrateHadoopMetadataFactory
+org.apache.paimon.iceberg.IcebergRESTMetadataCommitterFactory
 org.apache.paimon.rest.auth.BearTokenAuthProviderFactory
 org.apache.paimon.rest.auth.DLFAuthProviderFactory
 org.apache.paimon.rest.auth.DLFLocalFileTokenLoaderFactory

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/RESTCatalogITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/RESTCatalogITCase.java
@@ -19,13 +19,26 @@
 package org.apache.paimon.flink;
 
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.options.CatalogOptions;
+import org.apache.paimon.rest.RESTCatalogInternalOptions;
+import org.apache.paimon.rest.RESTCatalogServer;
 import org.apache.paimon.rest.RESTToken;
+import org.apache.paimon.rest.RESTTokenFileIO;
+import org.apache.paimon.rest.auth.AuthProvider;
+import org.apache.paimon.rest.auth.BearTokenAuthProvider;
+import org.apache.paimon.rest.responses.ConfigResponse;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -101,5 +114,96 @@ class RESTCatalogITCase extends RESTCatalogITCaseBase {
                         DATABASE_NAME, TABLE_NAME));
         assertThat(batchSql(String.format("SELECT * FROM %s.%s", DATABASE_NAME, TABLE_NAME)))
                 .containsExactlyInAnyOrder(Row.of("1", 11.0D), Row.of("2", 22.0D));
+    }
+
+    @ParameterizedTest
+    // TODO add other file types back
+    @ValueSource(strings = {"avro"})
+    public void testIcebergRESTCatalog(String format) throws Exception {
+        String initToken = "init_token";
+        String dataPath = tempFile.toUri().toString();
+        String restWarehouse = UUID.randomUUID().toString();
+        ConfigResponse config =
+                new ConfigResponse(
+                        ImmutableMap.of(
+                                RESTCatalogInternalOptions.PREFIX.key(),
+                                "paimon",
+                                RESTTokenFileIO.DATA_TOKEN_ENABLED.key(),
+                                "true",
+                                CatalogOptions.WAREHOUSE.key(),
+                                restWarehouse),
+                        ImmutableMap.of());
+        AuthProvider authProvider = new BearTokenAuthProvider(initToken);
+        RESTCatalogServer restCatalogServer =
+                new RESTCatalogServer(dataPath, authProvider, config, restWarehouse);
+        restCatalogServer.start();
+        String serverUrl = restCatalogServer.getUrl();
+
+        String warehouse = getTempDirPath();
+        TableEnvironment tEnv = tableEnvironmentBuilder().batchMode().parallelism(2).build();
+        tEnv.executeSql(
+                "CREATE CATALOG paimon WITH (\n"
+                        + "  'type' = 'paimon',\n"
+                        + "  'warehouse' = '"
+                        + warehouse
+                        + "'\n"
+                        + ")");
+        tEnv.executeSql(
+                "CREATE TABLE paimon.`default`.T (\n"
+                        + "  k INT,\n"
+                        + "  v MAP<INT, ARRAY<ROW(f1 STRING, f2 INT)>>,\n"
+                        + "  v2 BIGINT\n"
+                        + ") WITH (\n"
+                        + "  'metadata.iceberg.storage' = 'rest-catalog',\n"
+                        + "  'metadata.iceberg.uri' = '"
+                        + serverUrl
+                        + "',\n"
+                        + "  'metadata.iceberg.rest-warehouse' = '"
+                        + restWarehouse
+                        + "',\n"
+                        + "  'file.format' = '"
+                        + format
+                        + "'\n"
+                        + ")");
+        tEnv.executeSql(
+                        "INSERT INTO paimon.`default`.T VALUES "
+                                + "(1, MAP[10, ARRAY[ROW('apple', 100), ROW('banana', 101)], 20, ARRAY[ROW('cat', 102), ROW('dog', 103)]], 1000), "
+                                + "(2, MAP[10, ARRAY[ROW('cherry', 200), ROW('pear', 201)], 20, ARRAY[ROW('tiger', 202), ROW('wolf', 203)]], 2000)")
+                .await();
+
+        tEnv.executeSql(
+                "CREATE CATALOG iceberg WITH (\n"
+                        + "  'type' = 'iceberg',\n"
+                        + "  'catalog-type' = 'rest',\n"
+                        + "  'uri' = '"
+                        + serverUrl
+                        + "',\n"
+                        + "  'cache-enabled' = 'false'\n"
+                        + ")");
+        assertThat(collect(tEnv.executeSql("SELECT k, v[10], v2 FROM iceberg.`default`.T")))
+                .containsExactlyInAnyOrder(
+                        Row.of(1, new Row[] {Row.of("apple", 100), Row.of("banana", 101)}, 1000L),
+                        Row.of(2, new Row[] {Row.of("cherry", 200), Row.of("pear", 201)}, 2000L));
+
+        tEnv.executeSql(
+                        "INSERT INTO paimon.`default`.T VALUES "
+                                + "(3, MAP[10, ARRAY[ROW('mango', 300), ROW('watermelon', 301)], 20, ARRAY[ROW('rabbit', 302), ROW('lion', 303)]], 3000)")
+                .await();
+        assertThat(
+                        collect(
+                                tEnv.executeSql(
+                                        "SELECT k, v[10][2].f1, v2 FROM iceberg.`default`.T WHERE v[20][1].f2 > 200")))
+                .containsExactlyInAnyOrder(
+                        Row.of(2, "pear", 2000L), Row.of(3, "watermelon", 3000L));
+    }
+
+    private List<Row> collect(TableResult result) throws Exception {
+        List<Row> rows = new ArrayList<>();
+        try (CloseableIterator<Row> it = result.collect()) {
+            while (it.hasNext()) {
+                rows.add(it.next());
+            }
+        }
+        return rows;
     }
 }


### PR DESCRIPTION
This is a work in progress and not ready for merging. I am opening it as a draft to share my work and to post my notes. Feedback is welcomed and appreciated.

I am exploring two design decisions:

1.  Use [Paimon RESTCatalog](https://github.com/apache/paimon/blob/master/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java#L88) or [Iceberg RESTCatalog](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java#L47)
2. If using Iceberg RESTCatalog, whether to use it as an http client directly and call functions like [`create`](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java#L754) or through a Spark/Flink/Trino catalog instance, like [this](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java#L47)) and use DDL for create database, create table, alter table.

There are pros and cons to each. Some factors are:
- The Paimon and Iceberg REST APIs are not the same. They would need to be adapted. This encourages the use of Iceberg RESTCatalog.
- Paimon has 2 REST auth providers [(bear, dlf)](https://paimon.apache.org/docs/master/concepts/rest/overview/) and these rely on using classes in the Paimon codebase to function. If using Iceberg RESTCatalog they would require code changes to work.
- Using a Spark/Flink/Trino catalog and DDL would require some engine specific code to execute statements to create database, create table, alter table. Currently `IcebergCommitCallback` and related classes are not specific to any engine.

My personal motivation is to get Iceberg REST working with the REST catalog servers provided by Apache Polaris and AWS Glue but I also want to support the community's interests.