### PR TITLE
[core] fix that batch CompactAction makes no sense with all level-0 files

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1112,6 +1112,15 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "The mode of streaming read that specifies to read the data of table file or log.");
 
+    @ExcludeFromDocumentation("Internal use only")
+    public static final ConfigOption<BatchScanMode> BATCH_SCAN_MODE =
+            key("batch-scan-mode")
+                    .enumType(BatchScanMode.class)
+                    .defaultValue(BatchScanMode.NONE)
+                    .withDescription(
+                            "Only used to force TableScan to construct suitable 'StartingUpScanner' and 'FollowUpScanner' "
+                                    + "dedicated internal streaming scan.");
+
     public static final ConfigOption<Duration> CONSUMER_EXPIRATION_TIME =
             key("consumer.expiration-time")
                     .durationType()
@@ -3055,6 +3064,34 @@ public class CoreOptions implements Serializable {
         private final String description;
 
         StreamScanMode(String value, String description) {
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return text(description);
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    /** Inner batch scan mode for some internal requirements. */
+    public enum BatchScanMode implements DescribedEnum {
+        NONE("none", "No requirement."),
+        COMPACT("compact", "Compaction for batch mode.");
+
+        private final String value;
+        private final String description;
+
+        BatchScanMode(String value, String description) {
             this.value = value;
             this.description = description;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
@@ -52,7 +52,11 @@ public class DataTableBatchScan extends AbstractDataTableScan {
         this.defaultValueAssigner = DefaultValueAssigner.create(schema);
 
         if (!schema.primaryKeys().isEmpty() && options.batchScanSkipLevel0()) {
-            snapshotReader.withLevelFilter(level -> level > 0).enableValueFilter();
+            if (options.toConfiguration()
+                    .get(CoreOptions.BATCH_SCAN_MODE)
+                    .equals(CoreOptions.BatchScanMode.NONE)) {
+                snapshotReader.withLevelFilter(level -> level > 0).enableValueFilter();
+            }
         }
         if (options.bucket() == BucketMode.POSTPONE_BUCKET) {
             snapshotReader.onlyReadRealBuckets();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
@@ -167,6 +167,9 @@ public class CompactorSourceBuilder {
                 put(CoreOptions.SCAN_TIMESTAMP.key(), null);
                 put(CoreOptions.SCAN_SNAPSHOT_ID.key(), null);
                 put(CoreOptions.SCAN_MODE.key(), CoreOptions.StartupMode.LATEST_FULL.toString());
+                put(
+                        CoreOptions.BATCH_SCAN_MODE.key(),
+                        CoreOptions.BatchScanMode.COMPACT.getValue());
             }
         };
     }


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

If the table is dv enabled or using first-row as merge engine, and its writing job is write-only, compact action in batch mode for this table will generate 0 splits. This is because `DataTableBatchScan` will skip all level-0 files when dv enabled or with first-row merge engine while files written with write-only set to true are all in level-0. 

This pr introduced a new option "batch-scan-mode" which should only be used internally, if `batch-scan-mode = compact`, the `scan` won't apply the level-0 filter.

### Tests

<!-- List UT and IT cases to verify this change -->
CompactActionITCase#testCompactWhenSkipLevel0

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
