### PR TITLE
Fix: Exlude parquet 1.13.1 from spark-sql in paimon-spark-ut to avoid overwriting parquet 1.15.1.

### DIFF
--- a/paimon-spark/paimon-spark-ut/pom.xml
+++ b/paimon-spark/paimon-spark-ut/pom.xml
@@ -106,6 +106,10 @@ under the License.
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.parquet</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Fix: Exlude parquet 1.13.1 from spark-sql in paimon-spark-ut to avoid overwriting parquet 1.15.1.

bugfix: when running org.apache.paimon.spark.sql.BucketedTableQueryTest, got following error message:
![image](https://github.com/user-attachments/assets/09bb2477-3aad-42dc-829d-1e54587ad2b1)

root cause: Importing spark-sql in test scope will improt parquet 1.13.1 too. However, Paimon uses parquet 1.15.1 and there are some new functions  in 1.15.1 called by Paimon.

After exluding, tests case run successfully.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
