### PR TITLE
[paimon-core] Add support for map value type and array element type evolution

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -417,25 +417,36 @@ public class SchemaManager implements Serializable {
                         newFields,
                         update.fieldNames(),
                         (field) -> {
-                            DataType targetType = update.newDataType();
+                            // find the dataType at depth and update the type for it
+                            DataType sourceRootType =
+                                    getRootType(field.type(), 1, update.fieldNames().length);
+                            DataType targetRootType = update.newDataType();
                             if (update.keepNullability()) {
-                                targetType = targetType.copy(field.type().isNullable());
+                                targetRootType = targetRootType.copy(sourceRootType.isNullable());
                             } else {
                                 assertNullabilityChange(
-                                        field.type().isNullable(),
-                                        update.newDataType().isNullable(),
+                                        sourceRootType.isNullable(),
+                                        targetRootType.isNullable(),
                                         StringUtils.join(Arrays.asList(update.fieldNames()), "."),
                                         disableNullToNotNull);
                             }
                             checkState(
-                                    DataTypeCasts.supportsExplicitCast(field.type(), targetType)
-                                            && CastExecutors.resolve(field.type(), targetType)
+                                    DataTypeCasts.supportsExplicitCast(
+                                                    sourceRootType, targetRootType)
+                                            && CastExecutors.resolve(sourceRootType, targetRootType)
                                                     != null,
                                     String.format(
                                             "Column type %s[%s] cannot be converted to %s without loosing information.",
-                                            field.name(), field.type(), targetType));
+                                            field.name(), sourceRootType, targetRootType));
                             return new DataField(
-                                    field.id(), field.name(), targetType, field.description());
+                                    field.id(),
+                                    field.name(),
+                                    getArrayMapTypeWithTargetTypeRoot(
+                                            field.type(),
+                                            targetRootType,
+                                            1,
+                                            update.fieldNames().length),
+                                    field.description());
                         });
             } else if (change instanceof UpdateColumnNullability) {
                 UpdateColumnNullability update = (UpdateColumnNullability) change;
@@ -449,15 +460,23 @@ public class SchemaManager implements Serializable {
                         newFields,
                         update.fieldNames(),
                         (field) -> {
+                            // find the DataType at depth and update that DataTypes nullability
+                            DataType sourceRootType =
+                                    getRootType(field.type(), 1, update.fieldNames().length);
                             assertNullabilityChange(
-                                    field.type().isNullable(),
+                                    sourceRootType.isNullable(),
                                     update.newNullability(),
                                     StringUtils.join(Arrays.asList(update.fieldNames()), "."),
                                     disableNullToNotNull);
+                            sourceRootType = sourceRootType.copy(update.newNullability());
                             return new DataField(
                                     field.id(),
                                     field.name(),
-                                    field.type().copy(update.newNullability()),
+                                    getArrayMapTypeWithTargetTypeRoot(
+                                            field.type(),
+                                            sourceRootType,
+                                            1,
+                                            update.fieldNames().length),
                                     field.description());
                         });
             } else if (change instanceof UpdateColumnComment) {
@@ -500,6 +519,58 @@ public class SchemaManager implements Serializable {
                 newSchema.primaryKeys(),
                 newSchema.options(),
                 newSchema.comment());
+    }
+
+    // gets the rootType at the defined depth
+    // ex: ARRAY<MAP<STRING, ARRAY<INT>>>
+    // if we want to update ARRAY<INT> -> ARRAY<BIGINT>
+    // the maxDepth will be based on updateFieldNames
+    // which in the case will be [v, element, value, element],
+    // so maxDepth is 4 and return DataType will be INT
+    private DataType getRootType(DataType type, int currDepth, int maxDepth) {
+        if (currDepth == maxDepth) {
+            return type;
+        }
+        switch (type.getTypeRoot()) {
+            case ARRAY:
+                return getRootType(((ArrayType) type).getElementType(), currDepth + 1, maxDepth);
+            case MAP:
+                return getRootType(((MapType) type).getValueType(), currDepth + 1, maxDepth);
+            default:
+                return type;
+        }
+    }
+
+    // builds the targetType from source type based on the maxDepth which needs to be updated
+    // ex: ARRAY<MAP<STRING, ARRAY<INT>>> -> ARRAY<MAP<STRING, ARRAY<BIGINT>>>
+    // here we only need to update type of ARRAY<INT> to ARRAY<BIGINT> and rest of the type
+    // remains same. This function achieves this.
+    private DataType getArrayMapTypeWithTargetTypeRoot(
+            DataType source, DataType target, int currDepth, int maxDepth) {
+        if (currDepth == maxDepth) {
+            return target;
+        }
+        switch (source.getTypeRoot()) {
+            case ARRAY:
+                return new ArrayType(
+                        source.isNullable(),
+                        getArrayMapTypeWithTargetTypeRoot(
+                                ((ArrayType) source).getElementType(),
+                                target,
+                                currDepth + 1,
+                                maxDepth));
+            case MAP:
+                return new MapType(
+                        source.isNullable(),
+                        ((MapType) source).getKeyType(),
+                        getArrayMapTypeWithTargetTypeRoot(
+                                ((MapType) source).getValueType(),
+                                target,
+                                currDepth + 1,
+                                maxDepth));
+            default:
+                return target;
+        }
     }
 
     private void assertNullabilityChange(
@@ -671,10 +742,22 @@ public class SchemaManager implements Serializable {
             this.updateFieldNames = updateFieldNames;
         }
 
-        public void updateIntermediateColumn(List<DataField> newFields, int depth)
+        private void updateIntermediateColumn(
+                List<DataField> newFields, List<DataField> previousFields, int depth, int prevDepth)
                 throws Catalog.ColumnNotExistException, Catalog.ColumnAlreadyExistException {
             if (depth == updateFieldNames.length - 1) {
                 updateLastColumn(newFields, updateFieldNames[depth]);
+                return;
+            } else if (depth >= updateFieldNames.length) {
+                // to handle the case of ARRAY or MAP type evolution
+                // for instance : ARRAY<INT> -> ARRAY<BIGINT>
+                // the updateFieldNames in this case is [v, element] where v is array field name
+                // the depth returned by extractRowDataFields is 2 which will overflow.
+                // So the logic is to go to previous depth and update the column using previous
+                // fields which will have DataFields from prevDepth
+                // The reason for this handling is the addition of element and value for array
+                // and map type in FlinkCatalog as dummy column name
+                updateLastColumn(previousFields, updateFieldNames[prevDepth]);
                 return;
             }
 
@@ -683,13 +766,10 @@ public class SchemaManager implements Serializable {
                 if (!field.name().equals(updateFieldNames[depth])) {
                     continue;
                 }
-
-                String fullFieldName =
-                        String.join(".", Arrays.asList(updateFieldNames).subList(0, depth + 1));
                 List<DataField> nestedFields = new ArrayList<>();
-                int newDepth =
-                        depth + extractRowDataFields(field.type(), fullFieldName, nestedFields);
-                updateIntermediateColumn(nestedFields, newDepth);
+                int newDepth = depth + extractRowDataFields(field.type(), nestedFields);
+                updateIntermediateColumn(nestedFields, newFields, newDepth, depth);
+                field = newFields.get(i);
                 newFields.set(
                         i,
                         new DataField(
@@ -705,25 +785,23 @@ public class SchemaManager implements Serializable {
                     String.join(".", Arrays.asList(updateFieldNames).subList(0, depth + 1)));
         }
 
-        private int extractRowDataFields(
-                DataType type, String fullFieldName, List<DataField> nestedFields) {
+        public void updateIntermediateColumn(List<DataField> newFields, int depth)
+                throws Catalog.ColumnNotExistException, Catalog.ColumnAlreadyExistException {
+            updateIntermediateColumn(newFields, newFields, depth, depth);
+        }
+
+        private int extractRowDataFields(DataType type, List<DataField> nestedFields) {
             switch (type.getTypeRoot()) {
                 case ROW:
                     nestedFields.addAll(((RowType) type).getFields());
                     return 1;
                 case ARRAY:
-                    return extractRowDataFields(
-                                    ((ArrayType) type).getElementType(),
-                                    fullFieldName,
-                                    nestedFields)
+                    return extractRowDataFields(((ArrayType) type).getElementType(), nestedFields)
                             + 1;
                 case MAP:
-                    return extractRowDataFields(
-                                    ((MapType) type).getValueType(), fullFieldName, nestedFields)
-                            + 1;
+                    return extractRowDataFields(((MapType) type).getValueType(), nestedFields) + 1;
                 default:
-                    throw new IllegalArgumentException(
-                            fullFieldName + " is not a structured type.");
+                    return 1;
             }
         }
 
@@ -742,8 +820,7 @@ public class SchemaManager implements Serializable {
                             mapType.getKeyType(),
                             wrapNewRowType(mapType.getValueType(), nestedFields));
                 default:
-                    throw new IllegalStateException(
-                            "Trying to wrap a row type in " + type + ". This is unexpected.");
+                    return type;
             }
         }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
@@ -1351,4 +1351,184 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
         assertThat(sql("SELECT * FROM T"))
                 .containsExactlyInAnyOrder(Row.of(1, 10L), Row.of(2, 20L));
     }
+
+    @Test
+    public void testAlterColumnTypeNestedArrayAndMap() {
+        sql("CREATE TABLE T ( k INT, v ARRAY<ARRAY<ARRAY<INT>>>, PRIMARY KEY(k) NOT ENFORCED )");
+        sql("INSERT INTO T VALUES (1, ARRAY[ARRAY[ARRAY[1, 2]]]), (2, ARRAY[ARRAY[ARRAY[3, 4]]])");
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(
+                        Row.of(1, new Integer[][][] {{{1, 2}}}),
+                        Row.of(2, new Integer[][][] {{{3, 4}}}));
+        sql("ALTER TABLE T MODIFY v ARRAY<ARRAY<ARRAY<BIGINT>>>");
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(
+                        Row.of(1, new Long[][][] {{{1L, 2L}}}),
+                        Row.of(2, new Long[][][] {{{3L, 4L}}}));
+        assertThatCode(() -> sql("ALTER TABLE T MODIFY v ARRAY<ARRAY<ARRAY<BIGINT NOT NULL>>>"))
+                .hasStackTraceContaining(
+                        "Cannot update column type from nullable to non nullable for v.element.element.element");
+
+        sql("DROP TABLE T");
+
+        sql(
+                "CREATE TABLE T ( k INT, v MAP<STRING, MAP<STRING, MAP<STRING, INT NOT NULL>>>, PRIMARY KEY(k) NOT ENFORCED )");
+        Map<String, Map<String, Map<String, Integer>>> mp1 = new HashMap<>();
+        Map<String, Map<String, Integer>> l1Mp1 = new HashMap<>();
+        Map<String, Integer> l2Mp1 = new HashMap<>();
+        l2Mp1.put("aaa", 1);
+        l2Mp1.put("aab", 2);
+        l1Mp1.put("aa", l2Mp1);
+        mp1.put("a", l1Mp1);
+        Map<String, Map<String, Map<String, Integer>>> mp2 = new HashMap<>();
+        Map<String, Map<String, Integer>> l1Mp2 = new HashMap<>();
+        Map<String, Integer> l2Mp2 = new HashMap<>();
+        l2Mp2.put("bbb", 3);
+        l2Mp2.put("bbc", 4);
+        l1Mp2.put("bb", l2Mp2);
+        mp2.put("b", l1Mp2);
+        sql(
+                "INSERT INTO T VALUES (1, MAP['a', MAP['aa', MAP['aaa', 1, 'aab', 2]]]), (2, MAP['b', MAP['bb', MAP['bbb', 3, 'bbc', 4]]])");
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(Row.of(1, mp1), Row.of(2, mp2));
+        sql("ALTER TABLE T MODIFY v MAP<STRING, MAP<STRING, MAP<STRING, BIGINT>>>");
+        Map<String, Map<String, Map<String, Long>>> mp3 = new HashMap<>();
+        Map<String, Map<String, Long>> l1Mp3 = new HashMap<>();
+        Map<String, Long> l2Mp3 = new HashMap<>();
+        l2Mp3.put("aaa", 1L);
+        l2Mp3.put("aab", 2L);
+        l1Mp3.put("aa", l2Mp3);
+        mp3.put("a", l1Mp3);
+        Map<String, Map<String, Map<String, Long>>> mp4 = new HashMap<>();
+        Map<String, Map<String, Long>> l1Mp4 = new HashMap<>();
+        Map<String, Long> l2Mp4 = new HashMap<>();
+        l2Mp4.put("bbb", 3L);
+        l2Mp4.put("bbc", 4L);
+        l1Mp4.put("bb", l2Mp4);
+        mp4.put("b", l1Mp4);
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(Row.of(1, mp3), Row.of(2, mp4));
+        assertThatCode(
+                        () ->
+                                sql(
+                                        "ALTER TABLE T MODIFY v MAP<STRING, MAP<STRING, MAP<STRING, BIGINT NOT NULL>>>"))
+                .hasStackTraceContaining(
+                        "Cannot update column type from nullable to non nullable for v.value.value.value");
+
+        sql("DROP TABLE T");
+
+        sql(
+                "CREATE TABLE T ( k INT, a ARRAY<INT NOT NULL>, b MAP<STRING, INT NOT NULL>, PRIMARY KEY(k) NOT ENFORCED )");
+        sql("INSERT INTO T VALUES (1, ARRAY[1, 2, 3, 4], MAP['a', 1, 'b', 2])");
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(
+                        Row.of(
+                                1,
+                                new Integer[] {1, 2, 3, 4},
+                                new HashMap<String, Integer>() {
+                                    {
+                                        put("a", 1);
+                                    }
+
+                                    {
+                                        put("b", 2);
+                                    }
+                                }));
+        sql("ALTER TABLE T MODIFY a ARRAY<BIGINT>");
+        sql("INSERT INTO T VALUES (2, ARRAY[5, 6, 7, CAST(NULL AS BIGINT)], MAP['c', 3, 'd', 4])");
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(
+                        Row.of(
+                                1,
+                                new Long[] {1L, 2L, 3L, 4L},
+                                new HashMap<String, Integer>() {
+                                    {
+                                        put("a", 1);
+                                    }
+
+                                    {
+                                        put("b", 2);
+                                    }
+                                }),
+                        Row.of(
+                                2,
+                                new Long[] {5L, 6L, 7L, null},
+                                new HashMap<String, Integer>() {
+                                    {
+                                        put("c", 3);
+                                    }
+
+                                    {
+                                        put("d", 4);
+                                    }
+                                }));
+        assertThatCode(() -> sql("ALTER TABLE T MODIFY a ARRAY<BIGINT NOT NULL>"))
+                .hasStackTraceContaining(
+                        "Cannot update column type from nullable to non nullable for a.element");
+        sql("ALTER TABLE T MODIFY b MAP<STRING, BIGINT>");
+        sql(
+                "INSERT INTO T VALUES (2, ARRAY[5, 6, 7, CAST(NULL AS BIGINT)], MAP['c', 3, 'd', CAST(NULL AS BIGINT)])");
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(
+                        Row.of(
+                                1,
+                                new Long[] {1L, 2L, 3L, 4L},
+                                new HashMap<String, Long>() {
+                                    {
+                                        put("a", 1L);
+                                    }
+
+                                    {
+                                        put("b", 2L);
+                                    }
+                                }),
+                        Row.of(
+                                2,
+                                new Long[] {5L, 6L, 7L, null},
+                                new HashMap<String, Long>() {
+                                    {
+                                        put("c", 3L);
+                                    }
+
+                                    {
+                                        put("d", null);
+                                    }
+                                }));
+        assertThatCode(() -> sql("ALTER TABLE T MODIFY b MAP<STRING, BIGINT NOT NULL>"))
+                .hasStackTraceContaining(
+                        "Cannot update column type from nullable to non nullable for b.value");
+
+        sql("DROP TABLE T");
+        sql(
+                "CREATE TABLE T ( k INT, a MAP<STRING, ARRAY<INT NOT NULL>>, PRIMARY KEY(k) NOT ENFORCED )");
+        sql("INSERT INTO T VALUES (1, MAP['a', ARRAY[1, 2, 3]])");
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(
+                        Row.of(
+                                1,
+                                new HashMap<String, Integer[]>() {
+                                    {
+                                        put("a", new Integer[] {1, 2, 3});
+                                    }
+                                }));
+        sql("ALTER TABLE T MODIFY a MAP<STRING, ARRAY<BIGINT>>");
+        sql(
+                "INSERT INTO T VALUES(1, MAP['a', ARRAY[1, 2, 3], 'b', ARRAY[2, 3, CAST(NULL AS BIGINT)]])");
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(
+                        Row.of(
+                                1,
+                                new HashMap<String, Long[]>() {
+                                    {
+                                        put("a", new Long[] {1L, 2L, 3L});
+                                    }
+
+                                    {
+                                        put("b", new Long[] {2L, 3L, null});
+                                    }
+                                }));
+        assertThatCode(() -> sql("ALTER TABLE T MODIFY a MAP<STRING, ARRAY<BIGINT NOT NULL>>"))
+                .hasStackTraceContaining(
+                        "Cannot update column type from nullable to non nullable for a.value.element");
+    }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
This PR adds support for map value type and array element type evolution. For ex: ARRAY<INT> -> ARRAY<BIGINT>

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
As of today there is no support for evolution map value type and array element type. This change adds support for the same. Consider the case as follows:
```
- CREATE CATALOG paimon WITH ('type' = 'paimon', 'warehouse' = 'file:/Users/ashish/Documents/flink-1.20.1/paimon_warehouse');

- USE CATALOG paimon;

- CREATE TABLE evolution_test(field1 INT, field2 ARRAY<INT>, PRIMARY KEY (field1) NOT ENFORCED);

- ALTER TABLE evolution_test MODIFY field2 ARRAY<BIGINT>;
# this throws exception : java.lang.IllegalArgumentException: field2 is not a structured type.

- CREATE TABLE evolution_test1(field1 INT, field2 ARRAY<ROW(f1 INT, f2 INT) NOT NULL>);

- ALTER TABLE evolution_test1 MODIFY field2 ARRAY<ROW(f1 INT, f2 INT)>;
# this throws exception : java.lang.ArrayIndexOutOfBoundsException: 2


With the added support both the above commands evolve the schema as expected
```

### Tests
Added new tests in SchemaChangeITCase to verify the change.
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
