### PR TITLE
[Flink] Support withShard read of Flink

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -162,7 +162,7 @@ under the License.
             <td><h5>scan.split-enumerator.mode</h5></td>
             <td style="word-wrap: break-word;">fair</td>
             <td><p>Enum</p></td>
-            <td>The mode used by StaticFileStoreSplitEnumerator to assign splits.<br /><br />Possible values:<ul><li>"fair": Distribute splits evenly when batch reading to prevent a few tasks from reading all.</li><li>"preemptive": Distribute splits preemptively according to the consumption speed of the task.</li></ul></td>
+            <td>The mode used by StaticFileStoreSplitEnumerator to assign splits.<br /><br />Possible values:<ul><li>"fair": Distribute splits evenly when batch reading to prevent a few tasks from reading all.</li><li>"preemptive": Distribute splits preemptively according to the consumption speed of the task.</li><li>"shard_read": Distribute empty split, the real splits will generate on TaskManager.</li></ul></td>
         </tr>
         <tr>
             <td><h5>scan.watermark.alignment.group</h5></td>

--- a/paimon-common/src/main/java/org/apache/paimon/utils/ReflectionUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ReflectionUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.utils;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -80,5 +81,16 @@ public class ReflectionUtils {
             }
         }
         throw new NoSuchFieldException(fieldName);
+    }
+
+    public static Constructor<?> getPrivateStaticClassConstructor(
+            String classPath, Class<?>... parameterTypes)
+            throws ClassNotFoundException, NoSuchMethodException {
+        Class<?> innerClass;
+        Constructor<?> constructor;
+        innerClass = Class.forName(classPath);
+        constructor = innerClass.getDeclaredConstructor(parameterTypes);
+        constructor.setAccessible(true);
+        return constructor;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
@@ -173,6 +173,12 @@ abstract class AbstractDataTableScan implements DataTableScan {
         return this;
     }
 
+    @Override
+    public AbstractDataTableScan withSnapshotId(long snapshotId) {
+        snapshotReader.withSnapshot(snapshotId);
+        return this;
+    }
+
     public CoreOptions options() {
         return options;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableScan.java
@@ -76,4 +76,8 @@ public interface InnerTableScan extends TableScan {
         // do nothing, should implement this if need
         return this;
     }
+
+    default InnerTableScan withSnapshotId(long snapshotId) {
+        return this;
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
@@ -139,6 +139,9 @@ public interface ReadBuilder extends Serializable {
      */
     ReadBuilder withShard(int indexOfThisSubtask, int numberOfParallelSubtasks);
 
+    /** Specify the snapshotId to be read. */
+    ReadBuilder withSnapshot(long snapshotId);
+
     /** Delete stats in scan plan result. */
     ReadBuilder dropStats();
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -50,6 +50,8 @@ public class ReadBuilderImpl implements ReadBuilder {
     private @Nullable Integer specifiedBucket = null;
     private Filter<Integer> bucketFilter;
 
+    private @Nullable Long specifiedSnapshotId = null;
+
     private @Nullable RowType readType;
 
     private boolean dropStats = false;
@@ -122,6 +124,12 @@ public class ReadBuilderImpl implements ReadBuilder {
     }
 
     @Override
+    public ReadBuilder withSnapshot(long snapshotId) {
+        this.specifiedSnapshotId = snapshotId;
+        return this;
+    }
+
+    @Override
     public ReadBuilder withBucket(int bucket) {
         this.specifiedBucket = bucket;
         return this;
@@ -176,6 +184,9 @@ public class ReadBuilderImpl implements ReadBuilder {
         }
         if (dropStats) {
             scan.dropStats();
+        }
+        if (specifiedSnapshotId != null) {
+            scan.withSnapshotId(specifiedSnapshotId);
         }
         return scan;
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -547,7 +547,10 @@ public class FlinkConnectorOptions {
                 "Distribute splits evenly when batch reading to prevent a few tasks from reading all."),
         PREEMPTIVE(
                 "preemptive",
-                "Distribute splits preemptively according to the consumption speed of the task.");
+                "Distribute splits preemptively according to the consumption speed of the task."),
+        SHARD_READ(
+                "shard_read",
+                "Distribute empty split, the real splits will generate on TaskManager.");
 
         private final String value;
         private final String description;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataTableSource.java
@@ -156,7 +156,6 @@ public class DataTableSource extends BaseDataTableSource
                 !table.partitionKeys().isEmpty(),
                 "Cannot apply dynamic filtering to non-partitioned Paimon table '%s'.",
                 table.name());
-
         this.dynamicPartitionFilteringFields = candidateFilterFields;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceSplitGenerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceSplitGenerator.java
@@ -48,6 +48,10 @@ public class FileStoreSourceSplitGenerator {
                 .collect(Collectors.toList());
     }
 
+    public FileStoreSourceSplit createSplit(Split split) {
+        return new FileStoreSourceSplit(getNextId(), split);
+    }
+
     protected final String getNextId() {
         // because we just increment numbers, we increment the char representation directly,
         // rather than incrementing an integer and converting it to a string representation

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSource.java
@@ -22,6 +22,7 @@ import org.apache.paimon.flink.NestedProjectedRowData;
 import org.apache.paimon.flink.metrics.FlinkMetricRegistry;
 import org.apache.paimon.flink.source.assigners.FIFOSplitAssigner;
 import org.apache.paimon.flink.source.assigners.PreAssignSplitAssigner;
+import org.apache.paimon.flink.source.assigners.ShardReadSplitAssigner;
 import org.apache.paimon.flink.source.assigners.SplitAssigner;
 import org.apache.paimon.table.source.InnerTableScan;
 import org.apache.paimon.table.source.ReadBuilder;
@@ -87,7 +88,7 @@ public class StaticFileStoreSource extends FlinkSource {
                 context, null, splitAssigner, dynamicPartitionFilteringInfo);
     }
 
-    private List<FileStoreSourceSplit> getSplits(SplitEnumeratorContext context) {
+    public List<FileStoreSourceSplit> getSplits(SplitEnumeratorContext context) {
         FileStoreSourceSplitGenerator splitGenerator = new FileStoreSourceSplitGenerator();
         TableScan scan = readBuilder.newScan();
         // register scan metrics
@@ -108,6 +109,8 @@ public class StaticFileStoreSource extends FlinkSource {
                 return new PreAssignSplitAssigner(splitBatchSize, context, splits);
             case PREEMPTIVE:
                 return new FIFOSplitAssigner(splits);
+            case SHARD_READ:
+                return new ShardReadSplitAssigner(splitBatchSize, context, splits);
             default:
                 throw new UnsupportedOperationException(
                         "Unsupported assign mode " + splitAssignMode);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/ShardReadSplitAssigner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/ShardReadSplitAssigner.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.assigners;
+
+import org.apache.paimon.codegen.Projection;
+import org.apache.paimon.flink.source.FileStoreSourceSplit;
+import org.apache.paimon.flink.source.FileStoreSourceSplitGenerator;
+import org.apache.paimon.flink.source.shardread.FileStoreSourceSplitWithDpp;
+import org.apache.paimon.table.source.DataSplit;
+
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.table.connector.source.DynamicFilteringData;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.paimon.data.BinaryRow.EMPTY_ROW;
+
+/**
+ * The SplitAssigner for shard read. Each reader will only be assigned an empty split, the real
+ * splits will generate on TaskManager.
+ */
+public class ShardReadSplitAssigner extends PreAssignSplitAssigner {
+
+    private final FileStoreSourceSplitGenerator splitGenerator =
+            new FileStoreSourceSplitGenerator();
+
+    public ShardReadSplitAssigner(
+            int splitBatchSize,
+            SplitEnumeratorContext<FileStoreSourceSplit> context,
+            Collection<FileStoreSourceSplit> splits) {
+        super(splitBatchSize, context, splits);
+    }
+
+    private ShardReadSplitAssigner(
+            int splitBatchSize,
+            int parallelism,
+            Collection<FileStoreSourceSplit> splits,
+            Projection partitionRowProjection,
+            DynamicFilteringData dynamicFilteringData) {
+        super(partitionRowProjection, dynamicFilteringData, splitBatchSize, parallelism, splits);
+    }
+
+    @Override
+    public void addSplitsBack(int subtask, List<FileStoreSourceSplit> splits) {
+        /**
+         * if a reader fail, we still add a mock split to pendingSplitAssignment, after the reader
+         * restart, it will call StaticFileStoreSplitEnumerator#handleSplitRequest ->
+         * ShardSourceReader#addSplits, then do withShard plan on TaskManagers.
+         */
+        LinkedList<FileStoreSourceSplit> remainingSplits =
+                pendingSplitAssignment.computeIfAbsent(subtask, k -> new LinkedList<>());
+
+        FileStoreSourceSplit fileStoreSourceSplit =
+                splitGenerator.createSplit(
+                        DataSplit.builder()
+                                .withPartition(EMPTY_ROW)
+                                .withBucket(0)
+                                .withDataFiles(Collections.emptyList())
+                                .withBucketPath("")
+                                .build());
+
+        if (partitionRowProjection != null && dynamicFilteringData != null) {
+            remainingSplits.add(
+                    FileStoreSourceSplitWithDpp.fromFileStoreSourceSplit(
+                            fileStoreSourceSplit, partitionRowProjection, dynamicFilteringData));
+        } else {
+            remainingSplits.add(fileStoreSourceSplit);
+        }
+
+        numberOfPendingSplits.getAndAdd(1);
+    }
+
+    @Override
+    public Map<Integer, LinkedList<FileStoreSourceSplit>> createBatchFairSplitAssignment(
+            Collection<FileStoreSourceSplit> splits, int numReaders) {
+        if (splits.size() != numReaders) {
+            throw new IllegalArgumentException(
+                    "Error, splits.size() must be equal with numReaders."
+                            + " splits.size() is : "
+                            + splits.size()
+                            + ", numReaders is : "
+                            + numReaders);
+        }
+
+        Map<Integer, LinkedList<FileStoreSourceSplit>> assignment = new HashMap<>(numReaders);
+
+        int readerIndex = 0;
+        for (FileStoreSourceSplit fileStoreSourceSplit : splits) {
+            LinkedList<FileStoreSourceSplit> splitList = new LinkedList<>();
+            if (partitionRowProjection != null && dynamicFilteringData != null) {
+                splitList.add(
+                        FileStoreSourceSplitWithDpp.fromFileStoreSourceSplit(
+                                fileStoreSourceSplit,
+                                partitionRowProjection,
+                                dynamicFilteringData));
+            } else {
+                splitList.add(fileStoreSourceSplit);
+            }
+
+            assignment.put(readerIndex++, splitList);
+        }
+
+        return assignment;
+    }
+
+    public SplitAssigner ofDynamicPartitionPruning(
+            Projection partitionRowProjection, DynamicFilteringData dynamicFilteringData) {
+        return new ShardReadSplitAssigner(
+                splitBatchSize, parallelism, splits, partitionRowProjection, dynamicFilteringData);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/shardread/FileStoreSourceSplitWithDpp.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/shardread/FileStoreSourceSplitWithDpp.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.shardread;
+
+import org.apache.paimon.codegen.Projection;
+import org.apache.paimon.flink.source.FileStoreSourceSplit;
+import org.apache.paimon.table.source.Split;
+
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.table.connector.source.DynamicFilteringData;
+
+import java.util.Objects;
+
+/** {@link SourceSplit} with DynamicPartitionPruning info of file store. */
+public class FileStoreSourceSplitWithDpp extends FileStoreSourceSplit {
+
+    private final Projection partitionRowProjection;
+    private final DynamicFilteringData dynamicFilteringData;
+
+    private FileStoreSourceSplitWithDpp(
+            String id,
+            Split split,
+            long recordsToSkip,
+            Projection partitionRowProjection,
+            DynamicFilteringData dynamicFilteringData) {
+        super(id, split, recordsToSkip);
+        this.partitionRowProjection = partitionRowProjection;
+        this.dynamicFilteringData = dynamicFilteringData;
+    }
+
+    public static FileStoreSourceSplitWithDpp fromFileStoreSourceSplit(
+            FileStoreSourceSplit fileStoreSourceSplit,
+            Projection partitionRowProjection,
+            DynamicFilteringData dynamicFilteringData) {
+        return new FileStoreSourceSplitWithDpp(
+                fileStoreSourceSplit.splitId(),
+                fileStoreSourceSplit.split(),
+                fileStoreSourceSplit.recordsToSkip(),
+                partitionRowProjection,
+                dynamicFilteringData);
+    }
+
+    public Projection getPartitionRowProjection() {
+        return partitionRowProjection;
+    }
+
+    public DynamicFilteringData getDynamicFilteringData() {
+        return dynamicFilteringData;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        FileStoreSourceSplitWithDpp other = (FileStoreSourceSplitWithDpp) o;
+        return partitionRowProjection.equals(other.partitionRowProjection)
+                && DynamicFilteringData.isEqual(dynamicFilteringData, other.dynamicFilteringData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), partitionRowProjection, dynamicFilteringData);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/shardread/ShardSourceReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/shardread/ShardSourceReader.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.shardread;
+
+import org.apache.paimon.codegen.Projection;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.flink.NestedProjectedRowData;
+import org.apache.paimon.flink.source.FileStoreSourceReader;
+import org.apache.paimon.flink.source.FileStoreSourceSplit;
+import org.apache.paimon.flink.source.FileStoreSourceSplitGenerator;
+import org.apache.paimon.flink.source.metrics.FileStoreSourceReaderMetrics;
+import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.utils.ReflectionUtils;
+
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.table.connector.source.DynamicFilteringData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.flink.source.assigners.DynamicPartitionPruningAssigner.filter;
+
+/** The FileStoreSourceReader for shard read. */
+public class ShardSourceReader extends FileStoreSourceReader {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ShardSourceReader.class);
+
+    private static final String SPLIT_STATES_FIELD_NAME = "splitStates";
+    private static final String SPLIT_CONTEXT_CLASS_PATH =
+            "org.apache.flink.connector.base.source.reader.SourceReaderBase$SplitContext";
+
+    private final TableScan tableScan;
+
+    public ShardSourceReader(
+            SourceReaderContext readerContext,
+            TableRead tableRead,
+            TableScan tableScan,
+            FileStoreSourceReaderMetrics metrics,
+            IOManager ioManager,
+            @Nullable Long limit,
+            @Nullable NestedProjectedRowData rowData) {
+        super(readerContext, tableRead, metrics, ioManager, limit, rowData);
+        this.tableScan = tableScan;
+    }
+
+    @Override
+    public void addSplits(List<FileStoreSourceSplit> splits) {
+        LOG.info("Adding split(s) {} to reader : {}", splits, this);
+
+        if (splits.size() != 1) {
+            throw new IllegalArgumentException(
+                    "This is a bug, when use shard read, the splits.size() must be equal to 1.");
+        }
+
+        List<FileStoreSourceSplit> splitsBelongToThisReader =
+                new FileStoreSourceSplitGenerator().createSplits(tableScan.plan());
+
+        FileStoreSourceSplit fileStoreSourceSplit = splits.get(0);
+        if (fileStoreSourceSplit instanceof FileStoreSourceSplitWithDpp) {
+            LOG.info(
+                    "Before DynamicPartitionPruning splitsBelongToThisReader is {}.",
+                    splitsBelongToThisReader);
+            splitsBelongToThisReader =
+                    filterSplitsIfDynamicPartitionPruning(
+                            fileStoreSourceSplit, splitsBelongToThisReader);
+            LOG.info(
+                    "After DynamicPartitionPruning splitsBelongToThisReader is {}.",
+                    splitsBelongToThisReader);
+        }
+
+        if (splitsBelongToThisReader.size() == 0) {
+            // if this reader need not read any split, this reader will finish by follow step.
+            // 1. This reader call context.sendSplitRequest here.
+            // 2. JobManager send signalNoMoreSplits to this reader.
+            // 3. This reader will finish.
+            context.sendSplitRequest();
+            return;
+        }
+
+        Map<String, Object> splitStates = getSplitStatesByReflection();
+        Constructor<?> constructor = getSplitContextConstructorByReflection();
+
+        splitsBelongToThisReader.forEach(
+                s -> {
+                    try {
+                        splitStates.put(
+                                s.splitId(),
+                                constructor.newInstance(s.splitId(), initializedState(s)));
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+
+        this.splitFetcherManager.addSplits(splitsBelongToThisReader);
+    }
+
+    private List<FileStoreSourceSplit> filterSplitsIfDynamicPartitionPruning(
+            FileStoreSourceSplit splitsFromEnumerator,
+            List<FileStoreSourceSplit> splitsBelongToThisReader) {
+        List<FileStoreSourceSplit> splitsAfterDynamicPartitionPruning;
+        Projection partitionRowProjection =
+                ((FileStoreSourceSplitWithDpp) splitsFromEnumerator).getPartitionRowProjection();
+        DynamicFilteringData dynamicFilteringData =
+                ((FileStoreSourceSplitWithDpp) splitsFromEnumerator).getDynamicFilteringData();
+        splitsAfterDynamicPartitionPruning =
+                splitsBelongToThisReader.stream()
+                        .filter(
+                                newSplit ->
+                                        filter(
+                                                newSplit,
+                                                partitionRowProjection,
+                                                dynamicFilteringData))
+                        .collect(Collectors.toList());
+        return splitsAfterDynamicPartitionPruning;
+    }
+
+    private Map<String, Object> getSplitStatesByReflection() {
+        Map<String, Object> splitStates;
+        try {
+            splitStates = ReflectionUtils.getPrivateFieldValue(this, SPLIT_STATES_FIELD_NAME);
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException("The field " + SPLIT_STATES_FIELD_NAME + " not exist.", e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(
+                    "The field " + SPLIT_STATES_FIELD_NAME + " cannot be accessed.", e);
+        }
+
+        return splitStates;
+    }
+
+    private Constructor<?> getSplitContextConstructorByReflection() {
+        Constructor<?> constructor;
+        try {
+            constructor =
+                    ReflectionUtils.getPrivateStaticClassConstructor(
+                            SPLIT_CONTEXT_CLASS_PATH, String.class, Object.class);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(
+                    "The static inner class " + SPLIT_CONTEXT_CLASS_PATH + " cannot be found.", e);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(
+                    "The static inner class " + SPLIT_CONTEXT_CLASS_PATH + " not exist.", e);
+        }
+
+        return constructor;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/shardread/ShardStaticFileStoreSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/shardread/ShardStaticFileStoreSource.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.shardread;
+
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.flink.NestedProjectedRowData;
+import org.apache.paimon.flink.metrics.FlinkMetricRegistry;
+import org.apache.paimon.flink.source.DynamicPartitionFilteringInfo;
+import org.apache.paimon.flink.source.FileStoreSourceSplit;
+import org.apache.paimon.flink.source.FileStoreSourceSplitGenerator;
+import org.apache.paimon.flink.source.FlinkSource;
+import org.apache.paimon.flink.source.StaticFileStoreSource;
+import org.apache.paimon.flink.source.metrics.FileStoreSourceReaderMetrics;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.table.source.TableScan;
+
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.metrics.groups.SourceReaderMetricGroup;
+import org.apache.flink.table.data.RowData;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.paimon.data.BinaryRow.EMPTY_ROW;
+import static org.apache.paimon.disk.IOManagerImpl.splitPaths;
+import static org.apache.paimon.flink.FlinkConnectorOptions.SplitAssignMode;
+
+/** Bounded {@link FlinkSource} for reading records of shard read. */
+public class ShardStaticFileStoreSource extends StaticFileStoreSource {
+
+    private static final long serialVersionUID = 3L;
+
+    private final long latestSnapshotId;
+
+    public ShardStaticFileStoreSource(
+            ReadBuilder readBuilder,
+            @Nullable Long limit,
+            int splitBatchSize,
+            SplitAssignMode splitAssignMode,
+            @Nullable DynamicPartitionFilteringInfo dynamicPartitionFilteringInfo,
+            @Nullable NestedProjectedRowData rowData,
+            long latestSnapshotId) {
+        super(
+                readBuilder,
+                limit,
+                splitBatchSize,
+                splitAssignMode,
+                dynamicPartitionFilteringInfo,
+                rowData);
+
+        this.latestSnapshotId = latestSnapshotId;
+    }
+
+    @Override
+    public SourceReader<RowData, FileStoreSourceSplit> createReader(SourceReaderContext context) {
+        IOManager ioManager =
+                IOManager.create(splitPaths(context.getConfiguration().get(CoreOptions.TMP_DIRS)));
+        SourceReaderMetricGroup metricGroup = context.metricGroup();
+        FileStoreSourceReaderMetrics sourceReaderMetrics =
+                new FileStoreSourceReaderMetrics(metricGroup);
+        TableRead tableRead =
+                readBuilder.newRead().withMetricRegistry(new FlinkMetricRegistry(metricGroup));
+        TableScan tableScan =
+                readBuilder
+                        .withSnapshot(latestSnapshotId)
+                        .withShard(context.getIndexOfSubtask(), context.currentParallelism())
+                        .newScan();
+
+        return new ShardSourceReader(
+                context,
+                tableRead,
+                tableScan,
+                sourceReaderMetrics,
+                ioManager,
+                limit,
+                NestedProjectedRowData.copy(rowData));
+    }
+
+    @Override
+    public List<FileStoreSourceSplit> getSplits(SplitEnumeratorContext context) {
+        FileStoreSourceSplitGenerator splitGenerator = new FileStoreSourceSplitGenerator();
+
+        List<Split> splits = new ArrayList<>(context.currentParallelism());
+        for (int i = 0; i < context.currentParallelism(); ++i) {
+            splits.add(
+                    DataSplit.builder()
+                            .withPartition(EMPTY_ROW)
+                            .withBucket(0)
+                            .withDataFiles(Collections.emptyList())
+                            .withBucketPath("")
+                            .build());
+        }
+        return splitGenerator.createSplits(splits);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitGeneratorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitGeneratorTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.stats.StatsTestUtils;
 import org.apache.paimon.table.source.DataFilePlan;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.Split;
 
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class FileStoreSourceSplitGeneratorTest {
 
     @Test
-    public void test() {
+    public void testCreateSplitsByPlan() {
         List<DataSplit> scanSplits =
                 Arrays.asList(
                         dataSplit(1, 0, "f0", "f1"),
@@ -57,8 +58,38 @@ public class FileStoreSourceSplitGeneratorTest {
                         dataSplit(6, 1, "f14"));
         DataFilePlan tableScanPlan = new DataFilePlan(scanSplits);
 
-        List<FileStoreSourceSplit> splits =
-                new FileStoreSourceSplitGenerator().createSplits(tableScanPlan);
+        assertCreateSplitsInternal(new FileStoreSourceSplitGenerator().createSplits(tableScanPlan));
+    }
+
+    @Test
+    public void testCreateSplitsBySplitList() {
+        List<Split> splits =
+                Arrays.asList(
+                        dataSplit(1, 0, "f0", "f1"),
+                        dataSplit(1, 1, "f2"),
+                        dataSplit(2, 0, "f3", "f4", "f5"),
+                        dataSplit(2, 1, "f6"),
+                        dataSplit(3, 0, "f7"),
+                        dataSplit(3, 1, "f8"),
+                        dataSplit(4, 0, "f9"),
+                        dataSplit(4, 1, "f10"),
+                        dataSplit(5, 0, "f11"),
+                        dataSplit(5, 1, "f12"),
+                        dataSplit(6, 0, "f13"),
+                        dataSplit(6, 1, "f14"));
+
+        assertCreateSplitsInternal(new FileStoreSourceSplitGenerator().createSplits(splits));
+    }
+
+    @Test
+    public void testCreateSplit() {
+        Split split = dataSplit(2, 0, "f3", "f4", "f5");
+        FileStoreSourceSplit fileStoreSourceSplit =
+                new FileStoreSourceSplitGenerator().createSplit(split);
+        assertSplit(fileStoreSourceSplit, "0000000001", 2, 0, Arrays.asList("f3", "f4", "f5"));
+    }
+
+    private void assertCreateSplitsInternal(List<FileStoreSourceSplit> splits) {
         assertThat(splits.size()).isEqualTo(12);
         splits.sort(
                 Comparator.comparingInt(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/StaticFileStoreSplitEnumeratorTestBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/StaticFileStoreSplitEnumeratorTestBase.java
@@ -48,7 +48,7 @@ public abstract class StaticFileStoreSplitEnumeratorTestBase extends FileSplitEn
     @Test
     public void testDynamicPartitionFilteringAfterStarted() {
         final TestingSplitEnumeratorContext<FileStoreSourceSplit> context =
-                getSplitEnumeratorContext(1);
+                getSplitEnumeratorContext(getParallelism());
 
         List<FileStoreSourceSplit> initialSplits = new ArrayList<>();
         for (int i = 0; i < 4; i++) {
@@ -83,6 +83,15 @@ public abstract class StaticFileStoreSplitEnumeratorTestBase extends FileSplitEn
         // request one split and check
         enumerator.handleSplitRequest(0, "test-host");
 
+        assertResultOftestDynamicPartitionFilteringAfterStarted(
+                assignments, initialSplits, enumerator);
+    }
+
+    public void assertResultOftestDynamicPartitionFilteringAfterStarted(
+            Map<Integer, TestingSplitEnumeratorContext.SplitAssignmentState<FileStoreSourceSplit>>
+                    assignments,
+            List<FileStoreSourceSplit> initialSplits,
+            StaticFileStoreSplitEnumerator enumerator) {
         assertThat(assignments.get(0).getAssignedSplits()).containsExactly(initialSplits.get(3));
         assertThat(enumerator.getSplitAssigner().remainingSplits()).isEmpty();
     }
@@ -90,7 +99,7 @@ public abstract class StaticFileStoreSplitEnumeratorTestBase extends FileSplitEn
     @Test
     public void testDynamicPartitionFilteringWithProjection() {
         final TestingSplitEnumeratorContext<FileStoreSourceSplit> context =
-                getSplitEnumeratorContext(1);
+                getSplitEnumeratorContext(getParallelism());
 
         List<FileStoreSourceSplit> initialSplits = new ArrayList<>();
         for (int i = 0; i < 4; i++) {
@@ -118,6 +127,15 @@ public abstract class StaticFileStoreSplitEnumeratorTestBase extends FileSplitEn
         enumerator.handleSplitRequest(0, "test-host");
 
         // check
+        assertResultOfTestDynamicPartitionFilteringWithProjection(
+                assignments, initialSplits, enumerator);
+    }
+
+    public void assertResultOfTestDynamicPartitionFilteringWithProjection(
+            Map<Integer, TestingSplitEnumeratorContext.SplitAssignmentState<FileStoreSourceSplit>>
+                    assignments,
+            List<FileStoreSourceSplit> initialSplits,
+            StaticFileStoreSplitEnumerator enumerator) {
         assertThat(assignments.get(0).getAssignedSplits())
                 .containsExactly(initialSplits.get(0), initialSplits.get(1));
         assertThat(enumerator.getSplitAssigner().remainingSplits()).isEmpty();
@@ -130,7 +148,7 @@ public abstract class StaticFileStoreSplitEnumeratorTestBase extends FileSplitEn
                 context, null, createSplitAssigner(context, 10, splitAssignMode(), splits));
     }
 
-    private StaticFileStoreSplitEnumerator getSplitEnumerator(
+    protected StaticFileStoreSplitEnumerator getSplitEnumerator(
             SplitEnumeratorContext<FileStoreSourceSplit> context,
             List<FileStoreSourceSplit> splits,
             RowType partitionRowProjection,
@@ -148,7 +166,12 @@ public abstract class StaticFileStoreSplitEnumeratorTestBase extends FileSplitEn
 
     protected abstract FlinkConnectorOptions.SplitAssignMode splitAssignMode();
 
-    private static class MockDynamicFilteringData extends DynamicFilteringData {
+    public int getParallelism() {
+        return 1;
+    }
+
+    /** Mock {@link DynamicFilteringData} for UT case. */
+    public static class MockDynamicFilteringData extends DynamicFilteringData {
 
         private final org.apache.flink.table.types.logical.RowType rowType;
         private final RowData[] neededPartitions;

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/shardread/ShardReadAssignModeTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/shardread/ShardReadAssignModeTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.shardread;
+
+import org.apache.paimon.flink.source.FileStoreSourceSplit;
+import org.apache.paimon.flink.source.StaticFileStoreSplitEnumerator;
+import org.apache.paimon.flink.source.StaticFileStoreSplitEnumeratorTestBase;
+
+import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext.SplitAssignmentState;
+import static org.apache.paimon.flink.FlinkConnectorOptions.SplitAssignMode;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link StaticFileStoreSplitEnumerator} with {@link SplitAssignMode#SHARD_READ}. */
+public class ShardReadAssignModeTest extends StaticFileStoreSplitEnumeratorTestBase {
+
+    @Test
+    public void testSplitAllocation() {
+        final TestingSplitEnumeratorContext<FileStoreSourceSplit> context =
+                getSplitEnumeratorContext(4);
+
+        List<FileStoreSourceSplit> splits = new ArrayList<>();
+        for (int i = 1; i <= 4; i++) {
+            splits.add(createSnapshotSplit(i, 0, Collections.emptyList()));
+        }
+        StaticFileStoreSplitEnumerator enumerator = getSplitEnumerator(context, splits);
+
+        // test assign
+        enumerator.handleSplitRequest(0, "test-host");
+        enumerator.handleSplitRequest(1, "test-host");
+        enumerator.handleSplitRequest(2, "test-host");
+        enumerator.handleSplitRequest(3, "test-host");
+        Map<Integer, SplitAssignmentState<FileStoreSourceSplit>> assignments =
+                context.getSplitAssignments();
+
+        assertThat(assignments).containsOnlyKeys(0, 1, 2, 3);
+        assertThat(assignments.get(0).getAssignedSplits()).containsExactly(splits.get(0));
+        assertThat(assignments.get(1).getAssignedSplits()).containsExactly(splits.get(1));
+        assertThat(assignments.get(2).getAssignedSplits()).containsExactly(splits.get(2));
+        assertThat(assignments.get(3).getAssignedSplits()).containsExactly(splits.get(3));
+    }
+
+    @Test
+    public void testSplitAllocationWithException() {
+        final TestingSplitEnumeratorContext<FileStoreSourceSplit> context =
+                getSplitEnumeratorContext(4);
+
+        List<FileStoreSourceSplit> splits = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            splits.add(createSnapshotSplit(i, 0, Collections.emptyList()));
+        }
+
+        try {
+            getSplitEnumerator(context, splits);
+        } catch (IllegalArgumentException e) {
+            assertThat(e)
+                    .hasMessageContaining("Error, splits.size() must be equal with numReaders");
+        }
+    }
+
+    @Override
+    public void assertResultOftestDynamicPartitionFilteringAfterStarted(
+            Map<Integer, TestingSplitEnumeratorContext.SplitAssignmentState<FileStoreSourceSplit>>
+                    assignments,
+            List<FileStoreSourceSplit> initialSplits,
+            StaticFileStoreSplitEnumerator enumerator) {
+        assertThat(assignments.get(0).getAssignedSplits().size()).isEqualTo(1);
+        Assertions.assertTrue(
+                assignments.get(0).getAssignedSplits().get(0)
+                        instanceof FileStoreSourceSplitWithDpp);
+        assertThat(enumerator.getSplitAssigner().remainingSplits().size()).isEqualTo(3);
+    }
+
+    @Override
+    public void assertResultOfTestDynamicPartitionFilteringWithProjection(
+            Map<Integer, TestingSplitEnumeratorContext.SplitAssignmentState<FileStoreSourceSplit>>
+                    assignments,
+            List<FileStoreSourceSplit> initialSplits,
+            StaticFileStoreSplitEnumerator enumerator) {
+        assertThat(assignments.get(0).getAssignedSplits().size()).isEqualTo(1);
+        Assertions.assertTrue(
+                assignments.get(0).getAssignedSplits().get(0)
+                        instanceof FileStoreSourceSplitWithDpp);
+        assertThat(enumerator.getSplitAssigner().remainingSplits().size()).isEqualTo(3);
+    }
+
+    @Override
+    protected SplitAssignMode splitAssignMode() {
+        return SplitAssignMode.SHARD_READ;
+    }
+
+    @Override
+    public int getParallelism() {
+        return 4;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/shardread/ShardReadITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/shardread/ShardReadITCase.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.shardread;
+
+import org.apache.paimon.flink.CatalogITCaseBase;
+
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
+
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+/** IT case for shard read. */
+public class ShardReadITCase extends CatalogITCaseBase {
+
+    @Override
+    public List<String> ddl() {
+        return ImmutableList.of("CREATE TABLE T (" + "a INT, b INT, c STRING) PARTITIONED BY (a);");
+    }
+
+    @BeforeEach
+    @Override
+    public void before() throws IOException {
+        super.before();
+    }
+
+    @Test
+    public void testAllTaskReadRealSplit() {
+        batchSql(
+                "INSERT INTO T /*+ OPTIONS('target-file-size'='1b') */ VALUES (1, 1, '1'), (1, 2, '2'), (2, 3, '3'), (3, 3, '3');");
+        String sql = "SELECT * FROM T /*+ OPTIONS('scan.split-enumerator.mode'='shard_read') */";
+        List<Row> result = batchSql(sql);
+        Assertions.assertThat(result)
+                .containsExactlyInAnyOrder(
+                        Row.ofKind(RowKind.INSERT, 1, 1, "1"),
+                        Row.ofKind(RowKind.INSERT, 1, 2, "2"),
+                        Row.ofKind(RowKind.INSERT, 2, 3, "3"),
+                        Row.ofKind(RowKind.INSERT, 3, 3, "3"));
+    }
+
+    @Test
+    public void testSomeTaskNotReadRealSplit() {
+        batchSql("INSERT INTO T VALUES (1, 1, '1'), (1, 2, '2'), (2, 3, '3'), (3, 3, '3')");
+        String sql =
+                "SELECT * FROM T /*+ OPTIONS('scan.split-enumerator.mode'='shard_read') */ where a = 1 limit 1";
+        List<Row> result = batchSql(sql);
+        Assertions.assertThat(result)
+                .containsExactlyInAnyOrder(Row.ofKind(RowKind.INSERT, 1, 1, "1"));
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/shardread/ShardSourceReaderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/shardread/ShardSourceReaderTest.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.shardread;
+
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.flink.source.DynamicPartitionFilteringInfo;
+import org.apache.paimon.flink.source.FileStoreSourceReader;
+import org.apache.paimon.flink.source.FileStoreSourceReaderTest;
+import org.apache.paimon.flink.source.FileStoreSourceSplit;
+import org.apache.paimon.flink.source.StaticFileStoreSplitEnumeratorTestBase;
+import org.apache.paimon.flink.source.metrics.FileStoreSourceReaderMetrics;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.sink.StreamTableCommit;
+import org.apache.paimon.table.sink.StreamTableWrite;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
+import org.apache.flink.table.connector.source.DynamicFilteringData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.IntType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.paimon.flink.source.FileStoreSourceSplitSerializerTest.newSourceSplit;
+import static org.apache.paimon.io.DataFileTestUtils.row;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for the {@link ShardSourceReader}. */
+public class ShardSourceReaderTest extends FileStoreSourceReaderTest {
+
+    private static final String COMMIT_USER = "commit_user";
+
+    private FileStoreTable table;
+
+    @BeforeEach
+    @Override
+    public void beforeEach() throws Exception {
+        super.beforeEach();
+        FileIO fileIO = LocalFileIO.create();
+        Path tablePath = new Path(tempDir.toUri());
+        SchemaManager schemaManager = new SchemaManager(fileIO, tablePath);
+        TableSchema tableSchema = schemaManager.latest().get();
+        this.table = FileStoreTableFactory.create(fileIO, tablePath, tableSchema);
+    }
+
+    @Test
+    public void testPlanResultIsEmpty() {
+        final TestingReaderContext context = new TestingReaderContext();
+        final ShardSourceReader reader = (ShardSourceReader) createReader(context);
+
+        reader.start();
+        assertThat(context.getNumSplitRequests()).isEqualTo(1);
+
+        reader.addSplits(Collections.singletonList(createTestFileSplit("id1")));
+
+        // splits are only requested when a checkpoint is ready to be triggered
+        assertThat(context.getNumSplitRequests()).isEqualTo(2);
+    }
+
+    @Test
+    public void testPlanResultIsNotEmpty() throws Exception {
+        writeTable();
+        final TestingReaderContext context = new TestingReaderContext();
+        final ShardSourceReader reader = (ShardSourceReader) createReader(context);
+
+        reader.start();
+        assertThat(context.getNumSplitRequests()).isEqualTo(1);
+
+        reader.addSplits(Collections.singletonList(createTestFileSplit("id1")));
+
+        // splits are only requested when a checkpoint is ready to be triggered
+        assertThat(context.getNumSplitRequests()).isEqualTo(1);
+    }
+
+    @Test
+    public void testNoSplitRequestWhenSplitRestored() throws Exception {
+        final TestingReaderContext context = new TestingReaderContext();
+        final ShardSourceReader reader = (ShardSourceReader) createReader(context);
+
+        reader.addSplits(Collections.singletonList(createTestFileSplit("id1")));
+        reader.start();
+        reader.close();
+
+        assertThat(context.getNumSplitRequests()).isEqualTo(2);
+    }
+
+    @Test
+    public void testFilterSplitsIfDynamicPartitionPruning()
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        final TestingReaderContext context = new TestingReaderContext();
+        final ShardSourceReader reader = (ShardSourceReader) createReader(context);
+
+        DynamicFilteringData dynamicFilteringData =
+                new StaticFileStoreSplitEnumeratorTestBase.MockDynamicFilteringData(
+                        org.apache.flink.table.types.logical.RowType.of(
+                                new IntType(), new IntType()),
+                        new RowData[] {GenericRowData.of(1, 1)});
+
+        RowType partitionRowProjection = RowType.of(DataTypes.INT(), DataTypes.INT());
+        List<String> dynamicPartitionFilteringFields = Arrays.asList("f0", "f1");
+        DynamicPartitionFilteringInfo dynamicPartitionFilteringInfo =
+                new DynamicPartitionFilteringInfo(
+                        partitionRowProjection, dynamicPartitionFilteringFields);
+
+        FileStoreSourceSplit splitFromEnumerator =
+                FileStoreSourceSplitWithDpp.fromFileStoreSourceSplit(
+                        newSourceSplit("id1", row(0, 0), 0, Collections.emptyList()),
+                        dynamicPartitionFilteringInfo.getPartitionRowProjection(),
+                        dynamicFilteringData);
+
+        List<FileStoreSourceSplit> splitsBelongToThisReader =
+                Arrays.asList(
+                        newSourceSplit("id1", row(0, 0), 0, Collections.emptyList()),
+                        newSourceSplit("id2", row(0, 1), 0, Collections.emptyList()),
+                        newSourceSplit("id1", row(1, 0), 0, Collections.emptyList()),
+                        newSourceSplit("id2", row(1, 1), 0, Collections.emptyList()));
+
+        Method method =
+                reader.getClass()
+                        .getDeclaredMethod(
+                                "filterSplitsIfDynamicPartitionPruning",
+                                FileStoreSourceSplit.class,
+                                List.class);
+        method.setAccessible(true);
+        List<FileStoreSourceSplit> finalSplits =
+                (List<FileStoreSourceSplit>)
+                        method.invoke(reader, splitFromEnumerator, splitsBelongToThisReader);
+
+        assertThat(finalSplits.size()).isEqualTo(1);
+        assertThat(finalSplits).containsExactly(splitsBelongToThisReader.get(3));
+    }
+
+    @Test
+    public void testFilterSplitsIfDynamicPartitionPruningWithProjection()
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        final TestingReaderContext context = new TestingReaderContext();
+        final ShardSourceReader reader = (ShardSourceReader) createReader(context);
+
+        DynamicFilteringData dynamicFilteringData =
+                new StaticFileStoreSplitEnumeratorTestBase.MockDynamicFilteringData(
+                        org.apache.flink.table.types.logical.RowType.of(new IntType()),
+                        new RowData[] {GenericRowData.of(1)});
+
+        RowType partitionRowProjection = RowType.of(DataTypes.INT(), DataTypes.INT());
+        List<String> dynamicPartitionFilteringFields = Collections.singletonList("f0");
+        DynamicPartitionFilteringInfo dynamicPartitionFilteringInfo =
+                new DynamicPartitionFilteringInfo(
+                        partitionRowProjection, dynamicPartitionFilteringFields);
+
+        FileStoreSourceSplit splitFromEnumerator =
+                FileStoreSourceSplitWithDpp.fromFileStoreSourceSplit(
+                        newSourceSplit("id1", row(0, 0), 0, Collections.emptyList()),
+                        dynamicPartitionFilteringInfo.getPartitionRowProjection(),
+                        dynamicFilteringData);
+
+        List<FileStoreSourceSplit> splitsBelongToThisReader =
+                Arrays.asList(
+                        newSourceSplit("id0", row(0, 0), 0, Collections.emptyList()),
+                        newSourceSplit("id1", row(0, 1), 0, Collections.emptyList()),
+                        newSourceSplit("id2", row(1, 0), 0, Collections.emptyList()),
+                        newSourceSplit("id3", row(1, 1), 0, Collections.emptyList()));
+
+        Method method =
+                reader.getClass()
+                        .getDeclaredMethod(
+                                "filterSplitsIfDynamicPartitionPruning",
+                                FileStoreSourceSplit.class,
+                                List.class);
+        method.setAccessible(true);
+        List<FileStoreSourceSplit> finalSplits =
+                (List<FileStoreSourceSplit>)
+                        method.invoke(reader, splitFromEnumerator, splitsBelongToThisReader);
+
+        assertThat(finalSplits.size()).isEqualTo(2);
+        assertThat(finalSplits)
+                .containsExactlyInAnyOrder(
+                        splitsBelongToThisReader.get(2), splitsBelongToThisReader.get(3));
+    }
+
+    @Override
+    protected FileStoreSourceReader createReader(
+            TestingReaderContext context, TableRead tableRead) {
+
+        ReadBuilder readBuilder = table.newReadBuilder();
+        TableScan tableScan = readBuilder.withShard(0, 3).newScan();
+
+        return new ShardSourceReader(
+                context,
+                tableRead,
+                tableScan,
+                new FileStoreSourceReaderMetrics(new DummyMetricGroup()),
+                IOManager.create(tempDir.toString()),
+                null,
+                null);
+    }
+
+    private void writeTable() throws Exception {
+        try (StreamTableWrite write = table.newWrite(COMMIT_USER);
+                StreamTableCommit commit = table.newCommit(COMMIT_USER)) {
+
+            write.write(GenericRow.of(1L, 11L, 101), 0);
+            write.write(GenericRow.of(2L, 22L, 202), 1);
+            write.write(GenericRow.of(3L, 33L, 303), 2);
+            commit.commit(1, write.prepareCommit(true, 0));
+        }
+    }
+
+    @Test
+    public void testReaderOnSplitFinished() throws Exception {}
+
+    @Test
+    public void testAddMultipleSplits() throws Exception {}
+
+    @Test
+    public void testIOManagerIsSet() throws Exception {}
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

In my company, we use Flink session cluster read paimon for OLAP.

When the QPS of search is high, many problems are gradually becoming apparent.
1、The JobManager's IO is high. Because all job's plan will read meta on FileSystem.
2、To accelerate queries, when we scale-up `scan.manifest.parallelism`, the memory of JobManager is high. 
3、The query speed become slow. Because when QPS is high, the JobManager is busy, this will reduce the speed of the plan or other logic.
4、When QPS is high, the memory is heavy, even though we DropStats after plan.

We found the reason is all job's plan is run on JobManager. In order for the system can accept higher QPS and the query speed can be faster, we we want add an option that user can move the plan to TaskManager.

Be more detailed, when open the option, ShardStaticFileStoreSource will create as many splits as source parallelism, this splits will be assigned to reader. In ShardSourceReader#addSplits we use TableScan withShard feature to get the splits that belong to this reader.
![image](https://github.com/user-attachments/assets/c1fcd845-1a67-40d3-9aca-bd160eaa4f50)

When DynamicPartitionPruning enabled, we add the DynamicPartitionPruning info into MockSplit, after reader receive it, reader will filter partitions after plan withShard.
![image](https://github.com/user-attachments/assets/8093ca49-6f23-4672-ae08-e2f5c994b393)


### Tests

1、UT cases
org.apache.paimon.flink.source.shardread.ShardReadAssignModeTest
org.apache.paimon.flink.source.shardread.ShardSourceReaderTest

2、IT cases
org.apache.paimon.flink.source.shardread.ShardReadITCase

3、Job Test
We run some jobs to test data integrity. The result is no problem.
(1) Without ShardRead
![image](https://github.com/user-attachments/assets/f020aef5-5ddb-417a-ae02-5a0304077498)

(2)ShardRead Without Failover Without Speculation Execution.
![image](https://github.com/user-attachments/assets/03c1d853-c263-4833-984e-77c22bb09cbc)

(3) ShardRead Without Failover with Speculation Execution.
![image](https://github.com/user-attachments/assets/f1130212-953b-4b8f-8c3a-35b527230a12)

(4)ShardRead With Failover Without Speculation Execution.
![image](https://github.com/user-attachments/assets/52a0941c-cd08-49d1-b636-8c343cb9b44e)

(5) ShardRead With Failover With Speculation Execution.
![image](https://github.com/user-attachments/assets/c34e2c44-9190-4afb-9780-a1f598375f7d)

4、Our production environment benefits
Our Flink session OLAP cluster, the JM Core is 16, Memory is 64G, we test submit 5 jobs(select * from paimon table;) .
(1) Without this pr, when do paimon plan, the memory of jm is heavy, and cpu/io is busy. Some job's plan cost 2-3 minutes.
![image](https://github.com/user-attachments/assets/018cb94c-4d9f-44f8-99dc-22cccc4f5575)
![image](https://github.com/user-attachments/assets/a33c8008-6689-46cc-babf-3ef6eae3466d)
![image](https://github.com/user-attachments/assets/e21be5ed-8b98-4f22-849f-2a7bdfa2e804)

(2) With this pr, we move plan from jm to tm, the jm's memory and cpu is not heavy, the flink session cluster can endure more greater QPS.
![image](https://github.com/user-attachments/assets/8ad6082d-e796-420b-87af-d59d8716082d)
![image](https://github.com/user-attachments/assets/f58eeaea-27f3-4e76-bae7-bc37f80c9be3)
![image](https://github.com/user-attachments/assets/d3cda113-50f5-40f1-a73a-a83ed343e0d8)

So in our production environment, we need this feature.


<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
