### PR TITLE
[rest] fix base header options in RESTApi

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
@@ -170,13 +170,13 @@ public class RESTApi {
         this.client = new HttpClient(options.get(RESTCatalogOptions.URI));
         AuthProvider authProvider = createAuthProvider(options);
         Map<String, String> baseHeaders = Collections.emptyMap();
+        baseHeaders = extractPrefixMap(options, HEADER_PREFIX);
         if (configRequired) {
             String warehouse = options.get(WAREHOUSE);
             Map<String, String> queryParams =
                     StringUtils.isNotEmpty(warehouse)
                             ? ImmutableMap.of(WAREHOUSE.key(), RESTUtil.encodeString(warehouse))
                             : ImmutableMap.of();
-            baseHeaders = extractPrefixMap(options, HEADER_PREFIX);
             options =
                     new Options(
                             client.get(

--- a/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
@@ -169,8 +169,7 @@ public class RESTApi {
     public RESTApi(Options options, boolean configRequired) {
         this.client = new HttpClient(options.get(RESTCatalogOptions.URI));
         AuthProvider authProvider = createAuthProvider(options);
-        Map<String, String> baseHeaders = Collections.emptyMap();
-        baseHeaders = extractPrefixMap(options, HEADER_PREFIX);
+        Map<String, String> baseHeaders = extractPrefixMap(options, HEADER_PREFIX);
         if (configRequired) {
             String warehouse = options.get(WAREHOUSE);
             Map<String, String> queryParams =

--- a/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTCatalogTest.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.apache.paimon.rest.RESTApi.HEADER_PREFIX;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -146,6 +147,22 @@ class MockRESTCatalogTest extends RESTCatalogTest {
         assertEquals(
                 headers.get(BearTokenAuthProvider.AUTHORIZATION_HEADER_KEY), "Bearer init_token");
         assertEquals(headers.get(serverDefineHeaderName), serverDefineHeaderValue);
+    }
+
+    @Test
+    void testHeaderOptions() throws Exception {
+        options.set(HEADER_PREFIX + "User-Agent", "test");
+        RESTCatalog restCatalog = initCatalog(false);
+
+        Map<String, String> parameters = new HashMap<>();
+        RESTAuthParameter restAuthParameter =
+                new RESTAuthParameter("/path", parameters, "method", "data");
+        Map<String, String> headers = restCatalog.api().authFunction().apply(restAuthParameter);
+        assertEquals(headers.get("User-Agent"), "test");
+
+        RESTCatalog restCatalog2 = restCatalog.catalogLoader().load();
+        Map<String, String> headers2 = restCatalog2.api().authFunction().apply(restAuthParameter);
+        assertEquals(headers2.get("User-Agent"), "test");
     }
 
     private void testDlfAuth(RESTCatalog restCatalog) throws Exception {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Fixed base header not being set when 'configRequired' is false

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
org.apache.paimon.rest.MockRESTCatalogTest#testHeaderOptions

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
