### PR TITLE
[core] Rename PartitionListener to CommitListener

### DIFF
--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MarkPartitionDoneProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/MarkPartitionDoneProcedure.java
@@ -32,7 +32,7 @@ import org.apache.flink.table.procedure.ProcedureContext;
 import java.io.IOException;
 import java.util.List;
 
-import static org.apache.paimon.flink.sink.partition.PartitionMarkDone.markDone;
+import static org.apache.paimon.flink.sink.partition.PartitionMarkDoneListener.markDone;
 import static org.apache.paimon.utils.ParameterUtils.getPartitions;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MarkPartitionDoneAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MarkPartitionDoneAction.java
@@ -26,7 +26,7 @@ import org.apache.paimon.utils.PartitionPathUtils;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.paimon.flink.sink.partition.PartitionMarkDone.markDone;
+import static org.apache.paimon.flink.sink.partition.PartitionMarkDoneListener.markDone;
 
 /** Table partition mark done action for Flink. */
 public class MarkPartitionDoneAction extends TableActionBase {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MarkPartitionDoneProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/MarkPartitionDoneProcedure.java
@@ -35,7 +35,7 @@ import org.apache.flink.table.procedure.ProcedureContext;
 import java.io.IOException;
 import java.util.List;
 
-import static org.apache.paimon.flink.sink.partition.PartitionMarkDone.markDone;
+import static org.apache.paimon.flink.sink.partition.PartitionMarkDoneListener.markDone;
 import static org.apache.paimon.utils.ParameterUtils.getPartitions;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
@@ -20,7 +20,7 @@ package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.flink.metrics.FlinkMetricRegistry;
-import org.apache.paimon.flink.sink.partition.PartitionListeners;
+import org.apache.paimon.flink.sink.partition.CommitListeners;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.table.BucketMode;
@@ -44,7 +44,7 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
 
     private final TableCommitImpl commit;
     @Nullable private final CommitterMetrics committerMetrics;
-    private final PartitionListeners partitionListeners;
+    private final CommitListeners commitListeners;
     private final boolean allowLogOffsetDuplicate;
 
     public StoreCommitter(FileStoreTable table, TableCommit commit, Context context) {
@@ -58,7 +58,7 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
         }
 
         try {
-            this.partitionListeners = PartitionListeners.create(context, table);
+            this.commitListeners = CommitListeners.create(context, table);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -110,7 +110,7 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
             throws IOException, InterruptedException {
         commit.commitMultiple(committables, false);
         calcNumBytesAndRecordsOut(committables);
-        partitionListeners.notifyCommittable(committables);
+        commitListeners.notifyCommittable(committables);
     }
 
     @Override
@@ -119,7 +119,7 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
             boolean checkAppendFiles,
             boolean partitionMarkDoneRecoverFromState) {
         int committed = commit.filterAndCommitMultiple(globalCommittables, checkAppendFiles);
-        partitionListeners.notifyCommittable(globalCommittables, partitionMarkDoneRecoverFromState);
+        commitListeners.notifyCommittable(globalCommittables, partitionMarkDoneRecoverFromState);
 
         return committed;
     }
@@ -127,7 +127,7 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
     @Override
     public Map<Long, List<Committable>> groupByCheckpoint(Collection<Committable> committables) {
         try {
-            partitionListeners.snapshotState();
+            commitListeners.snapshotState();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -142,7 +142,7 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
     @Override
     public void close() throws Exception {
         commit.close();
-        partitionListeners.close();
+        commitListeners.close();
     }
 
     public boolean allowLogOffsetDuplicate() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/CommitListener.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/CommitListener.java
@@ -24,10 +24,9 @@ import java.io.Closeable;
 import java.util.List;
 
 /** The partition listener. */
-public interface PartitionListener extends Closeable {
+public interface CommitListener extends Closeable {
 
-    void notifyCommittable(
-            List<ManifestCommittable> committables, boolean partitionMarkDoneRecoverFromState);
+    void notifyCommittable(List<ManifestCommittable> committables);
 
     void snapshotState() throws Exception;
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/ReportPartStatsListener.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/partition/ReportPartStatsListener.java
@@ -50,7 +50,7 @@ import java.util.Set;
  * This listener will collect data from the newly touched partition and then decide when to trigger
  * a report based on the partition's idle time.
  */
-public class ReportPartStatsListener implements PartitionListener {
+public class ReportPartStatsListener implements CommitListener {
 
     @SuppressWarnings("unchecked")
     private static final ListStateDescriptor<Map<String, Long>> PENDING_REPORT_STATE_DESC =
@@ -85,8 +85,8 @@ public class ReportPartStatsListener implements PartitionListener {
         this.idleTime = idleTime;
     }
 
-    public void notifyCommittable(
-            List<ManifestCommittable> committables, boolean partitionMarkDoneRecoverFromState) {
+    @Override
+    public void notifyCommittable(List<ManifestCommittable> committables) {
         Set<String> partition = new HashSet<>();
         boolean endInput = false;
         for (ManifestCommittable committable : committables) {
@@ -136,6 +136,7 @@ public class ReportPartStatsListener implements PartitionListener {
         return result;
     }
 
+    @Override
     public void snapshotState() throws Exception {
         pendingPartitionsState.update(Collections.singletonList(pendingPartitions));
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/CustomPartitionMarkDoneActionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/CustomPartitionMarkDoneActionTest.java
@@ -62,7 +62,7 @@ public class CustomPartitionMarkDoneActionTest extends TableTestBase {
         // set.
         Assertions.assertThatThrownBy(
                         () ->
-                                PartitionMarkDone.create(
+                                PartitionMarkDoneListener.create(
                                         getClass().getClassLoader(),
                                         false,
                                         false,
@@ -85,8 +85,8 @@ public class CustomPartitionMarkDoneActionTest extends TableTestBase {
 
         FileStoreTable table2 = (FileStoreTable) catalog.getTable(identifier);
 
-        PartitionMarkDone markDone =
-                PartitionMarkDone.create(
+        PartitionMarkDoneListener markDone =
+                PartitionMarkDoneListener.create(
                                 getClass().getClassLoader(),
                                 false,
                                 false,

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/PartitionMarkDoneTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/PartitionMarkDoneTest.java
@@ -146,7 +146,9 @@ class PartitionMarkDoneTest extends TableTestBase {
                             new IndexIncrement(emptyList()));
         }
         committable.addFileCommittable(compactMessage);
-        markDone.notifyCommittable(singletonList(committable), partitionMarkDoneRecoverFromState);
+        if (partitionMarkDoneRecoverFromState) {
+            markDone.notifyCommittable(singletonList(committable));
+        }
     }
 
     public static class MockOperatorStateStore implements OperatorStateStore {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/PartitionMarkDoneTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/partition/PartitionMarkDoneTest.java
@@ -91,8 +91,8 @@ class PartitionMarkDoneTest extends TableTestBase {
         FileStoreTable table = (FileStoreTable) catalog.getTable(identifier);
         Path location = table.location();
         Path successFile = new Path(location, "a=0/_SUCCESS");
-        PartitionMarkDone markDone =
-                PartitionMarkDone.create(
+        PartitionMarkDoneListener markDone =
+                PartitionMarkDoneListener.create(
                                 getClass().getClassLoader(),
                                 false,
                                 false,
@@ -115,12 +115,12 @@ class PartitionMarkDoneTest extends TableTestBase {
         }
     }
 
-    public static void notifyCommits(PartitionMarkDone markDone, boolean isCompact) {
+    public static void notifyCommits(PartitionMarkDoneListener markDone, boolean isCompact) {
         notifyCommits(markDone, isCompact, true);
     }
 
     private static void notifyCommits(
-            PartitionMarkDone markDone,
+            PartitionMarkDoneListener markDone,
             boolean isCompact,
             boolean partitionMarkDoneRecoverFromState) {
         ManifestCommittable committable = new ManifestCommittable(Long.MAX_VALUE);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
1. It should be CommitListener
2. Do not add `partitionMarkDoneRecoverFromState` to CommitListener

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
