### PR TITLE
ISSUE-5658: Handle null uncompact BigDecimal and Timestamp

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/AbstractBinaryWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/AbstractBinaryWriter.java
@@ -126,8 +126,11 @@ abstract class AbstractBinaryWriter implements BinaryWriter {
         assert value == null || (value.precision() == precision);
 
         if (Decimal.isCompact(precision)) {
-            assert value != null;
-            writeLong(pos, value.toUnscaledLong());
+            if (value == null) {
+                setNullBit(pos);
+            } else {
+                writeLong(pos, value.toUnscaledLong());
+            }
         } else {
             // grow the global buffer before writing data.
             ensureCapacity(16);
@@ -159,7 +162,11 @@ abstract class AbstractBinaryWriter implements BinaryWriter {
     @Override
     public void writeTimestamp(int pos, Timestamp value, int precision) {
         if (Timestamp.isCompact(precision)) {
-            writeLong(pos, value.getMillisecond());
+            if (value == null) {
+                setNullBit(pos);
+            } else {
+                writeLong(pos, value.getMillisecond());
+            }
         } else {
             // store the nanoOfMillisecond in fixed-length part as offset and nanoOfMillisecond
             ensureCapacity(8);

--- a/paimon-common/src/main/java/org/apache/paimon/data/BinaryRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BinaryRow.java
@@ -172,7 +172,11 @@ public final class BinaryRow extends BinarySection implements InternalRow, DataS
 
         if (Decimal.isCompact(precision)) {
             // compact format
-            setLong(pos, value.toUnscaledLong());
+            if (value == null) {
+                setNullAt(pos);
+            } else {
+                setLong(pos, value.toUnscaledLong());
+            }
         } else {
             int fieldOffset = getFieldOffset(pos);
             int cursor = (int) (segments[0].getLong(fieldOffset) >>> 32);
@@ -202,7 +206,11 @@ public final class BinaryRow extends BinarySection implements InternalRow, DataS
         assertIndexIsValid(pos);
 
         if (Timestamp.isCompact(precision)) {
-            setLong(pos, value.getMillisecond());
+            if (value == null) {
+                setNullAt(pos);
+            } else {
+                setLong(pos, value.getMillisecond());
+            }
         } else {
             int fieldOffset = getFieldOffset(pos);
             int cursor = (int) (segments[0].getLong(fieldOffset) >>> 32);

--- a/paimon-common/src/test/java/org/apache/paimon/data/BinaryRowTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/BinaryRowTest.java
@@ -395,23 +395,27 @@ public class BinaryRowTest {
 
     @Test
     public void testDecimal() {
-        // 1.compact
+        // 1. compact
         {
             int precision = 4;
             int scale = 2;
-            BinaryRow row = new BinaryRow(2);
+            BinaryRow row = new BinaryRow(3);
             BinaryRowWriter writer = new BinaryRowWriter(row);
             writer.writeDecimal(0, Decimal.fromUnscaledLong(5, precision, scale), precision);
             writer.setNullAt(1);
+            writer.writeDecimal(2, null, precision);
             writer.complete();
 
             assertThat(row.getDecimal(0, precision, scale).toString()).isEqualTo("0.05");
             assertThat(row.isNullAt(1)).isTrue();
+            assertThat(row.isNullAt(2)).isTrue();
             row.setDecimal(0, Decimal.fromUnscaledLong(6, precision, scale), precision);
             assertThat(row.getDecimal(0, precision, scale).toString()).isEqualTo("0.06");
+            row.setDecimal(1, null, precision);
+            assertThat(row.isNullAt(1)).isTrue();
         }
 
-        // 2.not compact
+        // 2. not compact
         {
             int precision = 25;
             int scale = 5;
@@ -428,6 +432,8 @@ public class BinaryRowTest {
             assertThat(row.isNullAt(1)).isTrue();
             row.setDecimal(0, decimal2, precision);
             assertThat(row.getDecimal(0, precision, scale).toString()).isEqualTo("6.55000");
+            row.setDecimal(1, null, precision);
+            assertThat(row.isNullAt(1)).isTrue();
         }
     }
 
@@ -848,16 +854,20 @@ public class BinaryRowTest {
         // 1. compact
         {
             final int precision = 3;
-            BinaryRow row = new BinaryRow(2);
+            BinaryRow row = new BinaryRow(3);
             BinaryRowWriter writer = new BinaryRowWriter(row);
             writer.writeTimestamp(0, Timestamp.fromEpochMillis(123L), precision);
             writer.setNullAt(1);
+            writer.writeTimestamp(2, null, precision);
             writer.complete();
 
             assertThat(row.getTimestamp(0, 3).toString()).isEqualTo("1970-01-01T00:00:00.123");
             assertThat(row.isNullAt(1)).isTrue();
+            assertThat(row.isNullAt(2)).isTrue();
             row.setTimestamp(0, Timestamp.fromEpochMillis(-123L), precision);
             assertThat(row.getTimestamp(0, 3).toString()).isEqualTo("1969-12-31T23:59:59.877");
+            row.setTimestamp(1, null, precision);
+            assertThat(row.isNullAt(2)).isTrue();
         }
 
         // 2. not compact


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5658

<!-- What is the purpose of the change -->
Fix JavaApi NPE

### Tests

<!-- List UT and IT cases to verify this change -->
BinaryRowTest

### API and Format

<!-- Does this change affect API or storage format -->
No changes.

### Documentation

<!-- Does this change introduce a new feature -->
No
