### PR TITLE
[core] Don't use snapshotManager.latestSnapshot in AbstractFileStoreWrite to prevent flooding catalog

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -433,7 +433,10 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
             }
         }
 
-        Snapshot previousSnapshot = ignorePreviousFiles ? null : snapshotManager.latestSnapshot();
+        // NOTE: don't use snapshotManager.latestSnapshot() here,
+        // because we don't want to flood the catalog with high concurrency
+        Snapshot previousSnapshot =
+                ignorePreviousFiles ? null : snapshotManager.latestSnapshotFromFileSystem();
         List<DataFileMeta> restoreFiles = new ArrayList<>();
         int totalBuckets;
         if (previousSnapshot != null) {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -172,7 +172,11 @@ public class SnapshotManager implements Serializable {
                 throw new UncheckedIOException(e);
             }
         }
-        Long snapshotId = latestSnapshotId();
+        return latestSnapshotFromFileSystem();
+    }
+
+    public @Nullable Snapshot latestSnapshotFromFileSystem() {
+        Long snapshotId = latestSnapshotIdFromFileSystem();
         return snapshotId == null ? null : snapshot(snapshotId);
     }
 
@@ -184,6 +188,14 @@ public class SnapshotManager implements Serializable {
                 } catch (UnsupportedOperationException ignored) {
                 }
             }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to find latest snapshot id", e);
+        }
+        return latestSnapshotIdFromFileSystem();
+    }
+
+    public @Nullable Long latestSnapshotIdFromFileSystem() {
+        try {
             return findLatest(snapshotDirectory(), SNAPSHOT_PREFIX, this::snapshotPath);
         } catch (IOException e) {
             throw new RuntimeException("Failed to find latest snapshot id", e);


### PR DESCRIPTION
### Purpose

This PR creates a `latestSnapshotFromFileSystem` method in `SnapshotManager` and use it in `AbstractFileStoreWrite`. Because `latestSnapshot` will query from REST catalog (if the table is created from REST catalog) and we don't want to flood the catalog with high concurrency.

### Tests

Existing tests should cover this change.

### API and Format

No format changes.

### Documentation

No new feature.
