### PR TITLE
[hive][clone] support excluding some tables when clone all tables in a catalog or database.

### DIFF
--- a/docs/content/migration/clone-to-paimon.md
+++ b/docs/content/migration/clone-to-paimon.md
@@ -70,7 +70,23 @@ clone \
 --target_database test \
 --parallelism 10 \
 --target_catalog_conf warehouse=my_warehouse
+--excluded_tables <excluded_tables_spec>
 ```
+You can use excluded tables spec to specify the tables that don't need to be cloned. The format is `<database1>.<table1>,<database2>.<table2>,<database3>.<table3>`.
+
+## Clone Hive Catalog
+
+```bash
+<FLINK_HOME>/flink run ./paimon-flink-action-{{< version >}}.jar \
+clone \
+--catalog_conf metastore=hive \
+--catalog_conf uri=thrift://localhost:9088 \
+--parallelism 10 \
+--target_catalog_conf warehouse=my_warehouse
+--excluded_tables <excluded_tables_spec>
+```
+You can use excluded tables spec to specify the tables that don't need to be cloned. The format is `<database1>.<table1>,<database2>.<table2>,<database3>.<table3>`.
+
 
 ## Clone Hudi Tables
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CloneAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CloneAction.java
@@ -37,6 +37,7 @@ import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
 
 import javax.annotation.Nullable;
 
+import java.util.List;
 import java.util.Map;
 
 /** Clone source table to target table. */
@@ -52,6 +53,7 @@ public class CloneAction extends ActionBase {
 
     private final int parallelism;
     @Nullable private final String whereSql;
+    @Nullable private final List<String> excludedTables;
 
     public CloneAction(
             String sourceDatabase,
@@ -61,7 +63,8 @@ public class CloneAction extends ActionBase {
             String targetTableName,
             Map<String, String> targetCatalogConfig,
             @Nullable Integer parallelism,
-            @Nullable String whereSql) {
+            @Nullable String whereSql,
+            @Nullable List<String> excludedTables) {
         super(sourceCatalogConfig);
 
         Catalog sourceCatalog = catalog;
@@ -84,6 +87,7 @@ public class CloneAction extends ActionBase {
 
         this.parallelism = parallelism == null ? env.getParallelism() : parallelism;
         this.whereSql = whereSql;
+        this.excludedTables = excludedTables;
     }
 
     @Override
@@ -96,6 +100,7 @@ public class CloneAction extends ActionBase {
                         targetDatabase,
                         targetTableName,
                         catalog,
+                        excludedTables,
                         env);
 
         DataStream<Tuple2<Identifier, Identifier>> partitionedSource =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CloneActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CloneActionFactory.java
@@ -18,7 +18,11 @@
 
 package org.apache.paimon.flink.action;
 
+import org.apache.paimon.utils.StringUtils;
+
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -32,6 +36,7 @@ public class CloneActionFactory implements ActionFactory {
     private static final String TARGET_CATALOG_CONF = "target_catalog_conf";
     private static final String PARALLELISM = "parallelism";
     private static final String WHERE = "where";
+    private static final String EXCLUDED_TABLES = "excluded_tables";
 
     @Override
     public String identifier() {
@@ -51,6 +56,12 @@ public class CloneActionFactory implements ActionFactory {
 
         String parallelism = params.get(PARALLELISM);
 
+        String excludedTablesStr = params.get(EXCLUDED_TABLES);
+        List<String> excludedTables =
+                StringUtils.isNullOrWhitespaceOnly(excludedTablesStr)
+                        ? null
+                        : Arrays.asList(StringUtils.split(excludedTablesStr, ","));
+
         CloneAction cloneAction =
                 new CloneAction(
                         params.get(DATABASE),
@@ -60,7 +71,8 @@ public class CloneActionFactory implements ActionFactory {
                         params.get(TARGET_TABLE),
                         targetCatalogConfig,
                         parallelism == null ? null : Integer.parseInt(parallelism),
-                        params.get(WHERE));
+                        params.get(WHERE),
+                        excludedTables);
 
         return Optional.of(cloneAction);
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/CloneUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/CloneUtils.java
@@ -96,7 +96,7 @@ public class CloneUtils {
                     !StringUtils.isNullOrWhitespaceOnly(targetTableName),
                     "targetTableName must not be blank when clone a table.");
             checkArgument(
-                    CollectionUtils.isNotEmpty(excludedTables),
+                    CollectionUtils.isEmpty(excludedTables),
                     "excludedTables must be empty when clone a single table.");
             result.add(
                     new Tuple2<>(

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCloneUtilsTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCloneUtilsTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.hive;
+
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.hive.clone.HiveCloneUtils;
+
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Test for {@link HiveCloneUtils}. */
+public class HiveCloneUtilsTest {
+
+    @Test
+    public void listAllTablesForCatalog() throws Exception {
+        HiveCatalog mockHiveCatalog = mock(HiveCatalog.class);
+        IMetaStoreClient mockClient = mock(IMetaStoreClient.class);
+        when(mockHiveCatalog.getHmsClient()).thenReturn(mockClient);
+        when(mockClient.getAllDatabases()).thenReturn(Arrays.asList("db1", "db2"));
+        when(mockClient.getAllTables("db1")).thenReturn(Arrays.asList("tbl1", "tbl2", "tbl3"));
+        when(mockClient.getAllTables("db2")).thenReturn(Arrays.asList("tbl1", "tbl2", "tbl3"));
+
+        List<Identifier> sourceTables = HiveCloneUtils.listTables(mockHiveCatalog, null);
+        List<Identifier> expectedTables =
+                Arrays.asList(
+                        Identifier.create("db1", "tbl1"),
+                        Identifier.create("db1", "tbl2"),
+                        Identifier.create("db1", "tbl3"),
+                        Identifier.create("db2", "tbl1"),
+                        Identifier.create("db2", "tbl2"),
+                        Identifier.create("db2", "tbl3"));
+        Assertions.assertThatList(sourceTables).containsExactlyInAnyOrderElementsOf(expectedTables);
+
+        sourceTables =
+                HiveCloneUtils.listTables(mockHiveCatalog, Arrays.asList("db1.tbl3", "db2.tbl1"));
+        expectedTables =
+                Arrays.asList(
+                        Identifier.create("db1", "tbl1"),
+                        Identifier.create("db1", "tbl2"),
+                        Identifier.create("db2", "tbl2"),
+                        Identifier.create("db2", "tbl3"));
+        Assertions.assertThatList(sourceTables).containsExactlyInAnyOrderElementsOf(expectedTables);
+    }
+
+    @Test
+    public void listAllTablesForDatabases() throws Exception {
+        HiveCatalog mockHiveCatalog = mock(HiveCatalog.class);
+        IMetaStoreClient mockClient = mock(IMetaStoreClient.class);
+        when(mockHiveCatalog.getHmsClient()).thenReturn(mockClient);
+        when(mockClient.getAllTables("db1")).thenReturn(Arrays.asList("tbl1", "tbl2", "tbl3"));
+
+        List<Identifier> sourceTables = HiveCloneUtils.listTables(mockHiveCatalog, "db1", null);
+        List<Identifier> expectedTables =
+                Arrays.asList(
+                        Identifier.create("db1", "tbl1"),
+                        Identifier.create("db1", "tbl2"),
+                        Identifier.create("db1", "tbl3"));
+        Assertions.assertThatList(sourceTables).containsExactlyInAnyOrderElementsOf(expectedTables);
+
+        sourceTables = HiveCloneUtils.listTables(mockHiveCatalog, "db1", Arrays.asList("db1.tbl1"));
+        expectedTables =
+                Arrays.asList(Identifier.create("db1", "tbl2"), Identifier.create("db1", "tbl3"));
+        Assertions.assertThatList(sourceTables).containsExactlyInAnyOrderElementsOf(expectedTables);
+    }
+}

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCloneUtilsTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCloneUtilsTest.java
@@ -66,7 +66,7 @@ public class HiveCloneUtilsTest {
     }
 
     @Test
-    public void listAllTablesForDatabases() throws Exception {
+    public void listAllTablesForDatabase() throws Exception {
         HiveCatalog mockHiveCatalog = mock(HiveCatalog.class);
         IMetaStoreClient mockClient = mock(IMetaStoreClient.class);
         when(mockHiveCatalog.getHmsClient()).thenReturn(mockClient);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
support excluding some tables when clone all tables in a catalog or database.

### Tests

<!-- List UT and IT cases to verify this change -->
org.apache.paimon.hive.HiveCloneUtilsTest#listAllTablesForCatalog
org.apache.paimon.hive.HiveCloneUtilsTest#listAllTablesForDatabase
org.apache.paimon.hive.procedure.CloneActionITCase#testMigrateWholeCatalogWithExcludedTables

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

