### PR TITLE
[core] Support off-peak hours

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -237,6 +237,18 @@ under the License.
             <td>Allows you to set a different (by default, more aggressive) percentage ratio for determining  whether larger sorted run's size are included in compactions during off-peak hours. Works in the  same way as compaction.size-ratio. Only applies if offpeak.start.hour and  offpeak.end.hour are also enabled.</td>
         </tr>
         <tr>
+            <td><h5>compaction.offpeak.end.hour</h5></td>
+            <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
+            <td>The end of off-peak hours, expressed as an integer between 0 and 23, inclusive. Set to -1 to disable off-peak.</td>
+        </tr>
+        <tr>
+            <td><h5>compaction.offpeak.start.hour</h5></td>
+            <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
+            <td>The start of off-peak hours, expressed as an integer between 0 and 23, inclusive Set to -1 to disable off-peak</td>
+        </tr>
+        <tr>
             <td><h5>compaction.optimization-interval</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
@@ -694,18 +706,6 @@ This config option does not affect the default filesystem metastore.</td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
             <td>The number of sorted runs that trigger the stopping of writes, the default value is 'num-sorted-run.compaction-trigger' + 3.</td>
-        </tr>
-        <tr>
-            <td><h5>offpeak.end.hour</h5></td>
-            <td style="word-wrap: break-word;">-1</td>
-            <td>Integer</td>
-            <td>The end of off-peak hours, expressed as an integer between 0 and 23, inclusive. Set to -1 to disable off-peak.</td>
-        </tr>
-        <tr>
-            <td><h5>offpeak.start.hour</h5></td>
-            <td style="word-wrap: break-word;">-1</td>
-            <td>Integer</td>
-            <td>The start of off-peak hours, expressed as an integer between 0 and 23, inclusive Set to -1 to disable off-peak</td>
         </tr>
         <tr>
             <td><h5>page-size</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -234,7 +234,7 @@ under the License.
             <td><h5>compaction.offpeak-ratio</h5></td>
             <td style="word-wrap: break-word;">0</td>
             <td>Integer</td>
-            <td>Allows you to set a different (by default, more aggressive) percentage ratio for determining  whether larger sorted run's size are included in compactions during off-peak hours. Works in the  same way as compaction.size-ratio. Only applies if offpeak.start.hour and  offpeak.end.hour are also enabled.</td>
+            <td>Allows you to set a different (by default, more aggressive) percentage ratio for determining  whether larger sorted run's size are included in compactions during off-peak hours. Works in the  same way as compaction.size-ratio. Only applies if offpeak.start.hour and  offpeak.end.hour are also enabled. <br /> For instance, if your cluster experiences low pressure between 2 AM  and 6 PM ,  you can configure `compaction.offpeak.start.hour=2` and `compaction.offpeak.end.hour=18` to define this period as off-peak hours.  During these hours, you can increase the off-peak compaction ratio (e.g. `compaction.offpeak-ratio=20`) to enable more aggressive data compaction</td>
         </tr>
         <tr>
             <td><h5>compaction.offpeak.end.hour</h5></td>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -57,6 +57,12 @@ under the License.
             <td>Bucket number for file store.<br />It should either be equal to -1 (dynamic bucket mode), -2 (postpone bucket mode), or it must be greater than 0 (fixed bucket mode).</td>
         </tr>
         <tr>
+            <td><h5>bucket-append-ordered</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to ignore the order of the buckets when reading data from an append-only table.</td>
+        </tr>
+        <tr>
             <td><h5>bucket-function.type</h5></td>
             <td style="word-wrap: break-word;">default</td>
             <td><p>Enum</p></td>
@@ -67,12 +73,6 @@ under the License.
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
             <td>Specify the paimon distribution policy. Data is assigned to each bucket according to the hash value of bucket-key.<br />If you specify multiple fields, delimiter is ','.<br />If not specified, the primary key will be used; if there is no primary key, the full row will be used.</td>
-        </tr>
-        <tr>
-            <td><h5>bucket-append-ordered</h5></td>
-            <td style="word-wrap: break-word;">true</td>
-            <td>Boolean</td>
-            <td>Whether to ignore the order of the buckets when reading data from an append-only table.</td>
         </tr>
         <tr>
             <td><h5>cache-page-size</h5></td>
@@ -229,6 +229,12 @@ under the License.
             <td style="word-wrap: break-word;">5</td>
             <td>Integer</td>
             <td>For file set [f_0,...,f_N], the minimum file number to trigger a compaction for append-only table.</td>
+        </tr>
+        <tr>
+            <td><h5>compaction.offpeak-ratio</h5></td>
+            <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
+            <td>Allows you to set a different (by default, more aggressive) percentage ratio for determining  whether larger sorted run's size are included in compactions during off-peak hours. Works in the  same way as compaction.size-ratio. Only applies if offpeak.start.hour and  offpeak.end.hour are also enabled.</td>
         </tr>
         <tr>
             <td><h5>compaction.optimization-interval</h5></td>
@@ -688,6 +694,18 @@ This config option does not affect the default filesystem metastore.</td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
             <td>The number of sorted runs that trigger the stopping of writes, the default value is 'num-sorted-run.compaction-trigger' + 3.</td>
+        </tr>
+        <tr>
+            <td><h5>offpeak.end.hour</h5></td>
+            <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
+            <td>The end of off-peak hours, expressed as an integer between 0 and 23, inclusive. Set to -1 to disable off-peak.</td>
+        </tr>
+        <tr>
+            <td><h5>offpeak.start.hour</h5></td>
+            <td style="word-wrap: break-word;">-1</td>
+            <td>Integer</td>
+            <td>The start of off-peak hours, expressed as an integer between 0 and 23, inclusive Set to -1 to disable off-peak</td>
         </tr>
         <tr>
             <td><h5>page-size</h5></td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -680,6 +680,32 @@ public class CoreOptions implements Serializable {
                                     + "size is 1% smaller than the next sorted run's size, then include next sorted run "
                                     + "into this candidate set.");
 
+    public static final ConfigOption<Integer> OFFPEAK_START_HOUR =
+            key("offpeak.start.hour")
+                    .intType()
+                    .defaultValue(-1)
+                    .withDescription(
+                            "The start of off-peak hours, expressed as an integer between 0 and 23, inclusive"
+                                    + " Set to -1 to disable off-peak");
+
+    public static final ConfigOption<Integer> OFFPEAK_END_HOUR =
+            key("offpeak.end.hour")
+                    .intType()
+                    .defaultValue(-1)
+                    .withDescription(
+                            "The end of off-peak hours, expressed as an integer between 0 and 23, inclusive. Set"
+                                    + " to -1 to disable off-peak.");
+
+    public static final ConfigOption<Integer> COMPACTION_OFFPEAK_RATIO =
+            key("compaction.offpeak-ratio")
+                    .intType()
+                    .defaultValue(0)
+                    .withDescription(
+                            "Allows you to set a different (by default, more aggressive) percentage ratio for determining "
+                                    + " whether larger sorted run's size are included in compactions during off-peak hours. Works in the "
+                                    + " same way as compaction.size-ratio. Only applies if offpeak.start.hour and "
+                                    + " offpeak.end.hour are also enabled.");
+
     public static final ConfigOption<Duration> COMPACTION_OPTIMIZATION_INTERVAL =
             key("compaction.optimization-interval")
                     .durationType()
@@ -2317,6 +2343,15 @@ public class CoreOptions implements Serializable {
 
     public int sortedRunSizeRatio() {
         return options.get(COMPACTION_SIZE_RATIO);
+    }
+
+    public OffPeakHours offPeakHours() {
+        return OffPeakHours.getInstance(
+                options.get(OFFPEAK_START_HOUR), options.get(OFFPEAK_END_HOUR));
+    }
+
+    public int compactOffPeakRatio() {
+        return options.get(COMPACTION_OFFPEAK_RATIO);
     }
 
     public int compactionMinFileNum() {

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -680,16 +680,16 @@ public class CoreOptions implements Serializable {
                                     + "size is 1% smaller than the next sorted run's size, then include next sorted run "
                                     + "into this candidate set.");
 
-    public static final ConfigOption<Integer> OFFPEAK_START_HOUR =
-            key("offpeak.start.hour")
+    public static final ConfigOption<Integer> COMPACT_OFFPEAK_START_HOUR =
+            key("compaction.offpeak.start.hour")
                     .intType()
                     .defaultValue(-1)
                     .withDescription(
                             "The start of off-peak hours, expressed as an integer between 0 and 23, inclusive"
                                     + " Set to -1 to disable off-peak");
 
-    public static final ConfigOption<Integer> OFFPEAK_END_HOUR =
-            key("offpeak.end.hour")
+    public static final ConfigOption<Integer> COMPACT_OFFPEAK_END_HOUR =
+            key("compaction.offpeak.end.hour")
                     .intType()
                     .defaultValue(-1)
                     .withDescription(
@@ -2347,7 +2347,7 @@ public class CoreOptions implements Serializable {
 
     public OffPeakHours offPeakHours() {
         return OffPeakHours.getInstance(
-                options.get(OFFPEAK_START_HOUR), options.get(OFFPEAK_END_HOUR));
+                options.get(COMPACT_OFFPEAK_START_HOUR), options.get(COMPACT_OFFPEAK_END_HOUR));
     }
 
     public int compactOffPeakRatio() {

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -701,10 +701,18 @@ public class CoreOptions implements Serializable {
                     .intType()
                     .defaultValue(0)
                     .withDescription(
-                            "Allows you to set a different (by default, more aggressive) percentage ratio for determining "
-                                    + " whether larger sorted run's size are included in compactions during off-peak hours. Works in the "
-                                    + " same way as compaction.size-ratio. Only applies if offpeak.start.hour and "
-                                    + " offpeak.end.hour are also enabled.");
+                            Description.builder()
+                                    .text(
+                                            "Allows you to set a different (by default, more aggressive) percentage ratio for determining "
+                                                    + " whether larger sorted run's size are included in compactions during off-peak hours. Works in the "
+                                                    + " same way as compaction.size-ratio. Only applies if offpeak.start.hour and "
+                                                    + " offpeak.end.hour are also enabled. ")
+                                    .linebreak()
+                                    .text(
+                                            " For instance, if your cluster experiences low pressure between 2 AM  and 6 PM , "
+                                                    + " you can configure `compaction.offpeak.start.hour=2` and `compaction.offpeak.end.hour=18` to define this period as off-peak hours. "
+                                                    + " During these hours, you can increase the off-peak compaction ratio (e.g. `compaction.offpeak-ratio=20`) to enable more aggressive data compaction")
+                                    .build());
 
     public static final ConfigOption<Duration> COMPACTION_OPTIMIZATION_INTERVAL =
             key("compaction.optimization-interval")

--- a/paimon-api/src/main/java/org/apache/paimon/OffPeakHours.java
+++ b/paimon-api/src/main/java/org/apache/paimon/OffPeakHours.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+/** OffPeakHours. */
+public abstract class OffPeakHours {
+    private static final Logger LOG = LoggerFactory.getLogger(OffPeakHours.class);
+
+    public static final OffPeakHours DISABLED =
+            new OffPeakHours() {
+                @Override
+                public boolean isOffPeak() {
+                    return false;
+                }
+
+                @Override
+                public boolean isOffPeak(int targetHour) {
+                    return false;
+                }
+            };
+
+    /**
+     * @param startHour inclusive
+     * @param endHour exclusive
+     */
+    public static OffPeakHours getInstance(int startHour, int endHour) {
+        if (startHour == -1 && endHour == -1) {
+            return DISABLED;
+        }
+
+        if (!isValidHour(startHour) || !isValidHour(endHour)) {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn(
+                        "Ignoring invalid start/end hour for peak hour : start = "
+                                + startHour
+                                + " end = "
+                                + endHour
+                                + ". Valid numbers are [0-23]");
+            }
+            return DISABLED;
+        }
+
+        if (startHour == endHour) {
+            return DISABLED;
+        }
+
+        return new OffPeakHoursImpl(startHour, endHour);
+    }
+
+    private static boolean isValidHour(int hour) {
+        return 0 <= hour && hour <= 23;
+    }
+
+    /** Returns whether {@code targetHour} is off-peak hour. */
+    public abstract boolean isOffPeak(int targetHour);
+
+    /** Returns whether it is off-peak hour. */
+    public abstract boolean isOffPeak();
+
+    private static class OffPeakHoursImpl extends OffPeakHours {
+        final int startHour;
+        final int endHour;
+
+        /**
+         * @param startHour inclusive
+         * @param endHour exclusive
+         */
+        OffPeakHoursImpl(int startHour, int endHour) {
+            this.startHour = startHour;
+            this.endHour = endHour;
+        }
+
+        @Override
+        public boolean isOffPeak() {
+            return isOffPeak(ZonedDateTime.now(ZoneOffset.UTC).getHour());
+        }
+
+        @Override
+        public boolean isOffPeak(int targetHour) {
+            if (startHour <= endHour) {
+                return startHour <= targetHour && targetHour < endHour;
+            }
+            return targetHour < endHour || startHour <= targetHour;
+        }
+    }
+}

--- a/paimon-api/src/main/java/org/apache/paimon/OffPeakHours.java
+++ b/paimon-api/src/main/java/org/apache/paimon/OffPeakHours.java
@@ -21,7 +21,7 @@ package org.apache.paimon;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 /** OffPeakHours. */
@@ -94,7 +94,7 @@ public abstract class OffPeakHours {
 
         @Override
         public boolean isOffPeak() {
-            return isOffPeak(ZonedDateTime.now(ZoneOffset.UTC).getHour());
+            return isOffPeak(ZonedDateTime.now(ZoneId.systemDefault()).getHour());
         }
 
         @Override

--- a/paimon-api/src/test/java/org/apache/paimon/offpeak/OffPeakHoursTest.java
+++ b/paimon-api/src/test/java/org/apache/paimon/offpeak/OffPeakHoursTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.offpeak;
+
+import org.apache.paimon.OffPeakHours;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link OffPeakHours}. */
+public class OffPeakHoursTest {
+
+    @Test
+    public void testDisabledInstance() {
+        OffPeakHours disabled = OffPeakHours.DISABLED;
+        assertThat(disabled.isOffPeak()).isFalse();
+        for (int hour = 0; hour < 24; hour++) {
+            assertThat(disabled.isOffPeak(hour)).isFalse();
+        }
+    }
+
+    @Test
+    public void testGetInstanceWithDisabledValues() {
+        OffPeakHours offPeakHours = OffPeakHours.getInstance(-1, -1);
+        assertThat(offPeakHours).isSameAs(OffPeakHours.DISABLED);
+    }
+
+    @Test
+    public void testGetInstanceWithSameStartAndEnd() {
+        for (int hour = 0; hour < 24; hour++) {
+            OffPeakHours offPeakHours = OffPeakHours.getInstance(hour, hour);
+            assertThat(offPeakHours).isSameAs(OffPeakHours.DISABLED);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-2, -1, 24, 25, 100})
+    public void testGetInstanceWithInvalidStartHour(int invalidHour) {
+        OffPeakHours offPeakHours = OffPeakHours.getInstance(invalidHour, 10);
+        assertThat(offPeakHours).isSameAs(OffPeakHours.DISABLED);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-2, -1, 24, 25, 100})
+    public void testGetInstanceWithInvalidEndHour(int invalidHour) {
+        OffPeakHours offPeakHours = OffPeakHours.getInstance(10, invalidHour);
+        assertThat(offPeakHours).isSameAs(OffPeakHours.DISABLED);
+    }
+
+    @Test
+    public void testNormalRangeOffPeakHours() {
+        // Test normal range: 9 AM to 5 PM (9-17)
+        OffPeakHours offPeakHours = OffPeakHours.getInstance(9, 17);
+
+        // Hours before start should not be off-peak
+        for (int hour = 0; hour < 9; hour++) {
+            assertThat(offPeakHours.isOffPeak(hour))
+                    .as("Hour %d should not be off-peak", hour)
+                    .isFalse();
+        }
+
+        // Hours in range should be off-peak (start inclusive, end exclusive)
+        for (int hour = 9; hour < 17; hour++) {
+            assertThat(offPeakHours.isOffPeak(hour))
+                    .as("Hour %d should be off-peak", hour)
+                    .isTrue();
+        }
+
+        // Hours after end should not be off-peak
+        for (int hour = 17; hour < 24; hour++) {
+            assertThat(offPeakHours.isOffPeak(hour))
+                    .as("Hour %d should not be off-peak", hour)
+                    .isFalse();
+        }
+    }
+
+    @Test
+    public void testWrapAroundRangeOffPeakHours() {
+        OffPeakHours offPeakHours = OffPeakHours.getInstance(22, 6);
+
+        // Hours before end (0-5) should be off-peak
+        for (int hour = 0; hour < 6; hour++) {
+            assertThat(offPeakHours.isOffPeak(hour))
+                    .as("Hour %d should be off-peak", hour)
+                    .isTrue();
+        }
+
+        // Hours between end and start (6-21) should not be off-peak
+        for (int hour = 6; hour < 22; hour++) {
+            assertThat(offPeakHours.isOffPeak(hour))
+                    .as("Hour %d should not be off-peak", hour)
+                    .isFalse();
+        }
+
+        // Hours from start to end of day (22-23) should be off-peak
+        for (int hour = 22; hour < 24; hour++) {
+            assertThat(offPeakHours.isOffPeak(hour))
+                    .as("Hour %d should be off-peak", hour)
+                    .isTrue();
+        }
+    }
+
+    @Test
+    public void testSingleHourRange() {
+        // Test single hour range: 12 to 13
+        OffPeakHours offPeakHours = OffPeakHours.getInstance(12, 13);
+
+        // Only hour 12 should be off-peak
+        for (int hour = 0; hour < 24; hour++) {
+            if (hour == 12) {
+                assertThat(offPeakHours.isOffPeak(hour))
+                        .as("Hour %d should be off-peak", hour)
+                        .isTrue();
+            } else {
+                assertThat(offPeakHours.isOffPeak(hour))
+                        .as("Hour %d should not be off-peak", hour)
+                        .isFalse();
+            }
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -226,14 +226,18 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                                 options.maxSizeAmplificationPercent(),
                                 options.sortedRunSizeRatio(),
                                 options.numSortedRunCompactionTrigger(),
-                                options.optimizedCompactionInterval()));
+                                options.optimizedCompactionInterval(),
+                                options.offPeakHours(),
+                                options.compactOffPeakRatio()));
             } else if (CoreOptions.LookupCompactMode.GENTLE.equals(options.lookupCompact())) {
                 return new UniversalCompaction(
                         options.maxSizeAmplificationPercent(),
                         options.sortedRunSizeRatio(),
                         options.numSortedRunCompactionTrigger(),
                         options.optimizedCompactionInterval(),
-                        options.lookupCompactMaxInterval());
+                        options.lookupCompactMaxInterval(),
+                        options.offPeakHours(),
+                        options.compactOffPeakRatio());
             }
         }
 
@@ -242,7 +246,9 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                         options.maxSizeAmplificationPercent(),
                         options.sortedRunSizeRatio(),
                         options.numSortedRunCompactionTrigger(),
-                        options.optimizedCompactionInterval());
+                        options.optimizedCompactionInterval(),
+                        options.offPeakHours(),
+                        options.compactOffPeakRatio());
         if (options.compactionForceUpLevel0()) {
             return new ForceUpLevel0Compaction(universal);
         } else {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Implementing a feature similar to HBase's off-peak:

Allows set a different (by default, more aggressive) percentage ratio for determining whether larger sorted run sizes are included in compactions during off-peak hours. Works in the same way as compaction.size-ratio. Only applies if offpeak.start.hour and offpeak.end.hour are also enabled.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

Add UT cases: OffPeakHoursTest、UniversalCompactionTest#testOffPeakRatioThreshold

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
