### PR TITLE
[flink-cdc] Added support for nested schema evolution in CDC 

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/NestedSchemaUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/NestedSchemaUtils.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.schema;
+
+import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeRoot;
+import org.apache.paimon.types.MapType;
+import org.apache.paimon.types.MultisetType;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.Preconditions;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Utility class for handling nested column schema changes. This provides shared logic for both
+ * FlinkCatalog and CDC sources to handle schema evolution for nested types (arrays, maps,
+ * multisets, rows) consistently.
+ */
+public class NestedSchemaUtils {
+
+    /**
+     * Generates nested column updates for schema evolution. Handles all nested types: ROW, ARRAY,
+     * MAP, MULTISET. Creates proper field paths with markers like "element" for arrays and "value"
+     * for maps.
+     *
+     * @param fieldNames The current field path as a list of field names
+     * @param oldType The old data type
+     * @param newType The new data type
+     * @param schemaChanges List to collect the generated schema changes
+     */
+    public static void generateNestedColumnUpdates(
+            List<String> fieldNames,
+            DataType oldType,
+            DataType newType,
+            List<SchemaChange> schemaChanges) {
+
+        String joinedNames = String.join(".", fieldNames);
+
+        if (oldType.getTypeRoot() == DataTypeRoot.ROW) {
+            handleRowTypeUpdate(fieldNames, oldType, newType, schemaChanges, joinedNames);
+        } else if (oldType.getTypeRoot() == DataTypeRoot.ARRAY) {
+            handleArrayTypeUpdate(fieldNames, oldType, newType, schemaChanges, joinedNames);
+        } else if (oldType.getTypeRoot() == DataTypeRoot.MAP) {
+            handleMapTypeUpdate(fieldNames, oldType, newType, schemaChanges, joinedNames);
+        } else if (oldType.getTypeRoot() == DataTypeRoot.MULTISET) {
+            handleMultisetTypeUpdate(fieldNames, oldType, newType, schemaChanges, joinedNames);
+        } else {
+            // For primitive types, update the column type directly
+            handlePrimitiveTypeUpdate(fieldNames, oldType, newType, schemaChanges);
+        }
+
+        // Handle nullability changes for all types
+        handleNullabilityChange(fieldNames, oldType, newType, schemaChanges);
+    }
+
+    private static void handleRowTypeUpdate(
+            List<String> fieldNames,
+            DataType oldType,
+            DataType newType,
+            List<SchemaChange> schemaChanges,
+            String joinedNames) {
+
+        Preconditions.checkArgument(
+                newType.getTypeRoot() == DataTypeRoot.ROW,
+                "Column %s can only be updated to row type, and cannot be updated to %s type",
+                joinedNames,
+                newType.getTypeRoot());
+
+        RowType oldRowType = (RowType) oldType;
+        RowType newRowType = (RowType) newType;
+
+        // check that existing fields maintain their order
+        Map<String, Integer> oldFieldOrders = new HashMap<>();
+        for (int i = 0; i < oldRowType.getFieldCount(); i++) {
+            oldFieldOrders.put(oldRowType.getFields().get(i).name(), i);
+        }
+
+        int lastIdx = -1;
+        String lastFieldName = "";
+        for (DataField newField : newRowType.getFields()) {
+            String name = newField.name();
+            if (oldFieldOrders.containsKey(name)) {
+                int idx = oldFieldOrders.get(name);
+                Preconditions.checkState(
+                        lastIdx < idx,
+                        "Order of existing fields in column %s must be kept the same. "
+                                + "However, field %s and %s have changed their orders.",
+                        joinedNames,
+                        lastFieldName,
+                        name);
+                lastIdx = idx;
+                lastFieldName = name;
+            }
+        }
+
+        // drop fields
+        Set<String> newFieldNames = new HashSet<>(newRowType.getFieldNames());
+        for (String name : oldRowType.getFieldNames()) {
+            if (!newFieldNames.contains(name)) {
+                List<String> dropColumnNames = new ArrayList<>(fieldNames);
+                dropColumnNames.add(name);
+                schemaChanges.add(SchemaChange.dropColumn(dropColumnNames.toArray(new String[0])));
+            }
+        }
+
+        for (int i = 0; i < newRowType.getFieldCount(); i++) {
+            DataField field = newRowType.getFields().get(i);
+            String name = field.name();
+            List<String> fullFieldNames = new ArrayList<>(fieldNames);
+            fullFieldNames.add(name);
+
+            if (!oldFieldOrders.containsKey(name)) {
+                // add fields
+                SchemaChange.Move move;
+                if (i == 0) {
+                    move = SchemaChange.Move.first(name);
+                } else {
+                    String lastName = newRowType.getFields().get(i - 1).name();
+                    move = SchemaChange.Move.after(name, lastName);
+                }
+                schemaChanges.add(
+                        SchemaChange.addColumn(
+                                fullFieldNames.toArray(new String[0]),
+                                field.type(),
+                                field.description(),
+                                move));
+            } else {
+                // update existing fields
+                DataField oldField = oldRowType.getFields().get(oldFieldOrders.get(name));
+                if (!Objects.equals(oldField.description(), field.description())) {
+                    schemaChanges.add(
+                            SchemaChange.updateColumnComment(
+                                    fullFieldNames.toArray(new String[0]), field.description()));
+                }
+                generateNestedColumnUpdates(
+                        fullFieldNames, oldField.type(), field.type(), schemaChanges);
+            }
+        }
+    }
+
+    private static void handleArrayTypeUpdate(
+            List<String> fieldNames,
+            DataType oldType,
+            DataType newType,
+            List<SchemaChange> schemaChanges,
+            String joinedNames) {
+
+        Preconditions.checkArgument(
+                newType.getTypeRoot() == DataTypeRoot.ARRAY,
+                "Column %s can only be updated to array type, and cannot be updated to %s type",
+                joinedNames,
+                newType);
+
+        List<String> fullFieldNames = new ArrayList<>(fieldNames);
+        // add a dummy column name indicating the element of array
+        fullFieldNames.add("element");
+
+        generateNestedColumnUpdates(
+                fullFieldNames,
+                ((ArrayType) oldType).getElementType(),
+                ((ArrayType) newType).getElementType(),
+                schemaChanges);
+    }
+
+    private static void handleMapTypeUpdate(
+            List<String> fieldNames,
+            DataType oldType,
+            DataType newType,
+            List<SchemaChange> schemaChanges,
+            String joinedNames) {
+
+        Preconditions.checkArgument(
+                newType.getTypeRoot() == DataTypeRoot.MAP,
+                "Column %s can only be updated to map type, and cannot be updated to %s type",
+                joinedNames,
+                newType);
+
+        MapType oldMapType = (MapType) oldType;
+        MapType newMapType = (MapType) newType;
+
+        Preconditions.checkArgument(
+                oldMapType.getKeyType().equals(newMapType.getKeyType()),
+                "Cannot update key type of column %s from %s type to %s type",
+                joinedNames,
+                oldMapType.getKeyType(),
+                newMapType.getKeyType());
+
+        List<String> fullFieldNames = new ArrayList<>(fieldNames);
+        // add a dummy column name indicating the value of map
+        fullFieldNames.add("value");
+
+        generateNestedColumnUpdates(
+                fullFieldNames,
+                oldMapType.getValueType(),
+                newMapType.getValueType(),
+                schemaChanges);
+    }
+
+    private static void handleMultisetTypeUpdate(
+            List<String> fieldNames,
+            DataType oldType,
+            DataType newType,
+            List<SchemaChange> schemaChanges,
+            String joinedNames) {
+
+        Preconditions.checkArgument(
+                newType.getTypeRoot() == DataTypeRoot.MULTISET,
+                "Column %s can only be updated to multiset type, and cannot be updated to %s type",
+                joinedNames,
+                newType);
+
+        List<String> fullFieldNames = new ArrayList<>(fieldNames);
+        // Add the special "element" marker for multiset element access
+        fullFieldNames.add("element");
+
+        generateNestedColumnUpdates(
+                fullFieldNames,
+                ((MultisetType) oldType).getElementType(),
+                ((MultisetType) newType).getElementType(),
+                schemaChanges);
+    }
+
+    private static void handlePrimitiveTypeUpdate(
+            List<String> fieldNames,
+            DataType oldType,
+            DataType newType,
+            List<SchemaChange> schemaChanges) {
+
+        if (!oldType.equalsIgnoreNullable(newType)) {
+            schemaChanges.add(
+                    SchemaChange.updateColumnType(
+                            fieldNames.toArray(new String[0]), newType, false));
+        }
+    }
+
+    private static void handleNullabilityChange(
+            List<String> fieldNames,
+            DataType oldType,
+            DataType newType,
+            List<SchemaChange> schemaChanges) {
+
+        if (oldType.isNullable() != newType.isNullable()) {
+            schemaChanges.add(
+                    SchemaChange.updateColumnNullability(
+                            fieldNames.toArray(new String[0]), newType.isNullable()));
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -417,25 +417,36 @@ public class SchemaManager implements Serializable {
                         newFields,
                         update.fieldNames(),
                         (field) -> {
-                            DataType targetType = update.newDataType();
+                            // find the dataType at depth and update the type for it
+                            DataType sourceRootType =
+                                    getRootType(field.type(), 1, update.fieldNames().length);
+                            DataType targetRootType = update.newDataType();
                             if (update.keepNullability()) {
-                                targetType = targetType.copy(field.type().isNullable());
+                                targetRootType = targetRootType.copy(sourceRootType.isNullable());
                             } else {
                                 assertNullabilityChange(
-                                        field.type().isNullable(),
-                                        update.newDataType().isNullable(),
+                                        sourceRootType.isNullable(),
+                                        targetRootType.isNullable(),
                                         StringUtils.join(Arrays.asList(update.fieldNames()), "."),
                                         disableNullToNotNull);
                             }
                             checkState(
-                                    DataTypeCasts.supportsExplicitCast(field.type(), targetType)
-                                            && CastExecutors.resolve(field.type(), targetType)
+                                    DataTypeCasts.supportsExplicitCast(
+                                                    sourceRootType, targetRootType)
+                                            && CastExecutors.resolve(sourceRootType, targetRootType)
                                                     != null,
                                     String.format(
                                             "Column type %s[%s] cannot be converted to %s without loosing information.",
-                                            field.name(), field.type(), targetType));
+                                            field.name(), sourceRootType, targetRootType));
                             return new DataField(
-                                    field.id(), field.name(), targetType, field.description());
+                                    field.id(),
+                                    field.name(),
+                                    getArrayMapTypeWithTargetTypeRoot(
+                                            field.type(),
+                                            targetRootType,
+                                            1,
+                                            update.fieldNames().length),
+                                    field.description());
                         });
             } else if (change instanceof UpdateColumnNullability) {
                 UpdateColumnNullability update = (UpdateColumnNullability) change;
@@ -449,15 +460,23 @@ public class SchemaManager implements Serializable {
                         newFields,
                         update.fieldNames(),
                         (field) -> {
+                            // find the DataType at depth and update that DataTypes nullability
+                            DataType sourceRootType =
+                                    getRootType(field.type(), 1, update.fieldNames().length);
                             assertNullabilityChange(
-                                    field.type().isNullable(),
+                                    sourceRootType.isNullable(),
                                     update.newNullability(),
                                     StringUtils.join(Arrays.asList(update.fieldNames()), "."),
                                     disableNullToNotNull);
+                            sourceRootType = sourceRootType.copy(update.newNullability());
                             return new DataField(
                                     field.id(),
                                     field.name(),
-                                    field.type().copy(update.newNullability()),
+                                    getArrayMapTypeWithTargetTypeRoot(
+                                            field.type(),
+                                            sourceRootType,
+                                            1,
+                                            update.fieldNames().length),
                                     field.description());
                         });
             } else if (change instanceof UpdateColumnComment) {
@@ -500,6 +519,58 @@ public class SchemaManager implements Serializable {
                 newSchema.primaryKeys(),
                 newSchema.options(),
                 newSchema.comment());
+    }
+
+    // gets the rootType at the defined depth
+    // ex: ARRAY<MAP<STRING, ARRAY<INT>>>
+    // if we want to update ARRAY<INT> -> ARRAY<BIGINT>
+    // the maxDepth will be based on updateFieldNames
+    // which in the case will be [v, element, value, element],
+    // so maxDepth is 4 and return DataType will be INT
+    private DataType getRootType(DataType type, int currDepth, int maxDepth) {
+        if (currDepth == maxDepth) {
+            return type;
+        }
+        switch (type.getTypeRoot()) {
+            case ARRAY:
+                return getRootType(((ArrayType) type).getElementType(), currDepth + 1, maxDepth);
+            case MAP:
+                return getRootType(((MapType) type).getValueType(), currDepth + 1, maxDepth);
+            default:
+                return type;
+        }
+    }
+
+    // builds the targetType from source type based on the maxDepth which needs to be updated
+    // ex: ARRAY<MAP<STRING, ARRAY<INT>>> -> ARRAY<MAP<STRING, ARRAY<BIGINT>>>
+    // here we only need to update type of ARRAY<INT> to ARRAY<BIGINT> and rest of the type
+    // remains same. This function achieves this.
+    private DataType getArrayMapTypeWithTargetTypeRoot(
+            DataType source, DataType target, int currDepth, int maxDepth) {
+        if (currDepth == maxDepth) {
+            return target;
+        }
+        switch (source.getTypeRoot()) {
+            case ARRAY:
+                return new ArrayType(
+                        source.isNullable(),
+                        getArrayMapTypeWithTargetTypeRoot(
+                                ((ArrayType) source).getElementType(),
+                                target,
+                                currDepth + 1,
+                                maxDepth));
+            case MAP:
+                return new MapType(
+                        source.isNullable(),
+                        ((MapType) source).getKeyType(),
+                        getArrayMapTypeWithTargetTypeRoot(
+                                ((MapType) source).getValueType(),
+                                target,
+                                currDepth + 1,
+                                maxDepth));
+            default:
+                return target;
+        }
     }
 
     private void assertNullabilityChange(
@@ -671,10 +742,22 @@ public class SchemaManager implements Serializable {
             this.updateFieldNames = updateFieldNames;
         }
 
-        public void updateIntermediateColumn(List<DataField> newFields, int depth)
+        private void updateIntermediateColumn(
+                List<DataField> newFields, List<DataField> previousFields, int depth, int prevDepth)
                 throws Catalog.ColumnNotExistException, Catalog.ColumnAlreadyExistException {
             if (depth == updateFieldNames.length - 1) {
                 updateLastColumn(newFields, updateFieldNames[depth]);
+                return;
+            } else if (depth >= updateFieldNames.length) {
+                // to handle the case of ARRAY or MAP type evolution
+                // for instance : ARRAY<INT> -> ARRAY<BIGINT>
+                // the updateFieldNames in this case is [v, element] where v is array field name
+                // the depth returned by extractRowDataFields is 2 which will overflow.
+                // So the logic is to go to previous depth and update the column using previous
+                // fields which will have DataFields from prevDepth
+                // The reason for this handling is the addition of element and value for array
+                // and map type in FlinkCatalog as dummy column name
+                updateLastColumn(previousFields, updateFieldNames[prevDepth]);
                 return;
             }
 
@@ -683,13 +766,10 @@ public class SchemaManager implements Serializable {
                 if (!field.name().equals(updateFieldNames[depth])) {
                     continue;
                 }
-
-                String fullFieldName =
-                        String.join(".", Arrays.asList(updateFieldNames).subList(0, depth + 1));
                 List<DataField> nestedFields = new ArrayList<>();
-                int newDepth =
-                        depth + extractRowDataFields(field.type(), fullFieldName, nestedFields);
-                updateIntermediateColumn(nestedFields, newDepth);
+                int newDepth = depth + extractRowDataFields(field.type(), nestedFields);
+                updateIntermediateColumn(nestedFields, newFields, newDepth, depth);
+                field = newFields.get(i);
                 newFields.set(
                         i,
                         new DataField(
@@ -705,25 +785,23 @@ public class SchemaManager implements Serializable {
                     String.join(".", Arrays.asList(updateFieldNames).subList(0, depth + 1)));
         }
 
-        private int extractRowDataFields(
-                DataType type, String fullFieldName, List<DataField> nestedFields) {
+        public void updateIntermediateColumn(List<DataField> newFields, int depth)
+                throws Catalog.ColumnNotExistException, Catalog.ColumnAlreadyExistException {
+            updateIntermediateColumn(newFields, newFields, depth, depth);
+        }
+
+        private int extractRowDataFields(DataType type, List<DataField> nestedFields) {
             switch (type.getTypeRoot()) {
                 case ROW:
                     nestedFields.addAll(((RowType) type).getFields());
                     return 1;
                 case ARRAY:
-                    return extractRowDataFields(
-                                    ((ArrayType) type).getElementType(),
-                                    fullFieldName,
-                                    nestedFields)
+                    return extractRowDataFields(((ArrayType) type).getElementType(), nestedFields)
                             + 1;
                 case MAP:
-                    return extractRowDataFields(
-                                    ((MapType) type).getValueType(), fullFieldName, nestedFields)
-                            + 1;
+                    return extractRowDataFields(((MapType) type).getValueType(), nestedFields) + 1;
                 default:
-                    throw new IllegalArgumentException(
-                            fullFieldName + " is not a structured type.");
+                    return 1;
             }
         }
 
@@ -742,8 +820,7 @@ public class SchemaManager implements Serializable {
                             mapType.getKeyType(),
                             wrapNewRowType(mapType.getValueType(), nestedFields));
                 default:
-                    throw new IllegalStateException(
-                            "Trying to wrap a row type in " + type + ". This is unexpected.");
+                    return type;
             }
         }
 

--- a/paimon-core/src/test/java/org/apache/paimon/schema/NestedSchemaUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/NestedSchemaUtilsTest.java
@@ -1,0 +1,669 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.schema;
+
+import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.MapType;
+import org.apache.paimon.types.MultisetType;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.VarCharType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link NestedSchemaUtils}. */
+public class NestedSchemaUtilsTest {
+
+    @Test
+    public void testPrimitiveTypeUpdate() {
+        List<String> fieldNames = Arrays.asList("column1");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        // Test type conversion (INT -> BIGINT)
+        NestedSchemaUtils.generateNestedColumnUpdates(
+                fieldNames, DataTypes.INT(), DataTypes.BIGINT(), schemaChanges);
+
+        assertThat(schemaChanges).hasSize(1);
+        assertThat(schemaChanges.get(0)).isInstanceOf(SchemaChange.UpdateColumnType.class);
+        SchemaChange.UpdateColumnType typeChange =
+                (SchemaChange.UpdateColumnType) schemaChanges.get(0);
+        assertThat(typeChange.fieldNames()).containsExactly("column1");
+        assertThat(typeChange.newDataType()).isEqualTo(DataTypes.BIGINT());
+    }
+
+    @Test
+    public void testPrimitiveTypeUpdateWithSameType() {
+        List<String> fieldNames = Arrays.asList("column1");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        // Same type should not generate any changes
+        NestedSchemaUtils.generateNestedColumnUpdates(
+                fieldNames, DataTypes.INT(), DataTypes.INT(), schemaChanges);
+
+        assertThat(schemaChanges).isEmpty();
+    }
+
+    @Test
+    public void testNullabilityChangeOnly() {
+        List<String> fieldNames = Arrays.asList("column1");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        // Test nullable to non-nullable
+        NestedSchemaUtils.generateNestedColumnUpdates(
+                fieldNames, DataTypes.INT().nullable(), DataTypes.INT().notNull(), schemaChanges);
+
+        assertThat(schemaChanges).hasSize(1);
+        assertThat(schemaChanges.get(0)).isInstanceOf(SchemaChange.UpdateColumnNullability.class);
+        SchemaChange.UpdateColumnNullability nullabilityChange =
+                (SchemaChange.UpdateColumnNullability) schemaChanges.get(0);
+        assertThat(nullabilityChange.fieldNames()).containsExactly("column1");
+        assertThat(nullabilityChange.newNullability()).isFalse();
+    }
+
+    @Test
+    public void testTypeAndNullabilityChange() {
+        List<String> fieldNames = Arrays.asList("column1");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        // Test type change and nullability change together
+        NestedSchemaUtils.generateNestedColumnUpdates(
+                fieldNames,
+                DataTypes.INT().nullable(),
+                DataTypes.BIGINT().notNull(),
+                schemaChanges);
+
+        assertThat(schemaChanges).hasSize(2);
+
+        // Should have both type and nullability changes
+        assertThat(schemaChanges)
+                .anyMatch(change -> change instanceof SchemaChange.UpdateColumnType);
+        assertThat(schemaChanges)
+                .anyMatch(change -> change instanceof SchemaChange.UpdateColumnNullability);
+    }
+
+    @Test
+    public void testArrayTypeUpdateElement() {
+        List<String> fieldNames = Arrays.asList("arr_column");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        ArrayType oldType = new ArrayType(true, DataTypes.INT());
+        ArrayType newType = new ArrayType(true, DataTypes.BIGINT());
+
+        NestedSchemaUtils.generateNestedColumnUpdates(fieldNames, oldType, newType, schemaChanges);
+
+        assertThat(schemaChanges).hasSize(1);
+        assertThat(schemaChanges.get(0)).isInstanceOf(SchemaChange.UpdateColumnType.class);
+        SchemaChange.UpdateColumnType typeChange =
+                (SchemaChange.UpdateColumnType) schemaChanges.get(0);
+        assertThat(typeChange.fieldNames()).containsExactly("arr_column", "element");
+        assertThat(typeChange.newDataType()).isEqualTo(DataTypes.BIGINT());
+    }
+
+    @Test
+    public void testArrayTypeUpdateNullability() {
+        List<String> fieldNames = Arrays.asList("arr_column");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        ArrayType oldType = new ArrayType(true, DataTypes.INT());
+        ArrayType newType = new ArrayType(false, DataTypes.INT());
+
+        NestedSchemaUtils.generateNestedColumnUpdates(fieldNames, oldType, newType, schemaChanges);
+
+        assertThat(schemaChanges).hasSize(1);
+        assertThat(schemaChanges.get(0)).isInstanceOf(SchemaChange.UpdateColumnNullability.class);
+        SchemaChange.UpdateColumnNullability nullabilityChange =
+                (SchemaChange.UpdateColumnNullability) schemaChanges.get(0);
+        assertThat(nullabilityChange.fieldNames()).containsExactly("arr_column");
+        assertThat(nullabilityChange.newNullability()).isFalse();
+    }
+
+    @Test
+    public void testArrayWithIncompatibleTypeThrowsException() {
+        List<String> fieldNames = Arrays.asList("arr_column");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        ArrayType oldType = new ArrayType(true, DataTypes.INT());
+        RowType newElementType = RowType.of(DataTypes.STRING()); // Incompatible type
+
+        assertThatThrownBy(
+                        () -> {
+                            NestedSchemaUtils.generateNestedColumnUpdates(
+                                    fieldNames, oldType, newElementType, schemaChanges);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("can only be updated to array type");
+    }
+
+    @Test
+    public void testMapTypeUpdateValue() {
+        List<String> fieldNames = Arrays.asList("map_column");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        MapType oldType = new MapType(true, DataTypes.STRING(), DataTypes.INT());
+        MapType newType = new MapType(true, DataTypes.STRING(), DataTypes.BIGINT());
+
+        NestedSchemaUtils.generateNestedColumnUpdates(fieldNames, oldType, newType, schemaChanges);
+
+        assertThat(schemaChanges).hasSize(1);
+        assertThat(schemaChanges.get(0)).isInstanceOf(SchemaChange.UpdateColumnType.class);
+        SchemaChange.UpdateColumnType typeChange =
+                (SchemaChange.UpdateColumnType) schemaChanges.get(0);
+        assertThat(typeChange.fieldNames()).containsExactly("map_column", "value");
+        assertThat(typeChange.newDataType()).isEqualTo(DataTypes.BIGINT());
+    }
+
+    @Test
+    public void testMapTypeUpdateNullability() {
+        List<String> fieldNames = Arrays.asList("map_column");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        MapType oldType = new MapType(true, DataTypes.STRING(), DataTypes.INT());
+        MapType newType = new MapType(false, DataTypes.STRING(), DataTypes.INT());
+
+        NestedSchemaUtils.generateNestedColumnUpdates(fieldNames, oldType, newType, schemaChanges);
+
+        assertThat(schemaChanges).hasSize(1);
+        assertThat(schemaChanges.get(0)).isInstanceOf(SchemaChange.UpdateColumnNullability.class);
+        SchemaChange.UpdateColumnNullability nullabilityChange =
+                (SchemaChange.UpdateColumnNullability) schemaChanges.get(0);
+        assertThat(nullabilityChange.fieldNames()).containsExactly("map_column");
+        assertThat(nullabilityChange.newNullability()).isFalse();
+    }
+
+    @Test
+    public void testMapWithIncompatibleKeyTypeThrowsException() {
+        List<String> fieldNames = Arrays.asList("map_column");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        MapType oldType = new MapType(true, DataTypes.STRING(), DataTypes.INT());
+        MapType newType = new MapType(true, DataTypes.INT(), DataTypes.INT()); // Different key type
+
+        assertThatThrownBy(
+                        () -> {
+                            NestedSchemaUtils.generateNestedColumnUpdates(
+                                    fieldNames, oldType, newType, schemaChanges);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot update key type");
+    }
+
+    @Test
+    public void testMapWithIncompatibleTypeThrowsException() {
+        List<String> fieldNames = Arrays.asList("map_column");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        MapType oldType = new MapType(true, DataTypes.STRING(), DataTypes.INT());
+        ArrayType newType = new ArrayType(true, DataTypes.INT()); // Incompatible type
+
+        assertThatThrownBy(
+                        () -> {
+                            NestedSchemaUtils.generateNestedColumnUpdates(
+                                    fieldNames, oldType, newType, schemaChanges);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("can only be updated to map type");
+    }
+
+    @Test
+    public void testMultisetTypeUpdateElement() {
+        List<String> fieldNames = Arrays.asList("multiset_column");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        MultisetType oldType = new MultisetType(true, DataTypes.INT());
+        MultisetType newType = new MultisetType(true, DataTypes.BIGINT());
+
+        NestedSchemaUtils.generateNestedColumnUpdates(fieldNames, oldType, newType, schemaChanges);
+
+        assertThat(schemaChanges).hasSize(1);
+        assertThat(schemaChanges.get(0)).isInstanceOf(SchemaChange.UpdateColumnType.class);
+        SchemaChange.UpdateColumnType typeChange =
+                (SchemaChange.UpdateColumnType) schemaChanges.get(0);
+        assertThat(typeChange.fieldNames()).containsExactly("multiset_column", "element");
+        assertThat(typeChange.newDataType()).isEqualTo(DataTypes.BIGINT());
+    }
+
+    @Test
+    public void testMultisetWithIncompatibleTypeThrowsException() {
+        List<String> fieldNames = Arrays.asList("multiset_column");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        MultisetType oldType = new MultisetType(true, DataTypes.INT());
+        MapType newType =
+                new MapType(true, DataTypes.STRING(), DataTypes.INT()); // Incompatible type
+
+        assertThatThrownBy(
+                        () -> {
+                            NestedSchemaUtils.generateNestedColumnUpdates(
+                                    fieldNames, oldType, newType, schemaChanges);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("can only be updated to multiset type");
+    }
+
+    @Test
+    public void testRowTypeAddField() {
+        List<String> fieldNames = Arrays.asList("row_column");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        RowType oldType =
+                RowType.of(
+                        new DataField(0, "f1", DataTypes.INT()),
+                        new DataField(1, "f2", DataTypes.STRING()));
+        RowType newType =
+                RowType.of(
+                        new DataField(0, "f1", DataTypes.INT()),
+                        new DataField(1, "f2", DataTypes.STRING()),
+                        new DataField(2, "f3", DataTypes.DOUBLE()));
+
+        NestedSchemaUtils.generateNestedColumnUpdates(fieldNames, oldType, newType, schemaChanges);
+
+        assertThat(schemaChanges).hasSize(1);
+        assertThat(schemaChanges.get(0)).isInstanceOf(SchemaChange.AddColumn.class);
+        SchemaChange.AddColumn addColumn = (SchemaChange.AddColumn) schemaChanges.get(0);
+        assertThat(addColumn.fieldNames()).containsExactly("row_column", "f3");
+        assertThat(addColumn.dataType()).isEqualTo(DataTypes.DOUBLE());
+    }
+
+    @Test
+    public void testRowTypeDropField() {
+        List<String> fieldNames = Arrays.asList("row_column");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        RowType oldType =
+                RowType.of(
+                        new DataField(0, "f1", DataTypes.INT()),
+                        new DataField(1, "f2", DataTypes.STRING()),
+                        new DataField(2, "f3", DataTypes.DOUBLE()));
+        RowType newType =
+                RowType.of(
+                        new DataField(0, "f1", DataTypes.INT()),
+                        new DataField(1, "f2", DataTypes.STRING()));
+
+        NestedSchemaUtils.generateNestedColumnUpdates(fieldNames, oldType, newType, schemaChanges);
+
+        assertThat(schemaChanges).hasSize(1);
+        assertThat(schemaChanges.get(0)).isInstanceOf(SchemaChange.DropColumn.class);
+        SchemaChange.DropColumn dropColumn = (SchemaChange.DropColumn) schemaChanges.get(0);
+        assertThat(dropColumn.fieldNames()).containsExactly("row_column", "f3");
+    }
+
+    @Test
+    public void testRowTypeUpdateExistingField() {
+        List<String> fieldNames = Arrays.asList("row_column");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        RowType oldType =
+                RowType.of(
+                        new DataField(0, "f1", DataTypes.INT()),
+                        new DataField(1, "f2", DataTypes.STRING()));
+        RowType newType =
+                RowType.of(
+                        new DataField(0, "f1", DataTypes.BIGINT()), // Type changed
+                        new DataField(1, "f2", DataTypes.STRING()));
+
+        NestedSchemaUtils.generateNestedColumnUpdates(fieldNames, oldType, newType, schemaChanges);
+
+        assertThat(schemaChanges).hasSize(1);
+        assertThat(schemaChanges.get(0)).isInstanceOf(SchemaChange.UpdateColumnType.class);
+        SchemaChange.UpdateColumnType typeChange =
+                (SchemaChange.UpdateColumnType) schemaChanges.get(0);
+        assertThat(typeChange.fieldNames()).containsExactly("row_column", "f1");
+        assertThat(typeChange.newDataType()).isEqualTo(DataTypes.BIGINT());
+    }
+
+    @Test
+    public void testRowTypeUpdateFieldComment() {
+        List<String> fieldNames = Arrays.asList("row_column");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        RowType oldType =
+                RowType.of(
+                        new DataField(0, "f1", DataTypes.INT(), "old comment"),
+                        new DataField(1, "f2", DataTypes.STRING()));
+        RowType newType =
+                RowType.of(
+                        new DataField(0, "f1", DataTypes.INT(), "new comment"),
+                        new DataField(1, "f2", DataTypes.STRING()));
+
+        NestedSchemaUtils.generateNestedColumnUpdates(fieldNames, oldType, newType, schemaChanges);
+
+        assertThat(schemaChanges).hasSize(1);
+        assertThat(schemaChanges.get(0)).isInstanceOf(SchemaChange.UpdateColumnComment.class);
+        SchemaChange.UpdateColumnComment commentChange =
+                (SchemaChange.UpdateColumnComment) schemaChanges.get(0);
+        assertThat(commentChange.fieldNames()).containsExactly("row_column", "f1");
+        assertThat(commentChange.newDescription()).isEqualTo("new comment");
+    }
+
+    @Test
+    public void testRowTypeReorderFields() {
+        List<String> fieldNames = Arrays.asList("row_column");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        RowType oldType =
+                RowType.of(
+                        new DataField(0, "f1", DataTypes.INT()),
+                        new DataField(1, "f2", DataTypes.STRING()),
+                        new DataField(2, "f3", DataTypes.DOUBLE()));
+        RowType newType =
+                RowType.of(
+                        new DataField(0, "f1", DataTypes.INT()),
+                        new DataField(2, "f3", DataTypes.DOUBLE()),
+                        new DataField(1, "f2", DataTypes.STRING()) // f2 and f3 swapped
+                        );
+
+        assertThatThrownBy(
+                        () -> {
+                            NestedSchemaUtils.generateNestedColumnUpdates(
+                                    fieldNames, oldType, newType, schemaChanges);
+                        })
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Order of existing fields");
+    }
+
+    @Test
+    public void testRowWithIncompatibleTypeThrowsException() {
+        List<String> fieldNames = Arrays.asList("row_column");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        RowType oldType = RowType.of(new DataField(0, "f1", DataTypes.INT()));
+        ArrayType newType = new ArrayType(true, DataTypes.INT()); // Incompatible type
+
+        assertThatThrownBy(
+                        () -> {
+                            NestedSchemaUtils.generateNestedColumnUpdates(
+                                    fieldNames, oldType, newType, schemaChanges);
+                        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("can only be updated to row type");
+    }
+
+    @Test
+    public void testComplexNestedStructure() {
+        List<String> fieldNames = Arrays.asList("complex_column");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        // Old: ARRAY<MAP<STRING, ROW<f1 INT, f2 STRING>>>
+        RowType oldInnerRowType =
+                RowType.of(
+                        new DataField(0, "f1", DataTypes.INT()),
+                        new DataField(1, "f2", DataTypes.STRING()));
+        MapType oldMapType = new MapType(true, DataTypes.STRING(), oldInnerRowType);
+        ArrayType oldType = new ArrayType(true, oldMapType);
+
+        // New: ARRAY<MAP<STRING, ROW<f1 BIGINT, f2 STRING, f3 DOUBLE>>>
+        RowType newInnerRowType =
+                RowType.of(
+                        new DataField(0, "f1", DataTypes.BIGINT()), // Type changed
+                        new DataField(1, "f2", DataTypes.STRING()),
+                        new DataField(2, "f3", DataTypes.DOUBLE()) // New field added
+                        );
+        MapType newMapType = new MapType(true, DataTypes.STRING(), newInnerRowType);
+        ArrayType newType = new ArrayType(true, newMapType);
+
+        NestedSchemaUtils.generateNestedColumnUpdates(fieldNames, oldType, newType, schemaChanges);
+
+        assertThat(schemaChanges).hasSize(2);
+
+        // Should have one type update and one add column
+        SchemaChange.UpdateColumnType typeChange =
+                schemaChanges.stream()
+                        .filter(change -> change instanceof SchemaChange.UpdateColumnType)
+                        .map(change -> (SchemaChange.UpdateColumnType) change)
+                        .findFirst()
+                        .orElse(null);
+        assertThat(typeChange).isNotNull();
+        assertThat(typeChange.fieldNames())
+                .containsExactly("complex_column", "element", "value", "f1");
+        assertThat(typeChange.newDataType()).isEqualTo(DataTypes.BIGINT());
+
+        SchemaChange.AddColumn addColumn =
+                schemaChanges.stream()
+                        .filter(change -> change instanceof SchemaChange.AddColumn)
+                        .map(change -> (SchemaChange.AddColumn) change)
+                        .findFirst()
+                        .orElse(null);
+        assertThat(addColumn).isNotNull();
+        assertThat(addColumn.fieldNames())
+                .containsExactly("complex_column", "element", "value", "f3");
+        assertThat(addColumn.dataType()).isEqualTo(DataTypes.DOUBLE());
+    }
+
+    @Test
+    public void testNestedFieldPaths() {
+        List<String> fieldNames = Arrays.asList("outer", "inner");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        // Test that nested field names are properly combined
+        NestedSchemaUtils.generateNestedColumnUpdates(
+                fieldNames, DataTypes.INT(), DataTypes.BIGINT(), schemaChanges);
+
+        assertThat(schemaChanges).hasSize(1);
+        assertThat(schemaChanges.get(0)).isInstanceOf(SchemaChange.UpdateColumnType.class);
+        SchemaChange.UpdateColumnType typeChange =
+                (SchemaChange.UpdateColumnType) schemaChanges.get(0);
+        assertThat(typeChange.fieldNames()).containsExactly("outer", "inner");
+    }
+
+    @Test
+    public void testEmptyFieldNames() {
+        List<String> fieldNames = Collections.emptyList();
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        NestedSchemaUtils.generateNestedColumnUpdates(
+                fieldNames, DataTypes.INT(), DataTypes.BIGINT(), schemaChanges);
+
+        assertThat(schemaChanges).hasSize(1);
+        assertThat(schemaChanges.get(0)).isInstanceOf(SchemaChange.UpdateColumnType.class);
+        SchemaChange.UpdateColumnType typeChange =
+                (SchemaChange.UpdateColumnType) schemaChanges.get(0);
+        assertThat(typeChange.fieldNames()).isEmpty();
+    }
+
+    @Test
+    public void testVarCharTypeExtension() {
+        List<String> fieldNames = Arrays.asList("varchar_column");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        VarCharType oldType = new VarCharType(true, 10);
+        VarCharType newType = new VarCharType(true, 20);
+
+        NestedSchemaUtils.generateNestedColumnUpdates(fieldNames, oldType, newType, schemaChanges);
+
+        assertThat(schemaChanges).hasSize(1);
+        assertThat(schemaChanges.get(0)).isInstanceOf(SchemaChange.UpdateColumnType.class);
+        SchemaChange.UpdateColumnType typeChange =
+                (SchemaChange.UpdateColumnType) schemaChanges.get(0);
+        assertThat(typeChange.fieldNames()).containsExactly("varchar_column");
+        assertThat(typeChange.newDataType()).isEqualTo(newType);
+    }
+
+    @Test
+    public void testMultipleNestedChanges() {
+        List<String> fieldNames = Arrays.asList("root");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        // Old: ROW<f1 INT NULL, f2 STRING>
+        RowType oldType =
+                RowType.of(
+                        new DataField(0, "f1", DataTypes.INT().nullable()),
+                        new DataField(1, "f2", DataTypes.STRING()));
+
+        // New: ROW<f1 BIGINT NOT NULL, f2 STRING, f3 DOUBLE>
+        RowType newType =
+                RowType.of(
+                        new DataField(
+                                0,
+                                "f1",
+                                DataTypes.BIGINT().notNull()), // Type and nullability changed
+                        new DataField(1, "f2", DataTypes.STRING()),
+                        new DataField(2, "f3", DataTypes.DOUBLE()) // New field
+                        );
+
+        NestedSchemaUtils.generateNestedColumnUpdates(fieldNames, oldType, newType, schemaChanges);
+
+        assertThat(schemaChanges).hasSize(3);
+
+        // Should have: add column, update type, update nullability
+        assertThat(schemaChanges).anyMatch(change -> change instanceof SchemaChange.AddColumn);
+        assertThat(schemaChanges)
+                .anyMatch(change -> change instanceof SchemaChange.UpdateColumnType);
+        assertThat(schemaChanges)
+                .anyMatch(change -> change instanceof SchemaChange.UpdateColumnNullability);
+    }
+
+    @Test
+    public void testArrayOfRowsWithFieldChanges() {
+        List<String> fieldNames = Arrays.asList("array_of_rows");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        // Old: ARRAY<ROW<id INT, name STRING>>
+        RowType oldRowType =
+                RowType.of(
+                        new DataField(0, "id", DataTypes.INT()),
+                        new DataField(1, "name", DataTypes.STRING()));
+        ArrayType oldType = new ArrayType(true, oldRowType);
+
+        // New: ARRAY<ROW<id BIGINT, name STRING, active BOOLEAN>>
+        RowType newRowType =
+                RowType.of(
+                        new DataField(0, "id", DataTypes.BIGINT()), // Type changed
+                        new DataField(1, "name", DataTypes.STRING()),
+                        new DataField(2, "active", DataTypes.BOOLEAN()) // New field
+                        );
+        ArrayType newType = new ArrayType(true, newRowType);
+
+        NestedSchemaUtils.generateNestedColumnUpdates(fieldNames, oldType, newType, schemaChanges);
+
+        assertThat(schemaChanges).hasSize(2);
+
+        // Verify field paths include "element" for array access
+        SchemaChange.UpdateColumnType typeChange =
+                schemaChanges.stream()
+                        .filter(change -> change instanceof SchemaChange.UpdateColumnType)
+                        .map(change -> (SchemaChange.UpdateColumnType) change)
+                        .findFirst()
+                        .orElse(null);
+        assertThat(typeChange).isNotNull();
+        assertThat(typeChange.fieldNames()).containsExactly("array_of_rows", "element", "id");
+
+        SchemaChange.AddColumn addColumn =
+                schemaChanges.stream()
+                        .filter(change -> change instanceof SchemaChange.AddColumn)
+                        .map(change -> (SchemaChange.AddColumn) change)
+                        .findFirst()
+                        .orElse(null);
+        assertThat(addColumn).isNotNull();
+        assertThat(addColumn.fieldNames()).containsExactly("array_of_rows", "element", "active");
+    }
+
+    @Test
+    public void testMapOfRowsWithFieldChanges() {
+        List<String> fieldNames = Arrays.asList("map_of_rows");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        // Old: MAP<STRING, ROW<id INT, name STRING>>
+        RowType oldRowType =
+                RowType.of(
+                        new DataField(0, "id", DataTypes.INT()),
+                        new DataField(1, "name", DataTypes.STRING()));
+        MapType oldType = new MapType(true, DataTypes.STRING(), oldRowType);
+
+        // New: MAP<STRING, ROW<id BIGINT, name STRING, active BOOLEAN>>
+        RowType newRowType =
+                RowType.of(
+                        new DataField(0, "id", DataTypes.BIGINT()), // Type changed
+                        new DataField(1, "name", DataTypes.STRING()),
+                        new DataField(2, "active", DataTypes.BOOLEAN()) // New field
+                        );
+        MapType newType = new MapType(true, DataTypes.STRING(), newRowType);
+
+        NestedSchemaUtils.generateNestedColumnUpdates(fieldNames, oldType, newType, schemaChanges);
+
+        assertThat(schemaChanges).hasSize(2);
+
+        // Verify field paths include "value" for map value access
+        SchemaChange.UpdateColumnType typeChange =
+                schemaChanges.stream()
+                        .filter(change -> change instanceof SchemaChange.UpdateColumnType)
+                        .map(change -> (SchemaChange.UpdateColumnType) change)
+                        .findFirst()
+                        .orElse(null);
+        assertThat(typeChange).isNotNull();
+        assertThat(typeChange.fieldNames()).containsExactly("map_of_rows", "value", "id");
+
+        SchemaChange.AddColumn addColumn =
+                schemaChanges.stream()
+                        .filter(change -> change instanceof SchemaChange.AddColumn)
+                        .map(change -> (SchemaChange.AddColumn) change)
+                        .findFirst()
+                        .orElse(null);
+        assertThat(addColumn).isNotNull();
+        assertThat(addColumn.fieldNames()).containsExactly("map_of_rows", "value", "active");
+    }
+
+    @Test
+    public void testMultisetOfComplexType() {
+        List<String> fieldNames = Arrays.asList("multiset_column");
+        List<SchemaChange> schemaChanges = new ArrayList<>();
+
+        // Old: MULTISET<ROW<id INT>>
+        RowType oldRowType = RowType.of(new DataField(0, "id", DataTypes.INT()));
+        MultisetType oldType = new MultisetType(true, oldRowType);
+
+        // New: MULTISET<ROW<id BIGINT, name STRING>>
+        RowType newRowType =
+                RowType.of(
+                        new DataField(0, "id", DataTypes.BIGINT()),
+                        new DataField(1, "name", DataTypes.STRING()));
+        MultisetType newType = new MultisetType(true, newRowType);
+
+        NestedSchemaUtils.generateNestedColumnUpdates(fieldNames, oldType, newType, schemaChanges);
+
+        assertThat(schemaChanges).hasSize(2);
+
+        // Verify field paths include "element" for multiset element access
+        SchemaChange.UpdateColumnType typeChange =
+                schemaChanges.stream()
+                        .filter(change -> change instanceof SchemaChange.UpdateColumnType)
+                        .map(change -> (SchemaChange.UpdateColumnType) change)
+                        .findFirst()
+                        .orElse(null);
+        assertThat(typeChange).isNotNull();
+        assertThat(typeChange.fieldNames()).containsExactly("multiset_column", "element", "id");
+
+        SchemaChange.AddColumn addColumn =
+                schemaChanges.stream()
+                        .filter(change -> change instanceof SchemaChange.AddColumn)
+                        .map(change -> (SchemaChange.AddColumn) change)
+                        .findFirst()
+                        .orElse(null);
+        assertThat(addColumn).isNotNull();
+        assertThat(addColumn.fieldNames()).containsExactly("multiset_column", "element", "name");
+    }
+}

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/MultiTableUpdatedDataFieldsProcessFunction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/MultiTableUpdatedDataFieldsProcessFunction.java
@@ -101,7 +101,7 @@ public class MultiTableUpdatedDataFieldsProcessFunction
                         updatedSchema.f1.comment());
 
         for (SchemaChange schemaChange : extractSchemaChanges(schemaManager, actualUpdatedSchema)) {
-            applySchemaChange(schemaManager, schemaChange, tableId);
+            applySchemaChange(schemaManager, schemaChange, tableId, actualUpdatedSchema);
         }
         /*
          * Here, actualUpdatedDataFields cannot be used to update latestFields because there is a

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunction.java
@@ -74,7 +74,7 @@ public class UpdatedDataFieldsProcessFunction
                         updatedSchema.primaryKeys(),
                         updatedSchema.comment());
         for (SchemaChange schemaChange : extractSchemaChanges(schemaManager, actualUpdatedSchema)) {
-            applySchemaChange(schemaManager, schemaChange, identifier);
+            applySchemaChange(schemaManager, schemaChange, identifier, actualUpdatedSchema);
         }
         /*
          * Here, actualUpdatedDataFields cannot be used to update latestFields because there is a

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunctionBaseTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunctionBaseTest.java
@@ -19,14 +19,22 @@
 package org.apache.paimon.flink.sink.cdc;
 
 import org.apache.paimon.flink.action.cdc.TypeMapping;
+import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.BigIntType;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.MapType;
+import org.apache.paimon.types.MultisetType;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.SmallIntType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.VarCharType;
 
 import org.junit.Test;
+
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -103,5 +111,509 @@ public class UpdatedDataFieldsProcessFunctionBaseTest {
                         oldType, smallerLengthTimestamp, TypeMapping.defaultMapping());
 
         assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.IGNORE, convertAction);
+    }
+
+    @Test
+    public void testArrayNullabilityEvolution() {
+        // Test 1: Nullable array to non-nullable array (should fail)
+        ArrayType oldType = new ArrayType(true, DataTypes.INT());
+        ArrayType newType = new ArrayType(false, DataTypes.INT());
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldType, newType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.EXCEPTION, convertAction);
+
+        // Test 2: Non-nullable array to nullable array (should succeed)
+        oldType = new ArrayType(false, DataTypes.INT());
+        newType = new ArrayType(true, DataTypes.INT());
+
+        convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldType, newType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.CONVERT, convertAction);
+
+        // Test 3: Array with nullable elements to non-nullable elements (should fail)
+        oldType = new ArrayType(true, new IntType(true));
+        newType = new ArrayType(true, new IntType(false));
+
+        convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldType, newType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.EXCEPTION, convertAction);
+    }
+
+    @Test
+    public void testNestedRowNullabilityEvolution() {
+        // Old type: ROW(f1 ROW(inner1 INT NULL, inner2 STRING) NULL)
+        RowType oldInnerType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "inner1", new IntType(true)),
+                                new DataField(2, "inner2", DataTypes.STRING())));
+        RowType oldRowType = new RowType(true, Arrays.asList(new DataField(1, "f1", oldInnerType)));
+
+        // Test 1: Making nested row non-nullable (should fail)
+        RowType newInnerType =
+                new RowType(
+                        false, // Changed to non-nullable
+                        Arrays.asList(
+                                new DataField(1, "inner1", new IntType(true)),
+                                new DataField(2, "inner2", DataTypes.STRING())));
+        RowType newRowType = new RowType(true, Arrays.asList(new DataField(1, "f1", newInnerType)));
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldRowType, newRowType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.EXCEPTION, convertAction);
+
+        // Test 2: Making nested field non-nullable (should fail)
+        newInnerType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(
+                                        1, "inner1", new IntType(false)), // Changed to non-nullable
+                                new DataField(2, "inner2", DataTypes.STRING())));
+        newRowType = new RowType(true, Arrays.asList(new DataField(1, "f1", newInnerType)));
+
+        convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldRowType, newRowType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.EXCEPTION, convertAction);
+    }
+
+    @Test
+    public void testMultisetNullabilityEvolution() {
+        // Test 1: Nullable multiset to non-nullable multiset (should fail)
+        MultisetType oldType = new MultisetType(true, DataTypes.INT());
+        MultisetType newType = new MultisetType(false, DataTypes.INT());
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldType, newType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.EXCEPTION, convertAction);
+
+        // Test 2: Non-nullable multiset to nullable multiset (should succeed)
+        oldType = new MultisetType(false, DataTypes.INT());
+        newType = new MultisetType(true, DataTypes.INT());
+
+        convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldType, newType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.CONVERT, convertAction);
+
+        // Test 3: Multiset with nullable elements to non-nullable elements (should fail)
+        oldType = new MultisetType(true, new IntType(true));
+        newType = new MultisetType(true, new IntType(false));
+
+        convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldType, newType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.EXCEPTION, convertAction);
+    }
+
+    @Test
+    public void testComplexNestedNullabilityEvolution() {
+        // Old type: ROW(
+        //   f1 ARRAY<ROW<x INT NULL, y STRING> NULL> NULL,
+        //   f2 MAP<STRING, ROW<a INT NULL, b STRING> NULL> NULL
+        // )
+        RowType oldArrayInnerType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "x", new IntType(true)),
+                                new DataField(2, "y", DataTypes.STRING())));
+        ArrayType oldArrayType = new ArrayType(true, oldArrayInnerType);
+
+        RowType oldMapValueType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "a", new IntType(true)),
+                                new DataField(2, "b", DataTypes.STRING())));
+        MapType oldMapType = new MapType(true, DataTypes.STRING(), oldMapValueType);
+
+        RowType oldRowType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "f1", oldArrayType),
+                                new DataField(2, "f2", oldMapType)));
+
+        // Test 1: Making nested array's row type non-nullable (should fail)
+        RowType newArrayInnerType =
+                new RowType(
+                        false, // Changed to non-nullable
+                        Arrays.asList(
+                                new DataField(1, "x", new IntType(true)),
+                                new DataField(2, "y", DataTypes.STRING())));
+        ArrayType newArrayType = new ArrayType(true, newArrayInnerType);
+        MapType newMapType = oldMapType; // Keep the same
+
+        RowType newRowType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "f1", newArrayType),
+                                new DataField(2, "f2", newMapType)));
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldRowType, newRowType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.EXCEPTION, convertAction);
+
+        // Test 2: Making map's value type's field non-nullable (should fail)
+        newArrayType = oldArrayType; // Restore to original
+        RowType newMapValueType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(
+                                        1, "a", new IntType(false)), // Changed to non-nullable
+                                new DataField(2, "b", DataTypes.STRING())));
+        newMapType = new MapType(true, DataTypes.STRING(), newMapValueType);
+
+        newRowType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "f1", newArrayType),
+                                new DataField(2, "f2", newMapType)));
+
+        convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldRowType, newRowType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.EXCEPTION, convertAction);
+    }
+
+    @Test
+    public void testNestedRowTypeConversion() {
+        // Old type: ROW(f1 INT, f2 STRING)
+        RowType oldRowType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "f1", DataTypes.INT()),
+                                new DataField(2, "f2", DataTypes.STRING())));
+
+        // New type: ROW(f1 BIGINT, f2 STRING, f3 DOUBLE)
+        RowType newRowType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "f1", DataTypes.BIGINT()),
+                                new DataField(2, "f2", DataTypes.STRING()),
+                                new DataField(3, "f3", DataTypes.DOUBLE())));
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldRowType, newRowType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.CONVERT, convertAction);
+    }
+
+    @Test
+    public void testNestedArrayTypeConversion() {
+        // Old type: ARRAY<INT>
+        ArrayType oldArrayType = new ArrayType(true, DataTypes.INT());
+
+        // New type: ARRAY<BIGINT>
+        ArrayType newArrayType = new ArrayType(true, DataTypes.BIGINT());
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldArrayType, newArrayType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.CONVERT, convertAction);
+    }
+
+    @Test
+    public void testNestedMapTypeConversion() {
+        // Old type: MAP<STRING, INT>
+        MapType oldMapType = new MapType(true, DataTypes.STRING(), DataTypes.INT());
+
+        // New type: MAP<STRING, BIGINT>
+        MapType newMapType = new MapType(true, DataTypes.STRING(), DataTypes.BIGINT());
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldMapType, newMapType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.CONVERT, convertAction);
+    }
+
+    @Test
+    public void testMapWithNullableComplexTypes() {
+        // Old type: MAP<STRING, ROW<f1 ARRAY<INT> NULL, f2 ROW<x INT, y STRING> NULL>>
+        RowType oldInnerRowType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "x", DataTypes.INT()),
+                                new DataField(2, "y", DataTypes.STRING())));
+
+        RowType oldValueType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "f1", new ArrayType(true, DataTypes.INT())),
+                                new DataField(2, "f2", oldInnerRowType)));
+
+        MapType oldType = new MapType(true, DataTypes.STRING(), oldValueType);
+
+        // New type: MAP<STRING, ROW<f1 ARRAY<BIGINT> NULL, f2 ROW<x BIGINT, y STRING, z DOUBLE>
+        // NULL>>
+        RowType newInnerRowType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "x", DataTypes.BIGINT()),
+                                new DataField(2, "y", DataTypes.STRING()),
+                                new DataField(3, "z", DataTypes.DOUBLE())));
+
+        RowType newValueType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "f1", new ArrayType(true, DataTypes.BIGINT())),
+                                new DataField(2, "f2", newInnerRowType)));
+
+        MapType newType = new MapType(true, DataTypes.STRING(), newValueType);
+
+        // Test compatible evolution
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldType, newType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.CONVERT, convertAction);
+
+        // Test incompatible element type
+        RowType incompatibleValueType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(
+                                        1,
+                                        "f1",
+                                        new ArrayType(
+                                                true, DataTypes.STRING())), // INT to STRING is
+                                // incompatible
+                                new DataField(2, "f2", newInnerRowType)));
+
+        MapType incompatibleType = new MapType(true, DataTypes.STRING(), incompatibleValueType);
+
+        convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldType, incompatibleType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.EXCEPTION, convertAction);
+    }
+
+    @Test
+    public void testComplexNestedTypeConversion() {
+        // Old type: ARRAY<MAP<INT, ROW(f1 INT, f2 STRING)>>
+        RowType oldInnerRowType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "f1", DataTypes.INT()),
+                                new DataField(2, "f2", DataTypes.STRING())));
+        MapType oldMapType = new MapType(true, DataTypes.INT(), oldInnerRowType);
+        ArrayType oldType = new ArrayType(true, oldMapType);
+
+        // New type: ARRAY<MAP<INT, ROW(f1 BIGINT, f2 STRING, f3 DOUBLE)>>
+        RowType newInnerRowType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "f1", DataTypes.BIGINT()),
+                                new DataField(2, "f2", DataTypes.STRING()),
+                                new DataField(3, "f3", DataTypes.DOUBLE())));
+        MapType newMapType = new MapType(true, DataTypes.INT(), newInnerRowType);
+        ArrayType newType = new ArrayType(true, newMapType);
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldType, newType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.CONVERT, convertAction);
+    }
+
+    @Test
+    public void testRowTypeWithMultipleChanges() {
+        // Old type: ROW(f1 INT, f2 STRING, f3 DOUBLE)
+        RowType oldRowType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "f1", DataTypes.INT()),
+                                new DataField(2, "f2", DataTypes.STRING()),
+                                new DataField(3, "f3", DataTypes.DOUBLE())));
+
+        // New type: ROW(f1 BIGINT, f2 VARCHAR(100), f4 INT)
+        RowType newRowType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "f1", DataTypes.BIGINT()),
+                                new DataField(2, "f2", new VarCharType(true, 100)),
+                                new DataField(4, "f4", DataTypes.INT())));
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldRowType, newRowType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.CONVERT, convertAction);
+    }
+
+    @Test
+    public void testNonNullableFieldRemoval() {
+        // Old type: ROW(f1 INT NOT NULL, f2 STRING)
+        RowType oldRowType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "f1", new IntType(false)),
+                                new DataField(2, "f2", DataTypes.STRING())));
+
+        // New type: ROW(f2 STRING)
+        RowType newRowType =
+                new RowType(true, Arrays.asList(new DataField(2, "f2", DataTypes.STRING())));
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldRowType, newRowType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.EXCEPTION, convertAction);
+    }
+
+    @Test
+    public void testAddingNonNullableField() {
+        // Old type: ROW(f1 INT)
+        RowType oldRowType =
+                new RowType(true, Arrays.asList(new DataField(1, "f1", DataTypes.INT())));
+
+        // New type: ROW(f1 INT, f2 STRING NOT NULL)
+        RowType newRowType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "f1", DataTypes.INT()),
+                                new DataField(2, "f2", new VarCharType(false, 100))));
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldRowType, newRowType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.EXCEPTION, convertAction);
+    }
+
+    @Test
+    public void testNestedRowWithinRowEvolution() {
+        // Old type: ROW(f1 ROW(inner1 INT, inner2 STRING))
+        RowType oldInnerType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "inner1", DataTypes.INT()),
+                                new DataField(2, "inner2", DataTypes.STRING())));
+        RowType oldRowType = new RowType(true, Arrays.asList(new DataField(1, "f1", oldInnerType)));
+
+        // New type: ROW(f1 ROW(inner1 BIGINT, inner2 STRING, inner3 DOUBLE))
+        RowType newInnerType =
+                new RowType(
+                        true,
+                        Arrays.asList(
+                                new DataField(1, "inner1", DataTypes.BIGINT()),
+                                new DataField(2, "inner2", DataTypes.STRING()),
+                                new DataField(3, "inner3", DataTypes.DOUBLE())));
+        RowType newRowType = new RowType(true, Arrays.asList(new DataField(1, "f1", newInnerType)));
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldRowType, newRowType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.CONVERT, convertAction);
+    }
+
+    @Test
+    public void testArrayOfArraysEvolution() {
+        // Old type: ARRAY<ARRAY<INT>>
+        ArrayType oldInnerArray = new ArrayType(true, DataTypes.INT());
+        ArrayType oldType = new ArrayType(true, oldInnerArray);
+
+        // New type: ARRAY<ARRAY<BIGINT>>
+        ArrayType newInnerArray = new ArrayType(true, DataTypes.BIGINT());
+        ArrayType newType = new ArrayType(true, newInnerArray);
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldType, newType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.CONVERT, convertAction);
+    }
+
+    @Test
+    public void testArrayWithIncompatibleElementType() {
+        // Old type: ARRAY<INT>
+        ArrayType oldType = new ArrayType(true, DataTypes.INT());
+
+        // New type: ARRAY<STRING>
+        ArrayType newType = new ArrayType(true, DataTypes.STRING());
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldType, newType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.EXCEPTION, convertAction);
+    }
+
+    @Test
+    public void testMapOfMapsEvolution() {
+        // Old type: MAP<STRING, MAP<INT, STRING>>
+        MapType oldInnerMap = new MapType(true, DataTypes.INT(), DataTypes.STRING());
+        MapType oldType = new MapType(true, DataTypes.STRING(), oldInnerMap);
+
+        // New type: MAP<STRING, MAP<INT, VARCHAR(100)>>
+        MapType newInnerMap = new MapType(true, DataTypes.INT(), new VarCharType(true, 100));
+        MapType newType = new MapType(true, DataTypes.STRING(), newInnerMap);
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldType, newType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.IGNORE, convertAction);
+    }
+
+    @Test
+    public void testMapWithIncompatibleValueType() {
+        // Old type: MAP<STRING, INT>
+        MapType oldType = new MapType(true, DataTypes.STRING(), DataTypes.INT());
+
+        // New type: MAP<STRING, BOOLEAN>
+        MapType newType = new MapType(true, DataTypes.STRING(), DataTypes.BOOLEAN());
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldType, newType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.EXCEPTION, convertAction);
+    }
+
+    @Test
+    public void testMultisetTypeEvolution() {
+        // Old type: MULTISET<INT>
+        MultisetType oldType = new MultisetType(true, DataTypes.INT());
+
+        // New type: MULTISET<BIGINT>
+        MultisetType newType = new MultisetType(true, DataTypes.BIGINT());
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldType, newType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.CONVERT, convertAction);
+    }
+
+    @Test
+    public void testIncompatibleMultisetTypeEvolution() {
+        // Old type: MULTISET<INT>
+        MultisetType oldType = new MultisetType(true, DataTypes.INT());
+
+        // New type: MULTISET<STRING>
+        MultisetType newType = new MultisetType(true, DataTypes.STRING());
+
+        UpdatedDataFieldsProcessFunctionBase.ConvertAction convertAction =
+                UpdatedDataFieldsProcessFunctionBase.canConvert(
+                        oldType, newType, TypeMapping.defaultMapping());
+        assertEquals(UpdatedDataFieldsProcessFunctionBase.ConvertAction.EXCEPTION, convertAction);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
@@ -1351,4 +1351,184 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
         assertThat(sql("SELECT * FROM T"))
                 .containsExactlyInAnyOrder(Row.of(1, 10L), Row.of(2, 20L));
     }
+
+    @Test
+    public void testAlterColumnTypeNestedArrayAndMap() {
+        sql("CREATE TABLE T ( k INT, v ARRAY<ARRAY<ARRAY<INT>>>, PRIMARY KEY(k) NOT ENFORCED )");
+        sql("INSERT INTO T VALUES (1, ARRAY[ARRAY[ARRAY[1, 2]]]), (2, ARRAY[ARRAY[ARRAY[3, 4]]])");
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(
+                        Row.of(1, new Integer[][][] {{{1, 2}}}),
+                        Row.of(2, new Integer[][][] {{{3, 4}}}));
+        sql("ALTER TABLE T MODIFY v ARRAY<ARRAY<ARRAY<BIGINT>>>");
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(
+                        Row.of(1, new Long[][][] {{{1L, 2L}}}),
+                        Row.of(2, new Long[][][] {{{3L, 4L}}}));
+        assertThatCode(() -> sql("ALTER TABLE T MODIFY v ARRAY<ARRAY<ARRAY<BIGINT NOT NULL>>>"))
+                .hasStackTraceContaining(
+                        "Cannot update column type from nullable to non nullable for v.element.element.element");
+
+        sql("DROP TABLE T");
+
+        sql(
+                "CREATE TABLE T ( k INT, v MAP<STRING, MAP<STRING, MAP<STRING, INT NOT NULL>>>, PRIMARY KEY(k) NOT ENFORCED )");
+        Map<String, Map<String, Map<String, Integer>>> mp1 = new HashMap<>();
+        Map<String, Map<String, Integer>> l1Mp1 = new HashMap<>();
+        Map<String, Integer> l2Mp1 = new HashMap<>();
+        l2Mp1.put("aaa", 1);
+        l2Mp1.put("aab", 2);
+        l1Mp1.put("aa", l2Mp1);
+        mp1.put("a", l1Mp1);
+        Map<String, Map<String, Map<String, Integer>>> mp2 = new HashMap<>();
+        Map<String, Map<String, Integer>> l1Mp2 = new HashMap<>();
+        Map<String, Integer> l2Mp2 = new HashMap<>();
+        l2Mp2.put("bbb", 3);
+        l2Mp2.put("bbc", 4);
+        l1Mp2.put("bb", l2Mp2);
+        mp2.put("b", l1Mp2);
+        sql(
+                "INSERT INTO T VALUES (1, MAP['a', MAP['aa', MAP['aaa', 1, 'aab', 2]]]), (2, MAP['b', MAP['bb', MAP['bbb', 3, 'bbc', 4]]])");
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(Row.of(1, mp1), Row.of(2, mp2));
+        sql("ALTER TABLE T MODIFY v MAP<STRING, MAP<STRING, MAP<STRING, BIGINT>>>");
+        Map<String, Map<String, Map<String, Long>>> mp3 = new HashMap<>();
+        Map<String, Map<String, Long>> l1Mp3 = new HashMap<>();
+        Map<String, Long> l2Mp3 = new HashMap<>();
+        l2Mp3.put("aaa", 1L);
+        l2Mp3.put("aab", 2L);
+        l1Mp3.put("aa", l2Mp3);
+        mp3.put("a", l1Mp3);
+        Map<String, Map<String, Map<String, Long>>> mp4 = new HashMap<>();
+        Map<String, Map<String, Long>> l1Mp4 = new HashMap<>();
+        Map<String, Long> l2Mp4 = new HashMap<>();
+        l2Mp4.put("bbb", 3L);
+        l2Mp4.put("bbc", 4L);
+        l1Mp4.put("bb", l2Mp4);
+        mp4.put("b", l1Mp4);
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(Row.of(1, mp3), Row.of(2, mp4));
+        assertThatCode(
+                        () ->
+                                sql(
+                                        "ALTER TABLE T MODIFY v MAP<STRING, MAP<STRING, MAP<STRING, BIGINT NOT NULL>>>"))
+                .hasStackTraceContaining(
+                        "Cannot update column type from nullable to non nullable for v.value.value.value");
+
+        sql("DROP TABLE T");
+
+        sql(
+                "CREATE TABLE T ( k INT, a ARRAY<INT NOT NULL>, b MAP<STRING, INT NOT NULL>, PRIMARY KEY(k) NOT ENFORCED )");
+        sql("INSERT INTO T VALUES (1, ARRAY[1, 2, 3, 4], MAP['a', 1, 'b', 2])");
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(
+                        Row.of(
+                                1,
+                                new Integer[] {1, 2, 3, 4},
+                                new HashMap<String, Integer>() {
+                                    {
+                                        put("a", 1);
+                                    }
+
+                                    {
+                                        put("b", 2);
+                                    }
+                                }));
+        sql("ALTER TABLE T MODIFY a ARRAY<BIGINT>");
+        sql("INSERT INTO T VALUES (2, ARRAY[5, 6, 7, CAST(NULL AS BIGINT)], MAP['c', 3, 'd', 4])");
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(
+                        Row.of(
+                                1,
+                                new Long[] {1L, 2L, 3L, 4L},
+                                new HashMap<String, Integer>() {
+                                    {
+                                        put("a", 1);
+                                    }
+
+                                    {
+                                        put("b", 2);
+                                    }
+                                }),
+                        Row.of(
+                                2,
+                                new Long[] {5L, 6L, 7L, null},
+                                new HashMap<String, Integer>() {
+                                    {
+                                        put("c", 3);
+                                    }
+
+                                    {
+                                        put("d", 4);
+                                    }
+                                }));
+        assertThatCode(() -> sql("ALTER TABLE T MODIFY a ARRAY<BIGINT NOT NULL>"))
+                .hasStackTraceContaining(
+                        "Cannot update column type from nullable to non nullable for a.element");
+        sql("ALTER TABLE T MODIFY b MAP<STRING, BIGINT>");
+        sql(
+                "INSERT INTO T VALUES (2, ARRAY[5, 6, 7, CAST(NULL AS BIGINT)], MAP['c', 3, 'd', CAST(NULL AS BIGINT)])");
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(
+                        Row.of(
+                                1,
+                                new Long[] {1L, 2L, 3L, 4L},
+                                new HashMap<String, Long>() {
+                                    {
+                                        put("a", 1L);
+                                    }
+
+                                    {
+                                        put("b", 2L);
+                                    }
+                                }),
+                        Row.of(
+                                2,
+                                new Long[] {5L, 6L, 7L, null},
+                                new HashMap<String, Long>() {
+                                    {
+                                        put("c", 3L);
+                                    }
+
+                                    {
+                                        put("d", null);
+                                    }
+                                }));
+        assertThatCode(() -> sql("ALTER TABLE T MODIFY b MAP<STRING, BIGINT NOT NULL>"))
+                .hasStackTraceContaining(
+                        "Cannot update column type from nullable to non nullable for b.value");
+
+        sql("DROP TABLE T");
+        sql(
+                "CREATE TABLE T ( k INT, a MAP<STRING, ARRAY<INT NOT NULL>>, PRIMARY KEY(k) NOT ENFORCED )");
+        sql("INSERT INTO T VALUES (1, MAP['a', ARRAY[1, 2, 3]])");
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(
+                        Row.of(
+                                1,
+                                new HashMap<String, Integer[]>() {
+                                    {
+                                        put("a", new Integer[] {1, 2, 3});
+                                    }
+                                }));
+        sql("ALTER TABLE T MODIFY a MAP<STRING, ARRAY<BIGINT>>");
+        sql(
+                "INSERT INTO T VALUES(1, MAP['a', ARRAY[1, 2, 3], 'b', ARRAY[2, 3, CAST(NULL AS BIGINT)]])");
+        assertThat(sql("SELECT * FROM T"))
+                .containsExactlyInAnyOrder(
+                        Row.of(
+                                1,
+                                new HashMap<String, Long[]>() {
+                                    {
+                                        put("a", new Long[] {1L, 2L, 3L});
+                                    }
+
+                                    {
+                                        put("b", new Long[] {2L, 3L, null});
+                                    }
+                                }));
+        assertThatCode(() -> sql("ALTER TABLE T MODIFY a MAP<STRING, ARRAY<BIGINT NOT NULL>>"))
+                .hasStackTraceContaining(
+                        "Cannot update column type from nullable to non nullable for a.value.element");
+    }
 }


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3922 

Added support for nested schema evolution in CDC 

Extracts existing functionality that generates `SchemaChange` from [here](https://github.com/apache/paimon/blob/master/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java#L752-L788) into a utility class that is called by Flink CDC ingestion. 

This PR also uses changes from https://github.com/apache/paimon/pull/5673

### Tests

Added test cases to validate the right schema changes are generated.

```
// after setting up a flink cdc ingestion job
// Starting schema
Flink SQL> describe complex_types_test;
+-------------------+------------------------------------------------------------------+------+-----+--------+-----------+
|              name |                                                             type | null | key | extras | watermark |
+-------------------+------------------------------------------------------------------+------+-----+--------+-----------+
|       simpleArray |                                                       ARRAY<INT> | TRUE |     |        |           |
|      nonNullArray |                                                       ARRAY<INT> | TRUE |     |        |           |
|         simpleMap |                                                 MAP<STRING, INT> | TRUE |     |        |           |
| mapWithNonNullInt |                                                 MAP<STRING, INT> | TRUE |     |        |           |
|         simpleRow |                                         ROW<`a` INT, `b` STRING> | TRUE |     |        |           |
|        complexMap | MAP<STRING, ROW<`f1` ARRAY<INT>, `f2` ROW<`x` INT, `y` STRING>>> | TRUE |     |        |           |
|       arrayOfMaps |                   ARRAY<MAP<STRING, ROW<`f1` INT, `f2` STRING>>> | TRUE |     |        |           |
|        event_time |                                                           BIGINT | TRUE |     |        |           |
|                dt |                                                           STRING | TRUE |     |        |           |
+-------------------+------------------------------------------------------------------+------+-----+--------+-----------+
9 rows in set

Flink SQL> describe complex_types_test;
+-------------------+------------------------------------------------------------------------------------------+------+-----+--------+-----------+
|              name |                                                                                     type | null | key | extras | watermark |
+-------------------+------------------------------------------------------------------------------------------+------+-----+--------+-----------+
|       simpleArray |                                                                            ARRAY<BIGINT> | TRUE |     |        |           |
|      nonNullArray |                                                                               ARRAY<INT> | TRUE |     |        |           |
|         simpleMap |                                                                      MAP<STRING, BIGINT> | TRUE |     |        |           |
| mapWithNonNullInt |                                                                         MAP<STRING, INT> | TRUE |     |        |           |
|         simpleRow |                                            ROW<`a` BIGINT, `b` STRING, `c` DOUBLE '...'> | TRUE |     |        |           |
|        complexMap | MAP<STRING, ROW<`f1` ARRAY<BIGINT>, `f2` ROW<`x` BIGINT, `y` STRING, `z` DOUBLE '...'>>> | TRUE |     |        |           |
|       arrayOfMaps |                     ARRAY<MAP<STRING, ROW<`f1` BIGINT, `f2` STRING, `f3` DOUBLE '...'>>> | TRUE |     |        |           |
|        event_time |                                                                                   BIGINT | TRUE |     |        |           |
|                dt |                                                                                   STRING | TRUE |     |        |           |
+-------------------+------------------------------------------------------------------------------------------+------+-----+--------+-----------+
9 rows in set

Flink SQL> show create table complex_types_test;
CREATE TABLE `paimon`.`some_db`.`complex_types_test` (
  `simpleArray` ARRAY<BIGINT>,
  `nonNullArray` ARRAY<INT>,
  `simpleMap` MAP<VARCHAR(2147483647), BIGINT>,
  `mapWithNonNullInt` MAP<VARCHAR(2147483647), INT>,
  `simpleRow` ROW<`a` BIGINT, `b` VARCHAR(2147483647), `c` DOUBLE 'some stuff'>,
  `complexMap` MAP<VARCHAR(2147483647), ROW<`f1` ARRAY<BIGINT>, `f2` ROW<`x` BIGINT, `y` VARCHAR(2147483647), `z` DOUBLE 'some stuff'>>>,
  `arrayOfMaps` ARRAY<MAP<VARCHAR(2147483647), ROW<`f1` BIGINT, `f2` VARCHAR(2147483647), `f3` DOUBLE 'some stuff'>>>,
  `event_time` BIGINT,
  `dt` VARCHAR(2147483647)
) PARTITIONED BY (`dt`)
```
