### PR TITLE
[spark] Instantiate FileStoreTable by accessing HMS (Hive Metastore) via tableId in SparkSource#loadTable.

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -165,6 +165,13 @@ public class CoreOptions implements Serializable {
                     .noDefaultValue()
                     .withDescription("The file path of this table in the filesystem.");
 
+    @ExcludeFromDocumentation("Internal use only")
+    public static final ConfigOption<String> TABLE_ID =
+            key("table")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The full name of the table.");
+
     @ExcludeFromDocumentation("Avoid using deprecated options")
     public static final ConfigOption<String> BRANCH =
             key("branch").stringType().defaultValue("main").withDescription("Specify branch name.");
@@ -1807,6 +1814,10 @@ public class CoreOptions implements Serializable {
 
     public static Path path(Options options) {
         return new Path(options.get(PATH));
+    }
+
+    public static String tableId(Map<String, String> options) {
+        return options.get(TABLE_ID.key());
     }
 
     public TableType type() {


### PR DESCRIPTION
### Purpose

This PR aims to retrieve FileStoreTable information via HMS in SparkSource#loadTable.
1.  DataFrame can be written using df.write.format("paimon").mode("append").option("table",  "default.T").save()"

2. The operation remains functional even if the table path in MetaStore deviates from the strict format like "warehouse_path/your_database.db/your_table" .


<!-- Linking this pull request to the issue -->
Linked issue:  #5770 