### PR TITLE
[core]fix: rest catalog options uri schema could be empty

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -195,6 +195,11 @@ public class HttpClient implements RESTClient {
         return fullPath;
     }
 
+    @VisibleForTesting
+    public String uri() {
+        return uri;
+    }
+
     private <T extends RESTResponse> T exec(Request request, Class<T> responseType) {
         try (Response response = HTTP_CLIENT.newCall(request).execute()) {
             String responseBodyStr = response.body() != null ? response.body().string() : null;

--- a/paimon-api/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -68,11 +68,20 @@ public class HttpClient implements RESTClient {
     private ErrorHandler errorHandler;
 
     public HttpClient(String uri) {
-        if (uri != null && uri.endsWith("/")) {
-            this.uri = uri.substring(0, uri.length() - 1);
+        String serverUri;
+        if (StringUtils.isNotEmpty(uri)) {
+            if (uri.endsWith("/")) {
+                serverUri = uri.substring(0, uri.length() - 1);
+            } else {
+                serverUri = uri;
+            }
+            if (!uri.startsWith("http://") && !uri.startsWith("https://")) {
+                serverUri = String.format("http://%s", serverUri);
+            }
         } else {
-            this.uri = uri;
+            throw new IllegalArgumentException("uri is empty which must be define");
         }
+        this.uri = serverUri;
         this.errorHandler = DefaultErrorHandler.getInstance();
     }
 
@@ -173,6 +182,9 @@ public class HttpClient implements RESTClient {
     @VisibleForTesting
     protected static String getRequestUrl(
             String uri, String path, Map<String, String> queryParams) {
+        if (!uri.startsWith("http://") && !uri.startsWith("https://")) {
+            throw new IllegalArgumentException("uri is not start with http:// or https://");
+        }
         String fullPath = StringUtils.isNullOrWhitespaceOnly(path) ? uri : uri + path;
         if (queryParams != null && !queryParams.isEmpty()) {
             HttpUrl httpUrl = HttpUrl.parse(fullPath);

--- a/paimon-api/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -79,7 +79,7 @@ public class HttpClient implements RESTClient {
                 serverUri = String.format("http://%s", serverUri);
             }
         } else {
-            throw new IllegalArgumentException("uri is empty which must be define");
+            throw new IllegalArgumentException("uri is empty which must be defined.");
         }
         this.uri = serverUri;
         this.errorHandler = DefaultErrorHandler.getInstance();
@@ -96,7 +96,7 @@ public class HttpClient implements RESTClient {
         Map<String, String> authHeaders = getHeaders(path, "GET", "", restAuthFunction);
         Request request =
                 new Request.Builder()
-                        .url(getRequestUrl(uri, path, null))
+                        .url(getRequestUrl(path, null))
                         .get()
                         .headers(Headers.of(authHeaders))
                         .build();
@@ -113,7 +113,7 @@ public class HttpClient implements RESTClient {
                 getHeaders(path, queryParams, "GET", "", restAuthFunction);
         Request request =
                 new Request.Builder()
-                        .url(getRequestUrl(uri, path, queryParams))
+                        .url(getRequestUrl(path, queryParams))
                         .get()
                         .headers(Headers.of(authHeaders))
                         .build();
@@ -138,7 +138,7 @@ public class HttpClient implements RESTClient {
             RequestBody requestBody = buildRequestBody(bodyStr);
             Request request =
                     new Request.Builder()
-                            .url(getRequestUrl(uri, path, null))
+                            .url(getRequestUrl(path, null))
                             .post(requestBody)
                             .headers(Headers.of(authHeaders))
                             .build();
@@ -153,7 +153,7 @@ public class HttpClient implements RESTClient {
         Map<String, String> authHeaders = getHeaders(path, "DELETE", "", restAuthFunction);
         Request request =
                 new Request.Builder()
-                        .url(getRequestUrl(uri, path, null))
+                        .url(getRequestUrl(path, null))
                         .delete()
                         .headers(Headers.of(authHeaders))
                         .build();
@@ -169,7 +169,7 @@ public class HttpClient implements RESTClient {
             RequestBody requestBody = buildRequestBody(bodyStr);
             Request request =
                     new Request.Builder()
-                            .url(getRequestUrl(uri, path, null))
+                            .url(getRequestUrl(path, null))
                             .delete(requestBody)
                             .headers(Headers.of(authHeaders))
                             .build();
@@ -180,11 +180,7 @@ public class HttpClient implements RESTClient {
     }
 
     @VisibleForTesting
-    protected static String getRequestUrl(
-            String uri, String path, Map<String, String> queryParams) {
-        if (!uri.startsWith("http://") && !uri.startsWith("https://")) {
-            throw new IllegalArgumentException("uri is not start with http:// or https://");
-        }
+    protected String getRequestUrl(String path, Map<String, String> queryParams) {
         String fullPath = StringUtils.isNullOrWhitespaceOnly(path) ? uri : uri + path;
         if (queryParams != null && !queryParams.isEmpty()) {
             HttpUrl httpUrl = HttpUrl.parse(fullPath);

--- a/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
@@ -196,12 +196,10 @@ public class HttpClientTest {
                         "GET",
                         "");
         String url =
-                HttpClient.getRequestUrl(
-                        "http://a.b.c:8080",
-                        "/api/v1/tables/my_table$schemas",
-                        ImmutableMap.of("pageToken", "dt=20230101"));
-        Assertions.assertThrows(
-                IllegalArgumentException.class, () -> HttpClient.getRequestUrl("a.b.c", "", null));
+                (new HttpClient("http://a.b.c:8080"))
+                        .getRequestUrl(
+                                "/api/v1/tables/my_table$schemas",
+                                ImmutableMap.of("pageToken", "dt=20230101"));
         assertEquals(
                 "http://a.b.c:8080/api/v1/tables/my_table$schemas?pageToken=dt%3D20230101", url);
         Map<String, String> queryParameters = getParameters(url);

--- a/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
@@ -82,6 +82,11 @@ public class HttpClientTest {
     }
 
     @Test
+    public void testCreateHttpClientWhenUriNoSchema() {
+        Assertions.assertDoesNotThrow(() -> new HttpClient("localhost"));
+    }
+
+    @Test
     public void testGetSuccess() {
         server.enqueueResponse(mockResponseDataStr, 200);
         MockRESTData response = httpClient.get(MOCK_PATH, MockRESTData.class, restAuthFunction);
@@ -193,6 +198,8 @@ public class HttpClientTest {
                         "http://a.b.c:8080",
                         "/api/v1/tables/my_table$schemas",
                         ImmutableMap.of("pageToken", "dt=20230101"));
+        Assertions.assertThrows(
+                IllegalArgumentException.class, () -> HttpClient.getRequestUrl("a.b.c", "", null));
         assertEquals(
                 "http://a.b.c:8080/api/v1/tables/my_table$schemas?pageToken=dt%3D20230101", url);
         Map<String, String> queryParameters = getParameters(url);

--- a/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
@@ -82,8 +82,10 @@ public class HttpClientTest {
     }
 
     @Test
-    public void testCreateHttpClientWhenUriNoSchema() {
-        Assertions.assertDoesNotThrow(() -> new HttpClient("localhost"));
+    public void testServerUriSchema() {
+        assertEquals("http://localhost", (new HttpClient("localhost")).uri());
+        assertEquals("http://localhost", (new HttpClient("http://localhost")).uri());
+        assertEquals("https://localhost", (new HttpClient("https://localhost")).uri());
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Fix: when users use the  rest catalog URI, it must be with schema

<!-- What is the purpose of the change -->

### Tests
- HttpClientTest.testServerUriSchema

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
