### PR TITLE
[5863] if table exist but instead of paimon, this exception should be…

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -996,6 +996,23 @@ public class HiveCatalog extends AbstractCatalog {
 
     @Override
     protected void createTableImpl(Identifier identifier, Schema schema) {
+        try {
+            boolean tableExists =
+                    clients.run(
+                            (client ->
+                                    client.tableExists(
+                                            identifier.getDatabaseName(),
+                                            identifier.getTableName())));
+            if (tableExists) {
+                throw new RuntimeException(
+                        "Table "
+                                + identifier.getFullName()
+                                + " already exists, but this table is not a paimon table.");
+            }
+        } catch (TException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
         Pair<Path, Boolean> pair = initialTableLocation(schema.options(), identifier);
         Path location = pair.getLeft();
         boolean externalTable = pair.getRight();


### PR DESCRIPTION
… thrown out and prevent step create table operations.

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #5863

<!-- What is the purpose of the change -->

### Tests
```
CREATE TABLE `dlink_task`(
  `id` bigint COMMENT 'primary key', 
  `name` varchar(255) COMMENT 'jobname', 
  `tenant_id` int COMMENT 'tenant id', 
  `alias` varchar(255) COMMENT 'job alias', 
  `dialect` varchar(50) COMMENT 'FlinkSQL、FlinkJar', 
  `type` varchar(50) COMMENT 'cluster type', 
  `check_point` int COMMENT 'CheckPoint trigger milliseconds', 
  `save_point_strategy` int COMMENT 'SavePoint strategy', 
  `save_point_path` varchar(255) COMMENT 'SavePoint path', 
  `parallelism` int COMMENT 'parallelism', 
  `statement_set` tinyint COMMENT 'enable statement', 
  `batch_model` tinyint COMMENT 'batch mode', 
  `cluster_id` int COMMENT 'Flink cluster id', 
  `cluster_configuration_id` int COMMENT 'K8s/yar cluster id', 
  `jar_id` int COMMENT 'JarFile  ID', 
  `config_json` string COMMENT 'job config json', 
  `note` varchar(255) COMMENT 'detail', 
  `step` int COMMENT 'Job lifecycle', 
  `job_instance_id` bigint COMMENT 'jobinstance id', 
  `enabled` tinyint COMMENT 'is enable', 
  `create_time` timestamp COMMENT 'create time', 
  `update_time` timestamp COMMENT 'update time', 
  `version_id` int COMMENT 'fe version id', 
  `datachange_lasttime` timestamp COMMENT 'data chanage last time', 
  `user_id` int COMMENT ' user id', 
  `app_id` varchar(32) COMMENT 'paas id', 
  `hive_account` varchar(128) COMMENT 'hiveaccount', 
  `jm_mem` int COMMENT 'jm mem', 
  `tm_mem` int COMMENT 'tm mem', 
  `tm_slot` int COMMENT 'taskmanager slot', 
  `enable_checkpoint` tinyint COMMENT 'enable checkpoint', 
  `restart_on_failure` int COMMENT 'if online manually', 
  `parallelism_limit` int COMMENT 'max parallelism limit', 
  `project_id` int COMMENT 'project id', 
  `is_delete` tinyint COMMENT 'is delete', 
  `jm_limit_cpu` float COMMENT 'k8s limit cpu', 
  `tm_limit_cpu` float COMMENT 'k8s limit cpu', 
  `job_level` varchar(16) COMMENT 'job scheduler level', 
  `main_class` varchar(256) COMMENT 'flink api  main class', 
  `user_params` string COMMENT 'flink api  user main class ', 
  `cdc_task_name` varchar(255) COMMENT 'cdc task name', 
  `dtctype` int COMMENT 'flink cdc source / sink，0-sink，1-source', 
  `git_branch_id` bigint COMMENT 'git branch url')
COMMENT 'Task'
PARTITIONED BY ( 
  `d` string COMMENT 'date', 
  `h` string COMMENT 'hour')
ROW FORMAT SERDE 
  'org.apache.hadoop.hive.ql.io.orc.OrcSerde' 
STORED AS INPUTFORMAT 
  'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat' 
OUTPUTFORMAT 
  'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
--LOCATION
--  'hdfs://ns/user/hive/warehouse/ods_syscinkdb.db/dlink_task'
--TBLPROPERTIES (
--  'dp_last_modified_time'='1752113930415,1752110329700,1752102899125,1752095959330,1752092150221,1752088364522,1752081658707', 
--  'metadata.partition.life'='-1', 
--  'transient_lastDdlTime'='1727680705')
```
![image](https://github.com/user-attachments/assets/5f727773-305f-4054-98f1-d4c03578b87c)

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
