### PR TITLE
[hive] Format table: Support field delimiter in HMS 

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveTableUtils.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveTableUtils.java
@@ -77,13 +77,10 @@ class HiveTableUtils {
                 format = Format.JSON;
             } else {
                 format = Format.CSV;
-                if (!options.contains(FIELD_DELIMITER)) {
-                    options.set(
-                            FIELD_DELIMITER,
-                            serdeInfo
-                                    .getParameters()
-                                    .getOrDefault(FIELD_DELIM, HIVE_FIELD_DELIM_DEFAULT));
-                }
+                // hive default field delimiter is '\u0001'
+                options.set(
+                    FIELD_DELIMITER,
+                    serdeInfo.getParameters().getOrDefault(FIELD_DELIM, HIVE_FIELD_DELIM_DEFAULT));
             }
         } else {
             throw new UnsupportedOperationException("Unsupported table: " + hiveTable);

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveTableUtils.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveTableUtils.java
@@ -37,6 +37,7 @@ import static org.apache.paimon.CoreOptions.PATH;
 import static org.apache.paimon.CoreOptions.TYPE;
 import static org.apache.paimon.TableType.FORMAT_TABLE;
 import static org.apache.paimon.catalog.Catalog.COMMENT_PROP;
+import static org.apache.paimon.hive.HiveCatalog.HIVE_FIELD_DELIM_DEFAULT;
 import static org.apache.paimon.hive.HiveCatalog.isView;
 import static org.apache.paimon.table.FormatTableOptions.FIELD_DELIMITER;
 
@@ -76,10 +77,13 @@ class HiveTableUtils {
                 format = Format.JSON;
             } else {
                 format = Format.CSV;
-                // hive default field delimiter is '\u0001'
-                options.set(
-                        FIELD_DELIMITER,
-                        serdeInfo.getParameters().getOrDefault(FIELD_DELIM, "\u0001"));
+                if (!options.contains(FIELD_DELIMITER)) {
+                    options.set(
+                            FIELD_DELIMITER,
+                            serdeInfo
+                                    .getParameters()
+                                    .getOrDefault(FIELD_DELIM, HIVE_FIELD_DELIM_DEFAULT));
+                }
             }
         } else {
             throw new UnsupportedOperationException("Unsupported table: " + hiveTable);

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveTableUtils.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveTableUtils.java
@@ -77,10 +77,11 @@ class HiveTableUtils {
                 format = Format.JSON;
             } else {
                 format = Format.CSV;
-                // hive default field delimiter is '\u0001'
                 options.set(
-                    FIELD_DELIMITER,
-                    serdeInfo.getParameters().getOrDefault(FIELD_DELIM, HIVE_FIELD_DELIM_DEFAULT));
+                        FIELD_DELIMITER,
+                        serdeInfo
+                                .getParameters()
+                                .getOrDefault(FIELD_DELIM, HIVE_FIELD_DELIM_DEFAULT));
             }
         } else {
             throw new UnsupportedOperationException("Unsupported table: " + hiveTable);

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/FormatTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/FormatTableTestBase.scala
@@ -117,4 +117,12 @@ abstract class FormatTableTestBase extends PaimonHiveTestBase {
       }
     }
   }
+
+  test("Format table: field delimiter in HMS") {
+    withTable("t1") {
+      sql("CREATE TABLE t1 (id INT, p1 INT, p2 INT) USING csv OPTIONS ('field-delimiter' ';')")
+      val row = sql("SHOW CREATE TABLE t1").collect()(0)
+      assert(row.toString().contains("'field-delimiter' = ';'"))
+    }
+  }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Always sync properties to HMS for format table

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
