### PR TITLE
[core] Adjust default value of 'delete-file.thread-num' to 30

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -304,9 +304,9 @@ under the License.
         </tr>
         <tr>
             <td><h5>delete-file.thread-num</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
+            <td style="word-wrap: break-word;">30</td>
             <td>Integer</td>
-            <td>The maximum number of concurrent deleting files. By default is the number of processors available to the Java virtual machine.</td>
+            <td>The maximum number of concurrent deleting files in a process.</td>
         </tr>
         <tr>
             <td><h5>delete.force-produce-changelog</h5></td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1636,10 +1636,9 @@ public class CoreOptions implements Serializable {
     public static final ConfigOption<Integer> DELETE_FILE_THREAD_NUM =
             key("delete-file.thread-num")
                     .intType()
-                    .noDefaultValue()
+                    .defaultValue(30)
                     .withDescription(
-                            "The maximum number of concurrent deleting files. "
-                                    + "By default is the number of processors available to the Java virtual machine.");
+                            "The maximum number of concurrent deleting files in a process.");
 
     public static final ConfigOption<String> SCAN_FALLBACK_BRANCH =
             key("scan.fallback-branch")


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In K8S, the default number of cores is too small (3).

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
