### PR TITLE
[arrow] Fix map type conversion from paimon type to arrow type

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/ArrowUtils.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/ArrowUtils.java
@@ -145,11 +145,7 @@ public class ArrowUtils {
                             keyField.getChildren());
 
             Field valueField =
-                    toArrowField(
-                            MapVector.VALUE_NAME,
-                            fieldId,
-                            mapType.getValueType().notNull(),
-                            depth + 1);
+                    toArrowField(MapVector.VALUE_NAME, fieldId, mapType.getValueType(), depth + 1);
             FieldType valueType = valueField.getFieldType();
             valueField =
                     new Field(

--- a/paimon-arrow/src/test/java/org/apache/paimon/arrow/ArrowUtilsTest.java
+++ b/paimon-arrow/src/test/java/org/apache/paimon/arrow/ArrowUtilsTest.java
@@ -19,11 +19,13 @@
 package org.apache.paimon.arrow;
 
 import org.apache.paimon.schema.Schema;
+import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -92,5 +94,18 @@ public class ArrowUtilsTest {
                                             .get(ArrowUtils.PARQUET_FIELD_ID)))
                     .isEqualTo(i);
         }
+    }
+
+    @Test
+    public void testMap() {
+        DataType type = DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING());
+        FieldType fieldType =
+                ArrowUtils.toArrowField("test", 0, type, 0)
+                        .getChildren()
+                        .get(0)
+                        .getChildren()
+                        .get(1)
+                        .getFieldType();
+        Assertions.assertThat(fieldType.isNullable()).isTrue();
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Map value type should be nullable if paimon map type value is nullable.
Do not force non-null for arrow map value type.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
