### PR TITLE
[hotfix] Rest: optimize return type of ListTablesGlobally & ListViewsGlobally

### DIFF
--- a/docs/static/rest-catalog-open-api.yaml
+++ b/docs/static/rest-catalog-open-api.yaml
@@ -367,7 +367,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListTablesResponse'
+                $ref: '#/components/schemas/ListTablesGloballyResponse'
         "401":
           $ref: '#/components/responses/UnauthorizedErrorResponse'
         "500":
@@ -1237,7 +1237,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListViewsResponse'
+                $ref: '#/components/schemas/ListViewsGloballyResponse'
         "401":
           $ref: '#/components/responses/UnauthorizedErrorResponse'
         "500":
@@ -2624,7 +2624,7 @@ components:
           type: array
           items:
             type: string
-            description: table name or full table name of the table. full table name format is like "db.table"
+            description: table name of the table.
         nextPageToken:
           type: string
     ListTableDetailsResponse:
@@ -2634,6 +2634,16 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/GetTableResponse'
+        nextPageToken:
+          type: string
+    ListTablesGloballyResponse:
+      type: object
+      properties:
+        tables:
+          type: array
+          items:
+            identifier:
+              $ref: '#/components/schemas/Identifier'
         nextPageToken:
           type: string
     ConfigResponse:
@@ -2702,7 +2712,7 @@ components:
           type: array
           items:
             type: string
-            description: view name or full view name of the view. full view name format is like "db.view"
+            description: view name of the view.
         nextPageToken:
           type: string
     ListViewDetailsResponse:
@@ -2712,6 +2722,16 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/GetViewResponse'
+        nextPageToken:
+          type: string
+    ListViewsGloballyResponse:
+      type: object
+      properties:
+        tables:
+          type: array
+          items:
+            identifier:
+              $ref: '#/components/schemas/Identifier'
         nextPageToken:
           type: string
     ListFunctionsResponse:

--- a/docs/static/rest-catalog-open-api.yaml
+++ b/docs/static/rest-catalog-open-api.yaml
@@ -333,7 +333,7 @@ paths:
       tags:
         - table
       summary: List tables globally
-      operationId: List tables globally
+      operationId: ListTablesGlobally
       description: list tables paged globally which matches the given database name pattern and table name pattern both.
       parameters:
         - name: prefix

--- a/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
@@ -65,8 +65,10 @@ import org.apache.paimon.rest.responses.ListFunctionsResponse;
 import org.apache.paimon.rest.responses.ListPartitionsResponse;
 import org.apache.paimon.rest.responses.ListSnapshotsResponse;
 import org.apache.paimon.rest.responses.ListTableDetailsResponse;
+import org.apache.paimon.rest.responses.ListTablesGloballyResponse;
 import org.apache.paimon.rest.responses.ListTablesResponse;
 import org.apache.paimon.rest.responses.ListViewDetailsResponse;
+import org.apache.paimon.rest.responses.ListViewsGloballyResponse;
 import org.apache.paimon.rest.responses.ListViewsResponse;
 import org.apache.paimon.rest.responses.PagedResponse;
 import org.apache.paimon.schema.Schema;
@@ -425,12 +427,12 @@ public class RESTApi {
      * @throws ForbiddenException Exception thrown on HTTP 403 means don't have the permission for
      *     this database
      */
-    public PagedList<String> listTablesPagedGlobally(
+    public PagedList<Identifier> listTablesPagedGlobally(
             @Nullable String databaseNamePattern,
             @Nullable String tableNamePattern,
             @Nullable Integer maxResults,
             @Nullable String pageToken) {
-        ListTablesResponse response =
+        ListTablesGloballyResponse response =
                 client.get(
                         resourcePaths.tables(),
                         buildPagedQueryParams(
@@ -438,9 +440,9 @@ public class RESTApi {
                                 pageToken,
                                 Pair.of(DATABASE_NAME_PATTERN, databaseNamePattern),
                                 Pair.of(TABLE_NAME_PATTERN, tableNamePattern)),
-                        ListTablesResponse.class,
+                        ListTablesGloballyResponse.class,
                         restAuthFunction);
-        List<String> tables = response.getTables();
+        List<Identifier> tables = response.getTables();
         if (tables == null) {
             return new PagedList<>(emptyList(), null);
         }
@@ -1073,12 +1075,12 @@ public class RESTApi {
      * @throws ForbiddenException Exception thrown on HTTP 403 means don't have the permission for
      *     this database
      */
-    public PagedList<String> listViewsPagedGlobally(
+    public PagedList<Identifier> listViewsPagedGlobally(
             @Nullable String databaseNamePattern,
             @Nullable String viewNamePattern,
             @Nullable Integer maxResults,
             @Nullable String pageToken) {
-        ListViewsResponse response =
+        ListViewsGloballyResponse response =
                 client.get(
                         resourcePaths.views(),
                         buildPagedQueryParams(
@@ -1086,9 +1088,9 @@ public class RESTApi {
                                 pageToken,
                                 Pair.of(DATABASE_NAME_PATTERN, databaseNamePattern),
                                 Pair.of(VIEW_NAME_PATTERN, viewNamePattern)),
-                        ListViewsResponse.class,
+                        ListViewsGloballyResponse.class,
                         restAuthFunction);
-        List<String> views = response.getViews();
+        List<Identifier> views = response.getViews();
         if (views == null) {
             return new PagedList<>(emptyList(), null);
         }

--- a/paimon-api/src/main/java/org/apache/paimon/rest/responses/ListTablesGloballyResponse.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/responses/ListTablesGloballyResponse.java
@@ -27,7 +27,7 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonPro
 
 import java.util.List;
 
-/** Response for listing tables. */
+/** Response for listing tables globally. */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ListTablesGloballyResponse implements PagedResponse<Identifier> {
 

--- a/paimon-api/src/main/java/org/apache/paimon/rest/responses/ListTablesGloballyResponse.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/responses/ListTablesGloballyResponse.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest.responses;
+
+import org.apache.paimon.catalog.Identifier;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/** Response for listing tables. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ListTablesGloballyResponse implements PagedResponse<Identifier> {
+
+    private static final String FIELD_TABLES = "tables";
+    private static final String FIELD_NEXT_PAGE_TOKEN = "nextPageToken";
+
+    @JsonProperty(FIELD_TABLES)
+    private final List<Identifier> tables;
+
+    @JsonProperty(FIELD_NEXT_PAGE_TOKEN)
+    private final String nextPageToken;
+
+    public ListTablesGloballyResponse(@JsonProperty(FIELD_TABLES) List<Identifier> tables) {
+        this(tables, null);
+    }
+
+    @JsonCreator
+    public ListTablesGloballyResponse(
+            @JsonProperty(FIELD_TABLES) List<Identifier> tables,
+            @JsonProperty(FIELD_NEXT_PAGE_TOKEN) String nextPageToken) {
+        this.tables = tables;
+        this.nextPageToken = nextPageToken;
+    }
+
+    @JsonGetter(FIELD_TABLES)
+    public List<Identifier> getTables() {
+        return this.tables;
+    }
+
+    @JsonGetter(FIELD_NEXT_PAGE_TOKEN)
+    public String getNextPageToken() {
+        return this.nextPageToken;
+    }
+
+    @Override
+    public List<Identifier> data() {
+        return getTables();
+    }
+}

--- a/paimon-api/src/main/java/org/apache/paimon/rest/responses/ListViewsGloballyResponse.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/responses/ListViewsGloballyResponse.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest.responses;
+
+import org.apache.paimon.catalog.Identifier;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/** Response for listing views. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ListViewsGloballyResponse implements PagedResponse<Identifier> {
+
+    private static final String FIELD_VIEWS = "views";
+
+    private static final String FIELD_NEXT_PAGE_TOKEN = "nextPageToken";
+
+    @JsonProperty(FIELD_VIEWS)
+    private final List<Identifier> views;
+
+    @JsonProperty(FIELD_NEXT_PAGE_TOKEN)
+    private final String nextPageToken;
+
+    public ListViewsGloballyResponse(@JsonProperty(FIELD_VIEWS) List<Identifier> views) {
+        this(views, null);
+    }
+
+    @JsonCreator
+    public ListViewsGloballyResponse(
+            @JsonProperty(FIELD_VIEWS) List<Identifier> views,
+            @JsonProperty(FIELD_NEXT_PAGE_TOKEN) String nextPageToken) {
+        this.views = views;
+        this.nextPageToken = nextPageToken;
+    }
+
+    @JsonGetter(FIELD_VIEWS)
+    public List<Identifier> getViews() {
+        return this.views;
+    }
+
+    @JsonGetter(FIELD_NEXT_PAGE_TOKEN)
+    public String getNextPageToken() {
+        return this.nextPageToken;
+    }
+
+    @Override
+    public List<Identifier> data() {
+        return getViews();
+    }
+}

--- a/paimon-api/src/main/java/org/apache/paimon/rest/responses/ListViewsGloballyResponse.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/responses/ListViewsGloballyResponse.java
@@ -27,7 +27,7 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonPro
 
 import java.util.List;
 
-/** Response for listing views. */
+/** Response for listing views globally. */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ListViewsGloballyResponse implements PagedResponse<Identifier> {
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -235,7 +235,7 @@ public interface Catalog extends AutoCloseable {
      * @throws UnsupportedOperationException if does not {@link #supportsListObjectsPaged()} or does
      *     not {@link #supportsListByPattern()}.
      */
-    default PagedList<String> listTablesPagedGlobally(
+    default PagedList<Identifier> listTablesPagedGlobally(
             @Nullable String databaseNamePattern,
             @Nullable String tableNamePattern,
             @Nullable Integer maxResults,
@@ -500,7 +500,7 @@ public interface Catalog extends AutoCloseable {
      * @throws UnsupportedOperationException if does not {@link #supportsListObjectsPaged()} or does
      *     not {@link #supportsListByPattern()}}.
      */
-    default PagedList<String> listViewsPagedGlobally(
+    default PagedList<Identifier> listViewsPagedGlobally(
             @Nullable String databaseNamePattern,
             @Nullable String viewNamePattern,
             @Nullable Integer maxResults,

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -115,7 +115,7 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
-    public PagedList<String> listTablesPagedGlobally(
+    public PagedList<Identifier> listTablesPagedGlobally(
             String databaseNamePattern,
             String tableNamePattern,
             Integer maxResults,
@@ -316,7 +316,7 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
-    public PagedList<String> listViewsPagedGlobally(
+    public PagedList<Identifier> listViewsPagedGlobally(
             String databaseNamePattern,
             String viewNamePattern,
             Integer maxResults,

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -251,12 +251,12 @@ public class RESTCatalog implements Catalog {
     }
 
     @Override
-    public PagedList<String> listTablesPagedGlobally(
+    public PagedList<Identifier> listTablesPagedGlobally(
             @Nullable String databaseNamePattern,
             @Nullable String tableNamePattern,
             @Nullable Integer maxResults,
             @Nullable String pageToken) {
-        PagedList<String> tables =
+        PagedList<Identifier> tables =
                 api.listTablesPagedGlobally(
                         databaseNamePattern, tableNamePattern, maxResults, pageToken);
         return new PagedList<>(tables.getElements(), tables.getNextPageToken());
@@ -819,12 +819,12 @@ public class RESTCatalog implements Catalog {
     }
 
     @Override
-    public PagedList<String> listViewsPagedGlobally(
+    public PagedList<Identifier> listViewsPagedGlobally(
             @Nullable String databaseNamePattern,
             @Nullable String viewNamePattern,
             @Nullable Integer maxResults,
             @Nullable String pageToken) {
-        PagedList<String> views =
+        PagedList<Identifier> views =
                 api.listViewsPagedGlobally(
                         databaseNamePattern, viewNamePattern, maxResults, pageToken);
         return new PagedList<>(views.getElements(), views.getNextPageToken());

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -76,8 +76,10 @@ import org.apache.paimon.rest.responses.ListFunctionsResponse;
 import org.apache.paimon.rest.responses.ListPartitionsResponse;
 import org.apache.paimon.rest.responses.ListSnapshotsResponse;
 import org.apache.paimon.rest.responses.ListTableDetailsResponse;
+import org.apache.paimon.rest.responses.ListTablesGloballyResponse;
 import org.apache.paimon.rest.responses.ListTablesResponse;
 import org.apache.paimon.rest.responses.ListViewDetailsResponse;
+import org.apache.paimon.rest.responses.ListViewsGloballyResponse;
 import org.apache.paimon.rest.responses.ListViewsResponse;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
@@ -1051,34 +1053,35 @@ public class RESTCatalogServer {
         return mockResponse(response, 200);
     }
 
-    private <T> PagedList<T> buildPagedEntities(List<T> names, int maxResults, String pageToken) {
-        return buildPagedEntities(names, maxResults, pageToken, false);
+    private <T> PagedList<T> buildPagedEntities(
+            List<T> entities, int maxResults, String pageToken) {
+        return buildPagedEntities(entities, maxResults, pageToken, false);
     }
 
     private <T> PagedList<T> buildPagedEntities(
-            List<T> names, int maxResults, String pageToken, boolean desc) {
+            List<T> entities, int maxResults, String pageToken, boolean desc) {
         Comparator<Object> comparator = this::compareTo;
         if (desc) {
             comparator = comparator.reversed();
         }
-        List<T> sortedNames = names.stream().sorted(comparator).collect(Collectors.toList());
-        List<T> pagedNames = new ArrayList<>();
-        for (T sortedName : sortedNames) {
-            if (pagedNames.size() < maxResults) {
+        List<T> sortedEntities = entities.stream().sorted(comparator).collect(Collectors.toList());
+        List<T> pagedEntities = new ArrayList<>();
+        for (T sortedEntity : sortedEntities) {
+            if (pagedEntities.size() < maxResults) {
                 if (pageToken == null) {
-                    pagedNames.add(sortedName);
-                } else if (comparator.compare(sortedName, pageToken) > 0) {
-                    pagedNames.add(sortedName);
+                    pagedEntities.add(sortedEntity);
+                } else if (comparator.compare(sortedEntity, pageToken) > 0) {
+                    pagedEntities.add(sortedEntity);
                 }
             } else {
                 break;
             }
         }
-        if (maxResults > sortedNames.size() && pageToken == null) {
-            return new PagedList<>(pagedNames, null);
+        if (maxResults > sortedEntities.size() && pageToken == null) {
+            return new PagedList<>(pagedEntities, null);
         } else {
-            String nextPageToken = getNextPageTokenForEntities(pagedNames, maxResults);
-            return new PagedList<>(pagedNames, nextPageToken);
+            String nextPageToken = getNextPageTokenForEntities(pagedEntities, maxResults);
+            return new PagedList<>(pagedEntities, nextPageToken);
         }
     }
 
@@ -1293,7 +1296,7 @@ public class RESTCatalogServer {
 
     private MockResponse tablesHandle(Map<String, String> parameters) {
         RESTResponse response;
-        List<String> tables = listTables(parameters);
+        List<Identifier> tables = listTables(parameters);
         if (!tables.isEmpty()) {
             int maxResults;
             try {
@@ -1302,9 +1305,9 @@ public class RESTCatalogServer {
                 return handleInvalidMaxResults(parameters);
             }
             String pageToken = parameters.get(PAGE_TOKEN);
-            PagedList<String> pagedTables = buildPagedEntities(tables, maxResults, pageToken);
+            PagedList<Identifier> pagedTables = buildPagedEntities(tables, maxResults, pageToken);
             response =
-                    new ListTablesResponse(
+                    new ListTablesGloballyResponse(
                             pagedTables.getElements(), pagedTables.getNextPageToken());
         } else {
             response = new ListTablesResponse(Collections.emptyList(), null);
@@ -1312,10 +1315,10 @@ public class RESTCatalogServer {
         return mockResponse(response, 200);
     }
 
-    private List<String> listTables(Map<String, String> parameters) {
+    private List<Identifier> listTables(Map<String, String> parameters) {
         String tableNamePattern = parameters.get(TABLE_NAME_PATTERN);
         String databaseNamePattern = parameters.get(DATABASE_NAME_PATTERN);
-        List<String> tables = new ArrayList<>();
+        List<Identifier> tables = new ArrayList<>();
         for (Map.Entry<String, TableMetadata> entry : tableMetadataStore.entrySet()) {
             Identifier identifier = Identifier.fromString(entry.getKey());
             if ((Objects.isNull(databaseNamePattern))
@@ -1323,7 +1326,7 @@ public class RESTCatalogServer {
                             && (Objects.isNull(tableNamePattern)
                                     || matchNamePattern(
                                             identifier.getTableName(), tableNamePattern))) {
-                tables.add(identifier.getFullName());
+                tables.add(identifier);
             }
         }
         return tables;
@@ -1674,7 +1677,7 @@ public class RESTCatalogServer {
 
     private MockResponse viewsHandle(Map<String, String> parameters) {
         RESTResponse response;
-        List<String> views = listViews(parameters);
+        List<Identifier> views = listViews(parameters);
         if (!views.isEmpty()) {
             int maxResults;
             try {
@@ -1683,19 +1686,20 @@ public class RESTCatalogServer {
                 return handleInvalidMaxResults(parameters);
             }
             String pageToken = parameters.get(PAGE_TOKEN);
-            PagedList<String> pagedViews = buildPagedEntities(views, maxResults, pageToken);
+            PagedList<Identifier> pagedViews = buildPagedEntities(views, maxResults, pageToken);
             response =
-                    new ListViewsResponse(pagedViews.getElements(), pagedViews.getNextPageToken());
+                    new ListViewsGloballyResponse(
+                            pagedViews.getElements(), pagedViews.getNextPageToken());
         } else {
             response = new ListViewsResponse(Collections.emptyList(), null);
         }
         return mockResponse(response, 200);
     }
 
-    private List<String> listViews(Map<String, String> parameters) {
+    private List<Identifier> listViews(Map<String, String> parameters) {
         String viewNamePattern = parameters.get(VIEW_NAME_PATTERN);
         String databaseNamePattern = parameters.get(DATABASE_NAME_PATTERN);
-        List<String> fullViews = new ArrayList<>();
+        List<Identifier> fullViews = new ArrayList<>();
         for (Map.Entry<String, View> entry : viewStore.entrySet()) {
             Identifier identifier = Identifier.fromString(entry.getKey());
             if ((Objects.isNull(databaseNamePattern))
@@ -1703,7 +1707,7 @@ public class RESTCatalogServer {
                             && (Objects.isNull(viewNamePattern)
                                     || matchNamePattern(
                                             identifier.getTableName(), viewNamePattern))) {
-                fullViews.add(identifier.getFullName());
+                fullViews.add(identifier);
             }
         }
         return fullViews;

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -547,7 +547,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     public void testListTablesPagedGlobally() throws Exception {
         // List table paged globally returns an empty list when there are no tables in the catalog
 
-        PagedList<String> pagedTables = catalog.listTablesPagedGlobally(null, null, null, null);
+        PagedList<Identifier> pagedTables = catalog.listTablesPagedGlobally(null, null, null, null);
         assertThat(pagedTables.getElements()).isEmpty();
         assertNull(pagedTables.getNextPageToken());
 
@@ -559,10 +559,12 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         };
         prepareDataForListTablesPagedGlobally(databaseName, databaseName2, tableNames);
 
-        String[] expectedTableNames =
-                Arrays.stream(tableNames).map((databaseName + ".")::concat).toArray(String[]::new);
-        String[] fullTableNames = Arrays.copyOf(expectedTableNames, tableNames.length + 1);
-        fullTableNames[tableNames.length] = databaseName2 + ".table1";
+        Identifier[] expectedTableNames =
+                Arrays.stream(tableNames)
+                        .map(tableName -> Identifier.create(databaseName, tableName))
+                        .toArray(Identifier[]::new);
+        Identifier[] fullTableNames = Arrays.copyOf(expectedTableNames, tableNames.length + 1);
+        fullTableNames[tableNames.length] = Identifier.create(databaseName2, "table1");
 
         pagedTables = catalog.listTablesPagedGlobally(databaseNamePattern, null, null, null);
         assertThat(pagedTables.getElements()).containsExactlyInAnyOrder(expectedTableNames);
@@ -611,10 +613,10 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     }
 
     protected void assertListTablesPagedGloballyWithLoop(
-            String databaseNamePattern, String[] expectedTableNames) {
+            String databaseNamePattern, Identifier[] expectedTableNames) {
         int maxResults = 2;
-        PagedList<String> pagedTables;
-        List<String> tables = new ArrayList<>();
+        PagedList<Identifier> pagedTables;
+        List<Identifier> tables = new ArrayList<>();
         String pageToken = null;
         do {
             pagedTables =
@@ -636,9 +638,9 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     }
 
     protected void assertListTablesPagedGloballyWithTablePattern(
-            String databaseName, String databaseNamePattern, String[] expectedTableNames) {
+            String databaseName, String databaseNamePattern, Identifier[] expectedTableNames) {
         int maxResults = 9;
-        PagedList<String> pagedTables =
+        PagedList<Identifier> pagedTables =
                 catalog.listTablesPagedGlobally(databaseNamePattern, null, maxResults, null);
         assertEquals(
                 Math.min(maxResults, expectedTableNames.length), pagedTables.getElements().size());
@@ -649,10 +651,10 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         assertEquals(4, pagedTables.getElements().size());
         assertThat(pagedTables.getElements())
                 .containsExactlyInAnyOrder(
-                        buildFullName(databaseName, "table1"),
-                        buildFullName(databaseName, "table2"),
-                        buildFullName(databaseName, "table3"),
-                        buildFullName(databaseName, "table_name"));
+                        Identifier.create(databaseName, "table1"),
+                        Identifier.create(databaseName, "table2"),
+                        Identifier.create(databaseName, "table3"),
+                        Identifier.create(databaseName, "table_name"));
         assertNull(pagedTables.getNextPageToken());
 
         pagedTables = catalog.listTablesPagedGlobally(databaseNamePattern, "table_", null, null);
@@ -662,7 +664,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         pagedTables = catalog.listTablesPagedGlobally(databaseNamePattern, "table_%", null, null);
         assertEquals(1, pagedTables.getElements().size());
         assertThat(pagedTables.getElements())
-                .containsExactlyInAnyOrder(buildFullName(databaseName, "table_name"));
+                .containsExactlyInAnyOrder(Identifier.create(databaseName, "table_name"));
         assertNull(pagedTables.getNextPageToken());
 
         pagedTables = catalog.listTablesPagedGlobally(databaseNamePattern, "tabl_", null, null);
@@ -878,7 +880,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     public void testListViewsPagedGlobally() throws Exception {
         // list views paged globally returns an empty list when there are no views in the catalog
 
-        PagedList<String> pagedViews = catalog.listViewsPagedGlobally(null, null, null, null);
+        PagedList<Identifier> pagedViews = catalog.listViewsPagedGlobally(null, null, null, null);
         assertThat(pagedViews.getElements()).isEmpty();
         assertNull(pagedViews.getNextPageToken());
 
@@ -888,10 +890,12 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         String[] viewNames = {"view1", "view2", "view3", "abd", "def", "opr", "view_name"};
         prepareDataForListViewsPagedGlobally(databaseName, databaseName2, viewNames);
 
-        String[] expectedViewNames =
-                Arrays.stream(viewNames).map((databaseName + ".")::concat).toArray(String[]::new);
-        String[] fullTableNames = Arrays.copyOf(expectedViewNames, viewNames.length + 1);
-        fullTableNames[viewNames.length] = databaseName2 + ".view1";
+        Identifier[] expectedViewNames =
+                Arrays.stream(viewNames)
+                        .map(viewName -> Identifier.create(databaseName, viewName))
+                        .toArray(Identifier[]::new);
+        Identifier[] fullTableNames = Arrays.copyOf(expectedViewNames, viewNames.length + 1);
+        fullTableNames[viewNames.length] = Identifier.create(databaseName2, "view1");
 
         pagedViews = catalog.listViewsPagedGlobally(databaseNamePattern, null, null, null);
         assertEquals(expectedViewNames.length, pagedViews.getElements().size());
@@ -921,10 +925,10 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     }
 
     protected void assertListViewsPagedGloballyWithLoop(
-            String databaseNamePattern, String[] expectedViewNames) {
+            String databaseNamePattern, Identifier[] expectedViewNames) {
         int maxResults = 2;
-        PagedList<String> pagedViews;
-        List<String> views = new ArrayList<>();
+        PagedList<Identifier> pagedViews;
+        List<Identifier> views = new ArrayList<>();
         String pageToken = null;
         do {
             pagedViews =
@@ -946,9 +950,9 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     }
 
     protected void assertListViewsPagedGloballyWithViewPattern(
-            String databaseName, String databaseNamePattern, String[] expectedViewNames) {
+            String databaseName, String databaseNamePattern, Identifier[] expectedViewNames) {
         int maxResults = 8;
-        PagedList<String> pagedViews =
+        PagedList<Identifier> pagedViews =
                 catalog.listViewsPagedGlobally(databaseNamePattern, null, maxResults, null);
         assertEquals(
                 Math.min(maxResults, expectedViewNames.length), pagedViews.getElements().size());
@@ -959,10 +963,10 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         assertEquals(4, pagedViews.getElements().size());
         assertThat(pagedViews.getElements())
                 .containsExactlyInAnyOrder(
-                        buildFullName(databaseName, "view1"),
-                        buildFullName(databaseName, "view2"),
-                        buildFullName(databaseName, "view3"),
-                        buildFullName(databaseName, "view_name"));
+                        Identifier.create(databaseName, "view1"),
+                        Identifier.create(databaseName, "view2"),
+                        Identifier.create(databaseName, "view3"),
+                        Identifier.create(databaseName, "view_name"));
         assertNull(pagedViews.getNextPageToken());
 
         pagedViews = catalog.listViewsPagedGlobally(databaseNamePattern, "view_", null, null);
@@ -972,7 +976,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         pagedViews = catalog.listViewsPagedGlobally(databaseNamePattern, "view_%", null, null);
         assertEquals(1, pagedViews.getElements().size());
         assertThat(pagedViews.getElements())
-                .containsExactlyInAnyOrder(buildFullName(databaseName, "view_name"));
+                .containsExactlyInAnyOrder(Identifier.create(databaseName, "view_name"));
         assertNull(pagedViews.getNextPageToken());
 
         Assertions.assertThrows(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

optimize return type of ListTablesGlobally & ListViewsGlobally

<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->

### Tests
RestCatalogTest.testListTablesPagedGlobally
RestCatalogTest.testListViewsPagedGlobally

<!-- List UT and IT cases to verify this change -->

### API and Format
rest-catalog-open-api.yaml: listTablesGlobally & listViewsGlobally


<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
