### PR TITLE
[fix] Update maven javadoc plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -971,7 +971,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.9.1</version><!--$NO-MVN-MAN-VER$-->
+                    <version>3.1.1</version><!--$NO-MVN-MAN-VER$-->
                     <configuration>
                         <quiet>true</quiet>
                         <detectOfflineLinks>false</detectOfflineLinks>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

When using Mac OS and JAVA_HOME is not set.
exec : mvn clean deploy -DskipTests -Drat.skip=true -Pdocs-and-source 
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.9.1:jar (attach-javadocs) on project paimon-api: MavenReportException: Error while creating archive: Unable to find javadoc command: The environment variable JAVA_HOME is not correctly set. 
```
This is `maven-javadoc-plugin:2.9.1` 's bug  and  I compared the versions of `maven-javadoc-plugin` of other open source components. At least 3.x or above. I think it's time to upgrade the plugin.

Relation issue : 
https://stackoverflow.com/questions/20313453/java-home-on-osx-with-eclipse-and-maven
https://github.com/apache/flink/pull/25265

### Purpose


<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
