### PR TITLE
[spark] Restrict bucket creation to not exceed max bucket limit

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/index/PartitionIndex.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/PartitionIndex.java
@@ -91,21 +91,16 @@ public class PartitionIndex {
             }
         }
 
-        if (-1 == maxBucketsNum || totalBucketSet.isEmpty() || maxBucketId < maxBucketsNum - 1) {
+        int globalMaxBucketId = (maxBucketsNum == -1 ? Short.MAX_VALUE : maxBucketsNum) - 1;
+        if (totalBucketSet.isEmpty() || maxBucketId < globalMaxBucketId) {
             // 3. create a new bucket
-            for (int i = 0; i < Short.MAX_VALUE; i++) {
+            for (int i = 0; i <= globalMaxBucketId; i++) {
                 if (bucketFilter.test(i) && !totalBucketSet.contains(i)) {
-                    // The new bucketId may still be larger than the upper bound
-                    if (-1 == maxBucketsNum || i <= maxBucketsNum - 1) {
-                        nonFullBucketInformation.put(i, 1L);
-                        totalBucketSet.add(i);
-                        totalBucketArray.add(i);
-                        hash2Bucket.put(hash, (short) i);
-                        return i;
-                    } else {
-                        // No need to enter the next iteration when upper bound exceeded
-                        break;
-                    }
+                    nonFullBucketInformation.put(i, 1L);
+                    totalBucketSet.add(i);
+                    totalBucketArray.add(i);
+                    hash2Bucket.put(hash, (short) i);
+                    return i;
                 }
             }
             if (-1 == maxBucketsNum) {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -58,12 +58,13 @@ case class PaimonSparkWriter(table: FileStoreTable) {
 
   private lazy val bucketMode = table.bucketMode
 
+  private lazy val coreOptions = table.coreOptions()
+
   private lazy val disableReportStats = {
-    val options = table.coreOptions()
-    val config = options.toConfiguration
+    val config = coreOptions.toConfiguration
     config.get(CoreOptions.PARTITION_IDLE_TIME_TO_REPORT_STATISTIC).toMillis <= 0 ||
     table.partitionKeys.isEmpty ||
-    !options.partitionedTableInMetastore ||
+    !coreOptions.partitionedTableInMetastore ||
     table.catalogEnvironment.partitionHandler() == null
   }
 
@@ -163,7 +164,7 @@ case class PaimonSparkWriter(table: FileStoreTable) {
       case CROSS_PARTITION =>
         // Topology: input -> bootstrap -> shuffle by key hash -> bucket-assigner -> shuffle by partition & bucket
         val rowType = SparkTypeUtils.toPaimonType(withInitBucketCol.schema).asInstanceOf[RowType]
-        val assignerParallelism = Option(table.coreOptions.dynamicBucketAssignerParallelism)
+        val assignerParallelism = Option(coreOptions.dynamicBucketAssignerParallelism)
           .map(_.toInt)
           .getOrElse(sparkParallelism)
         val bootstrapped = bootstrapAndRepartitionByKeyHash(
@@ -186,10 +187,17 @@ case class PaimonSparkWriter(table: FileStoreTable) {
         writeWithBucket(repartitioned)
 
       case HASH_DYNAMIC =>
-        val assignerParallelism = Option(table.coreOptions.dynamicBucketAssignerParallelism)
-          .map(_.toInt)
-          .getOrElse(sparkParallelism)
-        val numAssigners = Option(table.coreOptions.dynamicBucketInitialBuckets)
+        val assignerParallelism = {
+          val parallelism = Option(coreOptions.dynamicBucketAssignerParallelism)
+            .map(_.toInt)
+            .getOrElse(sparkParallelism)
+          if (coreOptions.dynamicBucketMaxBuckets() != -1) {
+            Math.min(coreOptions.dynamicBucketMaxBuckets().toInt, parallelism)
+          } else {
+            parallelism
+          }
+        }
+        val numAssigners = Option(coreOptions.dynamicBucketInitialBuckets)
           .map(initialBuckets => Math.min(initialBuckets.toInt, assignerParallelism))
           .getOrElse(assignerParallelism)
 
@@ -212,8 +220,8 @@ case class PaimonSparkWriter(table: FileStoreTable) {
                 new SimpleHashBucketAssigner(
                   numAssigners,
                   TaskContext.getPartitionId(),
-                  table.coreOptions.dynamicBucketTargetRowNum,
-                  table.coreOptions.dynamicBucketMaxBuckets
+                  coreOptions.dynamicBucketTargetRowNum,
+                  coreOptions.dynamicBucketMaxBuckets
                 )
               row => {
                 val sparkRow = new SparkRow(rowType, row)
@@ -242,7 +250,7 @@ case class PaimonSparkWriter(table: FileStoreTable) {
       case HASH_FIXED =>
         if (paimonExtensionEnabled && BucketFunction.supportsTable(table)) {
           // Topology: input -> shuffle by partition & bucket
-          val bucketNumber = table.coreOptions().bucket()
+          val bucketNumber = coreOptions.bucket()
           val bucketKeyCol = tableSchema
             .bucketKeys()
             .asScala
@@ -333,12 +341,11 @@ case class PaimonSparkWriter(table: FileStoreTable) {
       return
     }
 
-    val options = table.coreOptions()
     val partitionComputer = new InternalRowPartitionComputer(
-      options.partitionDefaultName,
+      coreOptions.partitionDefaultName,
       table.schema.logicalPartitionType,
       table.partitionKeys.toArray(new Array[String](0)),
-      options.legacyPartitionName()
+      coreOptions.legacyPartitionName()
     )
     val hmsReporter = new PartitionStatisticsReporter(
       table,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Limit the maximum number of buckets by limiting the number of assigners

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
