### PR TITLE
[WIP][core] Optimize FileChannelManager.close with concurrent file deletion

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/disk/FileChannelManagerImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/FileChannelManagerImpl.java
@@ -123,11 +123,12 @@ public class FileChannelManagerImpl implements FileChannelManager {
     /** Remove all the temp directories. */
     @Override
     public void close() throws Exception {
-        IOUtils.closeAll(
+        IOUtils.closeAllConcurrently(
                 Arrays.stream(paths)
                         .filter(File::exists)
                         .map(this::getFileCloser)
-                        .collect(Collectors.toList()));
+                        .collect(Collectors.toList()),
+                Exception.class);
         LOG.info(
                 "Closed {} with directories:\n\t{}",
                 FileChannelManager.class.getSimpleName(),


### PR DESCRIPTION
### Purpose

In a Flink job that writes to Paimon on Alibaba cloud, the user found out that it takes relatively long time for the Flink job to finish or be cancelled. Looking into the stack trace of the subtask, we discovered that the Paimon operator is busy deleting its temporary files in the closing process.
![image](https://github.com/user-attachments/assets/b9192b01-d005-4a21-841a-8b41e4e536e8)
![image](https://github.com/user-attachments/assets/fa75344c-714c-405b-b743-1e28d03aacdd)

Therefore, this PR proposes to execute temporary file deletions concurrently to reduce the closing time of Paimon operators in cases like above.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
