### PR TITLE
[flink] Fix stability of Flink 2.0 test workflow

### DIFF
--- a/.github/workflows/utitcase-flink-2.x-jdk11.yml
+++ b/.github/workflows/utitcase-flink-2.x-jdk11.yml
@@ -1,0 +1,62 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+name: UTCase and ITCase Flink 2.x on JDK 11
+
+on:
+  push:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+
+env:
+  JDK_VERSION: 11
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up JDK ${{ env.JDK_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JDK_VERSION }}
+          distribution: 'temurin'
+
+      - name: Build Flink
+        run:  |
+          mvn -T 2C -B clean install -DskipTests -Pflink2,spark3
+
+      - name: Test Flink
+        run: |
+          # run tests with random timezone to find out timezone related bugs
+          . .github/workflows/utils.sh
+          jvm_timezone=$(random_timezone)
+          echo "JVM timezone is set to $jvm_timezone"
+          test_modules=""
+          for suffix in 2.0 common; do
+          test_modules+="org.apache.paimon:paimon-flink-${suffix},"
+          done
+          test_modules="${test_modules%,}"
+          mvn -T 2C -B test verify -Pflink2,spark3 -pl "${test_modules}" -Duser.timezone=$jvm_timezone
+        env:
+          MAVEN_OPTS: -Xmx4096m

--- a/.github/workflows/utitcase-flink-2.x-jdk11.yml
+++ b/.github/workflows/utitcase-flink-2.x-jdk11.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     steps:
       - name: Checkout code

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -955,9 +955,9 @@ public class CatalogTableITCase extends CatalogITCaseBase {
                 BlockingIterator.of(
                         streamSqlIter(
                                 "SELECT * FROM T /*+ OPTIONS('consumer-id'='my1','consumer.expiration-time'='3h') */"));
+        assertThat(iterator.collect(2)).containsExactlyInAnyOrder(Row.of(1, 2), Row.of(3, 4));
 
         batchSql("INSERT INTO T VALUES (5, 6), (7, 8)");
-        assertThat(iterator.collect(2)).containsExactlyInAnyOrder(Row.of(1, 2), Row.of(3, 4));
 
         List<Row> result;
         do {

--- a/paimon-flink/paimon-flink1-common/pom.xml
+++ b/paimon-flink/paimon-flink1-common/pom.xml
@@ -33,7 +33,7 @@ under the License.
     <name>Paimon : Flink 1.x : Common</name>
 
     <properties>
-        <flink.version>${paimon-flink-common.flink.version}</flink.version>
+        <flink.version>1.20.1</flink.version>
     </properties>
 
     <dependencies>

--- a/paimon-flink/pom.xml
+++ b/paimon-flink/pom.xml
@@ -34,8 +34,10 @@ under the License.
     <packaging>pom</packaging>
 
     <modules>
+        <module>paimon-flink1-common</module>
         <module>paimon-flink-common</module>
         <module>paimon-flink-action</module>
+        <module>paimon-flink-cdc</module>
     </modules>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -423,14 +423,12 @@ under the License.
                 <test.flink.version>1.20.1</test.flink.version>
             </properties>
             <modules>
-                <module>paimon-flink/paimon-flink1-common</module>
                 <module>paimon-flink/paimon-flink-1.15</module>
                 <module>paimon-flink/paimon-flink-1.16</module>
                 <module>paimon-flink/paimon-flink-1.17</module>
                 <module>paimon-flink/paimon-flink-1.18</module>
                 <module>paimon-flink/paimon-flink-1.19</module>
                 <module>paimon-flink/paimon-flink-1.20</module>
-                <module>paimon-flink/paimon-flink-cdc</module>
             </modules>
             <activation>
                 <activeByDefault>true</activeByDefault>


### PR DESCRIPTION
### Purpose

Linked issue: close #5876

This PR fixes the problems that affect the stability of Flink 2.0 test workflow and add back the workflow script again, which was once removed in https://github.com/apache/paimon/commit/a6d2e8376cfb93accfbb2112048edefeb48bc77e.

I counted the most recent 100 Action executions before the script is removed, and the problems that caused the failures are as follows.

1. (79%) The Action run successfully.
2. (11%) paimon-flink-cdc module download timeout.
4. (7%) CatalogTableITCase#testConsumersTable failed. It is a flaky test with race condition.
5. (3%) Various failures that appeared only once.

So we need to fix the problems mentioned in 2 and 3 before enabling the Action again. The fixing is as follows.

#### 2. Build paimon-flink-cdc under Flink 2.0

Example failure Action log: https://github.com/apache/paimon/actions/runs/15804130573/job/44546474506

The failure was because that `paimon-e2e-tests` and `paimon-docs` relies on `paimon-flink-cdc` module, but this module is not compiled when profile `flink2` is enabled. In the attempt to download the snapshot of this module, network connection timeout might occur.

This PR fixes the failure by enabling the compilation of `paimon-flink-cdc` and its pre-module (`paimon-flink1-common`) under `-Pflink2`. This change is supposed not to affect the production code and the releasing process.

#### 3. Fix race condition in CatalogTableITCase#testConsumersTable

Example failure Action log: https://github.com/apache/paimon/actions/runs/15822438299/job/44594579766

This failure was because that the Flink job with the consumer source might not have completed its initialization before the second batch of data is written to the Paimon table. In order to fix it, a blocking operation is added to force the test case to wait for the source's initialization before the next write.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
