### PR TITLE
[core] Fix scan metric report for extra file-index files

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
@@ -155,6 +155,8 @@ public class AppendOnlyFileStore extends AbstractFileStore<InternalRow> {
                 schemaManager,
                 schema,
                 manifestFileFactory(),
+                fileIO,
+                pathFactory(),
                 options.scanManifestParallelism(),
                 options.fileIndexReadEnabled());
     }

--- a/paimon-core/src/main/java/org/apache/paimon/io/FileIndexEvaluator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/FileIndexEvaluator.java
@@ -22,7 +22,6 @@ import org.apache.paimon.fileindex.FileIndexPredicate;
 import org.apache.paimon.fileindex.FileIndexResult;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.predicate.Predicate;
-import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.schema.TableSchema;
 
 import java.io.IOException;
@@ -35,17 +34,16 @@ public class FileIndexEvaluator {
     public static FileIndexResult evaluate(
             FileIO fileIO,
             TableSchema dataSchema,
-            List<Predicate> dataFilter,
+            Predicate dataPredicate,
             DataFilePathFactory dataFilePathFactory,
             DataFileMeta file)
             throws IOException {
-        if (dataFilter != null && !dataFilter.isEmpty()) {
+        if (dataPredicate != null) {
             byte[] embeddedIndex = file.embeddedIndex();
             if (embeddedIndex != null) {
                 try (FileIndexPredicate predicate =
                         new FileIndexPredicate(embeddedIndex, dataSchema.logicalRowType())) {
-                    return predicate.evaluate(
-                            PredicateBuilder.and(dataFilter.toArray(new Predicate[0])));
+                    return predicate.evaluate(dataPredicate);
                 }
             }
 
@@ -65,8 +63,7 @@ public class FileIndexEvaluator {
                                 dataFilePathFactory.toAlignedPath(indexFiles.get(0), file),
                                 fileIO,
                                 dataSchema.logicalRowType())) {
-                    return predicate.evaluate(
-                            PredicateBuilder.and(dataFilter.toArray(new Predicate[0])));
+                    return predicate.evaluate(dataPredicate);
                 }
             }
         }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AppendOnlyFileStoreScan.java
@@ -54,9 +54,9 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
     // cache evolved filter by schema id
     private final Map<Long, Predicate> evolvedFilterMapping = new ConcurrentHashMap<>();
 
-    private FileIO fileIO;
+    private final FileIO fileIO;
 
-    private FileStorePathFactory pathFactory;
+    private final FileStorePathFactory pathFactory;
 
     public AppendOnlyFileStoreScan(
             ManifestsReader manifestsReader,
@@ -139,9 +139,9 @@ public class AppendOnlyFileStoreScan extends AbstractFileStoreScan {
                         id ->
                                 simpleStatsEvolutions.tryDevolveFilter(
                                         entry.file().schemaId(), inputFilter));
-
         DataFilePathFactory dataFilePathFactory =
                 pathFactory.createDataFilePathFactory(entry.partition(), entry.bucket());
+
         try {
             return FileIndexEvaluator.evaluate(
                             fileIO, tableSchema, dataPredicate, dataFilePathFactory, entry.file())

--- a/paimon-core/src/main/java/org/apache/paimon/operation/RawFileSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/RawFileSplitRead.java
@@ -199,17 +199,20 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
             throws IOException {
         FileIndexResult fileIndexResult = null;
         if (fileIndexReadEnabled) {
-            Predicate dataPredicate =
-                    PredicateBuilder.and(
-                            formatReaderMapping.getDataFilters().toArray(new Predicate[0]));
-            fileIndexResult =
-                    FileIndexEvaluator.evaluate(
-                            fileIO,
-                            formatReaderMapping.getDataSchema(),
-                            dataPredicate,
-                            dataFilePathFactory,
-                            file);
-            if (!fileIndexResult.remain()) {
+            List<Predicate> dataFilters = formatReaderMapping.getDataFilters();
+            if (dataFilters != null && !dataFilters.isEmpty()) {
+                Predicate dataPredicate =
+                        PredicateBuilder.and(
+                                formatReaderMapping.getDataFilters().toArray(new Predicate[0]));
+                fileIndexResult =
+                        FileIndexEvaluator.evaluate(
+                                fileIO,
+                                formatReaderMapping.getDataSchema(),
+                                dataPredicate,
+                                dataFilePathFactory,
+                                file);
+            }
+            if (fileIndexResult != null && !fileIndexResult.remain()) {
                 return new EmptyFileRecordReader<>();
             }
         }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/RawFileSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/RawFileSplitRead.java
@@ -38,6 +38,7 @@ import org.apache.paimon.io.FileIndexEvaluator;
 import org.apache.paimon.mergetree.compact.ConcatRecordReader;
 import org.apache.paimon.partition.PartitionUtils;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.reader.EmptyFileRecordReader;
 import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.reader.ReaderSupplier;
@@ -198,11 +199,14 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
             throws IOException {
         FileIndexResult fileIndexResult = null;
         if (fileIndexReadEnabled) {
+            Predicate dataPredicate =
+                    PredicateBuilder.and(
+                            formatReaderMapping.getDataFilters().toArray(new Predicate[0]));
             fileIndexResult =
                     FileIndexEvaluator.evaluate(
                             fileIO,
                             formatReaderMapping.getDataSchema(),
-                            formatReaderMapping.getDataFilters(),
+                            dataPredicate,
                             dataFilePathFactory,
                             file);
             if (!fileIndexResult.remain()) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlySimpleTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlySimpleTableTest.java
@@ -577,7 +577,7 @@ public class AppendOnlySimpleTableTest extends SimpleTableTestBase {
                 plan.splits().stream()
                         .flatMap(split -> ((DataSplit) split).dataFiles().stream())
                         .collect(Collectors.toList());
-        assertThat(metas.size()).isEqualTo(2);
+        assertThat(metas.size()).isEqualTo(1);
 
         RecordReader<InternalRow> reader =
                 table.newRead()
@@ -717,7 +717,7 @@ public class AppendOnlySimpleTableTest extends SimpleTableTestBase {
                 plan.splits().stream()
                         .flatMap(split -> ((DataSplit) split).dataFiles().stream())
                         .collect(Collectors.toList());
-        assertThat(metas.size()).isEqualTo(2);
+        assertThat(metas.size()).isEqualTo(1);
 
         RecordReader<InternalRow> reader =
                 table.newRead().withFilter(predicate).createReader(plan.splits());
@@ -967,7 +967,7 @@ public class AppendOnlySimpleTableTest extends SimpleTableTestBase {
                 plan.splits().stream()
                         .flatMap(split -> ((DataSplit) split).dataFiles().stream())
                         .collect(Collectors.toList());
-        assertThat(metas.size()).isEqualTo(2);
+        assertThat(metas.size()).isEqualTo(1);
 
         RecordReader<InternalRow> reader =
                 table.newRead().withFilter(predicate).createReader(plan.splits());

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/fileindex/FileIndexTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/fileindex/FileIndexTest.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.fileindex
+
+import org.apache.paimon.operation.AppendOnlyFileStoreScan
+import org.apache.paimon.predicate.PredicateBuilder
+import org.apache.paimon.spark.PaimonSparkTestBase
+import org.apache.paimon.table.FileStoreTable
+
+import scala.jdk.CollectionConverters._
+
+class FileIndexTest extends PaimonSparkTestBase {
+
+  test("test file index in plan phase") {
+    Seq("bloom-filter", "bitmap", "bsi").foreach {
+      filter =>
+        Seq("1B", "1MB").foreach {
+          size =>
+            val fileIndexProp = if (filter == "bloom-filter") {
+              s" 'file-index.bloom-filter.columns' = 'id'"
+            } else if (filter.equals("bitmap")) {
+              s" 'file-index.bitmap.columns' = 'id'"
+            } else if (filter.equals("bsi")) {
+              s" 'file-index.bsi.columns' = 'id'"
+            }
+
+            withTable("T") {
+              spark.sql(s"""
+                           |create table T (
+                           |id int,
+                           |name string)
+                           |USING paimon
+                           |TBLPROPERTIES(
+                           |  $fileIndexProp,
+                           |  'file-index.in-manifest-threshold'= '$size')
+                           |""".stripMargin)
+
+              spark.sql("insert into T values(1,'a')")
+              spark.sql("insert into T values(2,'b')")
+              spark.sql("insert into T values(3,'c')")
+              assert(sql("select * from `T$files`").collect().length == 3)
+
+              val fileNames = spark.sql("select input_file_name() from T where id == 2 ").collect()
+              assert(fileNames.length == 1)
+              val location = fileNames(0).getString(0)
+              val fileName = location.substring(location.lastIndexOf('/') + 1)
+
+              val table: FileStoreTable = loadTable("T")
+              val predicateBuilder = new PredicateBuilder(table.rowType)
+              // predicate is 'id=2'
+              val predicate = predicateBuilder.equal(0, 2)
+              val files = table
+                .store()
+                .newScan()
+                .asInstanceOf[AppendOnlyFileStoreScan]
+                .withFilter(predicate)
+                .plan()
+                .files()
+                .asScala
+                .map(x => x.fileName())
+              assert(files.length == 1)
+              assert(fileName.equals(files.head))
+            }
+        }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Reading table files contains scan phase and partition read phase. When we use bloom-filter or other file indexs, we found the scan metrics are the total data files of table, the file index seem to be not effective.

After analysis, in scan phase, the file index evaluation works  just effectively  for embedded file index, it does not work for extra file index. But extra file index actually works in partition read phase, this results inaccurate reporting metrics.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
