### PR TITLE
[test][spark] Fix the unstable testHiveCatalogOptions  

### DIFF
--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithHiveTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithHiveTest.java
@@ -109,6 +109,7 @@ public class SparkCatalogWithHiveTest {
                                     .collect(Collectors.toList()))
                     .containsExactlyInAnyOrder("[1,1,1]", "[2,2,2]");
         }
+        spark.stop();
     }
 
     @Test

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/catalog/functions/BucketFunctionTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/catalog/functions/BucketFunctionTest.java
@@ -56,6 +56,7 @@ import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 
 import org.apache.spark.sql.SparkSession;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -188,6 +189,11 @@ public class BucketFunctionTest {
     @AfterEach
     public void after() {
         spark.sql(String.format("DROP TABLE IF EXISTS %s", TABLE_NAME));
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        spark.stop();
     }
 
     public static void setupTable(String... bucketColumns) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

drop database created in testBuildWithHive

```
Error:  org.apache.paimon.spark.SparkGenericCatalogWithHiveTest.testBuildWithHive(Path)  Time elapsed: 0.058 s  <<< ERROR!
org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException: 
[SCHEMA_ALREADY_EXISTS] Cannot create schema `my_db` because it already exists.
Choose a different name, drop the existing schema, or add the IF NOT EXISTS clause to tolerate pre-existing schema.
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
