### PR TITLE
[cdc] Support postpone bucket tables in Paimon CDC

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
@@ -36,6 +36,8 @@ import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.CatalogEnvironment;
 import org.apache.paimon.types.RowType;
 
+import javax.annotation.Nullable;
+
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -89,12 +91,14 @@ public class AppendOnlyFileStore extends AbstractFileStore<InternalRow> {
 
     @Override
     public BaseAppendFileStoreWrite newWrite(String commitUser) {
-        return newWrite(commitUser, null);
+        return newWrite(commitUser, null, null);
     }
 
     @Override
     public BaseAppendFileStoreWrite newWrite(
-            String commitUser, ManifestCacheFilter manifestFilter) {
+            String commitUser,
+            @Nullable ManifestCacheFilter manifestFilter,
+            @Nullable Integer writeId) {
         DeletionVectorsMaintainer.Factory dvMaintainerFactory =
                 options.deletionVectorsEnabled()
                         ? DeletionVectorsMaintainer.factory(newIndexFileHandler())

--- a/paimon-core/src/main/java/org/apache/paimon/FileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/FileStore.java
@@ -88,7 +88,10 @@ public interface FileStore<T> {
 
     FileStoreWrite<T> newWrite(String commitUser);
 
-    FileStoreWrite<T> newWrite(String commitUser, ManifestCacheFilter manifestFilter);
+    FileStoreWrite<T> newWrite(
+            String commitUser,
+            @Nullable ManifestCacheFilter manifestFilter,
+            @Nullable Integer writeId);
 
     FileStoreCommit newCommit(String commitUser, FileStoreTable table);
 

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -46,6 +46,8 @@ import org.apache.paimon.utils.KeyComparatorSupplier;
 import org.apache.paimon.utils.UserDefinedSeqComparator;
 import org.apache.paimon.utils.ValueEqualiserSupplier;
 
+import javax.annotation.Nullable;
+
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -154,12 +156,14 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
 
     @Override
     public AbstractFileStoreWrite<KeyValue> newWrite(String commitUser) {
-        return newWrite(commitUser, null);
+        return newWrite(commitUser, null, null);
     }
 
     @Override
     public AbstractFileStoreWrite<KeyValue> newWrite(
-            String commitUser, ManifestCacheFilter manifestFilter) {
+            String commitUser,
+            @Nullable ManifestCacheFilter manifestFilter,
+            @Nullable Integer writeId) {
         IndexMaintainer.Factory<KeyValue> indexFactory = null;
         if (bucketMode() == BucketMode.HASH_DYNAMIC) {
             indexFactory = new HashIndexMaintainer.Factory(newIndexFileHandler());
@@ -182,7 +186,8 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                     snapshotManager(),
                     newScan(ScanType.FOR_WRITE).withManifestCacheFilter(manifestFilter),
                     options,
-                    tableName);
+                    tableName,
+                    writeId);
         } else {
             return new KeyValueFileStoreWrite(
                     fileIO,

--- a/paimon-core/src/main/java/org/apache/paimon/postpone/PostponeBucketWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/postpone/PostponeBucketWriter.java
@@ -44,11 +44,9 @@ public class PostponeBucketWriter implements RecordWriter<KeyValue> {
     private RollingFileWriter<KeyValue, DataFileMeta> writer;
 
     public PostponeBucketWriter(
-            KeyValueFileWriterFactory writerFactory,
-            List<DataFileMeta> restoreFiles,
-            @Nullable CommitIncrement restoreIncrement) {
+            KeyValueFileWriterFactory writerFactory, @Nullable CommitIncrement restoreIncrement) {
         this.writerFactory = writerFactory;
-        this.files = new ArrayList<>(restoreFiles);
+        this.files = new ArrayList<>();
         if (restoreIncrement != null) {
             files.addAll(restoreIncrement.newFilesIncrement().newFiles());
         }
@@ -74,7 +72,7 @@ public class PostponeBucketWriter implements RecordWriter<KeyValue> {
 
     @Override
     public Collection<DataFileMeta> dataFiles() {
-        return files;
+        return new ArrayList<>(files);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStore.java
@@ -147,9 +147,12 @@ public class PrivilegedFileStore<T> implements FileStore<T> {
     }
 
     @Override
-    public FileStoreWrite<T> newWrite(String commitUser, ManifestCacheFilter manifestFilter) {
+    public FileStoreWrite<T> newWrite(
+            String commitUser,
+            @Nullable ManifestCacheFilter manifestFilter,
+            @Nullable Integer writeId) {
         privilegeChecker.assertCanInsert(identifier);
-        return wrapped.newWrite(commitUser, manifestFilter);
+        return wrapped.newWrite(commitUser, manifestFilter, writeId);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStoreTable.java
@@ -41,6 +41,8 @@ import org.apache.paimon.utils.ChangelogManager;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
+import javax.annotation.Nullable;
+
 import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
@@ -228,9 +230,12 @@ public class PrivilegedFileStoreTable extends DelegatedFileStoreTable {
     }
 
     @Override
-    public TableWriteImpl<?> newWrite(String commitUser, ManifestCacheFilter manifestFilter) {
+    public TableWriteImpl<?> newWrite(
+            String commitUser,
+            @Nullable ManifestCacheFilter manifestFilter,
+            @Nullable Integer writeId) {
         privilegeChecker.assertCanInsert(identifier);
-        return wrapped.newWrite(commitUser, manifestFilter);
+        return wrapped.newWrite(commitUser, manifestFilter, writeId);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -42,6 +42,8 @@ import org.apache.paimon.table.source.SplitGenerator;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Preconditions;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.function.BiConsumer;
 
@@ -125,13 +127,15 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
 
     @Override
     public TableWriteImpl<InternalRow> newWrite(String commitUser) {
-        return newWrite(commitUser, null);
+        return newWrite(commitUser, null, null);
     }
 
     @Override
     public TableWriteImpl<InternalRow> newWrite(
-            String commitUser, ManifestCacheFilter manifestFilter) {
-        BaseAppendFileStoreWrite writer = store().newWrite(commitUser, manifestFilter);
+            String commitUser,
+            @Nullable ManifestCacheFilter manifestFilter,
+            @Nullable Integer writeId) {
+        BaseAppendFileStoreWrite writer = store().newWrite(commitUser, manifestFilter, writeId);
         return new TableWriteImpl<>(
                 rowType(),
                 writer,

--- a/paimon-core/src/main/java/org/apache/paimon/table/DelegatedFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/DelegatedFileStoreTable.java
@@ -49,6 +49,8 @@ import org.apache.paimon.utils.TagManager;
 
 import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
 
+import javax.annotation.Nullable;
+
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
@@ -292,8 +294,11 @@ public abstract class DelegatedFileStoreTable implements FileStoreTable {
     }
 
     @Override
-    public TableWriteImpl<?> newWrite(String commitUser, ManifestCacheFilter manifestFilter) {
-        return wrapped.newWrite(commitUser, manifestFilter);
+    public TableWriteImpl<?> newWrite(
+            String commitUser,
+            @Nullable ManifestCacheFilter manifestFilter,
+            @Nullable Integer writeId) {
+        return wrapped.newWrite(commitUser, manifestFilter, writeId);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTable.java
@@ -41,6 +41,8 @@ import org.apache.paimon.utils.TagManager;
 
 import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
 
+import javax.annotation.Nullable;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -111,7 +113,10 @@ public interface FileStoreTable extends DataTable {
     @Override
     TableWriteImpl<?> newWrite(String commitUser);
 
-    TableWriteImpl<?> newWrite(String commitUser, ManifestCacheFilter manifestFilter);
+    TableWriteImpl<?> newWrite(
+            String commitUser,
+            @Nullable ManifestCacheFilter manifestFilter,
+            @Nullable Integer writeId);
 
     @Override
     TableCommitImpl newCommit(String commitUser);

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
@@ -152,16 +152,18 @@ public class PrimaryKeyFileStoreTable extends AbstractFileStoreTable {
 
     @Override
     public TableWriteImpl<KeyValue> newWrite(String commitUser) {
-        return newWrite(commitUser, null);
+        return newWrite(commitUser, null, null);
     }
 
     @Override
     public TableWriteImpl<KeyValue> newWrite(
-            String commitUser, ManifestCacheFilter manifestFilter) {
+            String commitUser,
+            @Nullable ManifestCacheFilter manifestFilter,
+            @Nullable Integer writeId) {
         KeyValue kv = new KeyValue();
         return new TableWriteImpl<>(
                 rowType(),
-                store().newWrite(commitUser, manifestFilter),
+                store().newWrite(commitUser, manifestFilter, writeId),
                 createRowKeyExtractor(),
                 (record, rowKind) ->
                         kv.replace(

--- a/paimon-core/src/main/java/org/apache/paimon/table/object/ObjectTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/object/ObjectTable.java
@@ -30,6 +30,8 @@ import org.apache.paimon.table.sink.TableWriteImpl;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
+import javax.annotation.Nullable;
+
 import java.util.HashSet;
 import java.util.Map;
 
@@ -157,7 +159,10 @@ public interface ObjectTable extends FileStoreTable {
         }
 
         @Override
-        public TableWriteImpl<?> newWrite(String commitUser, ManifestCacheFilter manifestFilter) {
+        public TableWriteImpl<?> newWrite(
+                String commitUser,
+                @Nullable ManifestCacheFilter manifestFilter,
+                @Nullable Integer writeId) {
             throw new UnsupportedOperationException("Object table does not support Write.");
         }
 

--- a/paimon-flink/paimon-flink-cdc/pom.xml
+++ b/paimon-flink/paimon-flink-cdc/pom.xml
@@ -59,12 +59,7 @@ under the License.
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-flink-common</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Flink dependencies -->

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcPostponeBucketChannelComputer.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcPostponeBucketChannelComputer.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.cdc;
+
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.sink.ChannelComputer;
+import org.apache.paimon.table.sink.KeyAndBucketExtractor;
+
+/**
+ * {@link ChannelComputer} for writing {@link CdcRecord}s into postpone bucket tables. Records with
+ * same primary keys are distributed to the same subtask.
+ */
+public class CdcPostponeBucketChannelComputer implements ChannelComputer<CdcRecord> {
+
+    private final TableSchema schema;
+
+    private transient int numChannels;
+    private transient KeyAndBucketExtractor<CdcRecord> extractor;
+
+    public CdcPostponeBucketChannelComputer(TableSchema schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public void setup(int numChannels) {
+        this.numChannels = numChannels;
+        this.extractor = new CdcRecordKeyAndBucketExtractor(schema);
+    }
+
+    @Override
+    public int channel(CdcRecord record) {
+        extractor.setRecord(record);
+        return Math.abs(
+                (extractor.partition().hashCode() + extractor.trimmedPrimaryKey().hashCode())
+                        % numChannels);
+    }
+}

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperator.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperator.java
@@ -30,6 +30,7 @@ import org.apache.paimon.flink.sink.StoreSinkWrite;
 import org.apache.paimon.flink.sink.StoreSinkWriteImpl;
 import org.apache.paimon.flink.sink.StoreSinkWriteState;
 import org.apache.paimon.flink.sink.StoreSinkWriteStateImpl;
+import org.apache.paimon.flink.utils.RuntimeContextUtils;
 import org.apache.paimon.memory.HeapMemorySegmentPool;
 import org.apache.paimon.memory.MemoryPoolFactory;
 import org.apache.paimon.options.Options;
@@ -107,7 +108,11 @@ public class CdcRecordStoreMultiWriteOperator
                         context, "commit_user_state", String.class, initialCommitUser);
 
         // TODO: should use CdcRecordMultiChannelComputer to filter
-        state = new StoreSinkWriteStateImpl(context, (tableName, partition, bucket) -> true);
+        state =
+                new StoreSinkWriteStateImpl(
+                        RuntimeContextUtils.getIndexOfThisSubtask(getRuntimeContext()),
+                        context,
+                        (tableName, partition, bucket) -> true);
         tables = new HashMap<>();
         writes = new HashMap<>();
         compactExecutor =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
@@ -113,6 +113,7 @@ public class MultiTablesStoreCompactOperator
 
         state =
                 new StoreSinkWriteStateImpl(
+                        RuntimeContextUtils.getIndexOfThisSubtask(getRuntimeContext()),
                         context,
                         (tableName, partition, bucket) ->
                                 ChannelComputer.select(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/NoopStoreSinkWriteState.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/NoopStoreSinkWriteState.java
@@ -28,9 +28,11 @@ import java.util.List;
  */
 public class NoopStoreSinkWriteState implements StoreSinkWriteState {
 
+    private final int subtaskId;
     private final StateValueFilter stateValueFilter;
 
-    public NoopStoreSinkWriteState(StateValueFilter stateValueFilter) {
+    public NoopStoreSinkWriteState(int subtaskId, StateValueFilter stateValueFilter) {
+        this.subtaskId = subtaskId;
         this.stateValueFilter = stateValueFilter;
     }
 
@@ -49,4 +51,9 @@ public class NoopStoreSinkWriteState implements StoreSinkWriteState {
 
     @Override
     public void snapshotState() throws Exception {}
+
+    @Override
+    public int getSubtaskId() {
+        return subtaskId;
+    }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowAppendTableSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowAppendTableSink.java
@@ -45,27 +45,27 @@ public class RowAppendTableSink extends AppendTableSink<InternalRow> {
         return new RowDataStoreWriteOperator.Factory(
                 table, logSinkFunction, writeProvider, commitUser) {
             @Override
+            @SuppressWarnings("unchecked, rawtypes")
             public StreamOperator createStreamOperator(StreamOperatorParameters parameters) {
                 return new RowDataStoreWriteOperator(
                         parameters, table, logSinkFunction, writeProvider, commitUser) {
 
                     @Override
                     protected StoreSinkWriteState createState(
+                            int subtaskId,
                             StateInitializationContext context,
                             StoreSinkWriteState.StateValueFilter stateFilter)
                             throws Exception {
                         // No conflicts will occur in append only unaware bucket writer, so no state
-                        // is
-                        // needed.
-                        return new NoopStoreSinkWriteState(stateFilter);
+                        // is needed.
+                        return new NoopStoreSinkWriteState(subtaskId, stateFilter);
                     }
 
                     @Override
                     protected String getCommitUser(StateInitializationContext context)
                             throws Exception {
                         // No conflicts will occur in append only unaware bucket writer, so
-                        // commitUser does
-                        // not matter.
+                        // commitUser does not matter.
                         return commitUser;
                     }
                 };

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCompactOperator.java
@@ -93,6 +93,7 @@ public class StoreCompactOperator extends PrepareCommitOperator<RowData, Committ
 
         state =
                 new StoreSinkWriteStateImpl(
+                        RuntimeContextUtils.getIndexOfThisSubtask(getRuntimeContext()),
                         context,
                         (tableName, partition, bucket) ->
                                 ChannelComputer.select(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteImpl.java
@@ -145,7 +145,8 @@ public class StoreSinkWriteImpl implements StoreSinkWrite {
                 table.newWrite(
                                 commitUser,
                                 (part, bucket) ->
-                                        state.stateValueFilter().filter(table.name(), part, bucket))
+                                        state.stateValueFilter().filter(table.name(), part, bucket),
+                                state.getSubtaskId())
                         .withIOManager(paimonIOManager)
                         .withIgnorePreviousFiles(ignorePreviousFiles)
                         .withExecutionMode(isStreamingMode)

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteState.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteState.java
@@ -39,6 +39,8 @@ public interface StoreSinkWriteState {
 
     void snapshotState() throws Exception;
 
+    int getSubtaskId();
+
     /**
      * A state value for {@link StoreSinkWrite}. All state values should be given a partition and a
      * bucket so that they can be redistributed once the sink parallelism is changed.

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteStateImpl.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWriteStateImpl.java
@@ -46,6 +46,7 @@ import java.util.Map;
  */
 public class StoreSinkWriteStateImpl implements StoreSinkWriteState {
 
+    private final int subtaskId;
     private final StoreSinkWriteState.StateValueFilter stateValueFilter;
 
     private final ListState<Tuple5<String, String, byte[], Integer, byte[]>> listState;
@@ -53,10 +54,13 @@ public class StoreSinkWriteStateImpl implements StoreSinkWriteState {
 
     @SuppressWarnings("unchecked")
     public StoreSinkWriteStateImpl(
+            int subtaskId,
             StateInitializationContext context,
             StoreSinkWriteState.StateValueFilter stateValueFilter)
             throws Exception {
+        this.subtaskId = subtaskId;
         this.stateValueFilter = stateValueFilter;
+
         TupleSerializer<Tuple5<String, String, byte[], Integer, byte[]>> listStateSerializer =
                 new TupleSerializer<>(
                         (Class<Tuple5<String, String, byte[], Integer, byte[]>>)
@@ -119,5 +123,10 @@ public class StoreSinkWriteStateImpl implements StoreSinkWriteState {
             }
         }
         listState.update(list);
+    }
+
+    @Override
+    public int getSubtaskId() {
+        return subtaskId;
     }
 }


### PR DESCRIPTION
### Purpose

This PR supports postpone bucket tables in Paimon CDC, both for syncing tables and syncing databases.

### Tests

* `FlinkCdcSyncTableSinkITCase#testRandomCdcEventsPostponeBucket`
* `FlinkCdcSyncDatabaseSinkITCase#testRandomCdcEventsPostponeBucket`

### API and Format

No format changes.

### Documentation

No new feature.
