### PR TITLE
[core] keep lowest high-level kv for lookup compaction.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapper.java
@@ -114,7 +114,7 @@ public class LookupChangelogMergeFunctionWrapper<T>
             KeyValue kv = descending.next();
             if (kv.level() > 0) {
                 descending.remove();
-                if (highLevel == null) {
+                if (highLevel == null || kv.level() < highLevel.level()) {
                     highLevel = kv;
                 }
             } else {


### PR DESCRIPTION
### Purpose

Linked issue: close #5631



### Tests

`org.apache.paimon.mergetree.compact.LookupChangelogMergeFunctionWrapperTest#testKeepLowestHighLevel`
