### PR TITLE
[core] formatTable supports defaultValue

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -56,6 +56,7 @@ import org.apache.paimon.utils.PartitionPathUtils;
 import org.apache.paimon.view.View;
 import org.apache.paimon.view.ViewImpl;
 
+import org.apache.paimon.shade.guava30.com.google.common.base.Joiner;
 import org.apache.paimon.shade.guava30.com.google.common.collect.Lists;
 
 import org.apache.flink.table.hive.LegacyHiveClasses;
@@ -154,6 +155,7 @@ public class HiveCatalog extends AbstractCatalog {
     private static final String HIVE_LAST_UPDATE_TIME_PROP = "transient_lastDdlTime";
     // hive default field delimiter is '\u0001'
     public static final String HIVE_FIELD_DELIM_DEFAULT = "\u0001";
+    public static final String DEFAULT_VALUE = "defaultValue";
 
     private final HiveConf hiveConf;
     private final String clientClassName;
@@ -1071,6 +1073,13 @@ public class HiveCatalog extends AbstractCatalog {
         FormatTable.Format provider = FormatTable.parseFormat(coreOptions.formatType());
 
         Map<String, String> tblProperties = new HashMap<>();
+        tableSchema.fields().stream()
+                .filter(dataField -> Objects.nonNull(dataField.defaultValue()))
+                .forEach(
+                        dataField ->
+                                tblProperties.put(
+                                        Joiner.on(".").join(dataField.name(), DEFAULT_VALUE),
+                                        dataField.defaultValue()));
 
         Table table = newHmsTable(identifier, tblProperties, provider, externalTable);
         updateHmsTable(table, identifier, tableSchema, provider, location);

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTestBase.scala
@@ -747,11 +747,9 @@ abstract class DDLWithHiveCatalogTestBase extends PaimonHiveTestBase {
 
               // test non paimon table
               // todo: support default value for paimon format table
-              if (catalogName != paimonHiveCatalogName) {
-                spark.sql("CREATE TABLE t2 (a INT, b int default 3) using csv")
-                spark.sql("INSERT INTO t2 (a) VALUES (1)")
-                checkAnswer(spark.sql("SELECT * FROM t2"), Seq(Row(1, 3)))
-              }
+              spark.sql("CREATE TABLE t2 (a INT, b int default 3) using csv")
+              spark.sql("INSERT INTO t2 (a) VALUES (1)")
+              checkAnswer(spark.sql("SELECT * FROM t2"), Seq(Row(1, 3)))
             }
           }
       }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

 Purpose
formatTable supports defaultValue

<!-- Linking this pull request to the issue -->
### Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests
DDLWithHiveCatalogTestBase.test("Paimon DDL with hive catalog: default value")

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
