### PR TITLE
add a judgment of high level befor records on whether it has been deleted or not

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsMaintainer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsMaintainer.java
@@ -63,12 +63,14 @@ public class DeletionVectorsMaintainer {
      * @param fileName The name of the file where the deletion occurred.
      * @param position The row position within the file that has been deleted.
      */
-    public void notifyNewDeletion(String fileName, long position) {
+    public boolean notifyNewDeletion(String fileName, long position) {
         DeletionVector deletionVector =
                 deletionVectors.computeIfAbsent(fileName, k -> createNewDeletionVector());
-        if (deletionVector.checkedDelete(position)) {
-            modified = true;
+        boolean modified = deletionVector.checkedDelete(position);
+        if (modified) {
+            this.modified = true;
         }
+        return modified;
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapper.java
@@ -114,9 +114,10 @@ public class LookupChangelogMergeFunctionWrapper<T>
             if (lookupResult != null) {
                 if (lookupStrategy.deletionVector) {
                     PositionedKeyValue positionedKeyValue = (PositionedKeyValue) lookupResult;
-                    highLevel = positionedKeyValue.keyValue();
-                    deletionVectorsMaintainer.notifyNewDeletion(
-                            positionedKeyValue.fileName(), positionedKeyValue.rowPosition());
+                    if (deletionVectorsMaintainer.notifyNewDeletion(
+                            positionedKeyValue.fileName(), positionedKeyValue.rowPosition())) {
+                        highLevel = positionedKeyValue.keyValue();
+                    }
                 } else {
                     highLevel = (KeyValue) lookupResult;
                 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapper.java
@@ -114,6 +114,7 @@ public class LookupChangelogMergeFunctionWrapper<T>
             if (lookupResult != null) {
                 if (lookupStrategy.deletionVector) {
                     PositionedKeyValue positionedKeyValue = (PositionedKeyValue) lookupResult;
+                    // Notify and check whether the record has been deleted in the deletion vector
                     if (deletionVectorsMaintainer.notifyNewDeletion(
                             positionedKeyValue.fileName(), positionedKeyValue.rowPosition())) {
                         highLevel = positionedKeyValue.keyValue();

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
@@ -23,7 +23,9 @@ import org.apache.paimon.KeyValue;
 import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.InternalRow.FieldGetter;
+import org.apache.paimon.deletionvectors.DeletionVectorsMaintainer;
 import org.apache.paimon.lookup.LookupStrategy;
+import org.apache.paimon.mergetree.LookupLevels;
 import org.apache.paimon.mergetree.compact.aggregate.AggregateMergeFunction;
 import org.apache.paimon.mergetree.compact.aggregate.FieldAggregator;
 import org.apache.paimon.mergetree.compact.aggregate.factory.FieldLastValueAggFactory;
@@ -546,5 +548,67 @@ public class LookupChangelogMergeFunctionWrapperTest {
         assertThat(changelogs.get(1).value().getInt(0)).isEqualTo(3);
         kv = result.result();
         assertThat(kv.value().getInt(0)).isEqualTo(3);
+    }
+
+    @Test
+    public void testWithDeletionVectorsMaintainer() {
+        DeletionVectorsMaintainer dvMaintainer = DeletionVectorsMaintainer.factory(null).create();
+        Map<InternalRow, LookupLevels.PositionedKeyValue> lookup = new HashMap<>();
+        LookupChangelogMergeFunctionWrapper function =
+                new LookupChangelogMergeFunctionWrapper(
+                        LookupMergeFunction.wrap(DeduplicateMergeFunction.factory()),
+                        lookup::get,
+                        EQUALISER,
+                        LookupStrategy.from(false, true, true, true),
+                        dvMaintainer,
+                        null);
+
+        // With level-0, with level-x in lookup, with level-x (x > 0) deleted in dvMaintainer
+        function.reset();
+        LookupLevels.PositionedKeyValue positionedKv =
+                new LookupLevels.PositionedKeyValue(
+                        new KeyValue().replace(row(1), 1, INSERT, row(2)).setLevel(5), "f1", 1);
+        lookup.put(row(1), positionedKv);
+        dvMaintainer.notifyNewDeletion("f1", 1);
+        function.add(new KeyValue().replace(row(1), 2, INSERT, row(2)).setLevel(0));
+        ChangelogResult result = function.getResult();
+        assertThat(result).isNotNull();
+        List<KeyValue> changelogs = result.changelogs();
+        assertThat(changelogs).hasSize(1);
+        assertThat(changelogs.get(0).valueKind()).isEqualTo(INSERT);
+        assertThat(changelogs.get(0).value().getInt(0)).isEqualTo(2);
+        KeyValue kv = result.result();
+        assertThat(kv).isNotNull();
+        assertThat(kv.value().getInt(0)).isEqualTo(2);
+
+        // With level-0, with level-x in lookup, without level-x deleted in dvMaintainer
+        function.reset();
+        lookup.clear();
+        positionedKv =
+                new LookupLevels.PositionedKeyValue(
+                        new KeyValue().replace(row(1), 1, INSERT, row(2)).setLevel(5), "f2", 1);
+        lookup.put(row(1), positionedKv);
+        function.add(new KeyValue().replace(row(1), 2, INSERT, row(2)).setLevel(0));
+        result = function.getResult();
+        assertThat(result).isNotNull();
+        kv = result.result();
+        assertThat(kv).isNotNull();
+        assertThat(kv.value().getInt(0)).isEqualTo(2);
+        changelogs = result.changelogs();
+        assertThat(changelogs).hasSize(0);
+
+        // With level-0, without level-x in lookup, without level-x deleted in dvMaintainer
+        function.reset();
+        lookup.clear();
+        function.add(new KeyValue().replace(row(1), 2, INSERT, row(2)).setLevel(0));
+        result = function.getResult();
+        assertThat(result).isNotNull();
+        kv = result.result();
+        assertThat(kv).isNotNull();
+        assertThat(kv.value().getInt(0)).isEqualTo(2);
+        changelogs = result.changelogs();
+        assertThat(changelogs).hasSize(1);
+        assertThat(changelogs.get(0).valueKind()).isEqualTo(INSERT);
+        assertThat(changelogs.get(0).value().getInt(0)).isEqualTo(2);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
@@ -23,7 +23,9 @@ import org.apache.paimon.KeyValue;
 import org.apache.paimon.codegen.RecordEqualiser;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.InternalRow.FieldGetter;
+import org.apache.paimon.deletionvectors.DeletionVectorsIndexFile;
 import org.apache.paimon.deletionvectors.DeletionVectorsMaintainer;
+import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.lookup.LookupStrategy;
 import org.apache.paimon.mergetree.LookupLevels;
 import org.apache.paimon.mergetree.compact.aggregate.AggregateMergeFunction;
@@ -552,7 +554,15 @@ public class LookupChangelogMergeFunctionWrapperTest {
 
     @Test
     public void testWithDeletionVectorsMaintainer() {
-        DeletionVectorsMaintainer dvMaintainer = DeletionVectorsMaintainer.factory(null).create();
+        IndexFileHandler indexFileHandler =
+                new IndexFileHandler(
+                        null,
+                        null,
+                        null,
+                        null,
+                        new DeletionVectorsIndexFile(null, null, null, true));
+        DeletionVectorsMaintainer dvMaintainer =
+                DeletionVectorsMaintainer.factory(indexFileHandler).create();
         Map<InternalRow, LookupLevels.PositionedKeyValue> lookup = new HashMap<>();
         LookupChangelogMergeFunctionWrapper function =
                 new LookupChangelogMergeFunctionWrapper(

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
@@ -573,7 +573,7 @@ public class LookupChangelogMergeFunctionWrapperTest {
                         dvMaintainer,
                         null);
 
-        // With level-0, with level-x in lookup, with level-x (x > 0) deleted in dvMaintainer
+        // With level-0, with level-x in lookup, with level-x deleted in dvMaintainer
         function.reset();
         LookupLevels.PositionedKeyValue positionedKv =
                 new LookupLevels.PositionedKeyValue(

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/LookupChangelogMergeFunctionWrapperTest.java
@@ -579,8 +579,10 @@ public class LookupChangelogMergeFunctionWrapperTest {
                 new LookupLevels.PositionedKeyValue(
                         new KeyValue().replace(row(1), 1, INSERT, row(2)).setLevel(5), "f1", 1);
         lookup.put(row(1), positionedKv);
+        // Simulation scenario: (file:"f1", pos: 1) has been deleted
         dvMaintainer.notifyNewDeletion("f1", 1);
         function.add(new KeyValue().replace(row(1), 2, INSERT, row(2)).setLevel(0));
+        // notifyNewDeletion will return 'false' because (file:"f1", pos: 1) has been deleted
         ChangelogResult result = function.getResult();
         assertThat(result).isNotNull();
         List<KeyValue> changelogs = result.changelogs();
@@ -598,7 +600,10 @@ public class LookupChangelogMergeFunctionWrapperTest {
                 new LookupLevels.PositionedKeyValue(
                         new KeyValue().replace(row(1), 1, INSERT, row(2)).setLevel(5), "f2", 1);
         lookup.put(row(1), positionedKv);
+        // Simulation scenario: (file:"f2", pos: 2) has been deleted but not (file:"f2", pos: 1)
+        dvMaintainer.notifyNewDeletion("f2", 2);
         function.add(new KeyValue().replace(row(1), 2, INSERT, row(2)).setLevel(0));
+        // notifyNewDeletion will return 'true' because (file:"f2", pos: 1) has not been deleted
         result = function.getResult();
         assertThat(result).isNotNull();
         kv = result.result();
@@ -613,6 +618,7 @@ public class LookupChangelogMergeFunctionWrapperTest {
         function.add(new KeyValue().replace(row(1), 2, INSERT, row(2)).setLevel(0));
         result = function.getResult();
         assertThat(result).isNotNull();
+        // NotifyNewDeletion will not be called
         kv = result.result();
         assertThat(kv).isNotNull();
         assertThat(kv.value().getInt(0)).isEqualTo(2);


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5724 

<!-- What is the purpose of the change -->
When LookupChangelogMergeFunctionWrapper is used for changelog and config: 'changelog-producer.row-deduplicate' = 'true' , add a judgment of 'highLevel'  record on whether it has been deleted or not before the changelog is generated.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
