### PR TITLE
[cdc] Fix paimon 1.1.1+ kafka canal-json deserialize error

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaDebeziumJsonDeserializationSchema.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaDebeziumJsonDeserializationSchema.java
@@ -66,7 +66,7 @@ public class KafkaDebeziumJsonDeserializationSchema
         try {
             byte[] key = message.key();
             JsonNode keyNode = null;
-            if (key != null) {
+            if (key != null && key.length > 0) {
                 keyNode = objectMapper.readValue(key, JsonNode.class);
             }
 


### PR DESCRIPTION
…d-of-input.

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5850 

byte[] key length is 0, MismatchedInputException: No content to map due to end-of-input
 at [Source: (byte[])""; line: 1, column: 0]

``` 
Caused by: java.io.IOException: Failed to deserialize consumer record ConsumerRecord(topic = input_bd_input_test.column_type, partition = 0, leaderEpoch = 0, offset = 1, CreateTime = 1751959179914, serialized key size = 0, serialized value size = 804, headers = RecordHeaders(headers = [], isReadOnly = false), key = [B@7d4932cc, value = [B@3b78bfde).
	at org.apache.flink.connector.kafka.source.reader.deserializer.KafkaDeserializationSchemaWrapper.deserialize(KafkaDeserializationSchemaWrapper.java:59) ~[flink-sql-connector-kafka-3.4.0-1.20.jar:3.4.0-1.20]
	at org.apache.flink.connector.kafka.source.reader.KafkaRecordEmitter.emitRecord(KafkaRecordEmitter.java:53) ~[flink-sql-connector-kafka-3.4.0-1.20.jar:3.4.0-1.20]
	... 14 more
Caused by: org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.exc.MismatchedInputException: No content to map due to end-of-input
 at [Source: (byte[])""; line: 1, column: 0]
	at org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:59) ~[paimon-flink-1.20-1.2.0.jar:1.2.0]
	at org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper._initForReading(ObjectMapper.java:4821) ~[paimon-flink-1.20-1.2.0.jar:1.2.0]
	at org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4723) ~[paimon-flink-1.20-1.2.0.jar:1.2.0]
	at org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3738) ~[paimon-flink-1.20-1.2.0.jar:1.2.0]
	at org.apache.paimon.flink.action.cdc.kafka.KafkaDebeziumJsonDeserializationSchema.deserialize(KafkaDebeziumJsonDeserializationSchema.java:70) ~[paimon-flink-1.20-1.2.0.jar:1.2.0]
	at org.apache.paimon.flink.action.cdc.kafka.KafkaDebeziumJsonDeserializationSchema.deserialize(KafkaDebeziumJsonDeserializationSchema.java:39) ~[paimon-flink-1.20-1.2.0.jar:1.2.0]
	at org.apache.flink.streaming.connectors.kafka.KafkaDeserializationSchema.deserialize(KafkaDeserializationSchema.java:81) ~[flink-sql-connector-kafka-3.4.0-1.20.jar:3.4.0-1.20]
	at org.apache.flink.connector.kafka.source.reader.deserializer.KafkaDeserializationSchemaWrapper.deserialize(KafkaDeserializationSchemaWrapper.java:56) ~[flink-sql-connector-kafka-3.4.0-1.20.jar:3.4.0-1.20]
	at org.apache.flink.connector.kafka.source.reader.KafkaRecordEmitter.emitRecord(KafkaRecordEmitter.java:53) ~[flink-sql-connector-kafka-3.4.0-1.20.jar:3.4.0-1.20]
	... 14 more
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
