### PR TITLE
[flink] Fix paimon-flink-2.0 releasing process

### DIFF
--- a/paimon-flink/paimon-flink-1.15/pom.xml
+++ b/paimon-flink/paimon-flink-1.15/pom.xml
@@ -51,6 +51,18 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-flink1-common</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-flink-cdc</artifactId>
             <version>${project.version}</version>
             <exclusions>
@@ -131,6 +143,7 @@ under the License.
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>org.apache.paimon:paimon-flink-common</include>
+                                    <include>org.apache.paimon:paimon-flink1-common</include>
                                     <include>org.apache.paimon:paimon-flink-cdc</include>
                                 </includes>
                             </artifactSet>

--- a/paimon-flink/paimon-flink-1.16/pom.xml
+++ b/paimon-flink/paimon-flink-1.16/pom.xml
@@ -54,6 +54,18 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-flink1-common</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-flink-cdc</artifactId>
             <version>${project.version}</version>
             <exclusions>
@@ -126,6 +138,7 @@ under the License.
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>org.apache.paimon:paimon-flink-common</include>
+                                    <include>org.apache.paimon:paimon-flink1-common</include>
                                     <include>org.apache.paimon:paimon-flink-cdc</include>
                                 </includes>
                             </artifactSet>

--- a/paimon-flink/paimon-flink-1.17/pom.xml
+++ b/paimon-flink/paimon-flink-1.17/pom.xml
@@ -61,6 +61,18 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-flink1-common</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-flink-cdc</artifactId>
             <version>${project.version}</version>
             <exclusions>
@@ -140,6 +152,7 @@ under the License.
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>org.apache.paimon:paimon-flink-common</include>
+                                    <include>org.apache.paimon:paimon-flink1-common</include>
                                     <include>org.apache.paimon:paimon-flink-cdc</include>
                                 </includes>
                             </artifactSet>

--- a/paimon-flink/paimon-flink-1.18/pom.xml
+++ b/paimon-flink/paimon-flink-1.18/pom.xml
@@ -53,6 +53,18 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-flink1-common</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-flink-cdc</artifactId>
             <version>${project.version}</version>
             <exclusions>
@@ -125,6 +137,7 @@ under the License.
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>org.apache.paimon:paimon-flink-common</include>
+                                    <include>org.apache.paimon:paimon-flink1-common</include>
                                     <include>org.apache.paimon:paimon-flink-cdc</include>
                                 </includes>
                             </artifactSet>

--- a/paimon-flink/paimon-flink-1.19/pom.xml
+++ b/paimon-flink/paimon-flink-1.19/pom.xml
@@ -53,6 +53,18 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-flink1-common</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-flink-cdc</artifactId>
             <version>${project.version}</version>
             <exclusions>
@@ -132,6 +144,7 @@ under the License.
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>org.apache.paimon:paimon-flink-common</include>
+                                    <include>org.apache.paimon:paimon-flink1-common</include>
                                     <include>org.apache.paimon:paimon-flink-cdc</include>
                                 </includes>
                             </artifactSet>

--- a/paimon-flink/paimon-flink-1.20/pom.xml
+++ b/paimon-flink/paimon-flink-1.20/pom.xml
@@ -46,6 +46,12 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-flink1-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-flink-cdc</artifactId>
             <version>${project.version}</version>
             <exclusions>
@@ -87,6 +93,7 @@ under the License.
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>org.apache.paimon:paimon-flink-common</include>
+                                    <include>org.apache.paimon:paimon-flink1-common</include>
                                     <include>org.apache.paimon:paimon-flink-cdc</include>
                                 </includes>
                             </artifactSet>

--- a/paimon-flink/paimon-flink-2.0/pom.xml
+++ b/paimon-flink/paimon-flink-2.0/pom.xml
@@ -45,6 +45,12 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-flink2-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
@@ -75,6 +81,7 @@ under the License.
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>org.apache.paimon:paimon-flink-common</include>
+                                    <include>org.apache.paimon:paimon-flink2-common</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/paimon-flink/paimon-flink-cdc/pom.xml
+++ b/paimon-flink/paimon-flink-cdc/pom.xml
@@ -62,6 +62,18 @@ under the License.
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-flink1-common</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- Flink dependencies -->
 
         <dependency>

--- a/paimon-flink/paimon-flink-common/pom.xml
+++ b/paimon-flink/paimon-flink-common/pom.xml
@@ -232,7 +232,6 @@ under the License.
                                     <include>org.apache.paimon:paimon-service-client</include>
                                     <include>org.apache.paimon:paimon-service-runtime</include>
                                     <include>org.apache.paimon:paimon-shade-netty-4</include>
-                                    <include>org.apache.paimon:${paimon-flinkx-common}</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/paimon-flink/pom.xml
+++ b/paimon-flink/pom.xml
@@ -34,7 +34,6 @@ under the License.
     <packaging>pom</packaging>
 
     <modules>
-        <module>${paimon-flinkx-common}</module>
         <module>paimon-flink-common</module>
         <module>paimon-flink-action</module>
     </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -421,6 +421,7 @@ under the License.
                 <test.flink.version>1.20.1</test.flink.version>
             </properties>
             <modules>
+                <module>paimon-flink/paimon-flink1-common</module>
                 <module>paimon-flink/paimon-flink-1.15</module>
                 <module>paimon-flink/paimon-flink-1.16</module>
                 <module>paimon-flink/paimon-flink-1.17</module>
@@ -446,6 +447,7 @@ under the License.
                 <test.flink.version>2.0.0</test.flink.version>
             </properties>
             <modules>
+                <module>paimon-flink/paimon-flink2-common</module>
                 <module>paimon-flink/paimon-flink-2.0</module>
             </modules>
             <activation>


### PR DESCRIPTION
### Purpose

This PR fixes the bug that `update_branch_version.sh` does not work for paimon-flink1-common and paimon-flink2-common.

* Extracts paimon-flinkx-common from paimon-flink-common's jar

### Tests

Manually verified that `update_branch_version.sh` could now work on all pom.xml.

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
