### PR TITLE
[flink] All lookup writers should store active buckets in state to make sure changelog can be produced

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2726,11 +2726,6 @@ public class CoreOptions implements Serializable {
         return options.get(LOOKUP_WAIT);
     }
 
-    public boolean laziedLookup() {
-        return needLookup()
-                && (!options.get(LOOKUP_WAIT) || LookupCompactMode.GENTLE.equals(lookupCompact()));
-    }
-
     public LookupCompactMode lookupCompact() {
         return options.get(LOOKUP_COMPACT);
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -143,10 +143,10 @@ public abstract class FlinkSink<T> implements Serializable {
             }
         }
 
-        if (coreOptions.laziedLookup()) {
+        if (coreOptions.needLookup()) {
             return (table, commitUser, state, ioManager, memoryPool, metricGroup) -> {
                 assertNoSinkMaterializer.run();
-                return new AsyncLookupSinkWrite(
+                return new LookupSinkWrite(
                         table,
                         commitUser,
                         state,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -141,22 +141,22 @@ public abstract class FlinkSink<T> implements Serializable {
                             metricGroup);
                 };
             }
-        }
 
-        if (coreOptions.needLookup()) {
-            return (table, commitUser, state, ioManager, memoryPool, metricGroup) -> {
-                assertNoSinkMaterializer.run();
-                return new LookupSinkWrite(
-                        table,
-                        commitUser,
-                        state,
-                        ioManager,
-                        ignorePreviousFiles,
-                        waitCompaction,
-                        isStreaming,
-                        memoryPool,
-                        metricGroup);
-            };
+            if (coreOptions.needLookup()) {
+                return (table, commitUser, state, ioManager, memoryPool, metricGroup) -> {
+                    assertNoSinkMaterializer.run();
+                    return new LookupSinkWrite(
+                            table,
+                            commitUser,
+                            state,
+                            ioManager,
+                            ignorePreviousFiles,
+                            waitCompaction,
+                            isStreaming,
+                            memoryPool,
+                            metricGroup);
+                };
+            }
         }
 
         return (table, commitUser, state, ioManager, memoryPool, metricGroup) -> {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/LookupSinkWrite.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/LookupSinkWrite.java
@@ -32,17 +32,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-/**
- * {@link StoreSinkWrite} for tables with lookup changelog producer and {@link
- * org.apache.paimon.CoreOptions#LOOKUP_WAIT} set to false.
- */
-public class AsyncLookupSinkWrite extends StoreSinkWriteImpl {
+/** {@link StoreSinkWrite} for tables with lookup changelog producer . */
+public class LookupSinkWrite extends StoreSinkWriteImpl {
 
+    // keep this state name for compatibility reasons
     private static final String ACTIVE_BUCKETS_STATE_NAME = "paimon_async_lookup_active_buckets";
 
     private final String tableName;
 
-    public AsyncLookupSinkWrite(
+    public LookupSinkWrite(
             FileStoreTable table,
             String commitUser,
             StoreSinkWriteState state,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
@@ -297,9 +297,9 @@ public class MultiTablesStoreCompactOperator
             }
         }
 
-        if (coreOptions.needLookup() && !coreOptions.prepareCommitWaitCompaction()) {
+        if (coreOptions.needLookup()) {
             return (table, commitUser, state, ioManager, memoryPool, metricGroup) ->
-                    new AsyncLookupSinkWrite(
+                    new LookupSinkWrite(
                             table,
                             commitUser,
                             state,

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PrimaryKeyFileStoreTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PrimaryKeyFileStoreTableITCase.java
@@ -66,7 +66,10 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 /** Tests for changelog table with primary keys. */
 public class PrimaryKeyFileStoreTableITCase extends AbstractTestBase {
 
-    private static final int TIMEOUT = 480;
+    // This test is to discover unknown consistency bugs.
+    // When this test fails, look carefully into its core reason.
+    // Do not simply increase the timeout and pretend that everything is OK.
+    private static final int TIMEOUT = 180;
     private static final Logger LOG = LoggerFactory.getLogger(PrimaryKeyFileStoreTableITCase.class);
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
### Purpose

This PR fixes the same bug in #3512, but in the scenario when `lookup-wait` is `true`. Consider the following case:

A lookup writer has produced both new files and compacted changelogs during one checkpoint, however only the APPEND snapshot is committed and the COMPACT snapshot fails to commit due to exception.

When the job restarts, the COMPACT snapshot will not be committed again to avoid potential manifest conflicts. If records of this bucket never comes after restart, the changelogs will be lost.

### Tests

* `WriterOperatorTest#testLookupWithFailure`.

### API and Format

No format changes.

### Documentation

No new feature.
