### PR TITLE
[spark] delete with metadata columns generates duplicate relation fields

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
@@ -164,12 +164,9 @@ trait PaimonCommand extends WithFileStoreTable with ExpressionHelper with SQLCon
     assert(sparkTable.table.isInstanceOf[FileStoreTable])
     val knownSplitsTable =
       KnownSplitsTable.create(sparkTable.table.asInstanceOf[FileStoreTable], splits.toArray)
-    // We re-plan the relation to skip analyze phase, so we should append all
-    // metadata columns manually and let Spark do column pruning during optimization.
+    // We re-plan the relation to skip analyze phase, so we should let Spark do column pruning during optimization.
     relation.copy(
-      table = relation.table.asInstanceOf[SparkTable].copy(table = knownSplitsTable),
-      output = relation.output ++ sparkTable.metadataColumns.map(
-        _.asInstanceOf[PaimonMetadataColumn].toAttribute)
+      table = relation.table.asInstanceOf[SparkTable].copy(table = knownSplitsTable)
     )
   }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
@@ -36,7 +36,7 @@ import org.apache.paimon.utils.SerializationUtils
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils.createDataset
 import org.apache.spark.sql.catalyst.SQLConfHelper
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.logical.{Filter => FilterLogicalNode, LogicalPlan, Project}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -164,10 +164,34 @@ trait PaimonCommand extends WithFileStoreTable with ExpressionHelper with SQLCon
     assert(sparkTable.table.isInstanceOf[FileStoreTable])
     val knownSplitsTable =
       KnownSplitsTable.create(sparkTable.table.asInstanceOf[FileStoreTable], splits.toArray)
-    // We re-plan the relation to skip analyze phase, so we should let Spark do column pruning during optimization.
-    relation.copy(
-      table = relation.table.asInstanceOf[SparkTable].copy(table = knownSplitsTable)
-    )
+    val metadataColumns =
+      sparkTable.metadataColumns.map(_.asInstanceOf[PaimonMetadataColumn].toAttribute)
+
+    if (needAddMetadataColumns(metadataColumns, relation)) {
+      // We re-plan the relation to skip analyze phase, so we should append all
+      // metadata columns manually and let Spark do column pruning during optimization.
+      relation.copy(
+        table = relation.table.asInstanceOf[SparkTable].copy(table = knownSplitsTable),
+        output = relation.output ++ metadataColumns
+      )
+    } else {
+      // Only re-plan the relation with new table info.
+      relation.copy(
+        table = relation.table.asInstanceOf[SparkTable].copy(table = knownSplitsTable)
+      )
+    }
+  }
+
+  /** Check whether relation output already contains paimon metadata columns. */
+  private def needAddMetadataColumns(
+      metadataColumns: Array[AttributeReference],
+      relation: DataSourceV2Relation): Boolean = {
+    val resolve = conf.resolver
+    val outputNames = relation.outputSet.map(_.name)
+
+    def isOutputColumn(colName: String): Boolean = outputNames.exists(resolve(colName, _))
+
+    !metadataColumns.exists(col => isOutputColumn(col.name))
   }
 
   /** Notice that, the key is a relative path, not just the file name. */


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
link https://github.com/apache/paimon/issues/5801

In https://github.com/apache/paimon/pull/3462, implemented the SupportsMetadataColumns interface. The metadata columns will be added first in spark `AddMetadataColumns` rule. But in paimon, add them again.
```scala
override def metadataColumns: Array[MetadataColumn] = {
    val partitionType = SparkTypeUtils.toSparkPartitionType(table)
    Array[MetadataColumn](
      PaimonMetadataColumn.FILE_PATH,
      PaimonMetadataColumn.ROW_INDEX,
      PaimonMetadataColumn.PARTITION(partitionType),
      PaimonMetadataColumn.BUCKET
    )
  }
```

As a delete sql with metadata column, metadata will add twice.
```sql
delete from T where __paimon_file_path = 'file_name';

-- default LogicalPlan
RelationV2[id#53L, c1#54, __paimon_file_path#55, __paimon_row_index#56L, __paimon_partition#57, __paimon_bucket#58] test.T

-- new LogicalPlan
Filter (__paimon_file_path#55 = data-)
+- RelationV2[id#53L, c1#54, __paimon_file_path#55, __paimon_row_index#56L, __paimon_partition#57, __paimon_bucket#58, __paimon_file_path#59, __paimon_row_index#60L, __paimon_partition#61, __paimon_bucket#62] test.T
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
