### PR TITLE
[core] Introduce commit strict mode to avoid data loss in rescale job

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -159,16 +159,10 @@ under the License.
             <td>Maximum number of retries when commit failed.</td>
         </tr>
         <tr>
-            <td><h5>commit.strict-mode</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>If true, committer will check if there are other commit user's COMPACT / OVERWRITE snapshot between its last and current commit. If found, commit will be aborted.</td>
-        </tr>
-        <tr>
             <td><h5>commit.strict-mode.last-safe-snapshot</h5></td>
-            <td style="word-wrap: break-word;">-1</td>
-            <td>Integer</td>
-            <td>When commit.strict-mode is set to true, starting checking from the snapshot after this one. If the value of this option is -1, committer will not check for its first commit.</td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Long</td>
+            <td>If set, committer will check if there are other commit user's COMPACT / OVERWRITE snapshot, starting from the snapshot after this one. If found, commit will be aborted. If the value of this option is -1, committer will not check for its first commit.</td>
         </tr>
         <tr>
             <td><h5>commit.timeout</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -159,6 +159,18 @@ under the License.
             <td>Maximum number of retries when commit failed.</td>
         </tr>
         <tr>
+            <td><h5>commit.strict-mode</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>If true, committer will check if there are other commit user's COMPACT / OVERWRITE snapshot between its last and current commit. If found, commit will be aborted.</td>
+        </tr>
+        <tr>
+            <td><h5>commit.strict-mode.last-safe-snapshot</h5></td>
+            <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
+            <td>When commit.strict-mode is set to true, starting checking from the snapshot after this one. If the value of this option is -1, committer will not check for its first commit.</td>
+        </tr>
+        <tr>
             <td><h5>commit.timeout</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1744,6 +1744,24 @@ public class CoreOptions implements Serializable {
                             "If true, it disables explicit type casting. For ex: it disables converting LONG type to INT type. "
                                     + "Users can enable this option to disable explicit type casting");
 
+    public static final ConfigOption<Boolean> COMMIT_STRICT_MODE =
+            ConfigOptions.key("commit.strict-mode")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "If true, committer will check if there are other commit user's COMPACT / OVERWRITE snapshot "
+                                    + "between its last and current commit. If found, commit will be aborted.");
+
+    public static final ConfigOption<Integer> COMMIT_STRICT_MODE_LAST_SAFE_SNAPSHOT =
+            ConfigOptions.key("commit.strict-mode.last-safe-snapshot")
+                    .intType()
+                    .defaultValue(-1)
+                    .withDescription(
+                            "When "
+                                    + COMMIT_STRICT_MODE.key()
+                                    + " is set to true, starting checking from the snapshot after this one. "
+                                    + "If the value of this option is -1, committer will not check for its first commit.");
+
     private final Options options;
 
     public CoreOptions(Map<String, String> options) {
@@ -2715,6 +2733,14 @@ public class CoreOptions implements Serializable {
 
     public boolean aggregationRemoveRecordOnDelete() {
         return options.get(AGGREGATION_REMOVE_RECORD_ON_DELETE);
+    }
+
+    public boolean commitStrictMode() {
+        return options.get(COMMIT_STRICT_MODE);
+    }
+
+    public int commitStrictModeLastSafeSnapshot() {
+        return options.get(COMMIT_STRICT_MODE_LAST_SAFE_SNAPSHOT);
     }
 
     /** Specifies the merge engine for table with primary key. */

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1744,22 +1744,13 @@ public class CoreOptions implements Serializable {
                             "If true, it disables explicit type casting. For ex: it disables converting LONG type to INT type. "
                                     + "Users can enable this option to disable explicit type casting");
 
-    public static final ConfigOption<Boolean> COMMIT_STRICT_MODE =
-            ConfigOptions.key("commit.strict-mode")
-                    .booleanType()
-                    .defaultValue(false)
-                    .withDescription(
-                            "If true, committer will check if there are other commit user's COMPACT / OVERWRITE snapshot "
-                                    + "between its last and current commit. If found, commit will be aborted.");
-
-    public static final ConfigOption<Integer> COMMIT_STRICT_MODE_LAST_SAFE_SNAPSHOT =
+    public static final ConfigOption<Long> COMMIT_STRICT_MODE_LAST_SAFE_SNAPSHOT =
             ConfigOptions.key("commit.strict-mode.last-safe-snapshot")
-                    .intType()
-                    .defaultValue(-1)
+                    .longType()
+                    .noDefaultValue()
                     .withDescription(
-                            "When "
-                                    + COMMIT_STRICT_MODE.key()
-                                    + " is set to true, starting checking from the snapshot after this one. "
+                            "If set, committer will check if there are other commit user's COMPACT / OVERWRITE snapshot, "
+                                    + "starting from the snapshot after this one. If found, commit will be aborted. "
                                     + "If the value of this option is -1, committer will not check for its first commit.");
 
     private final Options options;
@@ -2735,12 +2726,8 @@ public class CoreOptions implements Serializable {
         return options.get(AGGREGATION_REMOVE_RECORD_ON_DELETE);
     }
 
-    public boolean commitStrictMode() {
-        return options.get(COMMIT_STRICT_MODE);
-    }
-
-    public int commitStrictModeLastSafeSnapshot() {
-        return options.get(COMMIT_STRICT_MODE_LAST_SAFE_SNAPSHOT);
+    public Optional<Long> commitStrictModeLastSafeSnapshot() {
+        return options.getOptional(COMMIT_STRICT_MODE_LAST_SAFE_SNAPSHOT);
     }
 
     /** Specifies the merge engine for table with primary key. */

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -321,7 +321,9 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 options.scanManifestParallelism(),
                 createCommitCallbacks(commitUser, table),
                 options.commitMaxRetries(),
-                options.commitTimeout());
+                options.commitTimeout(),
+                options.commitStrictMode(),
+                options.commitStrictModeLastSafeSnapshot());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -322,8 +322,7 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 createCommitCallbacks(commitUser, table),
                 options.commitMaxRetries(),
                 options.commitTimeout(),
-                options.commitStrictMode(),
-                options.commitStrictModeLastSafeSnapshot());
+                options.commitStrictModeLastSafeSnapshot().orElse(null));
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RescaleAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RescaleAction.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink.action;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.flink.sink.FlinkSinkBuilder;
 import org.apache.paimon.flink.source.FlinkSourceBuilder;
 import org.apache.paimon.manifest.ManifestEntry;
@@ -41,6 +42,7 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 
 /** Action to rescale one partition of a table. */
 public class RescaleAction extends TableActionBase {
@@ -81,6 +83,22 @@ public class RescaleAction extends TableActionBase {
         env.configure(flinkConf);
 
         FileStoreTable fileStoreTable = (FileStoreTable) table;
+        Optional<Snapshot> optionalSnapshot = fileStoreTable.latestSnapshot();
+        if (!optionalSnapshot.isPresent()) {
+            throw new IllegalArgumentException(
+                    "Table " + table.fullName() + " has no snapshot. No need to rescale.");
+        }
+        Snapshot snapshot = optionalSnapshot.get();
+
+        // If someone commits while the rescale job is running, this commit will be lost.
+        // So we use strict mode to make sure nothing is lost.
+        Map<String, String> dynamicOptions = new HashMap<>();
+        dynamicOptions.put(CoreOptions.COMMIT_STRICT_MODE.key(), "true");
+        dynamicOptions.put(
+                CoreOptions.COMMIT_STRICT_MODE_LAST_SAFE_SNAPSHOT.key(),
+                String.valueOf(snapshot.id()));
+        fileStoreTable = fileStoreTable.copy(dynamicOptions);
+
         RowType partitionType = fileStoreTable.schema().logicalPartitionType();
         Predicate partitionPredicate =
                 PartitionPredicate.createPartitionPredicate(
@@ -94,7 +112,9 @@ public class RescaleAction extends TableActionBase {
                         .env(env)
                         .sourceBounded(true)
                         .sourceParallelism(
-                                scanParallelism == null ? currentBucketNum() : scanParallelism)
+                                scanParallelism == null
+                                        ? currentBucketNum(snapshot)
+                                        : scanParallelism)
                         .predicate(partitionPredicate)
                         .build();
 
@@ -118,14 +138,15 @@ public class RescaleAction extends TableActionBase {
     @Override
     public void run() throws Exception {
         build();
-        env.execute("Rescale Postpone Bucket : " + table.fullName());
+        env.execute("Rescale : " + table.fullName());
     }
 
-    private int currentBucketNum() {
+    private int currentBucketNum(Snapshot snapshot) {
         FileStoreTable fileStoreTable = (FileStoreTable) table;
         Iterator<ManifestEntry> it =
                 fileStoreTable
                         .newSnapshotReader()
+                        .withSnapshot(snapshot)
                         .withPartitionFilter(partition)
                         .readFileIterator();
         Preconditions.checkArgument(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RescaleAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RescaleAction.java
@@ -93,7 +93,6 @@ public class RescaleAction extends TableActionBase {
         // If someone commits while the rescale job is running, this commit will be lost.
         // So we use strict mode to make sure nothing is lost.
         Map<String, String> dynamicOptions = new HashMap<>();
-        dynamicOptions.put(CoreOptions.COMMIT_STRICT_MODE.key(), "true");
         dynamicOptions.put(
                 CoreOptions.COMMIT_STRICT_MODE_LAST_SAFE_SNAPSHOT.key(),
                 String.valueOf(snapshot.id()));


### PR DESCRIPTION
### Purpose

Consider the following scenario: For a postpone bucket table, when a rescale job is running, another compact job commits. However, as the rescale job is started without knowing the COMMIT snapshot, the resulting snapshot will not include its changes and the data is lost.

This PR adds a "strict mode" for commit, where commit is aborted if committer found another user's COMPACT / OVERWRITE snapshot.

### Tests

* `TableCommitTest#testStrictMode`.

### API and Format

No format changes.

### Documentation

Document is updated.
