### PR TITLE
[core] Don't use snapshotManager.latestSnapshotOfUser in writers to prevent flooding catalog

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/index/HashBucketAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/HashBucketAssigner.java
@@ -118,7 +118,7 @@ public class HashBucketAssigner implements BucketAssigner {
         } else {
             latestCommittedIdentifier =
                     snapshotManager
-                            .latestSnapshotOfUser(commitUser)
+                            .latestSnapshotOfUserFromFilesystem(commitUser)
                             .map(Snapshot::commitIdentifier)
                             .orElse(Long.MIN_VALUE);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -280,7 +280,7 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
                     String commitUser, SnapshotManager snapshotManager) {
         long latestCommittedIdentifier =
                 snapshotManager
-                        .latestSnapshotOfUser(commitUser)
+                        .latestSnapshotOfUserFromFilesystem(commitUser)
                         .map(Snapshot::commitIdentifier)
                         .orElse(Long.MIN_VALUE);
         if (LOG.isDebugEnabled()) {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -578,7 +578,14 @@ public class SnapshotManager implements Serializable {
     }
 
     public Optional<Snapshot> latestSnapshotOfUser(String user) {
-        Long latestId = latestSnapshotId();
+        return latestSnapshotOfUser(user, latestSnapshotId());
+    }
+
+    public Optional<Snapshot> latestSnapshotOfUserFromFilesystem(String user) {
+        return latestSnapshotOfUser(user, latestSnapshotIdFromFileSystem());
+    }
+
+    private Optional<Snapshot> latestSnapshotOfUser(String user, Long latestId) {
         if (latestId == null) {
             return Optional.empty();
         }


### PR DESCRIPTION
### Purpose

Just like #5680, this PR creates a `latestSnapshotOfUserFromFileSystem` method in `SnapshotManager` and use it in writers Because `latestSnapshotOfUser` will query from REST catalog (if the table is created from REST catalog) and we don't want to flood the catalog with high concurrency.

### Tests

Existing tests should cover this change.

### API and Format

No format changes.

### Documentation

No new feature.
