### PR TITLE
Provide option to disable use of source primary keys if primary keys in action command are not specified for CDC ingestion.

### DIFF
--- a/docs/layouts/shortcodes/generated/kafka_sync_database.html
+++ b/docs/layouts/shortcodes/generated/kafka_sync_database.html
@@ -115,8 +115,14 @@ under the License.
     <tr>
         <td><h5>--primary_keys</h5></td>
         <td>The primary keys for Paimon table. If there are multiple primary keys, connect them with comma, for example "buyer_id,seller_id".
-            If the keys are not in source table, but the source table has primary keys, the sink table will use source table's primary keys.
-            Otherwise, the sink table won't set primary keys.</td>
+            If the keys are not provided, but the source has primary keys, the sink table will use source's primary keys.
+            Otherwise, the sink table won't set primary keys.
+            If the keys are not provided, but the source has primary keys, and you don't want to use source's primary keys,
+            use --use_pkeys_from_source_for_paimon_schema.</td>
+    </tr>
+    <tr>
+        <td><h5>--use_pkeys_from_source_for_paimon_schema</h5></td>
+        <td>This is used to specify if primary keys from source should be used in paimon schema if primary keys using --primary_keys are not specified. The default is true.</td>
     </tr>
     <tr>
     <tr>

--- a/docs/layouts/shortcodes/generated/kafka_sync_table.html
+++ b/docs/layouts/shortcodes/generated/kafka_sync_table.html
@@ -63,6 +63,10 @@ under the License.
         </td>
     </tr>
     <tr>
+        <td><h5>--use_pkeys_from_source_for_paimon_schema</h5></td>
+        <td>This is used to specify if primary keys from source should be used in paimon schema if primary keys using --primary_keys are not specified. The default is true.</td>
+    </tr>
+    <tr>
         <td><h5>--computed_column</h5></td>
         <td>The definitions of computed columns. The argument field is from Kafka topic's table field name. See <a href="../overview/#computed-functions">here</a> for a complete list of configurations. </td>
     </tr>

--- a/docs/layouts/shortcodes/generated/mongodb_sync_database.html
+++ b/docs/layouts/shortcodes/generated/mongodb_sync_database.html
@@ -57,8 +57,14 @@ under the License.
     <tr>
         <td><h5>--primary_keys</h5></td>
         <td>The primary keys for Paimon table. If there are multiple primary keys, connect them with comma, for example "buyer_id,seller_id".
-            If the keys are not in source table, but the source table has primary keys, the sink table will use source table's primary keys.
-            Otherwise, the sink table won't set primary keys.</td>
+            If the keys are not provided, but the source has primary keys, the sink table will use source's primary keys.
+            Otherwise, the sink table won't set primary keys.
+            If the keys are not provided, but the source has primary keys, and you don't want to use source's primary keys,
+            use --use_pkeys_from_source_for_paimon_schema.</td>
+    </tr>
+    <tr>
+        <td><h5>--use_pkeys_from_source_for_paimon_schema</h5></td>
+        <td>This is used to specify if primary keys from source should be used in paimon schema if primary keys using --primary_keys are not specified. The default is true.</td>
     </tr>
     <tr>
         <td><h5>--mongodb_conf</h5></td>

--- a/docs/layouts/shortcodes/generated/mysql_sync_database.html
+++ b/docs/layouts/shortcodes/generated/mysql_sync_database.html
@@ -89,8 +89,14 @@ under the License.
     <tr>
         <td><h5>--primary_keys</h5></td>
         <td>The primary keys for Paimon table. If there are multiple primary keys, connect them with comma, for example "buyer_id,seller_id".
-            If the keys are not in source table, but the source table has primary keys, the sink table will use source table's primary keys.
-            Otherwise, the sink table won't set primary keys.</td>
+            If the keys are not provided, but the source has primary keys, the sink table will use source's primary keys.
+            Otherwise, the sink table won't set primary keys.
+            If the keys are not provided, but the source has primary keys, and you don't want to use source's primary keys,
+            use --use_pkeys_from_source_for_paimon_schema.</td>
+    </tr>
+    <tr>
+        <td><h5>--use_pkeys_from_source_for_paimon_schema</h5></td>
+        <td>This is used to specify if primary keys from source should be used in paimon schema if primary keys using --primary_keys are not specified. The default is true.</td>
     </tr>
     <tr>
         <td><h5>--mysql_conf</h5></td>

--- a/docs/layouts/shortcodes/generated/mysql_sync_table.html
+++ b/docs/layouts/shortcodes/generated/mysql_sync_table.html
@@ -62,6 +62,10 @@ under the License.
         </td>
     </tr>
     <tr>
+        <td><h5>--use_pkeys_from_source_for_paimon_schema</h5></td>
+        <td>This is used to specify if primary keys from source should be used in paimon schema if primary keys using --primary_keys are not specified. The default is true.</td>
+    </tr>
+    <tr>
         <td><h5>--computed_column</h5></td>
         <td>The definitions of computed columns. The argument field is from MySQL table field name. See <a href="../overview/#computed-functions">here</a> for a complete list of configurations. </td>
     </tr>

--- a/docs/layouts/shortcodes/generated/postgres_sync_table.html
+++ b/docs/layouts/shortcodes/generated/postgres_sync_table.html
@@ -55,6 +55,10 @@ under the License.
         </td>
     </tr>
     <tr>
+        <td><h5>--use_pkeys_from_source_for_paimon_schema</h5></td>
+        <td>This is used to specify if primary keys from source should be used in paimon schema if primary keys using --primary_keys are not specified. The default is true.</td>
+    </tr>
+    <tr>
         <td><h5>--computed_column</h5></td>
         <td>The definitions of computed columns. The argument field is from PostgreSQL table field name. See <a href="../overview/#computed-functions">here</a> for a complete list of configurations. </td>
     </tr>

--- a/docs/layouts/shortcodes/generated/pulsar_sync_database.html
+++ b/docs/layouts/shortcodes/generated/pulsar_sync_database.html
@@ -77,8 +77,14 @@ under the License.
     <tr>
         <td><h5>--primary_keys</h5></td>
         <td>The primary keys for Paimon table. If there are multiple primary keys, connect them with comma, for example "buyer_id,seller_id".
-            If the keys are not in source table, but the source table has primary keys, the sink table will use source table's primary keys.
-            Otherwise, the sink table won't set primary keys.</td>
+            If the keys are not provided, but the source has primary keys, the sink table will use source's primary keys.
+            Otherwise, the sink table won't set primary keys.
+            If the keys are not provided, but the source has primary keys, and you don't want to use source's primary keys,
+            use --use_pkeys_from_source_for_paimon_schema.</td>
+    </tr>
+    <tr>
+        <td><h5>--use_pkeys_from_source_for_paimon_schema</h5></td>
+        <td>This is used to specify if primary keys from source should be used in paimon schema if primary keys using --primary_keys are not specified. The default is true.</td>
     </tr>
     <tr>
         <td><h5>--pulsar_conf</h5></td>

--- a/docs/layouts/shortcodes/generated/pulsar_sync_table.html
+++ b/docs/layouts/shortcodes/generated/pulsar_sync_table.html
@@ -62,6 +62,10 @@ under the License.
         </td>
     </tr>
     <tr>
+        <td><h5>--use_pkeys_from_source_for_paimon_schema</h5></td>
+        <td>This is used to specify if primary keys from source should be used in paimon schema if primary keys using --primary_keys are not specified. The default is true.</td>
+    </tr>
+    <tr>
         <td><h5>--computed_column</h5></td>
         <td>The definitions of computed columns. The argument field is from Pulsar topic's table field name. See <a href="../overview/#computed-functions">here</a> for a complete list of configurations. </td>
     </tr>

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/CdcActionCommonUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/CdcActionCommonUtils.java
@@ -70,6 +70,8 @@ public class CdcActionCommonUtils {
     public static final String METADATA_COLUMN = "metadata_column";
     public static final String MULTIPLE_TABLE_PARTITION_KEYS = "multiple_table_partition_keys";
     public static final String EAGER_INIT = "eager_init";
+    public static final String USE_PKEYS_FROM_SOURCE_FOR_PAIMON_SCHEMA =
+            "use_pkeys_from_source_for_paimon_schema";
 
     public static void assertSchemaCompatible(
             TableSchema paimonSchema, List<DataField> sourceTableFields) {
@@ -122,7 +124,8 @@ public class CdcActionCommonUtils {
             CdcMetadataConverter[] metadataConverters,
             boolean caseSensitive,
             boolean strictlyCheckSpecified,
-            boolean requirePrimaryKeys) {
+            boolean requirePrimaryKeys,
+            boolean usePKeysFromSourceForPaimonSchema) {
         Schema.Builder builder = Schema.newBuilder();
 
         // options
@@ -165,7 +168,8 @@ public class CdcActionCommonUtils {
                 sourceSchemaPrimaryKeys,
                 allFieldNames,
                 strictlyCheckSpecified,
-                requirePrimaryKeys);
+                requirePrimaryKeys,
+                usePKeysFromSourceForPaimonSchema);
 
         // partition keys
         specifiedPartitionKeys = listCaseConvert(specifiedPartitionKeys, caseSensitive);
@@ -185,7 +189,8 @@ public class CdcActionCommonUtils {
             List<String> sourceSchemaPrimaryKeys,
             List<String> allFieldNames,
             boolean strictlyCheckSpecified,
-            boolean requirePrimaryKeys) {
+            boolean requirePrimaryKeys,
+            boolean usePKeysFromSourceForPaimonSchema) {
         if (!specifiedPrimaryKeys.isEmpty()) {
             if (allFieldNames.containsAll(specifiedPrimaryKeys)) {
                 builder.primaryKey(specifiedPrimaryKeys);
@@ -205,7 +210,7 @@ public class CdcActionCommonUtils {
             }
         }
 
-        if (!sourceSchemaPrimaryKeys.isEmpty()) {
+        if (usePKeysFromSourceForPaimonSchema && !sourceSchemaPrimaryKeys.isEmpty()) {
             builder.primaryKey(sourceSchemaPrimaryKeys);
             return;
         }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/MessageQueueSyncTableActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/MessageQueueSyncTableActionBase.java
@@ -52,7 +52,6 @@ import java.util.Map;
  * </ul>
  */
 public abstract class MessageQueueSyncTableActionBase extends SyncTableActionBase {
-
     public MessageQueueSyncTableActionBase(
             String database,
             String table,
@@ -87,6 +86,7 @@ public abstract class MessageQueueSyncTableActionBase extends SyncTableActionBas
                 metadataConverters,
                 caseSensitive,
                 true,
-                false);
+                false,
+                this.usePKeysFromSourceForPaimonSchema);
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
@@ -202,6 +202,7 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
                         partitionKeys,
                         primaryKeys,
                         requirePrimaryKeys(),
+                        usePKeysFromSourceForPaimonSchema,
                         partitionKeyMultiple,
                         metadataConverters);
         Pattern tblIncludingPattern = Pattern.compile(includingTables);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionFactoryBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionFactoryBase.java
@@ -40,6 +40,7 @@ import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.TABLE_PREF
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.TABLE_SUFFIX;
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.TABLE_SUFFIX_DB;
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.TYPE_MAPPING;
+import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.USE_PKEYS_FROM_SOURCE_FOR_PAIMON_SCHEMA;
 
 /** Base {@link ActionFactory} for synchronizing into database. */
 public abstract class SyncDatabaseActionFactoryBase<T extends SyncDatabaseActionBase>
@@ -85,6 +86,11 @@ public abstract class SyncDatabaseActionFactoryBase<T extends SyncDatabaseAction
         if (params.has(COMPUTED_COLUMN)) {
             action.withComputedColumnArgs(
                     new ArrayList<>(params.getMultiParameter(COMPUTED_COLUMN)));
+        }
+
+        if (params.has(USE_PKEYS_FROM_SOURCE_FOR_PAIMON_SCHEMA)) {
+            action.usePKeysFromSourceForPaimonSchema(
+                    Boolean.parseBoolean(params.get(USE_PKEYS_FROM_SOURCE_FOR_PAIMON_SCHEMA)));
         }
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionBase.java
@@ -107,7 +107,8 @@ public abstract class SyncTableActionBase extends SynchronizationActionBase {
                 metadataConverters,
                 caseSensitive,
                 true,
-                true);
+                true,
+                this.usePKeysFromSourceForPaimonSchema);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionFactoryBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncTableActionFactoryBase.java
@@ -32,6 +32,7 @@ import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.METADATA_C
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.PARTITION_KEYS;
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.PRIMARY_KEYS;
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.TYPE_MAPPING;
+import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.USE_PKEYS_FROM_SOURCE_FOR_PAIMON_SCHEMA;
 
 /** Base {@link ActionFactory} for synchronizing into one Paimon table. */
 public abstract class SyncTableActionFactoryBase
@@ -75,6 +76,12 @@ public abstract class SyncTableActionFactoryBase
         if (params.has(TYPE_MAPPING)) {
             String[] options = params.get(TYPE_MAPPING).split(",");
             action.withTypeMapping(TypeMapping.parse(options));
+        }
+
+        if (params.has(USE_PKEYS_FROM_SOURCE_FOR_PAIMON_SCHEMA)) {
+            boolean flag =
+                    Boolean.parseBoolean(params.get(USE_PKEYS_FROM_SOURCE_FOR_PAIMON_SCHEMA));
+            action.usePKeysFromSourceForPaimonSchema(flag);
         }
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SynchronizationActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SynchronizationActionBase.java
@@ -68,6 +68,9 @@ public abstract class SynchronizationActionBase extends ActionBase {
 
     protected Map<String, String> tableConfig = new HashMap<>();
     protected TypeMapping typeMapping = TypeMapping.defaultMapping();
+    // this is to specify if we should use primary keys from source
+    // in paimon schema if pkeys are not specified in action command
+    protected boolean usePKeysFromSourceForPaimonSchema = true;
     protected CdcMetadataConverter[] metadataConverters = new CdcMetadataConverter[] {};
 
     public SynchronizationActionBase(
@@ -99,6 +102,11 @@ public abstract class SynchronizationActionBase extends ActionBase {
                 metadataColumns.stream()
                         .map(this.syncJobHandler::provideMetadataConverter)
                         .toArray(CdcMetadataConverter[]::new);
+        return this;
+    }
+
+    public SynchronizationActionBase usePKeysFromSourceForPaimonSchema(boolean flag) {
+        this.usePKeysFromSourceForPaimonSchema = flag;
         return this;
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseAction.java
@@ -154,7 +154,8 @@ public class MySqlSyncDatabaseAction extends SyncDatabaseActionBase {
                             metadataConverters,
                             caseSensitive,
                             false,
-                            true);
+                            true,
+                            this.usePKeysFromSourceForPaimonSchema);
             try {
                 table = (FileStoreTable) catalog.getTable(identifier);
                 Supplier<String> errMsg =

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/NewTableSchemaBuilder.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/NewTableSchemaBuilder.java
@@ -38,6 +38,7 @@ public class NewTableSchemaBuilder implements Serializable {
     private final List<String> partitionKeys;
     private final List<String> primaryKeys;
     private final boolean requirePrimaryKeys;
+    private final boolean usePKeysFromSourceForPaimonSchema;
     private final CdcMetadataConverter[] metadataConverters;
     private final Map<String, List<String>> partitionKeyMultiple;
 
@@ -47,6 +48,7 @@ public class NewTableSchemaBuilder implements Serializable {
             List<String> partitionKeys,
             List<String> primaryKeys,
             boolean requirePrimaryKeys,
+            boolean usePKeysFromSourceForPaimonSchema,
             Map<String, List<String>> partitionKeyMultiple,
             CdcMetadataConverter[] metadataConverters) {
         this.tableConfig = tableConfig;
@@ -55,6 +57,7 @@ public class NewTableSchemaBuilder implements Serializable {
         this.partitionKeys = partitionKeys;
         this.primaryKeys = primaryKeys;
         this.requirePrimaryKeys = requirePrimaryKeys;
+        this.usePKeysFromSourceForPaimonSchema = usePKeysFromSourceForPaimonSchema;
         this.partitionKeyMultiple = partitionKeyMultiple;
     }
 
@@ -80,6 +83,7 @@ public class NewTableSchemaBuilder implements Serializable {
                         metadataConverters,
                         caseSensitive,
                         false,
-                        requirePrimaryKeys));
+                        requirePrimaryKeys,
+                        usePKeysFromSourceForPaimonSchema));
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
To add an option to not use source primary keys when doing CDC ingestion. 

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
We have a use case where we want to do ingestion of keyed topics from kafka in append only mode. In the existing case the table is created with primary keys even if we don't specify primary keys using `--primary_keys`. This change will help us to automatically create tables without having primary keys even for keyed topics (cdc topics) using action jar. The default is kept as true as I didn't want to change the existing behaviour.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
