### PR TITLE
[flink] Fix the document of Fixed Bucket Large Scale Lookup optimization

### DIFF
--- a/docs/content/flink/sql-lookup.md
+++ b/docs/content/flink/sql-lookup.md
@@ -137,6 +137,8 @@ FOR SYSTEM_TIME AS OF o.proc_time AS c
 ON o.customer_id = c.id;
 ```
 
+Note that this optimization only takes effect when the join keys contain all the bucket keys.
+
 ## Dynamic Partition
 
 In traditional data warehouses, each partition often maintains the latest full data, so this partition table only 


### PR DESCRIPTION
### Purpose

This PR fixes the document for Fixed Bucket Large Scale Lookup optimization. This optimization takes effect only when the join keys contain all the bucket keys (See BaseDataTableSource#supportBucketShufflePartitioner). The current document missed this point.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
