### PR TITLE
[core] Call Iceberg callback on replace_tag procedure

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -587,9 +587,19 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
             Snapshot latestSnapshot = snapshotManager().latestSnapshot();
             SnapshotNotExistException.checkNotNull(
                     latestSnapshot, "Cannot replace tag because latest snapshot doesn't exist.");
-            tagManager().replaceTag(latestSnapshot, tagName, timeRetained);
+            tagManager()
+                    .replaceTag(
+                            latestSnapshot,
+                            tagName,
+                            timeRetained,
+                            store().createTagCallbacks(this));
         } else {
-            tagManager().replaceTag(findSnapshot(fromSnapshotId), tagName, timeRetained);
+            tagManager()
+                    .replaceTag(
+                            findSnapshot(fromSnapshotId),
+                            tagName,
+                            timeRetained,
+                            store().createTagCallbacks(this));
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -122,7 +122,7 @@ public class TagManager {
                 tagName,
                 timeRetained,
                 callbacks.stream()
-                        .filter(callback -> IcebergCommitCallback.class.isInstance(callback))
+                        .filter(callback -> callback instanceof IcebergCommitCallback)
                         .collect(Collectors.toList()));
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -23,6 +23,7 @@ import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileStatus;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.iceberg.IcebergCommitCallback;
 import org.apache.paimon.manifest.ExpireFileEntry;
 import org.apache.paimon.operation.TagDeletion;
 import org.apache.paimon.table.sink.TagCallback;
@@ -112,10 +113,17 @@ public class TagManager {
     }
 
     /** Replace a tag from given snapshot and save it in the storage. */
-    public void replaceTag(Snapshot snapshot, String tagName, Duration timeRetained) {
+    public void replaceTag(
+            Snapshot snapshot, String tagName, Duration timeRetained, List<TagCallback> callbacks) {
         checkArgument(!StringUtils.isNullOrWhitespaceOnly(tagName), "Tag name shouldn't be blank.");
         checkArgument(tagExists(tagName), "Tag '%s' doesn't exist.", tagName);
-        createOrReplaceTag(snapshot, tagName, timeRetained, null);
+        createOrReplaceTag(
+                snapshot,
+                tagName,
+                timeRetained,
+                callbacks.stream()
+                        .filter(callback -> IcebergCommitCallback.class.isInstance(callback))
+                        .collect(Collectors.toList()));
     }
 
     private void createOrReplaceTag(

--- a/paimon-flink/paimon-flink-1.16/src/test/java/org/apache/paimon/flink/iceberg/Flink116IcebergITCase.java
+++ b/paimon-flink/paimon-flink-1.16/src/test/java/org/apache/paimon/flink/iceberg/Flink116IcebergITCase.java
@@ -36,4 +36,9 @@ public class Flink116IcebergITCase extends FlinkIcebergITCaseBase {
     public void testDeleteTags(String format) throws Exception {
         // Flink 1.16 does not support delete_tag procedure so we skip this test.
     }
+
+    @Override
+    public void testReplaceTags(String format) throws Exception {
+        // Flink 1.17 does not support replace_tag procedure so we skip this test.
+    }
 }

--- a/paimon-flink/paimon-flink-1.16/src/test/java/org/apache/paimon/flink/iceberg/Flink116IcebergITCase.java
+++ b/paimon-flink/paimon-flink-1.16/src/test/java/org/apache/paimon/flink/iceberg/Flink116IcebergITCase.java
@@ -39,6 +39,6 @@ public class Flink116IcebergITCase extends FlinkIcebergITCaseBase {
 
     @Override
     public void testReplaceTags(String format) throws Exception {
-        // Flink 1.17 does not support replace_tag procedure so we skip this test.
+        // Flink 1.16 does not support replace_tag procedure so we skip this test.
     }
 }

--- a/paimon-flink/paimon-flink-1.17/src/test/java/org/apache/paimon/flink/iceberg/Flink117IcebergITCase.java
+++ b/paimon-flink/paimon-flink-1.17/src/test/java/org/apache/paimon/flink/iceberg/Flink117IcebergITCase.java
@@ -29,4 +29,9 @@ public class Flink117IcebergITCase extends FlinkIcebergITCaseBase {
     public void testDeleteTags(String format) throws Exception {
         // Flink 1.17 does not support delete_tag procedure so we skip this test.
     }
+
+    @Override
+    public void testReplaceTags(String format) throws Exception {
+        // Flink 1.17 does not support replace_tag procedure so we skip this test.
+    }
 }


### PR DESCRIPTION
Issue:  https://github.com/apache/paimon/pull/5570

Relates to https://github.com/apache/paimon/pull/5570

I will use Iceberg tags in production soon and want replace_tag to update Iceberg metadata. Otherwise the Iceberg tags can become inconsistent with Paimon tags.

In https://github.com/apache/paimon/pull/4346#discussion_r1807119066 there was discussion of not adding callbacks on tag replace. For Iceberg it makes sense. The other callbacks - success file and add partition - may not be idempotent so I only added the Iceberg callback.