### PR TITLE
[spark] Introduce upsert-key for insert into non-pk table 

### DIFF
--- a/docs/content/spark/dataframe.md
+++ b/docs/content/spark/dataframe.md
@@ -1,5 +1,5 @@
 ---
-title: "Dataframe"
+title: "DataFrame"
 weight: 9
 type: docs
 aliases:

--- a/docs/content/spark/sql-upsert.md
+++ b/docs/content/spark/sql-upsert.md
@@ -1,0 +1,95 @@
+---
+title: "SQL Upsert"
+weight: 10
+type: docs
+aliases:
+- /spark/sql-upsert.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# SQL Upsert
+
+For table without primary key, Paimon supports upsert write mode: If the row with the same upsert key already exists, perform update; otherwise, perform insert.
+
+## Usage
+
+Specify the following table properties when creating the table
+
+* `upsert-key`: Defines the key columns used for upsert, cannot be used together with primary key. 
+Unlike primary key, the upsert key value can be `null`, and null-equality matching is supported.
+Multiple columns separated by commas.
+
+* `sequence.field` (optional): When new record share the same upsert key, the row with the larger `sequence.field` value is kept as the merge result.
+And it will also deduplicate the data being written. 
+If `sequence.field` is not set, new record share the same upsert key simply update the existing one and no deduplication is performed.
+Multiple columns separated by commas.
+
+## Example
+
+Create table:
+
+```sql
+CREATE TABLE t (k1 INT, k2 INT, ts1 INT, ts2 INT, v STRING)
+TBLPROPERTIES ('upsert-key' = 'k1,k2', 'sequence.field' = 'ts1,ts2')
+```
+
+Insert data1:
+
+```sql
+INSERT INTO t values
+(null, null, 2, 1, 'v1'),
+(null, null, 2, 2, 'v4'),
+(1, null, 1, 1, 'v1'),
+(1, 2, 1, 1, 'v1'),
+(1, 2, 2, 1, 'v2')
+```
+
+Query result:
+
+```sql
+SELECT * FROM t ORDER BY k1, k2
+
+-- null, null, 2, 2, "v4"
+-- 1, null, 1, 1, "v1"
+-- 1, 2, 2, 1, "v2"
+```
+
+Insert data2:
+
+```sql
+INSERT INTO t values
+(null, null, 2, 1, 'v5'),
+(null, 1, 1, 1, 'v1'),
+(1, null, 2, 1, 'v2'),
+(1, 1, 1, 1, 'v1'),
+(1, 2, 2, 0, 'v3')
+```
+
+Query result:
+
+```sql
+SELECT * FROM t ORDER BY k1, k2
+
+-- null, null, 2, 2, "v4"
+-- null, 1, 1, 1, "v1"
+-- 1, null, 2, 1, "v2"
+-- 1, 1, 1, 1, "v1"
+-- 1, 2, 2, 1, "v2"
+```

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -1189,6 +1189,12 @@ If the data size allocated for the sorting task is uneven,which may lead to perf
             <td>Type of the table.<br /><br />Possible values:<ul><li>"table": Normal Paimon table.</li><li>"format-table": A file format table refers to a directory that contains multiple files of the same format.</li><li>"materialized-table": A materialized table combines normal Paimon table and materialized SQL.</li><li>"object-table": An object table combines normal Paimon table and object location.</li></ul></td>
         </tr>
         <tr>
+            <td><h5>upsert-key</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Define upsert key to do MERGE INTO when executing INSERT INTO, cannot be defined with primary key.</td>
+        </tr>
+        <tr>
             <td><h5>write-buffer-for-append</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -366,6 +366,13 @@ public class CoreOptions implements Serializable {
                             "To avoid frequent manifest merges, this parameter specifies the minimum number "
                                     + "of ManifestFileMeta to merge.");
 
+    public static final ConfigOption<String> UPSERT_KEY =
+            key("upsert-key")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Define upsert key to do MERGE INTO when executing INSERT INTO, cannot be defined with primary key.");
+
     public static final ConfigOption<String> PARTITION_DEFAULT_NAME =
             key("partition.default-name")
                     .stringType()
@@ -2065,6 +2072,14 @@ public class CoreOptions implements Serializable {
 
     public String fieldsDefaultFunc() {
         return options.get(FIELDS_DEFAULT_AGG_FUNC);
+    }
+
+    public List<String> upsertKey() {
+        String upsertKey = options.get(UPSERT_KEY);
+        if (StringUtils.isEmpty(upsertKey)) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(upsertKey.split(","));
     }
 
     public static String createCommitUser(Options options) {

--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/spark/sql/paimon/shims/MinorVersionShim.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/spark/sql/paimon/shims/MinorVersionShim.scala
@@ -18,8 +18,8 @@
 
 package org.apache.spark.sql.paimon.shims
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.logical.CTERelationRef
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.{CTERelationRef, LogicalPlan, MergeAction, MergeIntoTable}
 
 object MinorVersionShim {
 
@@ -28,4 +28,14 @@ object MinorVersionShim {
       resolved: Boolean,
       output: Seq[Attribute],
       isStreaming: Boolean): CTERelationRef = CTERelationRef(cteId, resolved, output)
+
+  def createMergeIntoTable(
+      targetTable: LogicalPlan,
+      sourceTable: LogicalPlan,
+      mergeCondition: Expression,
+      matchedActions: Seq[MergeAction],
+      notMatchedActions: Seq[MergeAction],
+      notMatchedBySourceActions: Seq[MergeAction]): MergeIntoTable = {
+    MergeIntoTable(targetTable, sourceTable, mergeCondition, matchedActions, notMatchedActions)
+  }
 }

--- a/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/sql/RewriteUpsertTableTest.scala
+++ b/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/sql/RewriteUpsertTableTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+class RewriteUpsertTableTest extends RewriteUpsertTableTestBase {}

--- a/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/spark/sql/paimon/shims/MinorVersionShim.scala
+++ b/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/spark/sql/paimon/shims/MinorVersionShim.scala
@@ -18,8 +18,8 @@
 
 package org.apache.spark.sql.paimon.shims
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.logical.CTERelationRef
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.{CTERelationRef, LogicalPlan, MergeAction, MergeIntoTable}
 
 object MinorVersionShim {
 
@@ -28,4 +28,14 @@ object MinorVersionShim {
       resolved: Boolean,
       output: Seq[Attribute],
       isStreaming: Boolean): CTERelationRef = CTERelationRef(cteId, resolved, output)
+
+  def createMergeIntoTable(
+      targetTable: LogicalPlan,
+      sourceTable: LogicalPlan,
+      mergeCondition: Expression,
+      matchedActions: Seq[MergeAction],
+      notMatchedActions: Seq[MergeAction],
+      notMatchedBySourceActions: Seq[MergeAction]): MergeIntoTable = {
+    MergeIntoTable(targetTable, sourceTable, mergeCondition, matchedActions, notMatchedActions)
+  }
 }

--- a/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/RewriteUpsertTableTest.scala
+++ b/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/RewriteUpsertTableTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+class RewriteUpsertTableTest extends RewriteUpsertTableTestBase {}

--- a/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/RewriteUpsertTableTest.scala
+++ b/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/RewriteUpsertTableTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+class RewriteUpsertTableTest extends RewriteUpsertTableTestBase {}

--- a/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/RewriteUpsertTableTest.scala
+++ b/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/RewriteUpsertTableTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+class RewriteUpsertTableTest extends RewriteUpsertTableTestBase {}

--- a/paimon-spark/paimon-spark-4.0/src/test/scala/org/apache/paimon/spark/sql/RewriteUpsertTableTest.scala
+++ b/paimon-spark/paimon-spark-4.0/src/test/scala/org/apache/paimon/spark/sql/RewriteUpsertTableTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+class RewriteUpsertTableTest extends RewriteUpsertTableTestBase {}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/RewriteUpsertTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/RewriteUpsertTable.scala
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.catalyst.analysis
+
+import org.apache.paimon.spark.SparkTable
+import org.apache.paimon.spark.catalyst.Compatibility
+import org.apache.paimon.table.FileStoreTable
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedStar}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, Attribute, CurrentRow, Descending, EqualNullSafe, EqualTo, LessThanOrEqual, Literal, RowFrame, RowNumber, SortOrder, SpecifiedWindowFrame, UnboundedPreceding, WindowExpression, WindowSpecDefinition}
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.paimon.shims.SparkShimLoader
+
+import scala.collection.JavaConverters._
+
+/** Rewrite upsert table to merge into. */
+case class RewriteUpsertTable(spark: SparkSession) extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsDown {
+    case p @ PaimonV2WriteCommand(table) =>
+      val (usingUpsert, upsertKey, sequenceField) = usingUpsertTable(table)
+      if (!usingUpsert) {
+        return p
+      }
+
+      p match {
+        case AppendData(target, source, _, _, _, _) =>
+          val deduplicatedSource = if (sequenceField.nonEmpty) {
+            deduplicateBySequenceField(source, upsertKey, sequenceField)
+          } else {
+            source
+          }
+
+          rewriteToMergeInto(target, deduplicatedSource, upsertKey, sequenceField)
+        case _ => p
+      }
+  }
+
+  private def usingUpsertTable(table: DataSourceV2Relation): (Boolean, Seq[String], Seq[String]) = {
+    table.table match {
+      case SparkTable(fileStoreTable: FileStoreTable) =>
+        val coreOptions = fileStoreTable.coreOptions()
+        val upsertKey = coreOptions.upsertKey().asScala.toSeq
+        val sequenceField = coreOptions.sequenceField().asScala.toSeq
+        if (fileStoreTable.primaryKeys().isEmpty && upsertKey.nonEmpty) {
+          (true, upsertKey, sequenceField)
+        } else {
+          (false, Seq.empty, Seq.empty)
+        }
+      case _ => (false, Seq.empty, Seq.empty)
+    }
+  }
+
+  private def deduplicateBySequenceField(
+      source: LogicalPlan,
+      upsertKey: Seq[String],
+      sequenceField: Seq[String]): LogicalPlan = {
+    val winSpec = WindowSpecDefinition(
+      cols(source.output, upsertKey),
+      cols(source.output, sequenceField).map(SortOrder(_, Descending)),
+      SpecifiedWindowFrame(RowFrame, UnboundedPreceding, CurrentRow)
+    )
+    val rnAlias = Alias(WindowExpression(RowNumber(), winSpec), "__rn__")()
+    val withRN = Project(UnresolvedStar(None) :: rnAlias :: Nil, source)
+    val filtered = Filter(EqualTo(UnresolvedAttribute("__rn__"), Literal(1)), withRN)
+    Project(source.output, filtered)
+  }
+
+  private def rewriteToMergeInto(
+      target: LogicalPlan,
+      source: LogicalPlan,
+      upsertKey: Seq[String],
+      sequenceField: Seq[String]
+  ): MergeIntoTable = {
+    val mergeCondition = upsertKey
+      .map(k => EqualNullSafe(col(target.output, k), col(source.output, k)))
+      .reduce(And)
+
+    val updateCondiction = if (sequenceField.nonEmpty) {
+      Option.apply(
+        sequenceField
+          .map(s => LessThanOrEqual(col(target.output, s), col(source.output, s)))
+          .reduce(And))
+    } else {
+      Option.empty
+    }
+
+    val assignments: Seq[Assignment] =
+      target.output.zip(source.output).map(a => Assignment(a._1, a._2))
+
+    val mergeActions = Seq(UpdateAction(updateCondiction, assignments))
+    val notMatchedActions = Seq(InsertAction(None, assignments))
+
+    SparkShimLoader.shim.createMergeIntoTable(
+      target,
+      source,
+      mergeCondition,
+      mergeActions,
+      notMatchedActions,
+      Seq.empty,
+      withSchemaEvolution = false)
+  }
+
+  private def cols(input: Seq[Attribute], colsNames: Seq[String]): Seq[Attribute] = {
+    colsNames.map(c => col(input, c))
+  }
+
+  private def col(input: Seq[Attribute], colsName: String): Attribute = {
+    input.find(_.name == colsName).get
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/extensions/PaimonSparkSessionExtensions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/extensions/PaimonSparkSessionExtensions.scala
@@ -18,7 +18,7 @@
 
 package org.apache.paimon.spark.extensions
 
-import org.apache.paimon.spark.catalyst.analysis.{PaimonAnalysis, PaimonDeleteTable, PaimonIncompatiblePHRRules, PaimonIncompatibleResolutionRules, PaimonMergeInto, PaimonPostHocResolutionRules, PaimonProcedureResolver, PaimonUpdateTable, PaimonViewResolver, ReplacePaimonFunctions}
+import org.apache.paimon.spark.catalyst.analysis.{PaimonAnalysis, PaimonDeleteTable, PaimonIncompatiblePHRRules, PaimonIncompatibleResolutionRules, PaimonMergeInto, PaimonPostHocResolutionRules, PaimonProcedureResolver, PaimonUpdateTable, PaimonViewResolver, ReplacePaimonFunctions, RewriteUpsertTable}
 import org.apache.paimon.spark.catalyst.optimizer.{EvalSubqueriesForDeleteTable, MergePaimonScalarSubqueries}
 import org.apache.paimon.spark.catalyst.plans.logical.PaimonTableValuedFunctions
 import org.apache.paimon.spark.commands.BucketExpression
@@ -41,6 +41,7 @@ class PaimonSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
     extensions.injectResolutionRule(spark => PaimonViewResolver(spark))
     extensions.injectResolutionRule(spark => SparkShimLoader.shim.createCustomResolution(spark))
     extensions.injectResolutionRule(spark => PaimonIncompatibleResolutionRules(spark))
+    extensions.injectResolutionRule(spark => RewriteUpsertTable(spark))
 
     extensions.injectPostHocResolutionRule(spark => ReplacePaimonFunctions(spark))
     extensions.injectPostHocResolutionRule(spark => PaimonPostHocResolutionRules(spark))

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/paimon/shims/SparkShim.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/paimon/shims/SparkShim.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.parser.ParserInterface
-import org.apache.spark.sql.catalyst.plans.logical.{CTERelationRef, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{CTERelationRef, LogicalPlan, MergeAction, MergeIntoTable}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableCatalog}
@@ -73,6 +73,15 @@ trait SparkShim {
   def supportsObjectHashAggregate(
       aggregateExpressions: Seq[AggregateExpression],
       groupByExpressions: Seq[Expression]): Boolean
+
+  def createMergeIntoTable(
+      targetTable: LogicalPlan,
+      sourceTable: LogicalPlan,
+      mergeCondition: Expression,
+      matchedActions: Seq[MergeAction],
+      notMatchedActions: Seq[MergeAction],
+      notMatchedBySourceActions: Seq[MergeAction],
+      withSchemaEvolution: Boolean): MergeIntoTable
 
   // for variant
   def toPaimonVariant(o: Object): Variant

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RewriteUpsertTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RewriteUpsertTableTestBase.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+import org.apache.paimon.spark.PaimonSparkTestBase
+
+import org.apache.spark.sql.Row
+
+abstract class RewriteUpsertTableTestBase extends PaimonSparkTestBase {
+
+  test("Rewrite Upsert Table: rewrite insert without sequence field") {
+    sql("""
+          |CREATE TABLE T (k INT, a INT, b STRING)
+          |TBLPROPERTIES ('upsert-key' = 'k')
+          |""".stripMargin)
+
+    sql("INSERT INTO T values (1, 1, 'c1'), (null, 2, 'c2'), (3, 3, 'c3')")
+    sql("INSERT INTO T values (null, 22, 'c22'), (1, 11, 'c11'), (4, 4, 'c4')")
+
+    checkAnswer(
+      sql("SELECT * FROM T ORDER BY k"),
+      Seq(Row(null, 22, "c22"), Row(1, 11, "c11"), Row(3, 3, "c3"), Row(4, 4, "c4")))
+  }
+
+  test("Rewrite Upsert Table: rewrite insert with sequence field") {
+    sql("""
+          |CREATE TABLE T (k1 INT, k2 INT, ts1 INT, ts2 INT, c STRING)
+          |TBLPROPERTIES ('upsert-key' = 'k1,k2', 'sequence.field' = 'ts1,ts2')
+          |""".stripMargin)
+
+    // test insert deduplicate
+    sql("""
+          |INSERT INTO T values
+          |(null, null, 2, 1, 'v3'),
+          |(null, null, 2, 2, 'v4'),
+          |(null, null, 1, 1, 'v1'),
+          |(null, null, 1, 2, 'v2'),
+          |(1, null, 1, 1, 'v1'),
+          |(1, 2, 1, 1, 'v1'),
+          |(1, 2, 2, 1, 'v2')
+          |""".stripMargin)
+    checkAnswer(
+      sql("SELECT * FROM T ORDER BY k1, k2"),
+      Seq(Row(null, null, 2, 2, "v4"), Row(1, null, 1, 1, "v1"), Row(1, 2, 2, 1, "v2")))
+
+    // test inset with different sequence field
+    sql("""
+          |INSERT INTO T values
+          |(null, null, 2, 1, 'v44'),
+          |(1, null, 2, 1, 'v2'),
+          |(null, 1, 1, 1, 'v1'),
+          |(1, 2, 2, 2, 'v3'),
+          |(1, 1, 1, 1, 'v1')
+          |""".stripMargin)
+    checkAnswer(
+      sql("SELECT * FROM T ORDER BY k1, k2"),
+      Seq(
+        Row(null, null, 2, 2, "v4"),
+        Row(null, 1, 1, 1, "v1"),
+        Row(1, null, 2, 1, "v2"),
+        Row(1, 1, 1, 1, "v1"),
+        Row(1, 2, 2, 2, "v3")))
+  }
+}

--- a/paimon-spark/paimon-spark3-common/src/main/scala/org/apache/spark/sql/paimon/shims/MinorVersionShim.scala
+++ b/paimon-spark/paimon-spark3-common/src/main/scala/org/apache/spark/sql/paimon/shims/MinorVersionShim.scala
@@ -18,8 +18,8 @@
 
 package org.apache.spark.sql.paimon.shims
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.logical.CTERelationRef
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.{CTERelationRef, LogicalPlan, MergeAction, MergeIntoTable}
 
 object MinorVersionShim {
 
@@ -28,4 +28,20 @@ object MinorVersionShim {
       resolved: Boolean,
       output: Seq[Attribute],
       isStreaming: Boolean): CTERelationRef = CTERelationRef(cteId, resolved, output, isStreaming)
+
+  def createMergeIntoTable(
+      targetTable: LogicalPlan,
+      sourceTable: LogicalPlan,
+      mergeCondition: Expression,
+      matchedActions: Seq[MergeAction],
+      notMatchedActions: Seq[MergeAction],
+      notMatchedBySourceActions: Seq[MergeAction]): MergeIntoTable = {
+    MergeIntoTable(
+      targetTable,
+      sourceTable,
+      mergeCondition,
+      matchedActions,
+      notMatchedActions,
+      notMatchedBySourceActions)
+  }
 }

--- a/paimon-spark/paimon-spark3-common/src/main/scala/org/apache/spark/sql/paimon/shims/Spark3Shim.scala
+++ b/paimon-spark/paimon-spark3-common/src/main/scala/org/apache/spark/sql/paimon/shims/Spark3Shim.scala
@@ -24,17 +24,16 @@ import org.apache.paimon.spark.catalyst.parser.extensions.PaimonSpark3SqlExtensi
 import org.apache.paimon.spark.data.{Spark3ArrayData, Spark3InternalRow, SparkArrayData, SparkInternalRow}
 import org.apache.paimon.types.{DataType, RowType}
 
-import org.apache.spark.sql.{Column, SparkSession}
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.parser.ParserInterface
-import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, CTERelationRef, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableCatalog}
 import org.apache.spark.sql.connector.expressions.Transform
-import org.apache.spark.sql.execution.command.CommandUtils
 import org.apache.spark.sql.types.StructType
 
 import java.util.{Map => JMap}
@@ -85,6 +84,23 @@ class Spark3Shim extends SparkShim {
       groupByExpressions: Seq[Expression]): Boolean =
     Aggregate.supportsObjectHashAggregate(aggregateExpressions)
 
+  override def createMergeIntoTable(
+      targetTable: LogicalPlan,
+      sourceTable: LogicalPlan,
+      mergeCondition: Expression,
+      matchedActions: Seq[MergeAction],
+      notMatchedActions: Seq[MergeAction],
+      notMatchedBySourceActions: Seq[MergeAction],
+      withSchemaEvolution: Boolean): MergeIntoTable = {
+    MinorVersionShim.createMergeIntoTable(
+      targetTable,
+      sourceTable,
+      mergeCondition,
+      matchedActions,
+      notMatchedActions,
+      notMatchedBySourceActions)
+  }
+
   override def toPaimonVariant(o: Object): Variant = throw new UnsupportedOperationException()
 
   override def isSparkVariantType(dataType: org.apache.spark.sql.types.DataType): Boolean =
@@ -98,5 +114,4 @@ class Spark3Shim extends SparkShim {
 
   override def toPaimonVariant(array: ArrayData, pos: Int): Variant =
     throw new UnsupportedOperationException()
-
 }

--- a/paimon-spark/paimon-spark4-common/src/main/scala/org/apache/spark/sql/paimon/shims/Spark4Shim.scala
+++ b/paimon-spark/paimon-spark4-common/src/main/scala/org/apache/spark/sql/paimon/shims/Spark4Shim.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.parser.ParserInterface
-import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, CTERelationRef, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, CTERelationRef, LogicalPlan, MergeAction, MergeIntoTable}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier, Table, TableCatalog}
@@ -87,6 +87,24 @@ class Spark4Shim extends SparkShim {
       aggregateExpressions: Seq[AggregateExpression],
       groupByExpressions: Seq[Expression]): Boolean =
     Aggregate.supportsObjectHashAggregate(aggregateExpressions.toSeq, groupByExpressions.toSeq)
+
+  override def createMergeIntoTable(
+      targetTable: LogicalPlan,
+      sourceTable: LogicalPlan,
+      mergeCondition: Expression,
+      matchedActions: Seq[MergeAction],
+      notMatchedActions: Seq[MergeAction],
+      notMatchedBySourceActions: Seq[MergeAction],
+      withSchemaEvolution: Boolean): MergeIntoTable = {
+    MergeIntoTable(
+      targetTable,
+      sourceTable,
+      mergeCondition,
+      matchedActions,
+      notMatchedActions,
+      notMatchedBySourceActions,
+      withSchemaEvolution)
+  }
 
   override def toPaimonVariant(o: Object): Variant = {
     val v = o.asInstanceOf[VariantVal]


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

```sql
CREATE TABLE T (k INT, ts INT, c STRING)
TBLPROPERTIES ('upsert-key' = 'k', 'sequence.field' = 'ts')

INSERT INTO T values (1, 1, 'c1'), (null, 2, 'c2'), (3, 3, 'c3')
INSERT INTO T values (null, 22, 'c22'), (1, 11, 'c11'), (4, 4, 'c4')
```

select  result
```sql
Row(null, 22, "c22"), Row(1, 11, "c11"), Row(3, 3, "c3"), Row(4, 4, "c4")
```



### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
