### PR TITLE
[iceberg] support partition predicate for clone-iceberg

### DIFF
--- a/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergHiveCloneExtractor.java
+++ b/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergHiveCloneExtractor.java
@@ -143,7 +143,9 @@ public class IcebergHiveCloneExtractor extends HiveTableCloneExtractor {
                 BinaryRow partitionRow =
                         FileMetaUtils.writePartitionValue(
                                 partitionRowType, partitionValues, valueSetters);
-                results.add(toHivePartitionFiles(entry.getValue(), partitionRow));
+                if (predicate == null || predicate.test(partitionRow)) {
+                    results.add(toHivePartitionFiles(entry.getValue(), partitionRow));
+                }
             }
             return results;
         }

--- a/paimon-iceberg/src/test/java/org/apache/paimon/flink/CloneActionForIcebergITCase.java
+++ b/paimon-iceberg/src/test/java/org/apache/paimon/flink/CloneActionForIcebergITCase.java
@@ -171,7 +171,8 @@ public class CloneActionForIcebergITCase extends ActionITCaseBase {
                 tableName,
                 String.join(",", insertValues));
 
-        List<Row> r1 = sql(tEnv, "SELECT * FROM my_iceberg.`%s`.`%s`", dbName, tableName);
+        List<Row> r1 =
+                sql(tEnv, "SELECT * FROM my_iceberg.`%s`.`%s` WHERE price > 0", dbName, tableName);
 
         sql(tEnv, "CREATE CATALOG PAIMON WITH ('type'='paimon', 'warehouse' = '%s')", warehouse);
         tEnv.useCatalog("PAIMON");
@@ -193,7 +194,9 @@ public class CloneActionForIcebergITCase extends ActionITCaseBase {
                         "--target_table",
                         "test_table",
                         "--target_catalog_conf",
-                        "warehouse=" + warehouse)
+                        "warehouse=" + warehouse,
+                        "--where",
+                        "price > 0")
                 .run();
 
         List<Row> r2 = sql(tEnv, "SELECT * FROM test.test_table");


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
pr-https://github.com/apache/paimon/pull/5888 had supported clone iceberg tables in hive to paimon, but it don't apply the `PartitionPredicate`. This pr will fix it.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
