### PR TITLE
[expire] Optimize expired partition strategy

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -804,6 +804,18 @@ This config option does not affect the default filesystem metastore.</td>
             <td>You can specify a pattern to get a timestamp from partitions. The formatter pattern is defined by 'partition.timestamp-formatter'.<ul><li>By default, read from the first field.</li><li>If the timestamp in the partition is a single field called 'dt', you can use '$dt'.</li><li>If it is spread across multiple fields for year, month, day, and hour, you can use '$year-$month-$day $hour:00:00'.</li><li>If the timestamp is in fields dt and hour, you can use '$dt $hour:00:00'.</li></ul></td>
         </tr>
         <tr>
+            <td><h5>partition.expiration.timestamp-formatter</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The formatter to format timestamp from string. It can be used with 'partition.expiration.timestamp-pattern' to create a formatter using the specified value.<ul><li>Default formatter is 'yyyy-MM-dd HH:mm:ss' and 'yyyy-MM-dd 23:59:59'.</li><li>Supports multiple partition fields like '$year-$month-$day $hour:59:59'.</li><li>The timestamp-formatter is compatible with Java's DateTimeFormatter.</li></ul></td>
+        </tr>
+        <tr>
+            <td><h5>partition.expiration.timestamp-pattern</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>You can specify a pattern to get a timestamp from partition to expire. The formatter pattern is defined by 'partition.expiration.timestamp-formatter'.<ul><li>By default, read from the first field.</li><li>If the timestamp in the partition is a single field called 'dt', you can use '$dt'.</li><li>If it is spread across multiple fields for year, month, day, and hour, you can use '$year-$month-$day $hour:59:59'.</li><li>If the timestamp is in fields dt and hour, you can use '$dt $hour:59:59'.</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>primary-key</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -920,7 +920,45 @@ public class CoreOptions implements Serializable {
                             "The batch size of partition expiration. "
                                     + "By default, all partitions to be expired will be expired together, which may cause a risk of out-of-memory. "
                                     + "Use this parameter to divide partition expiration process and mitigate memory pressure.");
+    public static final ConfigOption<String> PARTITION_EXPIRATION_TIMESTAMP_FORMATTER =
+            key("partition.expiration.timestamp-formatter")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The formatter to format timestamp from string. It can be used"
+                                                    + " with 'partition.expiration.timestamp-pattern' to create a formatter"
+                                                    + " using the specified value.")
+                                    .list(
+                                            text(
+                                                    "Default formatter is 'yyyy-MM-dd HH:mm:ss' and 'yyyy-MM-dd'."),
+                                            text(
+                                                    "Supports multiple partition fields like '$year-$month-$day $hour:59:59'."),
+                                            text(
+                                                    "The timestamp-formatter is compatible with Java's DateTimeFormatter."))
+                                    .build());
 
+    public static final ConfigOption<String> PARTITION_EXPIRATION_TIMESTAMP_PATTERN =
+            key("partition.expiration.timestamp-pattern")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "You can specify a pattern to get a timestamp from partition to expire. "
+                                                    + "The formatter pattern is defined by 'partition.expiration.timestamp-formatter'.")
+                                    .list(
+                                            text("By default, read from the first field."),
+                                            text(
+                                                    "If the timestamp in the partition is a single field called 'dt', you can use '$dt'."),
+                                            text(
+                                                    "If it is spread across multiple fields for year, month, day, and hour,"
+                                                            + " you can use '$year-$month-$day $hour:59:59'."),
+                                            text(
+                                                    "If the timestamp is in fields dt and hour, you can use '$dt "
+                                                            + "$hour:59:59'."))
+                                    .build());
     public static final ConfigOption<String> PARTITION_TIMESTAMP_FORMATTER =
             key("partition.timestamp-formatter")
                     .stringType()
@@ -2508,6 +2546,14 @@ public class CoreOptions implements Serializable {
 
     public String partitionTimestampPattern() {
         return options.get(PARTITION_TIMESTAMP_PATTERN);
+    }
+
+    public String partitionExpireTimestampFormatter() {
+        return options.get(PARTITION_EXPIRATION_TIMESTAMP_FORMATTER);
+    }
+
+    public String partitionExpireTimestampPattern() {
+        return options.get(PARTITION_EXPIRATION_TIMESTAMP_PATTERN);
     }
 
     public String httpReportMarkDoneActionUrl() {

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -932,7 +932,7 @@ public class CoreOptions implements Serializable {
                                                     + " using the specified value.")
                                     .list(
                                             text(
-                                                    "Default formatter is 'yyyy-MM-dd HH:mm:ss' and 'yyyy-MM-dd'."),
+                                                    "Default formatter is 'yyyy-MM-dd HH:mm:ss' and 'yyyy-MM-dd 23:59:59'."),
                                             text(
                                                     "Supports multiple partition fields like '$year-$month-$day $hour:59:59'."),
                                             text(

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2549,11 +2549,15 @@ public class CoreOptions implements Serializable {
     }
 
     public String partitionExpireTimestampFormatter() {
-        return options.get(PARTITION_EXPIRATION_TIMESTAMP_FORMATTER);
+        return options.get(PARTITION_EXPIRATION_TIMESTAMP_FORMATTER) != null
+                ? options.get(PARTITION_EXPIRATION_TIMESTAMP_FORMATTER)
+                : partitionTimestampFormatter();
     }
 
     public String partitionExpireTimestampPattern() {
-        return options.get(PARTITION_EXPIRATION_TIMESTAMP_PATTERN);
+        return options.get(PARTITION_EXPIRATION_TIMESTAMP_PATTERN) != null
+                ? options.get(PARTITION_EXPIRATION_TIMESTAMP_PATTERN)
+                : partitionTimestampPattern();
     }
 
     public String httpReportMarkDoneActionUrl() {

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionTimeExtractor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionTimeExtractor.java
@@ -89,6 +89,11 @@ public class PartitionTimeExtractor {
     }
 
     public LocalDateTime extract(List<String> partitionKeys, List<?> partitionValues) {
+        return extract(partitionKeys, partitionValues, LocalTime.MIDNIGHT);
+    }
+
+    public LocalDateTime extract(
+            List<String> partitionKeys, List<?> partitionValues, LocalTime defaultLocalTime) {
         String timestampString;
         if (pattern == null) {
             timestampString = partitionValues.get(0).toString();
@@ -100,14 +105,14 @@ public class PartitionTimeExtractor {
                                 "\\$" + partitionKeys.get(i), partitionValues.get(i).toString());
             }
         }
-        return toLocalDateTime(timestampString, this.formatter);
+        return toLocalDateTime(timestampString, this.formatter, defaultLocalTime);
     }
 
     private static LocalDateTime toLocalDateTime(
-            String timestampString, @Nullable String formatterPattern) {
+            String timestampString, @Nullable String formatterPattern, LocalTime defaultLocalTime) {
 
         if (formatterPattern == null) {
-            return PartitionTimeExtractor.toLocalDateTimeDefault(timestampString);
+            return PartitionTimeExtractor.toLocalDateTimeDefault(timestampString, defaultLocalTime);
         }
         DateTimeFormatter dateTimeFormatter =
                 DateTimeFormatter.ofPattern(Objects.requireNonNull(formatterPattern), Locale.ROOT);
@@ -116,16 +121,17 @@ public class PartitionTimeExtractor {
         } catch (DateTimeParseException e) {
             return LocalDateTime.of(
                     LocalDate.parse(timestampString, Objects.requireNonNull(dateTimeFormatter)),
-                    LocalTime.MIDNIGHT);
+                    defaultLocalTime);
         }
     }
 
-    public static LocalDateTime toLocalDateTimeDefault(String timestampString) {
+    public static LocalDateTime toLocalDateTimeDefault(
+            String timestampString, LocalTime defaultLocalTime) {
         try {
             return LocalDateTime.parse(timestampString, TIMESTAMP_FORMATTER);
         } catch (DateTimeParseException e) {
             return LocalDateTime.of(
-                    LocalDate.parse(timestampString, DATE_FORMATTER), LocalTime.MIDNIGHT);
+                    LocalDate.parse(timestampString, DATE_FORMATTER), defaultLocalTime);
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionValuesTimeExpireStrategy.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionValuesTimeExpireStrategy.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.List;
@@ -49,8 +50,8 @@ public class PartitionValuesTimeExpireStrategy extends PartitionExpireStrategy {
 
     public PartitionValuesTimeExpireStrategy(CoreOptions options, RowType partitionType) {
         super(partitionType);
-        String timePattern = options.partitionTimestampPattern();
-        String timeFormatter = options.partitionTimestampFormatter();
+        String timePattern = options.partitionExpireTimestampPattern();
+        String timeFormatter = options.partitionExpireTimestampFormatter();
         this.timeExtractor = new PartitionTimeExtractor(timePattern, timeFormatter);
     }
 
@@ -78,7 +79,8 @@ public class PartitionValuesTimeExpireStrategy extends PartitionExpireStrategy {
         public boolean test(BinaryRow partition) {
             Object[] array = convertPartition(partition);
             try {
-                LocalDateTime partTime = timeExtractor.extract(partitionKeys, Arrays.asList(array));
+                LocalDateTime partTime =
+                        timeExtractor.extract(partitionKeys, Arrays.asList(array), LocalTime.MAX);
                 return expireDateTime.isAfter(partTime);
             } catch (DateTimeParseException e) {
                 LOG.warn(

--- a/paimon-core/src/test/java/org/apache/paimon/partition/PartitionExpireTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/partition/PartitionExpireTableTest.java
@@ -38,6 +38,8 @@ import static org.apache.paimon.CoreOptions.PARTITION_EXPIRATION_STRATEGY;
 import static org.apache.paimon.CoreOptions.PARTITION_EXPIRATION_TIME;
 import static org.apache.paimon.CoreOptions.PARTITION_EXPIRATION_TIMESTAMP_FORMATTER;
 import static org.apache.paimon.CoreOptions.PARTITION_EXPIRATION_TIMESTAMP_PATTERN;
+import static org.apache.paimon.CoreOptions.PARTITION_TIMESTAMP_FORMATTER;
+import static org.apache.paimon.CoreOptions.PARTITION_TIMESTAMP_PATTERN;
 import static org.apache.paimon.partition.CustomPartitionExpirationFactory.TABLE_EXPIRE_PARTITIONS;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -98,7 +100,7 @@ class PartitionExpireTableTest extends TableTestBase {
     }
 
     @Test
-    public void testValuesTimeExpireCustom() throws Exception {
+    public void testValuesTimeExpireCustomExpFORMATTER() throws Exception {
         Schema.Builder schemaBuilder = Schema.newBuilder();
         schemaBuilder.column("f0", DataTypes.INT());
         schemaBuilder.column("pt", DataTypes.STRING());
@@ -108,6 +110,35 @@ class PartitionExpireTableTest extends TableTestBase {
         schemaBuilder.option(END_INPUT_CHECK_PARTITION_EXPIRE.key(), "true");
         schemaBuilder.option(PARTITION_EXPIRATION_TIMESTAMP_PATTERN.key(), "$pt:59:59");
         schemaBuilder.option(PARTITION_EXPIRATION_TIMESTAMP_FORMATTER.key(), "yyyy-MM-dd HH:mm:ss");
+        catalog.createTable(identifier(), schemaBuilder.build(), true);
+
+        LocalDate day = LocalDate.now();
+        int hour1 = LocalTime.now().minusHours(2).getHour();
+        int hour2 = LocalTime.now().minusHours(1).getHour();
+        int hour3 = LocalTime.now().getHour();
+
+        GenericRow row1 = GenericRow.of(1, BinaryString.fromString(day + " " + hour1));
+        GenericRow row2 = GenericRow.of(2, BinaryString.fromString(day + " " + hour2));
+        GenericRow row3 = GenericRow.of(3, BinaryString.fromString(day + " " + hour3));
+
+        Table table = catalog.getTable(identifier());
+        write(table, row1);
+        write(table, row2);
+        write(table, row3);
+        assertThat(read(table)).containsExactlyInAnyOrder(row2, row3);
+    }
+
+    @Test
+    public void testValuesTimeExpireCustomFORMATTER() throws Exception {
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.column("f0", DataTypes.INT());
+        schemaBuilder.column("pt", DataTypes.STRING());
+        schemaBuilder.partitionKeys("pt");
+        schemaBuilder.option(PARTITION_EXPIRATION_STRATEGY.key(), "values-time");
+        schemaBuilder.option(PARTITION_EXPIRATION_TIME.key(), "1 H");
+        schemaBuilder.option(END_INPUT_CHECK_PARTITION_EXPIRE.key(), "true");
+        schemaBuilder.option(PARTITION_TIMESTAMP_PATTERN.key(), "$pt:59:59");
+        schemaBuilder.option(PARTITION_TIMESTAMP_FORMATTER.key(), "yyyy-MM-dd HH:mm:ss");
         catalog.createTable(identifier(), schemaBuilder.build(), true);
 
         LocalDate day = LocalDate.now();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

The current parsing of partition time uses the earliest time of the partition, which is unreasonable for partition expiration checks.

Example:

Set partition.expiration-time = '1 d' .

Current time: 2025-06-27 09:00:00, we need to verify if data in the 25th partition can be deleted.
The default parsed time for the 26th partition is 2025-06-26 00:00:00.
2025-06-27 09:00:00 - 2025-06-26 00:00:00 = 33 hours > 24 hours, triggering incorrect deletion eligibility.

Proposed solution:

Default to parsing the latest time of the day for partitions, and support user-defined configurations .
Examples:
Hourly partitions: $day $hour:59:59
Minute partitions: $day $hour:$minute:59

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
