### PR TITLE
[flink] Partition predicate builder push down to core, avoid stack overflow in building partition predicates.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/Either.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/Either.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import java.io.Serializable;
+
+/** Either class, A or B. Reference to Flink. */
+public abstract class Either<L, R> implements Serializable {
+
+    public static <L, R> Either<L, R> Left(L value) {
+        return new Left<>(value);
+    }
+
+    public static <L, R> Either<L, R> Right(R value) {
+        return new Right<>(value);
+    }
+
+    public abstract L left() throws IllegalStateException;
+
+    public abstract R right() throws IllegalStateException;
+
+    public final boolean isLeft() {
+        return this.getClass() == Left.class;
+    }
+
+    public final boolean isRight() {
+        return this.getClass() == Right.class;
+    }
+
+    public static class Left<L, R> extends Either<L, R> {
+        private L value;
+
+        public Left(L value) {
+            this.value = value;
+        }
+
+        public L left() {
+            return this.value;
+        }
+
+        public R right() {
+            throw new IllegalStateException("Cannot retrieve Right value on a Left");
+        }
+
+        public void setValue(L value) {
+            this.value = value;
+        }
+
+        public boolean equals(Object object) {
+            if (object instanceof Left) {
+                Left<?, ?> other = (Left<?, ?>) object;
+                return this.value.equals(other.value);
+            } else {
+                return false;
+            }
+        }
+
+        public int hashCode() {
+            return this.value.hashCode();
+        }
+
+        public String toString() {
+            return "Left(" + this.value.toString() + ")";
+        }
+
+        public static <L, R> Left<L, R> of(L left) {
+            return new Left<L, R>(left);
+        }
+    }
+
+    public static class Right<L, R> extends Either<L, R> {
+        private R value;
+
+        public Right(R value) {
+            this.value = value;
+        }
+
+        public L left() {
+            throw new IllegalStateException("Cannot retrieve Left value on a Right");
+        }
+
+        public R right() {
+            return this.value;
+        }
+
+        public void setValue(R value) {
+            this.value = value;
+        }
+
+        public boolean equals(Object object) {
+            if (object instanceof Right) {
+                Right<?, ?> other = (Right<?, ?>) object;
+                return this.value.equals(other.value);
+            } else {
+                return false;
+            }
+        }
+
+        public int hashCode() {
+            return this.value.hashCode();
+        }
+
+        public String toString() {
+            return "Right(" + this.value.toString() + ")";
+        }
+
+        public static <L, R> Right<L, R> of(R right) {
+            return new Right<>(right);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
@@ -26,6 +26,8 @@ import org.apache.paimon.table.Table;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
 
+import javax.annotation.Nullable;
+
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
@@ -95,10 +97,13 @@ public interface ReadBuilder extends Serializable {
      * Push filters, will filter the data as much as possible, but it is not guaranteed that it is a
      * complete filter.
      */
-    ReadBuilder withFilter(Predicate predicate);
+    ReadBuilder withFilter(@Nullable Predicate predicate);
 
     /** Push partition filter. */
     ReadBuilder withPartitionFilter(Map<String, String> partitionSpec);
+
+    /** Push partition filters. */
+    ReadBuilder withPartitionFilter(@Nullable List<Map<String, String>> partitions);
 
     ReadBuilder withBucket(int bucket);
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -26,6 +26,8 @@ import org.apache.paimon.utils.Filter;
 
 import javax.annotation.Nullable;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -45,7 +47,7 @@ public class ReadBuilderImpl implements ReadBuilder {
     private Integer shardIndexOfThisSubtask;
     private Integer shardNumberOfParallelSubtasks;
 
-    private Map<String, String> partitionSpec;
+    private @Nullable List<Map<String, String>> partitionFilter;
 
     private @Nullable Integer specifiedBucket = null;
     private Filter<Integer> bucketFilter;
@@ -84,7 +86,13 @@ public class ReadBuilderImpl implements ReadBuilder {
 
     @Override
     public ReadBuilder withPartitionFilter(Map<String, String> partitionSpec) {
-        this.partitionSpec = partitionSpec;
+        return withPartitionFilter(
+                partitionSpec == null ? null : Collections.singletonList(partitionSpec));
+    }
+
+    @Override
+    public ReadBuilder withPartitionFilter(@Nullable List<Map<String, String>> partitions) {
+        this.partitionFilter = partitions;
         return this;
     }
 
@@ -154,7 +162,7 @@ public class ReadBuilderImpl implements ReadBuilder {
     }
 
     private InnerTableScan configureScan(InnerTableScan scan) {
-        scan.withFilter(filter).withReadType(readType).withPartitionFilter(partitionSpec);
+        scan.withFilter(filter).withReadType(readType).withPartitionsFilter(partitionFilter);
         checkState(
                 bucketFilter == null || shardIndexOfThisSubtask == null,
                 "Bucket filter and shard configuration cannot be used together. "

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/AppendTableCompactBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/AppendTableCompactBuilder.java
@@ -27,6 +27,7 @@ import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.Either;
 import org.apache.paimon.utils.Preconditions;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -62,7 +63,7 @@ public class AppendTableCompactBuilder {
 
     private boolean isContinuous = false;
 
-    @Nullable private Predicate partitionPredicate;
+    @Nullable private Either<Predicate, List<Map<String, String>>> partitionPredicate;
     @Nullable private Duration partitionIdleTime = null;
 
     public AppendTableCompactBuilder(
@@ -76,7 +77,7 @@ public class AppendTableCompactBuilder {
         this.isContinuous = isContinuous;
     }
 
-    public void withPartitionPredicate(Predicate predicate) {
+    public void withPartitionPredicate(Either<Predicate, List<Map<String, String>>> predicate) {
         this.partitionPredicate = predicate;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
@@ -44,6 +44,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.Split;
+import org.apache.paimon.utils.Either;
 import org.apache.paimon.utils.Projection;
 
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
@@ -218,7 +219,7 @@ public abstract class BaseDataTableSource extends FlinkTableSource
                         .sourceBounded(!unbounded)
                         .logSourceProvider(logSourceProvider)
                         .projection(projectFields)
-                        .predicate(getPredicateWithScanPartitions())
+                        .predicate(Either.Left(getPredicateWithScanPartitions()))
                         .limit(limit)
                         .watermarkStrategy(watermarkStrategy)
                         .dynamicPartitionFilteringFields(dynamicPartitionFilteringFields());

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactActionITCase.java
@@ -309,6 +309,45 @@ public class CompactActionITCase extends CompactActionITCaseBase {
     }
 
     @Test
+    public void testLotsOfPartitionsCompact() throws Exception {
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put(CoreOptions.BUCKET.key(), "-1");
+        tableOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
+
+        FileStoreTable table =
+                prepareTable(
+                        Collections.singletonList("k"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        tableOptions);
+
+        // base records
+        writeData(
+                rowData(1, 100, 15, BinaryString.fromString("20221208")),
+                rowData(1, 100, 16, BinaryString.fromString("20221208")),
+                rowData(1, 100, 15, BinaryString.fromString("20221209")));
+
+        writeData(
+                rowData(1, 100, 15, BinaryString.fromString("20221208")),
+                rowData(1, 100, 16, BinaryString.fromString("20221208")),
+                rowData(1, 100, 15, BinaryString.fromString("20221209")));
+
+        checkLatestSnapshot(table, 2, Snapshot.CommitKind.APPEND);
+
+        List<String> partitions = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            partitions.add("--partition");
+            partitions.add("k=" + i);
+        }
+
+        // repairing that the ut don't specify the real partition of table
+        runActionForUnawareTable(false, partitions);
+
+        // first compaction, snapshot will be 3.
+        checkFileAndRowSize(table, 3L, 0L, 1, 6);
+    }
+
+    @Test
     public void testTableConf() throws Exception {
         prepareTable(
                 Arrays.asList("dt", "hh"),
@@ -390,14 +429,20 @@ public class CompactActionITCase extends CompactActionITCaseBase {
     }
 
     private void runAction(boolean isStreaming) throws Exception {
-        runAction(isStreaming, false);
+        runAction(isStreaming, false, Collections.emptyList());
+    }
+
+    private void runActionForUnawareTable(boolean isStreaming, List<String> extra)
+            throws Exception {
+        runAction(isStreaming, true, extra);
     }
 
     private void runActionForUnawareTable(boolean isStreaming) throws Exception {
-        runAction(isStreaming, true);
+        runAction(isStreaming, true, Collections.emptyList());
     }
 
-    private void runAction(boolean isStreaming, boolean unawareBucket) throws Exception {
+    private void runAction(boolean isStreaming, boolean unawareBucket, List<String> extra)
+            throws Exception {
         StreamExecutionEnvironment env;
         if (isStreaming) {
             env = streamExecutionEnvironmentBuilder().streamingMode().build();
@@ -435,6 +480,8 @@ public class CompactActionITCase extends CompactActionITCaseBase {
                                 "dt=20221209,hh=15"));
             }
         }
+
+        baseArgs.addAll(extra);
 
         CompactAction action = createAction(CompactAction.class, baseArgs.toArray(new String[0]));
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CompactorSinkITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CompactorSinkITCase.java
@@ -47,6 +47,7 @@ import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.Either;
 import org.apache.paimon.utils.SnapshotManager;
 
 import org.apache.flink.api.common.ExecutionConfig;
@@ -131,7 +132,7 @@ public class CompactorSinkITCase extends AbstractTestBase {
                 sourceBuilder
                         .withEnv(env)
                         .withContinuousMode(false)
-                        .withPartitionPredicate(predicate)
+                        .withPartitionPredicate(Either.Left(predicate))
                         .build();
         new CompactorSinkBuilder(table, true).withInput(source).build();
         env.execute();
@@ -171,7 +172,7 @@ public class CompactorSinkITCase extends AbstractTestBase {
                 sourceBuilder
                         .withEnv(env)
                         .withContinuousMode(false)
-                        .withPartitionPredicate(predicate)
+                        .withPartitionPredicate(Either.Left(predicate))
                         .build();
         Integer sinkParalellism = new Random().nextInt(100) + 1;
         new CompactorSinkBuilder(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/CompactorSourceITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/CompactorSourceITCase.java
@@ -27,7 +27,6 @@ import org.apache.paimon.flink.util.AbstractTestBase;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.io.DataFileMetaSerializer;
-import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
@@ -39,6 +38,7 @@ import org.apache.paimon.table.sink.StreamWriteBuilder;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.Either;
 
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -60,7 +60,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.apache.paimon.partition.PartitionPredicate.createPartitionPredicate;
 import static org.apache.paimon.utils.SerializationUtils.deserializeBinaryRow;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -264,16 +263,11 @@ public class CompactorSourceITCase extends AbstractTestBase {
 
         StreamExecutionEnvironment env =
                 streamExecutionEnvironmentBuilder().streamingMode().build();
-        Predicate partitionPredicate =
-                createPartitionPredicate(
-                        specifiedPartitions,
-                        table.rowType(),
-                        table.coreOptions().partitionDefaultName());
         DataStreamSource<RowData> compactorSource =
                 new CompactorSourceBuilder("test", table)
                         .withContinuousMode(isStreaming)
                         .withEnv(env)
-                        .withPartitionPredicate(partitionPredicate)
+                        .withPartitionPredicate(Either.Right(specifiedPartitions))
                         .build();
         CloseableIterator<RowData> it = compactorSource.executeAndCollect();
 


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Avoid List<Map<String, String>> partitions convert to class Predicate.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
