### PR TITLE
[core] Add more commit info logs

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
@@ -135,6 +135,8 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
 
     @VisibleForTesting
     public int expireUntil(long earliestId, long endExclusiveId) {
+        long startTime = System.currentTimeMillis();
+
         if (endExclusiveId <= earliestId) {
             // No expire happens:
             // write the hint file in order to see the earliest snapshot directly next time
@@ -156,11 +158,6 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
                 beginInclusiveId = id + 1;
                 break;
             }
-        }
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug(
-                    "Snapshot expire range is [" + beginInclusiveId + ", " + endExclusiveId + ")");
         }
 
         List<Snapshot> taggedSnapshots = tagManager.taggedSnapshots();
@@ -269,6 +266,12 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         }
 
         writeEarliestHint(endExclusiveId);
+        long duration = System.currentTimeMillis() - startTime;
+        LOG.info(
+                "Finished expire snapshots, duration {} ms, range is [{}, {})",
+                duration,
+                beginInclusiveId,
+                endExclusiveId);
         return (int) (endExclusiveId - beginInclusiveId);
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

```
INFO  org.apache.paimon.operation.FileStoreCommitImpl [] - Ready to commit to table T, number of commit messages: 2
INFO  org.apache.paimon.operation.FileStoreCommitImpl [] - Finished collecting changes, including: 2 append table files
INFO  org.apache.paimon.operation.FileStoreCommitImpl [] - Successfully commit snapshot 1 to table T by user 9565778e-6649-429b-9ca9-f0cca34bc44b with identifier 9223372036854775807 and kind APPEND.
INFO  org.apache.paimon.operation.FileStoreCommitImpl [] - Finished commit to table T, duration 77 ms
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
