### PR TITLE
[flink] support specify max_pt for partition level

### DIFF
--- a/docs/content/flink/sql-lookup.md
+++ b/docs/content/flink/sql-lookup.md
@@ -173,6 +173,12 @@ The option `scan.partitions` can also specify fixed partitions in the form of `k
 Multiple partitions should be separated by semicolon (`;`).
 When specifying fixed partitions, this option can also be used in batch joins.
 
+The option `scan.partitions` can also specify max_pt() for parent partition in the form of `key1=max_pt(),key2=max_pt()`.
+All subpartitions for the latest parent partition will be loaded. For example, if partition keys is `'year', 'day', 'hh'`, 
+you can specify `year=max_pt()`, it will find the latest partition for `year` and load all its subpartitions for lookup.
+Only supports partitions to be specified hierarchically. For example, if setting `year=max_pt(),hh=max_pt()`, `hh=max_pt()`
+makes no sense.
+
 ## Query Service
 
 You can run a Flink Streaming Job to start query service for the table. When QueryService exists, Flink Lookup Join

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/DynamicPartitionLevelLoader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/DynamicPartitionLevelLoader.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.lookup;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/** Dynamic partition loader which can specify the partition level to load for lookup. */
+public class DynamicPartitionLevelLoader extends DynamicPartitionLoader {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DynamicPartitionLevelLoader.class);
+
+    private static final long serialVersionUID = 2L;
+
+    private final int maxPartitionLoadLevel;
+    private final List<InternalRow.FieldGetter> fieldGetters;
+
+    DynamicPartitionLevelLoader(
+            FileStoreTable table,
+            Duration refreshInterval,
+            Map<String, String> partitionLoadConfig) {
+        super(table, refreshInterval);
+        maxPartitionLoadLevel =
+                getMaxPartitionLoadLevel(partitionLoadConfig, table.partitionKeys());
+        fieldGetters = createPartitionFieldGetters();
+    }
+
+    @Override
+    public boolean checkRefresh() {
+        if (lastRefresh != null
+                && !lastRefresh.plus(refreshInterval).isBefore(LocalDateTime.now())) {
+            return false;
+        }
+
+        LOG.info(
+                "DynamicPartitionLevelLoader(maxPartitionLoadLevel={},table={}) refreshed after {} second(s), refreshing",
+                maxPartitionLoadLevel,
+                table.name(),
+                refreshInterval.toMillis() / 1000);
+
+        List<BinaryRow> newPartitions = getMaxPartitions();
+        lastRefresh = LocalDateTime.now();
+
+        if (newPartitions.size() != partitions.size()) {
+            partitions = newPartitions;
+            logNewPartitions();
+            return true;
+        } else {
+            for (int i = 0; i < newPartitions.size(); i++) {
+                if (comparator.compare(newPartitions.get(i), partitions.get(i)) != 0) {
+                    partitions = newPartitions;
+                    logNewPartitions();
+                    return true;
+                }
+            }
+            LOG.info(
+                    "DynamicPartitionLevelLoader(maxPartitionLoadLevel={},table={}) didn't find new partitions.",
+                    maxPartitionLoadLevel,
+                    table.name());
+            return false;
+        }
+    }
+
+    @Override
+    protected List<BinaryRow> getMaxPartitions() {
+        List<BinaryRow> newPartitions =
+                table.newReadBuilder().newScan().listPartitions().stream()
+                        .sorted(comparator.reversed())
+                        .collect(Collectors.toList());
+
+        if (maxPartitionLoadLevel == table.partitionKeys().size() - 1) {
+            // if maxPartitionLoadLevel is the max partition level, we only need to load the max
+            // partition
+            if (newPartitions.size() <= 1) {
+                return newPartitions;
+            } else {
+                return newPartitions.subList(0, 1);
+            }
+        }
+
+        for (int level = 0; level <= maxPartitionLoadLevel; level++) {
+            newPartitions = extractMaxPartitionsForFixedLevel(newPartitions, level);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "DynamicPartitionLevelLoader(currentPartitionLoadLevel={},table={}) finds new partitions: {}.",
+                        level,
+                        table.name(),
+                        partitionsToString(newPartitions));
+            }
+        }
+        return newPartitions;
+    }
+
+    private int getMaxPartitionLoadLevel(
+            Map<String, String> partitionLoadConfig, List<String> partitionFields) {
+        Preconditions.checkArgument(partitionLoadConfig.size() <= partitionFields.size());
+
+        int maxLoadLevel = -1;
+        for (int i = 0; i < partitionFields.size(); i++) {
+            String config = partitionLoadConfig.getOrDefault(partitionFields.get(i), null);
+
+            if (i == 0) {
+                Preconditions.checkArgument(
+                        config != null, "the top level partition must set load config.");
+            }
+            if (config != null) {
+                Preconditions.checkArgument(
+                        config.equals(MAX_PT),
+                        "unsupported load config '{}' for partition field '{}', currently only support '{}'.",
+                        config,
+                        partitionFields.get(i),
+                        MAX_PT);
+                maxLoadLevel = Math.max(maxLoadLevel, i);
+
+            } else {
+                // if level-i partition don't set config, we won't consider the partition level
+                // which is greater than level-i
+                return maxLoadLevel;
+            }
+        }
+        return maxLoadLevel;
+    }
+
+    private List<InternalRow.FieldGetter> createPartitionFieldGetters() {
+        List<InternalRow.FieldGetter> fieldGetters = new ArrayList<>();
+
+        RowType partitionType = table.rowType().project(table.partitionKeys());
+
+        for (int i = 0; i < maxPartitionLoadLevel + 1; i++) {
+            fieldGetters.add(InternalRow.createFieldGetter(partitionType.getTypeAt(i), i));
+        }
+        return fieldGetters;
+    }
+
+    private List<BinaryRow> extractMaxPartitionsForFixedLevel(
+            List<BinaryRow> partitions, int level) {
+        AtomicInteger currentDistinct = new AtomicInteger(0);
+        Object lastField = null;
+        for (int i = 0; i < partitions.size(); i++) {
+            BinaryRow partition = partitions.get(i);
+            Object newField = fieldGetters.get(level).getFieldOrNull(partition);
+            Preconditions.checkNotNull(newField);
+            if (lastField == null || !lastField.equals(newField)) {
+                lastField = newField;
+                if (currentDistinct.addAndGet(1) > 1) {
+                    return partitions.subList(0, i);
+                }
+            }
+        }
+        return partitions;
+    }
+
+    private void logNewPartitions() {
+        String partitionsStr = partitionsToString(partitions);
+
+        LOG.info(
+                "DynamicPartitionLevelLoader(maxPartitionLoadLevel={},table={}) finds new partitions: {}.",
+                maxPartitionLoadLevel,
+                table.name(),
+                partitionsStr);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/DynamicPartitionLevelLoader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/DynamicPartitionLevelLoader.java
@@ -169,7 +169,10 @@ public class DynamicPartitionLevelLoader extends DynamicPartitionLoader {
         for (int i = 0; i < partitions.size(); i++) {
             BinaryRow partition = partitions.get(i);
             Object newField = fieldGetters.get(level).getFieldOrNull(partition);
-            Preconditions.checkNotNull(newField);
+            // if newField is null, it's the default partition
+            if (newField == null) {
+                newField = "__DEFAULT_PARTITION__";
+            }
             if (lastField == null || !lastField.equals(newField)) {
                 lastField = newField;
                 if (currentDistinct.addAndGet(1) > 1) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/DynamicPartitionNumberLoader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/DynamicPartitionNumberLoader.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -34,7 +33,7 @@ public class DynamicPartitionNumberLoader extends DynamicPartitionLoader {
 
     private static final Logger LOG = LoggerFactory.getLogger(DynamicPartitionNumberLoader.class);
 
-    private static final long serialVersionUID = 2L;
+    private static final long serialVersionUID = 1L;
 
     private final int maxPartitionNum;
 
@@ -42,52 +41,10 @@ public class DynamicPartitionNumberLoader extends DynamicPartitionLoader {
             FileStoreTable table, Duration refreshInterval, int maxPartitionNum) {
         super(table, refreshInterval);
         this.maxPartitionNum = maxPartitionNum;
-    }
-
-    @Override
-    public boolean checkRefresh() {
-        if (lastRefresh != null
-                && !lastRefresh.plus(refreshInterval).isBefore(LocalDateTime.now())) {
-            return false;
-        }
-
         LOG.info(
-                "DynamicPartitionNumberLoader(maxPartitionNum={},table={}) refreshed after {} second(s), refreshing",
-                maxPartitionNum,
+                "Init DynamicPartitionNumberLoader(table={}),maxPartitionNum is {}",
                 table.name(),
-                refreshInterval.toMillis() / 1000);
-
-        List<BinaryRow> newPartitions = getMaxPartitions();
-        lastRefresh = LocalDateTime.now();
-
-        if (newPartitions.size() != partitions.size()) {
-            partitions = newPartitions;
-            logNewPartitions();
-            return true;
-        } else {
-            for (int i = 0; i < newPartitions.size(); i++) {
-                if (comparator.compare(newPartitions.get(i), partitions.get(i)) != 0) {
-                    partitions = newPartitions;
-                    logNewPartitions();
-                    return true;
-                }
-            }
-            LOG.info(
-                    "DynamicPartitionNumberLoader(maxPartitionNum={},table={}) didn't find new partitions.",
-                    maxPartitionNum,
-                    table.name());
-            return false;
-        }
-    }
-
-    private void logNewPartitions() {
-        String partitionsStr = partitionsToString(partitions);
-
-        LOG.info(
-                "DynamicPartitionNumberLoader(maxPartitionNum={},table={}) finds new partitions: {}.",
-                maxPartitionNum,
-                table.name(),
-                partitionsStr);
+                maxPartitionNum);
     }
 
     protected List<BinaryRow> getMaxPartitions() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/DynamicPartitionNumberLoader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/DynamicPartitionNumberLoader.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.lookup;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.table.FileStoreTable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Dynamic partition loader which can specify the max partition number to load for lookup. */
+public class DynamicPartitionNumberLoader extends DynamicPartitionLoader {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DynamicPartitionNumberLoader.class);
+
+    private static final long serialVersionUID = 2L;
+
+    private final int maxPartitionNum;
+
+    DynamicPartitionNumberLoader(
+            FileStoreTable table, Duration refreshInterval, int maxPartitionNum) {
+        super(table, refreshInterval);
+        this.maxPartitionNum = maxPartitionNum;
+    }
+
+    @Override
+    public boolean checkRefresh() {
+        if (lastRefresh != null
+                && !lastRefresh.plus(refreshInterval).isBefore(LocalDateTime.now())) {
+            return false;
+        }
+
+        LOG.info(
+                "DynamicPartitionNumberLoader(maxPartitionNum={},table={}) refreshed after {} second(s), refreshing",
+                maxPartitionNum,
+                table.name(),
+                refreshInterval.toMillis() / 1000);
+
+        List<BinaryRow> newPartitions = getMaxPartitions();
+        lastRefresh = LocalDateTime.now();
+
+        if (newPartitions.size() != partitions.size()) {
+            partitions = newPartitions;
+            logNewPartitions();
+            return true;
+        } else {
+            for (int i = 0; i < newPartitions.size(); i++) {
+                if (comparator.compare(newPartitions.get(i), partitions.get(i)) != 0) {
+                    partitions = newPartitions;
+                    logNewPartitions();
+                    return true;
+                }
+            }
+            LOG.info(
+                    "DynamicPartitionNumberLoader(maxPartitionNum={},table={}) didn't find new partitions.",
+                    maxPartitionNum,
+                    table.name());
+            return false;
+        }
+    }
+
+    private void logNewPartitions() {
+        String partitionsStr = partitionsToString(partitions);
+
+        LOG.info(
+                "DynamicPartitionNumberLoader(maxPartitionNum={},table={}) finds new partitions: {}.",
+                maxPartitionNum,
+                table.name(),
+                partitionsStr);
+    }
+
+    protected List<BinaryRow> getMaxPartitions() {
+        List<BinaryRow> newPartitions =
+                table.newReadBuilder().newScan().listPartitions().stream()
+                        .sorted(comparator.reversed())
+                        .collect(Collectors.toList());
+
+        if (newPartitions.size() <= maxPartitionNum) {
+            return newPartitions;
+        } else {
+            return newPartitions.subList(0, maxPartitionNum);
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -114,7 +114,7 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         }
 
         this.table = table;
-        this.partitionLoader = DynamicPartitionLoader.of(table);
+        this.partitionLoader = PartitionLoader.of(table);
 
         // join keys are based on projection fields
         RowType rowType = table.rowType();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PartitionLoader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PartitionLoader.java
@@ -44,8 +44,8 @@ public abstract class PartitionLoader implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static final String MAX_PT = "max_pt()";
-    private static final String MAX_TWO_PT = "max_two_pt()";
+    protected static final String MAX_PT = "max_pt()";
+    protected static final String MAX_TWO_PT = "max_two_pt()";
 
     protected final FileStoreTable table;
     private final RowDataToObjectArrayConverter partitionConverter;
@@ -128,12 +128,22 @@ public abstract class PartitionLoader implements Serializable {
         }
 
         if (maxPartitionNum == -1) {
+            if (scanPartitions.contains(MAX_PT)) {
+                Duration refresh =
+                        options.get(
+                                FlinkConnectorOptions.LOOKUP_DYNAMIC_PARTITION_REFRESH_INTERVAL);
+                return new DynamicPartitionLevelLoader(
+                        table,
+                        refresh,
+                        ParameterUtils.parseCommaSeparatedKeyValues(scanPartitions));
+            }
+
             return new StaticPartitionLoader(
                     table, ParameterUtils.getPartitions(scanPartitions.split(";")));
         } else {
             Duration refresh =
                     options.get(FlinkConnectorOptions.LOOKUP_DYNAMIC_PARTITION_REFRESH_INTERVAL);
-            return new DynamicPartitionLoader(table, refresh, maxPartitionNum);
+            return new DynamicPartitionNumberLoader(table, refresh, maxPartitionNum);
         }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PartitionLoader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PartitionLoader.java
@@ -127,11 +127,11 @@ public abstract class PartitionLoader implements Serializable {
                 break;
         }
 
+        Duration refresh =
+                options.get(FlinkConnectorOptions.LOOKUP_DYNAMIC_PARTITION_REFRESH_INTERVAL);
+
         if (maxPartitionNum == -1) {
             if (scanPartitions.contains(MAX_PT)) {
-                Duration refresh =
-                        options.get(
-                                FlinkConnectorOptions.LOOKUP_DYNAMIC_PARTITION_REFRESH_INTERVAL);
                 return new DynamicPartitionLevelLoader(
                         table,
                         refresh,
@@ -141,8 +141,6 @@ public abstract class PartitionLoader implements Serializable {
             return new StaticPartitionLoader(
                     table, ParameterUtils.getPartitions(scanPartitions.split(";")));
         } else {
-            Duration refresh =
-                    options.get(FlinkConnectorOptions.LOOKUP_DYNAMIC_PARTITION_REFRESH_INTERVAL);
             return new DynamicPartitionNumberLoader(table, refresh, maxPartitionNum);
         }
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LookupJoinITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LookupJoinITCase.java
@@ -1015,6 +1015,47 @@ public class LookupJoinITCase extends CatalogITCaseBase {
 
     @ParameterizedTest
     @EnumSource(LookupCacheMode.class)
+    public void testLookupPartitionLevelMaxPt(LookupCacheMode mode) throws Exception {
+        sql(
+                "CREATE TABLE PARTITIONED_DIM (pt1 STRING, pt2 INT, i INT, v INT)"
+                        + "PARTITIONED BY (`pt1`, `pt2`) WITH ("
+                        + "'scan.partitions' = 'pt1=max_pt()', "
+                        + "'lookup.dynamic-partition.refresh-interval' = '1 ms', "
+                        + "'lookup.cache' = '%s', "
+                        + "'continuous.discovery-interval'='1 ms')",
+                mode);
+
+        String query =
+                "SELECT D.pt1, D.pt2, T.i, D.v FROM T LEFT JOIN PARTITIONED_DIM for SYSTEM_TIME AS OF T.proctime AS D ON T.i = D.i";
+        BlockingIterator<Row, Row> iterator = BlockingIterator.of(sEnv.executeSql(query).collect());
+
+        sql(
+                "INSERT INTO PARTITIONED_DIM VALUES ('202415', 14, 1, 1), ('202415', 15, 1, 1), ('202414', 15, 1, 1)");
+        Thread.sleep(500); // wait refresh
+        sql("INSERT INTO T VALUES (1)");
+        List<Row> result = iterator.collect(2);
+        assertThat(result)
+                .containsExactlyInAnyOrder(Row.of("202415", 14, 1, 1), Row.of("202415", 15, 1, 1));
+
+        sql("INSERT INTO PARTITIONED_DIM VALUES ('202416', 14, 2, 2), ('202416', 15, 2, 2)");
+        Thread.sleep(500); // wait refresh
+        sql("INSERT INTO T VALUES (2)");
+        result = iterator.collect(2);
+        assertThat(result)
+                .containsExactlyInAnyOrder(Row.of("202416", 14, 2, 2), Row.of("202416", 15, 2, 2));
+
+        sql("ALTER TABLE PARTITIONED_DIM DROP PARTITION (pt1 = '202416',pt2 = '15')");
+        Thread.sleep(500); // wait refresh
+        sql("INSERT INTO T VALUES (1), (2)");
+        result = iterator.collect(2);
+        assertThat(result)
+                .containsExactlyInAnyOrder(Row.of(null, null, 1, null), Row.of("202416", 14, 2, 2));
+
+        iterator.close();
+    }
+
+    @ParameterizedTest
+    @EnumSource(LookupCacheMode.class)
     public void testLookupMaxTwoPt0(LookupCacheMode mode) throws Exception {
         sql(
                 "CREATE TABLE PARTITIONED_DIM (pt STRING, i INT, v INT)"

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/DynamicPartitionLevelLoaderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/DynamicPartitionLevelLoaderTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.lookup;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.flink.FlinkConnectorOptions;
+import org.apache.paimon.lookup.rocksdb.RocksDBOptions;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.sink.TableCommitImpl;
+import org.apache.paimon.table.sink.TableWriteImpl;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.InternalRowPartitionComputer;
+import org.apache.paimon.utils.RowDataToObjectArrayConverter;
+import org.apache.paimon.utils.TraceableFileIO;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link DynamicPartitionLevelLoader}. */
+public class DynamicPartitionLevelLoaderTest {
+
+    @TempDir private Path tempDir;
+
+    private final String commitUser = UUID.randomUUID().toString();
+    private final TraceableFileIO fileIO = new TraceableFileIO();
+
+    private org.apache.paimon.fs.Path tablePath;
+    private FileStoreTable table;
+
+    @BeforeEach
+    public void before() throws Exception {
+        tablePath = new org.apache.paimon.fs.Path(tempDir.toString());
+    }
+
+    @Test
+    public void testGetMaxPartitions() throws Exception {
+        List<String> partitionKeys = Arrays.asList("pt1", "pt2", "pt3");
+        table = createFileStoreTable(partitionKeys, Collections.emptyMap());
+        RowDataToObjectArrayConverter partitionConverter =
+                new RowDataToObjectArrayConverter(table.rowType().project(table.partitionKeys()));
+
+        TableWriteImpl<?> write = table.newWrite(commitUser);
+        TableCommitImpl commit = table.newCommit(commitUser);
+        write.write(GenericRow.of(BinaryString.fromString("2025"), 16, 2, 1, 1L));
+        write.write(GenericRow.of(BinaryString.fromString("2025"), 15, 1, 1, 1L));
+        write.write(GenericRow.of(BinaryString.fromString("2024"), 15, 1, 1, 1L));
+        write.write(GenericRow.of(BinaryString.fromString("2025"), 15, 2, 1, 1L));
+        write.write(GenericRow.of(BinaryString.fromString("2025"), 16, 1, 1, 1L));
+        write.write(GenericRow.of(BinaryString.fromString("2024"), 16, 1, 1, 1L));
+        commit.commit(1, write.prepareCommit(true, 1));
+
+        // test specify first-level partition
+        Map<String, String> customOptions = new HashMap<>();
+        customOptions.put(FlinkConnectorOptions.SCAN_PARTITIONS.key(), "pt1=max_pt()");
+        table = table.copy(customOptions);
+
+        DynamicPartitionLevelLoader partitionLoader =
+                (DynamicPartitionLevelLoader) PartitionLoader.of(table);
+        partitionLoader.open();
+        List<BinaryRow> partitions = partitionLoader.getMaxPartitions();
+        assertThat(partitions.size()).isEqualTo(4);
+        assertThat(partitionsToString(partitions))
+                .hasSameElementsAs(
+                        Arrays.asList("2025/16/2", "2025/16/1", "2025/15/2", "2025/15/1"));
+
+        // test specify first-level and second-level partition
+        customOptions.put(FlinkConnectorOptions.SCAN_PARTITIONS.key(), "pt1=max_pt(),pt2=max_pt()");
+        table = table.copy(customOptions);
+        partitionLoader = (DynamicPartitionLevelLoader) PartitionLoader.of(table);
+        partitionLoader.open();
+        partitions = partitionLoader.getMaxPartitions();
+        assertThat(partitions.size()).isEqualTo(2);
+        assertThat(partitionsToString(partitions))
+                .hasSameElementsAs(Arrays.asList("2025/16/2", "2025/16/1"));
+
+        // test specify all level partition
+        customOptions.put(
+                FlinkConnectorOptions.SCAN_PARTITIONS.key(),
+                "pt1=max_pt(),pt2=max_pt(),pt3=max_pt()");
+        table = table.copy(customOptions);
+
+        partitionLoader = (DynamicPartitionLevelLoader) PartitionLoader.of(table);
+        partitionLoader.open();
+        partitions = partitionLoader.getMaxPartitions();
+        assertThat(partitions.size()).isEqualTo(1);
+        assertThat(partitionsToString(partitions)).hasSameElementsAs(Arrays.asList("2025/16/2"));
+
+        write.close();
+        commit.close();
+    }
+
+    private FileStoreTable createFileStoreTable(
+            List<String> partitionKeys, Map<String, String> customOptions) throws Exception {
+        SchemaManager schemaManager = new SchemaManager(fileIO, tablePath);
+        Options conf = new Options(customOptions);
+        conf.set(CoreOptions.BUCKET, 2);
+        conf.set(RocksDBOptions.LOOKUP_CONTINUOUS_DISCOVERY_INTERVAL, Duration.ofSeconds(1));
+
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {
+                            DataTypes.STRING(),
+                            DataTypes.INT(),
+                            DataTypes.INT(),
+                            DataTypes.INT(),
+                            DataTypes.BIGINT()
+                        },
+                        new String[] {"pt1", "pt2", "pt3", "k", "v"});
+        List<String> primaryKeys = new ArrayList<>(partitionKeys);
+        primaryKeys.add("k");
+        Schema schema =
+                new Schema(rowType.getFields(), partitionKeys, primaryKeys, conf.toMap(), "");
+        TableSchema tableSchema = schemaManager.createTable(schema);
+        return FileStoreTableFactory.create(
+                fileIO, new org.apache.paimon.fs.Path(tempDir.toString()), tableSchema);
+    }
+
+    private List<String> partitionsToString(List<BinaryRow> partitions) {
+        return partitions.stream()
+                .map(
+                        partition ->
+                                InternalRowPartitionComputer.partToSimpleString(
+                                        table.rowType().project(table.partitionKeys()),
+                                        partition,
+                                        "/",
+                                        200))
+                .collect(Collectors.toList());
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/DynamicPartitionLevelLoaderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/DynamicPartitionLevelLoaderTest.java
@@ -193,8 +193,7 @@ public class DynamicPartitionLevelLoaderTest {
 
         assertThatCode(() -> PartitionLoader.of(table))
                 .hasMessage(
-                        "partition field(level=1,name=pt2) don't set config, "
-                                + "but the sub partition field(level=2,name=pt3) set config, this is unsupported.");
+                        "Max load level is 0, but partition field pt3 with a higher level 2 sets MAX_PT.");
 
         write.close();
         commit.close();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
Sometimes users want to specify max_pt() for a fixed-level partition and load all subpartitions for lookup. For example,  set 'scan.partitions' = 'ds=max_pt()', then all subpartitions in max 'ds' partition will be loaded.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
