### PR TITLE
[hudi][clone] Fix Hudi clone to pass configuration for Hudi extractFiles

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/clone/HiveCloneExtractor.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/clone/HiveCloneExtractor.java
@@ -43,6 +43,7 @@ public interface HiveCloneExtractor {
             throws Exception;
 
     List<HivePartitionFiles> extractFiles(
+            Map<String, String> configuration,
             IMetaStoreClient client,
             Table table,
             FileIO fileIO,

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/clone/HiveCloneUtils.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/clone/HiveCloneUtils.java
@@ -135,6 +135,7 @@ public class HiveCloneUtils {
                 client.getTable(identifier.getDatabaseName(), identifier.getTableName());
         return HiveCloneExtractor.getExtractor(sourceTable)
                 .extractFiles(
+                        hiveCatalog.options(),
                         hiveCatalog.getHmsClient(),
                         sourceTable,
                         hiveCatalog.fileIO(),

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/clone/HiveTableCloneExtractor.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/clone/HiveTableCloneExtractor.java
@@ -33,6 +33,8 @@ import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -54,6 +56,7 @@ import static org.apache.paimon.hive.clone.HiveCloneUtils.parseFormat;
 /** A {@link HiveCloneExtractor} for hive tables. */
 public class HiveTableCloneExtractor implements HiveCloneExtractor {
 
+    private static final Logger LOG = LoggerFactory.getLogger(HiveTableCloneExtractor.class);
     public static final HiveTableCloneExtractor INSTANCE = new HiveTableCloneExtractor();
 
     @Override
@@ -70,6 +73,7 @@ public class HiveTableCloneExtractor implements HiveCloneExtractor {
 
     @Override
     public List<HivePartitionFiles> extractFiles(
+            Map<String, String> configuration,
             IMetaStoreClient client,
             Table table,
             FileIO fileIO,

--- a/paimon-hudi/src/main/java/org/apache/paimon/hudi/HudiFileIndex.java
+++ b/paimon-hudi/src/main/java/org/apache/paimon/hudi/HudiFileIndex.java
@@ -43,6 +43,8 @@ import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.storage.hadoop.HoodieHadoopStorage;
 import org.apache.hudi.util.StreamerUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -64,6 +66,7 @@ import static org.apache.paimon.utils.Preconditions.checkState;
  * @see org.apache.hudi.source.FileIndex
  */
 public class HudiFileIndex {
+    private static final Logger LOG = LoggerFactory.getLogger(HudiFileIndex.class);
 
     private final Path path;
     private final HoodieMetadataConfig metadataConfig;
@@ -78,14 +81,16 @@ public class HudiFileIndex {
 
     public HudiFileIndex(
             String location,
-            Map<String, String> conf,
+            Map<String, String> tableOptions,
+            Map<String, String> configuration,
             RowType partitionType,
             @Nullable PartitionPredicate partitionPredicate) {
         this.path = new Path(location);
-        this.metadataConfig = metadataConfig(conf);
+        this.metadataConfig = metadataConfig(tableOptions);
         Configuration hadoopConf =
                 HadoopConfigurations.getHadoopConf(
-                        org.apache.flink.configuration.Configuration.fromMap(conf));
+                        org.apache.flink.configuration.Configuration.fromMap(configuration));
+        configuration.forEach(hadoopConf::set);
         this.partitionType = partitionType;
         this.partitionPredicate = partitionPredicate;
         this.engineContext = new HoodieFlinkEngineContext(hadoopConf);

--- a/paimon-hudi/src/main/java/org/apache/paimon/hudi/HudiHiveCloneExtractor.java
+++ b/paimon-hudi/src/main/java/org/apache/paimon/hudi/HudiHiveCloneExtractor.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -45,6 +47,7 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** A {@link HiveCloneExtractor} for Hudi tables. */
 public class HudiHiveCloneExtractor extends HiveTableCloneExtractor {
+    private static final Logger LOG = LoggerFactory.getLogger(HudiHiveCloneExtractor.class);
 
     @Override
     public boolean matches(Table table) {
@@ -62,13 +65,22 @@ public class HudiHiveCloneExtractor extends HiveTableCloneExtractor {
                 Arrays.stream(HoodieRecord.HoodieMetadataField.values())
                         .map(HoodieRecord.HoodieMetadataField::getFieldName)
                         .collect(Collectors.toSet());
-        return fields.stream()
-                .filter(f -> !hudiMetadataFields.contains(f.getName()))
-                .collect(Collectors.toList());
+        List<FieldSchema> resultFields =
+                fields.stream()
+                        .filter(f -> !hudiMetadataFields.contains(f.getName()))
+                        .collect(Collectors.toList());
+        LOG.info(
+                "Hudi table {}.{} with total field count {}, and result field count {} after filter",
+                database,
+                table,
+                fields.size(),
+                resultFields.size());
+        return resultFields;
     }
 
     @Override
     public List<HivePartitionFiles> extractFiles(
+            Map<String, String> configuration,
             IMetaStoreClient client,
             Table table,
             FileIO fileIO,
@@ -80,7 +92,8 @@ public class HudiHiveCloneExtractor extends HiveTableCloneExtractor {
         checkTableType(options);
 
         String location = table.getSd().getLocation();
-        HudiFileIndex fileIndex = new HudiFileIndex(location, options, partitionRowType, predicate);
+        HudiFileIndex fileIndex =
+                new HudiFileIndex(location, options, configuration, partitionRowType, predicate);
 
         if (fileIndex.isPartitioned()) {
             return fileIndex.getAllFilteredPartitionFiles(fileIO);


### PR DESCRIPTION
CloneHive tool meets problem when clone Hudi table to paimon, which is caused by some necessary FileSystem configuration not passed to Hudi connector.