### PR TITLE
[core][rest] Add tableId to commit snapshot to avoid wrong commit

### DIFF
--- a/docs/static/rest-catalog-open-api.yaml
+++ b/docs/static/rest-catalog-open-api.yaml
@@ -2395,6 +2395,8 @@ components:
     CommitTableRequest:
       type: object
       properties:
+        tableId:
+          type: string
         snapshot:
           $ref: '#/components/schemas/Snapshot'
         statistics:

--- a/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
@@ -544,6 +544,7 @@ public class RESTApi {
      * Commit snapshot for table.
      *
      * @param identifier database name and table name.
+     * @param tableUuid Uuid of the table to avoid wrong commit
      * @param snapshot snapshot for committing
      * @param statistics statistics for this snapshot incremental
      * @return true if commit success
@@ -552,8 +553,11 @@ public class RESTApi {
      *     this table
      */
     public boolean commitSnapshot(
-            Identifier identifier, Snapshot snapshot, List<PartitionStatistics> statistics) {
-        CommitTableRequest request = new CommitTableRequest(snapshot, statistics);
+            Identifier identifier,
+            @Nullable String tableUuid,
+            Snapshot snapshot,
+            List<PartitionStatistics> statistics) {
+        CommitTableRequest request = new CommitTableRequest(tableUuid, snapshot, statistics);
         CommitTableResponse response =
                 client.post(
                         resourcePaths.commitTable(

--- a/paimon-api/src/main/java/org/apache/paimon/rest/requests/CommitTableRequest.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/requests/CommitTableRequest.java
@@ -33,8 +33,12 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CommitTableRequest implements RESTRequest {
 
+    private static final String FIELD_TABLE_ID = "tableId";
     private static final String FIELD_SNAPSHOT = "snapshot";
     private static final String FIELD_STATISTICS = "statistics";
+
+    @JsonProperty(FIELD_TABLE_ID)
+    private final String tableId;
 
     @JsonProperty(FIELD_SNAPSHOT)
     private final Snapshot snapshot;
@@ -44,10 +48,17 @@ public class CommitTableRequest implements RESTRequest {
 
     @JsonCreator
     public CommitTableRequest(
+            @JsonProperty(FIELD_TABLE_ID) String tableId,
             @JsonProperty(FIELD_SNAPSHOT) Snapshot snapshot,
             @JsonProperty(FIELD_STATISTICS) List<PartitionStatistics> statistics) {
+        this.tableId = tableId;
         this.snapshot = snapshot;
         this.statistics = statistics;
+    }
+
+    @JsonGetter(FIELD_TABLE_ID)
+    public String getTableId() {
+        return tableId;
     }
 
     @JsonGetter(FIELD_SNAPSHOT)

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -477,7 +477,10 @@ public abstract class AbstractCatalog implements Catalog {
 
     @Override
     public boolean commitSnapshot(
-            Identifier identifier, Snapshot snapshot, List<PartitionStatistics> statistics) {
+            Identifier identifier,
+            @Nullable String tableUuid,
+            Snapshot snapshot,
+            List<PartitionStatistics> statistics) {
         throw new UnsupportedOperationException();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -617,6 +617,7 @@ public interface Catalog extends AutoCloseable {
      * Commit the {@link Snapshot} for table identified by the given {@link Identifier}.
      *
      * @param identifier Path of the table
+     * @param tableUuid Uuid of the table to avoid wrong commit
      * @param snapshot Snapshot to be committed
      * @param statistics statistics information of this change
      * @return Success or not
@@ -625,7 +626,10 @@ public interface Catalog extends AutoCloseable {
      *     #supportsVersionManagement()}
      */
     boolean commitSnapshot(
-            Identifier identifier, Snapshot snapshot, List<PartitionStatistics> statistics)
+            Identifier identifier,
+            @Nullable String tableUuid,
+            Snapshot snapshot,
+            List<PartitionStatistics> statistics)
             throws Catalog.TableNotExistException;
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogSnapshotCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogSnapshotCommit.java
@@ -22,6 +22,8 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.partition.PartitionStatistics;
 import org.apache.paimon.utils.SnapshotManager;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 
 /** A {@link SnapshotCommit} using {@link Catalog} to commit. */
@@ -29,10 +31,12 @@ public class CatalogSnapshotCommit implements SnapshotCommit {
 
     private final Catalog catalog;
     private final Identifier identifier;
+    @Nullable private final String uuid;
 
-    public CatalogSnapshotCommit(Catalog catalog, Identifier identifier) {
+    public CatalogSnapshotCommit(Catalog catalog, Identifier identifier, @Nullable String uuid) {
         this.catalog = catalog;
         this.identifier = identifier;
+        this.uuid = uuid;
     }
 
     @Override
@@ -40,7 +44,7 @@ public class CatalogSnapshotCommit implements SnapshotCommit {
             throws Exception {
         Identifier newIdentifier =
                 new Identifier(identifier.getDatabaseName(), identifier.getTableName(), branch);
-        return catalog.commitSnapshot(newIdentifier, snapshot, statistics);
+        return catalog.commitSnapshot(newIdentifier, uuid, snapshot, statistics);
     }
 
     @Override
@@ -54,14 +58,16 @@ public class CatalogSnapshotCommit implements SnapshotCommit {
         private static final long serialVersionUID = 1L;
 
         private final CatalogLoader catalogLoader;
+        @Nullable private final String uuid;
 
-        public Factory(CatalogLoader catalogLoader) {
+        public Factory(CatalogLoader catalogLoader, @Nullable String uuid) {
             this.catalogLoader = catalogLoader;
+            this.uuid = uuid;
         }
 
         @Override
         public SnapshotCommit create(Identifier identifier, SnapshotManager snapshotManager) {
-            return new CatalogSnapshotCommit(catalogLoader.load(), identifier);
+            return new CatalogSnapshotCommit(catalogLoader.load(), identifier, uuid);
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -212,9 +212,12 @@ public abstract class DelegateCatalog implements Catalog {
 
     @Override
     public boolean commitSnapshot(
-            Identifier identifier, Snapshot snapshot, List<PartitionStatistics> statistics)
+            Identifier identifier,
+            @Nullable String tableUuid,
+            Snapshot snapshot,
+            List<PartitionStatistics> statistics)
             throws TableNotExistException {
-        return wrapped.commitSnapshot(identifier, snapshot, statistics);
+        return wrapped.commitSnapshot(identifier, tableUuid, snapshot, statistics);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -39,7 +39,6 @@ import org.apache.paimon.rest.exceptions.ForbiddenException;
 import org.apache.paimon.rest.exceptions.NoSuchResourceException;
 import org.apache.paimon.rest.exceptions.NotImplementedException;
 import org.apache.paimon.rest.exceptions.ServiceFailureException;
-import org.apache.paimon.rest.requests.RollbackTableRequest;
 import org.apache.paimon.rest.responses.ErrorResponse;
 import org.apache.paimon.rest.responses.GetDatabaseResponse;
 import org.apache.paimon.rest.responses.GetFunctionResponse;
@@ -331,10 +330,13 @@ public class RESTCatalog implements Catalog {
 
     @Override
     public boolean commitSnapshot(
-            Identifier identifier, Snapshot snapshot, List<PartitionStatistics> statistics)
+            Identifier identifier,
+            @Nullable String tableUuid,
+            Snapshot snapshot,
+            List<PartitionStatistics> statistics)
             throws TableNotExistException {
         try {
-            return api.commitSnapshot(identifier, snapshot, statistics);
+            return api.commitSnapshot(identifier, tableUuid, snapshot, statistics);
         } catch (NoSuchResourceException e) {
             throw new TableNotExistException(identifier);
         } catch (ForbiddenException e) {
@@ -347,7 +349,6 @@ public class RESTCatalog implements Catalog {
     @Override
     public void rollbackTo(Identifier identifier, Instant instant)
             throws Catalog.TableNotExistException {
-        RollbackTableRequest request = new RollbackTableRequest(instant);
         try {
             api.rollbackTo(identifier, instant);
         } catch (NoSuchResourceException e) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
@@ -95,7 +95,7 @@ public class CatalogEnvironment implements Serializable {
     public SnapshotCommit snapshotCommit(SnapshotManager snapshotManager) {
         SnapshotCommit.Factory factory;
         if (catalogLoader != null && supportsVersionManagement) {
-            factory = new CatalogSnapshotCommit.Factory(catalogLoader);
+            factory = new CatalogSnapshotCommit.Factory(catalogLoader, uuid);
         } else {
             factory = new RenamingSnapshotCommit.Factory(lockFactory, lockContext);
         }

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -308,6 +308,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 () ->
                         restCatalog.commitSnapshot(
                                 identifier,
+                                "",
                                 createSnapshotWithMillis(1L, System.currentTimeMillis()),
                                 new ArrayList<PartitionStatistics>()));
     }
@@ -1263,10 +1264,21 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 () ->
                         restCatalog.commitSnapshot(
                                 hasSnapshotTableIdentifier,
+                                "",
                                 createSnapshotWithMillis(1L, System.currentTimeMillis()),
                                 new ArrayList<>()));
 
         createTable(hasSnapshotTableIdentifier, Maps.newHashMap(), Lists.newArrayList("col1"));
+
+        assertThrows(
+                Catalog.TableNotExistException.class,
+                () ->
+                        restCatalog.commitSnapshot(
+                                hasSnapshotTableIdentifier,
+                                "unknown_id",
+                                createSnapshotWithMillis(1L, System.currentTimeMillis()),
+                                new ArrayList<>()));
+
         long id = 10086;
         long millis = System.currentTimeMillis();
         updateSnapshotOnRestServer(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Consider situation:
1. Create a table named "a".
2. Run streaming job to write "a".
3. Drop table.
4. Create a new table named "a".

The streaming job may write wrong snapshot to new table, causing abnormal table status that cannot be restored.

We can add tableId to commit snapshot method, server can check the id should be the correct id.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
