### PR TITLE
[core] fix: add function name validate

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/function/FunctionNameValidator.java
+++ b/paimon-api/src/main/java/org/apache/paimon/function/FunctionNameValidator.java
@@ -25,13 +25,13 @@ public class FunctionNameValidator {
     private static final Pattern FUNCTION_NAME_PATTERN =
             Pattern.compile("^(?=.*[A-Za-z])[A-Za-z0-9._-]+$");
 
-    public static boolean validate(String name) {
+    public static boolean isValidName(String name) {
         return org.apache.paimon.utils.StringUtils.isNotEmpty(name)
                 && FUNCTION_NAME_PATTERN.matcher(name).matches();
     }
 
-    public static void checkValidName(String name) {
-        boolean isValid = validate(name);
+    public static void check(String name) {
+        boolean isValid = isValidName(name);
         if (!isValid) {
             throw new IllegalArgumentException("Invalid function name: " + name);
         }

--- a/paimon-api/src/main/java/org/apache/paimon/function/FunctionNameValidator.java
+++ b/paimon-api/src/main/java/org/apache/paimon/function/FunctionNameValidator.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.function;
+
+import java.util.regex.Pattern;
+
+/** Validator for function name. */
+public class FunctionNameValidator {
+    private static final Pattern FUNCTION_NAME_PATTERN =
+            Pattern.compile("^(?=.*[A-Za-z])[A-Za-z0-9._-]+$");
+
+    public static boolean validate(String name) {
+        return org.apache.paimon.utils.StringUtils.isNotEmpty(name)
+                && FUNCTION_NAME_PATTERN.matcher(name).matches();
+    }
+
+    public static void checkValidName(String name) {
+        boolean isValid = validate(name);
+        if (!isValid) {
+            throw new IllegalArgumentException("Invalid function name: " + name);
+        }
+    }
+}

--- a/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
@@ -24,6 +24,7 @@ import org.apache.paimon.annotation.Public;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.function.FunctionChange;
+import org.apache.paimon.function.FunctionNameValidator;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.partition.PartitionStatistics;
@@ -851,6 +852,7 @@ public class RESTApi {
      * @throws ForbiddenException if the user lacks permission to access the function
      */
     public GetFunctionResponse getFunction(Identifier identifier) {
+        FunctionNameValidator.checkValidName(identifier.getObjectName());
         return client.get(
                 resourcePaths.function(identifier.getDatabaseName(), identifier.getObjectName()),
                 GetFunctionResponse.class,
@@ -868,6 +870,7 @@ public class RESTApi {
      */
     public void createFunction(
             Identifier identifier, org.apache.paimon.function.Function function) {
+        FunctionNameValidator.checkValidName(identifier.getObjectName());
         client.post(
                 resourcePaths.functions(identifier.getDatabaseName()),
                 new CreateFunctionRequest(function),
@@ -883,6 +886,7 @@ public class RESTApi {
      *     this function
      */
     public void dropFunction(Identifier identifier) {
+        FunctionNameValidator.checkValidName(identifier.getObjectName());
         client.delete(
                 resourcePaths.function(identifier.getDatabaseName(), identifier.getObjectName()),
                 restAuthFunction);
@@ -897,6 +901,7 @@ public class RESTApi {
      * @throws ForbiddenException if the user lacks permission to modify the function
      */
     public void alterFunction(Identifier identifier, List<FunctionChange> changes) {
+        FunctionNameValidator.checkValidName(identifier.getObjectName());
         client.post(
                 resourcePaths.function(identifier.getDatabaseName(), identifier.getObjectName()),
                 new AlterFunctionRequest(changes),

--- a/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
@@ -852,7 +852,7 @@ public class RESTApi {
      * @throws ForbiddenException if the user lacks permission to access the function
      */
     public GetFunctionResponse getFunction(Identifier identifier) {
-        FunctionNameValidator.checkValidName(identifier.getObjectName());
+        FunctionNameValidator.check(identifier.getObjectName());
         return client.get(
                 resourcePaths.function(identifier.getDatabaseName(), identifier.getObjectName()),
                 GetFunctionResponse.class,
@@ -870,7 +870,7 @@ public class RESTApi {
      */
     public void createFunction(
             Identifier identifier, org.apache.paimon.function.Function function) {
-        FunctionNameValidator.checkValidName(identifier.getObjectName());
+        FunctionNameValidator.check(identifier.getObjectName());
         client.post(
                 resourcePaths.functions(identifier.getDatabaseName()),
                 new CreateFunctionRequest(function),
@@ -886,7 +886,7 @@ public class RESTApi {
      *     this function
      */
     public void dropFunction(Identifier identifier) {
-        FunctionNameValidator.checkValidName(identifier.getObjectName());
+        FunctionNameValidator.check(identifier.getObjectName());
         client.delete(
                 resourcePaths.function(identifier.getDatabaseName(), identifier.getObjectName()),
                 restAuthFunction);
@@ -901,7 +901,7 @@ public class RESTApi {
      * @throws ForbiddenException if the user lacks permission to modify the function
      */
     public void alterFunction(Identifier identifier, List<FunctionChange> changes) {
-        FunctionNameValidator.checkValidName(identifier.getObjectName());
+        FunctionNameValidator.check(identifier.getObjectName());
         client.post(
                 resourcePaths.function(identifier.getDatabaseName(), identifier.getObjectName()),
                 new AlterFunctionRequest(changes),

--- a/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
@@ -52,6 +52,7 @@ import org.apache.paimon.rest.responses.AlterDatabaseResponse;
 import org.apache.paimon.rest.responses.AuthTableQueryResponse;
 import org.apache.paimon.rest.responses.CommitTableResponse;
 import org.apache.paimon.rest.responses.ConfigResponse;
+import org.apache.paimon.rest.responses.ErrorResponse;
 import org.apache.paimon.rest.responses.GetDatabaseResponse;
 import org.apache.paimon.rest.responses.GetFunctionResponse;
 import org.apache.paimon.rest.responses.GetTableResponse;
@@ -852,11 +853,17 @@ public class RESTApi {
      * @throws ForbiddenException if the user lacks permission to access the function
      */
     public GetFunctionResponse getFunction(Identifier identifier) {
-        FunctionNameValidator.check(identifier.getObjectName());
-        return client.get(
-                resourcePaths.function(identifier.getDatabaseName(), identifier.getObjectName()),
-                GetFunctionResponse.class,
-                restAuthFunction);
+        if (FunctionNameValidator.isValidName(identifier.getObjectName())) {
+            return client.get(
+                    resourcePaths.function(
+                            identifier.getDatabaseName(), identifier.getObjectName()),
+                    GetFunctionResponse.class,
+                    restAuthFunction);
+        }
+        throw new NoSuchResourceException(
+                ErrorResponse.RESOURCE_TYPE_FUNCTION,
+                identifier.getObjectName(),
+                "Invalid function name: " + identifier.getObjectName());
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -71,6 +71,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.CoreOptions.BRANCH;
@@ -89,6 +90,9 @@ public class RESTCatalog implements Catalog {
     private final RESTApi api;
     private final CatalogContext context;
     private final boolean dataTokenEnabled;
+
+    private static final Pattern FUNCTION_NAME_PATTERN =
+            Pattern.compile("^(?=.*[A-Za-z])[A-Za-z0-9._-]+$");
 
     public RESTCatalog(CatalogContext context) {
         this(context, true);
@@ -667,9 +671,10 @@ public class RESTCatalog implements Catalog {
     public org.apache.paimon.function.Function getFunction(Identifier identifier)
             throws FunctionNotExistException {
         try {
+            checkFunctionName(identifier.getObjectName());
             GetFunctionResponse response = api.getFunction(identifier);
             return response.toFunction(identifier);
-        } catch (NoSuchResourceException e) {
+        } catch (NoSuchResourceException | IllegalArgumentException e) {
             throw new FunctionNotExistException(identifier, e);
         }
     }
@@ -681,6 +686,7 @@ public class RESTCatalog implements Catalog {
             boolean ignoreIfExists)
             throws FunctionAlreadyExistException, DatabaseNotExistException {
         try {
+            checkFunctionName(identifier.getObjectName());
             api.createFunction(identifier, function);
         } catch (NoSuchResourceException e) {
             throw new DatabaseNotExistException(identifier.getDatabaseName(), e);
@@ -696,6 +702,7 @@ public class RESTCatalog implements Catalog {
     public void dropFunction(Identifier identifier, boolean ignoreIfNotExists)
             throws FunctionNotExistException {
         try {
+            checkFunctionName(identifier.getObjectName());
             api.dropFunction(identifier);
         } catch (NoSuchResourceException e) {
             if (ignoreIfNotExists) {
@@ -711,6 +718,7 @@ public class RESTCatalog implements Catalog {
             throws FunctionNotExistException, DefinitionAlreadyExistException,
                     DefinitionNotExistException {
         try {
+            checkFunctionName(identifier.getObjectName());
             api.alterFunction(identifier, changes);
         } catch (AlreadyExistsException e) {
             throw new DefinitionAlreadyExistException(identifier, e.resourceName());
@@ -886,6 +894,15 @@ public class RESTCatalog implements Catalog {
     @VisibleForTesting
     RESTApi api() {
         return api;
+    }
+
+    protected static void checkFunctionName(String name) throws IllegalArgumentException {
+        boolean isValid =
+                org.apache.paimon.utils.StringUtils.isNotEmpty(name)
+                        && FUNCTION_NAME_PATTERN.matcher(name).matches();
+        if (!isValid) {
+            throw new IllegalArgumentException("Invalid function name: " + name);
+        }
     }
 
     protected GetTableTokenResponse loadTableToken(Identifier identifier)

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -669,7 +669,7 @@ public class RESTCatalog implements Catalog {
         try {
             GetFunctionResponse response = api.getFunction(identifier);
             return response.toFunction(identifier);
-        } catch (NoSuchResourceException | IllegalArgumentException e) {
+        } catch (NoSuchResourceException e) {
             throw new FunctionNotExistException(identifier, e);
         }
     }

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -1707,28 +1707,19 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
 
     @Test
     public void testValidateFunctionName() throws Exception {
-        assertDoesNotThrow(() -> FunctionNameValidator.checkValidName("a"));
-        assertDoesNotThrow(() -> FunctionNameValidator.checkValidName("a1_"));
-        assertDoesNotThrow(() -> FunctionNameValidator.checkValidName("a-b_c"));
-        assertDoesNotThrow(() -> FunctionNameValidator.checkValidName("a-b_c.1"));
+        assertDoesNotThrow(() -> FunctionNameValidator.check("a"));
+        assertDoesNotThrow(() -> FunctionNameValidator.check("a1_"));
+        assertDoesNotThrow(() -> FunctionNameValidator.check("a-b_c"));
+        assertDoesNotThrow(() -> FunctionNameValidator.check("a-b_c.1"));
 
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> FunctionNameValidator.checkValidName("a\\/b"));
-        assertThrows(
-                IllegalArgumentException.class, () -> FunctionNameValidator.checkValidName("a$?b"));
-        assertThrows(
-                IllegalArgumentException.class, () -> FunctionNameValidator.checkValidName("a@b"));
-        assertThrows(
-                IllegalArgumentException.class, () -> FunctionNameValidator.checkValidName("a*b"));
-        assertThrows(
-                IllegalArgumentException.class, () -> FunctionNameValidator.checkValidName("123"));
-        assertThrows(
-                IllegalArgumentException.class, () -> FunctionNameValidator.checkValidName("_-"));
-        assertThrows(
-                IllegalArgumentException.class, () -> FunctionNameValidator.checkValidName(""));
-        assertThrows(
-                IllegalArgumentException.class, () -> FunctionNameValidator.checkValidName(null));
+        assertThrows(IllegalArgumentException.class, () -> FunctionNameValidator.check("a\\/b"));
+        assertThrows(IllegalArgumentException.class, () -> FunctionNameValidator.check("a$?b"));
+        assertThrows(IllegalArgumentException.class, () -> FunctionNameValidator.check("a@b"));
+        assertThrows(IllegalArgumentException.class, () -> FunctionNameValidator.check("a*b"));
+        assertThrows(IllegalArgumentException.class, () -> FunctionNameValidator.check("123"));
+        assertThrows(IllegalArgumentException.class, () -> FunctionNameValidator.check("_-"));
+        assertThrows(IllegalArgumentException.class, () -> FunctionNameValidator.check(""));
+        assertThrows(IllegalArgumentException.class, () -> FunctionNameValidator.check(null));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->
Function name is allowed to contain characters such as letters (a-zA-Z), numbers (0-9), dots (.), hyphens (-), underscores (_), and must contain letters.
### Tests
- RESTCatalogTest.testValidateFunctionName
- RESTCatalogTest.testFunction
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
