### PR TITLE
[core] Add truncate bucket strategy

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -60,7 +60,13 @@ under the License.
             <td><h5>bucket-key</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Specify the paimon distribution policy. Data is assigned to each bucket according to the hash value of bucket-key.<br />If you specify multiple fields, delimiter is ','.<br />If not specified, the primary key will be used; if there is no primary key, the full row will be used.</td>
+            <td>Specify the paimon distribution policy. Data is assigned to each bucket according to the hash value of bucket-key by default.<br />If you specify multiple fields, delimiter is ','.<br />If not specified, the primary key will be used; if there is no primary key, the full row will be used.</td>
+        </tr>
+        <tr>
+            <td><h5>bucket-strategy</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Specify the strategy to assign data to each bucket.<br />Currently, only 'truncate[W]' is supported, where: <ul><li>'W' must be a positive integer (e.g., 'truncate[10]').</li><li>The bucket is calculated as: `bucket = (bucket_key_value - (bucket_key_value % W)) % total_buckets`.</li></ul>Note: This strategy requires 'bucket-key' to be a single INT column.</td>
         </tr>
         <tr>
             <td><h5>cache-page-size</h5></td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -116,13 +116,32 @@ public class CoreOptions implements Serializable {
                             Description.builder()
                                     .text(
                                             "Specify the paimon distribution policy. Data is assigned"
-                                                    + " to each bucket according to the hash value of bucket-key.")
+                                                    + " to each bucket according to the hash value of bucket-key by default.")
                                     .linebreak()
                                     .text("If you specify multiple fields, delimiter is ','.")
                                     .linebreak()
                                     .text(
                                             "If not specified, the primary key will be used; "
                                                     + "if there is no primary key, the full row will be used.")
+                                    .build());
+
+    @Immutable
+    public static final ConfigOption<String> BUCKET_STRATEGY =
+            key("bucket-strategy")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text("Specify the strategy to assign data to each bucket.")
+                                    .linebreak()
+                                    .text("Currently, only 'truncate[W]' is supported, where: ")
+                                    .list(
+                                            text(
+                                                    "'W' must be a positive integer (e.g., 'truncate[10]')."),
+                                            text(
+                                                    "The bucket is calculated as: `bucket = (bucket_key_value - (bucket_key_value % W)) % total_buckets`."))
+                                    .text(
+                                            "Note: This strategy requires 'bucket-key' to be a single INT column.")
                                     .build());
 
     public static final ConfigOption<String> DATA_FILE_EXTERNAL_PATHS =

--- a/paimon-api/src/main/java/org/apache/paimon/transform/BucketStrategy.java
+++ b/paimon-api/src/main/java/org/apache/paimon/transform/BucketStrategy.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.transform;
+
+import java.io.Serializable;
+
+/** A strategy used for bucketing . */
+public interface BucketStrategy<S> extends Serializable {
+
+    /**
+     * Transforms a value to its corresponding bucket value.
+     *
+     * @param value the source value
+     * @return a transformed bucket value
+     */
+    int apply(S value);
+}

--- a/paimon-api/src/main/java/org/apache/paimon/transform/Truncate.java
+++ b/paimon-api/src/main/java/org/apache/paimon/transform/Truncate.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.transform;
+
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeRoot;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.Preconditions.checkNotNull;
+
+/** Using truncate strategy to transform to bucket. */
+public abstract class Truncate<S> implements BucketStrategy<S> {
+
+    public static final Pattern TRUNCATE_PATTERN = Pattern.compile("truncate\\[(\\d+)]");
+
+    protected final int width;
+
+    public Truncate(int width) {
+        checkArgument(width > 0, "Invalid truncate width: %s (must be > 0)", width);
+        this.width = width;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    @Override
+    public String toString() {
+        return "truncate[width=" + width + "]";
+    }
+
+    @Nullable
+    @SuppressWarnings("unchecked")
+    public static <S> Truncate<S> fromString(
+            String bucketStrategy, List<DataField> bucketColumns, int numBuckets) {
+        checkArgument(numBuckets > 0, "numBuckets must be greater than 0");
+        Matcher widthMatcher = TRUNCATE_PATTERN.matcher(bucketStrategy);
+        if (widthMatcher.matches()) {
+            checkArgument(
+                    bucketColumns.size() == 1,
+                    "bucket key columns must contain exactly one column for truncate bucket strategy.");
+            int width = Integer.parseInt(widthMatcher.group(1));
+            DataType dataType = bucketColumns.get(0).type();
+            if (dataType.getTypeRoot() == DataTypeRoot.INTEGER) {
+                return (Truncate<S>) new TruncateInteger(width);
+            } else {
+                throw new IllegalArgumentException("Cannot truncate type: " + dataType);
+            }
+        }
+        return null;
+    }
+
+    private static class TruncateInteger extends Truncate<Integer> {
+        private static final long serialVersionUID = 1L;
+
+        private TruncateInteger(int width) {
+            super(width);
+        }
+
+        @Override
+        public int apply(Integer value) {
+            checkNotNull(value, "The source value to do bucket transform must not be null");
+
+            return value - (((value % width) + width) % width);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -57,6 +57,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.PartitionHandler;
 import org.apache.paimon.table.sink.CallbackUtils;
 import org.apache.paimon.table.sink.CommitCallback;
+import org.apache.paimon.table.sink.StrategyBasedBucketIdExtractor;
 import org.apache.paimon.table.sink.TagCallback;
 import org.apache.paimon.tag.SuccessFileTagCallback;
 import org.apache.paimon.tag.TagAutoManager;
@@ -96,6 +97,7 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
     protected final CoreOptions options;
     protected final RowType partitionType;
     protected final CatalogEnvironment catalogEnvironment;
+    @Nullable protected StrategyBasedBucketIdExtractor strategyBasedBucketIdExtractor;
 
     @Nullable private final SegmentsCache<Path> writeManifestCache;
     @Nullable private SegmentsCache<Path> readManifestCache;
@@ -119,6 +121,11 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
         this.writeManifestCache =
                 SegmentsCache.create(
                         options.pageSize(), options.writeManifestCache(), Long.MAX_VALUE);
+        this.strategyBasedBucketIdExtractor =
+                schema.bucketStrategy() == null
+                        ? null
+                        : new StrategyBasedBucketIdExtractor(
+                                schema.bucketStrategy(), schema.logicalBucketKeyType());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
@@ -151,7 +151,8 @@ public class AppendOnlyFileStore extends AbstractFileStore<InternalRow> {
                                     rowType.getFieldNames(),
                                     bucketKeyType.getFieldNames());
                     if (!bucketFilters.isEmpty()) {
-                        return BucketSelectConverter.create(and(bucketFilters), bucketKeyType);
+                        return BucketSelectConverter.create(
+                                and(bucketFilters), bucketKeyType, strategyBasedBucketIdExtractor);
                     }
                     return Optional.empty();
                 };

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -229,7 +229,8 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                                     keyType.getFieldNames(),
                                     bucketKeyType.getFieldNames());
                     if (!bucketFilters.isEmpty()) {
-                        return BucketSelectConverter.create(and(bucketFilters), bucketKeyType);
+                        return BucketSelectConverter.create(
+                                and(bucketFilters), bucketKeyType, strategyBasedBucketIdExtractor);
                     }
                     return Optional.empty();
                 };

--- a/paimon-core/src/main/java/org/apache/paimon/table/BucketSpec.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/BucketSpec.java
@@ -18,6 +18,10 @@
 
 package org.apache.paimon.table;
 
+import org.apache.paimon.transform.BucketStrategy;
+
+import javax.annotation.Nullable;
+
 import java.util.List;
 
 /**
@@ -32,11 +36,18 @@ public class BucketSpec {
     private final BucketMode bucketMode;
     private final List<String> bucketKeys;
     private final int numBuckets;
+    // null if bucket strategy is not defined
+    @Nullable private final BucketStrategy<?> bucketStrategy;
 
-    public BucketSpec(BucketMode bucketMode, List<String> bucketKeys, int numBuckets) {
+    public BucketSpec(
+            BucketMode bucketMode,
+            List<String> bucketKeys,
+            int numBuckets,
+            @Nullable BucketStrategy<?> bucketStrategy) {
         this.bucketMode = bucketMode;
         this.bucketKeys = bucketKeys;
         this.numBuckets = numBuckets;
+        this.bucketStrategy = bucketStrategy;
     }
 
     public BucketMode getBucketMode() {
@@ -60,6 +71,7 @@ public class BucketSpec {
                 + bucketKeys
                 + ", numBuckets="
                 + numBuckets
+                + (bucketStrategy == null ? "" : ", bucketStrategy=")
                 + '}';
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTable.java
@@ -76,7 +76,11 @@ public interface FileStoreTable extends DataTable {
     }
 
     default BucketSpec bucketSpec() {
-        return new BucketSpec(bucketMode(), schema().bucketKeys(), schema().numBuckets());
+        return new BucketSpec(
+                bucketMode(),
+                schema().bucketKeys(),
+                schema().numBuckets(),
+                schema().bucketStrategy());
     }
 
     default BucketMode bucketMode() {

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/StrategyBasedBucketIdExtractor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/StrategyBasedBucketIdExtractor.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.sink;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.transform.BucketStrategy;
+import org.apache.paimon.transform.Truncate;
+import org.apache.paimon.types.DataTypeRoot;
+import org.apache.paimon.types.RowType;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** A bucket id extractor to extract bucket id according to given {@link BucketStrategy}. */
+public class StrategyBasedBucketIdExtractor {
+    private final BucketStrategy<Integer> bucketStrategy;
+
+    public StrategyBasedBucketIdExtractor(BucketStrategy<?> bucketStrategy, RowType bucketKeyType) {
+        if (bucketStrategy instanceof Truncate) {
+            checkArgument(
+                    bucketKeyType.getFieldCount() == 1,
+                    "bucketKeys must contain exactly one key when use truncate strategy.");
+            checkArgument(
+                    bucketKeyType.getTypeAt(0).getTypeRoot() == DataTypeRoot.INTEGER,
+                    "when use truncate strategy, only integer bucket key type are supported currently. ");
+            // must be BucketStrategy<Integer>, cast directly
+            //noinspection unchecked
+            this.bucketStrategy = (BucketStrategy<Integer>) bucketStrategy;
+        } else {
+            throw new IllegalArgumentException("Unsupported bucket strategy: " + bucketStrategy);
+        }
+    }
+
+    public int extractBucket(InternalRow bucketRow) {
+        // must be truncate integer
+        return bucketStrategy.apply(bucketRow.getInt(0));
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -248,7 +248,11 @@ case class PaimonSparkWriter(table: FileStoreTable) {
         writeWithoutBucket(data)
 
       case HASH_FIXED =>
-        if (paimonExtensionEnabled && BucketFunction.supportsTable(table)) {
+        if (
+          paimonExtensionEnabled &&
+          // default bucket strategy can use Bucket
+          tableSchema.bucketStrategy() == null && BucketFunction.supportsTable(table)
+        ) {
           // Topology: input -> shuffle by partition & bucket
           val bucketNumber = coreOptions.bucket()
           val bucketKeyCol = tableSchema


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3538 

<!-- What is the purpose of the change -->
Introduce a [`truncate`](https://iceberg.apache.org/spec/#partition-transforms) strategy to distribute data into bucket instead of always using hash.

### Tests
Add the test in bucket releated code for `truncate` strategy to verify it works.

<!-- List UT and IT cases to verify this change -->


### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
