### PR TITLE
[cdc] Support computed columns when sync_database

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/ComputedColumnUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/ComputedColumnUtils.java
@@ -18,13 +18,18 @@
 
 package org.apache.paimon.flink.action.cdc;
 
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.utils.Preconditions;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -56,7 +61,7 @@ public class ComputedColumnUtils {
             }
             String columnName = kv[0].trim();
             String expression = kv[1].trim();
-            // parse expression
+            // parse expression-
             int left = expression.indexOf('(');
             int right = expression.indexOf(')');
             Preconditions.checkArgument(
@@ -75,6 +80,90 @@ public class ComputedColumnUtils {
                             Expression.create(typeMapping, caseSensitive, exprName, args)));
         }
 
-        return computedColumns;
+        return sortComputedColumns(computedColumns);
+    }
+
+    @VisibleForTesting
+    public static List<ComputedColumn> sortComputedColumns(List<ComputedColumn> columns) {
+        Set<String> columnNames = new HashSet<>();
+        for (ComputedColumn col : columns) {
+            columnNames.add(col.columnName());
+        }
+
+        // For simple processing, no reference or referring to another computed column, means
+        // independent
+        List<ComputedColumn> independent = new ArrayList<>();
+        List<ComputedColumn> dependent = new ArrayList<>();
+
+        for (ComputedColumn col : columns) {
+            if (col.fieldReference() == null || !columnNames.contains(col.fieldReference())) {
+                independent.add(col);
+            } else {
+                dependent.add(col);
+            }
+        }
+
+        // Sort dependent columns with topological sort
+        Map<String, ComputedColumn> columnMap = new HashMap<>();
+        Map<String, Set<String>> reverseDependencies = new HashMap<>();
+
+        for (ComputedColumn col : dependent) {
+            columnMap.put(col.columnName(), col);
+            reverseDependencies
+                    .computeIfAbsent(col.fieldReference(), k -> new HashSet<>())
+                    .add(col.columnName());
+        }
+
+        List<ComputedColumn> sortedDependent = new ArrayList<>();
+        Set<String> visited = new HashSet<>();
+        Set<String> tempMark = new HashSet<>(); // For cycle detection
+
+        for (ComputedColumn col : dependent) {
+            if (!visited.contains(col.columnName())) {
+                dfs(
+                        col.columnName(),
+                        reverseDependencies,
+                        columnMap,
+                        sortedDependent,
+                        visited,
+                        tempMark);
+            }
+        }
+
+        Collections.reverse(sortedDependent);
+
+        // Independent should precede dependent
+        List<ComputedColumn> result = new ArrayList<>();
+        result.addAll(independent);
+        result.addAll(sortedDependent);
+
+        return result;
+    }
+
+    private static void dfs(
+            String node,
+            Map<String, Set<String>> reverseDependencies,
+            Map<String, ComputedColumn> columnMap,
+            List<ComputedColumn> sorted,
+            Set<String> visited,
+            Set<String> tempMark) {
+        if (tempMark.contains(node)) {
+            throw new IllegalArgumentException("Cycle detected: " + node);
+        }
+        if (visited.contains(node)) {
+            return;
+        }
+
+        tempMark.add(node);
+        ComputedColumn current = columnMap.get(node);
+
+        // Process the dependencies
+        for (String dependent : reverseDependencies.getOrDefault(node, Collections.emptySet())) {
+            dfs(dependent, reverseDependencies, columnMap, sorted, visited, tempMark);
+        }
+
+        tempMark.remove(node);
+        visited.add(node);
+        sorted.add(current);
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/Expression.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/Expression.java
@@ -24,6 +24,7 @@ import org.apache.paimon.types.DataTypeFamily;
 import org.apache.paimon.types.DataTypeJsonParser;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.VariantType;
 import org.apache.paimon.utils.DateTimeUtils;
 import org.apache.paimon.utils.SerializableSupplier;
 import org.apache.paimon.utils.StringUtils;
@@ -226,11 +227,13 @@ public interface Expression extends Serializable {
                     StringUtils.toLowerCaseIfNeed(referencedField, caseSensitive);
 
             DataType fieldType =
-                    checkNotNull(
-                            typeMapping.get(referencedFieldCheckForm),
-                            String.format(
-                                    "Referenced field '%s' is not in given fields: %s.",
-                                    referencedFieldCheckForm, typeMapping.keySet()));
+                    typeMapping.isEmpty()
+                            ? new VariantType()
+                            : checkNotNull(
+                                    typeMapping.get(referencedFieldCheckForm),
+                                    String.format(
+                                            "Referenced field '%s' is not in given fields: %s.",
+                                            referencedFieldCheckForm, typeMapping.keySet()));
             return new ReferencedField(referencedField, fieldType, literals);
         }
 

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/ComputedColumnUtilsTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/ComputedColumnUtilsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action.cdc;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.flink.action.cdc.ComputedColumnUtils.sortComputedColumns;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Test for ComputedColumnUtils. */
+public class ComputedColumnUtilsTest {
+    @Test
+    public void test() {
+        List<ComputedColumn> columns =
+                Arrays.asList(
+                        new ComputedColumn("A", Expression.substring("B", "1")),
+                        new ComputedColumn("B", Expression.substring("ExistedColumn", "1")),
+                        new ComputedColumn("C", Expression.cast("No Reference")),
+                        new ComputedColumn("D", Expression.substring("A", "1")),
+                        new ComputedColumn("E", Expression.substring("C", "1")));
+
+        List<ComputedColumn> sortedColumns = sortComputedColumns(columns);
+        assertEquals(
+                Arrays.asList("B", "C", "E", "A", "D"),
+                sortedColumns.stream()
+                        .map(ComputedColumn::columnName)
+                        .collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testCycleReference() {
+        List<ComputedColumn> columns =
+                Arrays.asList(
+                        new ComputedColumn("A", Expression.substring("B", "1")),
+                        new ComputedColumn("B", Expression.substring("C", "1")),
+                        new ComputedColumn("C", Expression.substring("A", "1")));
+
+        assertThrows(IllegalArgumentException.class, () -> sortComputedColumns(columns));
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->
To use computed columns when sync_database. The computed columns could refer to existed fields or other computed columns.

### Tests

<!-- List UT and IT cases to verify this change -->
1. Test computed columns when sync_database, with e2e case 
org.apache.paimon.flink.action.cdc.kafka.KafkaCanalSyncDatabaseActionITCase#testExpressionNow
, by adding a new filed: pt=date_format(etl_update_time,yyyy-MM-dd).

2. Test the sortting of computed columns, with case: 
org.apache.paimon.flink.action.cdc.ComputedColumnUtilsTest

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
