### PR TITLE
[flink] Fix ClassNotFoundException when deserializing writer coordination response

### DIFF
--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/FileStoreBatchE2eTest.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/FileStoreBatchE2eTest.java
@@ -79,6 +79,9 @@ public class FileStoreBatchE2eTest extends E2eTestBase {
 
         String useCatalogCmd = "USE CATALOG ts_catalog;";
 
+        String flinkVersion = System.getProperty("test.flink.main.version");
+        boolean useCoordinator =
+                flinkVersion.compareTo("1.15") > 0 && ThreadLocalRandom.current().nextBoolean();
         // no infer parallelism, e2e will fail due to less resources
         String paimonDdl =
                 String.format(
@@ -91,7 +94,7 @@ public class FileStoreBatchE2eTest extends E2eTestBase {
                                 + ") PARTITIONED BY (dt, hr) WITH (\n"
                                 + "  'sink.writer-coordinator.enabled' = '%s'\n"
                                 + ");",
-                        ThreadLocalRandom.current().nextBoolean());
+                        useCoordinator);
 
         // prepare test data
         writeSharedFile(testDataSourceFile, String.join("\n", data));

--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/FileStoreBatchE2eTest.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/FileStoreBatchE2eTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 /** Tests for reading and writing file store in batch jobs. */
 public class FileStoreBatchE2eTest extends E2eTestBase {
@@ -80,13 +81,17 @@ public class FileStoreBatchE2eTest extends E2eTestBase {
 
         // no infer parallelism, e2e will fail due to less resources
         String paimonDdl =
-                "CREATE TABLE IF NOT EXISTS ts_table (\n"
-                        + "    dt VARCHAR,\n"
-                        + "    hr VARCHAR,\n"
-                        + "    person VARCHAR,\n"
-                        + "    category VARCHAR,\n"
-                        + "    price INT\n"
-                        + ") PARTITIONED BY (dt, hr);";
+                String.format(
+                        "CREATE TABLE IF NOT EXISTS ts_table (\n"
+                                + "    dt VARCHAR,\n"
+                                + "    hr VARCHAR,\n"
+                                + "    person VARCHAR,\n"
+                                + "    category VARCHAR,\n"
+                                + "    price INT\n"
+                                + ") PARTITIONED BY (dt, hr) WITH (\n"
+                                + "  'sink.writer-coordinator.enabled' = '%s'\n"
+                                + ");",
+                        ThreadLocalRandom.current().nextBoolean());
 
         // prepare test data
         writeSharedFile(testDataSourceFile, String.join("\n", data));

--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/cdc/MySqlCdcE2eTestBase.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/cdc/MySqlCdcE2eTestBase.java
@@ -117,6 +117,10 @@ public abstract class MySqlCdcE2eTestBase extends E2eTestBase {
 
     @Test
     public void testSyncTable() throws Exception {
+        String flinkVersion = System.getProperty("test.flink.main.version");
+        boolean useCoordinator =
+                flinkVersion.compareTo("1.15") > 0 && ThreadLocalRandom.current().nextBoolean();
+
         runAction(
                 ACTION_SYNC_TABLE,
                 "pt",
@@ -129,7 +133,7 @@ public abstract class MySqlCdcE2eTestBase extends E2eTestBase {
                         "bucket",
                         "2",
                         "sink.writer-coordinator.enabled",
-                        String.valueOf(ThreadLocalRandom.current().nextBoolean())));
+                        String.valueOf(useCoordinator)));
 
         try (Connection conn = getMySqlConnection();
                 Statement statement = conn.createStatement()) {

--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/cdc/MySqlCdcE2eTestBase.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/cdc/MySqlCdcE2eTestBase.java
@@ -42,6 +42,7 @@ import java.sql.Statement;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -124,7 +125,11 @@ public abstract class MySqlCdcE2eTestBase extends E2eTestBase {
                 ImmutableMap.of(),
                 ImmutableMap.of(
                         "database-name", "paimon_sync_table", "table-name", "schema_evolution_.+"),
-                ImmutableMap.of("bucket", "2"));
+                ImmutableMap.of(
+                        "bucket",
+                        "2",
+                        "sink.writer-coordinator.enabled",
+                        String.valueOf(ThreadLocalRandom.current().nextBoolean())));
 
         try (Connection conn = getMySqlConnection();
                 Statement statement = conn.createStatement()) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/coordinator/CoordinatedWriteRestore.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/coordinator/CoordinatedWriteRestore.java
@@ -52,8 +52,8 @@ public class CoordinatedWriteRestore implements WriteRestore {
         try {
             SerializedValue<CoordinationRequest> serializedRequest = new SerializedValue<>(request);
             LatestIdentifierResponse response =
-                    (LatestIdentifierResponse)
-                            gateway.sendRequestToCoordinator(operatorID, serializedRequest).get();
+                    CoordinationResponseUtils.unwrap(
+                            gateway.sendRequestToCoordinator(operatorID, serializedRequest).get());
             return response.latestIdentifier();
         } catch (IOException | ExecutionException | InterruptedException e) {
             throw new RuntimeException(e);
@@ -75,8 +75,8 @@ public class CoordinatedWriteRestore implements WriteRestore {
         try {
             SerializedValue<CoordinationRequest> serializedRequest = new SerializedValue<>(request);
             ScanCoordinationResponse response =
-                    (ScanCoordinationResponse)
-                            gateway.sendRequestToCoordinator(operatorID, serializedRequest).get();
+                    CoordinationResponseUtils.unwrap(
+                            gateway.sendRequestToCoordinator(operatorID, serializedRequest).get());
             return new RestoreFiles(
                     response.snapshot(),
                     response.totalBuckets(),

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/coordinator/CoordinationResponseUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/coordinator/CoordinationResponseUtils.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink.coordinator;
+
+import org.apache.paimon.utils.InstantiationUtil;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.streaming.api.operators.collect.CollectCoordinationResponse;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Utilities for wrapping and unwrapping {@link CoordinationResponse} by {@link
+ * CollectCoordinationResponse}.
+ *
+ * <p>This class is mostly copied from <a
+ * href="https://github.com/apache/flink-cdc/blob/23a1c2efb6fa9ce1c9f17b3836f6aaa995bb0660/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/common/CoordinationResponseUtils.java#L29">apache/flink-cdc</a>.
+ *
+ * <p>Currently, Flink's RPC gateway can only deserialize classes accessible from Flink's class
+ * loader (see <a
+ * href="https://github.com/apache/flink/blob/ce03ea11d10df28affa040847dbaf02680eb785d/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoRpcService.java#L543">apache/flink</a>),
+ * so we have to wrap our own response with a class ({@link CollectCoordinationResponse}) in Flink's
+ * project.
+ */
+public class CoordinationResponseUtils {
+
+    private static final String MAGIC_VERSION = "__paimon__";
+    private static final long MAGIC_OFFSET = 20250627L;
+
+    public static <R extends CoordinationResponse> CoordinationResponse wrap(R response) {
+        CoordinationResponseSerializer serializer = new CoordinationResponseSerializer();
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DataOutputStream out = new DataOutputStream(baos)) {
+            serializer.serialize(response, new DataOutputViewStreamWrapper(out));
+            return new CollectCoordinationResponse(
+                    MAGIC_VERSION, MAGIC_OFFSET, Collections.singletonList(baos.toByteArray()));
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Unable to wrap CoordinationResponse \"%s\" with type \"%s\"",
+                            response, response.getClass().getCanonicalName()),
+                    e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <R extends CoordinationResponse> R unwrap(CoordinationResponse response) {
+        try {
+            CollectCoordinationResponse rawResponse = (CollectCoordinationResponse) response;
+            List<CoordinationResponse> results =
+                    rawResponse.getResults(new CoordinationResponseSerializer());
+
+            return (R) results.get(0);
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to unwrap CoordinationResponse", e);
+        }
+    }
+
+    private static class CoordinationResponseSerializer
+            extends TypeSerializer<CoordinationResponse> {
+
+        @Override
+        public void serialize(CoordinationResponse record, DataOutputView target)
+                throws IOException {
+            byte[] serialized = InstantiationUtil.serializeObject(record);
+            target.writeInt(serialized.length);
+            target.write(serialized);
+        }
+
+        @Override
+        public CoordinationResponse deserialize(DataInputView source) throws IOException {
+            try {
+                int length = source.readInt();
+                byte[] serialized = new byte[length];
+                source.readFully(serialized);
+                return InstantiationUtil.deserializeObject(
+                        serialized, Thread.currentThread().getContextClassLoader());
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException("Unable to deserialize CoordinationResponse", e);
+            }
+        }
+
+        @Override
+        public CoordinationResponse deserialize(CoordinationResponse reuse, DataInputView source)
+                throws IOException {
+            return deserialize(source);
+        }
+
+        @Override
+        public boolean isImmutableType() {
+            return true;
+        }
+
+        @Override
+        public TypeSerializer<CoordinationResponse> duplicate() {
+            return new CoordinationResponseSerializer();
+        }
+
+        @Override
+        public CoordinationResponse createInstance() {
+            return new CoordinationResponse() {};
+        }
+
+        @Override
+        public CoordinationResponse copy(CoordinationResponse from) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CoordinationResponse copy(CoordinationResponse from, CoordinationResponse reuse) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getLength() {
+            return -1;
+        }
+
+        @Override
+        public void copy(DataInputView source, DataOutputView target) throws IOException {
+            CoordinationResponse deserialize = deserialize(source);
+            serialize(deserialize, target);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof CoordinationResponseSerializer;
+        }
+
+        @Override
+        public int hashCode() {
+            return getClass().hashCode();
+        }
+
+        @Override
+        public TypeSerializerSnapshot<CoordinationResponse> snapshotConfiguration() {
+            return new CoordinationResponseDeserializerSnapshot();
+        }
+
+        /** Serializer configuration snapshot for compatibility and format evolution. */
+        @SuppressWarnings("WeakerAccess")
+        public static final class CoordinationResponseDeserializerSnapshot
+                extends SimpleTypeSerializerSnapshot<CoordinationResponse> {
+
+            public CoordinationResponseDeserializerSnapshot() {
+                super(CoordinationResponseSerializer::new);
+            }
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/coordinator/WriteOperatorCoordinator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/coordinator/WriteOperatorCoordinator.java
@@ -78,17 +78,19 @@ public class WriteOperatorCoordinator implements OperatorCoordinator, Coordinati
         executor.execute(
                 () -> {
                     try {
+                        CoordinationResponse response;
                         if (request instanceof ScanCoordinationRequest) {
-                            future.complete(coordinator.scan((ScanCoordinationRequest) request));
+                            response = coordinator.scan((ScanCoordinationRequest) request);
                         } else if (request instanceof LatestIdentifierRequest) {
-                            future.complete(
+                            response =
                                     new LatestIdentifierResponse(
                                             coordinator.latestCommittedIdentifier(
-                                                    ((LatestIdentifierRequest) request).user())));
+                                                    ((LatestIdentifierRequest) request).user()));
                         } else {
                             throw new UnsupportedOperationException(
                                     "Unsupported request type: " + request);
                         }
+                        future.complete(CoordinationResponseUtils.wrap(response));
                     } catch (Exception e) {
                         future.completeExceptionally(e);
                     }


### PR DESCRIPTION
### Purpose

Currently, Flink's RPC gateway can only deserialize classes accessible from Flink's class loader (see [apache/flink](https://github.com/apache/flink/blob/ce03ea11d10df28affa040847dbaf02680eb785d/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoRpcService.java#L543), so we have to wrap our own response with a class (`CollectCoordinationResponse`) in Flink's project.

### Tests

E2e tests.

### API and Format

No format changes.

### Documentation

No new feature.
