### PR TITLE
[core] Add a config to support keeping first N columns' stats in metadata.

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -610,6 +610,12 @@ Mainly to resolve data skew on primary keys. We recommend starting with 64 mb wh
             <td>Whether to store statistic densely in metadata (manifest files), which will significantly reduce the storage size of metadata when the none statistic mode is set.<br />Note, when this mode is enabled with 'metadata.stats-mode:none', the Paimon sdk in reading engine requires at least version 0.9.1 or 1.0.0 or higher.</td>
         </tr>
         <tr>
+            <td><h5>metadata.stats-keep-first-n-columns</h5></td>
+            <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
+            <td>Define how many columns' stats are kept in metadata file from front to end. Default value '-1' means ignoring this config.</td>
+        </tr>
+        <tr>
             <td><h5>metadata.stats-mode</h5></td>
             <td style="word-wrap: break-word;">"truncate(16)"</td>
             <td>String</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1242,6 +1242,14 @@ public class CoreOptions implements Serializable {
                                                     + " reading engine requires at least version 0.9.1 or 1.0.0 or higher.")
                                     .build());
 
+    public static final ConfigOption<Integer> METADATA_STATS_KEEP_FIRST_N_COLUMNS =
+            key("metadata.stats-keep-first-n-columns")
+                    .intType()
+                    .defaultValue(-1)
+                    .withDescription(
+                            "Define how many columns' stats are kept in metadata file from front to end. "
+                                    + "Default value '-1' means ignoring this config.");
+
     public static final ConfigOption<String> COMMIT_CALLBACKS =
             key("commit.callbacks")
                     .stringType()
@@ -2727,6 +2735,10 @@ public class CoreOptions implements Serializable {
 
     public boolean statsDenseStore() {
         return options.get(METADATA_STATS_DENSE_STORE);
+    }
+
+    public int statsKeepFirstNColumns() {
+        return options.get(METADATA_STATS_KEEP_FIRST_N_COLUMNS);
     }
 
     public boolean dataFileThinMode() {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Users may not want to config the stats column by column, so I add a config to support keeping a fixed number columns' stats in metadata. The rest columns' stats will be set to none.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
org.apache.paimon.utils.StatsCollectorFactoriesTest#testPrefixStats

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
added
