### PR TITLE
[flink] Make PostponeBucketSink no state and no intended failure

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcAppendTableSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcAppendTableSink.java
@@ -19,8 +19,10 @@
 package org.apache.paimon.flink.sink.cdc;
 
 import org.apache.paimon.flink.sink.Committable;
+import org.apache.paimon.flink.sink.CommittableStateManager;
 import org.apache.paimon.flink.sink.FlinkWriteSink;
 import org.apache.paimon.flink.sink.StoreSinkWrite;
+import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -51,5 +53,10 @@ public class CdcAppendTableSink extends FlinkWriteSink<CdcRecord> {
     public DataStream<Committable> doWrite(
             DataStream<CdcRecord> input, String initialCommitUser, @Nullable Integer parallelism) {
         return super.doWrite(input, initialCommitUser, this.parallelism);
+    }
+
+    @Override
+    protected CommittableStateManager<ManifestCommittable> createCommittableStateManager() {
+        return createRestoreOnlyCommittableStateManager(table);
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcAppendTableWriteOperator.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcAppendTableWriteOperator.java
@@ -19,11 +19,14 @@
 package org.apache.paimon.flink.sink.cdc;
 
 import org.apache.paimon.flink.sink.Committable;
+import org.apache.paimon.flink.sink.NoopStoreSinkWriteState;
 import org.apache.paimon.flink.sink.PrepareCommitOperator;
 import org.apache.paimon.flink.sink.StoreSinkWrite;
+import org.apache.paimon.flink.sink.StoreSinkWriteState;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.RowKind;
 
+import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
@@ -38,6 +41,16 @@ public class CdcAppendTableWriteOperator extends CdcRecordStoreWriteOperator {
             StoreSinkWrite.Provider storeSinkWriteProvider,
             String initialCommitUser) {
         super(parameters, table, storeSinkWriteProvider, initialCommitUser);
+    }
+
+    @Override
+    protected StoreSinkWriteState createState(
+            int subtaskId,
+            StateInitializationContext context,
+            StoreSinkWriteState.StateValueFilter stateFilter) {
+        // No conflicts will occur in append only unaware bucket writer, so no state
+        // is needed.
+        return new NoopStoreSinkWriteState(subtaskId, stateFilter);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
@@ -177,6 +177,6 @@ public class FlinkCdcMultiTableSink implements Serializable {
 
     protected CommittableStateManager<WrappedManifestCommittable> createCommittableStateManager() {
         return new RestoreAndFailCommittableStateManager<>(
-                WrappedManifestCommittableSerializer::new);
+                WrappedManifestCommittableSerializer::new, true);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendTableSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendTableSink.java
@@ -48,6 +48,8 @@ import static org.apache.paimon.flink.utils.ParallelismUtils.setParallelism;
  */
 public abstract class AppendTableSink<T> extends FlinkWriteSink<T> {
 
+    private static final long serialVersionUID = 1L;
+
     protected final FileStoreTable table;
     protected final LogSinkFunction logSinkFunction;
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
@@ -300,7 +300,7 @@ public class FlinkSinkBuilder {
             channelComputer = new PostponeBucketChannelComputer(table.schema());
         }
         DataStream<InternalRow> partitioned = partition(input, channelComputer, parallelism);
-        FixedBucketSink sink = new FixedBucketSink(table, overwritePartition, null);
+        PostponeBucketSink sink = new PostponeBucketSink(table, overwritePartition);
         return sink.sinkFrom(partitioned);
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkWriteSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkWriteSink.java
@@ -18,10 +18,16 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.manifest.ManifestCommittableSerializer;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
+
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 
 import javax.annotation.Nullable;
 
@@ -60,6 +66,50 @@ public abstract class FlinkWriteSink<T> extends FlinkSink<T> {
     protected CommittableStateManager<ManifestCommittable> createCommittableStateManager() {
         Options options = table.coreOptions().toConfiguration();
         return new RestoreAndFailCommittableStateManager<>(
+                ManifestCommittableSerializer::new,
+                options.get(PARTITION_MARK_DONE_RECOVER_FROM_STATE));
+    }
+
+    protected static OneInputStreamOperatorFactory<InternalRow, Committable>
+            createNoStateRowWriteOperatorFactory(
+                    FileStoreTable table,
+                    LogSinkFunction logSinkFunction,
+                    StoreSinkWrite.Provider writeProvider,
+                    String commitUser) {
+        return new RowDataStoreWriteOperator.Factory(
+                table, logSinkFunction, writeProvider, commitUser) {
+            @Override
+            @SuppressWarnings("unchecked, rawtypes")
+            public StreamOperator createStreamOperator(StreamOperatorParameters parameters) {
+                return new RowDataStoreWriteOperator(
+                        parameters, table, logSinkFunction, writeProvider, commitUser) {
+
+                    @Override
+                    protected StoreSinkWriteState createState(
+                            int subtaskId,
+                            StateInitializationContext context,
+                            StoreSinkWriteState.StateValueFilter stateFilter) {
+                        // No conflicts will occur in append only unaware bucket writer, so no state
+                        // is needed.
+                        return new NoopStoreSinkWriteState(subtaskId, stateFilter);
+                    }
+
+                    @Override
+                    protected String getCommitUser(StateInitializationContext context)
+                            throws Exception {
+                        // No conflicts will occur in append only unaware bucket writer, so
+                        // commitUser does not matter.
+                        return commitUser;
+                    }
+                };
+            }
+        };
+    }
+
+    protected static CommittableStateManager<ManifestCommittable>
+            createRestoreOnlyCommittableStateManager(FileStoreTable table) {
+        Options options = table.coreOptions().toConfiguration();
+        return new RestoreCommittableStateManager<>(
                 ManifestCommittableSerializer::new,
                 options.get(PARTITION_MARK_DONE_RECOVER_FROM_STATE));
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/PostponeBucketSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/PostponeBucketSink.java
@@ -24,26 +24,24 @@ import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 
+import javax.annotation.Nullable;
+
 import java.util.Map;
 
-/** An {@link AppendTableSink} which handles {@link InternalRow}. */
-public class RowAppendTableSink extends AppendTableSink<InternalRow> {
+/** {@link FlinkSink} for writing records into fixed bucket Paimon table. */
+public class PostponeBucketSink extends FlinkWriteSink<InternalRow> {
 
     private static final long serialVersionUID = 1L;
 
-    public RowAppendTableSink(
-            FileStoreTable table,
-            Map<String, String> overwritePartitions,
-            LogSinkFunction logSinkFunction,
-            Integer parallelism) {
-        super(table, overwritePartitions, logSinkFunction, parallelism);
+    public PostponeBucketSink(
+            FileStoreTable table, @Nullable Map<String, String> overwritePartition) {
+        super(table, overwritePartition);
     }
 
     @Override
     protected OneInputStreamOperatorFactory<InternalRow, Committable> createWriteOperatorFactory(
             StoreSinkWrite.Provider writeProvider, String commitUser) {
-        return createNoStateRowWriteOperatorFactory(
-                table, logSinkFunction, writeProvider, commitUser);
+        return createNoStateRowWriteOperatorFactory(table, null, writeProvider, commitUser);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RestoreAndFailCommittableStateManager.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RestoreAndFailCommittableStateManager.java
@@ -19,18 +19,9 @@
 package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.data.serializer.VersionedSerializer;
-import org.apache.paimon.flink.VersionedSerializerWrapper;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.utils.SerializableSupplier;
 
-import org.apache.flink.api.common.state.ListState;
-import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
-import org.apache.flink.runtime.state.StateInitializationContext;
-import org.apache.flink.runtime.state.StateSnapshotContext;
-import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
-
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -44,52 +35,20 @@ import java.util.List;
  * store writers.
  */
 public class RestoreAndFailCommittableStateManager<GlobalCommitT>
-        implements CommittableStateManager<GlobalCommitT> {
+        extends RestoreCommittableStateManager<GlobalCommitT> {
 
     private static final long serialVersionUID = 1L;
-
-    /** The committable's serializer. */
-    private final SerializableSupplier<VersionedSerializer<GlobalCommitT>> committableSerializer;
-
-    private final boolean partitionMarkDoneRecoverFromState;
-
-    /** GlobalCommitT state of this job. Used to filter out previous successful commits. */
-    private ListState<GlobalCommitT> streamingCommitterState;
-
-    public RestoreAndFailCommittableStateManager(
-            SerializableSupplier<VersionedSerializer<GlobalCommitT>> committableSerializer) {
-        this(committableSerializer, true);
-    }
 
     public RestoreAndFailCommittableStateManager(
             SerializableSupplier<VersionedSerializer<GlobalCommitT>> committableSerializer,
             boolean partitionMarkDoneRecoverFromState) {
-        this.committableSerializer = committableSerializer;
-        this.partitionMarkDoneRecoverFromState = partitionMarkDoneRecoverFromState;
+        super(committableSerializer, partitionMarkDoneRecoverFromState);
     }
 
     @Override
-    public void initializeState(
-            StateInitializationContext context, Committer<?, GlobalCommitT> committer)
+    protected int recover(List<GlobalCommitT> committables, Committer<?, GlobalCommitT> committer)
             throws Exception {
-        streamingCommitterState =
-                new SimpleVersionedListState<>(
-                        context.getOperatorStateStore()
-                                .getListState(
-                                        new ListStateDescriptor<>(
-                                                "streaming_committer_raw_states",
-                                                BytePrimitiveArraySerializer.INSTANCE)),
-                        new VersionedSerializerWrapper<>(committableSerializer.get()));
-        List<GlobalCommitT> restored = new ArrayList<>();
-        streamingCommitterState.get().forEach(restored::add);
-        streamingCommitterState.clear();
-        recover(restored, committer);
-    }
-
-    private void recover(List<GlobalCommitT> committables, Committer<?, GlobalCommitT> committer)
-            throws Exception {
-        int numCommitted =
-                committer.filterAndCommit(committables, true, partitionMarkDoneRecoverFromState);
+        int numCommitted = super.recover(committables, committer);
         if (numCommitted > 0) {
             throw new RuntimeException(
                     "This exception is intentionally thrown "
@@ -97,11 +56,6 @@ public class RestoreAndFailCommittableStateManager<GlobalCommitT>
                             + "By restarting the job we hope that "
                             + "writers can start writing based on these new commits.");
         }
-    }
-
-    @Override
-    public void snapshotState(StateSnapshotContext context, List<GlobalCommitT> committables)
-            throws Exception {
-        streamingCommitterState.update(committables);
+        return numCommitted;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RestoreCommittableStateManager.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RestoreCommittableStateManager.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.data.serializer.VersionedSerializer;
+import org.apache.paimon.flink.VersionedSerializerWrapper;
+import org.apache.paimon.manifest.ManifestCommittable;
+import org.apache.paimon.utils.SerializableSupplier;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A {@link CommittableStateManager} which stores uncommitted {@link ManifestCommittable}s in state.
+ *
+ * <p>When the job restarts, these {@link ManifestCommittable}s will be restored and committed.
+ */
+public class RestoreCommittableStateManager<GlobalCommitT>
+        implements CommittableStateManager<GlobalCommitT> {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The committable's serializer. */
+    private final SerializableSupplier<VersionedSerializer<GlobalCommitT>> committableSerializer;
+
+    private final boolean partitionMarkDoneRecoverFromState;
+
+    /** GlobalCommitT state of this job. Used to filter out previous successful commits. */
+    private ListState<GlobalCommitT> streamingCommitterState;
+
+    public RestoreCommittableStateManager(
+            SerializableSupplier<VersionedSerializer<GlobalCommitT>> committableSerializer,
+            boolean partitionMarkDoneRecoverFromState) {
+        this.committableSerializer = committableSerializer;
+        this.partitionMarkDoneRecoverFromState = partitionMarkDoneRecoverFromState;
+    }
+
+    @Override
+    public void initializeState(
+            StateInitializationContext context, Committer<?, GlobalCommitT> committer)
+            throws Exception {
+        streamingCommitterState =
+                new SimpleVersionedListState<>(
+                        context.getOperatorStateStore()
+                                .getListState(
+                                        new ListStateDescriptor<>(
+                                                "streaming_committer_raw_states",
+                                                BytePrimitiveArraySerializer.INSTANCE)),
+                        new VersionedSerializerWrapper<>(committableSerializer.get()));
+        List<GlobalCommitT> restored = new ArrayList<>();
+        streamingCommitterState.get().forEach(restored::add);
+        streamingCommitterState.clear();
+        recover(restored, committer);
+    }
+
+    protected int recover(List<GlobalCommitT> committables, Committer<?, GlobalCommitT> committer)
+            throws Exception {
+        return committer.filterAndCommit(committables, true, partitionMarkDoneRecoverFromState);
+    }
+
+    @Override
+    public void snapshotState(StateSnapshotContext context, List<GlobalCommitT> committables)
+            throws Exception {
+        streamingCommitterState.update(committables);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/BatchWriteGeneratorTagOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/BatchWriteGeneratorTagOperatorTest.java
@@ -67,7 +67,7 @@ public class BatchWriteGeneratorTagOperatorTest extends CommitterOperatorTest {
                         table,
                         initialCommitUser,
                         new RestoreAndFailCommittableStateManager<>(
-                                ManifestCommittableSerializer::new));
+                                ManifestCommittableSerializer::new, true));
 
         OneInputStreamOperator<Committable, Committable> committerOperator =
                 committerOperatorFactory.createStreamOperator(
@@ -143,7 +143,7 @@ public class BatchWriteGeneratorTagOperatorTest extends CommitterOperatorTest {
                         table,
                         initialCommitUser,
                         new RestoreAndFailCommittableStateManager<>(
-                                ManifestCommittableSerializer::new));
+                                ManifestCommittableSerializer::new, true));
 
         OneInputStreamOperator<Committable, Committable> committerOperator =
                 committerOperatorFactory.createStreamOperator(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CommitterOperatorTest.java
@@ -665,7 +665,7 @@ public class CommitterOperatorTest extends CommitterOperatorTestBase {
                         table,
                         null,
                         new RestoreAndFailCommittableStateManager<>(
-                                ManifestCommittableSerializer::new));
+                                ManifestCommittableSerializer::new, true));
         OneInputStreamOperatorTestHarness<Committable, Committable> testHarness =
                 createTestHarness(operatorFactory);
         testHarness.open();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreMultiCommitterTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreMultiCommitterTest.java
@@ -652,7 +652,7 @@ class StoreMultiCommitterTest {
                         initialCommitUser,
                         context -> new StoreMultiCommitter(catalogLoader, context),
                         new RestoreAndFailCommittableStateManager<>(
-                                WrappedManifestCommittableSerializer::new));
+                                WrappedManifestCommittableSerializer::new, true));
         return createTestHarness(operator);
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
PostponeBucketSink and AppendTableSink do not need to have state and intended failure, Because its writing does not read snapshots

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
