### PR TITLE
[Typo] Fix typo in FileIndexFormat.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexFormat.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexFormat.java
@@ -202,8 +202,8 @@ public final class FileIndexFormat {
         private int calculateHeadLength(Map<String, Map<String, Pair<Integer, Integer>>> bodyInfo)
                 throws IOException {
             // magic 8 bytes, version 4 bytes, head length 4 bytes,
-            // column size 4 bytes, body info start&end 8 bytes per
-            // column-index, index type size 4 bytes per column, redundant length 4 bytes;
+            // column number 4 bytes, body info start&length 8 bytes per
+            // column-index, index number size 4 bytes per column, redundant length 4 bytes;
             int baseLength =
                     8
                             + 4


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

When I study the code of FileIndexFormat. I found that there are some details in the code comments and the top "image" of the class that do not match. 
In order to reduce misunderstandings among other students, now I have fixed these typos.

![image](https://github.com/user-attachments/assets/0795958a-2e85-4bc2-bd0a-6e519ca4ee5f)


<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
