### PR TITLE
[core] Fix npe problem in bitmap file index v2

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bitmap/BitmapFileIndexMetaV2.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bitmap/BitmapFileIndexMetaV2.java
@@ -233,7 +233,9 @@ public class BitmapFileIndexMetaV2 extends BitmapFileIndexMeta {
 
         LinkedList<BitmapIndexBlock> indexBlocks = new LinkedList<>();
         this.indexBlocks = indexBlocks;
-        indexBlocks.add(new BitmapIndexBlock(0));
+        if (!bitmapOffsets.isEmpty()) {
+            indexBlocks.add(new BitmapIndexBlock(0));
+        }
         Comparator<Object> comparator = getComparator(dataType);
         bitmapOffsets.entrySet().stream()
                 .map(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

When all values ​​are empty, a null pointer exception will be generated during the serialization of bitmap index v2.

<!-- What is the purpose of the change -->

### Tests

org.apache.paimon.fileindex.bitmapindex.BitmapFileIndexTest::testAllNull

