### PR TITLE
fix: The increment query result is not in the correct order

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/IncrementalDeltaStartingScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/IncrementalDeltaStartingScanner.java
@@ -129,6 +129,10 @@ public class IncrementalDeltaStartingScanner extends AbstractStartingScanner {
                                     entry.getValue().stream()
                                             .map(ManifestEntry::file)
                                             .collect(Collectors.toList()))) {
+                 List<DataFileMeta> files = splitGroup.files;
+                //  Sort the files by creation time from smallest to largest.
+                files= files.stream().sorted(Comparator.comparingLong(DataFileMeta::creationTimeEpochMillis))
+                        .collect(Collectors.toList());
                 DataSplit.Builder dataSplitBuilder =
                         DataSplit.builder()
                                 .isStreaming(true)
@@ -136,7 +140,7 @@ public class IncrementalDeltaStartingScanner extends AbstractStartingScanner {
                                 .withPartition(partition)
                                 .withBucket(bucket)
                                 .withTotalBuckets(entry.getValue().get(0).totalBuckets())
-                                .withDataFiles(splitGroup.files)
+                                .withDataFiles(files)
                                 .rawConvertible(splitGroup.rawConvertible)
                                 .withBucketPath(bucketPath);
                 result.add(dataSplitBuilder.build());


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5709 

fix branch : paimon-1.2-snapshot
<!-- What is the purpose of the change -->

### Tests
```
  spark.sql(
      """
        |create table my_table (
        |    k int,
        |    v string
        |) tblproperties (
        |    'primary-key' = 'k','changelog-producer' = 'lookup','bucket'='4'
        |);
        |""".stripMargin)
 
    spark.sql(" insert into my_table values (1, 'a'), (2, 'b')")
 
    spark.sql("delete from my_table where k = 1")
 
    spark.sql("insert into my_table values (11, 'a'), (2, 'bb')")

    spark.sql(
      """
        |SELECT * FROM paimon_incremental_query('`my_table$audit_log`', '0', '6')
        |""".stripMargin).show()

```

Before Fix , the result is not in correct order.

```
+-------+---+---+
|rowkind|  k|  v|
+-------+---+---+
|     -D|  1|  a|
|     +I|  1|  a|
|     -U|  2|  b|
|     +U|  2| bb|
|     +I|  2|  b|
|     +I| 11|  a|
+-------+---+---+

```

<!-- List UT and IT cases to verify this change -->
After the modification, the order of the  #5709  results is correct now.



```
+-------+---+---+
|rowkind|  k|  v|
+-------+---+---+
|     +I|  1|  a|
|     -D|  1|  a|
|     +I|  2|  b|
|     -U|  2|  b|
|     +U|  2| bb|
|     +I| 11|  a|
+-------+---+---+
```

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
