### PR TITLE
[core]  One snapshot should have only one auto tag

### DIFF
--- a/docs/content/spark/sql-ddl.md
+++ b/docs/content/spark/sql-ddl.md
@@ -340,7 +340,7 @@ ALTER TABLE T REPLACE TAG `TAG-4` AS OF VERSION 2 RETAIN 24 HOURS;
 -- create or replace a tag, create tag if it not exist, replace tag if it exists.
 ALTER TABLE T CREATE OR REPLACE TAG `TAG-5` AS OF VERSION 2 RETAIN 24 HOURS;
 ```
-> NOTE: If the table's property tag.automatic-creation is not none, which is default, only one auto-tag could be created for one snapshot. 
+NOTE: If tag.automatic-creation is set, only one auto-tag could be created for one snapshot.
 
 ### Delete Tag
 Delete a tag or multiple tags of a table.

--- a/docs/content/spark/sql-ddl.md
+++ b/docs/content/spark/sql-ddl.md
@@ -340,6 +340,7 @@ ALTER TABLE T REPLACE TAG `TAG-4` AS OF VERSION 2 RETAIN 24 HOURS;
 -- create or replace a tag, create tag if it not exist, replace tag if it exists.
 ALTER TABLE T CREATE OR REPLACE TAG `TAG-5` AS OF VERSION 2 RETAIN 24 HOURS;
 ```
+> NOTE: If the table's property tag.automatic-creation is not none, which is default, only one auto-tag could be created for one snapshot. 
 
 ### Delete Tag
 Delete a tag or multiple tags of a table.

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -78,6 +78,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import static org.apache.paimon.catalog.Identifier.DEFAULT_MAIN_BRANCH;
 import static org.apache.paimon.partition.PartitionExpireStrategy.createPartitionExpireStrategy;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
@@ -333,7 +334,7 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
 
     @Override
     public TagManager newTagManager() {
-        return new TagManager(fileIO, options.path());
+        return new TagManager(fileIO, options.path(), DEFAULT_MAIN_BRANCH, options);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -670,7 +670,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
 
     @Override
     public TagManager tagManager() {
-        return new TagManager(fileIO, path, currentBranch());
+        return new TagManager(fileIO, path, currentBranch(), coreOptions());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/TagsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/TagsTable.java
@@ -223,7 +223,10 @@ public class TagsTable implements ReadonlyTable {
             }
             Path location = ((TagsSplit) split).location;
             Predicate predicate = ((TagsSplit) split).tagPredicate;
-            TagManager tagManager = new TagManager(fileIO, location, branch);
+
+            // There should not be any tag creation related options here for tags table.
+            TagManager tagManager =
+                    new TagManager(fileIO, location, branch, CoreOptions.fromMap(options()));
 
             Map<String, Tag> nameToSnapshot = new TreeMap<>();
             Map<String, Tag> predicateMap = new TreeMap<>();

--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -141,12 +141,14 @@ public class TagManager {
             @Nullable Duration timeRetained,
             @Nullable List<TagCallback> callbacks) {
 
-        List<String> autoTags = getSnapshotAutoTags(snapshot);
-        if (!autoTags.isEmpty()) {
-            throw new RuntimeException(
-                    String.format(
-                            "Snapshot %s is already auto-tagged with %s.",
-                            snapshot.id(), autoTags));
+        if (isAutoTag(tagName)) {
+            List<String> autoTags = getSnapshotAutoTags(snapshot);
+            if (!autoTags.isEmpty()) {
+                throw new RuntimeException(
+                        String.format(
+                                "Snapshot %s is already auto-tagged with %s.",
+                                snapshot.id(), autoTags));
+            }
         }
 
         // When timeRetained is not defined, please do not write the tagCreatorTime field, as this
@@ -454,6 +456,11 @@ public class TagManager {
                 String.format(
                         "Didn't find tag with snapshot id '%s'. This is unexpected.",
                         taggedSnapshot.id()));
+    }
+
+    private boolean isAutoTag(String tagName) {
+        TagPeriodHandler periodHandler = TagPeriodHandler.create(coreOptions);
+        return periodHandler.isAutoTag(tagName);
     }
 
     private List<String> getSnapshotAutoTags(Snapshot snapshot) {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -30,6 +30,7 @@ import org.apache.paimon.operation.TagDeletion;
 import org.apache.paimon.table.sink.TagCallback;
 import org.apache.paimon.tag.Tag;
 import org.apache.paimon.tag.TagPeriodHandler;
+import org.apache.paimon.tag.TagTimeExtractor;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -458,15 +459,27 @@ public class TagManager {
                         taggedSnapshot.id()));
     }
 
+    /**
+     * @param tagName
+     * @return true only if auto-tag enabled and the name is in right format
+     */
     private boolean isAutoTag(String tagName) {
+        TagTimeExtractor extractor = TagTimeExtractor.createForAutoTag(coreOptions);
+        if (extractor == null) {
+            return false;
+        }
         TagPeriodHandler periodHandler = TagPeriodHandler.create(coreOptions);
         return periodHandler.isAutoTag(tagName);
     }
 
+    /**
+     * @param snapshot
+     * @return the auto-tag names of the snapshot, empty if auto-tag is not enabled
+     */
     private List<String> getSnapshotAutoTags(Snapshot snapshot) {
-        CoreOptions.TagCreationMode mode = coreOptions.tagCreationMode();
+        TagTimeExtractor extractor = TagTimeExtractor.createForAutoTag(coreOptions);
         // no auto-tagging, no auto-tags
-        if (mode == CoreOptions.TagCreationMode.NONE) {
+        if (extractor == null) {
             return Collections.emptyList();
         }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5800

<!-- What is the purpose of the change -->
Prevent different auto-tags created on the same snapshot.
If not, inserting data would incur errors as the issue #5800 shows.

### Tests

<!-- List UT and IT cases to verify this change -->
org.apache.paimon.tag.TagAutoManagerTest#testMultiAutoTagsOnOneSnapshot

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
No
