### PR TITLE
[flink] Fix deadlock and incorrect order in precommit changelog compaction

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/compact/CompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/CompactTask.java
@@ -69,7 +69,7 @@ public abstract class CompactTask implements Callable<CompactResult> {
                     LOG);
 
             if (LOG.isDebugEnabled()) {
-                logMetric(startMillis, result.before(), result.after());
+                LOG.debug(logMetric(startMillis, result.before(), result.after()));
             }
             return result;
         } finally {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/changelog/ChangelogCompactSortOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/changelog/ChangelogCompactSortOperator.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.compact.changelog;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.flink.sink.Committable;
+import org.apache.paimon.io.CompactIncrement;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.DataIncrement;
+import org.apache.paimon.io.IndexIncrement;
+import org.apache.paimon.table.sink.CommitMessageImpl;
+
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.function.BiConsumer;
+
+/** Operator to sort changelog files from each bucket by their creation time. */
+public class ChangelogCompactSortOperator extends AbstractStreamOperator<Committable>
+        implements OneInputStreamOperator<Committable, Committable>, BoundedOneInput {
+
+    private transient Map<BinaryRow, Map<Integer, List<DataFileMeta>>> newFileChangelogFiles;
+    private transient Map<BinaryRow, Map<Integer, List<DataFileMeta>>> compactChangelogFiles;
+    private transient Map<BinaryRow, Integer> numBuckets;
+
+    @Override
+    public void open() {
+        newFileChangelogFiles = new LinkedHashMap<>();
+        compactChangelogFiles = new LinkedHashMap<>();
+        numBuckets = new LinkedHashMap<>();
+    }
+
+    @Override
+    public void processElement(StreamRecord<Committable> record) throws Exception {
+        Committable committable = record.getValue();
+        if (committable.kind() != Committable.Kind.FILE) {
+            output.collect(record);
+            return;
+        }
+
+        CommitMessageImpl message = (CommitMessageImpl) committable.wrappedCommittable();
+        if (message.newFilesIncrement().changelogFiles().isEmpty()
+                && message.compactIncrement().changelogFiles().isEmpty()) {
+            output.collect(record);
+            return;
+        }
+
+        numBuckets.put(message.partition(), message.totalBuckets());
+
+        BiConsumer<DataFileMeta, Map<BinaryRow, Map<Integer, List<DataFileMeta>>>> addChangelog =
+                (meta, changelogFiles) ->
+                        changelogFiles
+                                .computeIfAbsent(message.partition(), p -> new TreeMap<>())
+                                .computeIfAbsent(message.bucket(), b -> new ArrayList<>())
+                                .add(meta);
+        for (DataFileMeta meta : message.newFilesIncrement().changelogFiles()) {
+            addChangelog.accept(meta, newFileChangelogFiles);
+        }
+        for (DataFileMeta meta : message.compactIncrement().changelogFiles()) {
+            addChangelog.accept(meta, compactChangelogFiles);
+        }
+
+        CommitMessageImpl newMessage =
+                new CommitMessageImpl(
+                        message.partition(),
+                        message.bucket(),
+                        message.totalBuckets(),
+                        new DataIncrement(
+                                message.newFilesIncrement().newFiles(),
+                                message.newFilesIncrement().deletedFiles(),
+                                Collections.emptyList()),
+                        new CompactIncrement(
+                                message.compactIncrement().compactBefore(),
+                                message.compactIncrement().compactAfter(),
+                                Collections.emptyList()),
+                        message.indexIncrement());
+        if (!newMessage.isEmpty()) {
+            Committable newCommittable =
+                    new Committable(committable.checkpointId(), Committable.Kind.FILE, newMessage);
+            output.collect(new StreamRecord<>(newCommittable));
+        }
+    }
+
+    @Override
+    public void prepareSnapshotPreBarrier(long checkpointId) {
+        emitAll(checkpointId);
+    }
+
+    @Override
+    public void endInput() {
+        emitAll(Long.MAX_VALUE);
+    }
+
+    private void emitAll(long checkpointId) {
+        Map<BinaryRow, Set<Integer>> activeBuckets = new LinkedHashMap<>();
+        collectActiveBuckets(newFileChangelogFiles, activeBuckets);
+        collectActiveBuckets(compactChangelogFiles, activeBuckets);
+
+        for (Map.Entry<BinaryRow, Set<Integer>> entry : activeBuckets.entrySet()) {
+            BinaryRow partition = entry.getKey();
+            for (int bucket : entry.getValue()) {
+                CommitMessageImpl newMessage =
+                        new CommitMessageImpl(
+                                partition,
+                                bucket,
+                                numBuckets.get(partition),
+                                new DataIncrement(
+                                        Collections.emptyList(),
+                                        Collections.emptyList(),
+                                        sortedChangelogs(newFileChangelogFiles, partition, bucket)),
+                                new CompactIncrement(
+                                        Collections.emptyList(),
+                                        Collections.emptyList(),
+                                        sortedChangelogs(compactChangelogFiles, partition, bucket)),
+                                new IndexIncrement(Collections.emptyList()));
+                Committable newCommittable =
+                        new Committable(checkpointId, Committable.Kind.FILE, newMessage);
+                output.collect(new StreamRecord<>(newCommittable));
+            }
+        }
+
+        newFileChangelogFiles.clear();
+        compactChangelogFiles.clear();
+        numBuckets.clear();
+    }
+
+    private void collectActiveBuckets(
+            Map<BinaryRow, Map<Integer, List<DataFileMeta>>> from,
+            Map<BinaryRow, Set<Integer>> activeBuckets) {
+        for (Map.Entry<BinaryRow, Map<Integer, List<DataFileMeta>>> entry : from.entrySet()) {
+            activeBuckets
+                    .computeIfAbsent(entry.getKey(), k -> new TreeSet<>())
+                    .addAll(entry.getValue().keySet());
+        }
+    }
+
+    private List<DataFileMeta> sortedChangelogs(
+            Map<BinaryRow, Map<Integer, List<DataFileMeta>>> from,
+            BinaryRow partition,
+            int bucket) {
+        List<DataFileMeta> result = new ArrayList<>();
+        if (from.containsKey(partition) && from.get(partition).containsKey(bucket)) {
+            result.addAll(from.get(partition).get(bucket));
+        }
+        result.sort(Comparator.comparingLong(DataFileMeta::creationTimeEpochMillis));
+        return result;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PrimaryKeyFileStoreTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PrimaryKeyFileStoreTableITCase.java
@@ -1259,6 +1259,10 @@ public class PrimaryKeyFileStoreTableITCase extends AbstractTestBase {
                         + tableProperties
                         + ")");
 
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Creating test table with properties {}", tableProperties);
+        }
+
         // input data must be strictly ordered
         tEnv.getConfig()
                 .getConfiguration()
@@ -1294,7 +1298,7 @@ public class PrimaryKeyFileStoreTableITCase extends AbstractTestBase {
                                 + "  'fields.i.kind' = 'sequence',"
                                 + "  'fields.i.start' = '0',"
                                 + "  'fields.i.end' = '"
-                                + (usefulNumRows - 1) * factor
+                                + (usefulNumRows * factor - 1)
                                 + "',"
                                 + "  'number-of-rows' = '"
                                 + usefulNumRows * factor

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/changelog/ChangelogCompactSortOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/changelog/ChangelogCompactSortOperatorTest.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.compact.changelog;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.flink.sink.Committable;
+import org.apache.paimon.flink.sink.CommittableTypeInfo;
+import org.apache.paimon.io.CompactIncrement;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.DataIncrement;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.table.sink.CommitMessageImpl;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.util.Preconditions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ChangelogCompactSortOperator}. */
+public class ChangelogCompactSortOperatorTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testChangelogSorted() throws Exception {
+        ChangelogCompactSortOperator operator = new ChangelogCompactSortOperator();
+        OneInputStreamOperatorTestHarness<Committable, Committable> testHarness =
+                createTestHarness(operator);
+
+        Function<Integer, BinaryRow> binaryRow =
+                i -> {
+                    BinaryRow row = new BinaryRow(1);
+                    BinaryRowWriter writer = new BinaryRowWriter(row);
+                    writer.writeInt(0, i);
+                    writer.complete();
+                    return row;
+                };
+
+        testHarness.open();
+
+        List<DataFileMeta> files = new ArrayList<>();
+        for (int i = 0; i <= 10; i++) {
+            files.add(createDataFileMeta(i, i * 100));
+        }
+
+        CommitMessageImpl onlyData =
+                new CommitMessageImpl(
+                        binaryRow.apply(0),
+                        0,
+                        2,
+                        new DataIncrement(
+                                Arrays.asList(files.get(2), files.get(1)),
+                                Collections.emptyList(),
+                                Collections.emptyList()),
+                        CompactIncrement.emptyIncrement());
+        testHarness.processElement(
+                new StreamRecord<>(new Committable(1, Committable.Kind.FILE, onlyData)));
+
+        CommitMessageImpl onlyChangelogBucket0 =
+                new CommitMessageImpl(
+                        binaryRow.apply(0),
+                        0,
+                        2,
+                        new DataIncrement(
+                                Collections.emptyList(),
+                                Collections.emptyList(),
+                                Arrays.asList(files.get(4), files.get(3))),
+                        CompactIncrement.emptyIncrement());
+        testHarness.processElement(
+                new StreamRecord<>(
+                        new Committable(1, Committable.Kind.FILE, onlyChangelogBucket0)));
+
+        CommitMessageImpl onlyChangelogBucket1 =
+                new CommitMessageImpl(
+                        binaryRow.apply(0),
+                        1,
+                        2,
+                        new DataIncrement(
+                                Collections.emptyList(),
+                                Collections.emptyList(),
+                                Arrays.asList(files.get(7), files.get(8))),
+                        CompactIncrement.emptyIncrement());
+        testHarness.processElement(
+                new StreamRecord<>(
+                        new Committable(1, Committable.Kind.FILE, onlyChangelogBucket1)));
+
+        CommitMessageImpl mixed =
+                new CommitMessageImpl(
+                        binaryRow.apply(0),
+                        1,
+                        2,
+                        new DataIncrement(
+                                Arrays.asList(files.get(10), files.get(9)),
+                                Collections.emptyList(),
+                                Arrays.asList(files.get(6), files.get(5))),
+                        CompactIncrement.emptyIncrement());
+        testHarness.processElement(
+                new StreamRecord<>(new Committable(1, Committable.Kind.FILE, mixed)));
+
+        testHarness.prepareSnapshotPreBarrier(1);
+
+        List<Object> output = new ArrayList<>(testHarness.getOutput());
+        assertThat(output).hasSize(4);
+
+        List<CommitMessageImpl> actual = new ArrayList<>();
+        for (Object o : output) {
+            actual.add(
+                    (CommitMessageImpl)
+                            ((StreamRecord<Committable>) o).getValue().wrappedCommittable());
+        }
+
+        assertThat(actual.get(0)).isEqualTo(onlyData);
+        assertThat(actual.get(1))
+                .isEqualTo(
+                        new CommitMessageImpl(
+                                binaryRow.apply(0),
+                                1,
+                                2,
+                                new DataIncrement(
+                                        Arrays.asList(files.get(10), files.get(9)),
+                                        Collections.emptyList(),
+                                        Collections.emptyList()),
+                                CompactIncrement.emptyIncrement()));
+        assertThat(actual.get(2))
+                .isEqualTo(
+                        new CommitMessageImpl(
+                                binaryRow.apply(0),
+                                0,
+                                2,
+                                new DataIncrement(
+                                        Collections.emptyList(),
+                                        Collections.emptyList(),
+                                        Arrays.asList(files.get(3), files.get(4))),
+                                CompactIncrement.emptyIncrement()));
+        assertThat(actual.get(3))
+                .isEqualTo(
+                        new CommitMessageImpl(
+                                binaryRow.apply(0),
+                                1,
+                                2,
+                                new DataIncrement(
+                                        Collections.emptyList(),
+                                        Collections.emptyList(),
+                                        Arrays.asList(
+                                                files.get(5),
+                                                files.get(6),
+                                                files.get(7),
+                                                files.get(8))),
+                                CompactIncrement.emptyIncrement()));
+
+        testHarness.close();
+    }
+
+    private DataFileMeta createDataFileMeta(int mb, long creationMillis) {
+        return new DataFileMeta(
+                UUID.randomUUID().toString(),
+                MemorySize.ofMebiBytes(mb).getBytes(),
+                0,
+                null,
+                null,
+                null,
+                null,
+                0,
+                0,
+                0,
+                0,
+                Collections.emptyList(),
+                Timestamp.fromEpochMillis(creationMillis),
+                null,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private OneInputStreamOperatorTestHarness<Committable, Committable> createTestHarness(
+            ChangelogCompactSortOperator operator) throws Exception {
+        TypeSerializer serializer =
+                new CommittableTypeInfo().createSerializer(new ExecutionConfig());
+        OneInputStreamOperatorTestHarness harness =
+                new OneInputStreamOperatorTestHarness(operator, 1, 1, 0);
+        harness.getStreamConfig().setupNetworkInputs(Preconditions.checkNotNull(serializer));
+        harness.getStreamConfig().serializeAllConfigs();
+        harness.setup(serializer);
+        return harness;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/changelog/ChangelogCompactTaskTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/changelog/ChangelogCompactTaskTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.compact.changelog;
+
+import org.apache.paimon.catalog.FileSystemCatalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.stats.SimpleStats;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.FileNotFoundException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link ChangelogCompactTask}. */
+public class ChangelogCompactTaskTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    @Test
+    public void testExceptionWhenRead() throws Exception {
+        FileSystemCatalog catalog =
+                new FileSystemCatalog(LocalFileIO.create(), new Path(tempDir.toString()));
+        catalog.createDatabase("default", false);
+        catalog.createTable(
+                Identifier.create("default", "T"),
+                new Schema(
+                        Arrays.asList(
+                                new DataField(0, "k", DataTypes.INT()),
+                                new DataField(1, "v", DataTypes.INT())),
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        new HashMap<>(),
+                        ""),
+                false);
+
+        Map<Integer, List<DataFileMeta>> files = new HashMap<>();
+        files.put(
+                0,
+                Collections.singletonList(
+                        DataFileMeta.forAppend(
+                                "unexisting-file",
+                                128,
+                                0,
+                                SimpleStats.EMPTY_STATS,
+                                0,
+                                0,
+                                1,
+                                Collections.emptyList(),
+                                null,
+                                null,
+                                null,
+                                null)));
+        ChangelogCompactTask task =
+                new ChangelogCompactTask(1, BinaryRow.EMPTY_ROW, 1, files, new HashMap<>());
+        assertThatThrownBy(
+                        () ->
+                                task.doCompact(
+                                        (FileStoreTable)
+                                                catalog.getTable(Identifier.create("default", "T")),
+                                        Executors.newFixedThreadPool(1),
+                                        MemorySize.ofMebiBytes(64)))
+                .isInstanceOf(FileNotFoundException.class)
+                .hasMessageContaining("unexisting-file");
+    }
+}


### PR DESCRIPTION
### Purpose

`ChangelogCompactTask` currently does not deal with exception correctly. If exception happens when reading files, the task will fall into a deadlock.

This class also does not deal with orders between changelog files correctly. To fix this problem, we add a sort operator at the end to sort changelog manifests in each bucket by their creation time.

### Tests

* `ChangelogCompactTaskTest`
* `ChangelogCompactSortOperatorTest`

### API and Format

No format changes.

### Documentation

No new feature.
