### PR TITLE
[core][spark] Introduce default value when writing from Spark DDL

### DIFF
--- a/docs/content/spark/default-value.md
+++ b/docs/content/spark/default-value.md
@@ -1,0 +1,54 @@
+---
+title: "Default Value"
+weight: 8
+type: docs
+aliases:
+- /spark/default-value.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Default Value
+
+Paimon allows specifying default values for columns. When users write to these tables without explicitly providing
+values for certain columns, Paimon automatically generates default values for these columns.
+
+## Create Table
+
+You can create a table with columns with default values using the following SQL:
+
+```sql
+CREATE TABLE my_table (
+    a BIGINT,
+    b STRING DEFAULT 'my_value',
+    c INT DEFAULT 5 
+);
+```
+
+## Insert Table
+
+For SQL commands that execute table writes, such as the `INSERT`, `UPDATE`, and `MERGE` commands, the `DEFAULT` keyword
+or `NULL` value is parsed into the default value specified for the corresponding column.
+
+## Limitation
+
+Currently, only specifying default values when creating tables is supported, and the following usage is not supported:
+
+1. Not support alter table add column with default value, for example: `ALTER TABLE T ADD COLUMN d INT DEFAULT 5;`.
+2. Not support alter table alter column set default value, for example: `ALTER TABLE T ALTER COLUMN d SET DEFAULT 5;`.

--- a/paimon-api/src/main/java/org/apache/paimon/schema/Schema.java
+++ b/paimon-api/src/main/java/org/apache/paimon/schema/Schema.java
@@ -175,7 +175,8 @@ public class Schema {
                                 field.id(),
                                 field.name(),
                                 field.type().copy(false),
-                                field.description()));
+                                field.description(),
+                                field.defaultValue()));
             } else {
                 newFields.add(field);
             }
@@ -302,12 +303,28 @@ public class Schema {
          * @param description description of the column
          */
         public Builder column(String columnName, DataType dataType, @Nullable String description) {
+            return column(columnName, dataType, description, null);
+        }
+
+        /**
+         * Declares a column that is appended to this schema.
+         *
+         * @param columnName column name
+         * @param dataType data type of the column
+         * @param description description of the column
+         * @param defaultValue default value of the column
+         */
+        public Builder column(
+                String columnName,
+                DataType dataType,
+                @Nullable String description,
+                @Nullable String defaultValue) {
             Preconditions.checkNotNull(columnName, "Column name must not be null.");
             Preconditions.checkNotNull(dataType, "Data type must not be null.");
 
             int id = highestFieldId.incrementAndGet();
             DataType reassignDataType = ReassignFieldId.reassign(dataType, highestFieldId);
-            columns.add(new DataField(id, columnName, reassignDataType, description));
+            columns.add(new DataField(id, columnName, reassignDataType, description, defaultValue));
             return this;
         }
 

--- a/paimon-api/src/main/java/org/apache/paimon/types/DataField.java
+++ b/paimon-api/src/main/java/org/apache/paimon/types/DataField.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.Objects;
 
+import static org.apache.paimon.types.DataTypeFamily.CHARACTER_STRING;
 import static org.apache.paimon.utils.EncodingUtils.escapeIdentifier;
 import static org.apache.paimon.utils.EncodingUtils.escapeSingleQuotes;
 
@@ -41,27 +42,31 @@ public final class DataField implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    public static final String FIELD_FORMAT_WITH_DESCRIPTION = "%s %s '%s'";
-
-    public static final String FIELD_FORMAT_NO_DESCRIPTION = "%s %s";
-
     private final int id;
-
     private final String name;
-
     private final DataType type;
-
     private final @Nullable String description;
+    private final @Nullable String defaultValue;
 
     public DataField(int id, String name, DataType dataType) {
-        this(id, name, dataType, null);
+        this(id, name, dataType, null, null);
     }
 
-    public DataField(int id, String name, DataType type, @Nullable String description) {
+    public DataField(int id, String name, DataType dataType, @Nullable String description) {
+        this(id, name, dataType, description, null);
+    }
+
+    public DataField(
+            int id,
+            String name,
+            DataType type,
+            @Nullable String description,
+            @Nullable String defaultValue) {
         this.id = id;
         this.name = name;
         this.type = type;
         this.description = description;
+        this.defaultValue = defaultValue;
     }
 
     public int id() {
@@ -76,20 +81,24 @@ public final class DataField implements Serializable {
         return type;
     }
 
-    public DataField newId(int newid) {
-        return new DataField(newid, name, type, description);
+    public DataField newId(int newId) {
+        return new DataField(newId, name, type, description, defaultValue);
     }
 
     public DataField newName(String newName) {
-        return new DataField(id, newName, type, description);
+        return new DataField(id, newName, type, description, defaultValue);
     }
 
     public DataField newType(DataType newType) {
-        return new DataField(id, name, newType, description);
+        return new DataField(id, name, newType, description, defaultValue);
     }
 
     public DataField newDescription(String newDescription) {
-        return new DataField(id, name, type, newDescription);
+        return new DataField(id, name, type, defaultValue, newDescription);
+    }
+
+    public DataField newDefaultValue(String newDefaultValue) {
+        return new DataField(id, name, type, newDefaultValue, description);
     }
 
     @Nullable
@@ -97,28 +106,34 @@ public final class DataField implements Serializable {
         return description;
     }
 
+    @Nullable
+    public String defaultValue() {
+        return defaultValue;
+    }
+
     public DataField copy() {
-        return new DataField(id, name, type.copy(), description);
+        return new DataField(id, name, type.copy(), description, defaultValue);
     }
 
     public DataField copy(boolean isNullable) {
-        return new DataField(id, name, type.copy(isNullable), description);
+        return new DataField(id, name, type.copy(isNullable), description, defaultValue);
     }
 
     public String asSQLString() {
-        return formatString(type.asSQLString());
-    }
-
-    private String formatString(String typeString) {
-        if (description == null) {
-            return String.format(FIELD_FORMAT_NO_DESCRIPTION, escapeIdentifier(name), typeString);
-        } else {
-            return String.format(
-                    FIELD_FORMAT_WITH_DESCRIPTION,
-                    escapeIdentifier(name),
-                    typeString,
-                    escapeSingleQuotes(description));
+        StringBuilder sb = new StringBuilder();
+        sb.append(escapeIdentifier(name)).append(" ").append(type.asSQLString());
+        if (description != null) {
+            sb.append(" COMMENT ").append(escapeSingleQuotes(description));
         }
+        if (defaultValue != null) {
+            sb.append(" DEFAULT ");
+            if (type.getTypeRoot().getFamilies().contains(CHARACTER_STRING)) {
+                sb.append(escapeSingleQuotes(defaultValue));
+            } else {
+                sb.append(defaultValue);
+            }
+        }
+        return sb.toString();
     }
 
     public void serializeJson(JsonGenerator generator) throws IOException {
@@ -129,6 +144,9 @@ public final class DataField implements Serializable {
         type.serializeJson(generator);
         if (description() != null) {
             generator.writeStringField("description", description());
+        }
+        if (defaultValue() != null) {
+            generator.writeStringField("defaultValue", defaultValue());
         }
         generator.writeEndObject();
     }
@@ -145,7 +163,8 @@ public final class DataField implements Serializable {
         return Objects.equals(id, field.id)
                 && Objects.equals(name, field.name)
                 && Objects.equals(type, field.type)
-                && Objects.equals(description, field.description);
+                && Objects.equals(description, field.description)
+                && Objects.equals(defaultValue, field.defaultValue);
     }
 
     public boolean equalsIgnoreFieldId(DataField other) {
@@ -157,7 +176,8 @@ public final class DataField implements Serializable {
         }
         return Objects.equals(name, other.name)
                 && type.equalsIgnoreFieldId(other.type)
-                && Objects.equals(description, other.description);
+                && Objects.equals(description, other.description)
+                && Objects.equals(defaultValue, other.defaultValue);
     }
 
     public boolean isPrunedFrom(DataField other) {
@@ -170,12 +190,13 @@ public final class DataField implements Serializable {
         return Objects.equals(id, other.id)
                 && Objects.equals(name, other.name)
                 && type.isPrunedFrom(other.type)
-                && Objects.equals(description, other.description);
+                && Objects.equals(description, other.description)
+                && Objects.equals(defaultValue, other.defaultValue);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, type, description);
+        return Objects.hash(id, name, type, description, defaultValue);
     }
 
     @Override
@@ -193,7 +214,8 @@ public final class DataField implements Serializable {
         } else if (dataField1 != null && dataField2 != null) {
             return Objects.equals(dataField1.name(), dataField2.name())
                     && Objects.equals(dataField1.type(), dataField2.type())
-                    && Objects.equals(dataField1.description(), dataField2.description());
+                    && Objects.equals(dataField1.description(), dataField2.description())
+                    && Objects.equals(dataField1.defaultValue(), dataField2.defaultValue());
         } else {
             return false;
         }

--- a/paimon-api/src/main/java/org/apache/paimon/types/DataTypeJsonParser.java
+++ b/paimon-api/src/main/java/org/apache/paimon/types/DataTypeJsonParser.java
@@ -58,7 +58,12 @@ public final class DataTypeJsonParser {
         if (descriptionNode != null) {
             description = descriptionNode.asText();
         }
-        return new DataField(id, name, type, description);
+        JsonNode defaultValueNode = json.get("defaultValue");
+        String defaultValue = null;
+        if (defaultValueNode != null) {
+            defaultValue = defaultValueNode.asText();
+        }
+        return new DataField(id, name, type, description, defaultValue);
     }
 
     public static DataType parseDataType(JsonNode json) {

--- a/paimon-api/src/main/java/org/apache/paimon/types/RowType.java
+++ b/paimon-api/src/main/java/org/apache/paimon/types/RowType.java
@@ -27,6 +27,8 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCre
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonGenerator;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -387,7 +389,7 @@ public final class RowType extends DataType {
             return this;
         }
 
-        public Builder field(String name, DataType type, String description) {
+        public Builder field(String name, DataType type, @Nullable String description) {
             fields.add(new DataField(fieldId.incrementAndGet(), name, type, description));
             return this;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DefaultValueAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DefaultValueAssigner.java
@@ -69,10 +69,6 @@ public class DefaultValueAssigner {
         return this;
     }
 
-    public boolean needToAssign() {
-        return needToAssign;
-    }
-
     /** assign default value for column which value is null. */
     public RecordReader<InternalRow> assignFieldsDefaultValue(RecordReader<InternalRow> reader) {
         if (!needToAssign) {

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -404,7 +404,8 @@ public class SchemaManager implements Serializable {
                                             field.id(),
                                             rename.newName(),
                                             field.type(),
-                                            field.description());
+                                            field.description(),
+                                            field.defaultValue());
                             newFields.set(i, newField);
                             return;
                         }
@@ -463,7 +464,8 @@ public class SchemaManager implements Serializable {
                                             targetRootType,
                                             depth,
                                             update.fieldNames().length),
-                                    field.description());
+                                    field.description(),
+                                    field.defaultValue());
                         });
             } else if (change instanceof UpdateColumnNullability) {
                 UpdateColumnNullability update = (UpdateColumnNullability) change;
@@ -494,7 +496,8 @@ public class SchemaManager implements Serializable {
                                             sourceRootType,
                                             depth,
                                             update.fieldNames().length),
-                                    field.description());
+                                    field.description(),
+                                    field.defaultValue());
                         });
             } else if (change instanceof UpdateColumnComment) {
                 UpdateColumnComment update = (UpdateColumnComment) change;
@@ -506,7 +509,8 @@ public class SchemaManager implements Serializable {
                                         field.id(),
                                         field.name(),
                                         field.type(),
-                                        update.newDescription()));
+                                        update.newDescription(),
+                                        field.defaultValue()));
             } else if (change instanceof UpdateColumnPosition) {
                 UpdateColumnPosition update = (UpdateColumnPosition) change;
                 SchemaChange.Move move = update.move();
@@ -793,7 +797,8 @@ public class SchemaManager implements Serializable {
                                 field.id(),
                                 field.name(),
                                 wrapNewRowType(field.type(), nestedFields),
-                                field.description()));
+                                field.description(),
+                                field.defaultValue()));
                 return;
             }
 

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaMergingUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaMergingUtils.java
@@ -119,7 +119,8 @@ public class SchemaMergingUtils {
                                                     baseField.id(),
                                                     baseField.name(),
                                                     updatedDataType,
-                                                    baseField.description());
+                                                    baseField.description(),
+                                                    baseField.defaultValue());
                                         } else {
                                             return baseField;
                                         }
@@ -226,6 +227,10 @@ public class SchemaMergingUtils {
     private static DataField assignIdForNewField(DataField field, AtomicInteger highestFieldId) {
         DataType dataType = ReassignFieldId.reassign(field.type(), highestFieldId);
         return new DataField(
-                highestFieldId.incrementAndGet(), field.name(), dataType, field.description());
+                highestFieldId.incrementAndGet(),
+                field.name(),
+                dataType,
+                field.description(),
+                field.defaultValue());
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/schema/DataTypeJsonParserTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/DataTypeJsonParserTest.java
@@ -168,6 +168,17 @@ public class DataTypeJsonParserTest {
                                                         "f1",
                                                         new BooleanType(),
                                                         "This as well.")))),
+                TestSpec.forString(
+                                "{\"type\":\"ROW\",\"fields\":[{\"id\":0,\"name\":\"f0\",\"type\":\"INT NOT NULL\",\"description\":\"my_comment\",\"defaultValue\":\"55\"}]}")
+                        .expectType(
+                                new RowType(
+                                        Collections.singletonList(
+                                                new DataField(
+                                                        0,
+                                                        "f0",
+                                                        new IntType(false),
+                                                        "my_comment",
+                                                        "55")))),
 
                 // error message testing
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcFileFormat.java
@@ -203,7 +203,8 @@ public class OrcFileFormat extends FileFormat {
                                                         f.id(),
                                                         f.name(),
                                                         refineDataType(f.type()),
-                                                        f.description()))
+                                                        f.description(),
+                                                        f.defaultValue()))
                                 .collect(Collectors.toList()));
             default:
                 return type;

--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/spark/sql/connector/catalog/TableCatalogCapability.java
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/spark/sql/connector/catalog/TableCatalogCapability.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog;
+
+/**
+ * Capabilities that can be provided by a {@link TableCatalog} implementation.
+ */
+public enum TableCatalogCapability {
+
+  /**
+   * Signals that the TableCatalog supports defining generated columns upon table creation in SQL.
+   * <p>
+   * Without this capability, any create/replace table statements with a generated column defined
+   * in the table schema will throw an exception during analysis.
+   * <p>
+   * A generated column is defined with syntax: {@code colName colType GENERATED ALWAYS AS (expr)}
+   * <p>
+   * Generation expression are included in the column definition for APIs like
+   * {@link TableCatalog#createTable}.
+   */
+  SUPPORTS_CREATE_TABLE_WITH_GENERATED_COLUMNS,
+
+  /**
+   * Signals that the TableCatalog supports defining column default value as expression in
+   * CREATE/REPLACE/ALTER TABLE.
+   * <p>
+   * Without this capability, any CREATE/REPLACE/ALTER TABLE statement with a column default value
+   * defined in the table schema will throw an exception during analysis.
+   * <p>
+   * A column default value is defined with syntax: {@code colName colType DEFAULT expr}
+   * <p>
+   * Column default value expression is included in the column definition for APIs like
+   * {@link TableCatalog#createTable}.
+   */
+  SUPPORT_COLUMN_DEFAULT_VALUE
+}

--- a/paimon-spark/paimon-spark-3.3/src/main/java/org/apache/spark/sql/connector/catalog/TableCatalogCapability.java
+++ b/paimon-spark/paimon-spark-3.3/src/main/java/org/apache/spark/sql/connector/catalog/TableCatalogCapability.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog;
+
+/** Capabilities that can be provided by a {@link TableCatalog} implementation. */
+public enum TableCatalogCapability {
+
+    /**
+     * Signals that the TableCatalog supports defining generated columns upon table creation in SQL.
+     *
+     * <p>Without this capability, any create/replace table statements with a generated column
+     * defined in the table schema will throw an exception during analysis.
+     *
+     * <p>A generated column is defined with syntax: {@code colName colType GENERATED ALWAYS AS
+     * (expr)}
+     *
+     * <p>Generation expression are included in the column definition for APIs like {@link
+     * TableCatalog#createTable}.
+     */
+    SUPPORTS_CREATE_TABLE_WITH_GENERATED_COLUMNS,
+
+    /**
+     * Signals that the TableCatalog supports defining column default value as expression in
+     * CREATE/REPLACE/ALTER TABLE.
+     *
+     * <p>Without this capability, any CREATE/REPLACE/ALTER TABLE statement with a column default
+     * value defined in the table schema will throw an exception during analysis.
+     *
+     * <p>A column default value is defined with syntax: {@code colName colType DEFAULT expr}
+     *
+     * <p>Column default value expression is included in the column definition for APIs like {@link
+     * TableCatalog#createTable}.
+     */
+    SUPPORT_COLUMN_DEFAULT_VALUE
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -36,6 +36,7 @@ import org.apache.paimon.spark.utils.CatalogUtils;
 import org.apache.paimon.table.FormatTable;
 import org.apache.paimon.table.FormatTableOptions;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
 import org.apache.paimon.utils.TypeUtils;
 
 import org.apache.spark.sql.PaimonSparkSession$;
@@ -50,6 +51,7 @@ import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.NamespaceChange;
 import org.apache.spark.sql.connector.catalog.SupportsNamespaces;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.catalog.TableCatalogCapability;
 import org.apache.spark.sql.connector.catalog.TableChange;
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
 import org.apache.spark.sql.connector.expressions.FieldReference;
@@ -77,18 +79,22 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.CoreOptions.FILE_FORMAT;
 import static org.apache.paimon.CoreOptions.TYPE;
 import static org.apache.paimon.TableType.FORMAT_TABLE;
 import static org.apache.paimon.spark.SparkCatalogOptions.DEFAULT_DATABASE;
+import static org.apache.paimon.spark.SparkTypeUtils.CURRENT_DEFAULT_COLUMN_METADATA_KEY;
 import static org.apache.paimon.spark.SparkTypeUtils.toPaimonType;
 import static org.apache.paimon.spark.util.OptionUtils.checkRequiredConfigurations;
 import static org.apache.paimon.spark.util.OptionUtils.copyWithSQLConf;
 import static org.apache.paimon.spark.utils.CatalogUtils.checkNamespace;
+import static org.apache.paimon.spark.utils.CatalogUtils.checkNoDefaultValue;
 import static org.apache.paimon.spark.utils.CatalogUtils.removeCatalogName;
 import static org.apache.paimon.spark.utils.CatalogUtils.toIdentifier;
+import static org.apache.spark.sql.connector.catalog.TableCatalogCapability.SUPPORT_COLUMN_DEFAULT_VALUE;
 
 /** Spark {@link TableCatalog} for paimon. */
 public class SparkCatalog extends SparkBaseCatalog
@@ -102,6 +108,10 @@ public class SparkCatalog extends SparkBaseCatalog
     protected Catalog catalog = null;
 
     private String defaultDatabase;
+
+    public Set<TableCatalogCapability> capabilities() {
+        return Collections.singleton(SUPPORT_COLUMN_DEFAULT_VALUE);
+    }
 
     @Override
     public void initialize(String name, CaseInsensitiveStringMap options) {
@@ -353,6 +363,7 @@ public class SparkCatalog extends SparkBaseCatalog
         } else if (change instanceof TableChange.AddColumn) {
             TableChange.AddColumn add = (TableChange.AddColumn) change;
             SchemaChange.Move move = getMove(add.position(), add.fieldNames());
+            checkNoDefaultValue(add);
             return SchemaChange.addColumn(
                     add.fieldNames(),
                     toPaimonType(add.dataType()).copy(add.isNullable()),
@@ -428,10 +439,16 @@ public class SparkCatalog extends SparkBaseCatalog
                         .comment(properties.getOrDefault(TableCatalog.PROP_COMMENT, null));
 
         for (StructField field : schema.fields()) {
-            schemaBuilder.column(
-                    field.name(),
-                    toPaimonType(field.dataType()).copy(field.nullable()),
-                    field.getComment().getOrElse(() -> null));
+            String name = field.name();
+            DataType type = toPaimonType(field.dataType()).copy(field.nullable());
+            String comment = field.getComment().getOrElse(() -> null);
+            if (field.metadata().contains(CURRENT_DEFAULT_COLUMN_METADATA_KEY)) {
+                String defaultValue =
+                        field.metadata().getString(CURRENT_DEFAULT_COLUMN_METADATA_KEY);
+                schemaBuilder.column(name, type, comment, defaultValue);
+            } else {
+                schemaBuilder.column(name, type, comment);
+            }
         }
         return schemaBuilder.build();
     }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/utils/CatalogUtils.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/utils/CatalogUtils.java
@@ -27,7 +27,9 @@ import org.apache.paimon.types.MultisetType;
 
 import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
 import org.apache.spark.sql.catalyst.util.GenericArrayData;
+import org.apache.spark.sql.connector.catalog.ColumnDefaultValue;
 import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableChange;
 import org.apache.spark.sql.types.BooleanType;
 import org.apache.spark.sql.types.ByteType;
 import org.apache.spark.sql.types.DataTypes;
@@ -247,5 +249,18 @@ public class CatalogUtils {
         }
 
         throw new IllegalArgumentException("Unsupported Spark data type: " + sparkType);
+    }
+
+    public static void checkNoDefaultValue(TableChange.AddColumn addColumn) {
+        try {
+            ColumnDefaultValue defaultValue = addColumn.defaultValue();
+            if (defaultValue != null) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Cannot add column %s with default value %s.",
+                                Arrays.toString(addColumn.fieldNames()), defaultValue));
+            }
+        } catch (NoClassDefFoundError ignored) {
+        }
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Paimon allows specifying default values for columns. When users write to these tables without explicitly providing
values for certain columns, Paimon automatically generates default values for these columns.

#### Create Table

You can create a table with columns with default values using the following SQL:

```sql
CREATE TABLE my_table (
    a BIGINT,
    b STRING DEFAULT 'my_value',
    c INT DEFAULT 5 
);
```

#### Insert Table

For SQL commands that execute table writes, such as the `INSERT`, `UPDATE`, and `MERGE` commands, the `DEFAULT` keyword
or `NULL` value is parsed into the default value specified for the corresponding column.

#### Limitation

Currently, only specifying default values when creating tables is supported, and the following usage is not supported:

1. Not support alter table add column with default value, for example: `ALTER TABLE T ADD COLUMN d INT DEFAULT 5;`.
2. Not support alter table alter column set default value, for example: `ALTER TABLE T ALTER COLUMN d SET DEFAULT 5;`.


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
