### PR TITLE
[hotfix] add detail information for NoPermissionException

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -1034,7 +1034,12 @@ public interface Catalog extends AutoCloseable {
         private final String database;
 
         public DatabaseNoPermissionException(String database, Throwable cause) {
-            super(String.format(MSG, database, cause.getMessage()), cause);
+            super(
+                    String.format(
+                            MSG,
+                            database,
+                            cause != null && cause.getMessage() != null ? cause.getMessage() : ""),
+                    cause);
             this.database = database;
         }
 
@@ -1098,7 +1103,12 @@ public interface Catalog extends AutoCloseable {
         private final Identifier identifier;
 
         public TableNoPermissionException(Identifier identifier, Throwable cause) {
-            super(String.format(MSG, identifier.getFullName(), cause.getMessage()), cause);
+            super(
+                    String.format(
+                            MSG,
+                            identifier.getFullName(),
+                            cause != null && cause.getMessage() != null ? cause.getMessage() : ""),
+                    cause);
             this.identifier = identifier;
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -1029,12 +1029,12 @@ public interface Catalog extends AutoCloseable {
 
     /** Exception for trying to operate on the database that doesn't have permission. */
     class DatabaseNoPermissionException extends RuntimeException {
-        private static final String MSG = "Database %s has no permission.";
+        private static final String MSG = "Database %s has no permission. Cause by %s.";
 
         private final String database;
 
         public DatabaseNoPermissionException(String database, Throwable cause) {
-            super(String.format(MSG, database), cause);
+            super(String.format(MSG, database, cause.getMessage()), cause);
             this.database = database;
         }
 
@@ -1093,12 +1093,12 @@ public interface Catalog extends AutoCloseable {
     /** Exception for trying to operate on the table that doesn't have permission. */
     class TableNoPermissionException extends RuntimeException {
 
-        private static final String MSG = "Table %s has no permission.";
+        private static final String MSG = "Table %s has no permission. Cause by %s.";
 
         private final Identifier identifier;
 
         public TableNoPermissionException(Identifier identifier, Throwable cause) {
-            super(String.format(MSG, identifier.getFullName()), cause);
+            super(String.format(MSG, identifier.getFullName(), cause.getMessage()), cause);
             this.identifier = identifier;
         }
 


### PR DESCRIPTION
### Purpose
We cannot judge where or why we have no permission for the table/database, so we need include more detailed descriptions of lacking permissions.

### Tests
MockRESTCatalogTest.testDatabaseApiWhenNoPermission
MockRESTCatalogTest.testApiWhenTableNoPermission

### API and Format

### Documentation
