### PR TITLE
[core] Refactored schema ID retrieval to use latest schema

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
@@ -328,7 +328,7 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
 
         String manifestListFileName = manifestList.writeWithoutRolling(manifestFileMetas);
 
-        int schemaId = (int) table.schema().id();
+        int schemaId = (int) schemaCache.getLatestSchemaId();
         IcebergSchema icebergSchema = schemaCache.get(schemaId);
         List<IcebergPartitionField> partitionFields =
                 getPartitionFields(table.schema().partitionKeys(), icebergSchema);
@@ -559,7 +559,7 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
 
         // add new schema if needed
         SchemaCache schemaCache = new SchemaCache();
-        int schemaId = (int) table.schema().id();
+        int schemaId = (int) schemaCache.getLatestSchemaId();
         IcebergSchema icebergSchema = schemaCache.get(schemaId);
         List<IcebergSchema> schemas = baseMetadata.schemas();
         if (baseMetadata.currentSchemaId() != schemaId) {
@@ -1188,6 +1188,10 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
         private IcebergSchema get(long schemaId) {
             return schemas.computeIfAbsent(
                     schemaId, id -> IcebergSchema.create(schemaManager.schema(id)));
+        }
+
+        private long getLatestSchemaId() {
+            return schemaManager.latest().get().id();
         }
     }
 }


### PR DESCRIPTION
### Purpose

Linked issue: close https://github.com/apache/paimon/issues/5700

It seems there was a regression in how CDC ingestion syncs Paimon and Iceberg metadata in `IcebergCommitCallback`. The `FileStoreTable` object passed to the committer may not be refreshed.

This PR resolves the problem discussed in the attached issue.

```
cat ~/.paimon-data/warehouse/default.db/test_table/metadata/v2.metadata.json | jq '.schemas[]'
{
  "type": "struct",
  "schema-id": 0,
  "fields": [
    {
      "id": 0,
      "name": "field1",
      "required": false,
      "type": "int",
      "doc": null
    },
    {
      "id": 1,
      "name": "field2",
      "required": false,
      "type": "float",
      "doc": null
    }
  ]
}
{
  "type": "struct",
  "schema-id": 1,
  "fields": [
    {
      "id": 0,
      "name": "field1",
      "required": false,
      "type": "int",
      "doc": null
    },
    {
      "id": 1,
      "name": "field2",
      "required": false,
      "type": "float",
      "doc": null
    },
    {
      "id": 2,
      "name": "field3",
      "required": false,
      "type": "float",
      "doc": null
    }
  ]
}
```