### PR TITLE
Support user agent for JindoFileIO

### DIFF
--- a/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
+++ b/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
@@ -125,7 +125,9 @@ public class JindoFileIO extends HadoopCompliantFileIO {
             // Add extended user agent if user-agent is configured
             if ("header.user-agent".equals(key.toLowerCase())) {
                 String value = context.options().get(key);
-                LOG.debug("Adding config entry for fs.oss.user.agent.extended as {} to Hadoop config", value);
+                LOG.debug(
+                        "Adding config entry for fs.oss.user.agent.extended as {} to Hadoop config",
+                        value);
                 hadoopOptions.set("fs.oss.user.agent.extended", value);
             }
         }

--- a/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
+++ b/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
@@ -122,6 +122,12 @@ public class JindoFileIO extends HadoopCompliantFileIO {
                             hadoopOptions.get(key));
                 }
             }
+            // Add extended user agent if user-agent is configured
+            if ("header.user-agent".equals(key.toLowerCase())) {
+                String value = context.options().get(key);
+                LOG.debug("Adding config entry for fs.oss.user.agent.extended as {} to Hadoop config", value);
+                hadoopOptions.set("fs.oss.user.agent.extended", value);
+            }
         }
     }
 


### PR DESCRIPTION
In RESTCatalog, header.user-agent is used to configure user agent for meta reat api. JindoFileIO also supports setting user agent for sending OSS requests. So we can use header.user-agent to configure both meta rest api and OSS requests so that access log in both sides can be easily distinguished by the same user agent tag.