### PR TITLE
[core] Remove get latest snapshot in FileStoreWrite when ignorePreviousFiles

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -433,11 +433,11 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
             }
         }
 
-        Snapshot latestSnapshot = snapshotManager.latestSnapshot();
+        Snapshot previousSnapshot = ignorePreviousFiles ? null : snapshotManager.latestSnapshot();
         List<DataFileMeta> restoreFiles = new ArrayList<>();
         int totalBuckets;
-        if (!ignorePreviousFiles && latestSnapshot != null) {
-            totalBuckets = scanExistingFileMetas(latestSnapshot, partition, bucket, restoreFiles);
+        if (previousSnapshot != null) {
+            totalBuckets = scanExistingFileMetas(previousSnapshot, partition, bucket, restoreFiles);
         } else {
             totalBuckets = getDefaultBucketNum(partition);
         }
@@ -445,13 +445,11 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
         IndexMaintainer<T> indexMaintainer =
                 indexFactory == null
                         ? null
-                        : indexFactory.createOrRestore(
-                                ignorePreviousFiles ? null : latestSnapshot, partition, bucket);
+                        : indexFactory.createOrRestore(previousSnapshot, partition, bucket);
         DeletionVectorsMaintainer deletionVectorsMaintainer =
                 dvMaintainerFactory == null
                         ? null
-                        : dvMaintainerFactory.createOrRestore(
-                                ignorePreviousFiles ? null : latestSnapshot, partition, bucket);
+                        : dvMaintainerFactory.createOrRestore(previousSnapshot, partition, bucket);
         RecordWriter<T> writer =
                 createWriter(
                         partition.copy(),
@@ -468,7 +466,7 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
                 totalBuckets,
                 indexMaintainer,
                 deletionVectorsMaintainer,
-                latestSnapshot == null ? null : latestSnapshot.id());
+                previousSnapshot == null ? null : previousSnapshot.id());
     }
 
     @Override


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
When ignorePreviousFiles, we don't need to read latest snapshot in `FileStoreWrite`, we already ignore the previous files.

This can improve performance when creating new writer.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
