### PR TITLE
[spark] Avoid partition to be negative when partition.hashCode() equals to Integer.MIN_VALUE

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -404,14 +404,14 @@ case class PaimonSparkWriter(table: FileStoreTable) {
                 row => {
                   val bytes: Array[Byte] =
                     SerializationUtils.serializeBinaryRow(bootstrapSer.toBinaryRow(row))
-                  (Math.abs(keyPartProject(row).hashCode()), (KeyPartOrRow.KEY_PART, bytes))
+                  (keyPartProject(row).hashCode(), (KeyPartOrRow.KEY_PART, bytes))
                 }) ++ iter.map(
               r => {
                 val sparkRow =
                   new SparkRow(rowType, r, SparkRowUtils.getRowKind(r, rowKindColIdx))
                 val bytes: Array[Byte] =
                   SerializationUtils.serializeBinaryRow(rowSer.toBinaryRow(sparkRow))
-                (Math.abs(rowProject(sparkRow).hashCode()), (KeyPartOrRow.ROW, bytes))
+                (rowProject(sparkRow).hashCode(), (KeyPartOrRow.ROW, bytes))
               })
           }
       }
@@ -471,6 +471,6 @@ case class PaimonSparkWriter(table: FileStoreTable) {
 
   private case class ModPartitioner(partitions: Int) extends Partitioner {
     override def numPartitions: Int = partitions
-    override def getPartition(key: Any): Int = key.asInstanceOf[Int] % numPartitions
+    override def getPartition(key: Any): Int = Math.abs(key.asInstanceOf[Int] % numPartitions)
   }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

like https://github.com/apache/paimon/pull/5623

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
