### PR TITLE
[Flink] Hot fix of partition mark down bug.

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -99,6 +99,12 @@ under the License.
             <td>How to trigger partition mark done action.<br /><br />Possible values:<ul><li>"process-time": Based on the time of the machine, mark the partition done once the processing time passes period time plus delay.</li><li>"watermark": Based on the watermark of the input, mark the partition done once the watermark passes period time plus delay.</li></ul></td>
         </tr>
         <tr>
+            <td><h5>partition.mark-done.recover-from-state</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether trigger partition mark done when recover from state.</td>
+        </tr>
+        <tr>
             <td><h5>partition.time-interval</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -378,6 +378,13 @@ public class FlinkConnectorOptions {
                             "You can specify time interval for partition, for example, "
                                     + "daily partition is '1 d', hourly partition is '1 h'.");
 
+    public static final ConfigOption<Boolean> PARTITION_MARK_DONE_RECOVER_FROM_STATE =
+            key("partition.mark-done.recover-from-state")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether trigger partition mark done when recover from state.");
+
     public static final ConfigOption<String> CLUSTERING_COLUMNS =
             key("sink.clustering.by-columns")
                     .stringType()

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CombinedTableCompactorSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CombinedTableCompactorSink.java
@@ -41,6 +41,7 @@ import java.util.Map;
 
 import static org.apache.paimon.CoreOptions.createCommitUser;
 import static org.apache.paimon.flink.FlinkConnectorOptions.END_INPUT_WATERMARK;
+import static org.apache.paimon.flink.FlinkConnectorOptions.PARTITION_MARK_DONE_RECOVER_FROM_STATE;
 import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_COMMITTER_OPERATOR_CHAINING;
 import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_MANAGED_WRITER_BUFFER_MEMORY;
 import static org.apache.paimon.flink.FlinkConnectorOptions.SINK_USE_MANAGED_MEMORY;
@@ -203,6 +204,7 @@ public class CombinedTableCompactorSink implements Serializable {
 
     protected CommittableStateManager<WrappedManifestCommittable> createCommittableStateManager() {
         return new RestoreAndFailCommittableStateManager<>(
-                WrappedManifestCommittableSerializer::new);
+                WrappedManifestCommittableSerializer::new,
+                options.get(PARTITION_MARK_DONE_RECOVER_FROM_STATE));
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
@@ -56,13 +56,8 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
     int filterAndCommit(
             List<GlobalCommitT> globalCommittables,
             boolean checkAppendFiles,
-            boolean recoveryFromState)
+            boolean partitionMarkDoneRecoverFromState)
             throws IOException;
-
-    default int filterAndCommitFromState(List<GlobalCommitT> globalCommittables)
-            throws IOException {
-        return filterAndCommit(globalCommittables, true, true);
-    }
 
     Map<Long, List<CommitT>> groupByCheckpoint(Collection<CommitT> committables);
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
@@ -210,7 +210,7 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
             // So when `endInput` is called, we must check if the corresponding snapshot exists.
             // However, if the snapshot does not exist, then append files must be new files. So
             // there is no need to check for duplicated append files.
-            committer.filterAndCommit(committables, false, false);
+            committer.filterAndCommit(committables, false, true);
         } else {
             committer.commit(committables);
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkWriteSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkWriteSink.java
@@ -20,11 +20,14 @@ package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.manifest.ManifestCommittableSerializer;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 
 import javax.annotation.Nullable;
 
 import java.util.Map;
+
+import static org.apache.paimon.flink.FlinkConnectorOptions.PARTITION_MARK_DONE_RECOVER_FROM_STATE;
 
 /** A {@link FlinkSink} to write records. */
 public abstract class FlinkWriteSink<T> extends FlinkSink<T> {
@@ -55,6 +58,9 @@ public abstract class FlinkWriteSink<T> extends FlinkSink<T> {
 
     @Override
     protected CommittableStateManager<ManifestCommittable> createCommittableStateManager() {
-        return new RestoreAndFailCommittableStateManager<>(ManifestCommittableSerializer::new);
+        Options options = table.coreOptions().toConfiguration();
+        return new RestoreAndFailCommittableStateManager<>(
+                ManifestCommittableSerializer::new,
+                options.get(PARTITION_MARK_DONE_RECOVER_FROM_STATE));
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
@@ -117,9 +117,9 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
     public int filterAndCommit(
             List<ManifestCommittable> globalCommittables,
             boolean checkAppendFiles,
-            boolean recoveryFromState) {
+            boolean partitionMarkDoneRecoverFromState) {
         int committed = commit.filterAndCommitMultiple(globalCommittables, checkAppendFiles);
-        partitionListeners.notifyCommittable(globalCommittables, recoveryFromState);
+        partitionListeners.notifyCommittable(globalCommittables, partitionMarkDoneRecoverFromState);
 
         return committed;
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
@@ -180,13 +180,16 @@ public class StoreMultiCommitter
     public int filterAndCommit(
             List<WrappedManifestCommittable> globalCommittables,
             boolean checkAppendFiles,
-            boolean recoveryFromState) {
+            boolean partitionMarkDoneRecoverFromState) {
         int result = 0;
         for (Map.Entry<Identifier, List<ManifestCommittable>> entry :
                 groupByTable(globalCommittables).entrySet()) {
             result +=
                     getStoreCommitter(entry.getKey())
-                            .filterAndCommit(entry.getValue(), checkAppendFiles, recoveryFromState);
+                            .filterAndCommit(
+                                    entry.getValue(),
+                                    checkAppendFiles,
+                                    partitionMarkDoneRecoverFromState);
         }
         return result;
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionListener.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionListener.java
@@ -26,7 +26,8 @@ import java.util.List;
 /** The partition listener. */
 public interface PartitionListener extends Closeable {
 
-    void notifyCommittable(List<ManifestCommittable> committables, boolean recoverFromState);
+    void notifyCommittable(
+            List<ManifestCommittable> committables, boolean partitionMarkDoneRecoverFromState);
 
     void snapshotState() throws Exception;
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionListeners.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionListeners.java
@@ -39,14 +39,14 @@ public class PartitionListeners implements Closeable {
 
     public void notifyCommittable(List<ManifestCommittable> committables) {
         for (PartitionListener trigger : listeners) {
-            trigger.notifyCommittable(committables, false);
+            trigger.notifyCommittable(committables, true);
         }
     }
 
     public void notifyCommittable(
-            List<ManifestCommittable> committables, boolean recoveryFromState) {
+            List<ManifestCommittable> committables, boolean partitionMarkDoneRecoverFromState) {
         for (PartitionListener trigger : listeners) {
-            trigger.notifyCommittable(committables, recoveryFromState);
+            trigger.notifyCommittable(committables, partitionMarkDoneRecoverFromState);
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionMarkDone.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/PartitionMarkDone.java
@@ -134,14 +134,13 @@ public class PartitionMarkDone implements PartitionListener {
 
     @Override
     public void notifyCommittable(
-            List<ManifestCommittable> committables, boolean recoverFromState) {
-        if (recoverFromState) {
-            return;
-        }
-        if (partitionMarkDoneActionMode == PartitionMarkDoneActionMode.WATERMARK) {
-            markDoneByWatermark(committables);
-        } else {
-            markDoneByProcessTime(committables);
+            List<ManifestCommittable> committables, boolean partitionMarkDoneRecoverFromState) {
+        if (partitionMarkDoneRecoverFromState) {
+            if (partitionMarkDoneActionMode == PartitionMarkDoneActionMode.WATERMARK) {
+                markDoneByWatermark(committables);
+            } else {
+                markDoneByProcessTime(committables);
+            }
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/ReportPartStatsListener.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/ReportPartStatsListener.java
@@ -86,7 +86,7 @@ public class ReportPartStatsListener implements PartitionListener {
     }
 
     public void notifyCommittable(
-            List<ManifestCommittable> committables, boolean recoverFromCheckpoint) {
+            List<ManifestCommittable> committables, boolean partitionMarkDoneRecoverFromState) {
         Set<String> partition = new HashSet<>();
         boolean endInput = false;
         for (ManifestCommittable committable : committables) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

After https://github.com/apache/paimon/pull/5581, we found a potential bug:

When a checkpoint finished, it should notify PartitionMarkDone in ComminterOperator#notifyCheckpointComplete. But failover before call ComminterOperator#notifyCheckpointComplete. 
Then after restarted, RestoreAndFailedCommittableStateManager#recover will be called, the PartitionMarkDone will not notify, which miss the PartitionMarkDone.

So we add an option here which means whether trigger partition mark done when recover from state, the default value is true.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
