### PR TITLE
if table exist but instead of paimon, this exception should be thrown…

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -365,6 +365,8 @@ public abstract class AbstractCatalog implements Catalog {
                 return;
             }
             throw new TableAlreadyExistException(identifier);
+        } catch (TableExistButNotPaimonException ignored) {
+            throw new TableExistButNotPaimonException(identifier);
         } catch (TableNotExistException ignored) {
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -1095,6 +1095,28 @@ public interface Catalog extends AutoCloseable {
         }
     }
 
+
+    /** Table exist but is not a paimon one or paimon metadata corrupted. */
+    class TableExistButNotPaimonException extends RuntimeException {
+
+        private static final String MSG = "Table %s exist, but this table is not a paimon table.";
+
+        private final Identifier identifier;
+
+        public TableExistButNotPaimonException(Identifier identifier) {
+            this(identifier, null);
+        }
+
+        public TableExistButNotPaimonException(Identifier identifier, Throwable cause) {
+            super(String.format(MSG, identifier.getFullName()), cause);
+            this.identifier = identifier;
+        }
+
+        public Identifier identifier() {
+            return identifier;
+        }
+    }
+
     /** Exception for trying to operate on the table that doesn't have permission. */
     class TableNoPermissionException extends RuntimeException {
 

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.hive;
 
+import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.PagedList;
 import org.apache.paimon.annotation.VisibleForTesting;
@@ -718,7 +719,9 @@ public class HiveCatalog extends AbstractCatalog {
             } catch (UnsupportedOperationException ignored) {
             }
         }
-
+        if (!isPaimonTable(table)) {
+            throw new TableExistButNotPaimonException(identifier);
+        }
         throw new TableNotExistException(identifier);
     }
 
@@ -1021,7 +1024,7 @@ public class HiveCatalog extends AbstractCatalog {
                                             identifier, tableSchema, location, externalTable)));
         } catch (Exception e) {
             try {
-                if (!externalTable) {
+                if (!externalTable && !(e instanceof AlreadyExistsException)) {
                     fileIO.deleteDirectoryQuietly(location);
                 }
             } catch (Exception ee) {


### PR DESCRIPTION
… out and prevent step create table operations.

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
