### PR TITLE
[core] Remove properties field in FileStoreCommit.commit

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
@@ -39,14 +39,8 @@ public interface FileStoreCommit extends AutoCloseable {
     /** Find out which committables need to be retried when recovering from the failure. */
     List<ManifestCommittable> filterCommitted(List<ManifestCommittable> committables);
 
-    /** Commit from manifest committable. */
-    void commit(ManifestCommittable committable, Map<String, String> properties);
-
     /** Commit from manifest committable with checkAppendFiles. */
-    void commit(
-            ManifestCommittable committable,
-            Map<String, String> properties,
-            boolean checkAppendFiles);
+    void commit(ManifestCommittable committable, boolean checkAppendFiles);
 
     /**
      * Overwrite from manifest committable and partition.

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -97,8 +97,8 @@ import static org.apache.paimon.utils.InternalRowPartitionComputer.partToSimpleS
  * <p>This class provides an atomic commit method to the user.
  *
  * <ol>
- *   <li>Before calling {@link #commit(ManifestCommittable, Map)}, if user cannot determine if this
- *       commit is done before, user should first call {@link #filterCommitted}.
+ *   <li>Before calling {@link #commit}, if user cannot determine if this commit is done before,
+ *       user should first call {@link #filterCommitted}.
  *   <li>Before committing, it will first check for conflicts by checking if all files to be removed
  *       currently exists, and if modified files have overlapping key ranges with existing files.
  *   <li>After that it use the external {@link SnapshotCommit} (if provided) or the atomic rename of
@@ -260,21 +260,13 @@ public class FileStoreCommitImpl implements FileStoreCommit {
     }
 
     @Override
-    public void commit(ManifestCommittable committable, Map<String, String> properties) {
-        commit(committable, properties, false);
-    }
-
-    @Override
-    public void commit(
-            ManifestCommittable committable,
-            Map<String, String> properties,
-            boolean checkAppendFiles) {
+    public void commit(ManifestCommittable committable, boolean checkAppendFiles) {
         LOG.info(
                 "Ready to commit to table {}, number of commit messages: {}",
                 tableName,
                 committable.fileCommittables().size());
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Ready to commit\n{}", committable.toString());
+            LOG.debug("Ready to commit\n{}", committable);
         }
 
         long started = System.nanoTime();

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
@@ -50,7 +50,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -215,7 +214,7 @@ public class TableCommitImpl implements InnerTableCommit {
     public void commitMultiple(List<ManifestCommittable> committables, boolean checkAppendFiles) {
         if (overwritePartition == null) {
             for (ManifestCommittable committable : committables) {
-                commit.commit(committable, new HashMap<>(), checkAppendFiles);
+                commit.commit(committable, checkAppendFiles);
             }
             if (!committables.isEmpty()) {
                 expire(committables.get(committables.size() - 1).identifier(), expireMainExecutor);

--- a/paimon-core/src/test/java/org/apache/paimon/TestAppendFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestAppendFileStore.java
@@ -101,7 +101,7 @@ public class TestAppendFileStore extends AppendOnlyFileStore {
         for (CommitMessage commitMessage : commitMessages) {
             committable.addFileCommittable(commitMessage);
         }
-        newCommit().commit(committable, Collections.emptyMap());
+        newCommit().commit(committable, false);
     }
 
     public CommitMessage removeIndexFiles(

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -217,7 +217,7 @@ public class TestFileStore extends KeyValueFileStore {
                 null,
                 watermark,
                 Collections.emptyList(),
-                (commit, committable) -> commit.commit(committable, Collections.emptyMap()));
+                (commit, committable) -> commit.commit(committable, false));
     }
 
     public List<Snapshot> commitData(
@@ -237,7 +237,7 @@ public class TestFileStore extends KeyValueFileStore {
                 (commit, committable) -> {
                     logOffsets.forEach(
                             (bucket, offset) -> committable.addLogOffset(bucket, offset, false));
-                    commit.commit(committable, Collections.emptyMap());
+                    commit.commit(committable, false);
                 });
     }
 
@@ -291,7 +291,7 @@ public class TestFileStore extends KeyValueFileStore {
                 null,
                 null,
                 Arrays.asList(indexFiles),
-                (commit, committable) -> commit.commit(committable, Collections.emptyMap()));
+                (commit, committable) -> commit.commit(committable, false));
     }
 
     public List<Snapshot> commitDataImpl(

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -532,7 +532,7 @@ public class FileStoreCommitTest {
                 null,
                 null,
                 Collections.emptyList(),
-                (commit, committable) -> commit.commit(committable, Collections.emptyMap()));
+                (commit, committable) -> commit.commit(committable, false));
         assertThat(store.snapshotManager().latestSnapshotId()).isEqualTo(snapshot.id());
 
         // commit empty new files
@@ -546,7 +546,7 @@ public class FileStoreCommitTest {
                 Collections.emptyList(),
                 (commit, committable) -> {
                     commit.ignoreEmptyCommit(false);
-                    commit.commit(committable, Collections.emptyMap());
+                    commit.commit(committable, false);
                 });
         assertThat(store.snapshotManager().latestSnapshotId()).isEqualTo(snapshot.id() + 1);
     }
@@ -567,20 +567,14 @@ public class FileStoreCommitTest {
                     null,
                     Collections.emptyList(),
                     (commit, committable) -> {
-                        commit.commit(committable, Collections.emptyMap());
+                        commit.commit(committable, false);
                         committables.add(committable);
                     });
         }
 
         // commit the first snapshot again, should throw exception due to conflicts
         for (int i = 0; i < 3; i++) {
-            assertThatThrownBy(
-                            () ->
-                                    store.newCommit()
-                                            .commit(
-                                                    committables.get(0),
-                                                    Collections.emptyMap(),
-                                                    true))
+            assertThatThrownBy(() -> store.newCommit().commit(committables.get(0), true))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining("Give up committing.");
         }
@@ -1024,7 +1018,7 @@ public class FileStoreCommitTest {
 
             // commit with empty properties, the properties in snapshot should be null
             ManifestCommittable manifestCommittable = new ManifestCommittable(0);
-            fileStoreCommit.commit(manifestCommittable, Collections.emptyMap());
+            fileStoreCommit.commit(manifestCommittable, false);
             Snapshot snapshot = checkNotNull(store.snapshotManager().latestSnapshot());
             assertThat(snapshot.properties()).isNull();
 
@@ -1032,7 +1026,7 @@ public class FileStoreCommitTest {
             manifestCommittable = new ManifestCommittable(0);
             manifestCommittable.addProperty("k1", "v1");
             manifestCommittable.addProperty("k2", "v2");
-            fileStoreCommit.commit(manifestCommittable, Collections.emptyMap());
+            fileStoreCommit.commit(manifestCommittable, false);
             snapshot = checkNotNull(store.snapshotManager().latestSnapshot());
             Map<String, String> expectedProps = new HashMap<>();
             expectedProps.put("k1", "v1");

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreTestUtils.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreTestUtils.java
@@ -35,7 +35,6 @@ import org.apache.paimon.utils.RecordWriter;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -111,7 +110,7 @@ public class FileStoreTestUtils {
         }
 
         try (FileStoreCommit commit = store.newCommit()) {
-            commit.commit(committable, Collections.emptyMap());
+            commit.commit(committable, false);
         }
 
         writers.values().stream()

--- a/paimon-core/src/test/java/org/apache/paimon/operation/TestCommitThread.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/TestCommitThread.java
@@ -151,7 +151,7 @@ public class TestCommitThread extends Thread {
                             inc.compactIncrement()));
         }
 
-        runWithRetry(committable, () -> commit.commit(committable, Collections.emptyMap()));
+        runWithRetry(committable, () -> commit.commit(committable, false));
     }
 
     private void doOverwrite() throws Exception {
@@ -193,7 +193,7 @@ public class TestCommitThread extends Thread {
                                     inc.newFilesIncrement(),
                                     inc.compactIncrement()));
                 }
-                commit.commit(committable, Collections.emptyMap());
+                commit.commit(committable, false);
                 break;
             } catch (Exception e) {
                 if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In https://github.com/apache/incubator-paimon/pull/5703 , there is properties in `ManifestCommittable`.

We don't need properties field in FileStoreCommit.commit.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
