### PR TITLE
[flink] Writer operator support SlotSharingGroup settings

### DIFF
--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -285,6 +285,18 @@ under the License.
             <td>If true, flink sink will use managed memory for merge tree; otherwise, it will create an independent memory allocator.</td>
         </tr>
         <tr>
+            <td><h5>sink.writer-cpu</h5></td>
+            <td style="word-wrap: break-word;">1.0</td>
+            <td>Double</td>
+            <td>Sink writer cpu to control cpu cores of writer.</td>
+        </tr>
+        <tr>
+            <td><h5>sink.writer-memory</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>MemorySize</td>
+            <td>Sink writer memory to control heap memory of writer.</td>
+        </tr>
+        <tr>
             <td><h5>source.checkpoint-align.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
@@ -50,7 +50,7 @@ import java.io.Serializable;
 import java.util.Collections;
 
 import static org.apache.paimon.flink.sink.FlinkSink.assertStreamingConfiguration;
-import static org.apache.paimon.flink.sink.FlinkSink.configureGlobalCommitter;
+import static org.apache.paimon.flink.sink.FlinkSink.configureSlotSharingGroup;
 import static org.apache.paimon.flink.utils.ParallelismUtils.forwardParallelism;
 
 /**
@@ -64,6 +64,8 @@ public class FlinkCdcMultiTableSink implements Serializable {
 
     private final boolean isOverwrite = false;
     private final CatalogLoader catalogLoader;
+    private final double writeCpuCores;
+    private final MemorySize writeHeapMemory;
     private final double commitCpuCores;
     @Nullable private final MemorySize commitHeapMemory;
     private final String commitUser;
@@ -72,12 +74,16 @@ public class FlinkCdcMultiTableSink implements Serializable {
 
     public FlinkCdcMultiTableSink(
             CatalogLoader catalogLoader,
+            double writeCpuCores,
+            @Nullable MemorySize writeHeapMemory,
             double commitCpuCores,
             @Nullable MemorySize commitHeapMemory,
             String commitUser,
             boolean eagerInit,
             TableFilter tableFilter) {
         this.catalogLoader = catalogLoader;
+        this.writeCpuCores = writeCpuCores;
+        this.writeHeapMemory = writeHeapMemory;
         this.commitCpuCores = commitCpuCores;
         this.commitHeapMemory = commitHeapMemory;
         this.commitUser = commitUser;
@@ -120,6 +126,7 @@ public class FlinkCdcMultiTableSink implements Serializable {
                 input.transform(
                         WRITER_NAME, typeInfo, createWriteOperator(sinkProvider, commitUser));
         forwardParallelism(written, input);
+        configureSlotSharingGroup(written, writeCpuCores, writeHeapMemory);
 
         // shuffle committables by table
         DataStream<MultiTableCommittable> partitioned =
@@ -139,7 +146,7 @@ public class FlinkCdcMultiTableSink implements Serializable {
                                 createCommitterFactory(tableFilter),
                                 createCommittableStateManager()));
         forwardParallelism(committed, input);
-        configureGlobalCommitter(committed, commitCpuCores, commitHeapMemory);
+        configureSlotSharingGroup(committed, commitCpuCores, commitHeapMemory);
         return committed.sinkTo(new DiscardingSink<>()).name("end").setParallelism(1);
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
@@ -67,6 +67,8 @@ public class FlinkCdcSyncDatabaseSinkBuilder<T> {
     private List<FileStoreTable> tables = new ArrayList<>();
 
     @Nullable private Integer parallelism;
+    private double writerCpu;
+    @Nullable private MemorySize writerMemory;
     private double committerCpu;
     @Nullable private MemorySize committerMemory;
 
@@ -107,6 +109,8 @@ public class FlinkCdcSyncDatabaseSinkBuilder<T> {
 
     public FlinkCdcSyncDatabaseSinkBuilder<T> withTableOptions(Options options) {
         this.parallelism = options.get(FlinkConnectorOptions.SINK_PARALLELISM);
+        this.writerCpu = options.get(FlinkConnectorOptions.SINK_WRITER_CPU);
+        this.writerMemory = options.get(FlinkConnectorOptions.SINK_WRITER_MEMORY);
         this.committerCpu = options.get(FlinkConnectorOptions.SINK_COMMITTER_CPU);
         this.committerMemory = options.get(FlinkConnectorOptions.SINK_COMMITTER_MEMORY);
         this.commitUser = createCommitUser(options);
@@ -190,6 +194,8 @@ public class FlinkCdcSyncDatabaseSinkBuilder<T> {
         FlinkCdcMultiTableSink sink =
                 new FlinkCdcMultiTableSink(
                         catalogLoader,
+                        writerCpu,
+                        writerMemory,
                         committerCpu,
                         committerMemory,
                         commitUser,

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSinkTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSinkTest.java
@@ -50,6 +50,8 @@ public class FlinkCdcMultiTableSinkTest {
         FlinkCdcMultiTableSink sink =
                 new FlinkCdcMultiTableSink(
                         () -> FlinkCatalogFactory.createPaimonCatalog(new Options()),
+                        FlinkConnectorOptions.SINK_WRITER_CPU.defaultValue(),
+                        null,
                         FlinkConnectorOptions.SINK_COMMITTER_CPU.defaultValue(),
                         null,
                         UUID.randomUUID().toString(),

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -342,6 +342,18 @@ public class FlinkConnectorOptions {
                     .withDescription(
                             "If true, a tag will be automatically created for the snapshot created by flink savepoint.");
 
+    public static final ConfigOption<Double> SINK_WRITER_CPU =
+            ConfigOptions.key("sink.writer-cpu")
+                    .doubleType()
+                    .defaultValue(1.0)
+                    .withDescription("Sink writer cpu to control cpu cores of writer.");
+
+    public static final ConfigOption<MemorySize> SINK_WRITER_MEMORY =
+            ConfigOptions.key("sink.writer-memory")
+                    .memoryType()
+                    .noDefaultValue()
+                    .withDescription("Sink writer memory to control heap memory of writer.");
+
     public static final ConfigOption<Double> SINK_COMMITTER_CPU =
             ConfigOptions.key("sink.committer-cpu")
                     .doubleType()


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This is a convenient way for users to set writer cpu and memory.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
