### PR TITLE
[hotfix] TagPreview utils support DataTable

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagPreview.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagPreview.java
@@ -20,7 +20,7 @@ package org.apache.paimon.tag;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.DataTable;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
@@ -67,7 +67,7 @@ public class TagPreview {
         return Optional.of(tag);
     }
 
-    public Map<String, String> timeTravel(FileStoreTable table, String tag) {
+    public Map<String, String> timeTravel(DataTable table, String tag) {
         TagManager tagManager = table.tagManager();
         if (tagManager.tagExists(tag)) {
             return singletonMap(SCAN_TAG_NAME.key(), tag);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
AuditLogTable (DataTable) also supports reading tags.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
