### PR TITLE
[cdc] Support computed columns when sync_database

### DIFF
--- a/docs/content/cdc-ingestion/kafka-cdc.md
+++ b/docs/content/cdc-ingestion/kafka-cdc.md
@@ -214,6 +214,7 @@ To use this feature through `flink run`, run the following shell command.
     [--type_mapping to-string] \
     [--partition_keys <partition_keys>] \
     [--primary_keys <primary-keys>] \
+    [--computed_column <'column-name=expr-name(args[, ...])'> [--computed_column ...]] \
     [--kafka_conf <kafka-source-conf> [--kafka_conf <kafka-source-conf> ...]] \
     [--catalog_conf <paimon-catalog-conf> [--catalog_conf <paimon-catalog-conf> ...]] \
     [--table_conf <paimon-table-sink-conf> [--table_conf <paimon-table-sink-conf> ...]]
@@ -244,7 +245,8 @@ Synchronization from one Kafka topic to Paimon database.
     --catalog_conf uri=thrift://hive-metastore:9083 \
     --table_conf bucket=4 \
     --table_conf changelog-producer=input \
-    --table_conf sink.parallelism=4
+    --table_conf sink.parallelism=4 \
+    --computed_column 'pt=date_format(event_tm, yyyyMMdd)'
 ```
 
 Synchronization from multiple Kafka topics to Paimon database.

--- a/docs/layouts/shortcodes/generated/kafka_sync_database.html
+++ b/docs/layouts/shortcodes/generated/kafka_sync_database.html
@@ -92,7 +92,7 @@ under the License.
     </tr>
     <tr>
         <td><h5>--computed_column</h5></td>
-        <td>The definitions of computed columns. The argument field is from Kafka topic's table field name. See <a href="../overview/#computed-functions">here</a> for a complete list of configurations. </td>
+        <td>The definitions of computed columns. The argument field is from Kafka topic's table field name. See <a href="../overview/#computed-functions">here</a> for a complete list of configurations. NOTICE: It returns null if the referenced column does not exist in the source table.</td>
     </tr>
     <tr>
         <td><h5>--eager_init</h5></td>

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/ComputedColumn.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/ComputedColumn.java
@@ -53,6 +53,11 @@ public class ComputedColumn implements Serializable {
         return expression.fieldReference();
     }
 
+    @Nullable
+    public DataType fieldReferenceType() {
+        return expression.fieldReferenceType();
+    }
+
     /** Compute column's value from given argument. Return null if input is null. */
     @Nullable
     public String eval(@Nullable String input) {
@@ -60,5 +65,14 @@ public class ComputedColumn implements Serializable {
             return null;
         }
         return expression.eval(input);
+    }
+
+    /** Compute column's value from given argument. Return null if input is null. */
+    @Nullable
+    public String eval(@Nullable String input, DataType inputType) {
+        if (fieldReference() != null && input == null) {
+            return null;
+        }
+        return expression.eval(input, inputType);
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/ComputedColumnUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/ComputedColumnUtils.java
@@ -18,13 +18,18 @@
 
 package org.apache.paimon.flink.action.cdc;
 
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.utils.Preconditions;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -75,6 +80,90 @@ public class ComputedColumnUtils {
                             Expression.create(typeMapping, caseSensitive, exprName, args)));
         }
 
-        return computedColumns;
+        return sortComputedColumns(computedColumns);
+    }
+
+    @VisibleForTesting
+    public static List<ComputedColumn> sortComputedColumns(List<ComputedColumn> columns) {
+        Set<String> columnNames = new HashSet<>();
+        for (ComputedColumn col : columns) {
+            columnNames.add(col.columnName());
+        }
+
+        // For simple processing, no reference or referring to another computed column, means
+        // independent
+        List<ComputedColumn> independent = new ArrayList<>();
+        List<ComputedColumn> dependent = new ArrayList<>();
+
+        for (ComputedColumn col : columns) {
+            if (col.fieldReference() == null || !columnNames.contains(col.fieldReference())) {
+                independent.add(col);
+            } else {
+                dependent.add(col);
+            }
+        }
+
+        // Sort dependent columns with topological sort
+        Map<String, ComputedColumn> columnMap = new HashMap<>();
+        Map<String, Set<String>> reverseDependencies = new HashMap<>();
+
+        for (ComputedColumn col : dependent) {
+            columnMap.put(col.columnName(), col);
+            reverseDependencies
+                    .computeIfAbsent(col.fieldReference(), k -> new HashSet<>())
+                    .add(col.columnName());
+        }
+
+        List<ComputedColumn> sortedDependent = new ArrayList<>();
+        Set<String> visited = new HashSet<>();
+        Set<String> tempMark = new HashSet<>(); // For cycle detection
+
+        for (ComputedColumn col : dependent) {
+            if (!visited.contains(col.columnName())) {
+                dfs(
+                        col.columnName(),
+                        reverseDependencies,
+                        columnMap,
+                        sortedDependent,
+                        visited,
+                        tempMark);
+            }
+        }
+
+        Collections.reverse(sortedDependent);
+
+        // Independent should precede dependent
+        List<ComputedColumn> result = new ArrayList<>();
+        result.addAll(independent);
+        result.addAll(sortedDependent);
+
+        return result;
+    }
+
+    private static void dfs(
+            String node,
+            Map<String, Set<String>> reverseDependencies,
+            Map<String, ComputedColumn> columnMap,
+            List<ComputedColumn> sorted,
+            Set<String> visited,
+            Set<String> tempMark) {
+        if (tempMark.contains(node)) {
+            throw new IllegalArgumentException("Cycle detected: " + node);
+        }
+        if (visited.contains(node)) {
+            return;
+        }
+
+        tempMark.add(node);
+        ComputedColumn current = columnMap.get(node);
+
+        // Process the dependencies
+        for (String dependent : reverseDependencies.getOrDefault(node, Collections.emptySet())) {
+            dfs(dependent, reverseDependencies, columnMap, sorted, visited, tempMark);
+        }
+
+        tempMark.remove(node);
+        visited.add(node);
+        sorted.add(current);
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/Expression.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/Expression.java
@@ -24,6 +24,7 @@ import org.apache.paimon.types.DataTypeFamily;
 import org.apache.paimon.types.DataTypeJsonParser;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.utils.DateTimeUtils;
 import org.apache.paimon.utils.SerializableSupplier;
 import org.apache.paimon.utils.StringUtils;
@@ -50,11 +51,17 @@ public interface Expression extends Serializable {
     /** Return name of referenced field. */
     String fieldReference();
 
+    /** Return {@link DataType} of referenced field. */
+    DataType fieldReferenceType();
+
     /** Return {@link DataType} of computed value. */
     DataType outputType();
 
     /** Compute value from given input. Input and output are serialized to string. */
     String eval(String input);
+
+    /** Compute value from given input. Input and output are serialized to string. */
+    String eval(String input, DataType inputType);
 
     /** Return name of this expression. */
     default String name() {
@@ -66,7 +73,7 @@ public interface Expression extends Serializable {
         YEAR(
                 (typeMapping, caseSensitive, args) -> {
                     ReferencedField referencedField =
-                            ReferencedField.checkArgument(typeMapping, caseSensitive, args);
+                            ReferencedField.create(typeMapping, caseSensitive, args);
                     return TemporalToIntConverter.create(
                             referencedField.field(),
                             referencedField.fieldType(),
@@ -76,7 +83,7 @@ public interface Expression extends Serializable {
         MONTH(
                 (typeMapping, caseSensitive, args) -> {
                     ReferencedField referencedField =
-                            ReferencedField.checkArgument(typeMapping, caseSensitive, args);
+                            ReferencedField.create(typeMapping, caseSensitive, args);
                     return TemporalToIntConverter.create(
                             referencedField.field(),
                             referencedField.fieldType(),
@@ -86,7 +93,7 @@ public interface Expression extends Serializable {
         DAY(
                 (typeMapping, caseSensitive, args) -> {
                     ReferencedField referencedField =
-                            ReferencedField.checkArgument(typeMapping, caseSensitive, args);
+                            ReferencedField.create(typeMapping, caseSensitive, args);
                     return TemporalToIntConverter.create(
                             referencedField.field(),
                             referencedField.fieldType(),
@@ -96,7 +103,7 @@ public interface Expression extends Serializable {
         HOUR(
                 (typeMapping, caseSensitive, args) -> {
                     ReferencedField referencedField =
-                            ReferencedField.checkArgument(typeMapping, caseSensitive, args);
+                            ReferencedField.create(typeMapping, caseSensitive, args);
                     return TemporalToIntConverter.create(
                             referencedField.field(),
                             referencedField.fieldType(),
@@ -106,7 +113,7 @@ public interface Expression extends Serializable {
         MINUTE(
                 (typeMapping, caseSensitive, args) -> {
                     ReferencedField referencedField =
-                            ReferencedField.checkArgument(typeMapping, caseSensitive, args);
+                            ReferencedField.create(typeMapping, caseSensitive, args);
                     return TemporalToIntConverter.create(
                             referencedField.field(),
                             referencedField.fieldType(),
@@ -116,7 +123,7 @@ public interface Expression extends Serializable {
         SECOND(
                 (typeMapping, caseSensitive, args) -> {
                     ReferencedField referencedField =
-                            ReferencedField.checkArgument(typeMapping, caseSensitive, args);
+                            ReferencedField.create(typeMapping, caseSensitive, args);
                     return TemporalToIntConverter.create(
                             referencedField.field(),
                             referencedField.fieldType(),
@@ -126,7 +133,7 @@ public interface Expression extends Serializable {
         DATE_FORMAT(
                 (typeMapping, caseSensitive, args) -> {
                     ReferencedField referencedField =
-                            ReferencedField.checkArgument(typeMapping, caseSensitive, args);
+                            ReferencedField.create(typeMapping, caseSensitive, args);
                     return DateFormat.create(
                             referencedField.field(),
                             referencedField.fieldType(),
@@ -135,13 +142,13 @@ public interface Expression extends Serializable {
         SUBSTRING(
                 (typeMapping, caseSensitive, args) -> {
                     ReferencedField referencedField =
-                            ReferencedField.checkArgument(typeMapping, caseSensitive, args);
+                            ReferencedField.create(typeMapping, caseSensitive, args);
                     return substring(referencedField.field(), referencedField.literals());
                 }),
         TRUNCATE(
                 (typeMapping, caseSensitive, args) -> {
                     ReferencedField referencedField =
-                            ReferencedField.checkArgument(typeMapping, caseSensitive, args);
+                            ReferencedField.create(typeMapping, caseSensitive, args);
                     return truncate(
                             referencedField.field(),
                             referencedField.fieldType(),
@@ -152,7 +159,7 @@ public interface Expression extends Serializable {
         UPPER(
                 (typeMapping, caseSensitive, args) -> {
                     ReferencedField referencedField =
-                            ReferencedField.checkArgument(typeMapping, caseSensitive, args);
+                            ReferencedField.create(typeMapping, caseSensitive, args);
                     return new UpperExpression(
                             referencedField.field(),
                             referencedField.fieldType(),
@@ -161,7 +168,7 @@ public interface Expression extends Serializable {
         LOWER(
                 (typeMapping, caseSensitive, args) -> {
                     ReferencedField referencedField =
-                            ReferencedField.checkArgument(typeMapping, caseSensitive, args);
+                            ReferencedField.create(typeMapping, caseSensitive, args);
                     return new LowerExpression(
                             referencedField.field(),
                             referencedField.fieldType(),
@@ -170,7 +177,7 @@ public interface Expression extends Serializable {
         TRIM(
                 (typeMapping, caseSensitive, args) -> {
                     ReferencedField referencedField =
-                            ReferencedField.checkArgument(typeMapping, caseSensitive, args);
+                            ReferencedField.create(typeMapping, caseSensitive, args);
                     return new TrimExpression(
                             referencedField.field(),
                             referencedField.fieldType(),
@@ -208,16 +215,16 @@ public interface Expression extends Serializable {
     /** Referenced field in expression input parameters. */
     class ReferencedField {
         private final String field;
-        private final DataType fieldType;
+        @Nullable private final DataType fieldType;
         private final String[] literals;
 
-        private ReferencedField(String field, DataType fieldType, String[] literals) {
+        private ReferencedField(String field, @Nullable DataType fieldType, String[] literals) {
             this.field = field;
             this.fieldType = fieldType;
             this.literals = literals;
         }
 
-        public static ReferencedField checkArgument(
+        public static ReferencedField create(
                 Map<String, DataType> typeMapping, boolean caseSensitive, String... args) {
             String referencedField = args[0].trim();
             String[] literals =
@@ -226,11 +233,13 @@ public interface Expression extends Serializable {
                     StringUtils.toLowerCaseIfNeed(referencedField, caseSensitive);
 
             DataType fieldType =
-                    checkNotNull(
-                            typeMapping.get(referencedFieldCheckForm),
-                            String.format(
-                                    "Referenced field '%s' is not in given fields: %s.",
-                                    referencedFieldCheckForm, typeMapping.keySet()));
+                    typeMapping.isEmpty()
+                            ? null
+                            : checkNotNull(
+                                    typeMapping.get(referencedFieldCheckForm),
+                                    String.format(
+                                            "Referenced field '%s' is not in given fields: %s.",
+                                            referencedFieldCheckForm, typeMapping.keySet()));
             return new ReferencedField(referencedField, fieldType, literals);
         }
 
@@ -326,16 +335,22 @@ public interface Expression extends Serializable {
         private static final List<Integer> SUPPORTED_PRECISION = Arrays.asList(0, 3, 6, 9);
 
         private final String fieldReference;
-        @Nullable private final Integer precision;
+        @Nullable private DataType fieldReferenceType;
+        @Nullable private Integer precision;
 
         private transient Function<LocalDateTime, T> converter;
 
         private TemporalExpressionBase(
-                String fieldReference, DataType fieldType, @Nullable Integer precision) {
+                String fieldReference, @Nullable DataType fieldType, @Nullable Integer precision) {
             this.fieldReference = fieldReference;
+            this.fieldReferenceType = fieldType;
 
             // when the input is INTEGER_NUMERIC, the precision must be set
-            if (fieldType.getTypeRoot().getFamilies().contains(DataTypeFamily.INTEGER_NUMERIC)
+            if (fieldType != null
+                    && fieldType
+                            .getTypeRoot()
+                            .getFamilies()
+                            .contains(DataTypeFamily.INTEGER_NUMERIC)
                     && precision == null) {
                 precision = 0;
             }
@@ -354,6 +369,11 @@ public interface Expression extends Serializable {
             return fieldReference;
         }
 
+        @Override
+        public DataType fieldReferenceType() {
+            return fieldReferenceType;
+        }
+
         /** If not, this must be overridden! */
         @Override
         public DataType outputType() {
@@ -368,6 +388,21 @@ public interface Expression extends Serializable {
 
             T result = converter.apply(toLocalDateTime(input));
             return String.valueOf(result);
+        }
+
+        @Override
+        public String eval(String input, DataType inputType) {
+            if (this.fieldReferenceType == null) {
+                this.fieldReferenceType = inputType;
+
+                // when the input is INTEGER_NUMERIC, the precision must be set
+                if (inputType.getTypeRoot().getFamilies().contains(DataTypeFamily.INTEGER_NUMERIC)
+                        && precision == null) {
+                    this.precision = 0;
+                }
+            }
+
+            return eval(input);
         }
 
         private LocalDateTime toLocalDateTime(String input) {
@@ -425,7 +460,7 @@ public interface Expression extends Serializable {
 
         private static TemporalToIntConverter create(
                 String fieldReference,
-                DataType fieldType,
+                @Nullable DataType fieldType,
                 SerializableSupplier<Function<LocalDateTime, Integer>> converterSupplier,
                 String... literals) {
             checkArgument(
@@ -505,6 +540,11 @@ public interface Expression extends Serializable {
         }
 
         @Override
+        public DataType fieldReferenceType() {
+            return new VarCharType();
+        }
+
+        @Override
         public DataType outputType() {
             return DataTypes.STRING();
         }
@@ -524,6 +564,11 @@ public interface Expression extends Serializable {
                                 input, beginInclusive, endExclusive));
             }
         }
+
+        @Override
+        public String eval(String input, DataType inputType) {
+            return eval(input);
+        }
     }
 
     /** Truncate numeric/decimal/string value. */
@@ -532,11 +577,11 @@ public interface Expression extends Serializable {
 
         private final String fieldReference;
 
-        private final DataType fieldType;
+        @Nullable private DataType fieldType;
 
         private final int width;
 
-        TruncateComputer(String fieldReference, DataType fieldType, String literal) {
+        TruncateComputer(String fieldReference, @Nullable DataType fieldType, String literal) {
             this.fieldReference = fieldReference;
             this.fieldType = fieldType;
             try {
@@ -552,6 +597,11 @@ public interface Expression extends Serializable {
         @Override
         public String fieldReference() {
             return fieldReference;
+        }
+
+        @Override
+        public DataType fieldReferenceType() {
+            return fieldType;
         }
 
         @Override
@@ -586,6 +636,14 @@ public interface Expression extends Serializable {
                                     "Unsupported field type for truncate function: %s.",
                                     fieldType.getTypeRoot().toString()));
             }
+        }
+
+        @Override
+        public String eval(String input, DataType inputType) {
+            if (this.fieldType == null) {
+                this.fieldType = inputType;
+            }
+            return eval(input);
         }
 
         private short truncateShort(int width, short value) {
@@ -633,12 +691,22 @@ public interface Expression extends Serializable {
         }
 
         @Override
+        public DataType fieldReferenceType() {
+            return null;
+        }
+
+        @Override
         public DataType outputType() {
             return dataType;
         }
 
         @Override
         public String eval(String input) {
+            return value;
+        }
+
+        @Override
+        public String eval(String input, DataType inputType) {
             return value;
         }
     }
@@ -651,6 +719,11 @@ public interface Expression extends Serializable {
         }
 
         @Override
+        public DataType fieldReferenceType() {
+            return null;
+        }
+
+        @Override
         public DataType outputType() {
             return DataTypes.TIMESTAMP(3);
         }
@@ -658,6 +731,11 @@ public interface Expression extends Serializable {
         @Override
         public String eval(String input) {
             return DateTimeUtils.formatLocalDateTime(LocalDateTime.now(), 3);
+        }
+
+        @Override
+        public String eval(String input, DataType inputType) {
+            return eval(input);
         }
     }
 
@@ -719,12 +797,14 @@ public interface Expression extends Serializable {
     abstract class NoLiteralsStringExpressionBase implements Expression {
 
         private final String fieldReference;
+        @Nullable protected DataType fieldReferenceType;
 
         public NoLiteralsStringExpressionBase(
-                String fieldReference, DataType fieldType, String... literals) {
+                String fieldReference, @Nullable DataType fieldType, String... literals) {
             this.fieldReference = fieldReference;
+            this.fieldReferenceType = fieldType;
             checkArgument(
-                    fieldType.getTypeRoot() == DataTypeRoot.VARCHAR,
+                    fieldType == null || fieldType.getTypeRoot() == DataTypeRoot.VARCHAR,
                     String.format(
                             "'%s' expression only supports type root of '%s', but found '%s'.",
                             name(), DataTypeRoot.VARCHAR, fieldType.getTypeRoot()));
@@ -743,6 +823,24 @@ public interface Expression extends Serializable {
         @Override
         public String fieldReference() {
             return fieldReference;
+        }
+
+        @Override
+        public DataType fieldReferenceType() {
+            return fieldReferenceType;
+        }
+
+        @Override
+        public String eval(String input, DataType inputType) {
+            if (this.fieldReferenceType == null) {
+                checkArgument(
+                        inputType.getTypeRoot() == DataTypeRoot.VARCHAR,
+                        String.format(
+                                "'%s' expression only supports type root of '%s', but found '%s'.",
+                                name(), DataTypeRoot.VARCHAR, inputType.getTypeRoot()));
+                this.fieldReferenceType = inputType;
+            }
+            return eval(input);
         }
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/ComputedColumnUtilsTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/ComputedColumnUtilsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action.cdc;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.flink.action.cdc.ComputedColumnUtils.sortComputedColumns;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Test for ComputedColumnUtils. */
+public class ComputedColumnUtilsTest {
+    @Test
+    public void test() {
+        List<ComputedColumn> columns =
+                Arrays.asList(
+                        new ComputedColumn("A", Expression.substring("B", "1")),
+                        new ComputedColumn("B", Expression.substring("ExistedColumn", "1")),
+                        new ComputedColumn("C", Expression.cast("No Reference")),
+                        new ComputedColumn("D", Expression.substring("A", "1")),
+                        new ComputedColumn("E", Expression.substring("C", "1")));
+
+        List<ComputedColumn> sortedColumns = sortComputedColumns(columns);
+        assertEquals(
+                Arrays.asList("B", "C", "E", "A", "D"),
+                sortedColumns.stream()
+                        .map(ComputedColumn::columnName)
+                        .collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testCycleReference() {
+        List<ComputedColumn> columns =
+                Arrays.asList(
+                        new ComputedColumn("A", Expression.substring("B", "1")),
+                        new ComputedColumn("B", Expression.substring("C", "1")),
+                        new ComputedColumn("C", Expression.substring("A", "1")));
+
+        assertThrows(IllegalArgumentException.class, () -> sortComputedColumns(columns));
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->
To use computed columns when sync_database. The computed columns could refer to existed fields or other computed columns.

### Tests

<!-- List UT and IT cases to verify this change -->
1. Test computed columns when sync_database, with e2e case 
org.apache.paimon.flink.action.cdc.kafka.KafkaCanalSyncDatabaseActionITCase#testExpressionNow
, by adding a new filed: pt=date_format(etl_update_time,yyyy-MM-dd).

2. Test the sortting of computed columns, with case: 
org.apache.paimon.flink.action.cdc.ComputedColumnUtilsTest

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
