### PR TITLE
[core] Copy max key in KeyValueDataFileWriter

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/reader/ArrowBatchReader.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/reader/ArrowBatchReader.java
@@ -23,7 +23,6 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.columnar.ColumnVector;
 import org.apache.paimon.data.columnar.ColumnarRow;
 import org.apache.paimon.data.columnar.VectorizedColumnBatch;
-import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 
@@ -39,14 +38,12 @@ import static org.apache.paimon.utils.StringUtils.toLowerCaseIfNeed;
 /** Reader from a {@link VectorSchemaRoot} to paimon rows. */
 public class ArrowBatchReader {
 
-    private final InternalRowSerializer internalRowSerializer;
     private final VectorizedColumnBatch batch;
     private final Arrow2PaimonVectorConverter[] convertors;
     private final RowType projectedRowType;
     private final boolean caseSensitive;
 
     public ArrowBatchReader(RowType rowType, boolean caseSensitive) {
-        this.internalRowSerializer = new InternalRowSerializer(rowType);
         ColumnVector[] columnVectors = new ColumnVector[rowType.getFieldCount()];
         this.convertors = new Arrow2PaimonVectorConverter[rowType.getFieldCount()];
         this.batch = new VectorizedColumnBatch(columnVectors);

--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/reader/ArrowBatchReader.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/reader/ArrowBatchReader.java
@@ -93,11 +93,7 @@ public class ArrowBatchReader {
                     public InternalRow next() {
                         columnarRow.setRowId(position);
                         position++;
-                        // when pk merge, the last value will be referenced by maxKey. If reader
-                        // close, the maxKey will be useless. We must avoid this situation
-                        return position == rowCount
-                                ? internalRowSerializer.toBinaryRow(columnarRow)
-                                : columnarRow;
+                        return columnarRow;
                     }
                 };
     }

--- a/paimon-common/src/main/java/org/apache/paimon/data/RowHelper.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/RowHelper.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.data;
+
+import org.apache.paimon.data.BinaryWriter.ValueSetter;
+import org.apache.paimon.data.InternalRow.FieldGetter;
+import org.apache.paimon.data.serializer.InternalSerializers;
+import org.apache.paimon.data.serializer.Serializer;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeChecks;
+import org.apache.paimon.types.DecimalType;
+import org.apache.paimon.types.LocalZonedTimestampType;
+import org.apache.paimon.types.TimestampType;
+
+import java.io.Serializable;
+import java.util.List;
+
+/** A keeper to keep {@link BinaryRow} from {@link InternalRow}. */
+public class RowHelper implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final FieldGetter[] fieldGetters;
+    private final ValueSetter[] valueSetters;
+    private final boolean[] writeNulls;
+    private final Serializer<?>[] serializers;
+
+    private transient BinaryRow reuseRow;
+    private transient BinaryRowWriter reuseWriter;
+
+    public RowHelper(List<DataType> types) {
+        this.fieldGetters = new FieldGetter[types.size()];
+        this.valueSetters = new ValueSetter[types.size()];
+        this.writeNulls = new boolean[types.size()];
+        this.serializers =
+                types.stream().map(InternalSerializers::create).toArray(Serializer[]::new);
+        for (int i = 0; i < types.size(); i++) {
+            DataType type = types.get(i);
+            fieldGetters[i] = InternalRow.createFieldGetter(type, i);
+            valueSetters[i] = BinaryWriter.createValueSetter(type, serializers[i]);
+            if (type instanceof DecimalType) {
+                writeNulls[i] = !Decimal.isCompact(DataTypeChecks.getPrecision(type));
+            } else if (type instanceof TimestampType || type instanceof LocalZonedTimestampType) {
+                writeNulls[i] = !Timestamp.isCompact(DataTypeChecks.getPrecision(type));
+            }
+        }
+    }
+
+    public void copyInto(InternalRow row) {
+        if (reuseRow == null) {
+            reuseRow = new BinaryRow(fieldGetters.length);
+            reuseWriter = new BinaryRowWriter(reuseRow);
+        }
+
+        reuseWriter.reset();
+        reuseWriter.writeRowKind(row.getRowKind());
+        for (int i = 0; i < fieldGetters.length; i++) {
+            Object field = fieldGetters[i].getFieldOrNull(row);
+            if (field == null && !writeNulls[i]) {
+                reuseWriter.setNullAt(i);
+            } else {
+                valueSetters[i].setValue(reuseWriter, i, field);
+            }
+        }
+        reuseWriter.complete();
+    }
+
+    public BinaryRow reuseRow() {
+        return reuseRow;
+    }
+
+    public BinaryRow copiedRow() {
+        return reuseRow.copy();
+    }
+
+    @SuppressWarnings("rawtypes")
+    public Serializer serializer(int i) {
+        return serializers[i];
+    }
+
+    public FieldGetter fieldGetter(int i) {
+        return fieldGetters[i];
+    }
+}

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedParquetRecordReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedParquetRecordReader.java
@@ -255,8 +255,6 @@ public class VectorizedParquetRecordReader implements FileRecordReader<InternalR
 
     public boolean nextBatch() throws IOException {
         try {
-            // Primary key table will use the last record, so we can't reset first
-            // TODO: remove usage of the last record by primary key table after batch reset
             if (rowsReturned >= totalRowCount) {
                 return false;
             }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
We should copy the maxKey, otherwise if the reader is closed first, the maxKey inside may be reset, such as the dictionary in Parquet Reader.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
