### PR TITLE
[spark] Fix read with scan.fallback-branch

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/ScanHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/ScanHelper.scala
@@ -20,10 +20,11 @@ package org.apache.paimon.spark
 
 import org.apache.paimon.CoreOptions
 import org.apache.paimon.io.DataFileMeta
+import org.apache.paimon.table.FallbackReadFileStoreTable.FallbackDataSplit
 import org.apache.paimon.table.source.{DataSplit, DeletionFile, Split}
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{PaimonSparkSession, SparkSession}
+import org.apache.spark.sql.PaimonSparkSession
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
@@ -46,6 +47,7 @@ trait ScanHelper extends Logging {
 
   def getInputPartitions(splits: Array[Split]): Seq[PaimonInputPartition] = {
     val (toReshuffle, reserved) = splits.partition {
+      case _: FallbackDataSplit => false
       case split: DataSplit => split.beforeFiles().isEmpty && split.rawConvertible()
       case _ => false
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

fix
```
Caused by: java.lang.ClassCastException: org.apache.paimon.table.source.DataSplit cannot be cast to org.apache.paimon.table.FallbackReadFileStoreTable$FallbackDataSplit
	at org.apache.paimon.table.FallbackReadFileStoreTable$Read.createReader(FallbackReadFileStoreTable.java:459)
	at org.apache.paimon.spark.PaimonPartitionReader.readSplit(PaimonPartitionReader.scala:104)
	at org.apache.paimon.spark.PaimonPartitionReader.<init>(PaimonPartitionReader.scala:46)
	at org.apache.paimon.spark.PaimonPartitionReaderFactory.createReader(PaimonPartitionReaderFactory.scala:37)
	at org.apache.spark.sql.execution.datasources.v2.DataSourceRDD$$anon$1.advanceToNextIter(DataSourceRDD.scala:84)
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
