### PR TITLE
[core] Add load version snapshot and list snapshots to Catalog

### DIFF
--- a/docs/static/rest-catalog-open-api.yaml
+++ b/docs/static/rest-catalog-open-api.yaml
@@ -732,6 +732,102 @@ paths:
                   $ref: '#/components/examples/SnapshotNotExistError'
         "500":
           $ref: '#/components/responses/ServerErrorResponse'
+  /v1/{prefix}/databases/{database}/tables/{table}/snapshots/{version}:
+    get:
+      tags:
+        - table
+      summary: Get version snapshot
+      operationId: getVersionSnapshot
+      parameters:
+        - name: prefix
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: database
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: table
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: version
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetVersionSnapshotResponse'
+        "401":
+          $ref: '#/components/responses/UnauthorizedErrorResponse'
+        404:
+          description:
+            Not Found
+            - TableNotExistException, table does not exist
+            - SnapshotNotExistException, the requested snapshot does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/ResourceNotExistErrorResponse'
+              examples:
+                TableNotExist:
+                  $ref: '#/components/examples/TableNotExistError'
+                SnapshotNotExist:
+                  $ref: '#/components/examples/SnapshotNotExistError'
+        "500":
+          $ref: '#/components/responses/ServerErrorResponse'
+  /v1/{prefix}/databases/{database}/tables/{table}/snapshots:
+    get:
+      tags:
+        - table
+      summary: List snapshots
+      operationId: listSnapshots
+      parameters:
+        - name: prefix
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: database
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: table
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: maxResults
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: pageToken
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListSnapshotsResponse'
+        "401":
+          $ref: '#/components/responses/UnauthorizedErrorResponse'
+        "404":
+          $ref: '#/components/responses/TableNotExistErrorResponse'
+        "500":
+          $ref: '#/components/responses/ServerErrorResponse'
   /v1/{prefix}/databases/{database}/tables/{table}/partitions:
     get:
       tags:
@@ -2428,6 +2524,20 @@ components:
       properties:
         snapshot:
           $ref: '#/components/schemas/TableSnapshot'
+    GetVersionSnapshotResponse:
+      type: object
+      properties:
+        snapshot:
+          $ref: '#/components/schemas/Snapshot'
+    ListSnapshotsResponse:
+      type: object
+      properties:
+        snapshots:
+          type: array
+          items:
+            $ref: '#/components/schemas/Snapshot'
+        nextPageToken:
+          type: string
     AuthTableQueryRequest:
       type: object
       properties:

--- a/paimon-api/src/main/java/org/apache/paimon/rest/ResourcePaths.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/ResourcePaths.java
@@ -32,6 +32,7 @@ public class ResourcePaths {
     protected static final String TABLES = "tables";
     protected static final String PARTITIONS = "partitions";
     protected static final String BRANCHES = "branches";
+    protected static final String SNAPSHOTS = "snapshots";
     protected static final String VIEWS = "views";
     protected static final String TABLE_DETAILS = "table-details";
     protected static final String VIEW_DETAILS = "view-details";
@@ -130,6 +131,29 @@ public class ResourcePaths {
                 TABLES,
                 encodeString(objectName),
                 "snapshot");
+    }
+
+    public String tableSnapshot(String databaseName, String objectName, String version) {
+        return SLASH.join(
+                V1,
+                prefix,
+                DATABASES,
+                encodeString(databaseName),
+                TABLES,
+                encodeString(objectName),
+                SNAPSHOTS,
+                version);
+    }
+
+    public String snapshots(String databaseName, String objectName) {
+        return SLASH.join(
+                V1,
+                prefix,
+                DATABASES,
+                encodeString(databaseName),
+                TABLES,
+                encodeString(objectName),
+                SNAPSHOTS);
     }
 
     public String authTable(String databaseName, String objectName) {

--- a/paimon-api/src/main/java/org/apache/paimon/rest/responses/GetVersionSnapshotResponse.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/responses/GetVersionSnapshotResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest.responses;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.rest.RESTResponse;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Response for table snapshot by a version. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GetVersionSnapshotResponse implements RESTResponse {
+
+    private static final String FIELD_SNAPSHOT = "snapshot";
+
+    @JsonProperty(FIELD_SNAPSHOT)
+    private final Snapshot snapshot;
+
+    @JsonCreator
+    public GetVersionSnapshotResponse(@JsonProperty(FIELD_SNAPSHOT) Snapshot snapshot) {
+        this.snapshot = snapshot;
+    }
+
+    @JsonGetter(FIELD_SNAPSHOT)
+    public Snapshot getSnapshot() {
+        return snapshot;
+    }
+}

--- a/paimon-api/src/main/java/org/apache/paimon/rest/responses/ListSnapshotsResponse.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/responses/ListSnapshotsResponse.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest.responses;
+
+import org.apache.paimon.Snapshot;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/** Response for list snapshots. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ListSnapshotsResponse implements PagedResponse<Snapshot> {
+
+    private static final String FIELD_SNAPSHOTS = "snapshots";
+    private static final String FIELD_NEXT_PAGE_TOKEN = "nextPageToken";
+
+    @JsonProperty(FIELD_SNAPSHOTS)
+    private final List<Snapshot> snapshots;
+
+    @JsonProperty(FIELD_NEXT_PAGE_TOKEN)
+    private final String nextPageToken;
+
+    public ListSnapshotsResponse(@JsonProperty(FIELD_SNAPSHOTS) List<Snapshot> snapshots) {
+        this(snapshots, null);
+    }
+
+    @JsonCreator
+    public ListSnapshotsResponse(
+            @JsonProperty(FIELD_SNAPSHOTS) List<Snapshot> snapshots,
+            @JsonProperty(FIELD_NEXT_PAGE_TOKEN) String nextPageToken) {
+        this.snapshots = snapshots;
+        this.nextPageToken = nextPageToken;
+    }
+
+    @JsonGetter(FIELD_SNAPSHOTS)
+    public List<Snapshot> getSnapshots() {
+        return this.snapshots;
+    }
+
+    @Override
+    public List<Snapshot> data() {
+        return snapshots;
+    }
+
+    @JsonGetter(FIELD_NEXT_PAGE_TOKEN)
+    public String getNextPageToken() {
+        return this.nextPageToken;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -487,6 +487,17 @@ public abstract class AbstractCatalog implements Catalog {
     }
 
     @Override
+    public Optional<Snapshot> loadSnapshot(Identifier identifier, String version) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PagedList<Snapshot> listSnapshotsPaged(
+            Identifier identifier, @Nullable Integer maxResults, @Nullable String pageToken) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void rollbackTo(Identifier identifier, Instant instant)
             throws Catalog.TableNotExistException {
         throw new UnsupportedOperationException();

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -352,7 +352,8 @@ public interface Catalog extends AutoCloseable {
     List<Partition> listPartitions(Identifier identifier) throws TableNotExistException;
 
     /**
-     * Get paged partitioned list of the table.
+     * Get paged partition list of the table, the partition list will be returned in descending
+     * order.
      *
      * @param identifier path of the table to list partitions
      * @param maxResults Optional parameter indicating the maximum number of results to include in
@@ -361,7 +362,7 @@ public interface Catalog extends AutoCloseable {
      * @param pageToken Optional parameter indicating the next page token allows list to be start
      *     from a specific point.
      * @param partitionNamePattern A sql LIKE pattern (%) for partition names. All partitions will
-     *     be * returned if not set or empty. Currently, only prefix matching is supported.
+     *     be returned if not set or empty. Currently, only prefix matching is supported.
      * @return a list of the partitions with provided page size(@param maxResults) in this table and
      *     next page token, or a list of all partitions of the table if the catalog does not {@link
      *     #supportsListObjectsPaged()}.
@@ -638,6 +639,46 @@ public interface Catalog extends AutoCloseable {
      */
     Optional<TableSnapshot> loadSnapshot(Identifier identifier)
             throws Catalog.TableNotExistException;
+
+    /**
+     * Return the snapshot of table for given version. Version parsing order is:
+     *
+     * <ul>
+     *   <li>1. If it is 'EARLIEST', get the earliest snapshot.
+     *   <li>2. If it is 'LATEST', get the latest snapshot.
+     *   <li>3. If it is a number, get snapshot by snapshot id.
+     *   <li>4. Else try to get snapshot from Tag name.
+     * </ul>
+     *
+     * @param identifier Path of the table
+     * @param version version to snapshot
+     * @return The requested snapshot
+     * @throws Catalog.TableNotExistException if the target does not exist
+     * @throws UnsupportedOperationException if the catalog does not {@link
+     *     #supportsVersionManagement()}
+     */
+    Optional<Snapshot> loadSnapshot(Identifier identifier, String version)
+            throws Catalog.TableNotExistException;
+
+    /**
+     * Get paged snapshot list of the table, the snapshot list will be returned in descending order.
+     *
+     * @param identifier path of the table to list partitions
+     * @param maxResults Optional parameter indicating the maximum number of results to include in
+     *     the result. If maxResults is not specified or set to 0, will return the default number of
+     *     max results.
+     * @param pageToken Optional parameter indicating the next page token allows list to be start
+     *     from a specific point.
+     * @return a list of the snapshots with provided page size(@param maxResults) in this table and
+     *     next page token, or a list of all snapshots of the table if the catalog does not {@link
+     *     #supportsListObjectsPaged()}.
+     * @throws TableNotExistException if the table does not exist
+     * @throws UnsupportedOperationException if the catalog does not {@link
+     *     #supportsVersionManagement()}
+     */
+    PagedList<Snapshot> listSnapshotsPaged(
+            Identifier identifier, @Nullable Integer maxResults, @Nullable String pageToken)
+            throws TableNotExistException;
 
     /**
      * rollback table by the given {@link Identifier} and instant.

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -171,6 +171,19 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
+    public Optional<Snapshot> loadSnapshot(Identifier identifier, String version)
+            throws TableNotExistException {
+        return wrapped.loadSnapshot(identifier, version);
+    }
+
+    @Override
+    public PagedList<Snapshot> listSnapshotsPaged(
+            Identifier identifier, @Nullable Integer maxResults, @Nullable String pageToken)
+            throws TableNotExistException {
+        return wrapped.listSnapshotsPaged(identifier, maxResults, pageToken);
+    }
+
+    @Override
     public void rollbackTo(Identifier identifier, Instant instant)
             throws Catalog.TableNotExistException {
         wrapped.rollbackTo(identifier, instant);

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -287,6 +287,34 @@ public class RESTCatalog implements Catalog {
     }
 
     @Override
+    public Optional<Snapshot> loadSnapshot(Identifier identifier, String version)
+            throws TableNotExistException {
+        try {
+            return Optional.ofNullable(api.loadSnapshot(identifier, version));
+        } catch (NoSuchResourceException e) {
+            if (StringUtils.equals(e.resourceType(), ErrorResponse.RESOURCE_TYPE_SNAPSHOT)) {
+                return Optional.empty();
+            }
+            throw new TableNotExistException(identifier);
+        } catch (ForbiddenException e) {
+            throw new TableNoPermissionException(identifier, e);
+        }
+    }
+
+    @Override
+    public PagedList<Snapshot> listSnapshotsPaged(
+            Identifier identifier, @Nullable Integer maxResults, @Nullable String pageToken)
+            throws TableNotExistException {
+        try {
+            return api.listSnapshotsPaged(identifier, maxResults, pageToken);
+        } catch (NoSuchResourceException e) {
+            throw new TableNotExistException(identifier);
+        } catch (ForbiddenException e) {
+            throw new TableNoPermissionException(identifier, e);
+        }
+    }
+
+    @Override
     public boolean supportsListObjectsPaged() {
         return true;
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Make the display of snapshots simpler, without having to read files, but relying on catalog service to query.

This PR adds:

```java
   /**
     * Return the snapshot of table for given version. Version parsing order is:
     *
     * <ul>
     *   <li>1. If it is 'EARLIEST', get the earliest snapshot.
     *   <li>2. If it is 'LATEST', get the latest snapshot.
     *   <li>3. If it is a number, get snapshot by snapshot id.
     *   <li>4. Else try to get snapshot from Tag name.
     * </ul>
     *
     * @param identifier Path of the table
     * @param version version to snapshot
     * @return The requested snapshot
     * @throws Catalog.TableNotExistException if the target does not exist
     * @throws UnsupportedOperationException if the catalog does not {@link
     *     #supportsVersionManagement()}
     */
    Optional<Snapshot> loadSnapshot(Identifier identifier, String version)
            throws Catalog.TableNotExistException;

    /**
     * Get paged snapshot list of the table, the snapshot list will be returned in descending order.
     *
     * @param identifier path of the table to list partitions
     * @param maxResults Optional parameter indicating the maximum number of results to include in
     *     the result. If maxResults is not specified or set to 0, will return the default number of
     *     max results.
     * @param pageToken Optional parameter indicating the next page token allows list to be start
     *     from a specific point.
     * @return a list of the snapshots with provided page size(@param maxResults) in this table and
     *     next page token, or a list of all snapshots of the table if the catalog does not {@link
     *     #supportsListObjectsPaged()}.
     * @throws TableNotExistException if the table does not exist
     * @throws UnsupportedOperationException if the catalog does not {@link
     *     #supportsVersionManagement()}
     */
    PagedList<Snapshot> listSnapshotsPaged(
            Identifier identifier, @Nullable Integer maxResults, @Nullable String pageToken)
            throws TableNotExistException;
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
