### PR TITLE
[tool] Improve create_source_release.sh

### DIFF
--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -77,7 +77,7 @@ rsync -a \
   --exclude ".travis.yml" \
   . paimon-${RELEASE_VERSION}
 
-tar czf ${RELEASE_DIR}/apache-paimon-${RELEASE_VERSION}-src.tgz paimon-${RELEASE_VERSION}
+tar czf ${RELEASE_DIR}/apache-paimon-${RELEASE_VERSION}-src.tgz --no-xattrs paimon-${RELEASE_VERSION}
 gpg --armor --detach-sig ${RELEASE_DIR}/apache-paimon-${RELEASE_VERSION}-src.tgz
 cd ${RELEASE_DIR}
 ${SHASUM} apache-paimon-${RELEASE_VERSION}-src.tgz > apache-paimon-${RELEASE_VERSION}-src.tgz.sha512


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Explictly disable file extra attributes to avoid that mac users tape archive the sources with mac-related attributes.
see:
https://www.gnu.org/software/tar/manual/html_section/create-options.html#Extended-File-Attributes
https://cwiki.apache.org/confluence/display/PAIMON/Creating+a+Paimon+Release

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
