### PR TITLE
[core] Simplify rollback to only clean snapshots

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/ChangelogDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ChangelogDeletion.java
@@ -87,6 +87,7 @@ public class ChangelogDeletion extends FileDeletionBase<Changelog> {
         // the index and statics manifest list should handle by snapshot deletion.
     }
 
+    @Override
     public Set<String> manifestSkippingSet(List<Snapshot> skippingSnapshots) {
         Set<String> skippingSet = new HashSet<>();
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/TagDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/TagDeletion.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -104,10 +103,6 @@ public class TagDeletion extends FileDeletionBase<Snapshot> {
     public void cleanUnusedManifests(Snapshot taggedSnapshot, Set<String> skippingSet) {
         // doesn't clean changelog files because they are handled by SnapshotDeletion
         cleanUnusedManifests(taggedSnapshot, skippingSet, true, false);
-    }
-
-    public Predicate<ExpireFileEntry> dataFileSkipper(Snapshot fromSnapshot) throws Exception {
-        return dataFileSkipper(Collections.singletonList(fromSnapshot));
     }
 
     public Predicate<ExpireFileEntry> dataFileSkipper(List<Snapshot> fromSnapshots)

--- a/paimon-core/src/test/java/org/apache/paimon/table/IndexFileExpireTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/IndexFileExpireTableTest.java
@@ -149,23 +149,15 @@ public class IndexFileExpireTableTest extends PrimaryKeyTableTestBase {
 
         table.rollbackTo(5);
         checkIndexFiles(5);
-        assertThat(indexFileSize()).isEqualTo(indexFileSize - 2);
-        assertThat(indexManifestSize()).isEqualTo(indexManifestSize - 2);
 
         table.rollbackTo(3);
         checkIndexFiles(3);
-        assertThat(indexFileSize()).isEqualTo(indexFileSize - 3);
-        assertThat(indexManifestSize()).isEqualTo(indexManifestSize - 3);
 
         table.rollbackTo(2);
         checkIndexFiles(2);
-        assertThat(indexFileSize()).isEqualTo(indexFileSize - 3);
-        assertThat(indexManifestSize()).isEqualTo(indexManifestSize - 3);
 
         table.rollbackTo(1);
         checkIndexFiles(1);
-        assertThat(indexFileSize()).isEqualTo(3);
-        assertThat(indexManifestSize()).isEqualTo(1);
     }
 
     @Test
@@ -181,13 +173,9 @@ public class IndexFileExpireTableTest extends PrimaryKeyTableTestBase {
 
         table.rollbackTo(5);
         checkIndexFiles(5);
-        assertThat(indexFileSize()).isEqualTo(indexFileSize - 2);
-        assertThat(indexManifestSize()).isEqualTo(indexManifestSize - 2);
 
         table.rollbackTo("tag1");
         checkIndexFiles(1);
-        assertThat(indexFileSize()).isEqualTo(3);
-        assertThat(indexManifestSize()).isEqualTo(1);
     }
 
     protected void prepareExpireTable() throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeySimpleTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeySimpleTableTest.java
@@ -71,6 +71,7 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.ChangelogManager;
 import org.apache.paimon.utils.Pair;
 
 import org.apache.parquet.hadoop.ParquetOutputFormat;
@@ -99,6 +100,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.apache.paimon.CoreOptions.BUCKET;
 import static org.apache.paimon.CoreOptions.CHANGELOG_FILE_FORMAT;
@@ -2245,15 +2247,10 @@ public class PrimaryKeySimpleTableTest extends SimpleTableTestBase {
 
         table.rollbackTo("test1");
 
-        List<java.nio.file.Path> files =
-                Files.walk(new File(tablePath.toUri().getPath()).toPath())
-                        .collect(Collectors.toList());
-        assertThat(files.size()).isEqualTo(19);
-        // rollback snapshot case testRollbackToSnapshotCase0 plus 4:
-        // table-path/tag/tag-test1
-        // table-path/changelog
-        // table-path/changelog/LATEST
-        // table-path/changelog/EARLIEST
+        assertRollbackTo(table, singletonList(1L), 1, 1, singletonList("test1"));
+        ChangelogManager changelogManager = table.changelogManager();
+        assertThat(changelogManager.earliestLongLivedChangelogId()).isNull();
+        assertThat(changelogManager.latestLongLivedChangelogId()).isNull();
     }
 
     @ParameterizedTest

--- a/paimon-core/src/test/java/org/apache/paimon/table/SimpleTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SimpleTableTestBase.java
@@ -1740,7 +1740,7 @@ public abstract class SimpleTableTestBase {
                 .containsExactlyInAnyOrder("0|0|0|binary|varbinary|mapKey:mapVal|multiset");
     }
 
-    private void assertRollbackTo(
+    protected void assertRollbackTo(
             FileStoreTable table,
             List<Long> expectedSnapshots,
             long expectedEarliest,

--- a/paimon-core/src/test/java/org/apache/paimon/table/SimpleTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SimpleTableTestBase.java
@@ -79,6 +79,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -95,6 +96,8 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.apache.paimon.CoreOptions.BUCKET;
 import static org.apache.paimon.CoreOptions.BUCKET_KEY;
 import static org.apache.paimon.CoreOptions.CHANGELOG_NUM_RETAINED_MAX;
@@ -291,12 +294,10 @@ public abstract class SimpleTableTestBase {
         TableRead read = table.newRead();
         assertThat(getResult(read, splits, binaryRow(1), 0, BATCH_ROW_TO_STRING))
                 .hasSameElementsAs(
-                        Collections.singletonList(
-                                "1|10|100|binary|varbinary|mapKey:mapVal|multiset"));
+                        singletonList("1|10|100|binary|varbinary|mapKey:mapVal|multiset"));
         assertThat(getResult(read, splits, binaryRow(2), 0, BATCH_ROW_TO_STRING))
                 .hasSameElementsAs(
-                        Collections.singletonList(
-                                "2|21|201|binary|varbinary|mapKey:mapVal|multiset"));
+                        singletonList("2|21|201|binary|varbinary|mapKey:mapVal|multiset"));
     }
 
     @Test
@@ -789,8 +790,7 @@ public abstract class SimpleTableTestBase {
         assertThat(result)
                 .containsExactlyInAnyOrder("0|0|0|binary|varbinary|mapKey:mapVal|multiset");
 
-        FileStatus[] files = table.fileIO().listFiles(table.location(), true);
-        assertThat(files).hasSize(8);
+        assertRollbackTo(table, singletonList(1L), 1, 1, emptyList());
     }
 
     // All tags are after the rollback snapshot
@@ -813,16 +813,7 @@ public abstract class SimpleTableTestBase {
         assertThat(result)
                 .containsExactlyInAnyOrder("0|0|0|binary|varbinary|mapKey:mapVal|multiset");
 
-        FileStatus[] files = table.fileIO().listFiles(table.location(), true);
-        assertThat(files).hasSize(8);
-        // table-path/snapshot/LATEST
-        // table-path/snapshot/EARLIEST
-        // table-path/snapshot/snapshot-1
-        // table-path/pt=0/bucket-0/data-0.orc
-        // table-path/manifest/manifest-list-1
-        // table-path/manifest/manifest-0
-        // table-path/manifest/manifest-list-0
-        // table-path/schema/schema-0
+        assertRollbackTo(table, singletonList(1L), 1, 1, emptyList());
     }
 
     // One tag is at the rollback snapshot and others are after it
@@ -856,10 +847,7 @@ public abstract class SimpleTableTestBase {
         assertThat(result)
                 .containsExactlyInAnyOrder("0|0|0|binary|varbinary|mapKey:mapVal|multiset");
 
-        FileStatus[] files = table.fileIO().listFiles(table.location(), true);
-        assertThat(files).hasSize(9);
-        // case 0 plus 1:
-        // table-path/tag/tag-test3
+        assertRollbackTo(table, singletonList(1L), 1, 1, singletonList("test3"));
     }
 
     // One tag is before the rollback snapshot and others are after it
@@ -895,15 +883,7 @@ public abstract class SimpleTableTestBase {
         assertThat(result)
                 .containsExactlyInAnyOrder("0|0|0|binary|varbinary|mapKey:mapVal|multiset");
 
-        FileStatus[] files = table.fileIO().listFiles(table.location(), true);
-        assertThat(files).hasSize(14);
-        // case 0 plus 6:
-        // table-path/manifest/manifest-list-2
-        // table-path/manifest/manifest-list-3
-        // table-path/manifest/manifest-1
-        // table-path/snapshot/snapshot-2
-        // table-path/tag/tag-test3
-        // table-path/pt=1/bucket-0/data-0.orc
+        assertRollbackTo(table, Arrays.asList(1L, 2L), 1, 2, singletonList("test3"));
     }
 
     @ParameterizedTest(name = "expire snapshots = {0}")
@@ -948,10 +928,7 @@ public abstract class SimpleTableTestBase {
         assertThat(result)
                 .containsExactlyInAnyOrder("0|0|0|binary|varbinary|mapKey:mapVal|multiset");
 
-        FileStatus[] files = table.fileIO().listFiles(table.location(), true);
-        assertThat(files).hasSize(9);
-        // rollback snapshot case 0 plus 1:
-        // table-path/tag/tag-test1
+        assertRollbackTo(table, singletonList(1L), 1, 1, singletonList("test1"));
     }
 
     private FileStoreTable prepareRollbackTable(int commitTimes) throws Exception {
@@ -1761,5 +1738,21 @@ public abstract class SimpleTableTestBase {
                                 toSplits(tableBranch.newSnapshotReader().read().dataSplits()),
                                 BATCH_ROW_TO_STRING))
                 .containsExactlyInAnyOrder("0|0|0|binary|varbinary|mapKey:mapVal|multiset");
+    }
+
+    private void assertRollbackTo(
+            FileStoreTable table,
+            List<Long> expectedSnapshots,
+            long expectedEarliest,
+            long expectedLatest,
+            List<String> expectedTags)
+            throws IOException {
+        SnapshotManager snapshotManager = table.snapshotManager();
+        List<Long> snapshots = snapshotManager.snapshotIdStream().collect(Collectors.toList());
+        assertThat(snapshots).containsExactlyInAnyOrderElementsOf(expectedSnapshots);
+        assertThat(snapshotManager.earliestSnapshotId()).isEqualTo(expectedEarliest);
+        assertThat(snapshotManager.latestSnapshotId()).isEqualTo(expectedLatest);
+        assertThat(table.tagManager().allTagNames())
+                .containsExactlyInAnyOrderElementsOf(expectedTags);
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
At present, rollback is a relatively dangerous operation. It not only deletes unnecessary snapshots, but also cleans up all unnecessary data files, which makes it very prone to problems. Once there is a bug, it will cause the table to malfunction.

Actually, rollback is a very low-frequency operation, and we don't need to clean up all the unnecessary data files. Just leave it to orphan file clean.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
