### PR TITLE
[core] Fix bug when both main branch and fallback branch have no primary key

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java
@@ -312,7 +312,7 @@ public class DataSplit implements Split {
         assign(deserialize(new DataInputViewStreamWrapper(in)));
     }
 
-    private void assign(DataSplit other) {
+    protected void assign(DataSplit other) {
         this.snapshotId = other.snapshotId;
         this.partition = other.partition;
         this.bucket = other.bucket;


### PR DESCRIPTION
### Purpose

Currently in `FallbackReadFileStoreTable#Read`, if data split has no primary key, it will be regarded as data from main branch. However, this is not true if both main branch and fallback branch have no primary key.

This PR fixes the issue.

### Tests

* `BranchSqlITCase#testMainAndFallbackNoPrimaryKeys`.

### API and Format

No format changes.

### Documentation

No new feature.
