### PR TITLE
[core] Start channel should not be negative when partition.hashCode() equals to Integer.MIN_VALUE

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/postpone/PostponeBucketCompactSplitSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/postpone/PostponeBucketCompactSplitSource.java
@@ -186,13 +186,8 @@ public class PostponeBucketCompactSplitSource extends AbstractNonCoordinatedSour
                     matcher.find(),
                     "Data file name %s does not match the pattern. This is unexpected.",
                     fileName);
-
-            // use long to avoid overflow
-            long subtaskId = Long.parseLong(matcher.group(1));
-            // send records written by the same subtask to the same subtask
-            // to make sure we replay the written records in the exact order
-            long channel = (Math.abs(dataSplit.partition().hashCode()) + subtaskId) % numChannels;
-            return (int) channel;
+            return ChannelComputer.select(
+                    dataSplit.partition(), Integer.parseInt(matcher.group(1)), numChannels);
         }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/PostponeBucketChannelComputer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/PostponeBucketChannelComputer.java
@@ -50,7 +50,8 @@ public class PostponeBucketChannelComputer implements ChannelComputer<InternalRo
     @Override
     public int channel(InternalRow record) {
         extractor.setRecord(record);
-        return Math.abs(extractor.partition().hashCode() + extractor.trimmedPrimaryKey().hashCode())
-                % numChannels;
+        return Math.abs(
+                (extractor.partition().hashCode() + extractor.trimmedPrimaryKey().hashCode())
+                        % numChannels);
     }
 }


### PR DESCRIPTION
### Purpose

Currently in `ChannelComputer`, if `partition.hashCode()` equals to `Integer.MIN_VALUE`, the resulting channel will also be negative. This PR fixes the issue.

### Tests

None.

### API and Format

No format changes.

### Documentation

No new feature.
