### PR TITLE
[deploy] Suppress doc generation error when using JDK17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -966,16 +966,19 @@ under the License.
                     </executions>
                 </plugin>
 
-
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.1</version><!--$NO-MVN-MAN-VER$-->
+                    <version>3.11.2</version><!--$NO-MVN-MAN-VER$-->
                     <configuration>
                         <quiet>true</quiet>
                         <detectOfflineLinks>false</detectOfflineLinks>
-                        <additionalJOptions combine.children="append">
+                        <release>8</release>
+                        <failOnError>false</failOnError>
+                        <additionalJOptions>
                             <additionalJOption>-Xdoclint:none</additionalJOption>
+                            <!-- Suppress the error that is accepted by JDK 8 but not by JDK 11. -->
+                            <additionalJOption>--ignore-source-errors</additionalJOption>
                         </additionalJOptions>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Skip the error in https://github.com/apache/paimon/actions/runs/16280610720

```
2025-07-15T00:05:43.1138113Z [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.1.1:jar (attach-javadocs) on project paimon-s3-impl: MavenReportException: Error while generating Javadoc: 
2025-07-15T00:05:43.1139650Z [ERROR] Exit code: 2 - error: No source files for package org.apache.paimon.s3
2025-07-15T00:05:43.1140303Z [ERROR] 1 error
```

Searched for a long time but didn't figure out how to fix it. Hope someone in the future can find the root cause.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
