### PR TITLE
[core] Introduce Row Id for append table

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/Snapshot.java
+++ b/paimon-api/src/main/java/org/apache/paimon/Snapshot.java
@@ -88,6 +88,7 @@ public class Snapshot implements Serializable {
     protected static final String FIELD_WATERMARK = "watermark";
     protected static final String FIELD_STATISTICS = "statistics";
     protected static final String FIELD_PROPERTIES = "properties";
+    protected static final String FIELD_NEXT_ROW_ID = "nextRowId";
 
     // version of snapshot
     // null for paimon <= 0.2
@@ -203,6 +204,11 @@ public class Snapshot implements Serializable {
     @Nullable
     protected final Map<String, String> properties;
 
+    @Nullable
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_NEXT_ROW_ID)
+    protected final Long nextRowId;
+
     public Snapshot(
             long id,
             long schemaId,
@@ -223,7 +229,8 @@ public class Snapshot implements Serializable {
             @Nullable Long changelogRecordCount,
             @Nullable Long watermark,
             @Nullable String statistics,
-            @Nullable Map<String, String> properties) {
+            @Nullable Map<String, String> properties,
+            @Nullable Long nextRowId) {
         this(
                 CURRENT_VERSION,
                 id,
@@ -245,7 +252,8 @@ public class Snapshot implements Serializable {
                 changelogRecordCount,
                 watermark,
                 statistics,
-                properties);
+                properties,
+                nextRowId);
     }
 
     @JsonCreator
@@ -271,7 +279,8 @@ public class Snapshot implements Serializable {
             @JsonProperty(FIELD_CHANGELOG_RECORD_COUNT) @Nullable Long changelogRecordCount,
             @JsonProperty(FIELD_WATERMARK) @Nullable Long watermark,
             @JsonProperty(FIELD_STATISTICS) @Nullable String statistics,
-            @JsonProperty(FIELD_PROPERTIES) @Nullable Map<String, String> properties) {
+            @JsonProperty(FIELD_PROPERTIES) @Nullable Map<String, String> properties,
+            @JsonProperty(FIELD_NEXT_ROW_ID) @Nullable Long nextRowId) {
         this.version = version;
         this.id = id;
         this.schemaId = schemaId;
@@ -293,6 +302,7 @@ public class Snapshot implements Serializable {
         this.watermark = watermark;
         this.statistics = statistics;
         this.properties = properties;
+        this.nextRowId = nextRowId;
     }
 
     @JsonGetter(FIELD_VERSION)
@@ -413,6 +423,12 @@ public class Snapshot implements Serializable {
         return properties;
     }
 
+    @JsonGetter(FIELD_NEXT_ROW_ID)
+    @Nullable
+    public Long nextRowId() {
+        return nextRowId;
+    }
+
     public String toJson() {
         return JsonSerdeUtil.toJson(this);
     }
@@ -440,7 +456,8 @@ public class Snapshot implements Serializable {
                 changelogRecordCount,
                 watermark,
                 statistics,
-                properties);
+                properties,
+                nextRowId);
     }
 
     @Override
@@ -472,7 +489,8 @@ public class Snapshot implements Serializable {
                 && Objects.equals(changelogRecordCount, that.changelogRecordCount)
                 && Objects.equals(watermark, that.watermark)
                 && Objects.equals(statistics, that.statistics)
-                && Objects.equals(properties, that.properties);
+                && Objects.equals(properties, that.properties)
+                && Objects.equals(nextRowId, that.nextRowId);
     }
 
     /** Type of changes in this snapshot. */

--- a/paimon-api/src/main/java/org/apache/paimon/table/SpecialFields.java
+++ b/paimon-api/src/main/java/org/apache/paimon/table/SpecialFields.java
@@ -87,6 +87,9 @@ public class SpecialFields {
             new DataField(
                     Integer.MAX_VALUE - 4, "rowkind", new VarCharType(VarCharType.MAX_LENGTH));
 
+    public static final DataField ROW_ID =
+            new DataField(Integer.MAX_VALUE - 5, "_row_id", DataTypes.BIGINT());
+
     public static final Set<String> SYSTEM_FIELD_NAMES =
             Stream.of(SEQUENCE_NUMBER.name(), VALUE_KIND.name(), LEVEL.name(), ROW_KIND.name())
                     .collect(Collectors.toSet());

--- a/paimon-common/src/main/java/org/apache/paimon/utils/Range.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/Range.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+/** Define a range with start (include) and end (exclude). */
+public class Range {
+
+    private final long start;
+    private final long end;
+
+    public Range(long start, long end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    public long getStart() {
+        return start;
+    }
+
+    public long getEnd() {
+        return end;
+    }
+
+    public boolean overlaps(Range other) {
+        return this.start < other.end && other.start < this.end;
+    }
+
+    public long offset(long value) {
+        if (value < start || value >= end) {
+            return -1;
+        }
+        return value - start;
+    }
+
+    public long count() {
+        return end - start;
+    }
+
+    public static Range of(long start, long end) {
+        return new Range(start, end);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Long.hashCode(start);
+        result = 31 * result + Long.hashCode(end);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Range range = (Range) obj;
+        return start == range.start && end == range.end;
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/RowIdSequence.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/RowIdSequence.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/** Row id ranges. */
+public final class RowIdSequence implements Iterable<Range> {
+
+    private final long min; // include
+    private final long max; // exclude
+    private final List<Range> ranges;
+
+    /**
+     * Creates a RowIdSequence with a single range from start (inclusive) to end (exclusive).
+     *
+     * @param start the starting row id (inclusive)
+     * @param end the ending row id (exclusive)
+     */
+    public RowIdSequence(long start, long end) {
+        Preconditions.checkArgument(end > start, "End must be greater than start.");
+        this.min = start;
+        this.max = end;
+        ranges = Collections.singletonList(Range.of(start, end));
+    }
+
+    public RowIdSequence(List<Range> ranges) {
+        Preconditions.checkArgument(
+                !ranges.isEmpty(), "RowIdSequence must have at least one range.");
+        this.min = ranges.get(0).getStart();
+        this.max = ranges.get(ranges.size() - 1).getEnd();
+        this.ranges = ranges;
+    }
+
+    public RowIdSequence(long... ranges) {
+        if (ranges.length % 2 != 0) {
+            throw new IllegalArgumentException("RowIdSequence must have even number of elements.");
+        }
+        List<Range> rangeList = new ArrayList<>();
+        for (int i = 0; i < ranges.length; i += 2) {
+            Preconditions.checkArgument(
+                    ranges[i + 1] > ranges[i],
+                    "End must be greater than start for range: ["
+                            + ranges[i]
+                            + ", "
+                            + ranges[i + 1]
+                            + "]");
+            if (i != 0) {
+                Preconditions.checkArgument(
+                        ranges[i] > ranges[i - 1],
+                        "Start of the current range must be greater than end of the previous range: "
+                                + "["
+                                + ranges[i - 1]
+                                + ", "
+                                + ranges[i]
+                                + "]");
+            }
+            rangeList.add(Range.of(ranges[i], ranges[i + 1]));
+        }
+        this.min = ranges[0];
+        this.max = ranges[ranges.length - 1];
+        this.ranges = Collections.unmodifiableList(rangeList);
+    }
+
+    public int size() {
+        return ranges.size();
+    }
+
+    public Range get(int index) {
+        Preconditions.checkElementIndex(index, ranges.size(), "Index out of bounds.");
+        return ranges.get(index);
+    }
+
+    @Override
+    public Iterator<Range> iterator() {
+        return ranges.iterator();
+    }
+
+    private boolean mayExist(long rowIndex) {
+        return rowIndex >= min && rowIndex < max;
+    }
+
+    public long toRowNumber(long rowIndex) {
+        if (mayExist(rowIndex)) {
+            long rowNumber = 0;
+            for (Range range : ranges) {
+                long offset = range.offset(rowIndex);
+                if (offset != -1) {
+                    return rowNumber + offset;
+                } else {
+                    rowNumber += range.count();
+                }
+            }
+        }
+        return -1;
+    }
+
+    public List<Range> ranges() {
+        return ranges;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("RowIdSequence{");
+        for (Range range : this) {
+            sb.append("[")
+                    .append(range.getStart())
+                    .append(", ")
+                    .append(range.getEnd())
+                    .append("],");
+        }
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Long.hashCode(min);
+        result = 31 * result + Long.hashCode(max);
+        for (Range range : ranges) {
+            result = 31 * result + range.hashCode();
+        }
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        RowIdSequence that = (RowIdSequence) obj;
+        return min == that.min && max == that.max && ranges.equals(that.ranges);
+    }
+
+    // serialize to bytes
+    public byte[] serialize() {
+        try {
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
+            dataOutputStream.writeLong(ranges.size());
+            for (Range range : ranges) {
+                dataOutputStream.writeLong(range.getStart());
+                dataOutputStream.writeLong(range.getEnd());
+            }
+            return byteArrayOutputStream.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to serialize RowIdSequence", e);
+        }
+    }
+
+    // deserialize from bytes
+    public static RowIdSequence deserialize(byte[] bytes) {
+        try {
+            if (bytes.length < 16) {
+                throw new IllegalArgumentException("Invalid byte array length for RowIdSequence.");
+            }
+            DataInputStream dataInputStream = new DataInputStream(new ByteArrayInputStream(bytes));
+            long size = dataInputStream.readLong();
+            List<Range> ranges = new ArrayList<>();
+            for (int i = 0; i < size; i++) {
+                long start = dataInputStream.readLong();
+                long end = dataInputStream.readLong();
+                ranges.add(Range.of(start, end));
+            }
+            return new RowIdSequence(ranges);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to deserialize RowIdSequence", e);
+        }
+    }
+
+    public int compareTo(@NotNull RowIdSequence o) {
+        if (this.min != o.min) {
+            return Long.compare(this.min, o.min);
+        }
+        if (this.max != o.max) {
+            return Long.compare(this.max, o.max);
+        }
+        return 0;
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/RowIdSequenceBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/RowIdSequenceBuilder.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RowIdSequenceBuilder {
+
+    private final List<Range> allExistingRanges;
+
+    private List<Range> current = new ArrayList<>();
+    private boolean noMore = false;
+    private int pageNum = 0;
+    private long startPos;
+    private long currentPos; // exclusive
+
+    public RowIdSequenceBuilder(Collection<Range> rangesUnsorted) {
+        Preconditions.checkArgument(
+                !rangesUnsorted.isEmpty(), "RowIdSequenceBuilder must have at least one range.");
+        List<Range> tempRanges =
+                rangesUnsorted.stream()
+                        .sorted(Comparator.comparingLong(Range::getStart))
+                        .collect(Collectors.toList());
+
+        this.allExistingRanges = new ArrayList<>();
+
+        for (Range range : tempRanges) {
+            if (allExistingRanges.isEmpty()) {
+                allExistingRanges.add(range);
+            } else {
+                Range lastRange = allExistingRanges.get(allExistingRanges.size() - 1);
+                if (lastRange.getEnd() == range.getStart()) {
+                    // merge with the last range
+                    allExistingRanges.set(
+                            allExistingRanges.size() - 1,
+                            Range.of(lastRange.getStart(), range.getEnd()));
+                } else if (!lastRange.overlaps(range)) {
+                    // add a new range
+                    allExistingRanges.add(range);
+                } else {
+                    throw new IllegalArgumentException(
+                            "RowIdSequenceBuilder cannot handle overlapping ranges: "
+                                    + lastRange
+                                    + " and "
+                                    + range);
+                }
+            }
+        }
+
+        this.startPos = allExistingRanges.get(0).getStart();
+        this.currentPos = startPos;
+    }
+
+    public void more() {
+        if (noMore) {
+            throw new IllegalStateException("No more ranges to process.");
+        }
+        Range current = allExistingRanges.get(pageNum);
+        currentPos++;
+        if (currentPos == current.getEnd()) {
+            this.current.add(
+                    startPos == current.getStart() ? current : Range.of(startPos, currentPos));
+
+            pageNum++;
+            if (pageNum < allExistingRanges.size()) {
+                current = allExistingRanges.get(pageNum);
+                startPos = current.getStart();
+                currentPos = startPos;
+            } else {
+                startPos = currentPos;
+                // No more ranges to process
+                noMore = true;
+            }
+        }
+    }
+
+    public @Nullable RowIdSequence build() {
+        if (currentPos != startPos) {
+            current.add(Range.of(startPos, currentPos));
+            startPos = currentPos;
+        }
+        RowIdSequence rowIdSequence = new RowIdSequence(current);
+        current = new ArrayList<>();
+        return rowIdSequence;
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/RowIdSequenceBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/RowIdSequenceBuilder.java
@@ -26,6 +26,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/** Build row id sequence from ranges. */
 public class RowIdSequenceBuilder {
 
     private final List<Range> allExistingRanges;

--- a/paimon-common/src/main/java/org/apache/paimon/utils/RowIdSequenceIterator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/RowIdSequenceIterator.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class RowIdSequenceIterator {
+
+    private final boolean allNull;
+    private final List<Range> ranges;
+    private long currentPage = 0L;
+    private long currentPos = 0L;
+
+    public RowIdSequenceIterator(@Nullable RowIdSequence rowIdSequence) {
+        if (rowIdSequence != null) {
+            this.ranges = rowIdSequence.ranges();
+            this.allNull = false;
+        } else {
+            this.allNull = true;
+            this.ranges = null;
+        }
+    }
+
+    public Long next() {
+        if (allNull) {
+            return null;
+        }
+
+        if (currentPage >= ranges.size()) {
+            return null;
+        }
+
+        Range range = ranges.get((int) currentPage);
+        long value = range.getStart() + currentPos;
+        currentPos++;
+        if (currentPos >= range.getEnd()) {
+            currentPage++;
+            currentPos = 0L;
+        }
+
+        return value;
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/RowIdSequenceIterator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/RowIdSequenceIterator.java
@@ -52,7 +52,7 @@ public class RowIdSequenceIterator {
         Range range = ranges.get((int) currentPage);
         long value = range.getStart() + currentPos;
         currentPos++;
-        if (currentPos >= range.getEnd()) {
+        if (range.getStart() + currentPos >= range.getEnd()) {
             currentPage++;
             currentPos = 0L;
         }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/RowIdSequenceIterator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/RowIdSequenceIterator.java
@@ -18,10 +18,11 @@
 
 package org.apache.paimon.utils;
 
-import org.jetbrains.annotations.Nullable;
+import javax.annotation.Nullable;
 
 import java.util.List;
 
+/** Row id sequence fetcher. */
 public class RowIdSequenceIterator {
 
     private final boolean allNull;

--- a/paimon-common/src/test/java/org/apache/paimon/utils/RowIdSequenceBuilderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/RowIdSequenceBuilderTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class RowIdSequenceBuilderTest {
+
+    @Test
+    public void testEmptyRanges() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new RowIdSequenceBuilder(Collections.emptyList()));
+    }
+
+    @Test
+    public void testSingleRange() {
+        Collection<Range> ranges = Collections.singletonList(Range.of(10, 20));
+        RowIdSequenceBuilder builder = new RowIdSequenceBuilder(ranges);
+        // Test building the whole sequence
+        for (int i = 0; i < 10; i++) {
+            builder.more();
+        }
+        assertEquals(new RowIdSequence(10, 20), builder.build());
+    }
+
+    @Test
+    public void testMultipleRanges() {
+        Collection<Range> ranges = Arrays.asList(Range.of(1, 3), Range.of(5, 8), Range.of(10, 11));
+        RowIdSequenceBuilder builder = new RowIdSequenceBuilder(ranges);
+
+        // Build the whole sequence
+        for (int i = 0; i < 2; i++) {
+            builder.more();
+        }
+        for (int i = 0; i < 3; i++) {
+            builder.more();
+        }
+        for (int i = 0; i < 1; i++) {
+            builder.more();
+        }
+        assertEquals(new RowIdSequence(1, 3, 5, 8, 10, 11), builder.build());
+    }
+
+    @Test
+    public void testMultipleRangesSplit() {
+        Collection<Range> ranges = Arrays.asList(Range.of(1, 3), Range.of(5, 8), Range.of(10, 15));
+        RowIdSequenceBuilder builder = new RowIdSequenceBuilder(ranges);
+
+        // Build the whole sequence
+        for (int i = 0; i < 1; i++) {
+            builder.more();
+        }
+        assertEquals(new RowIdSequence(1, 2), builder.build());
+        for (int i = 0; i < 5; i++) {
+            builder.more();
+        }
+        assertEquals(new RowIdSequence(2, 3, 5, 8, 10, 11), builder.build());
+        for (int i = 0; i < 4; i++) {
+            builder.more();
+        }
+        assertEquals(new RowIdSequence(11, 15), builder.build());
+    }
+
+    @Test
+    public void testNoMore() {
+        Collection<Range> ranges = Collections.singletonList(Range.of(0, 5));
+        RowIdSequenceBuilder builder = new RowIdSequenceBuilder(ranges);
+        for (int i = 0; i < 5; i++) {
+            builder.more();
+        }
+        builder.build();
+        assertThrows(IllegalStateException.class, builder::more);
+    }
+
+    @Test
+    public void testOverlappingRanges() {
+        Collection<Range> ranges = Arrays.asList(Range.of(1, 5), Range.of(3, 7));
+        assertThrows(IllegalArgumentException.class, () -> new RowIdSequenceBuilder(ranges));
+    }
+
+    @Test
+    public void testAdjacentRanges() {
+        Collection<Range> ranges = Arrays.asList(Range.of(1, 5), Range.of(5, 10));
+        RowIdSequenceBuilder builder = new RowIdSequenceBuilder(ranges);
+
+        for (int i = 0; i < 9; i++) {
+            builder.more();
+        }
+        assertEquals(new RowIdSequence(1, 10), builder.build());
+    }
+
+    @Test
+    public void testUnsortedRanges() {
+        Collection<Range> ranges = Arrays.asList(Range.of(5, 10), Range.of(1, 5));
+        RowIdSequenceBuilder builder = new RowIdSequenceBuilder(ranges);
+
+        for (int i = 0; i < 9; i++) {
+            builder.more();
+        }
+        assertEquals(new RowIdSequence(1, 10), builder.build());
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/utils/RowIdSequenceBuilderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/RowIdSequenceBuilderTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+/** Tests for {@link RowIdSequenceBuilder}. */
 public class RowIdSequenceBuilderTest {
 
     @Test

--- a/paimon-common/src/test/java/org/apache/paimon/utils/RowIdSequenceIteratorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/RowIdSequenceIteratorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class RowIdSequenceIteratorTest {
+
+    @Test
+    public void testAllNull() {
+        RowIdSequenceIterator reader = new RowIdSequenceIterator(null);
+        assertNull(reader.next());
+    }
+
+    @Test
+    public void testSingleRange() {
+        RowIdSequence sequence = new RowIdSequence(Arrays.asList(Range.of(10, 15)));
+        RowIdSequenceIterator reader = new RowIdSequenceIterator(sequence);
+
+        assertEquals(10L, reader.next());
+        assertEquals(11L, reader.next());
+        assertEquals(12L, reader.next());
+        assertEquals(13L, reader.next());
+        assertEquals(14L, reader.next());
+        assertNull(reader.next());
+    }
+
+    @Test
+    public void testMultipleRanges() {
+        RowIdSequence sequence =
+                new RowIdSequence(Arrays.asList(Range.of(1, 3), Range.of(5, 8), Range.of(10, 11)));
+        RowIdSequenceIterator reader = new RowIdSequenceIterator(sequence);
+
+        assertEquals(1L, reader.next());
+        assertEquals(2L, reader.next());
+        assertEquals(5L, reader.next());
+        assertEquals(6L, reader.next());
+        assertEquals(7L, reader.next());
+        assertEquals(10L, reader.next());
+        assertNull(reader.next());
+    }
+
+    @Test
+    public void testLargeRanges() {
+        RowIdSequence sequence =
+                new RowIdSequence(Arrays.asList(Range.of(0, 100), Range.of(200, 300)));
+        RowIdSequenceIterator reader = new RowIdSequenceIterator(sequence);
+
+        for (long i = 0; i < 100; i++) {
+            assertEquals(i, reader.next());
+        }
+        for (long i = 200; i < 300; i++) {
+            assertEquals(i, reader.next());
+        }
+        assertNull(reader.next());
+    }
+
+    @Test
+    public void testSingleElementRanges() {
+        RowIdSequence sequence =
+                new RowIdSequence(
+                        Arrays.asList(Range.of(5, 6), Range.of(10, 11), Range.of(15, 16)));
+        RowIdSequenceIterator reader = new RowIdSequenceIterator(sequence);
+
+        assertEquals(5L, reader.next());
+        assertEquals(10L, reader.next());
+        assertEquals(15L, reader.next());
+        assertNull(reader.next());
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/utils/RowIdSequenceIteratorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/RowIdSequenceIteratorTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+/** Tests for {@link RowIdSequenceIterator}. */
 public class RowIdSequenceIteratorTest {
 
     @Test

--- a/paimon-common/src/test/java/org/apache/paimon/utils/RowIdSequenceTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/RowIdSequenceTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link RowIdSequence}. */
+public class RowIdSequenceTest {
+
+    @Test
+    void testSingleRangeConstructor() {
+        RowIdSequence sequence = new RowIdSequence(0, 10);
+        assertThat(sequence.size()).isEqualTo(1);
+        assertThat(sequence.get(0)).isEqualTo(Range.of(0, 10));
+        assertThat(sequence.toRowNumber(5)).isEqualTo(5);
+        assertThat(sequence.toRowNumber(0)).isEqualTo(0);
+        assertThat(sequence.toRowNumber(9)).isEqualTo(9);
+        assertThat(sequence.toRowNumber(10)).isEqualTo(-1);
+        assertThat(sequence.toRowNumber(-1)).isEqualTo(-1);
+        assertThat(sequence.toString()).isEqualTo("RowIdSequence{[0, 10],}");
+    }
+
+    @Test
+    void testSingleRangeConstructorWithInvalidEnd() {
+        assertThatThrownBy(() -> new RowIdSequence(10, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("End must be greater than start.");
+        assertThatThrownBy(() -> new RowIdSequence(10, 5))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("End must be greater than start.");
+    }
+
+    @Test
+    void testMultiRangeConstructor() {
+        RowIdSequence sequence = new RowIdSequence(0, 5, 10, 15, 20, 25);
+        assertThat(sequence.size()).isEqualTo(3);
+        assertThat(sequence.get(0)).isEqualTo(Range.of(0, 5));
+        assertThat(sequence.get(1)).isEqualTo(Range.of(10, 15));
+        assertThat(sequence.get(2)).isEqualTo(Range.of(20, 25));
+
+        // Test toRowNumber
+        assertThat(sequence.toRowNumber(0)).isEqualTo(0);
+        assertThat(sequence.toRowNumber(4)).isEqualTo(4);
+        assertThat(sequence.toRowNumber(10)).isEqualTo(5); // 0-4 (5 elements) + 0 for next range
+        assertThat(sequence.toRowNumber(14))
+                .isEqualTo(9); // 0-4 (5 elements) + 0-4 for next range (5 elements) = 9
+        assertThat(sequence.toRowNumber(20)).isEqualTo(10); // 0-4 (5) + 0-4 (5) + 0 for next range
+        assertThat(sequence.toRowNumber(24)).isEqualTo(14); // 0-4 (5) + 0-4 (5) + 0-4 (5) = 14
+
+        assertThat(sequence.toRowNumber(5)).isEqualTo(-1); // Not in any range
+        assertThat(sequence.toRowNumber(7)).isEqualTo(-1); // Not in any range
+        assertThat(sequence.toRowNumber(15)).isEqualTo(-1); // Not in any range
+        assertThat(sequence.toRowNumber(25)).isEqualTo(-1); // Not in any range
+        assertThat(sequence.toString()).isEqualTo("RowIdSequence{[0, 5],[10, 15],[20, 25],}");
+    }
+
+    @Test
+    void testMultiRangeConstructorInvalidArguments() {
+        // Odd number of elements
+        assertThatThrownBy(() -> new RowIdSequence(0, 5, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("RowIdSequence must have even number of elements.");
+
+        // End not greater than start within a range
+        assertThatThrownBy(() -> new RowIdSequence(0, 5, 10, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("End must be greater than start for range: [10, 10]");
+        assertThatThrownBy(() -> new RowIdSequence(0, 5, 10, 8))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("End must be greater than start for range: [10, 8]");
+
+        // Overlapping or non-increasing ranges
+        assertThatThrownBy(() -> new RowIdSequence(0, 5, 4, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Start of the current range must be greater than end of the previous range: [5, 4]");
+        assertThatThrownBy(() -> new RowIdSequence(0, 5, 5, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Start of the current range must be greater than end of the previous range: [5, 5]");
+    }
+
+    @Test
+    void testEmptyRangesInConstructor() {
+        assertThatThrownBy(() -> new RowIdSequence(1L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("RowIdSequence must have even number of elements.");
+    }
+
+    @Test
+    void testGetMethodInvalidIndex() {
+        RowIdSequence sequence = new RowIdSequence(0, 10);
+        assertThatThrownBy(() -> sequence.get(1))
+                .isInstanceOf(IndexOutOfBoundsException.class)
+                .hasMessageContaining("Index out of bounds.");
+        assertThatThrownBy(() -> sequence.get(-1))
+                .isInstanceOf(IndexOutOfBoundsException.class)
+                .hasMessageContaining("Index out of bounds.");
+
+        RowIdSequence multiSequence = new RowIdSequence(0, 5, 10, 15);
+        assertThatThrownBy(() -> multiSequence.get(2))
+                .isInstanceOf(IndexOutOfBoundsException.class)
+                .hasMessageContaining("Index out of bounds.");
+    }
+
+    @Test
+    void testIterator() {
+        RowIdSequence sequence = new RowIdSequence(0, 5, 10, 15);
+        Iterator<Range> iterator = sequence.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+        assertThat(iterator.next()).isEqualTo(Range.of(0, 5));
+        assertThat(iterator.hasNext()).isTrue();
+        assertThat(iterator.next()).isEqualTo(Range.of(10, 15));
+        assertThat(iterator.hasNext()).isFalse();
+        assertThatThrownBy(iterator::next).isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        RowIdSequence seq1 = new RowIdSequence(0, 10);
+        RowIdSequence seq2 = new RowIdSequence(0, 10);
+        RowIdSequence seq3 = new RowIdSequence(0, 5, 10, 15);
+        RowIdSequence seq4 = new RowIdSequence(0, 5, 10, 15);
+        RowIdSequence seq5 = new RowIdSequence(1, 10); // Different start
+        RowIdSequence seq6 = new RowIdSequence(0, 11); // Different end
+
+        // Test equality
+        assertThat(seq1).isEqualTo(seq2);
+        assertThat(seq3).isEqualTo(seq4);
+        assertThat(seq1).isNotEqualTo(seq3);
+        assertThat(seq1).isNotEqualTo(seq5);
+        assertThat(seq1).isNotEqualTo(seq6);
+        assertThat(seq1).isNotEqualTo(null);
+        assertThat(seq1).isNotEqualTo("some string");
+
+        // Test hashCode
+        assertThat(seq1.hashCode()).isEqualTo(seq2.hashCode());
+        assertThat(seq3.hashCode()).isEqualTo(seq4.hashCode());
+        assertThat(seq1.hashCode()).isNotEqualTo(seq3.hashCode());
+        assertThat(seq1.hashCode()).isNotEqualTo(seq5.hashCode());
+        assertThat(seq1.hashCode()).isNotEqualTo(seq6.hashCode());
+    }
+
+    @Test
+    void testLargeRowNumbers() {
+        RowIdSequence sequence = new RowIdSequence(Long.MAX_VALUE - 10, Long.MAX_VALUE - 5);
+        assertThat(sequence.size()).isEqualTo(1);
+        assertThat(sequence.get(0)).isEqualTo(Range.of(Long.MAX_VALUE - 10, Long.MAX_VALUE - 5));
+        assertThat(sequence.toRowNumber(Long.MAX_VALUE - 8)).isEqualTo(2);
+
+        // Multi-range with large numbers
+        RowIdSequence multiSeq = new RowIdSequence(0, 1, Long.MAX_VALUE - 10, Long.MAX_VALUE - 5);
+        assertThat(multiSeq.size()).isEqualTo(2);
+        assertThat(multiSeq.toRowNumber(0)).isEqualTo(0);
+        assertThat(multiSeq.toRowNumber(Long.MAX_VALUE - 10))
+                .isEqualTo(1); // The second range starts at global offset 1
+        assertThat(multiSeq.toRowNumber(Long.MAX_VALUE - 6))
+                .isEqualTo(5); // 1 + (MAX-6 - (MAX-10)) = 1 + 4 = 5
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/Changelog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/Changelog.java
@@ -63,7 +63,8 @@ public class Changelog extends Snapshot {
                 snapshot.changelogRecordCount(),
                 snapshot.watermark(),
                 snapshot.statistics(),
-                snapshot.properties);
+                snapshot.properties,
+                snapshot.nextRowId);
     }
 
     @JsonCreator
@@ -89,7 +90,8 @@ public class Changelog extends Snapshot {
             @JsonProperty(FIELD_CHANGELOG_RECORD_COUNT) @Nullable Long changelogRecordCount,
             @JsonProperty(FIELD_WATERMARK) @Nullable Long watermark,
             @JsonProperty(FIELD_STATISTICS) @Nullable String statistics,
-            @JsonProperty(FIELD_PROPERTIES) Map<String, String> properties) {
+            @JsonProperty(FIELD_PROPERTIES) Map<String, String> properties,
+            @JsonProperty(FIELD_NEXT_ROW_ID) @Nullable Long nextRowId) {
         super(
                 version,
                 id,
@@ -111,7 +113,8 @@ public class Changelog extends Snapshot {
                 changelogRecordCount,
                 watermark,
                 statistics,
-                properties);
+                properties,
+                nextRowId);
     }
 
     public static Changelog fromJson(String json) {

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValue.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValue.java
@@ -51,6 +51,7 @@ public class KeyValue {
     private InternalRow value;
     // determined after read from file
     private int level;
+    private Long rowId;
 
     public KeyValue replace(InternalRow key, RowKind valueKind, InternalRow value) {
         return replace(key, UNKNOWN_SEQUENCE, valueKind, value);

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendCompactCoordinator.java
@@ -252,7 +252,14 @@ public class AppendCompactCoordinator {
             // we don't know how many parallel compact works there should be, so in order to pack
             // better, we will sort them first
             ArrayList<DataFileMeta> files = new ArrayList<>(toCompact);
-            files.sort(Comparator.comparingLong(DataFileMeta::fileSize));
+            boolean allContainsRowId =
+                    files.stream().allMatch(file -> file.rowIdSequence() != null);
+            if (allContainsRowId) {
+                // sort by rowIdSequence, so that we can combine small row id sequences
+                files.sort((f1, f2) -> f1.rowIdSequence().compareTo(f2.rowIdSequence()));
+            } else {
+                files.sort(Comparator.comparingLong(DataFileMeta::fileSize));
+            }
 
             List<List<DataFileMeta>> result = new ArrayList<>();
             FileBin fileBin = new FileBin();

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendCompactTask.java
@@ -33,6 +33,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.utils.Preconditions;
+import org.apache.paimon.utils.RowIdSequence;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -52,6 +53,15 @@ public class AppendCompactTask {
     public AppendCompactTask(BinaryRow partition, List<DataFileMeta> files) {
         Preconditions.checkArgument(files != null);
         this.partition = partition;
+        files.sort(
+                (f1, f2) -> {
+                    RowIdSequence f1RowId = f1.rowIdSequence();
+                    RowIdSequence f2RowId = f2.rowIdSequence();
+                    if (f1RowId == null || f2RowId == null) {
+                        return 0; // If either is null, we cannot compare, so keep original order.
+                    }
+                    return f1RowId.compareTo(f2RowId);
+                });
         compactBefore = new ArrayList<>(files);
         compactAfter = new ArrayList<>();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -300,7 +300,8 @@ public class AppendOnlyWriter implements BatchRecordWriter, MemoryOwner {
                 fileIndexOptions,
                 FileSource.APPEND,
                 asyncFileWrite,
-                statsDenseStore);
+                statsDenseStore,
+                null);
     }
 
     private void trySyncLatestCompaction(boolean blocking)

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta09Serializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta09Serializer.java
@@ -140,6 +140,7 @@ public class DataFileMeta09Serializer implements Serializable {
                 row.isNullAt(14) ? null : row.getBinary(14),
                 row.isNullAt(15) ? null : FileSource.fromByteValue(row.getByte(15)),
                 null,
+                null,
                 null);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta10LegacySerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta10LegacySerializer.java
@@ -145,6 +145,7 @@ public class DataFileMeta10LegacySerializer implements Serializable {
                 row.isNullAt(14) ? null : row.getBinary(14),
                 row.isNullAt(15) ? null : FileSource.fromByteValue(row.getByte(15)),
                 row.isNullAt(16) ? null : fromStringArrayData(row.getArray(16)),
+                null,
                 null);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta12LegacySerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta12LegacySerializer.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.safe.SafeBinaryRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.data.serializer.InternalSerializers;
+import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.stats.SimpleStats;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.BigIntType;
@@ -30,10 +31,12 @@ import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.TinyIntType;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.apache.paimon.utils.InternalRowUtils.fromStringArrayData;
@@ -43,35 +46,42 @@ import static org.apache.paimon.utils.SerializationUtils.newBytesType;
 import static org.apache.paimon.utils.SerializationUtils.newStringType;
 import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
 
-/** Serializer for {@link DataFileMeta} with safe deserializer. */
-public class DataFileMeta08Serializer implements Serializable {
+/** Serializer for {@link DataFileMeta} with 1.0 snapshot version. */
+public class DataFileMeta12LegacySerializer implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    public static final RowType SCHEMA =
+            new RowType(
+                    false,
+                    Arrays.asList(
+                            new DataField(0, "_FILE_NAME", newStringType(false)),
+                            new DataField(1, "_FILE_SIZE", new BigIntType(false)),
+                            new DataField(2, "_ROW_COUNT", new BigIntType(false)),
+                            new DataField(3, "_MIN_KEY", newBytesType(false)),
+                            new DataField(4, "_MAX_KEY", newBytesType(false)),
+                            new DataField(5, "_KEY_STATS", SimpleStats.SCHEMA),
+                            new DataField(6, "_VALUE_STATS", SimpleStats.SCHEMA),
+                            new DataField(7, "_MIN_SEQUENCE_NUMBER", new BigIntType(false)),
+                            new DataField(8, "_MAX_SEQUENCE_NUMBER", new BigIntType(false)),
+                            new DataField(9, "_SCHEMA_ID", new BigIntType(false)),
+                            new DataField(10, "_LEVEL", new IntType(false)),
+                            new DataField(
+                                    11, "_EXTRA_FILES", new ArrayType(false, newStringType(false))),
+                            new DataField(12, "_CREATION_TIME", DataTypes.TIMESTAMP_MILLIS()),
+                            new DataField(13, "_DELETE_ROW_COUNT", new BigIntType(true)),
+                            new DataField(14, "_EMBEDDED_FILE_INDEX", newBytesType(true)),
+                            new DataField(15, "_FILE_SOURCE", new TinyIntType(true)),
+                            new DataField(
+                                    16,
+                                    "_VALUE_STATS_COLS",
+                                    DataTypes.ARRAY(DataTypes.STRING().notNull())),
+                            new DataField(17, "_EXTERNAL_PATH", newStringType(true))));
+
     protected final InternalRowSerializer rowSerializer;
 
-    public DataFileMeta08Serializer() {
-        this.rowSerializer = InternalSerializers.create(schemaFor08());
-    }
-
-    private static RowType schemaFor08() {
-        List<DataField> fields = new ArrayList<>();
-        fields.add(new DataField(0, "_FILE_NAME", newStringType(false)));
-        fields.add(new DataField(1, "_FILE_SIZE", new BigIntType(false)));
-        fields.add(new DataField(2, "_ROW_COUNT", new BigIntType(false)));
-        fields.add(new DataField(3, "_MIN_KEY", newBytesType(false)));
-        fields.add(new DataField(4, "_MAX_KEY", newBytesType(false)));
-        fields.add(new DataField(5, "_KEY_STATS", SimpleStats.SCHEMA));
-        fields.add(new DataField(6, "_VALUE_STATS", SimpleStats.SCHEMA));
-        fields.add(new DataField(7, "_MIN_SEQUENCE_NUMBER", new BigIntType(false)));
-        fields.add(new DataField(8, "_MAX_SEQUENCE_NUMBER", new BigIntType(false)));
-        fields.add(new DataField(9, "_SCHEMA_ID", new BigIntType(false)));
-        fields.add(new DataField(10, "_LEVEL", new IntType(false)));
-        fields.add(new DataField(11, "_EXTRA_FILES", new ArrayType(false, newStringType(false))));
-        fields.add(new DataField(12, "_CREATION_TIME", DataTypes.TIMESTAMP_MILLIS()));
-        fields.add(new DataField(13, "_DELETE_ROW_COUNT", new BigIntType(true)));
-        fields.add(new DataField(14, "_EMBEDDED_FILE_INDEX", newBytesType(true)));
-        return new RowType(fields);
+    public DataFileMeta12LegacySerializer() {
+        this.rowSerializer = InternalSerializers.create(SCHEMA);
     }
 
     public final void serializeList(List<DataFileMeta> records, DataOutputView target)
@@ -99,7 +109,10 @@ public class DataFileMeta08Serializer implements Serializable {
                         toStringArrayData(meta.extraFiles()),
                         meta.creationTime(),
                         meta.deleteRowCount().orElse(null),
-                        meta.embeddedIndex());
+                        meta.embeddedIndex(),
+                        meta.fileSource().map(FileSource::toByteValue).orElse(null),
+                        toStringArrayData(meta.valueStatsCols()),
+                        meta.fileSource().map(FileSource::toByteValue).orElse(null));
         rowSerializer.serialize(row, target);
     }
 
@@ -132,9 +145,9 @@ public class DataFileMeta08Serializer implements Serializable {
                 row.getTimestamp(12, 3),
                 row.isNullAt(13) ? null : row.getLong(13),
                 row.isNullAt(14) ? null : row.getBinary(14),
-                null,
-                null,
-                null,
+                row.isNullAt(15) ? null : FileSource.fromByteValue(row.getByte(15)),
+                row.isNullAt(16) ? null : fromStringArrayData(row.getArray(16)),
+                row.isNullAt(17) ? null : row.getString(17).toString(),
                 null);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMetaSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMetaSerializer.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.stats.SimpleStats;
 import org.apache.paimon.utils.ObjectSerializer;
+import org.apache.paimon.utils.RowIdSequence;
 
 import static org.apache.paimon.utils.InternalRowUtils.fromStringArrayData;
 import static org.apache.paimon.utils.InternalRowUtils.toStringArrayData;
@@ -59,7 +60,8 @@ public class DataFileMetaSerializer extends ObjectSerializer<DataFileMeta> {
                 meta.embeddedIndex(),
                 meta.fileSource().map(FileSource::toByteValue).orElse(null),
                 toStringArrayData(meta.valueStatsCols()),
-                meta.externalPath().map(BinaryString::fromString).orElse(null));
+                meta.externalPath().map(BinaryString::fromString).orElse(null),
+                meta.rowIdSequence() == null ? null : meta.rowIdSequence().serialize());
     }
 
     @Override
@@ -82,6 +84,7 @@ public class DataFileMetaSerializer extends ObjectSerializer<DataFileMeta> {
                 row.isNullAt(14) ? null : row.getBinary(14),
                 row.isNullAt(15) ? null : FileSource.fromByteValue(row.getByte(15)),
                 row.isNullAt(16) ? null : fromStringArrayData(row.getArray(16)),
-                row.isNullAt(17) ? null : row.getString(17).toString());
+                row.isNullAt(17) ? null : row.getString(17).toString(),
+                row.isNullAt(18) ? null : RowIdSequence.deserialize(row.getBinary(18)));
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileWriter.java
@@ -187,7 +187,8 @@ public abstract class KeyValueDataFileWriter
                 indexResult.embeddedIndexBytes(),
                 fileSource,
                 valueStatsPair.getKey(),
-                externalPath);
+                externalPath,
+                null);
     }
 
     abstract Pair<SimpleColStats[], SimpleColStats[]> fetchKeyValueStats(SimpleColStats[] rowStats);

--- a/paimon-core/src/main/java/org/apache/paimon/io/RowDataRollingFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/RowDataRollingFileWriter.java
@@ -30,6 +30,9 @@ import org.apache.paimon.statistics.NoneSimpleColStatsCollector;
 import org.apache.paimon.statistics.SimpleColStatsCollector;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.LongCounter;
+import org.apache.paimon.utils.RowIdSequenceBuilder;
+
+import javax.annotation.Nullable;
 
 import java.util.Arrays;
 
@@ -49,7 +52,8 @@ public class RowDataRollingFileWriter extends RollingFileWriter<InternalRow, Dat
             FileIndexOptions fileIndexOptions,
             FileSource fileSource,
             boolean asyncFileWrite,
-            boolean statsDenseStore) {
+            boolean statsDenseStore,
+            @Nullable RowIdSequenceBuilder rowIdSequenceBuilder) {
         super(
                 () ->
                         new RowDataFileWriter(
@@ -64,7 +68,8 @@ public class RowDataRollingFileWriter extends RollingFileWriter<InternalRow, Dat
                                 fileSource,
                                 asyncFileWrite,
                                 statsDenseStore,
-                                pathFactory.isExternalPath()),
+                                pathFactory.isExternalPath(),
+                                rowIdSequenceBuilder),
                 targetFileSize);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/migrate/FileMetaUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/migrate/FileMetaUtils.java
@@ -218,6 +218,7 @@ public class FileMetaUtils {
                 null,
                 FileSource.APPEND,
                 null,
+                null,
                 null);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -1145,7 +1145,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         for (ManifestEntry entry : deltaFiles) {
             if (entry.file().rowIdSequence() == null) {
                 long rowCount = entry.file().rowCount();
-                maxRowId = startRowId + rowCount;
+                maxRowId = start + rowCount;
                 entry.file().setRowIdSequence(new RowIdSequence(start, maxRowId));
                 start = maxRowId;
             }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/SplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/SplitRead.java
@@ -44,6 +44,8 @@ public interface SplitRead<T> {
 
     SplitRead<T> withFilter(@Nullable Predicate predicate);
 
+    SplitRead<T> withRowId(boolean withRowId);
+
     /** Create a {@link RecordReader} from split. */
     RecordReader<T> createReader(DataSplit split) throws IOException;
 
@@ -71,6 +73,12 @@ public interface SplitRead<T> {
             @Override
             public SplitRead<R> withFilter(@Nullable Predicate predicate) {
                 read.withFilter(predicate);
+                return this;
+            }
+
+            @Override
+            public SplitRead<R> withRowId(boolean withRowId) {
+                read.withRowId(withRowId);
                 return this;
             }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -120,7 +120,7 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
 
             @Override
             public RecordReader<InternalRow> reader(Split split) throws IOException {
-                return read.createReader((DataSplit) split);
+                return read.withRowId(withRowId).createReader((DataSplit) split);
             }
         };
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/CommitMessageLegacyV2Serializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/CommitMessageLegacyV2Serializer.java
@@ -157,6 +157,7 @@ public class CommitMessageLegacyV2Serializer {
                     null,
                     null,
                     null,
+                    null,
                     null);
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
@@ -37,6 +37,7 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
 
     private RowType readType;
     private boolean executeFilter = false;
+    protected boolean withRowId = false;
     private Predicate predicate;
     private final TableSchema schema;
 
@@ -48,6 +49,11 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     public abstract void applyReadType(RowType readType);
 
     public abstract RecordReader<InternalRow> reader(Split split) throws IOException;
+
+    public InnerTableRead withRowId() {
+        this.withRowId = true;
+        return this;
+    }
 
     @Override
     public TableRead withIOManager(IOManager ioManager) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java
@@ -24,6 +24,7 @@ import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFileMeta08Serializer;
 import org.apache.paimon.io.DataFileMeta09Serializer;
 import org.apache.paimon.io.DataFileMeta10LegacySerializer;
+import org.apache.paimon.io.DataFileMeta12LegacySerializer;
 import org.apache.paimon.io.DataFileMetaSerializer;
 import org.apache.paimon.io.DataInputView;
 import org.apache.paimon.io.DataInputViewStreamWrapper;
@@ -58,7 +59,7 @@ public class DataSplit implements Split {
 
     private static final long serialVersionUID = 7L;
     private static final long MAGIC = -2394839472490812314L;
-    private static final int VERSION = 6;
+    private static final int VERSION = 7;
 
     private long snapshotId = 0;
     private BinaryRow partition;
@@ -426,7 +427,10 @@ public class DataSplit implements Split {
         } else if (version == 3 || version == 4) {
             DataFileMeta10LegacySerializer serializer = new DataFileMeta10LegacySerializer();
             return serializer::deserialize;
-        } else if (version >= 5) {
+        } else if (version == 5 || version == 6) {
+            DataFileMeta12LegacySerializer serializer = new DataFileMeta12LegacySerializer();
+            return serializer::deserialize;
+        } else if (version >= 7) {
             DataFileMetaSerializer serializer = new DataFileMetaSerializer();
             return serializer::deserialize;
         } else {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableRead.java
@@ -54,6 +54,10 @@ public interface InnerTableRead extends TableRead {
         return this;
     }
 
+    default InnerTableRead withRowId() {
+        return this;
+    }
+
     @Override
     default TableRead executeFilter() {
         return this;

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
@@ -120,7 +120,7 @@ public final class KeyValueTableRead extends AbstractDataTableRead {
         DataSplit dataSplit = (DataSplit) split;
         for (SplitReadProvider readProvider : readProviders) {
             if (readProvider.match(dataSplit, forceKeepDelete)) {
-                return readProvider.getOrCreate().createReader(dataSplit);
+                return readProvider.getOrCreate().withRowId(withRowId).createReader(dataSplit);
             }
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
@@ -84,6 +84,12 @@ public class IncrementalDiffSplitRead implements SplitRead<InternalRow> {
     }
 
     @Override
+    public SplitRead<InternalRow> withRowId(boolean withRowId) {
+        mergeRead.withRowId(withRowId);
+        return this;
+    }
+
+    @Override
     public RecordReader<InternalRow> createReader(DataSplit split) throws IOException {
         RecordReader<KeyValue> reader =
                 readDiff(

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
@@ -50,6 +50,7 @@ import static org.apache.paimon.table.system.SnapshotsTable.SNAPSHOTS;
 import static org.apache.paimon.table.system.StatisticTable.STATISTICS;
 import static org.apache.paimon.table.system.TableIndexesTable.TABLE_INDEXES;
 import static org.apache.paimon.table.system.TagsTable.TAGS;
+import static org.apache.paimon.table.system.WithRowIdTable.ROW_ID_TABLE;
 
 /** Loader to load system {@link Table}s. */
 public class SystemTableLoader {
@@ -72,6 +73,7 @@ public class SystemTableLoader {
                     .put(STATISTICS, StatisticTable::new)
                     .put(BINLOG, BinlogTable::new)
                     .put(TABLE_INDEXES, TableIndexesTable::new)
+                    .put(ROW_ID_TABLE, WithRowIdTable::new)
                     .build();
 
     public static final List<String> SYSTEM_TABLES = new ArrayList<>(SYSTEM_TABLE_LOADERS.keySet());

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/WithRowIdTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/WithRowIdTable.java
@@ -1,0 +1,688 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.system;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.consumer.ConsumerManager;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.JoinedRow;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.manifest.BucketEntry;
+import org.apache.paimon.manifest.IndexManifestEntry;
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.ManifestFileMeta;
+import org.apache.paimon.manifest.PartitionEntry;
+import org.apache.paimon.metrics.MetricRegistry;
+import org.apache.paimon.operation.ManifestsReader;
+import org.apache.paimon.predicate.LeafPredicate;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.predicate.PredicateReplaceVisitor;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.table.DataTable;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.ReadonlyTable;
+import org.apache.paimon.table.SpecialFields;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.source.DataTableScan;
+import org.apache.paimon.table.source.InnerTableRead;
+import org.apache.paimon.table.source.InnerTableScan;
+import org.apache.paimon.table.source.ScanMode;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.SplitGenerator;
+import org.apache.paimon.table.source.StreamDataTableScan;
+import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.table.source.snapshot.SnapshotReader;
+import org.apache.paimon.table.source.snapshot.StartingContext;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.BranchManager;
+import org.apache.paimon.utils.ChangelogManager;
+import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.Filter;
+import org.apache.paimon.utils.SimpleFileReader;
+import org.apache.paimon.utils.SnapshotManager;
+import org.apache.paimon.utils.TagManager;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.catalog.Identifier.SYSTEM_TABLE_SPLITTER;
+
+/** A {@link Table} for reading row id of table. */
+public class WithRowIdTable implements DataTable, ReadonlyTable {
+
+    public static final String ROW_ID_TABLE = "with_row_id";
+
+    public static final PredicateReplaceVisitor PREDICATE_CONVERTER =
+            p -> {
+                if (p.index() == 0) {
+                    return Optional.empty();
+                }
+                return Optional.of(
+                        new LeafPredicate(
+                                p.function(),
+                                p.type(),
+                                p.index() - 1,
+                                p.fieldName(),
+                                p.literals()));
+            };
+
+    private final FileStoreTable wrapped;
+
+    public WithRowIdTable(FileStoreTable wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public Optional<Snapshot> latestSnapshot() {
+        return wrapped.latestSnapshot();
+    }
+
+    @Override
+    public Snapshot snapshot(long snapshotId) {
+        return wrapped.snapshot(snapshotId);
+    }
+
+    @Override
+    public SimpleFileReader<ManifestFileMeta> manifestListReader() {
+        return wrapped.manifestListReader();
+    }
+
+    @Override
+    public SimpleFileReader<ManifestEntry> manifestFileReader() {
+        return wrapped.manifestFileReader();
+    }
+
+    @Override
+    public SimpleFileReader<IndexManifestEntry> indexManifestFileReader() {
+        return wrapped.indexManifestFileReader();
+    }
+
+    @Override
+    public String name() {
+        return wrapped.name() + SYSTEM_TABLE_SPLITTER + ROW_ID_TABLE;
+    }
+
+    @Override
+    public RowType rowType() {
+        List<DataField> fields = new ArrayList<>();
+        fields.add(SpecialFields.ROW_ID);
+        fields.addAll(wrapped.rowType().getFields());
+        return new RowType(fields);
+    }
+
+    @Override
+    public List<String> partitionKeys() {
+        return wrapped.partitionKeys();
+    }
+
+    @Override
+    public Map<String, String> options() {
+        return wrapped.options();
+    }
+
+    @Override
+    public List<String> primaryKeys() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public SnapshotReader newSnapshotReader() {
+        return new WithRowIdSnapshotReader(wrapped.newSnapshotReader());
+    }
+
+    @Override
+    public DataTableScan newScan() {
+        return new WithRowIdBatchScan(wrapped.newScan());
+    }
+
+    @Override
+    public StreamDataTableScan newStreamScan() {
+        return new WithRowIdStreamScan(wrapped.newStreamScan());
+    }
+
+    @Override
+    public CoreOptions coreOptions() {
+        return wrapped.coreOptions();
+    }
+
+    @Override
+    public Path location() {
+        return wrapped.location();
+    }
+
+    @Override
+    public SnapshotManager snapshotManager() {
+        return wrapped.snapshotManager();
+    }
+
+    @Override
+    public ChangelogManager changelogManager() {
+        return wrapped.changelogManager();
+    }
+
+    @Override
+    public ConsumerManager consumerManager() {
+        return wrapped.consumerManager();
+    }
+
+    @Override
+    public SchemaManager schemaManager() {
+        return wrapped.schemaManager();
+    }
+
+    @Override
+    public TagManager tagManager() {
+        return wrapped.tagManager();
+    }
+
+    @Override
+    public BranchManager branchManager() {
+        return wrapped.branchManager();
+    }
+
+    @Override
+    public DataTable switchToBranch(String branchName) {
+        return new WithRowIdTable(wrapped.switchToBranch(branchName));
+    }
+
+    @Override
+    public InnerTableRead newRead() {
+        return new WithRowIdTableRead(wrapped.newRead());
+    }
+
+    @Override
+    public Table copy(Map<String, String> dynamicOptions) {
+        return new WithRowIdTable(wrapped.copy(dynamicOptions));
+    }
+
+    @Override
+    public FileIO fileIO() {
+        return wrapped.fileIO();
+    }
+
+    /** Push down predicate to dataScan and dataRead. */
+    private Optional<Predicate> convert(Predicate predicate) {
+        List<Predicate> result =
+                PredicateBuilder.splitAnd(predicate).stream()
+                        .map(p -> p.visit(PREDICATE_CONVERTER))
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .collect(Collectors.toList());
+        if (result.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(PredicateBuilder.and(result));
+    }
+
+    private class WithRowIdSnapshotReader implements SnapshotReader {
+
+        private final SnapshotReader wrapped;
+
+        private WithRowIdSnapshotReader(SnapshotReader wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public Integer parallelism() {
+            return wrapped.parallelism();
+        }
+
+        @Override
+        public SnapshotManager snapshotManager() {
+            return wrapped.snapshotManager();
+        }
+
+        @Override
+        public ChangelogManager changelogManager() {
+            return wrapped.changelogManager();
+        }
+
+        @Override
+        public ManifestsReader manifestsReader() {
+            return wrapped.manifestsReader();
+        }
+
+        @Override
+        public List<ManifestEntry> readManifest(ManifestFileMeta manifest) {
+            return wrapped.readManifest(manifest);
+        }
+
+        @Override
+        public ConsumerManager consumerManager() {
+            return wrapped.consumerManager();
+        }
+
+        @Override
+        public SplitGenerator splitGenerator() {
+            return wrapped.splitGenerator();
+        }
+
+        @Override
+        public FileStorePathFactory pathFactory() {
+            return wrapped.pathFactory();
+        }
+
+        public SnapshotReader withSnapshot(long snapshotId) {
+            wrapped.withSnapshot(snapshotId);
+            return this;
+        }
+
+        public SnapshotReader withSnapshot(Snapshot snapshot) {
+            wrapped.withSnapshot(snapshot);
+            return this;
+        }
+
+        public SnapshotReader withFilter(Predicate predicate) {
+            convert(predicate).ifPresent(wrapped::withFilter);
+            return this;
+        }
+
+        @Override
+        public SnapshotReader withPartitionFilter(Map<String, String> partitionSpec) {
+            wrapped.withPartitionFilter(partitionSpec);
+            return this;
+        }
+
+        @Override
+        public SnapshotReader withPartitionFilter(Predicate predicate) {
+            wrapped.withPartitionFilter(predicate);
+            return this;
+        }
+
+        @Override
+        public SnapshotReader withPartitionFilter(List<BinaryRow> partitions) {
+            wrapped.withPartitionFilter(partitions);
+            return this;
+        }
+
+        @Override
+        public SnapshotReader withPartitionsFilter(List<Map<String, String>> partitions) {
+            wrapped.withPartitionsFilter(partitions);
+            return this;
+        }
+
+        @Override
+        public SnapshotReader withMode(ScanMode scanMode) {
+            wrapped.withMode(scanMode);
+            return this;
+        }
+
+        @Override
+        public SnapshotReader withLevel(int level) {
+            wrapped.withLevel(level);
+            return this;
+        }
+
+        @Override
+        public SnapshotReader withLevelFilter(Filter<Integer> levelFilter) {
+            wrapped.withLevelFilter(levelFilter);
+            return this;
+        }
+
+        @Override
+        public SnapshotReader enableValueFilter() {
+            wrapped.enableValueFilter();
+            return this;
+        }
+
+        @Override
+        public SnapshotReader withManifestEntryFilter(Filter<ManifestEntry> filter) {
+            wrapped.withManifestEntryFilter(filter);
+            return this;
+        }
+
+        public SnapshotReader withBucket(int bucket) {
+            wrapped.withBucket(bucket);
+            return this;
+        }
+
+        @Override
+        public SnapshotReader withBucketFilter(Filter<Integer> bucketFilter) {
+            wrapped.withBucketFilter(bucketFilter);
+            return this;
+        }
+
+        @Override
+        public SnapshotReader withDataFileNameFilter(Filter<String> fileNameFilter) {
+            wrapped.withDataFileNameFilter(fileNameFilter);
+            return this;
+        }
+
+        @Override
+        public SnapshotReader dropStats() {
+            wrapped.dropStats();
+            return this;
+        }
+
+        @Override
+        public SnapshotReader withShard(int indexOfThisSubtask, int numberOfParallelSubtasks) {
+            wrapped.withShard(indexOfThisSubtask, numberOfParallelSubtasks);
+            return this;
+        }
+
+        @Override
+        public SnapshotReader withMetricRegistry(MetricRegistry registry) {
+            wrapped.withMetricRegistry(registry);
+            return this;
+        }
+
+        @Override
+        public Plan read() {
+            return wrapped.read();
+        }
+
+        @Override
+        public Plan readChanges() {
+            return wrapped.readChanges();
+        }
+
+        @Override
+        public Plan readIncrementalDiff(Snapshot before) {
+            return wrapped.readIncrementalDiff(before);
+        }
+
+        @Override
+        public List<BinaryRow> partitions() {
+            return wrapped.partitions();
+        }
+
+        @Override
+        public List<PartitionEntry> partitionEntries() {
+            return wrapped.partitionEntries();
+        }
+
+        @Override
+        public List<BucketEntry> bucketEntries() {
+            return wrapped.bucketEntries();
+        }
+
+        @Override
+        public Iterator<ManifestEntry> readFileIterator() {
+            return wrapped.readFileIterator();
+        }
+    }
+
+    private class WithRowIdBatchScan implements DataTableScan {
+
+        private final DataTableScan batchScan;
+
+        private WithRowIdBatchScan(DataTableScan batchScan) {
+            this.batchScan = batchScan;
+        }
+
+        @Override
+        public InnerTableScan withFilter(Predicate predicate) {
+            convert(predicate).ifPresent(batchScan::withFilter);
+            return this;
+        }
+
+        @Override
+        public InnerTableScan withMetricRegistry(MetricRegistry metricsRegistry) {
+            batchScan.withMetricRegistry(metricsRegistry);
+            return this;
+        }
+
+        @Override
+        public InnerTableScan withLimit(int limit) {
+            batchScan.withLimit(limit);
+            return this;
+        }
+
+        @Override
+        public InnerTableScan withPartitionFilter(Map<String, String> partitionSpec) {
+            batchScan.withPartitionFilter(partitionSpec);
+            return this;
+        }
+
+        @Override
+        public InnerTableScan withPartitionFilter(List<BinaryRow> partitions) {
+            batchScan.withPartitionFilter(partitions);
+            return this;
+        }
+
+        @Override
+        public InnerTableScan withPartitionsFilter(List<Map<String, String>> partitions) {
+            batchScan.withPartitionsFilter(partitions);
+            return this;
+        }
+
+        @Override
+        public InnerTableScan withBucketFilter(Filter<Integer> bucketFilter) {
+            batchScan.withBucketFilter(bucketFilter);
+            return this;
+        }
+
+        @Override
+        public InnerTableScan withLevelFilter(Filter<Integer> levelFilter) {
+            batchScan.withLevelFilter(levelFilter);
+            return this;
+        }
+
+        @Override
+        public Plan plan() {
+            return batchScan.plan();
+        }
+
+        @Override
+        public List<PartitionEntry> listPartitionEntries() {
+            return batchScan.listPartitionEntries();
+        }
+
+        @Override
+        public DataTableScan withShard(int indexOfThisSubtask, int numberOfParallelSubtasks) {
+            batchScan.withShard(indexOfThisSubtask, numberOfParallelSubtasks);
+            return this;
+        }
+    }
+
+    private class WithRowIdStreamScan implements StreamDataTableScan {
+
+        private final StreamDataTableScan streamScan;
+
+        private WithRowIdStreamScan(StreamDataTableScan streamScan) {
+            this.streamScan = streamScan;
+        }
+
+        @Override
+        public StreamDataTableScan withFilter(Predicate predicate) {
+            convert(predicate).ifPresent(streamScan::withFilter);
+            return this;
+        }
+
+        @Override
+        public StartingContext startingContext() {
+            return streamScan.startingContext();
+        }
+
+        @Override
+        public Plan plan() {
+            return streamScan.plan();
+        }
+
+        @Override
+        public List<PartitionEntry> listPartitionEntries() {
+            return streamScan.listPartitionEntries();
+        }
+
+        @Nullable
+        @Override
+        public Long checkpoint() {
+            return streamScan.checkpoint();
+        }
+
+        @Nullable
+        @Override
+        public Long watermark() {
+            return streamScan.watermark();
+        }
+
+        @Override
+        public void restore(@Nullable Long nextSnapshotId) {
+            streamScan.restore(nextSnapshotId);
+        }
+
+        @Override
+        public void restore(@Nullable Long nextSnapshotId, boolean scanAllSnapshot) {
+            streamScan.restore(nextSnapshotId, scanAllSnapshot);
+        }
+
+        @Override
+        public void notifyCheckpointComplete(@Nullable Long nextSnapshot) {
+            streamScan.notifyCheckpointComplete(nextSnapshot);
+        }
+
+        @Override
+        public StreamDataTableScan withMetricRegistry(MetricRegistry metricsRegistry) {
+            streamScan.withMetricRegistry(metricsRegistry);
+            return this;
+        }
+
+        @Override
+        public DataTableScan withShard(int indexOfThisSubtask, int numberOfParallelSubtasks) {
+            streamScan.withShard(indexOfThisSubtask, numberOfParallelSubtasks);
+            return this;
+        }
+    }
+
+    class WithRowIdTableRead implements InnerTableRead {
+
+        protected final InnerTableRead dataRead;
+
+        protected int[] readProjection;
+
+        protected WithRowIdTableRead(InnerTableRead dataRead) {
+            this.dataRead = dataRead.withRowId();
+            this.readProjection = defaultProjection();
+        }
+
+        /** Default projection, just add row kind to the first. */
+        private int[] defaultProjection() {
+            int dataFieldCount = wrapped.rowType().getFieldCount();
+            int[] projection = new int[dataFieldCount + 1];
+            projection[0] = -1;
+            for (int i = 0; i < dataFieldCount; i++) {
+                projection[i + 1] = i;
+            }
+            return projection;
+        }
+
+        @Override
+        public InnerTableRead withFilter(Predicate predicate) {
+            convert(predicate).ifPresent(dataRead::withFilter);
+            return this;
+        }
+
+        @Override
+        public InnerTableRead withReadType(RowType readType) {
+            // data projection to push down to dataRead
+            List<DataField> dataReadFields = new ArrayList<>();
+
+            // read projection to handle record returned by dataRead
+            List<DataField> fields = readType.getFields();
+            int[] readProjection = new int[fields.size()];
+
+            boolean rowKindAppeared = false;
+            for (int i = 0; i < fields.size(); i++) {
+                String fieldName = fields.get(i).name();
+                if (fieldName.equals(SpecialFields.ROW_KIND.name())) {
+                    rowKindAppeared = true;
+                    readProjection[i] = -1;
+                } else {
+                    dataReadFields.add(fields.get(i));
+                    // There is no row kind field. Keep it as it is
+                    // Row kind field has occurred, and the following fields are offset by 1
+                    // position
+                    readProjection[i] = rowKindAppeared ? i - 1 : i;
+                }
+            }
+
+            this.readProjection = readProjection;
+            dataRead.withReadType(new RowType(readType.isNullable(), dataReadFields));
+            return this;
+        }
+
+        @Override
+        public TableRead withIOManager(IOManager ioManager) {
+            this.dataRead.withIOManager(ioManager);
+            return this;
+        }
+
+        @Override
+        public RecordReader<InternalRow> createReader(Split split) throws IOException {
+            final GenericRow idRow = new GenericRow(1);
+            final JoinedRow joinedRow = new JoinedRow();
+            final RecordReader<InternalRow> reader = dataRead.createReader(split);
+
+            return new RecordReader<InternalRow>() {
+                @Nullable
+                @Override
+                public RecordIterator<InternalRow> readBatch() throws IOException {
+                    RecordIterator<InternalRow> thisIterator = reader.readBatch();
+                    if (thisIterator == null) {
+                        return null;
+                    }
+                    return new RecordIterator<InternalRow>() {
+                        @Nullable
+                        @Override
+                        public InternalRow next() throws IOException {
+                            InternalRow n = thisIterator.next();
+                            if (n == null) {
+                                return null;
+                            }
+                            Long rowId = thisIterator.rowId();
+                            idRow.setField(0, rowId);
+                            return joinedRow.replace(idRow, n);
+                        }
+
+                        @Override
+                        public Long rowId() {
+                            return thisIterator.rowId();
+                        }
+
+                        @Override
+                        public void releaseBatch() {
+                            thisIterator.releaseBatch();
+                        }
+                    };
+                }
+
+                @Override
+                public void close() throws IOException {
+                    reader.close();
+                }
+            };
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/WithRowIdTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/WithRowIdTable.java
@@ -369,6 +369,12 @@ public class WithRowIdTable implements DataTable, ReadonlyTable {
         }
 
         @Override
+        public SnapshotReader onlyReadRealBuckets() {
+            wrapped.onlyReadRealBuckets();
+            return this;
+        }
+
+        @Override
         public SnapshotReader withBucketFilter(Filter<Integer> bucketFilter) {
             wrapped.withBucketFilter(bucketFilter);
             return this;

--- a/paimon-core/src/main/java/org/apache/paimon/tag/Tag.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/Tag.java
@@ -80,6 +80,7 @@ public class Tag extends Snapshot {
             @JsonProperty(FIELD_WATERMARK) @Nullable Long watermark,
             @JsonProperty(FIELD_STATISTICS) @Nullable String statistics,
             @JsonProperty(FIELD_PROPERTIES) Map<String, String> properties,
+            @JsonProperty(FIELD_NEXT_ROW_ID) @Nullable Long nextRowId,
             @JsonProperty(FIELD_TAG_CREATE_TIME) @Nullable LocalDateTime tagCreateTime,
             @JsonProperty(FIELD_TAG_TIME_RETAINED) @Nullable Duration tagTimeRetained) {
         super(
@@ -103,7 +104,8 @@ public class Tag extends Snapshot {
                 changelogRecordCount,
                 watermark,
                 statistics,
-                properties);
+                properties,
+                nextRowId);
         this.tagCreateTime = tagCreateTime;
         this.tagTimeRetained = tagTimeRetained;
     }
@@ -147,6 +149,7 @@ public class Tag extends Snapshot {
                 snapshot.watermark(),
                 snapshot.statistics(),
                 snapshot.properties(),
+                snapshot.nextRowId(),
                 tagCreateTime,
                 tagTimeRetained);
     }
@@ -173,7 +176,8 @@ public class Tag extends Snapshot {
                 changelogRecordCount,
                 watermark,
                 statistics,
-                properties);
+                properties,
+                nextRowId);
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendCompactCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendCompactCoordinatorTest.java
@@ -260,6 +260,7 @@ public class AppendCompactCoordinatorTest {
                 0L,
                 null,
                 FileSource.APPEND,
+                null,
                 null);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -732,6 +732,7 @@ public class AppendOnlyWriterTest {
                 null,
                 FileSource.APPEND,
                 null,
+                null,
                 null);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/crosspartition/IndexBootstrapTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/crosspartition/IndexBootstrapTest.java
@@ -161,6 +161,7 @@ public class IndexBootstrapTest extends TableTestBase {
                 null,
                 FileSource.APPEND,
                 null,
+                null,
                 null);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/io/DataFileTestDataGenerator.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/DataFileTestDataGenerator.java
@@ -165,6 +165,7 @@ public class DataFileTestDataGenerator {
                         kvs.stream().filter(kv -> kv.valueKind().isRetract()).count(),
                         null,
                         FileSource.APPEND,
+                        null,
                         null),
                 kvs);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/io/DataFileTestUtils.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/DataFileTestUtils.java
@@ -58,6 +58,7 @@ public class DataFileTestUtils {
                 null,
                 FileSource.APPEND,
                 null,
+                null,
                 null);
     }
 
@@ -77,6 +78,7 @@ public class DataFileTestUtils {
                 0L,
                 null,
                 FileSource.APPEND,
+                null,
                 null);
     }
 
@@ -102,6 +104,7 @@ public class DataFileTestUtils {
                 deleteRowCount,
                 null,
                 FileSource.APPEND,
+                null,
                 null);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/io/RollingFileWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/RollingFileWriterTest.java
@@ -97,7 +97,8 @@ public class RollingFileWriterTest {
                                         FileSource.APPEND,
                                         true,
                                         statsDenseStore,
-                                        false),
+                                        false,
+                                        null),
                         TARGET_FILE_SIZE);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestCommittableSerializerCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestCommittableSerializerCompatibilityTest.java
@@ -76,7 +76,8 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         new byte[] {1, 2, 4},
                         FileSource.COMPACT,
                         Arrays.asList("field1", "field2", "field3"),
-                        "hdfs://localhost:9000/path/to/file");
+                        "hdfs://localhost:9000/path/to/file",
+                        null);
         List<DataFileMeta> dataFiles = Collections.singletonList(dataFile);
 
         LinkedHashMap<String, DeletionVectorMeta> dvMetas = new LinkedHashMap<>();
@@ -150,7 +151,8 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         new byte[] {1, 2, 4},
                         FileSource.COMPACT,
                         Arrays.asList("field1", "field2", "field3"),
-                        "hdfs://localhost:9000/path/to/file");
+                        "hdfs://localhost:9000/path/to/file",
+                        null);
         List<DataFileMeta> dataFiles = Collections.singletonList(dataFile);
 
         LinkedHashMap<String, DeletionVectorMeta> dvMetas = new LinkedHashMap<>();
@@ -222,7 +224,8 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         new byte[] {1, 2, 4},
                         FileSource.COMPACT,
                         Arrays.asList("field1", "field2", "field3"),
-                        "hdfs://localhost:9000/path/to/file");
+                        "hdfs://localhost:9000/path/to/file",
+                        null);
         List<DataFileMeta> dataFiles = Collections.singletonList(dataFile);
 
         LinkedHashMap<String, DeletionVectorMeta> dvMetas = new LinkedHashMap<>();
@@ -294,6 +297,7 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         new byte[] {1, 2, 4},
                         FileSource.COMPACT,
                         Arrays.asList("field1", "field2", "field3"),
+                        null,
                         null);
         List<DataFileMeta> dataFiles = Collections.singletonList(dataFile);
 
@@ -365,6 +369,7 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         new byte[] {1, 2, 4},
                         FileSource.COMPACT,
                         Arrays.asList("field1", "field2", "field3"),
+                        null,
                         null);
         List<DataFileMeta> dataFiles = Collections.singletonList(dataFile);
 
@@ -436,6 +441,7 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         11L,
                         new byte[] {1, 2, 4},
                         FileSource.COMPACT,
+                        null,
                         null,
                         null);
         List<DataFileMeta> dataFiles = Collections.singletonList(dataFile);
@@ -509,6 +515,7 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         new byte[] {1, 2, 4},
                         null,
                         null,
+                        null,
                         null);
         List<DataFileMeta> dataFiles = Collections.singletonList(dataFile);
 
@@ -577,6 +584,7 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         3,
                         Arrays.asList("extra1", "extra2"),
                         Timestamp.fromLocalDateTime(LocalDateTime.parse("2022-03-02T20:20:12")),
+                        null,
                         null,
                         null,
                         null,

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestCommittableSerializerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestCommittableSerializerTest.java
@@ -116,6 +116,7 @@ public class ManifestCommittableSerializerTest {
                 0L,
                 null,
                 FileSource.APPEND,
+                null,
                 null);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTestBase.java
@@ -96,6 +96,7 @@ public abstract class ManifestFileMetaTestBase {
                         embeddedIndex, // not used
                         FileSource.APPEND,
                         null,
+                        null,
                         null));
     }
 
@@ -280,6 +281,7 @@ public abstract class ManifestFileMetaTestBase {
                         0L,
                         null,
                         FileSource.APPEND,
+                        null,
                         null));
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/LevelsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/LevelsTest.java
@@ -84,6 +84,7 @@ public class LevelsTest {
                 0L,
                 null,
                 FileSource.APPEND,
+                null,
                 null);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/IntervalPartitionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/IntervalPartitionTest.java
@@ -185,6 +185,7 @@ public class IntervalPartitionTest {
                 null,
                 FileSource.APPEND,
                 null,
+                null,
                 null);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/UniversalCompactionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/UniversalCompactionTest.java
@@ -421,6 +421,21 @@ public class UniversalCompactionTest {
 
     static DataFileMeta file(long size) {
         return new DataFileMeta(
-                "", size, 1, null, null, null, null, 0, 0, 0, 0, 0L, null, FileSource.APPEND, null);
+                "",
+                size,
+                1,
+                null,
+                null,
+                null,
+                null,
+                0,
+                0,
+                0,
+                0,
+                0L,
+                null,
+                FileSource.APPEND,
+                null,
+                null);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -284,6 +284,7 @@ public class ExpireSnapshotsTest {
                         null,
                         FileSource.APPEND,
                         null,
+                        null,
                         null);
         ManifestEntry add = new ManifestEntry(FileKind.ADD, partition, 0, 1, dataFile);
         ManifestEntry delete = new ManifestEntry(FileKind.DELETE, partition, 0, 1, dataFile);
@@ -345,7 +346,8 @@ public class ExpireSnapshotsTest {
                         null,
                         FileSource.APPEND,
                         null,
-                        myDataFile.toString());
+                        myDataFile.toString(),
+                        null);
         ManifestEntry add = new ManifestEntry(FileKind.ADD, partition, 0, 1, dataFile);
         ManifestEntry delete = new ManifestEntry(FileKind.DELETE, partition, 0, 1, dataFile);
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/SplitGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/SplitGeneratorTest.java
@@ -59,6 +59,7 @@ public class SplitGeneratorTest {
                 0L,
                 null,
                 FileSource.APPEND,
+                null,
                 null);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/SplitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/SplitTest.java
@@ -216,6 +216,7 @@ public class SplitTest {
                         new byte[] {1, 2, 4},
                         null,
                         null,
+                        null,
                         null);
         List<DataFileMeta> dataFiles = Collections.singletonList(dataFile);
 
@@ -278,6 +279,7 @@ public class SplitTest {
                         11L,
                         new byte[] {1, 2, 4},
                         FileSource.COMPACT,
+                        null,
                         null,
                         null);
         List<DataFileMeta> dataFiles = Collections.singletonList(dataFile);
@@ -342,6 +344,7 @@ public class SplitTest {
                         new byte[] {1, 2, 4},
                         FileSource.COMPACT,
                         Arrays.asList("field1", "field2", "field3"),
+                        null,
                         null);
         List<DataFileMeta> dataFiles = Collections.singletonList(dataFile);
 
@@ -409,6 +412,7 @@ public class SplitTest {
                         new byte[] {1, 2, 4},
                         FileSource.COMPACT,
                         Arrays.asList("field1", "field2", "field3"),
+                        null,
                         null);
         List<DataFileMeta> dataFiles = Collections.singletonList(dataFile);
 
@@ -476,7 +480,8 @@ public class SplitTest {
                         new byte[] {1, 2, 4},
                         FileSource.COMPACT,
                         Arrays.asList("field1", "field2", "field3"),
-                        "hdfs:///path/to/warehouse");
+                        "hdfs:///path/to/warehouse",
+                        null);
         List<DataFileMeta> dataFiles = Collections.singletonList(dataFile);
 
         DeletionFile deletionFile = new DeletionFile("deletion_file", 100, 22, 33L);
@@ -543,7 +548,8 @@ public class SplitTest {
                         new byte[] {1, 2, 4},
                         FileSource.COMPACT,
                         Arrays.asList("field1", "field2", "field3"),
-                        "hdfs:///path/to/warehouse");
+                        "hdfs:///path/to/warehouse",
+                        null);
         List<DataFileMeta> dataFiles = Collections.singletonList(dataFile);
 
         DeletionFile deletionFile = new DeletionFile("deletion_file", 100, 22, 33L);
@@ -597,6 +603,7 @@ public class SplitTest {
                 null,
                 null,
                 valueStatsCols,
+                null,
                 null);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoManagerTest.java
@@ -408,6 +408,7 @@ public class TagAutoManagerTest extends PrimaryKeyTableTestBase {
                         null,
                         null,
                         null,
+                        null,
                         null);
         tagManager.createTag(
                 snapshot1,
@@ -431,6 +432,7 @@ public class TagAutoManagerTest extends PrimaryKeyTableTestBase {
                         0L,
                         Snapshot.CommitKind.APPEND,
                         1000,
+                        null,
                         null,
                         null,
                         null,

--- a/paimon-core/src/test/java/org/apache/paimon/tag/TagTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/tag/TagTest.java
@@ -51,6 +51,7 @@ public class TagTest {
                     null,
                     null,
                     null,
+                    null,
                     null);
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -263,6 +263,7 @@ public class SnapshotManagerTest {
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 
@@ -287,6 +288,7 @@ public class SnapshotManagerTest {
                 null,
                 watermark,
                 null,
+                null,
                 null);
     }
 
@@ -306,6 +308,7 @@ public class SnapshotManagerTest {
                         0L,
                         Snapshot.CommitKind.APPEND,
                         millis,
+                        null,
                         null,
                         null,
                         null,
@@ -337,6 +340,7 @@ public class SnapshotManagerTest {
                             0L,
                             Snapshot.CommitKind.APPEND,
                             i * 1000,
+                            null,
                             null,
                             null,
                             null,
@@ -390,6 +394,7 @@ public class SnapshotManagerTest {
                             0L,
                             Snapshot.CommitKind.APPEND,
                             i * 1000,
+                            null,
                             null,
                             null,
                             null,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupCompactDiffRead.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupCompactDiffRead.java
@@ -58,9 +58,11 @@ public class LookupCompactDiffRead extends AbstractDataTableRead {
     public RecordReader<InternalRow> reader(Split split) throws IOException {
         DataSplit dataSplit = (DataSplit) split;
         if (dataSplit.beforeFiles().isEmpty()) {
-            return fullPhaseMergeRead.createReader(dataSplit); // full reading phase
+            return fullPhaseMergeRead
+                    .withRowId(withRowId)
+                    .createReader(dataSplit); // full reading phase
         } else {
-            return incrementalDiffRead.createReader((DataSplit) split);
+            return incrementalDiffRead.withRowId(withRowId).createReader((DataSplit) split);
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/AppendPreCommitCompactCoordinatorOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/AppendPreCommitCompactCoordinatorOperatorTest.java
@@ -243,6 +243,7 @@ public class AppendPreCommitCompactCoordinatorOperatorTest {
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/changelog/ChangelogCompactCoordinateOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/changelog/ChangelogCompactCoordinateOperatorTest.java
@@ -350,6 +350,7 @@ public class ChangelogCompactCoordinateOperatorTest {
                 null,
                 null,
                 null,
+                null,
                 null);
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/changelog/ChangelogCompactTaskSerializerTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/changelog/ChangelogCompactTaskSerializerTest.java
@@ -101,6 +101,7 @@ public class ChangelogCompactTaskSerializerTest {
                 0L,
                 null,
                 FileSource.APPEND,
+                null,
                 null);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CompactionTaskSimpleSerializerTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CompactionTaskSimpleSerializerTest.java
@@ -79,6 +79,7 @@ public class CompactionTaskSimpleSerializerTest {
                 0L,
                 null,
                 FileSource.APPEND,
+                null,
                 null);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitGeneratorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitGeneratorTest.java
@@ -116,6 +116,7 @@ public class FileStoreSourceSplitGeneratorTest {
                             0L, // not used
                             null, // not used
                             FileSource.APPEND,
+                            null,
                             null));
         }
         return DataSplit.builder()

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitSerializerTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitSerializerTest.java
@@ -89,6 +89,7 @@ public class FileStoreSourceSplitSerializerTest {
                 0L,
                 null,
                 FileSource.APPEND,
+                null,
                 null);
     }
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/ScanHelperTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/ScanHelperTest.scala
@@ -54,6 +54,7 @@ class ScanHelperTest extends PaimonSparkTestBase {
             null,
             FileSource.APPEND,
             null,
+            null,
             null)
       }
 
@@ -90,6 +91,7 @@ class ScanHelperTest extends PaimonSparkTestBase {
         new java.util.ArrayList[String](),
         null,
         FileSource.APPEND,
+        null,
         null,
         null)
     ).asJava


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This pull introduce global row id for paimon table.

A ROW ID is defined as a globally unique, auto-incrementing sequence, serving as the "identity card" for each piece of data. Every single data record has one, and only one, globally unique ROW ID.

ROW IDs possess the following characteristics:

* Immutability: Once a ROW ID is generated, it cannot be changed. It serves as the sole identifier for a data record. When performing COMPACTION (data merging), the corresponding ROW IDs must be merged, but they remain unchangeable themselves. When UPDATING data, a new ROW ID should be generated for the updated record, treating the updated data as a distinct record from the original.

* Auto-incrementing: ROW IDs are allocated based on the largest ROW ID from the previous SNAPSHOT. The maximum allocated ROW ID for the current SNAPSHOT is then recorded, facilitating allocation for the next SNAPSHOT.

* Hidden: The ROW ID functions as an internal sequence number. It is not recorded in the table schema and is not exposed or perceptible externally.

![image](https://github.com/user-attachments/assets/28a639c7-05fe-4b09-ad43-94e5307b8f21)

This pull request is the base of `Global Index` and `Quick Addition Column`

* System Table
Introduced system table for row id.
e.g.  
```
SELECT * FROM <table>$with_row_id
```
Results in:
_row_id, columns0, column1
0              a                 a
1              b                 b
2              c                 c

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
