### PR TITLE
[spark] Apply partition.sink-strategy to spark write

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/PaimonWriteRequirement.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/PaimonWriteRequirement.scala
@@ -18,7 +18,10 @@
 
 package org.apache.paimon.spark.write
 
+import org.apache.paimon.CoreOptions.PartitionSinkStrategy
+import org.apache.paimon.spark.SparkConnectorOptions.WriteDistributionMode
 import org.apache.paimon.spark.commands.BucketExpression.quote
+import org.apache.paimon.spark.util.OptionUtils
 import org.apache.paimon.table.BucketMode._
 import org.apache.paimon.table.FileStoreTable
 
@@ -56,7 +59,12 @@ object PaimonWriteRequirement {
     val clusteringExpressions =
       (partitionTransforms ++ bucketTransforms).map(identity[Expression]).toArray
 
-    if (clusteringExpressions.isEmpty) {
+    if (
+      clusteringExpressions.isEmpty || (bucketTransforms.isEmpty && table
+        .coreOptions()
+        .partitionSinkStrategy()
+        .equals(PartitionSinkStrategy.NONE))
+    ) {
       EMPTY
     } else {
       val distribution: ClusteredDistribution =

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/PaimonWriteRequirement.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/PaimonWriteRequirement.scala
@@ -19,9 +19,7 @@
 package org.apache.paimon.spark.write
 
 import org.apache.paimon.CoreOptions.PartitionSinkStrategy
-import org.apache.paimon.spark.SparkConnectorOptions.WriteDistributionMode
 import org.apache.paimon.spark.commands.BucketExpression.quote
-import org.apache.paimon.spark.util.OptionUtils
 import org.apache.paimon.table.BucketMode._
 import org.apache.paimon.table.FileStoreTable
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/WriteDistributeModeTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/WriteDistributeModeTest.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+import org.apache.paimon.spark.PaimonSparkTestBase
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.CommandResultExec
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeLike
+
+class WriteDistributeModeTest extends PaimonSparkTestBase with AdaptiveSparkPlanHelper {
+
+  test("Write distribute mode: write partitioned bucket -1 table") {
+    for (distributeMode <- Seq("none", "hash")) {
+      withTable("t") {
+        sql(
+          "CREATE TABLE t (id INT, pt STRING) partitioned by (pt) TBLPROPERTIES ('file.format'='avro')")
+        val query = "INSERT INTO t VALUES (1, 'p1'), (2, 'p2')"
+
+        withSparkSQLConf(
+          "spark.paimon.write.use-v2-write" -> "true",
+          "spark.paimon.partition.sink-strategy" -> distributeMode) {
+          val df = spark.sql(query)
+          val shuffleNodes = collect(
+            df.queryExecution.executedPlan.asInstanceOf[CommandResultExec].commandPhysicalPlan) {
+            case shuffle: ShuffleExchangeLike => shuffle
+          }
+
+          if (distributeMode == "none") {
+            assert(shuffleNodes.isEmpty)
+          } else {
+            assert(shuffleNodes.size == 1)
+          }
+
+          checkAnswer(spark.sql("SELECT * FROM t ORDER BY id"), Seq(Row(1, "p1"), Row(2, "p2")))
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Currently, in v2 write, writing to a partitioned table with bucket = -1 defaults to repartitioning the data by partition columns, which is inconsistent with the default behavior of v1 write. So a new option `spark.paimon.write.distribution-mode` has been added to control this behavior and align it between v1 and v2 writes.

This configuration only applies to bucket-unaware tables, because bucket tables always need repartition now.
Maybe in the furure, repartitioning for bucketed tables may also be optional — for example, when the write mode is set to write-only.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
