### PR TITLE
[core] Add custom tag expiration strategy

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -1039,6 +1039,12 @@ If the data size allocated for the sorting task is uneven,which may lead to perf
             <td>Use customized name when creating tags in Batch mode.</td>
         </tr>
         <tr>
+            <td><h5>tag.expiration-strategy</h5></td>
+            <td style="word-wrap: break-word;">hybrid</td>
+            <td><p>Enum</p></td>
+            <td>The strategy determines how to expire tags.<br /><br />Possible values:<ul><li>"retain-time": Expire tags by retain time only.</li><li>"retain-number": Expire tags by retain number only.</li><li>"hybrid": Expire tags by retain time and retain number.</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>tag.callback.#.param</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1433,7 +1433,7 @@ public class CoreOptions implements Serializable {
     public static final ConfigOption<TagExpireStrategy> TAG_EXPIRATION_STRATEGY =
             key("tag.expiration-strategy")
                     .enumType(TagExpireStrategy.class)
-                    .defaultValue(TagExpireStrategy.RETAIN_TIME)
+                    .defaultValue(TagExpireStrategy.HYBRID)
                     .withDescription("The strategy determines how to expire tags.");
 
     public static final ConfigOption<Duration> SNAPSHOT_WATERMARK_IDLE_TIMEOUT =

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1430,6 +1430,12 @@ public class CoreOptions implements Serializable {
                     .noDefaultValue()
                     .withDescription("Use customized name when creating tags in Batch mode.");
 
+    public static final ConfigOption<TagExpireStrategy> TAG_EXPIRATION_STRATEGY =
+            key("tag.expiration-strategy")
+                    .enumType(TagExpireStrategy.class)
+                    .defaultValue(TagExpireStrategy.HYBRID)
+                    .withDescription("The strategy determines how to expire tags.");
+
     public static final ConfigOption<Duration> SNAPSHOT_WATERMARK_IDLE_TIMEOUT =
             key("snapshot.watermark-idle-timeout")
                     .durationType()
@@ -2545,6 +2551,10 @@ public class CoreOptions implements Serializable {
         return options.get(TAG_BATCH_CUSTOMIZED_NAME);
     }
 
+    public TagExpireStrategy tagExpireStrategy() {
+        return options.get(TAG_EXPIRATION_STRATEGY);
+    }
+
     public Duration snapshotWatermarkIdleTimeout() {
         return options.get(SNAPSHOT_WATERMARK_IDLE_TIMEOUT);
     }
@@ -3295,6 +3305,33 @@ public class CoreOptions implements Serializable {
         }
 
         @Override
+        public String toString() {
+            return value;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return text(description);
+        }
+    }
+
+    /** The tag expiration strategy. */
+    public enum TagExpireStrategy implements DescribedEnum {
+        RETAIN_TIME("retain-time", "Expire tags by retain time only"),
+
+        RETAIN_NUMBER("retain-number", "Expire tags by retain number only."),
+
+        HYBRID("hybrid", "Expire tags by retain time and retain number.");
+
+        private final String value;
+
+        private final String description;
+
+        TagExpireStrategy(String value, String description) {
+            this.value = value;
+            this.description = description;
+        }
+
         public String toString() {
             return value;
         }

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1433,7 +1433,7 @@ public class CoreOptions implements Serializable {
     public static final ConfigOption<TagExpireStrategy> TAG_EXPIRATION_STRATEGY =
             key("tag.expiration-strategy")
                     .enumType(TagExpireStrategy.class)
-                    .defaultValue(TagExpireStrategy.HYBRID)
+                    .defaultValue(TagExpireStrategy.RETAIN_TIME)
                     .withDescription("The strategy determines how to expire tags.");
 
     public static final ConfigOption<Duration> SNAPSHOT_WATERMARK_IDLE_TIMEOUT =

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoManager.java
@@ -30,19 +30,19 @@ import java.util.List;
 public class TagAutoManager {
 
     private final TagAutoCreation tagAutoCreation;
-    private final TagTimeExpire tagTimeExpire;
+    private final TagExpire tagExpire;
 
-    private TagAutoManager(TagAutoCreation tagAutoCreation, TagTimeExpire tagTimeExpire) {
+    private TagAutoManager(TagAutoCreation tagAutoCreation, TagExpire tagExpire) {
         this.tagAutoCreation = tagAutoCreation;
-        this.tagTimeExpire = tagTimeExpire;
+        this.tagExpire = tagExpire;
     }
 
     public void run() {
         if (tagAutoCreation != null) {
             tagAutoCreation.run();
         }
-        if (tagTimeExpire != null) {
-            tagTimeExpire.expire();
+        if (tagExpire != null) {
+            tagExpire.expire();
         }
     }
 
@@ -60,14 +60,17 @@ public class TagAutoManager {
                         ? null
                         : TagAutoCreation.create(
                                 options, snapshotManager, tagManager, tagDeletion, callbacks),
-                TagTimeExpire.create(snapshotManager, tagManager, tagDeletion, callbacks));
+                options.tagCreationMode() == CoreOptions.TagCreationMode.BATCH
+                        ? null
+                        : TagExpire.createTagExpireStrategy(
+                                options, snapshotManager, tagManager, tagDeletion, callbacks));
     }
 
     public TagAutoCreation getTagAutoCreation() {
         return tagAutoCreation;
     }
 
-    public TagTimeExpire getTagTimeExpire() {
-        return tagTimeExpire;
+    public TagExpire getTagExpire() {
+        return tagExpire;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagExpire.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.tag;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.operation.TagDeletion;
+import org.apache.paimon.table.sink.TagCallback;
+import org.apache.paimon.utils.SnapshotManager;
+import org.apache.paimon.utils.TagManager;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** Strategy for tag expiration. */
+public abstract class TagExpire {
+
+    protected final CoreOptions options;
+
+    protected final SnapshotManager snapshotManager;
+
+    protected final TagManager tagManager;
+
+    protected final TagDeletion tagDeletion;
+
+    protected final List<TagCallback> callbacks;
+
+    protected TagExpire(
+            CoreOptions options,
+            SnapshotManager snapshotManager,
+            TagManager tagManager,
+            TagDeletion tagDeletion,
+            List<TagCallback> callbacks) {
+        this.options = options;
+        this.snapshotManager = snapshotManager;
+        this.tagManager = tagManager;
+        this.tagDeletion = tagDeletion;
+        this.callbacks = callbacks;
+    }
+
+    public abstract List<String> expire();
+
+    public abstract void withOlderThanTime(LocalDateTime olderThanTime);
+
+    public static TagExpire createTagExpireStrategy(
+            CoreOptions options,
+            SnapshotManager snapshotManager,
+            TagManager tagManager,
+            TagDeletion tagDeletion,
+            List<TagCallback> callbacks) {
+        switch (options.tagExpireStrategy()) {
+            case RETAIN_TIME:
+                return TagTimeExpire.create(
+                        options, snapshotManager, tagManager, tagDeletion, callbacks);
+            case RETAIN_NUMBER:
+                return TagNumberExpire.create(
+                        options, snapshotManager, tagManager, tagDeletion, callbacks);
+            case HYBRID:
+            default:
+                return TagHybridExpire.create(
+                        options, snapshotManager, tagManager, tagDeletion, callbacks);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagHybridExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagHybridExpire.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.tag;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.operation.TagDeletion;
+import org.apache.paimon.table.sink.TagCallback;
+import org.apache.paimon.utils.SnapshotManager;
+import org.apache.paimon.utils.TagManager;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** A strategy to expire tags by retain time and retain number. */
+public class TagHybridExpire extends TagExpire {
+
+    private final TagTimeExpire tagTimeExpire;
+
+    private final TagNumberExpire tagNumberExpire;
+
+    public TagHybridExpire(
+            CoreOptions options,
+            SnapshotManager snapshotManager,
+            TagManager tagManager,
+            TagDeletion tagDeletion,
+            List<TagCallback> callbacks) {
+        super(options, snapshotManager, tagManager, tagDeletion, callbacks);
+        this.tagTimeExpire =
+                TagTimeExpire.create(options, snapshotManager, tagManager, tagDeletion, callbacks);
+        this.tagNumberExpire =
+                TagNumberExpire.create(
+                        options, snapshotManager, tagManager, tagDeletion, callbacks);
+    }
+
+    @Override
+    public List<String> expire() {
+        List<String> expired = tagTimeExpire.expire();
+        expired.addAll(tagNumberExpire.expire());
+        return expired;
+    }
+
+    @Override
+    public void withOlderThanTime(LocalDateTime olderThanTime) {
+        if (tagTimeExpire != null) {
+            tagTimeExpire.withOlderThanTime(olderThanTime);
+        }
+    }
+
+    public static TagHybridExpire create(
+            CoreOptions options,
+            SnapshotManager snapshotManager,
+            TagManager tagManager,
+            TagDeletion tagDeletion,
+            List<TagCallback> callbacks) {
+        return new TagHybridExpire(options, snapshotManager, tagManager, tagDeletion, callbacks);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagNumberExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagNumberExpire.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.tag;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.operation.TagDeletion;
+import org.apache.paimon.table.sink.TagCallback;
+import org.apache.paimon.utils.SnapshotManager;
+import org.apache.paimon.utils.TagManager;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/** A strategy to expire tags by retain number. */
+public class TagNumberExpire extends TagExpire {
+
+    public TagNumberExpire(
+            CoreOptions options,
+            SnapshotManager snapshotManager,
+            TagManager tagManager,
+            TagDeletion tagDeletion,
+            List<TagCallback> callbacks) {
+        super(options, snapshotManager, tagManager, tagDeletion, callbacks);
+    }
+
+    @Override
+    public List<String> expire() {
+        Integer tagNumRetainedMax = options.tagNumRetainedMax();
+        boolean writeOnly = options.writeOnly();
+        List<String> expired = new ArrayList<>();
+        if (!writeOnly && tagNumRetainedMax != null) {
+            if (snapshotManager.latestSnapshot() == null) {
+                return expired;
+            }
+            long tagCount = tagManager.tagCount();
+
+            while (tagCount > tagNumRetainedMax) {
+                for (List<String> tagNames : tagManager.tags().values()) {
+                    if (tagCount - tagNames.size() > tagNumRetainedMax) {
+                        tagManager.deleteAllTagsOfOneSnapshot(
+                                tagNames, tagDeletion, snapshotManager);
+                        expired.addAll(tagNames);
+                        tagCount = tagCount - tagNames.size();
+                    } else {
+                        List<String> sortedTagNames = tagManager.sortTagsOfOneSnapshot(tagNames);
+                        for (String toBeDeleted : sortedTagNames) {
+                            tagManager.deleteTag(
+                                    toBeDeleted, tagDeletion, snapshotManager, callbacks);
+                            expired.add(toBeDeleted);
+                            tagCount--;
+                            if (tagCount == tagNumRetainedMax) {
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        return expired;
+    }
+
+    @Override
+    public void withOlderThanTime(LocalDateTime olderThanTime) {
+        // do nothing
+    }
+
+    public static TagNumberExpire create(
+            CoreOptions options,
+            SnapshotManager snapshotManager,
+            TagManager tagManager,
+            TagDeletion tagDeletion,
+            List<TagCallback> callbacks) {
+        return new TagNumberExpire(options, snapshotManager, tagManager, tagDeletion, callbacks);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagTimeExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagTimeExpire.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.tag;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.fs.FileStatus;
 import org.apache.paimon.operation.TagDeletion;
 import org.apache.paimon.table.sink.TagCallback;
@@ -35,29 +36,23 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-/** A manager to expire tags by time. */
-public class TagTimeExpire {
+/** A strategy to expire tags by retain time. */
+public class TagTimeExpire extends TagExpire {
 
     private static final Logger LOG = LoggerFactory.getLogger(TagTimeExpire.class);
-
-    private final SnapshotManager snapshotManager;
-    private final TagManager tagManager;
-    private final TagDeletion tagDeletion;
-    private final List<TagCallback> callbacks;
 
     private LocalDateTime olderThanTime;
 
     private TagTimeExpire(
+            CoreOptions options,
             SnapshotManager snapshotManager,
             TagManager tagManager,
             TagDeletion tagDeletion,
             List<TagCallback> callbacks) {
-        this.snapshotManager = snapshotManager;
-        this.tagManager = tagManager;
-        this.tagDeletion = tagDeletion;
-        this.callbacks = callbacks;
+        super(options, snapshotManager, tagManager, tagDeletion, callbacks);
     }
 
+    @Override
     public List<String> expire() {
         List<Pair<Tag, String>> tags = tagManager.tagObjects();
         List<String> expired = new ArrayList<>();
@@ -102,16 +97,17 @@ public class TagTimeExpire {
         return expired;
     }
 
-    public TagTimeExpire withOlderThanTime(LocalDateTime olderThanTime) {
+    @Override
+    public void withOlderThanTime(LocalDateTime olderThanTime) {
         this.olderThanTime = olderThanTime;
-        return this;
     }
 
     public static TagTimeExpire create(
+            CoreOptions options,
             SnapshotManager snapshotManager,
             TagManager tagManager,
             TagDeletion tagDeletion,
             List<TagCallback> callbacks) {
-        return new TagTimeExpire(snapshotManager, tagManager, tagDeletion, callbacks);
+        return new TagTimeExpire(options, snapshotManager, tagManager, tagDeletion, callbacks);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoManagerTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.tag;
 
 import org.apache.paimon.CoreOptions.TagCreationMode;
 import org.apache.paimon.CoreOptions.TagCreationPeriod;
+import org.apache.paimon.CoreOptions.TagExpireStrategy;
 import org.apache.paimon.CoreOptions.TagPeriodFormatter;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.catalog.PrimaryKeyTableTestBase;
@@ -45,6 +46,7 @@ import static org.apache.paimon.CoreOptions.TAG_AUTOMATIC_CREATION;
 import static org.apache.paimon.CoreOptions.TAG_CREATION_DELAY;
 import static org.apache.paimon.CoreOptions.TAG_CREATION_PERIOD;
 import static org.apache.paimon.CoreOptions.TAG_DEFAULT_TIME_RETAINED;
+import static org.apache.paimon.CoreOptions.TAG_EXPIRATION_STRATEGY;
 import static org.apache.paimon.CoreOptions.TAG_NUM_RETAINED_MAX;
 import static org.apache.paimon.CoreOptions.TAG_PERIOD_FORMATTER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -229,6 +231,7 @@ public class TagAutoManagerTest extends PrimaryKeyTableTestBase {
         Options options = new Options();
         options.set(TAG_AUTOMATIC_CREATION, TagCreationMode.WATERMARK);
         options.set(TAG_CREATION_PERIOD, TagCreationPeriod.HOURLY);
+        options.set(TAG_EXPIRATION_STRATEGY, TagExpireStrategy.RETAIN_TIME);
         options.set(TAG_NUM_RETAINED_MAX, 3);
         FileStoreTable table;
         TableCommitImpl commit;
@@ -313,6 +316,7 @@ public class TagAutoManagerTest extends PrimaryKeyTableTestBase {
         Options options = new Options();
         options.set(TAG_AUTOMATIC_CREATION, TagCreationMode.WATERMARK);
         options.set(TAG_CREATION_PERIOD, TagCreationPeriod.HOURLY);
+        options.set(TAG_EXPIRATION_STRATEGY, TagExpireStrategy.RETAIN_TIME);
         options.set(TAG_NUM_RETAINED_MAX, 1);
         FileStoreTable table = this.table.copy(options.toMap());
         TableCommitImpl commit = table.newCommit(commitUser).ignoreEmptyCommit(false);

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/ExpireTagsProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/ExpireTagsProcedure.java
@@ -20,7 +20,7 @@ package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.tag.TagTimeExpire;
+import org.apache.paimon.tag.TagExpire;
 import org.apache.paimon.utils.DateTimeUtils;
 
 import org.apache.flink.table.procedure.ProcedureContext;
@@ -42,8 +42,8 @@ public class ExpireTagsProcedure extends ProcedureBase {
     public String[] call(ProcedureContext procedureContext, String tableId, String olderThanStr)
             throws Catalog.TableNotExistException {
         FileStoreTable fileStoreTable = (FileStoreTable) table(tableId);
-        TagTimeExpire tagTimeExpire =
-                fileStoreTable.store().newTagCreationManager(fileStoreTable).getTagTimeExpire();
+        TagExpire tagTimeExpire =
+                fileStoreTable.store().newTagCreationManager(fileStoreTable).getTagExpire();
         if (olderThanStr != null) {
             LocalDateTime olderThanTime =
                     DateTimeUtils.parseTimestampData(olderThanStr, 3, TimeZone.getDefault())

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ExpireTagsProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/ExpireTagsProcedure.java
@@ -20,7 +20,7 @@ package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.tag.TagTimeExpire;
+import org.apache.paimon.tag.TagExpire;
 import org.apache.paimon.utils.DateTimeUtils;
 
 import org.apache.flink.table.annotation.ArgumentHint;
@@ -52,8 +52,8 @@ public class ExpireTagsProcedure extends ProcedureBase {
             ProcedureContext procedureContext, String tableId, @Nullable String olderThanStr)
             throws Catalog.TableNotExistException {
         FileStoreTable fileStoreTable = (FileStoreTable) table(tableId);
-        TagTimeExpire tagTimeExpire =
-                fileStoreTable.store().newTagCreationManager(fileStoreTable).getTagTimeExpire();
+        TagExpire tagTimeExpire =
+                fileStoreTable.store().newTagCreationManager(fileStoreTable).getTagExpire();
         if (olderThanStr != null) {
             LocalDateTime olderThanTime =
                     DateTimeUtils.parseTimestampData(olderThanStr, 3, TimeZone.getDefault())

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/ExpireTagsProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/ExpireTagsProcedure.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.spark.procedure;
 
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.tag.TagTimeExpire;
+import org.apache.paimon.tag.TagExpire;
 import org.apache.paimon.utils.DateTimeUtils;
 
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -73,19 +73,19 @@ public class ExpireTagsProcedure extends BaseProcedure {
                 tableIdent,
                 table -> {
                     FileStoreTable fileStoreTable = (FileStoreTable) table;
-                    TagTimeExpire tagTimeExpire =
+                    TagExpire tagExpire =
                             fileStoreTable
                                     .store()
                                     .newTagCreationManager(fileStoreTable)
-                                    .getTagTimeExpire();
+                                    .getTagExpire();
                     if (olderThanStr != null) {
                         LocalDateTime olderThanTime =
                                 DateTimeUtils.parseTimestampData(
                                                 olderThanStr, 3, TimeZone.getDefault())
                                         .toLocalDateTime();
-                        tagTimeExpire.withOlderThanTime(olderThanTime);
+                        tagExpire.withOlderThanTime(olderThanTime);
                     }
-                    List<String> expired = tagTimeExpire.expire();
+                    List<String> expired = tagExpire.expire();
                     return expired.isEmpty()
                             ? new InternalRow[] {
                                 newInternalRow(UTF8String.fromString("No expired tags."))

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/ExpireTagsProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/ExpireTagsProcedureTest.scala
@@ -230,9 +230,7 @@ class ExpireTagsProcedureTest extends PaimonSparkTestBase {
       "CALL paimon.sys.create_tag(table => 'test.T', tag => 'tag-3', snapshot => 3, time_retained => '1d')")
     spark.sql(
       "CALL paimon.sys.create_tag(table => 'test.T', tag => 'tag-4', snapshot => 4, time_retained => '1d')")
-    // check tag
-
-    Thread.sleep(1000)
+    checkAnswer(spark.sql("select count(tag_name) from `T$tags`"), Row(4) :: Nil)
 
     withSparkSQLConf("spark.paimon.tag.num-retained-max" -> "2") {
       // expire tag-1,tag-2, even if tag-2 has not reached the retention time


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Currently, there are some problems in tag expiration mechanism:
1. Normally, the expiration in the commit phase is based only on the tag retention time, and those tags without retention time are not processed, which needs to be expired separately.
2. When setting `tag.automatic-creation=batch`, it will first expire once in the commit phase, and then call its own separate expiration logic, which deletes only based on tag number, which will force the deletion of tags that have not expired, it is not reasonable.

so, we add the tag expiration strategy, it support three strategies:
- retain-time: expire only based on tag retain time.
- retain-number: expire only base on tag retain number even if the tag retain time is not reached. This strategy need set conf `tag.num-retained-max`.
- hybrid: first expire based the tag retain time, then consider retain number if conf `tag.num-retained-max` is set.

If we does not set `tag.num-retained-max`, the hybrid strategy is equivalent to retain-time strategy.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
