### PR TITLE
[core] Support dedicated full compact to external paths

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -183,6 +183,12 @@ under the License.
             <td>Ratio of the deleted rows in a data file to be forced compacted for append-only table.</td>
         </tr>
         <tr>
+            <td><h5>compaction.force-compact-all-files</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to force pick all files for a full compaction. Usually seen in a compaction task to external paths.</td>
+        </tr>
+        <tr>
             <td><h5>compaction.force-up-level-0</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -151,6 +151,13 @@ public class CoreOptions implements Serializable {
                                     + ExternalPathStrategy.SPECIFIC_FS
                                     + ", should be the prefix scheme of the external path, now supported are s3 and oss.");
 
+    public static final ConfigOption<Boolean> COMPACTION_FORCE_COMPACT_ALL_FILES =
+            key("compaction.force-compact-all-files")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to force pick all files for a full compaction. Usually seen in a compaction task to external paths.");
+
     @ExcludeFromDocumentation("Internal use only")
     public static final ConfigOption<String> PATH =
             key("path")
@@ -2464,6 +2471,10 @@ public class CoreOptions implements Serializable {
     @Nullable
     public String externalSpecificFS() {
         return options.get(DATA_FILE_EXTERNAL_PATHS_SPECIFIC_FS);
+    }
+
+    public Boolean forceCompactAllFiles() {
+        return options.get(COMPACTION_FORCE_COMPACT_ALL_FILES);
     }
 
     public String partitionTimestampFormatter() {

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/CompactStrategy.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/CompactStrategy.java
@@ -55,7 +55,8 @@ public interface CompactStrategy {
             int numLevels,
             List<LevelSortedRun> runs,
             @Nullable RecordLevelExpire recordLevelExpire,
-            @Nullable DeletionVectorsMaintainer dvMaintainer) {
+            @Nullable DeletionVectorsMaintainer dvMaintainer,
+            boolean forceCompactAllFiles) {
         int maxLevel = numLevels - 1;
         if (runs.isEmpty()) {
             // no sorted run, no need to compact
@@ -64,7 +65,10 @@ public interface CompactStrategy {
             List<DataFileMeta> filesToBeCompacted = new ArrayList<>();
 
             for (DataFileMeta file : runs.get(0).run().files()) {
-                if (recordLevelExpire != null && recordLevelExpire.isExpireFile(file)) {
+                if (forceCompactAllFiles) {
+                    // add all files when force compacted
+                    filesToBeCompacted.add(file);
+                } else if (recordLevelExpire != null && recordLevelExpire.isExpireFile(file)) {
                     // check record level expire for large files
                     filesToBeCompacted.add(file);
                 } else if (dvMaintainer != null

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManager.java
@@ -65,6 +65,7 @@ public class MergeTreeCompactManager extends CompactFutureManager {
     @Nullable private final DeletionVectorsMaintainer dvMaintainer;
     private final boolean lazyGenDeletionFile;
     private final boolean needLookup;
+    private final boolean forceCompactAllFiles;
 
     @Nullable private final RecordLevelExpire recordLevelExpire;
 
@@ -80,7 +81,8 @@ public class MergeTreeCompactManager extends CompactFutureManager {
             @Nullable DeletionVectorsMaintainer dvMaintainer,
             boolean lazyGenDeletionFile,
             boolean needLookup,
-            @Nullable RecordLevelExpire recordLevelExpire) {
+            @Nullable RecordLevelExpire recordLevelExpire,
+            boolean forceCompactAllFiles) {
         this.executor = executor;
         this.levels = levels;
         this.strategy = strategy;
@@ -93,6 +95,7 @@ public class MergeTreeCompactManager extends CompactFutureManager {
         this.lazyGenDeletionFile = lazyGenDeletionFile;
         this.recordLevelExpire = recordLevelExpire;
         this.needLookup = needLookup;
+        this.forceCompactAllFiles = forceCompactAllFiles;
 
         MetricUtils.safeCall(this::reportMetrics, LOG);
     }
@@ -135,7 +138,11 @@ public class MergeTreeCompactManager extends CompactFutureManager {
             }
             optionalUnit =
                     CompactStrategy.pickFullCompaction(
-                            levels.numberOfLevels(), runs, recordLevelExpire, dvMaintainer);
+                            levels.numberOfLevels(),
+                            runs,
+                            recordLevelExpire,
+                            dvMaintainer,
+                            forceCompactAllFiles);
         } else {
             if (taskFuture != null) {
                 return;
@@ -210,7 +217,8 @@ public class MergeTreeCompactManager extends CompactFutureManager {
                         metricsReporter,
                         compactDfSupplier,
                         dvMaintainer,
-                        recordLevelExpire);
+                        recordLevelExpire,
+                        forceCompactAllFiles);
         if (LOG.isDebugEnabled()) {
             LOG.debug(
                     "Pick these files (name, level, size) for compaction: {}",

--- a/paimon-core/src/main/java/org/apache/paimon/operation/BucketedAppendFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/BucketedAppendFileStoreWrite.java
@@ -91,6 +91,7 @@ public class BucketedAppendFileStoreWrite extends BaseAppendFileStoreWrite {
                     dvMaintainer,
                     options.compactionMinFileNum(),
                     options.targetFileSize(false),
+                    options.forceCompactAllFiles(),
                     files -> compactRewrite(partition, bucket, dvFactory, files),
                     compactionMetrics == null
                             ? null

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -290,7 +290,8 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                     dvMaintainer,
                     options.prepareCommitWaitCompaction(),
                     options.needLookup(),
-                    recordLevelExpire);
+                    recordLevelExpire,
+                    options.forceCompactAllFiles());
         }
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -652,6 +652,7 @@ public class AppendOnlyWriterTest {
                         null,
                         MIN_FILE_NUM,
                         targetFileSize,
+                        false,
                         compactBefore -> {
                             latch.await();
                             return compactBefore.isEmpty()

--- a/paimon-core/src/test/java/org/apache/paimon/append/BucketedAppendCompactManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/BucketedAppendCompactManagerTest.java
@@ -207,6 +207,7 @@ public class BucketedAppendCompactManagerTest {
                         null,
                         minFileNum,
                         targetFileSize,
+                        false,
                         null, // not used
                         null);
         Optional<List<DataFileMeta>> actual = manager.pickCompactBefore();

--- a/paimon-core/src/test/java/org/apache/paimon/append/FullCompactTaskTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/FullCompactTaskTest.java
@@ -123,7 +123,7 @@ public class FullCompactTaskTest {
                 Collection<DataFileMeta> inputs,
                 long targetFileSize,
                 BucketedAppendCompactManager.CompactRewriter rewriter) {
-            super(null, inputs, targetFileSize, rewriter, null);
+            super(null, inputs, targetFileSize, false, rewriter, null);
         }
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
@@ -87,7 +87,7 @@ public class FileFormatSuffixTest extends KeyValueFileReadWriteTest {
                         SCHEMA,
                         0,
                         new BucketedAppendCompactManager(
-                                null, toCompact, null, 4, 10, null, null), // not used
+                                null, toCompact, null, 4, 10, false, null, null), // not used
                         null,
                         false,
                         dataFilePathFactory,

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
@@ -454,7 +454,8 @@ public abstract class MergeTreeTestBase {
                 null,
                 false,
                 options.needLookup(),
-                null);
+                null,
+                false);
     }
 
     static class MockFailResultCompactionManager extends MergeTreeCompactManager {
@@ -478,7 +479,8 @@ public abstract class MergeTreeTestBase {
                     null,
                     false,
                     false,
-                    null);
+                    null,
+                    false);
         }
 
         protected CompactResult obtainCompactResult()

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManagerTest.java
@@ -208,7 +208,8 @@ public class MergeTreeCompactManagerTest {
                         null,
                         false,
                         true,
-                        null);
+                        null,
+                        false);
 
         MergeTreeCompactManager defaultManager =
                 new MergeTreeCompactManager(
@@ -223,7 +224,8 @@ public class MergeTreeCompactManagerTest {
                         null,
                         false,
                         false,
-                        null);
+                        null,
+                        false);
 
         assertThat(lookupManager.compactNotCompleted()).isTrue();
         assertThat(defaultManager.compactNotCompleted()).isFalse();
@@ -259,7 +261,8 @@ public class MergeTreeCompactManagerTest {
                         null,
                         false,
                         false,
-                        null);
+                        null,
+                        false);
         manager.triggerCompaction(false);
         manager.getCompactionResult(true);
         List<LevelMinMax> outputs =

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CompactProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CompactProcedureITCase.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.flink.CatalogITCaseBase;
+import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.StreamTableScan;
@@ -35,6 +36,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -192,6 +194,71 @@ public class CompactProcedureITCase extends CatalogITCaseBase {
             } else {
                 // not compacted
                 assertThat(split.dataFiles().size()).isEqualTo(3);
+            }
+        }
+    }
+
+    @Test
+    public void testForceCompactToExternalPath() throws Exception {
+        // test for pk table
+        String tmpPath = getTempDirPath("external/" + UUID.randomUUID());
+        sql(
+                "CREATE TABLE Tpk ("
+                        + " k INT,"
+                        + " v INT,"
+                        + " hh INT,"
+                        + " dt STRING,"
+                        + " PRIMARY KEY (k, dt, hh) NOT ENFORCED"
+                        + ") PARTITIONED BY (dt, hh) WITH ("
+                        + " 'write-only' = 'true',"
+                        + " 'bucket' = '1'"
+                        + ")");
+        FileStoreTable pkTable = paimonTable("Tpk");
+
+        sql(
+                "INSERT INTO Tpk VALUES (1, 100, 15, '20221208'), (1, 100, 16, '20221208'), (1, 100, 15, '20221209')");
+        sql(
+                "INSERT INTO Tpk VALUES (2, 100, 15, '20221208'), (2, 100, 16, '20221208'), (2, 100, 15, '20221209')");
+        tEnv.getConfig().set(TableConfigOptions.TABLE_DML_SYNC, true);
+        sql(
+                "CALL sys.compact(`table` => 'default.Tpk',"
+                        + " options => 'compaction.force-compact-all-files=true,data-file.external-paths=file://%s,data-file.external-paths.strategy=specific-fs,data-file.external-paths.specific-fs=file')",
+                tmpPath);
+        List<DataSplit> splits = pkTable.newSnapshotReader().read().dataSplits();
+        for (DataSplit split : splits) {
+            for (DataFileMeta meta : split.dataFiles()) {
+                assertThat(meta.externalPath().get().startsWith("file:" + tmpPath)).isTrue();
+            }
+        }
+
+        // test for append table
+        tmpPath = getTempDirPath("external/" + UUID.randomUUID());
+        sql(
+                "CREATE TABLE Tap ("
+                        + " k INT,"
+                        + " v INT,"
+                        + " hh INT,"
+                        + " dt STRING"
+                        + ") PARTITIONED BY (dt, hh) WITH ("
+                        + " 'write-only' = 'true',"
+                        + " 'bucket' = '1',"
+                        + " 'bucket-key' = 'k'"
+                        + ")");
+        FileStoreTable apTable = paimonTable("Tap");
+
+        sql(
+                "INSERT INTO Tap VALUES (1, 100, 15, '20221208'), (1, 100, 16, '20221208'), (1, 100, 15, '20221209')");
+        sql(
+                "INSERT INTO Tap VALUES (2, 100, 15, '20221208'), (2, 100, 16, '20221208'), (2, 100, 15, '20221209')");
+        tEnv.getConfig().set(TableConfigOptions.TABLE_DML_SYNC, true);
+        sql(
+                "CALL sys.compact(`table` => 'default.Tap',"
+                        + " options => 'compaction.force-compact-all-files=true,data-file.external-paths=file://%s,data-file.external-paths.strategy=specific-fs,data-file.external-paths.specific-fs=file')",
+                tmpPath);
+        splits = apTable.newSnapshotReader().read().dataSplits();
+        for (DataSplit split : splits) {
+            for (DataFileMeta meta : split.dataFiles()) {
+                assertThat(meta.externalPath().get().startsWith("file:" + tmpPath)).isTrue();
             }
         }
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue:  #3627

Make a full compaction to the chosen external paths.

Usage: 
```
CALL sys.compact(table => 'xxxx', partition_idle_time =>'7d', options => 'compaction.force-compact-all-files=true,data-file.external-paths.strategy=specific-fs,data-file.external-paths.specific-fs=oss');
```

note that table `xxxx` should have at least one external path whose scheme is prefixed with 'oss'.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
org.apache.paimon.flink.procedure.CompactProcedureITCase#testExternalCompact

### API and Format

<!-- Does this change affect API or storage format -->
Add a new table option `compaction.force-compact-all-files`, which should usually be dynamically configured in a compaction procedure.

### Documentation
added
<!-- Does this change introduce a new feature -->
