### PR TITLE
[core] process-time TagTimeExtractor supports custom zone

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -1153,6 +1153,12 @@ If the data size allocated for the sorting task is uneven,which may lead to perf
             <td>The date format for tag periods.<br /><br />Possible values:<ul><li>"with_dashes": Dates and hours with dashes, e.g., 'yyyy-MM-dd HH'</li><li>"without_dashes": Dates and hours without dashes, e.g., 'yyyyMMdd HH'</li><li>"without_dashes_and_spaces": Dates and hours without dashes and spaces, e.g., 'yyyyMMddHH'</li></ul></td>
         </tr>
         <tr>
+            <td><h5>tag.process-time-zone</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>When using tag.automatic-creation = process-time, use this option to set the time zone to parse the process time in milliseconds to TIMESTAMP value. The default value is JVM's default time zone. If you want to specify a time zone, you should either set a full name such as 'America/Los_Angeles' or a custom zone id such as 'GMT-08:00'.</td>
+        </tr>
+        <tr>
             <td><h5>target-file-size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>MemorySize</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -43,6 +43,7 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.time.Duration;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1461,6 +1462,16 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Whether to create tag automatically. And how to generate tags.");
 
+    public static final ConfigOption<String> TAG_PROCESS_TIME_ZONE =
+            key("tag.process-time-zone")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "When using tag.automatic-creation = process-time, use this option to set the time zone to "
+                                    + "parse the process time in milliseconds to TIMESTAMP value. The default value is "
+                                    + "JVM's default time zone. If you want to specify a time zone, you should either set "
+                                    + "a full name such as 'America/Los_Angeles' or a custom zone id such as 'GMT-08:00'.");
+
     public static final ConfigOption<Boolean> TAG_CREATE_SUCCESS_FILE =
             key("tag.create-success-file")
                     .booleanType()
@@ -2644,6 +2655,11 @@ public class CoreOptions implements Serializable {
 
     public TagCreationMode tagCreationMode() {
         return options.get(TAG_AUTOMATIC_CREATION);
+    }
+
+    public ZoneId tagProcessTimeZone() {
+        String zoneId = options.get(TAG_PROCESS_TIME_ZONE);
+        return zoneId == null ? ZoneId.systemDefault() : ZoneId.of(zoneId);
     }
 
     public TagCreationPeriod tagCreationPeriod() {

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagTimeExtractor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagTimeExtractor.java
@@ -36,12 +36,16 @@ public interface TagTimeExtractor {
     /** Extract time from snapshot time millis. */
     class ProcessTimeExtractor implements TagTimeExtractor {
 
+        private final ZoneId processTimeZoneId;
+
+        private ProcessTimeExtractor(ZoneId processTimeZoneId) {
+            this.processTimeZoneId = processTimeZoneId;
+        }
+
         @Override
         public Optional<LocalDateTime> extract(long timeMilli, @Nullable Long watermark) {
             return Optional.of(
-                    Instant.ofEpochMilli(timeMilli)
-                            .atZone(ZoneId.systemDefault())
-                            .toLocalDateTime());
+                    Instant.ofEpochMilli(timeMilli).atZone(processTimeZoneId).toLocalDateTime());
         }
     }
 
@@ -82,7 +86,7 @@ public interface TagTimeExtractor {
             case BATCH:
                 return null;
             case PROCESS_TIME:
-                return new ProcessTimeExtractor();
+                return new ProcessTimeExtractor(options.tagProcessTimeZone());
             case WATERMARK:
                 return new WatermarkExtractor(ZoneId.of(options.sinkWatermarkTimeZone()));
             default:


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In case that some full managed service machines cannot change timezone setting.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
