### PR TITLE
[core] Also remove metadata.stats-mode=none in postpone bucket writers when not using avro

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/postpone/PostponeBucketFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/postpone/PostponeBucketFileStoreWrite.java
@@ -77,10 +77,10 @@ public class PostponeBucketFileStoreWrite extends AbstractFileStoreWrite<KeyValu
             // use avro for postpone bucket
             AvroSchemaConverter.convertToSchema(schema.logicalRowType(), new HashMap<>());
             newOptions.set(CoreOptions.FILE_FORMAT, "avro");
+            newOptions.set(CoreOptions.METADATA_STATS_MODE, "none");
         } catch (Exception e) {
             // ignored, avro does not support certain types in schema
         }
-        newOptions.set(CoreOptions.METADATA_STATS_MODE, "none");
         // Each writer should have its unique prefix, so files from the same writer can be consumed
         // by the same compaction reader to keep the input order.
         // Also note that, for Paimon CDC, this object might be created multiple times in the same


### PR DESCRIPTION
### Purpose

Like #5733, this PR also remove `metadata.stats-mode=none` in postpone bucket writers when not using avro. Because collecting stats is costly only avro, but simple for other formats.

### Tests

This is a simple change without additional tests.

### API and Format

No format changes.

### Documentation

No new feature.
