### PR TITLE
[hive] Update columns when committing Iceberg metadata

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitter.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitter.java
@@ -147,6 +147,12 @@ public class IcebergHiveMetadataCommitter implements IcebergMetadataCommitter {
                     .put("previous_metadata_location", baseMetadataPath.toString());
         }
 
+        StorageDescriptor sd = hiveTable.getSd();
+        sd.setCols(
+                table.schema().fields().stream()
+                        .map(this::convertToFieldSchema)
+                        .collect(Collectors.toList()));
+
         Options options = new Options(table.options());
         boolean skipAWSGlueArchive = options.get(IcebergOptions.GLUE_SKIP_ARCHIVE);
         EnvironmentContext environmentContext = new EnvironmentContext();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5690

<!-- What is the purpose of the change -->

Previously, updating columns did not mirror the logic applied in createTable. This could lead to inconsistent table schemas. This PR refactors the update process to use the [same mechanism as table creation](https://github.com/apache/paimon/blob/e6c913216ce19a42f030bf463a9010454435df05/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitter.java#L210-L213).

### Tests

<!-- List UT and IT cases to verify this change -->

Verified that the new column appears in AWS Glue.

### API and Format

<!-- Does this change affect API or storage format -->
N/A

### Documentation

<!-- Does this change introduce a new feature -->

This PR matches the expected/assumed behavior. If explicit documentation is needed for this update, please advise and I can add/expand docs accordingly.

