### PR TITLE
[hive] Format table: Support field delimiter in HMS

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -1073,6 +1073,11 @@ public class HiveCatalog extends AbstractCatalog {
         Table table = newHmsTable(identifier, tblProperties, provider, externalTable);
         updateHmsTable(table, identifier, tableSchema, provider, location);
 
+        String fieldDelimiter = coreOptions.toConfiguration().get(FIELD_DELIMITER);
+        if (fieldDelimiter != null) {
+            table.getSd().getSerdeInfo().getParameters().put(FIELD_DELIM, fieldDelimiter);
+        }
+
         return table;
     }
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/FormatTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/FormatTableTestBase.scala
@@ -24,6 +24,7 @@ import org.apache.paimon.spark.PaimonHiveTestBase
 import org.apache.paimon.table.FormatTable
 import org.apache.paimon.utils.CompressUtils
 
+import org.apache.hadoop.hive.serde.serdeConstants.FIELD_DELIM
 import org.apache.spark.sql.Row
 
 abstract class FormatTableTestBase extends PaimonHiveTestBase {
@@ -115,6 +116,15 @@ abstract class FormatTableTestBase extends PaimonHiveTestBase {
         fileIO.deleteQuietly(new Path(file))
         checkAnswer(sql("SELECT * FROM compress_t"), Row(1, 2, 3))
       }
+    }
+  }
+
+  test("Format table: field delimiter in HMS") {
+    withTable("t1") {
+      sql("CREATE TABLE t1 (id INT, p1 INT, p2 INT) USING csv OPTIONS ('field-delimiter' ';')")
+      val hmsClient = getHmsClient(paimonCatalog)
+      val table = hmsClient.getTable(hiveDbName, "t1")
+      assert(table.getSd.getSerdeInfo.getParameters.get(FIELD_DELIM).equals(";"))
     }
   }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
