### PR TITLE
[flink] Move FlinkSink#createWriteProvider to a common place so other sinks can also use it

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
@@ -47,8 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.apache.paimon.CoreOptions.FULL_COMPACTION_DELTA_COMMITS;
-import static org.apache.paimon.flink.FlinkConnectorOptions.CHANGELOG_PRODUCER_FULL_COMPACTION_TRIGGER_INTERVAL;
 import static org.apache.paimon.utils.SerializationUtils.deserializeBinaryRow;
 
 /**
@@ -155,7 +153,8 @@ public class MultiTablesStoreCompactOperator
                         + " should not be true for MultiTablesStoreCompactOperator.");
 
         storeSinkWriteProvider =
-                createWriteProvider(table, checkpointConfig, isStreaming, ignorePreviousFiles);
+                StoreSinkWrite.createWriteProvider(
+                        table, checkpointConfig, isStreaming, ignorePreviousFiles, false);
 
         StoreSinkWrite write =
                 writes.computeIfAbsent(
@@ -251,77 +250,6 @@ public class MultiTablesStoreCompactOperator
             }
         }
         return table;
-    }
-
-    private StoreSinkWrite.Provider createWriteProvider(
-            FileStoreTable fileStoreTable,
-            CheckpointConfig checkpointConfig,
-            boolean isStreaming,
-            boolean ignorePreviousFiles) {
-        Options options = fileStoreTable.coreOptions().toConfiguration();
-        CoreOptions.ChangelogProducer changelogProducer =
-                fileStoreTable.coreOptions().changelogProducer();
-        boolean waitCompaction;
-        CoreOptions coreOptions = fileStoreTable.coreOptions();
-        if (coreOptions.writeOnly()) {
-            waitCompaction = false;
-        } else {
-            waitCompaction = coreOptions.prepareCommitWaitCompaction();
-            int deltaCommits = -1;
-            if (options.contains(FULL_COMPACTION_DELTA_COMMITS)) {
-                deltaCommits = options.get(FULL_COMPACTION_DELTA_COMMITS);
-            } else if (options.contains(CHANGELOG_PRODUCER_FULL_COMPACTION_TRIGGER_INTERVAL)) {
-                long fullCompactionThresholdMs =
-                        options.get(CHANGELOG_PRODUCER_FULL_COMPACTION_TRIGGER_INTERVAL).toMillis();
-                deltaCommits =
-                        (int)
-                                (fullCompactionThresholdMs
-                                        / checkpointConfig.getCheckpointInterval());
-            }
-
-            if (changelogProducer == CoreOptions.ChangelogProducer.FULL_COMPACTION
-                    || deltaCommits >= 0) {
-                int finalDeltaCommits = Math.max(deltaCommits, 1);
-                return (table, commitUser, state, ioManager, memoryPool, metricGroup) ->
-                        new GlobalFullCompactionSinkWrite(
-                                table,
-                                commitUser,
-                                state,
-                                ioManager,
-                                ignorePreviousFiles,
-                                waitCompaction,
-                                finalDeltaCommits,
-                                isStreaming,
-                                memoryPool,
-                                metricGroup);
-            }
-        }
-
-        if (coreOptions.needLookup()) {
-            return (table, commitUser, state, ioManager, memoryPool, metricGroup) ->
-                    new LookupSinkWrite(
-                            table,
-                            commitUser,
-                            state,
-                            ioManager,
-                            ignorePreviousFiles,
-                            waitCompaction,
-                            isStreaming,
-                            memoryPool,
-                            metricGroup);
-        }
-
-        return (table, commitUser, state, ioManager, memoryPool, metricGroup) ->
-                new StoreSinkWriteImpl(
-                        table,
-                        commitUser,
-                        state,
-                        ioManager,
-                        ignorePreviousFiles,
-                        waitCompaction,
-                        isStreaming,
-                        memoryPool,
-                        metricGroup);
     }
 
     /** {@link StreamOperatorFactory} of {@link MultiTablesStoreCompactOperator}. */

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWrite.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreSinkWrite.java
@@ -18,24 +18,33 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.memory.MemoryPoolFactory;
 import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.operation.WriteRestore;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.SinkRecord;
 import org.apache.paimon.table.sink.TableWriteImpl;
+import org.apache.paimon.utils.Preconditions;
+import org.apache.paimon.utils.SerializableRunnable;
 
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
+
+import static org.apache.paimon.CoreOptions.FULL_COMPACTION_DELTA_COMMITS;
+import static org.apache.paimon.flink.FlinkConnectorOptions.CHANGELOG_PRODUCER_FULL_COMPACTION_TRIGGER_INTERVAL;
 
 /** Helper class of {@link PrepareCommitOperator} for different types of paimon sinks. */
 public interface StoreSinkWrite {
@@ -89,6 +98,95 @@ public interface StoreSinkWrite {
                 IOManager ioManager,
                 @Nullable MemorySegmentPool memoryPool,
                 @Nullable MetricGroup metricGroup);
+    }
+
+    static StoreSinkWrite.Provider createWriteProvider(
+            FileStoreTable fileStoreTable,
+            CheckpointConfig checkpointConfig,
+            boolean isStreaming,
+            boolean ignorePreviousFiles,
+            boolean hasSinkMaterializer) {
+        SerializableRunnable assertNoSinkMaterializer =
+                () ->
+                        Preconditions.checkArgument(
+                                !hasSinkMaterializer,
+                                String.format(
+                                        "Sink materializer must not be used with Paimon sink. "
+                                                + "Please set '%s' to '%s' in Flink's config.",
+                                        ExecutionConfigOptions.TABLE_EXEC_SINK_UPSERT_MATERIALIZE
+                                                .key(),
+                                        ExecutionConfigOptions.UpsertMaterialize.NONE.name()));
+
+        Options options = fileStoreTable.coreOptions().toConfiguration();
+        CoreOptions.ChangelogProducer changelogProducer =
+                fileStoreTable.coreOptions().changelogProducer();
+        boolean waitCompaction;
+        CoreOptions coreOptions = fileStoreTable.coreOptions();
+        if (coreOptions.writeOnly()) {
+            waitCompaction = false;
+        } else {
+            waitCompaction = coreOptions.prepareCommitWaitCompaction();
+            int deltaCommits = -1;
+            if (options.contains(FULL_COMPACTION_DELTA_COMMITS)) {
+                deltaCommits = options.get(FULL_COMPACTION_DELTA_COMMITS);
+            } else if (options.contains(CHANGELOG_PRODUCER_FULL_COMPACTION_TRIGGER_INTERVAL)) {
+                long fullCompactionThresholdMs =
+                        options.get(CHANGELOG_PRODUCER_FULL_COMPACTION_TRIGGER_INTERVAL).toMillis();
+                deltaCommits =
+                        (int)
+                                (fullCompactionThresholdMs
+                                        / checkpointConfig.getCheckpointInterval());
+            }
+
+            if (changelogProducer == CoreOptions.ChangelogProducer.FULL_COMPACTION
+                    || deltaCommits >= 0) {
+                int finalDeltaCommits = Math.max(deltaCommits, 1);
+                return (table, commitUser, state, ioManager, memoryPool, metricGroup) -> {
+                    assertNoSinkMaterializer.run();
+                    return new GlobalFullCompactionSinkWrite(
+                            table,
+                            commitUser,
+                            state,
+                            ioManager,
+                            ignorePreviousFiles,
+                            waitCompaction,
+                            finalDeltaCommits,
+                            isStreaming,
+                            memoryPool,
+                            metricGroup);
+                };
+            }
+
+            if (coreOptions.needLookup()) {
+                return (table, commitUser, state, ioManager, memoryPool, metricGroup) -> {
+                    assertNoSinkMaterializer.run();
+                    return new LookupSinkWrite(
+                            table,
+                            commitUser,
+                            state,
+                            ioManager,
+                            ignorePreviousFiles,
+                            waitCompaction,
+                            isStreaming,
+                            memoryPool,
+                            metricGroup);
+                };
+            }
+        }
+
+        return (table, commitUser, state, ioManager, memoryPool, metricGroup) -> {
+            assertNoSinkMaterializer.run();
+            return new StoreSinkWriteImpl(
+                    table,
+                    commitUser,
+                    state,
+                    ioManager,
+                    ignorePreviousFiles,
+                    waitCompaction,
+                    isStreaming,
+                    memoryPool,
+                    metricGroup);
+        };
     }
 
     /** Provider of {@link StoreSinkWrite} that uses given write buffer. */


### PR DESCRIPTION
### Purpose

`FlinkSink` and `MultiTablesStoreCompactOperator` are both creating `StoreSinkWrite.Provider`. This PR moves the creation method to a common place so multiple sinks can all use it.

### Tests

Just a refactor. No tests.

### API and Format

No format changes.

### Documentation

No new feature.
