### PR TITLE
[core] pick large files which have dv index for full compaction

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManager.java
@@ -135,7 +135,7 @@ public class MergeTreeCompactManager extends CompactFutureManager {
             }
             optionalUnit =
                     CompactStrategy.pickFullCompaction(
-                            levels.numberOfLevels(), runs, recordLevelExpire);
+                            levels.numberOfLevels(), runs, recordLevelExpire, dvMaintainer);
         } else {
             if (taskFuture != null) {
                 return;
@@ -209,6 +209,7 @@ public class MergeTreeCompactManager extends CompactFutureManager {
                         levels.maxLevel(),
                         metricsReporter,
                         compactDfSupplier,
+                        dvMaintainer,
                         recordLevelExpire);
         if (LOG.isDebugEnabled()) {
             LOG.debug(

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
@@ -178,15 +178,9 @@ public class IcebergCompatibilityTest {
 
         write.compact(BinaryRow.EMPTY_ROW, 0, true);
         commit.commit(4, write.prepareCommit(true, 4));
-        if (deletionVector) {
-            // level 0 file is compacted into deletion vector, so max level data file does not
-            // change
-            // this is still a valid table state at some time in the history
-            assertThat(getIcebergResult())
-                    .containsExactlyInAnyOrder("Record(1, 10)", "Record(2, 21)");
-        } else {
-            assertThat(getIcebergResult()).containsExactlyInAnyOrder("Record(2, 21)");
-        }
+
+        // In dv mode, full compaction will remove all dv index and rewrite data files
+        assertThat(getIcebergResult()).containsExactlyInAnyOrder("Record(2, 21)");
 
         write.close();
         commit.close();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
In deletion-vector mode, all deletion vector index should be removed and the corresponding data files should be rewrite after full compaction. But for the following case below:

Only one file in maxLevel, and using `DELETE` sql to delete some records, it'll generate a dv for the file in maxLevel. When performing full compaction, it' possible that the file won't be picked for compaction, causing that the dv index can't be totally removed after full compaction which is unexpected.

### Tests

<!-- List UT and IT cases to verify this change -->
DeletionVectorITCase#testRemoveDvsAfterFullCompaction: test whether we can select the correct data after disabling dv.
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
