### PR TITLE
[hotfix] [doc] Fix invalid syntax for partition_idle_time in sys.compact example

### DIFF
--- a/docs/content/maintenance/dedicated-compaction.md
+++ b/docs/content/maintenance/dedicated-compaction.md
@@ -335,7 +335,7 @@ Run the following sql:
 
 ```sql
 -- history partition compact table
-CALL sys.compact(`table` => 'default.T', 'partition_idle_time' => '1 d')
+CALL sys.compact(`table` => 'default.T', partition_idle_time => '1 d')
 ```
 
 {{< /tab >}}


### PR DESCRIPTION
### Purpose

In the CALL sys.compact example, partition_idle_time as a key name is incorrectly written with single quotes:

`  CALL sys.compact(`table` => 'default.T', 'partition_idle_time' => '1 d')`

It should be:

`  CALL sys.compact(`table` => 'default.T', partition_idle_time => '1 d')`

This PR fixes the syntax to avoid confusion.


### Tests

Before fix:

```
Flink SQL> CALL sys.compact(`table` => 'default.word_count', 'partition_idle_time' => '1 d');
[ERROR] Could not execute SQL statement. Reason:
org.apache.flink.sql.parser.impl.ParseException: Encountered "=>" at line 1, column 73.
```

After fix:

```
Flink SQL> CALL sys.compact(`table` => 'default.word_count', partition_idle_time => '1 d');
+----------------------------------------+
|                                 result |
+----------------------------------------+
| JobID=<JobID>                          |
+----------------------------------------+
1 row in set
```

