### PR TITLE
[core] Support the range-bitmap file index.

### DIFF
--- a/docs/content/concepts/spec/fileindex.md
+++ b/docs/content/concepts/spec/fileindex.md
@@ -217,7 +217,100 @@ Integers are all BIG_ENDIAN.
 Bitmap only support the following data type: TinyIntType, SmallIntType, IntType, BigIntType, DateType, TimeType,
 LocalZonedTimestampType, TimestampType, CharType, VarCharType, StringType, BooleanType.
 
+## Index: Range Bitmap
+
+Advantage:
+1. Smaller than the bitmap index.
+2. Suitable for the point query and the range query in the high level of cardinality scenarios.
+3. Can be used conjunction with bitmap index.
+
+Shortcoming:
+1. The point query evaluation maybe slower than bitmap index.
+
+Options:
+* `file-index.range-bitmap.columns`: specify the columns that need range-bitmap index.
+* `file-index.range-bitmap.<column_name>.chunk-size`: to config the chunk size, default value is 16kb.
+
+<pre>
+Range Bitmap file index format (V1)
++-------------------------------------------------+-----------------
+| header length (4 bytes int)                     |
++-------------------------------------------------+
+| version (1 byte)                                |
++-------------------------------------------------+
+| row number (4 bytes int)                        |
++-------------------------------------------------+
+| cardinality (4 bytes int)                       |       HEAD
++-------------------------------------------------+
+| min value                                       |
++-------------------------------------------------+
+| max value                                       |
++-------------------------------------------------+
+| dictionary length (4 bytes int)                 |
++-------------------------------------------------+-----------------
+| dictionary serialize in bytes                   |
++-------------------------------------------------+       BODY
+| bit-slice index bitmap serialize in bytes       |
++-------------------------------------------------+-----------------
+</pre>
+
+<pre>
+Dictionary format (V1)
++-------------------------------------------------+-----------------
+| header length (4 bytes int)                     |
++-------------------------------------------------+
+| version (1 byte)                                |
++-------------------------------------------------+
+| the chunks size (4 bytes int)                   |       HEAD
++-------------------------------------------------+    
+| the offsets length (4 bytes int)                |       
++-------------------------------------------------+
+| the chunks length (4 bytes int)                 |
++-------------------------------------------------+-----------------
+| offsets serialize in bytes                      |
++-------------------------------------------------+
+| chunks serialize in bytes                       |       BODY
++-------------------------------------------------+
+| keys serialize in bytes                         |
++-------------------------------------------------+-----------------
+</pre>
+
+<pre>
+Bit-slice index bitmap format (V1)
++-------------------------------------------------+-----------------
+| header length (4 bytes int)                     |
++-------------------------------------------------+
+| version (1 byte)                                |
++-------------------------------------------------+
+| slices size (4 bytes int)                       |       HEAD
++-------------------------------------------------+    
+| existence bitmap length (4 bytes int)           |       
++-------------------------------------------------+
+| indexes length (4 bytes int)                    |
++-------------------------------------------------+
+| indexes serialize in bytes                      |
++-------------------------------------------------+-----------------
+| existence bitmap serialize in bytes             |
++-------------------------------------------------+
+| the bit 0 bitmap serialize in bytes             |
++-------------------------------------------------+
+| the bit 1 bitmap serialize in byte              |       BODY
++-------------------------------------------------+
+| the bit 2 bitmap serialize in byte              |
++-------------------------------------------------+
+| ...                                             |
++-------------------------------------------------+-----------------
+</pre>
+
+RangeBitmap only support the following data type: TinyIntType, SmallIntType, IntType, BigIntType, DateType, TimeType, LocalZonedTimestampType, TimestampType, CharType, VarCharType, StringType, BooleanType, DoubleType, FloatType.
+
 ## Index: Bit-Slice Index Bitmap
+
+{{< hint warning >}}
+
+Deprecated. Using the range-bitmap index instead.
+
+{{< /hint >}}
 
 BSI file index is a numeric range index, used to accelerate range query, it can be used with bitmap index.
 

--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/bitmap/RangeBitmapIndexBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/bitmap/RangeBitmapIndexBenchmark.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.benchmark.bitmap;
+
+import org.apache.paimon.benchmark.Benchmark;
+import org.apache.paimon.fileindex.FileIndexReader;
+import org.apache.paimon.fileindex.FileIndexResult;
+import org.apache.paimon.fileindex.FileIndexWriter;
+import org.apache.paimon.fileindex.bitmap.BitmapFileIndex;
+import org.apache.paimon.fileindex.bitmap.BitmapIndexResult;
+import org.apache.paimon.fileindex.bsi.BitSliceIndexBitmapFileIndex;
+import org.apache.paimon.fileindex.rangebitmap.RangeBitmapFileIndex;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.types.DataTypes;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
+import org.junit.jupiter.api.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+import java.util.StringJoiner;
+import java.util.function.BiFunction;
+
+/** Benchmark for {@link RangeBitmapFileIndex}. */
+public class RangeBitmapIndexBenchmark {
+
+    public static final int ROW_COUNT = 1000000;
+    public static final int[] BOUNDS =
+            new int[] {3000, 10000, 50000, 100000, 300000, 500000, 800000, 3000000};
+    public static final int NOT_EXISTS_PREDICATE = 123;
+
+    @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+    private File bsiFile;
+    private File bitmapFile;
+    private File rangebitmapFile;
+
+    @Test
+    public void testEQ() throws Exception {
+        for (int bound : BOUNDS) {
+            createIndex(bound);
+            Random random = new Random();
+            int value;
+            do {
+                value = random.nextInt(bound);
+            } while (value == NOT_EXISTS_PREDICATE);
+
+            int predicate = value;
+            Benchmark benchmark =
+                    new Benchmark(String.format("index-query-benchmark-%s", bound), 100)
+                            .setNumWarmupIters(1)
+                            .setOutputPerIteration(false);
+
+            BiFunction<FileIndexReader, FieldRef, FileIndexResult> func =
+                    (reader, field) -> reader.visitEqual(field, predicate);
+
+            benchmark.addCase("bsi-index", 10, () -> queryBsi(bsiFile, func));
+
+            benchmark.addCase("bitmap-index", 10, () -> queryBitmap(bitmapFile, func));
+
+            benchmark.addCase(
+                    "range-bitmap-index", 10, () -> queryRangeBitmap(rangebitmapFile, func));
+
+            benchmark.run();
+        }
+    }
+
+    @Test
+    public void testNotExists() throws Exception {
+        for (int bound : BOUNDS) {
+            createIndex(bound);
+
+            Benchmark benchmark =
+                    new Benchmark(String.format("index-query-benchmark-%s", bound), 100)
+                            .setNumWarmupIters(1)
+                            .setOutputPerIteration(false);
+
+            BiFunction<FileIndexReader, FieldRef, FileIndexResult> func =
+                    (reader, field) -> reader.visitEqual(field, NOT_EXISTS_PREDICATE);
+
+            benchmark.addCase("bsi-index", 10, () -> queryBsi(bsiFile, func));
+
+            benchmark.addCase("bitmap-index", 10, () -> queryBitmap(bitmapFile, func));
+
+            benchmark.addCase(
+                    "range-bitmap-index", 10, () -> queryRangeBitmap(rangebitmapFile, func));
+
+            benchmark.run();
+        }
+    }
+
+    @Test
+    public void testRange() throws Exception {
+        for (int bound : BOUNDS) {
+            createIndex(bound);
+            Random random = new Random();
+            int predicate = random.nextInt(bound);
+
+            Benchmark benchmark =
+                    new Benchmark(String.format("index-query-benchmark-%s", bound), 100)
+                            .setNumWarmupIters(1)
+                            .setOutputPerIteration(false);
+
+            BiFunction<FileIndexReader, FieldRef, FileIndexResult> func =
+                    (reader, field) -> reader.visitGreaterThan(field, predicate);
+
+            benchmark.addCase("bsi-index", 10, () -> queryBsi(bsiFile, func));
+
+            benchmark.addCase(
+                    "range-bitmap-index", 10, () -> queryRangeBitmap(rangebitmapFile, func));
+
+            benchmark.run();
+        }
+    }
+
+    @Test
+    public void testIsNotNull() throws IOException {
+        for (int bound : BOUNDS) {
+            createIndex(bound);
+
+            Benchmark benchmark =
+                    new Benchmark(String.format("index-query-benchmark-%s", bound), 100)
+                            .setNumWarmupIters(1)
+                            .setOutputPerIteration(false);
+
+            BiFunction<FileIndexReader, FieldRef, FileIndexResult> func =
+                    FileIndexReader::visitIsNotNull;
+
+            benchmark.addCase("bsi-index", 10, () -> queryBsi(bsiFile, func));
+
+            benchmark.addCase("bitmap-index", 10, () -> queryBitmap(bitmapFile, func));
+
+            benchmark.addCase(
+                    "range-bitmap-index", 10, () -> queryRangeBitmap(rangebitmapFile, func));
+
+            benchmark.run();
+        }
+    }
+
+    private void createIndex(int bound) throws IOException {
+        Random random = new Random();
+
+        FileIndexWriter bsiWriter =
+                new BitSliceIndexBitmapFileIndex(DataTypes.INT(), new Options()).createWriter();
+
+        Options bitmapOptions = new Options();
+        bitmapOptions.setInteger(BitmapFileIndex.VERSION, BitmapFileIndex.VERSION_2);
+        FileIndexWriter bitmapWriter =
+                new BitmapFileIndex(DataTypes.INT(), bitmapOptions).createWriter();
+
+        FileIndexWriter rangeWriter =
+                new RangeBitmapFileIndex(DataTypes.INT(), new Options()).createWriter();
+
+        for (int i = 0; i < ROW_COUNT; i++) {
+            Integer next;
+            if (random.nextInt(10) == 0) {
+                next = null;
+            } else {
+                next = random.nextInt(bound);
+                if (next == NOT_EXISTS_PREDICATE) {
+                    next = null;
+                }
+            }
+            bsiWriter.writeRecord(next);
+            bitmapWriter.writeRecord(next);
+            rangeWriter.writeRecord(next);
+        }
+
+        folder.create();
+
+        this.bsiFile = folder.newFile("bsi-index");
+        this.bitmapFile = folder.newFile("bitmap-index");
+        this.rangebitmapFile = folder.newFile("range-bitmap-index");
+
+        FileUtils.writeByteArrayToFile(bsiFile, bsiWriter.serializedBytes());
+        FileUtils.writeByteArrayToFile(bitmapFile, bitmapWriter.serializedBytes());
+        FileUtils.writeByteArrayToFile(rangebitmapFile, rangeWriter.serializedBytes());
+
+        List<File> files = Arrays.asList(bsiFile, bitmapFile, rangebitmapFile);
+        files.sort(Comparator.comparingLong(File::length));
+        StringJoiner joiner = new StringJoiner(" < ");
+        files.forEach(
+                file ->
+                        joiner.add(
+                                String.format("%s(%s kb)", file.getName(), file.length() / 1024)));
+        System.out.println("file size: " + joiner);
+    }
+
+    private void queryBsi(
+            File file, BiFunction<FileIndexReader, FieldRef, FileIndexResult> function) {
+        try {
+            FieldRef fieldRef = new FieldRef(0, "", DataTypes.INT());
+            Options options = new Options();
+            LocalFileIO.LocalSeekableInputStream localSeekableInputStream =
+                    new LocalFileIO.LocalSeekableInputStream(file);
+            FileIndexReader reader =
+                    new BitSliceIndexBitmapFileIndex(DataTypes.INT(), options)
+                            .createReader(localSeekableInputStream, 0, 0);
+            FileIndexResult result = function.apply(reader, fieldRef);
+            ((BitmapIndexResult) result).get();
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void queryBitmap(
+            File file, BiFunction<FileIndexReader, FieldRef, FileIndexResult> function) {
+        try {
+            FieldRef fieldRef = new FieldRef(0, "", DataTypes.INT());
+            Options options = new Options();
+            LocalFileIO.LocalSeekableInputStream localSeekableInputStream =
+                    new LocalFileIO.LocalSeekableInputStream(file);
+            FileIndexReader reader =
+                    new BitmapFileIndex(DataTypes.INT(), options)
+                            .createReader(localSeekableInputStream, 0, 0);
+            FileIndexResult result = function.apply(reader, fieldRef);
+            ((BitmapIndexResult) result).get();
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void queryRangeBitmap(
+            File file, BiFunction<FileIndexReader, FieldRef, FileIndexResult> function) {
+        try {
+            FieldRef fieldRef = new FieldRef(0, "", DataTypes.INT());
+            Options options = new Options();
+            LocalFileIO.LocalSeekableInputStream localSeekableInputStream =
+                    new LocalFileIO.LocalSeekableInputStream(file);
+            FileIndexReader reader =
+                    new RangeBitmapFileIndex(DataTypes.INT(), options)
+                            .createReader(localSeekableInputStream, 0, 0);
+            FileIndexResult result = function.apply(reader, fieldRef);
+            ((BitmapIndexResult) result).get();
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/BitSliceIndexBitmap.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/BitSliceIndexBitmap.java
@@ -1,0 +1,312 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex.rangebitmap;
+
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.utils.RoaringBitmap32;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Implementation of bit-slice index bitmap. */
+public class BitSliceIndexBitmap {
+
+    public static final byte VERSION_1 = 1;
+    public static final byte CURRENT_VERSION = VERSION_1;
+
+    private final byte version;
+    private final int ebmLength;
+    private final ByteBuffer indexes;
+    private final RoaringBitmap32[] slices;
+    private final SeekableInputStream in;
+    private final int bodyOffset;
+
+    private RoaringBitmap32 ebm;
+    private boolean initialized = false;
+
+    public BitSliceIndexBitmap(SeekableInputStream in, int offset) throws IOException {
+        in.seek(offset);
+        byte[] headerLengthInBytes = new byte[Integer.BYTES];
+        in.read(headerLengthInBytes);
+        int headerLength = ByteBuffer.wrap(headerLengthInBytes).getInt();
+
+        byte[] headerInBytes = new byte[headerLength];
+        in.read(headerInBytes);
+        ByteBuffer headers = ByteBuffer.wrap(headerInBytes);
+
+        version = headers.get();
+        if (version > CURRENT_VERSION) {
+            throw new RuntimeException(
+                    String.format(
+                            "deserialize bsi index fail, " + "current version is lower than %d",
+                            version));
+        }
+
+        // slices size
+        slices = new RoaringBitmap32[headers.get()];
+
+        // ebm length
+        ebmLength = headers.getInt();
+
+        // read indexes
+        int indexesLength = headers.getInt();
+        indexes = (ByteBuffer) headers.slice().limit(indexesLength);
+
+        this.in = in;
+        this.bodyOffset = offset + Integer.BYTES + headerLength;
+    }
+
+    @Nullable
+    public Integer get(int key) {
+        if (!isNotNull().contains(key)) {
+            return null;
+        }
+        int value = 0;
+        for (int i = 0; i < slices.length; i++) {
+            if (getSlice(i).contains(key)) {
+                value |= (1 << i);
+            }
+        }
+        return value;
+    }
+
+    public RoaringBitmap32 eq(int code) {
+        RoaringBitmap32 state = isNotNull();
+        if (state.isEmpty()) {
+            return new RoaringBitmap32();
+        }
+
+        loadSlices(0, slices.length);
+        for (int i = 0; i < slices.length; i++) {
+            int bit = (code >> i) & 1;
+            if (bit == 1) {
+                state.and(getSlice(i));
+            } else {
+                state.andNot(getSlice(i));
+            }
+        }
+        return state;
+    }
+
+    public RoaringBitmap32 gt(int code) {
+        if (code < 0) {
+            return isNotNull();
+        }
+
+        RoaringBitmap32 foundSet = isNotNull();
+        if (foundSet.isEmpty()) {
+            return new RoaringBitmap32();
+        }
+
+        // the state is always start from the empty bitmap
+        RoaringBitmap32 state = null;
+
+        // if there is a run of k set bits starting from 0, [0, k] operations can be eliminated.
+        int start = Long.numberOfTrailingZeros(~code);
+        loadSlices(start, slices.length);
+        for (int i = start; i < slices.length; i++) {
+            if (state == null) {
+                state = getSlice(i).clone();
+                continue;
+            }
+
+            long bit = (code >> i) & 1;
+            if (bit == 1) {
+                state.and(getSlice(i));
+            } else {
+                state.or(getSlice(i));
+            }
+        }
+
+        if (state == null) {
+            return new RoaringBitmap32();
+        }
+
+        state.and(foundSet);
+        return state;
+    }
+
+    public RoaringBitmap32 gte(int code) {
+        return gt(code - 1);
+    }
+
+    public RoaringBitmap32 isNotNull() {
+        if (ebm == null) {
+            try {
+                in.seek(bodyOffset);
+                byte[] bytes = new byte[ebmLength];
+                in.read(bytes);
+                RoaringBitmap32 bitmap = new RoaringBitmap32();
+                bitmap.deserialize(ByteBuffer.wrap(bytes));
+                ebm = bitmap;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return ebm.clone();
+    }
+
+    private void loadSlices(int begin, int end) {
+        if (initialized) {
+            return;
+        }
+
+        indexes.position(2 * Integer.BYTES * begin);
+        int offset = indexes.getInt();
+        int length = indexes.getInt();
+        int[] lengths = new int[end];
+        lengths[begin] = length;
+        for (int i = begin + 1; i < end; i++) {
+            indexes.getInt();
+            lengths[i] = indexes.getInt();
+            length += lengths[i];
+        }
+
+        try {
+            in.seek(bodyOffset + ebmLength + offset);
+            byte[] bytes = new byte[length];
+            in.read(bytes);
+            ByteBuffer buffer = ByteBuffer.wrap(bytes);
+
+            int position = 0;
+            for (int i = begin; i < end; i++) {
+                buffer.position(position);
+                RoaringBitmap32 slice = new RoaringBitmap32();
+                slice.deserialize((ByteBuffer) buffer.slice().limit(lengths[i]));
+                slices[i] = slice;
+                position += lengths[i];
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        initialized = true;
+    }
+
+    private RoaringBitmap32 getSlice(int index) {
+        if (slices[index] == null) {
+            indexes.position(2 * Integer.BYTES * index);
+            int offset = indexes.getInt();
+            int length = indexes.getInt();
+
+            try {
+                in.seek(bodyOffset + ebmLength + offset);
+                byte[] bytes = new byte[length];
+                in.read(bytes);
+                RoaringBitmap32 slice = new RoaringBitmap32();
+                slice.deserialize(ByteBuffer.wrap(bytes));
+                slices[index] = slice;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return slices[index];
+    }
+
+    /** A Builder for {@link BitSliceIndexBitmap}. */
+    public static final class Appender {
+
+        private final int min;
+        private final int max;
+        private final RoaringBitmap32 ebm;
+        private final RoaringBitmap32[] slices;
+
+        public Appender(int min, int max) {
+            this.min = min;
+            this.max = max;
+            this.ebm = new RoaringBitmap32();
+            this.slices = new RoaringBitmap32[Long.SIZE - Long.numberOfLeadingZeros(max)];
+            for (int i = 0; i < slices.length; i++) {
+                slices[i] = new RoaringBitmap32();
+            }
+        }
+
+        public void append(int key, int value) {
+            if (value < 0) {
+                throw new UnsupportedOperationException("value can not be negative");
+            }
+
+            if (value < min || value > max) {
+                throw new IllegalArgumentException("value not in range [" + min + "," + max + "]");
+            }
+
+            // only bit=1 need to set
+            long bits = value;
+            while (bits != 0) {
+                slices[Long.numberOfTrailingZeros(bits)].add(key);
+                bits &= (bits - 1);
+            }
+            ebm.add(key);
+        }
+
+        public ByteBuffer serialize() {
+            int indexesLength = 2 * Integer.BYTES * slices.length;
+
+            byte[] ebmSerializeInBytes = ebm.serialize();
+            int ebmLength = ebmSerializeInBytes.length;
+
+            int headerSize = 0;
+            headerSize += Byte.BYTES; // version
+            headerSize += Byte.BYTES; // slices size
+            headerSize += Integer.BYTES; // ebm length
+            headerSize += Integer.BYTES; // indexes length
+            headerSize += indexesLength; // indexes size in bytes
+
+            int bodySize = 0;
+            bodySize += ebmLength;
+
+            int offset = 0;
+            ByteBuffer indexes = ByteBuffer.allocate(indexesLength);
+            List<byte[]> slicesSerializeInBytes = new ArrayList<>();
+            for (RoaringBitmap32 slice : slices) {
+                byte[] sliceInBytes = slice.serialize();
+                slicesSerializeInBytes.add(sliceInBytes);
+
+                int length = sliceInBytes.length;
+                indexes.putInt(offset);
+                indexes.putInt(length);
+
+                offset += length;
+                bodySize += length;
+            }
+
+            ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES + headerSize + bodySize);
+            buffer.putInt(headerSize);
+
+            // write header
+            buffer.put(CURRENT_VERSION);
+            buffer.put((byte) slices.length);
+            buffer.putInt(ebmLength);
+            buffer.putInt(indexesLength);
+            buffer.put(indexes.array());
+
+            // write body
+            buffer.put(ebmSerializeInBytes);
+            for (byte[] slice : slicesSerializeInBytes) {
+                buffer.put(slice);
+            }
+
+            return buffer;
+        }
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmap.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmap.java
@@ -1,0 +1,310 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex.rangebitmap;
+
+import org.apache.paimon.fileindex.rangebitmap.dictionary.Dictionary;
+import org.apache.paimon.fileindex.rangebitmap.dictionary.chunked.ChunkedDictionary;
+import org.apache.paimon.fileindex.rangebitmap.dictionary.chunked.KeyFactory;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.utils.RoaringBitmap32;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/** Implementation of range-bitmap. */
+public class RangeBitmap {
+
+    public static final int VERSION_1 = 1;
+    public static final byte CURRENT_VERSION = VERSION_1;
+
+    private final byte version;
+    private final int rid;
+    private final int cardinality;
+    private final Object min;
+    private final Object max;
+    private final int dictionaryOffset;
+    private final int bsiOffset;
+
+    private final SeekableInputStream in;
+    private final KeyFactory factory;
+    private final Comparator<Object> comparator;
+
+    private Dictionary dictionary;
+    private BitSliceIndexBitmap bsi;
+
+    public RangeBitmap(SeekableInputStream in, int offset, KeyFactory factory) {
+        ByteBuffer headers;
+        int headerLength;
+        try {
+            in.seek(offset);
+            byte[] headerLengthInBytes = new byte[Integer.BYTES];
+            in.read(headerLengthInBytes);
+            headerLength = ByteBuffer.wrap(headerLengthInBytes).getInt();
+
+            byte[] headerInBytes = new byte[headerLength];
+            in.read(headerInBytes);
+            headers = ByteBuffer.wrap(headerInBytes);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        KeyFactory.KeyDeserializer deserializer = factory.createDeserializer();
+        this.version = headers.get();
+        if (version > CURRENT_VERSION) {
+            throw new RuntimeException("Invalid version " + version);
+        }
+        this.rid = headers.getInt();
+        this.cardinality = headers.getInt();
+        this.min = deserializer.deserialize(headers);
+        this.max = deserializer.deserialize(headers);
+        int dictionaryLength = headers.getInt();
+
+        this.dictionaryOffset = offset + Integer.BYTES + headerLength;
+        this.bsiOffset = dictionaryOffset + dictionaryLength;
+
+        this.in = in;
+        this.factory = factory;
+        this.comparator = factory.createComparator();
+    }
+
+    public RoaringBitmap32 eq(Object key) {
+        int compareMin = comparator.compare(key, min);
+        int compareMax = comparator.compare(key, max);
+        if (compareMin == 0 && compareMax == 0) {
+            return isNotNull();
+        } else if (compareMin < 0 || compareMax > 0) {
+            return new RoaringBitmap32();
+        }
+
+        int code = getDictionary().find(key);
+        if (code < 0) {
+            return new RoaringBitmap32();
+        }
+        return getBitSliceIndexBitmap().eq(code);
+    }
+
+    public RoaringBitmap32 neq(Object key) {
+        return not(eq(key));
+    }
+
+    public RoaringBitmap32 lte(Object key) {
+        int compareMin = comparator.compare(key, min);
+        int compareMax = comparator.compare(key, max);
+        if (compareMax >= 0) {
+            return isNotNull();
+        } else if (compareMin < 0) {
+            return new RoaringBitmap32();
+        }
+
+        return not(gt(key));
+    }
+
+    public RoaringBitmap32 lt(Object key) {
+        int compareMin = comparator.compare(key, min);
+        int compareMax = comparator.compare(key, max);
+        if (compareMax > 0) {
+            return isNotNull();
+        } else if (compareMin <= 0) {
+            return new RoaringBitmap32();
+        }
+
+        return not(gte(key));
+    }
+
+    public RoaringBitmap32 gte(Object key) {
+        int compareMin = comparator.compare(key, min);
+        int compareMax = comparator.compare(key, max);
+        if (compareMin <= 0) {
+            return isNotNull();
+        } else if (compareMax > 0) {
+            return new RoaringBitmap32();
+        }
+
+        int code = getDictionary().find(key);
+        return code < 0 ? getBitSliceIndexBitmap().gte(-code) : getBitSliceIndexBitmap().gte(code);
+    }
+
+    public RoaringBitmap32 gt(Object key) {
+        int compareMin = comparator.compare(key, min);
+        int compareMax = comparator.compare(key, max);
+        if (compareMin < 0) {
+            return isNotNull();
+        } else if (compareMax >= 0) {
+            return new RoaringBitmap32();
+        }
+
+        int code = getDictionary().find(key);
+        return code < 0 ? getBitSliceIndexBitmap().gte(-code) : getBitSliceIndexBitmap().gt(code);
+    }
+
+    public RoaringBitmap32 in(List<Object> keys) {
+        RoaringBitmap32 bitmap = new RoaringBitmap32();
+        for (Object key : keys) {
+            bitmap.or(eq(key));
+        }
+        return bitmap;
+    }
+
+    public RoaringBitmap32 notIn(List<Object> keys) {
+        return not(in(keys));
+    }
+
+    public RoaringBitmap32 isNull() {
+        RoaringBitmap32 bitmap = isNotNull();
+        bitmap.flip(0, rid);
+        return bitmap;
+    }
+
+    public RoaringBitmap32 isNotNull() {
+        return getBitSliceIndexBitmap().isNotNull();
+    }
+
+    public Object get(int position) {
+        if (position < 0 || position >= rid) {
+            return null;
+        }
+        Integer code = getBitSliceIndexBitmap().get(position);
+        if (code == null) {
+            return null;
+        }
+        return getDictionary().find(code);
+    }
+
+    private RoaringBitmap32 not(RoaringBitmap32 bitmap) {
+        bitmap.flip(0, rid);
+        bitmap.and(isNotNull());
+        return bitmap;
+    }
+
+    private Dictionary getDictionary() {
+        if (dictionary == null) {
+            try {
+                dictionary = new ChunkedDictionary(in, dictionaryOffset, factory);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return dictionary;
+    }
+
+    private BitSliceIndexBitmap getBitSliceIndexBitmap() {
+        if (bsi == null) {
+            try {
+                bsi = new BitSliceIndexBitmap(in, bsiOffset);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return bsi;
+    }
+
+    /** A Builder for {@link RangeBitmap}. */
+    public static class Appender {
+
+        private int rid;
+        private final TreeMap<Object, RoaringBitmap32> bitmaps;
+        private final Dictionary.Appender appender;
+        private final KeyFactory.KeySerializer serializer;
+
+        public Appender(KeyFactory factory, int limitedSerializedSizeInBytes) {
+            this.rid = 0;
+            this.bitmaps = new TreeMap<>(factory.createComparator());
+            this.appender = new ChunkedDictionary.Appender(factory, limitedSerializedSizeInBytes);
+            this.serializer = factory.createSerializer();
+        }
+
+        public void append(Object key) {
+            if (key != null) {
+                bitmaps.computeIfAbsent(key, (x) -> new RoaringBitmap32()).add(rid);
+            }
+            rid++;
+        }
+
+        public byte[] serialize() {
+            if (rid == 0) {
+                return new byte[] {};
+            }
+
+            int code = 0;
+            BitSliceIndexBitmap.Appender bsi =
+                    new BitSliceIndexBitmap.Appender(0, bitmaps.size() - 1);
+            for (Map.Entry<Object, RoaringBitmap32> entry : bitmaps.entrySet()) {
+                Object key = entry.getKey();
+                RoaringBitmap32 bitmap = entry.getValue();
+
+                // build the dictionary
+                appender.sortedAppend(key, code);
+
+                // build the relationship between position and code by the bsi
+                Iterator<Integer> iterator = bitmap.iterator();
+                while (iterator.hasNext()) {
+                    bsi.append(iterator.next(), code);
+                }
+
+                code++;
+            }
+
+            // min & max
+            Object min = bitmaps.firstKey();
+            Object max = bitmaps.lastKey();
+
+            int headerSize = 0;
+            headerSize += Byte.BYTES; // version
+            headerSize += Integer.BYTES; // rid
+            headerSize += Integer.BYTES; // cardinality
+            headerSize += serializer.serializedSizeInBytes(min); // min
+            headerSize += serializer.serializedSizeInBytes(max); // max
+            headerSize += Integer.BYTES; // dictionary length
+
+            // dictionary
+            byte[] dictionarySerializeInBytes = appender.serialize();
+            int dictionaryLength = dictionarySerializeInBytes.length;
+
+            // bsi
+            ByteBuffer bsiBuffer = bsi.serialize();
+            int bsiLength = bsiBuffer.array().length;
+
+            ByteBuffer buffer =
+                    ByteBuffer.allocate(Integer.BYTES + headerSize + dictionaryLength + bsiLength);
+            // write header length
+            buffer.putInt(headerSize);
+
+            // write header
+            buffer.put(CURRENT_VERSION);
+            buffer.putInt(rid);
+            buffer.putInt(bitmaps.size());
+            serializer.serialize(buffer, min);
+            serializer.serialize(buffer, max);
+            buffer.putInt(dictionaryLength);
+
+            // write dictionary
+            buffer.put(dictionarySerializeInBytes);
+
+            // write bsi
+            buffer.put(bsiBuffer.array());
+
+            return buffer.array();
+        }
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndex.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndex.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex.rangebitmap;
+
+import org.apache.paimon.fileindex.FileIndexReader;
+import org.apache.paimon.fileindex.FileIndexResult;
+import org.apache.paimon.fileindex.FileIndexWriter;
+import org.apache.paimon.fileindex.FileIndexer;
+import org.apache.paimon.fileindex.bitmap.BitmapIndexResult;
+import org.apache.paimon.fileindex.rangebitmap.dictionary.chunked.KeyFactory;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.types.DataType;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/** Implementation of range-bitmap file index. */
+public class RangeBitmapFileIndex implements FileIndexer {
+
+    public static final int VERSION_1 = 1;
+    public static final int CURRENT_VERSION = VERSION_1;
+
+    private final DataType dataType;
+    private final Options options;
+    public static final String CHUNK_SIZE = "chunk-size";
+
+    public RangeBitmapFileIndex(DataType dataType, Options options) {
+        this.dataType = dataType;
+        this.options = options;
+    }
+
+    @Override
+    public FileIndexWriter createWriter() {
+        return new Writer(dataType, options);
+    }
+
+    @Override
+    public FileIndexReader createReader(SeekableInputStream in, int start, int length) {
+        return new Reader(dataType, in, start);
+    }
+
+    private static class Writer extends FileIndexWriter {
+
+        private final Function<Object, Object> converter;
+        private final RangeBitmap.Appender appender;
+
+        public Writer(DataType dataType, Options options) {
+            KeyFactory factory = KeyFactory.create(dataType);
+            String chunkSize = options.getString(CHUNK_SIZE, factory.defaultChunkSize());
+            this.converter = factory.createConverter();
+            this.appender =
+                    new RangeBitmap.Appender(factory, (int) MemorySize.parse(chunkSize).getBytes());
+        }
+
+        @Override
+        public void write(Object key) {
+            appender.append(converter.apply(key));
+        }
+
+        @Override
+        public byte[] serializedBytes() {
+            return appender.serialize();
+        }
+    }
+
+    private static class Reader extends FileIndexReader {
+
+        private final Function<Object, Object> converter;
+        private final RangeBitmap bitmap;
+
+        public Reader(DataType dataType, SeekableInputStream in, int start) {
+            KeyFactory factory = KeyFactory.create(dataType);
+            this.converter = factory.createConverter();
+            this.bitmap = new RangeBitmap(in, start, factory);
+        }
+
+        @Override
+        public FileIndexResult visitIsNull(FieldRef fieldRef) {
+            return new BitmapIndexResult(bitmap::isNull);
+        }
+
+        @Override
+        public FileIndexResult visitIsNotNull(FieldRef fieldRef) {
+            return new BitmapIndexResult(bitmap::isNotNull);
+        }
+
+        @Override
+        public FileIndexResult visitEqual(FieldRef fieldRef, Object literal) {
+            return new BitmapIndexResult(() -> bitmap.eq(converter.apply(literal)));
+        }
+
+        @Override
+        public FileIndexResult visitNotEqual(FieldRef fieldRef, Object literal) {
+            return new BitmapIndexResult(() -> bitmap.neq(converter.apply(literal)));
+        }
+
+        @Override
+        public FileIndexResult visitIn(FieldRef fieldRef, List<Object> literals) {
+            return new BitmapIndexResult(
+                    () -> bitmap.in(literals.stream().map(converter).collect(Collectors.toList())));
+        }
+
+        @Override
+        public FileIndexResult visitNotIn(FieldRef fieldRef, List<Object> literals) {
+            return new BitmapIndexResult(
+                    () ->
+                            bitmap.notIn(
+                                    literals.stream().map(converter).collect(Collectors.toList())));
+        }
+
+        @Override
+        public FileIndexResult visitLessThan(FieldRef fieldRef, Object literal) {
+            return new BitmapIndexResult(() -> bitmap.lt(converter.apply(literal)));
+        }
+
+        @Override
+        public FileIndexResult visitLessOrEqual(FieldRef fieldRef, Object literal) {
+            return new BitmapIndexResult(() -> bitmap.lte(converter.apply(literal)));
+        }
+
+        @Override
+        public FileIndexResult visitGreaterThan(FieldRef fieldRef, Object literal) {
+            return new BitmapIndexResult(() -> bitmap.gt(converter.apply(literal)));
+        }
+
+        @Override
+        public FileIndexResult visitGreaterOrEqual(FieldRef fieldRef, Object literal) {
+            return new BitmapIndexResult(() -> bitmap.gte(converter.apply(literal)));
+        }
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndexFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndexFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex.rangebitmap;
+
+import org.apache.paimon.fileindex.FileIndexer;
+import org.apache.paimon.fileindex.FileIndexerFactory;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.types.DataType;
+
+/** Factory to create {@link RangeBitmapFileIndex}. */
+public class RangeBitmapFileIndexFactory implements FileIndexerFactory {
+
+    public static final String RANGE_BITMAP = "range-bitmap";
+
+    @Override
+    public String identifier() {
+        return RANGE_BITMAP;
+    }
+
+    @Override
+    public FileIndexer create(DataType dataType, Options options) {
+        return new RangeBitmapFileIndex(dataType, options);
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/Dictionary.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/Dictionary.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex.rangebitmap.dictionary;
+
+/** A dictionary to build the relationship between keys and codes. */
+public interface Dictionary {
+
+    int find(Object key);
+
+    Object find(int code);
+
+    /** Interface for Dictionary Appender. */
+    interface Appender {
+
+        void sortedAppend(Object key, int code);
+
+        byte[] serialize();
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/chunked/AbstractChunk.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/chunked/AbstractChunk.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex.rangebitmap.dictionary.chunked;
+
+import java.util.Comparator;
+
+/** Common implementation of {@link Chunk}. */
+public abstract class AbstractChunk implements Chunk {
+
+    private final Comparator<Object> comparator;
+
+    public AbstractChunk(Comparator<Object> comparator) {
+        this.comparator = comparator;
+    }
+
+    @Override
+    public int find(Object key) {
+        if (comparator.compare(key(), key) == 0) {
+            return code();
+        }
+        int low = 0;
+        int high = size() - 1;
+        while (low <= high) {
+            int mid = (low + high) >>> 1;
+            int result = comparator.compare(get(mid), key);
+            if (result > 0) {
+                high = mid - 1;
+            } else if (result < 0) {
+                low = mid + 1;
+            } else {
+                return code() + mid + 1;
+            }
+        }
+        return -(code() + low + 1);
+    }
+
+    @Override
+    public Object find(int code) {
+        int current = code();
+        if (current == code) {
+            return key();
+        }
+        int index = code - current - 1;
+        return get(index);
+    }
+
+    protected abstract int size();
+
+    protected abstract Object get(int index);
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/chunked/Chunk.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/chunked/Chunk.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex.rangebitmap.dictionary.chunked;
+
+/** A part of the {@link ChunkedDictionary}. */
+public interface Chunk {
+
+    boolean tryAdd(Object key);
+
+    int find(Object key);
+
+    Object find(int code);
+
+    Object key();
+
+    int code();
+
+    byte[] serializeChunk();
+
+    byte[] serializeKeys();
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/chunked/ChunkedDictionary.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/chunked/ChunkedDictionary.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex.rangebitmap.dictionary.chunked;
+
+import org.apache.paimon.fileindex.rangebitmap.dictionary.Dictionary;
+import org.apache.paimon.fs.SeekableInputStream;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Comparator;
+
+/** Chunked implementation of {@link Dictionary}. */
+public class ChunkedDictionary implements Dictionary {
+
+    public static final byte CURRENT_VERSION = 1;
+
+    private final byte version;
+    private final int size;
+    private final int offsetsLength;
+    private final int chunksLength;
+    private final int bodyOffset;
+    private final SeekableInputStream in;
+    private final KeyFactory factory;
+    private final Comparator<Object> comparator;
+    private final Chunk[] caches;
+
+    private ByteBuffer offsets;
+    private ByteBuffer chunks;
+
+    public ChunkedDictionary(SeekableInputStream in, int offset, KeyFactory factory)
+            throws IOException {
+        in.seek(offset);
+        byte[] headerLengthInBytes = new byte[Integer.BYTES];
+        in.read(headerLengthInBytes);
+        int headerLength = ByteBuffer.wrap(headerLengthInBytes).getInt();
+
+        byte[] headerInBytes = new byte[headerLength];
+        in.read(headerInBytes);
+        ByteBuffer header = ByteBuffer.wrap(headerInBytes);
+
+        this.version = header.get();
+        if (version > CURRENT_VERSION) {
+            throw new IllegalArgumentException(String.format("invalid version %d", version));
+        }
+        this.size = header.getInt();
+        this.offsetsLength = header.getInt();
+        this.chunksLength = header.getInt();
+        this.factory = factory;
+        this.comparator = factory.createComparator();
+        this.in = in;
+        this.bodyOffset = offset + Integer.BYTES + headerLength;
+        this.caches = new Chunk[size];
+    }
+
+    @Override
+    public int find(Object key) {
+        int low = 0;
+        int high = size - 1;
+        while (low <= high) {
+            int mid = (low + high) >>> 1;
+            Chunk found = get(mid);
+            int result = comparator.compare(found.key(), key);
+            if (result > 0) {
+                high = mid - 1;
+            } else if (result < 0) {
+                low = mid + 1;
+            } else {
+                return found.code();
+            }
+        }
+        return get(low - 1).find(key);
+    }
+
+    @Override
+    public Object find(int code) {
+        int low = 0;
+        int high = size - 1;
+        while (low <= high) {
+            int mid = (low + high) >>> 1;
+            Chunk found = get(mid);
+            int result = Integer.compare(found.code(), code);
+            if (result > 0) {
+                high = mid - 1;
+            } else if (result < 0) {
+                low = mid + 1;
+            } else {
+                return found.key();
+            }
+        }
+        return get(low - 1).find(code);
+    }
+
+    private Chunk get(int index) {
+        if (caches[index] != null) {
+            return caches[index];
+        }
+
+        if (offsets == null || chunks == null) {
+            try {
+                byte[] bytes = new byte[offsetsLength + chunksLength];
+                in.seek(bodyOffset);
+                in.read(bytes);
+
+                ByteBuffer buffer = ByteBuffer.wrap(bytes);
+                offsets = (ByteBuffer) buffer.slice().limit(offsetsLength);
+
+                buffer.position(offsetsLength);
+                chunks = (ByteBuffer) buffer.slice().limit(chunksLength);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        offsets.position(index * Integer.BYTES);
+        int offset = offsets.getInt();
+        chunks.position(offset);
+        ByteBuffer header =
+                offsets.position() == offsets.limit()
+                        ? (ByteBuffer) chunks.slice().limit(chunksLength - offset)
+                        : (ByteBuffer) chunks.slice().limit(offsets.getInt() - offset);
+        caches[index] = factory.mmapChunk(header, bodyOffset + offsetsLength + chunksLength, in);
+        return caches[index];
+    }
+
+    /** A Builder for {@link ChunkedDictionary}. */
+    public static class Appender implements Dictionary.Appender {
+
+        public static final byte CURRENT_VERSION = 1;
+
+        private final KeyFactory factory;
+        private final Comparator<Object> comparator;
+        private final int limitedSerializedSizeInBytes;
+        private final ByteArrayOutputStream offsetsBos;
+        private final DataOutputStream offsets;
+
+        private final ByteArrayOutputStream chunksBos;
+        private final DataOutputStream chunks;
+
+        private final ByteArrayOutputStream keysBos;
+        private final DataOutputStream keys;
+
+        private Chunk chunk;
+        private int chunksOffset;
+        private int keysOffset;
+        private int size;
+
+        private Object key;
+        private Integer code;
+
+        public Appender(KeyFactory factory, int limitedSerializedSizeInBytes) {
+            this.factory = factory;
+            this.comparator = factory.createComparator();
+            this.limitedSerializedSizeInBytes = limitedSerializedSizeInBytes;
+            this.offsetsBos = new ByteArrayOutputStream();
+            this.chunksBos = new ByteArrayOutputStream();
+            this.keysBos = new ByteArrayOutputStream();
+            this.offsets = new DataOutputStream(offsetsBos);
+            this.chunks = new DataOutputStream(chunksBos);
+            this.keys = new DataOutputStream(keysBos);
+            this.chunksOffset = 0;
+            this.keysOffset = 0;
+        }
+
+        @Override
+        public void sortedAppend(Object key, int code) {
+            if (key == null) {
+                throw new IllegalArgumentException("key should not be null");
+            }
+
+            if (this.key != null && comparator.compare(this.key, key) > 0) {
+                throw new IllegalArgumentException("key can not out of order");
+            } else {
+                this.key = key;
+            }
+
+            if (this.code != null && this.code.compareTo(code) > 0) {
+                throw new IllegalArgumentException("code can not out of order");
+            } else {
+                this.code = code;
+            }
+
+            append(key, code);
+        }
+
+        @Override
+        public byte[] serialize() {
+            if (chunk != null) {
+                flush();
+            }
+
+            int headerSize = 0;
+            headerSize += Byte.BYTES; // version
+            headerSize += Integer.BYTES; // size
+            headerSize += Integer.BYTES; // offsets length
+            headerSize += Integer.BYTES; // chunks length
+
+            int bodySize = 0;
+            bodySize += offsets.size();
+            bodySize += chunks.size();
+            bodySize += keys.size();
+
+            ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES + headerSize + bodySize);
+            // write header length
+            buffer.putInt(headerSize);
+
+            // write header
+            buffer.put(CURRENT_VERSION);
+            buffer.putInt(size);
+            buffer.putInt(offsets.size());
+            buffer.putInt(chunks.size());
+
+            // write body
+            buffer.put(offsetsBos.toByteArray());
+            buffer.put(chunksBos.toByteArray());
+            buffer.put(keysBos.toByteArray());
+
+            return buffer.array();
+        }
+
+        private void append(Object key, int code) {
+            if (chunk == null) {
+                chunk = factory.createChunk(key, code, keysOffset, limitedSerializedSizeInBytes);
+            } else {
+                if (chunk.tryAdd(key)) {
+                    return;
+                }
+                flush();
+                chunk = factory.createChunk(key, code, keysOffset, limitedSerializedSizeInBytes);
+            }
+        }
+
+        private void flush() {
+            try {
+                byte[] chunkInBytes = chunk.serializeChunk();
+                byte[] keysInBytes = chunk.serializeKeys();
+
+                offsets.writeInt(chunksOffset);
+                chunksOffset += chunkInBytes.length;
+                keysOffset += keysInBytes.length;
+
+                chunks.write(chunkInBytes);
+                keys.write(keysInBytes);
+
+                size += 1;
+                chunk = null;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/chunked/FixedLengthChunk.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/chunked/FixedLengthChunk.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex.rangebitmap.dictionary.chunked;
+
+import org.apache.paimon.fs.SeekableInputStream;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Comparator;
+
+/** Fixed length implementation of {@link Chunk}. */
+public class FixedLengthChunk extends AbstractChunk {
+
+    public static final byte CURRENT_VERSION = 1;
+
+    private final byte version;
+    private final Object key;
+    private final int code;
+    private final int offset;
+    private final int fixedLength;
+
+    private int size;
+    private int keysBaseOffset;
+    private int keysLength;
+    private SeekableInputStream in;
+    private ByteBuffer keys;
+    private KeyFactory.KeySerializer serializer;
+    private KeyFactory.KeyDeserializer deserializer;
+
+    public FixedLengthChunk(
+            Object key,
+            int code,
+            int offset,
+            int limitedSerializedSizeInBytes,
+            KeyFactory.KeySerializer serializer,
+            Comparator<Object> comparator) {
+        super(comparator);
+        this.version = CURRENT_VERSION;
+        this.key = key;
+        this.code = code;
+        this.offset = offset;
+        this.size = 0;
+        this.keys = ByteBuffer.allocate(limitedSerializedSizeInBytes);
+        this.serializer = serializer;
+        this.fixedLength = this.serializer.serializedSizeInBytes(key);
+    }
+
+    public FixedLengthChunk(
+            ByteBuffer headers,
+            int keysBaseOffset,
+            SeekableInputStream in,
+            KeyFactory.KeyDeserializer deserializer,
+            Comparator<Object> comparator) {
+        super(comparator);
+        this.version = headers.get();
+        if (version > CURRENT_VERSION) {
+            throw new IllegalArgumentException("version out of range");
+        }
+        this.key = deserializer.deserialize(headers);
+        this.code = headers.getInt();
+        this.offset = headers.getInt();
+        this.size = headers.getInt();
+        this.keysLength = headers.getInt();
+        this.fixedLength = headers.getInt();
+        this.keysBaseOffset = keysBaseOffset;
+        this.in = in;
+        this.deserializer = deserializer;
+    }
+
+    @Override
+    protected int size() {
+        return size;
+    }
+
+    @Override
+    protected Object get(int index) {
+        if (keys == null) {
+            try {
+                in.seek(keysBaseOffset + offset);
+                byte[] bytes = new byte[keysLength];
+                in.read(bytes);
+                keys = ByteBuffer.wrap(bytes);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        keys.position(index * fixedLength);
+        return deserializer.deserialize(keys);
+    }
+
+    @Override
+    public boolean tryAdd(Object key) {
+        if (fixedLength > keys.remaining()) {
+            return false;
+        }
+        serializer.serialize(keys, key);
+        size += 1;
+        return true;
+    }
+
+    @Override
+    public Object key() {
+        return key;
+    }
+
+    @Override
+    public int code() {
+        return code;
+    }
+
+    @Override
+    public byte[] serializeChunk() {
+        keys.flip();
+
+        int serializedSizeInBytes = 0;
+        serializedSizeInBytes += Byte.BYTES;
+        serializedSizeInBytes += fixedLength; // key length
+        serializedSizeInBytes += Integer.BYTES; // code
+        serializedSizeInBytes += Integer.BYTES; // offset
+        serializedSizeInBytes += Integer.BYTES; // size
+        serializedSizeInBytes += Integer.BYTES; // keys length
+        serializedSizeInBytes += Integer.BYTES; // fixed length
+
+        ByteBuffer buffer = ByteBuffer.allocate(serializedSizeInBytes);
+        buffer.put(version);
+        serializer.serialize(buffer, key);
+        buffer.putInt(code);
+        buffer.putInt(offset);
+        buffer.putInt(size);
+        buffer.putInt(keys.limit());
+        buffer.putInt(fixedLength);
+        return buffer.array();
+    }
+
+    @Override
+    public byte[] serializeKeys() {
+        return Arrays.copyOf(keys.array(), keys.limit());
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/chunked/KeyFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/chunked/KeyFactory.java
@@ -1,0 +1,554 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex.rangebitmap.dictionary.chunked;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Decimal;
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.fileindex.rangebitmap.RangeBitmapFileIndexFactory;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.types.BigIntType;
+import org.apache.paimon.types.BooleanType;
+import org.apache.paimon.types.CharType;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeDefaultVisitor;
+import org.apache.paimon.types.DateType;
+import org.apache.paimon.types.DecimalType;
+import org.apache.paimon.types.DoubleType;
+import org.apache.paimon.types.FloatType;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.LocalZonedTimestampType;
+import org.apache.paimon.types.SmallIntType;
+import org.apache.paimon.types.TimeType;
+import org.apache.paimon.types.TimestampType;
+import org.apache.paimon.types.TinyIntType;
+import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.utils.Preconditions;
+
+import java.nio.ByteBuffer;
+import java.util.Comparator;
+import java.util.function.Function;
+
+/** Common implementation of {@link Chunk}. */
+public interface KeyFactory {
+
+    static KeyFactory create(DataType type) {
+        return type.accept(
+                new DataTypeDefaultVisitor<KeyFactory>() {
+
+                    @Override
+                    public KeyFactory visit(CharType charType) {
+                        return new StringKeyFactory();
+                    }
+
+                    @Override
+                    public KeyFactory visit(VarCharType varCharType) {
+                        return new StringKeyFactory();
+                    }
+
+                    @Override
+                    public KeyFactory visit(BooleanType booleanType) {
+                        return new BooleanKeyFactory();
+                    }
+
+                    @Override
+                    public KeyFactory visit(DecimalType decimalType) {
+                        return new DecimalKeyFactory(decimalType.getPrecision());
+                    }
+
+                    @Override
+                    public KeyFactory visit(TinyIntType tinyIntType) {
+                        return new TinyIntKeyFactory();
+                    }
+
+                    @Override
+                    public KeyFactory visit(SmallIntType smallIntType) {
+                        return new SmallIntKeyFactory();
+                    }
+
+                    @Override
+                    public KeyFactory visit(IntType intType) {
+                        return new IntKeyFactory();
+                    }
+
+                    @Override
+                    public KeyFactory visit(BigIntType bigIntType) {
+                        return new BigIntKeyFactory();
+                    }
+
+                    @Override
+                    public KeyFactory visit(FloatType floatType) {
+                        return new FloatKeyFactory();
+                    }
+
+                    @Override
+                    public KeyFactory visit(DoubleType doubleType) {
+                        return new DoubleKeyFactory();
+                    }
+
+                    @Override
+                    public KeyFactory visit(DateType dateType) {
+                        return new IntKeyFactory();
+                    }
+
+                    @Override
+                    public KeyFactory visit(TimeType timeType) {
+                        return new IntKeyFactory();
+                    }
+
+                    @Override
+                    public KeyFactory visit(TimestampType timestampType) {
+                        return new TimestampKeyFactory(timestampType.getPrecision());
+                    }
+
+                    @Override
+                    public KeyFactory visit(LocalZonedTimestampType localZonedTimestampType) {
+                        return new TimestampKeyFactory(localZonedTimestampType.getPrecision());
+                    }
+
+                    @Override
+                    protected KeyFactory defaultMethod(DataType dataType) {
+                        throw new UnsupportedOperationException(
+                                "data type " + dataType + "is not supported.");
+                    }
+                });
+    }
+
+    default Function<Object, Object> createConverter() {
+        return Function.identity();
+    }
+
+    default String defaultChunkSize() {
+        return "16kb";
+    }
+
+    Comparator<Object> createComparator();
+
+    KeySerializer createSerializer();
+
+    KeyDeserializer createDeserializer();
+
+    Chunk createChunk(Object key, int code, int offset, int limitedSerializedSizeInBytes);
+
+    Chunk mmapChunk(ByteBuffer buffer, int offset, SeekableInputStream in);
+
+    /** The key serializer. */
+    interface KeySerializer {
+        void serialize(ByteBuffer buffer, Object key);
+
+        int serializedSizeInBytes(Object key);
+    }
+
+    /** The key deserializer. */
+    interface KeyDeserializer {
+        Object deserialize(ByteBuffer buffer);
+    }
+
+    /** Abstract KeyFactory for fixed length chunk. */
+    abstract class FixedLengthKeyFactory implements KeyFactory {
+
+        @Override
+        public Chunk createChunk(
+                Object key, int code, int offset, int limitedSerializedSizeInBytes) {
+            return new FixedLengthChunk(
+                    key,
+                    code,
+                    offset,
+                    limitedSerializedSizeInBytes,
+                    createSerializer(),
+                    createComparator());
+        }
+
+        @Override
+        public Chunk mmapChunk(ByteBuffer buffer, int offset, SeekableInputStream in) {
+            return new FixedLengthChunk(
+                    buffer, offset, in, createDeserializer(), createComparator());
+        }
+    }
+
+    /** Abstract KeyFactory for variable length chunk. */
+    abstract class VariableLengthKeyFactory implements KeyFactory {
+
+        @Override
+        public Chunk createChunk(
+                Object key, int code, int offset, int limitedSerializedSizeInBytes) {
+            return new VariableLengthChunk(
+                    key,
+                    code,
+                    offset,
+                    limitedSerializedSizeInBytes,
+                    createSerializer(),
+                    createComparator());
+        }
+
+        @Override
+        public Chunk mmapChunk(ByteBuffer buffer, int offset, SeekableInputStream in) {
+            return new VariableLengthChunk(
+                    buffer, offset, in, createDeserializer(), createComparator());
+        }
+    }
+
+    /** KeyFactory for INT & DATE & TIME. */
+    class IntKeyFactory extends FixedLengthKeyFactory {
+
+        @Override
+        public Comparator<Object> createComparator() {
+            return Comparator.comparing(o -> ((Integer) o));
+        }
+
+        @Override
+        public KeySerializer createSerializer() {
+            return new KeySerializer() {
+                @Override
+                public void serialize(ByteBuffer buffer, Object input) {
+                    buffer.putInt((Integer) input);
+                }
+
+                @Override
+                public int serializedSizeInBytes(Object input) {
+                    return Integer.BYTES;
+                }
+            };
+        }
+
+        @Override
+        public KeyDeserializer createDeserializer() {
+            return new KeyDeserializer() {
+
+                @Override
+                public Object deserialize(ByteBuffer buffer) {
+                    return buffer.getInt();
+                }
+            };
+        }
+    }
+
+    /** KeyFactory for BIGINT. */
+    class BigIntKeyFactory extends FixedLengthKeyFactory {
+
+        @Override
+        public Comparator<Object> createComparator() {
+            return Comparator.comparing(o -> ((Long) o));
+        }
+
+        @Override
+        public KeySerializer createSerializer() {
+            return new KeySerializer() {
+                @Override
+                public void serialize(ByteBuffer buffer, Object input) {
+                    buffer.putLong((Long) input);
+                }
+
+                @Override
+                public int serializedSizeInBytes(Object input) {
+                    return Long.BYTES;
+                }
+            };
+        }
+
+        @Override
+        public KeyDeserializer createDeserializer() {
+            return new KeyDeserializer() {
+
+                @Override
+                public Object deserialize(ByteBuffer buffer) {
+                    return buffer.getLong();
+                }
+            };
+        }
+    }
+
+    /** KeyFactory for BOOLEAN. */
+    class BooleanKeyFactory extends FixedLengthKeyFactory {
+
+        @Override
+        public Comparator<Object> createComparator() {
+            return Comparator.comparing(o -> ((Boolean) o));
+        }
+
+        @Override
+        public KeySerializer createSerializer() {
+            return new KeySerializer() {
+                @Override
+                public void serialize(ByteBuffer buffer, Object input) {
+                    buffer.put(Boolean.TRUE.equals(input) ? (byte) 1 : (byte) 0);
+                }
+
+                @Override
+                public int serializedSizeInBytes(Object input) {
+                    return Byte.BYTES;
+                }
+            };
+        }
+
+        @Override
+        public KeyDeserializer createDeserializer() {
+            return new KeyDeserializer() {
+
+                @Override
+                public Object deserialize(ByteBuffer buffer) {
+                    return buffer.get() == (byte) 1;
+                }
+            };
+        }
+
+        @Override
+        public String defaultChunkSize() {
+            // no chunking required
+            return "0b";
+        }
+    }
+
+    /** KeyFactory for TINYINT. */
+    class TinyIntKeyFactory extends FixedLengthKeyFactory {
+
+        @Override
+        public Comparator<Object> createComparator() {
+            return Comparator.comparing(o -> ((Byte) o));
+        }
+
+        @Override
+        public KeySerializer createSerializer() {
+            return new KeySerializer() {
+                @Override
+                public void serialize(ByteBuffer buffer, Object key) {
+                    buffer.put((Byte) key);
+                }
+
+                @Override
+                public int serializedSizeInBytes(Object key) {
+                    return Byte.BYTES;
+                }
+            };
+        }
+
+        @Override
+        public KeyDeserializer createDeserializer() {
+            return new KeyDeserializer() {
+                @Override
+                public Object deserialize(ByteBuffer buffer) {
+                    return buffer.get();
+                }
+            };
+        }
+
+        @Override
+        public String defaultChunkSize() {
+            // no chunking required
+            return "0b";
+        }
+    }
+
+    /** KeyFactory for SMALLINT. */
+    class SmallIntKeyFactory extends FixedLengthKeyFactory {
+
+        @Override
+        public Comparator<Object> createComparator() {
+            return Comparator.comparing(o -> ((Short) o));
+        }
+
+        @Override
+        public KeySerializer createSerializer() {
+            return new KeySerializer() {
+                @Override
+                public void serialize(ByteBuffer buffer, Object key) {
+                    buffer.putShort((Short) key);
+                }
+
+                @Override
+                public int serializedSizeInBytes(Object key) {
+                    return Short.BYTES;
+                }
+            };
+        }
+
+        @Override
+        public KeyDeserializer createDeserializer() {
+            return new KeyDeserializer() {
+                @Override
+                public Object deserialize(ByteBuffer buffer) {
+                    return buffer.getShort();
+                }
+            };
+        }
+
+        @Override
+        public String defaultChunkSize() {
+            // no chunking required
+            return "0b";
+        }
+    }
+
+    /** KeyFactory for FLOAT. */
+    class FloatKeyFactory extends FixedLengthKeyFactory {
+
+        @Override
+        public Comparator<Object> createComparator() {
+            return Comparator.comparing(o -> ((Float) o));
+        }
+
+        @Override
+        public KeySerializer createSerializer() {
+            return new KeySerializer() {
+                @Override
+                public void serialize(ByteBuffer buffer, Object key) {
+                    buffer.putFloat((Float) key);
+                }
+
+                @Override
+                public int serializedSizeInBytes(Object key) {
+                    return Float.BYTES;
+                }
+            };
+        }
+
+        @Override
+        public KeyDeserializer createDeserializer() {
+            return new KeyDeserializer() {
+                @Override
+                public Object deserialize(ByteBuffer buffer) {
+                    return buffer.getFloat();
+                }
+            };
+        }
+    }
+
+    /** KeyFactory for DOUBLE. */
+    class DoubleKeyFactory extends FixedLengthKeyFactory {
+
+        @Override
+        public Comparator<Object> createComparator() {
+            return Comparator.comparing(o -> ((Double) o));
+        }
+
+        @Override
+        public KeySerializer createSerializer() {
+            return new KeySerializer() {
+                @Override
+                public void serialize(ByteBuffer buffer, Object key) {
+                    buffer.putDouble((Double) key);
+                }
+
+                @Override
+                public int serializedSizeInBytes(Object key) {
+                    return Double.BYTES;
+                }
+            };
+        }
+
+        @Override
+        public KeyDeserializer createDeserializer() {
+            return new KeyDeserializer() {
+                @Override
+                public Object deserialize(ByteBuffer buffer) {
+                    return buffer.getDouble();
+                }
+            };
+        }
+    }
+
+    /** KeyFactory for DECIMAL. */
+    class DecimalKeyFactory extends BigIntKeyFactory {
+
+        public DecimalKeyFactory(int precision) {
+            Preconditions.checkArgument(
+                    precision <= 18,
+                    String.format(
+                            "The %s index only supports DECIMAL with a precision in [0, 18].",
+                            RangeBitmapFileIndexFactory.RANGE_BITMAP));
+        }
+
+        @Override
+        public Function<Object, Object> createConverter() {
+            return o -> o == null ? null : ((Decimal) o).toUnscaledLong();
+        }
+    }
+
+    /** KeyFactory for TIMESTAMP & TIMESTAMP_LTZ. */
+    class TimestampKeyFactory extends BigIntKeyFactory {
+
+        private final int precision;
+
+        public TimestampKeyFactory(int precision) {
+            Preconditions.checkArgument(
+                    precision <= 6,
+                    String.format(
+                            "The %s index only supports TIMESTAMP with a precision in [0, 6].",
+                            RangeBitmapFileIndexFactory.RANGE_BITMAP));
+            this.precision = precision;
+        }
+
+        @Override
+        public Function<Object, Object> createConverter() {
+            return o -> {
+                if (o == null) {
+                    return null;
+                } else if (precision <= 3) {
+                    return ((Timestamp) o).getMillisecond();
+                } else {
+                    return ((Timestamp) o).toMicros();
+                }
+            };
+        }
+    }
+
+    /** KeyFactory for STRING & VARCHAR & CHAR. */
+    class StringKeyFactory extends VariableLengthKeyFactory {
+
+        @Override
+        public Function<Object, Object> createConverter() {
+            return o -> o == null ? null : ((BinaryString) o).copy();
+        }
+
+        @Override
+        public Comparator<Object> createComparator() {
+            return Comparator.comparing(o -> ((BinaryString) o));
+        }
+
+        @Override
+        public KeySerializer createSerializer() {
+            return new KeySerializer() {
+                @Override
+                public void serialize(ByteBuffer buffer, Object input) {
+                    byte[] bytes = ((BinaryString) input).toBytes();
+                    buffer.putInt(bytes.length);
+                    buffer.put(bytes);
+                }
+
+                @Override
+                public int serializedSizeInBytes(Object input) {
+                    return Integer.BYTES + ((BinaryString) input).getSizeInBytes();
+                }
+            };
+        }
+
+        @Override
+        public KeyDeserializer createDeserializer() {
+            return new KeyDeserializer() {
+                @Override
+                public Object deserialize(ByteBuffer buffer) {
+                    int length = buffer.getInt();
+                    byte[] bytes = new byte[length];
+                    buffer.get(bytes);
+                    return BinaryString.fromBytes(bytes);
+                }
+            };
+        }
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/chunked/VariableLengthChunk.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/chunked/VariableLengthChunk.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex.rangebitmap.dictionary.chunked;
+
+import org.apache.paimon.fs.SeekableInputStream;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Comparator;
+
+/** Variable length implementation of {@link Chunk}. */
+public class VariableLengthChunk extends AbstractChunk {
+
+    public static final byte CURRENT_VERSION = 1;
+
+    private final byte version;
+    private final Object key;
+    private final int code;
+    private final int offset;
+
+    private int size;
+    private int currentOffset;
+
+    private int keysBaseOffset;
+    private int offsetsLength;
+    private int keysLength;
+    private SeekableInputStream in;
+    private ByteBuffer offsets;
+    private ByteBuffer keys;
+
+    private KeyFactory.KeySerializer serializer;
+    private KeyFactory.KeyDeserializer deserializer;
+
+    public VariableLengthChunk(
+            Object key,
+            int code,
+            int offset,
+            int limitedSerializedSizeInBytes,
+            KeyFactory.KeySerializer serializer,
+            Comparator<Object> comparator) {
+        super(comparator);
+        this.version = CURRENT_VERSION;
+        this.key = key;
+        this.code = code;
+        this.offset = offset;
+        this.size = 0;
+        this.currentOffset = 0;
+        this.serializer = serializer;
+        this.offsets = ByteBuffer.allocate(limitedSerializedSizeInBytes);
+        this.keys = ByteBuffer.allocate(limitedSerializedSizeInBytes);
+    }
+
+    public VariableLengthChunk(
+            ByteBuffer headers,
+            int keysBaseOffset,
+            SeekableInputStream in,
+            KeyFactory.KeyDeserializer deserializer,
+            Comparator<Object> comparator) {
+        super(comparator);
+        this.version = headers.get();
+        if (version > CURRENT_VERSION) {
+            throw new IllegalArgumentException("version out of range");
+        }
+        this.key = deserializer.deserialize(headers);
+        this.code = headers.getInt();
+        this.offset = headers.getInt();
+        this.size = headers.getInt();
+        this.offsetsLength = headers.getInt();
+        this.keysLength = headers.getInt();
+        this.keysBaseOffset = keysBaseOffset;
+        this.in = in;
+        this.deserializer = deserializer;
+    }
+
+    @Override
+    public boolean tryAdd(Object key) {
+        int length = serializer.serializedSizeInBytes(key);
+        if (length > keys.remaining() || Integer.BYTES > offsets.remaining()) {
+            return false;
+        }
+        offsets.putInt(currentOffset);
+        serializer.serialize(keys, key);
+        currentOffset += length;
+        size += 1;
+        return true;
+    }
+
+    @Override
+    public Object key() {
+        return key;
+    }
+
+    @Override
+    public int code() {
+        return code;
+    }
+
+    @Override
+    protected int size() {
+        return size;
+    }
+
+    @Override
+    protected Object get(int index) {
+        if (offsets == null || keys == null) {
+            try {
+                in.seek(keysBaseOffset + offset);
+                byte[] bytes = new byte[offsetsLength + keysLength];
+                in.read(bytes);
+
+                ByteBuffer buffer = ByteBuffer.wrap(bytes);
+                offsets = (ByteBuffer) buffer.slice().limit(offsetsLength);
+
+                buffer.position(offsetsLength);
+                keys = (ByteBuffer) buffer.slice().limit(keysLength);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        offsets.position(index * Integer.BYTES);
+        keys.position(offsets.getInt());
+        return deserializer.deserialize(keys);
+    }
+
+    @Override
+    public byte[] serializeChunk() {
+        offsets.flip();
+        keys.flip();
+
+        int serializedSizeInBytes = 0;
+        serializedSizeInBytes += Byte.BYTES;
+        serializedSizeInBytes += serializer.serializedSizeInBytes(key); // key
+        serializedSizeInBytes += Integer.BYTES; // code
+        serializedSizeInBytes += Integer.BYTES; // offset
+        serializedSizeInBytes += Integer.BYTES; // size
+        serializedSizeInBytes += Integer.BYTES; // offsets length
+        serializedSizeInBytes += Integer.BYTES; // keys length
+
+        ByteBuffer buffer = ByteBuffer.allocate(serializedSizeInBytes);
+        buffer.put(version);
+        serializer.serialize(buffer, key);
+        buffer.putInt(code);
+        buffer.putInt(offset);
+        buffer.putInt(size);
+        buffer.putInt(offsets.limit());
+        buffer.putInt(keys.limit());
+        return buffer.array();
+    }
+
+    @Override
+    public byte[] serializeKeys() {
+        ByteBuffer buffer = ByteBuffer.allocate(offsets.limit() + keys.limit());
+        buffer.put(offsets);
+        buffer.put(keys);
+        return buffer.array();
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/RoaringBitmap32.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/RoaringBitmap32.java
@@ -57,8 +57,16 @@ public class RoaringBitmap32 {
         roaringBitmap.add(x);
     }
 
+    public void and(RoaringBitmap32 other) {
+        roaringBitmap.and(other.roaringBitmap);
+    }
+
     public void or(RoaringBitmap32 other) {
         roaringBitmap.or(other.roaringBitmap);
+    }
+
+    public void andNot(RoaringBitmap32 other) {
+        roaringBitmap.andNot(other.roaringBitmap);
     }
 
     public boolean checkedAdd(int x) {

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/rangebitmap/BitSliceIndexBitmapTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/rangebitmap/BitSliceIndexBitmapTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex.rangebitmap;
+
+import org.apache.paimon.fs.ByteArraySeekableStream;
+import org.apache.paimon.utils.Pair;
+import org.apache.paimon.utils.RoaringBitmap32;
+
+import org.junit.jupiter.api.RepeatedTest;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test case for {@link BitSliceIndexBitmap}. */
+public class BitSliceIndexBitmapTest {
+
+    private static final int CARDINALITY = 100;
+    private static final int ROW_COUNT = 10000;
+
+    @RepeatedTest(5)
+    public void test() throws IOException {
+        Random random = new Random();
+        List<Pair<Integer, Integer>> pairs = new ArrayList<>();
+        BitSliceIndexBitmap.Appender appender = new BitSliceIndexBitmap.Appender(0, CARDINALITY);
+        for (int i = 0; i < ROW_COUNT; i++) {
+            Integer value = random.nextBoolean() ? random.nextInt(CARDINALITY) : null;
+            pairs.add(Pair.of(i, value));
+            if (value != null) {
+                appender.append(i, value);
+            }
+        }
+
+        ByteBuffer serialize = appender.serialize();
+        ByteArraySeekableStream in = new ByteArraySeekableStream(serialize.array());
+        BitSliceIndexBitmap bsi = new BitSliceIndexBitmap(in, 0);
+
+        // test eq
+        for (int i = 0; i < 10; i++) {
+            int code = random.nextInt(CARDINALITY);
+            RoaringBitmap32 bitmap = new RoaringBitmap32();
+            for (Pair<Integer, Integer> pair : pairs) {
+                if (Objects.equals(code, pair.getValue())) {
+                    bitmap.add(pair.getKey());
+                }
+            }
+            assertThat(bsi.eq(code)).isEqualTo(bitmap);
+        }
+
+        // test gt
+        for (int i = 0; i < 10; i++) {
+            int code = random.nextInt(CARDINALITY);
+            RoaringBitmap32 bitmap = new RoaringBitmap32();
+            for (Pair<Integer, Integer> pair : pairs) {
+                if (pair.getValue() != null && pair.getValue() > code) {
+                    bitmap.add(pair.getKey());
+                }
+            }
+            assertThat(bsi.gt(code)).isEqualTo(bitmap);
+        }
+
+        // test gte
+        for (int i = 0; i < 10; i++) {
+            int code = random.nextInt(CARDINALITY);
+            RoaringBitmap32 bitmap = new RoaringBitmap32();
+            for (Pair<Integer, Integer> pair : pairs) {
+                if (pair.getValue() != null && pair.getValue() >= code) {
+                    bitmap.add(pair.getKey());
+                }
+            }
+            assertThat(bsi.gte(code)).isEqualTo(bitmap);
+        }
+
+        // test is not null
+        {
+            RoaringBitmap32 bitmap = new RoaringBitmap32();
+            for (Pair<Integer, Integer> pair : pairs) {
+                if (pair.getValue() != null) {
+                    bitmap.add(pair.getKey());
+                }
+            }
+            assertThat(bsi.isNotNull()).isEqualTo(bitmap);
+        }
+
+        // test get
+        for (Pair<Integer, Integer> pair : pairs) {
+            assertThat(bsi.get(pair.getKey())).isEqualTo(pair.getValue());
+        }
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/rangebitmap/ChunkedDictionaryTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/rangebitmap/ChunkedDictionaryTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex.rangebitmap;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.fileindex.rangebitmap.dictionary.chunked.ChunkedDictionary;
+import org.apache.paimon.fileindex.rangebitmap.dictionary.chunked.KeyFactory;
+import org.apache.paimon.fs.ByteArraySeekableStream;
+
+import org.junit.jupiter.api.RepeatedTest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test case for {@link ChunkedDictionary}. */
+public class ChunkedDictionaryTest {
+
+    private static final int CARDINALITY = 10000;
+    private static final int BOUND = 1000000;
+
+    @RepeatedTest(10)
+    public void test() throws IOException {
+        testFixedLengthChunkedDictionary(0); // test no chunked
+        testFixedLengthChunkedDictionary(128); // test chunked
+
+        testVariableLengthChunkedDictionary(0); // test no chunked
+        testVariableLengthChunkedDictionary(512); // test chunked
+    }
+
+    private void testFixedLengthChunkedDictionary(int limitedSize) throws IOException {
+        Random random = new Random();
+        Set<Integer> set = new HashSet<>();
+        for (int i = 0; i < CARDINALITY; i++) {
+            int next;
+            do {
+                next = random.nextInt(BOUND);
+                next = random.nextBoolean() ? next : -next;
+            } while (set.contains(next));
+            set.add(next);
+        }
+
+        List<Integer> expected = set.stream().sorted().collect(Collectors.toList());
+
+        KeyFactory.IntKeyFactory factory = new KeyFactory.IntKeyFactory();
+        ChunkedDictionary.Appender appender = new ChunkedDictionary.Appender(factory, limitedSize);
+        for (int i = 0; i < expected.size(); i++) {
+            appender.sortedAppend(expected.get(i), i);
+        }
+
+        ChunkedDictionary dictionary =
+                new ChunkedDictionary(
+                        new ByteArraySeekableStream(appender.serialize()), 0, factory);
+        for (int i = 0; i < expected.size(); i++) {
+            Integer value = expected.get(i);
+
+            // find code by key
+            assertThat(dictionary.find(value)).isEqualTo(i);
+
+            // find key by code
+            assertThat(dictionary.find(i)).isEqualTo(value);
+        }
+
+        // not exists
+        for (int i = 0; i < 10; i++) {
+            Integer value = random.nextInt(BOUND) + BOUND;
+            // find code by key
+            assertThat(dictionary.find(value)).isNegative();
+            assertThat(dictionary.find(value))
+                    .isEqualTo(Collections.binarySearch(expected, value) + 1);
+        }
+    }
+
+    private void testVariableLengthChunkedDictionary(int limitedSize) throws IOException {
+        List<BinaryString> expected = new ArrayList<>(CARDINALITY);
+        for (int i = 0; i < CARDINALITY; i++) {
+            expected.add(BinaryString.fromString(UUID.randomUUID().toString()));
+        }
+        expected.sort(Comparator.comparing(o -> o));
+
+        KeyFactory.StringKeyFactory factory = new KeyFactory.StringKeyFactory();
+        ChunkedDictionary.Appender appender = new ChunkedDictionary.Appender(factory, limitedSize);
+        for (int i = 0; i < expected.size(); i++) {
+            appender.sortedAppend(expected.get(i), i);
+        }
+
+        ChunkedDictionary dictionary =
+                new ChunkedDictionary(
+                        new ByteArraySeekableStream(appender.serialize()), 0, factory);
+        for (int i = 0; i < expected.size(); i++) {
+            BinaryString value = expected.get(i);
+
+            // find code by key
+            assertThat(dictionary.find(value)).isEqualTo(i);
+
+            // find key by code
+            assertThat(dictionary.find(i)).isEqualTo(value);
+        }
+
+        // not exists
+        for (int i = 0; i < 10; i++) {
+            BinaryString value = BinaryString.fromString(UUID.randomUUID().toString() + i);
+            // find code by key
+            assertThat(dictionary.find(value)).isNegative();
+            assertThat(dictionary.find(value))
+                    .isEqualTo(Collections.binarySearch(expected, value) + 1);
+        }
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndexTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndexTest.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex.rangebitmap;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.fileindex.FileIndexReader;
+import org.apache.paimon.fileindex.FileIndexWriter;
+import org.apache.paimon.fileindex.bitmap.BitmapIndexResult;
+import org.apache.paimon.fs.ByteArraySeekableStream;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.utils.Pair;
+import org.apache.paimon.utils.RoaringBitmap32;
+
+import org.junit.jupiter.api.RepeatedTest;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** test for {@link RangeBitmapFileIndex}. */
+public class RangeBitmapFileIndexTest {
+
+    private static final int ROW_COUNT = 10000;
+    private static final int BOUND = 100;
+
+    @RepeatedTest(5)
+    public void test() {
+        String prefix = "hello-";
+        VarCharType varCharType = new VarCharType();
+        FieldRef fieldRef = new FieldRef(0, "", varCharType);
+
+        RangeBitmapFileIndex bitmapFileIndex = new RangeBitmapFileIndex(varCharType, new Options());
+        FileIndexWriter writer = bitmapFileIndex.createWriter();
+
+        Random random = new Random();
+        List<Pair<Integer, BinaryString>> pairs = new ArrayList<>();
+        for (int i = 0; i < ROW_COUNT; i++) {
+            BinaryString value =
+                    random.nextBoolean()
+                            ? BinaryString.fromString(prefix + random.nextInt(BOUND))
+                            : null;
+            pairs.add(Pair.of(i, value));
+            writer.writeRecord(value);
+        }
+
+        // build index
+        byte[] bytes = writer.serializedBytes();
+        ByteArraySeekableStream stream = new ByteArraySeekableStream(bytes);
+        FileIndexReader reader = bitmapFileIndex.createReader(stream, 0, bytes.length);
+
+        // test eq
+        for (int i = 0; i < 10; i++) {
+            BinaryString predicate = BinaryString.fromString(prefix + random.nextInt(BOUND));
+            RoaringBitmap32 bitmap = new RoaringBitmap32();
+            for (Pair<Integer, BinaryString> pair : pairs) {
+                BinaryString value = pair.getValue();
+                if (Objects.equals(value, predicate)) {
+                    bitmap.add(pair.getKey());
+                }
+            }
+            assertThat(((BitmapIndexResult) reader.visitEqual(fieldRef, predicate)).get())
+                    .isEqualTo(bitmap);
+        }
+
+        // test eq but value not exists
+        for (int i = 0; i < 10; i++) {
+            BinaryString predicate = BinaryString.fromString(prefix);
+            assertThat(((BitmapIndexResult) reader.visitEqual(fieldRef, predicate)).get())
+                    .isEqualTo(new RoaringBitmap32());
+        }
+
+        // test neq
+        for (int i = 0; i < 10; i++) {
+            BinaryString predicate = BinaryString.fromString(prefix + random.nextInt(BOUND));
+            RoaringBitmap32 bitmap = new RoaringBitmap32();
+            for (Pair<Integer, BinaryString> pair : pairs) {
+                BinaryString value = pair.getValue();
+                if (value != null && !Objects.equals(value, predicate)) {
+                    bitmap.add(pair.getKey());
+                }
+            }
+            assertThat(((BitmapIndexResult) reader.visitNotEqual(fieldRef, predicate)).get())
+                    .isEqualTo(bitmap);
+        }
+
+        // test lt
+        for (int i = 0; i < 10; i++) {
+            BinaryString predicate = BinaryString.fromString(prefix + random.nextInt(BOUND));
+            RoaringBitmap32 bitmap = new RoaringBitmap32();
+            for (Pair<Integer, BinaryString> pair : pairs) {
+                BinaryString value = pair.getValue();
+                if (value != null && value.compareTo(predicate) < 0) {
+                    bitmap.add(pair.getKey());
+                }
+            }
+            assertThat(((BitmapIndexResult) reader.visitLessThan(fieldRef, predicate)).get())
+                    .isEqualTo(bitmap);
+        }
+
+        // test lte
+        for (int i = 0; i < 10; i++) {
+            BinaryString predicate = BinaryString.fromString(prefix + random.nextInt(BOUND));
+            RoaringBitmap32 bitmap = new RoaringBitmap32();
+            for (Pair<Integer, BinaryString> pair : pairs) {
+                BinaryString value = pair.getValue();
+                if (value != null && value.compareTo(predicate) <= 0) {
+                    bitmap.add(pair.getKey());
+                }
+            }
+            assertThat(((BitmapIndexResult) reader.visitLessOrEqual(fieldRef, predicate)).get())
+                    .isEqualTo(bitmap);
+        }
+
+        // test gt
+        for (int i = 0; i < 10; i++) {
+            BinaryString predicate = BinaryString.fromString(prefix + random.nextInt(BOUND));
+            RoaringBitmap32 bitmap = new RoaringBitmap32();
+            for (Pair<Integer, BinaryString> pair : pairs) {
+                BinaryString value = pair.getValue();
+                if (value != null && value.compareTo(predicate) > 0) {
+                    bitmap.add(pair.getKey());
+                }
+            }
+            assertThat(((BitmapIndexResult) reader.visitGreaterThan(fieldRef, predicate)).get())
+                    .isEqualTo(bitmap);
+        }
+
+        // test gte
+        for (int i = 0; i < 10; i++) {
+            BinaryString predicate = BinaryString.fromString(prefix + random.nextInt(BOUND));
+            RoaringBitmap32 bitmap = new RoaringBitmap32();
+            for (Pair<Integer, BinaryString> pair : pairs) {
+                BinaryString value = pair.getValue();
+                if (value != null && value.compareTo(predicate) >= 0) {
+                    bitmap.add(pair.getKey());
+                }
+            }
+            assertThat(((BitmapIndexResult) reader.visitGreaterOrEqual(fieldRef, predicate)).get())
+                    .isEqualTo(bitmap);
+        }
+
+        // test in
+        for (int i = 0; i < 10; i++) {
+            int size = random.nextInt(5) + 3;
+            Set<Object> literals = new HashSet<>();
+            for (int j = 0; j < size; j++) {
+                literals.add(BinaryString.fromString(prefix + random.nextInt(BOUND)));
+            }
+            RoaringBitmap32 bitmap = new RoaringBitmap32();
+            for (Pair<Integer, BinaryString> pair : pairs) {
+                BinaryString value = pair.getValue();
+                if (value != null && literals.contains(value)) {
+                    bitmap.add(pair.getKey());
+                }
+            }
+            assertThat(
+                            ((BitmapIndexResult)
+                                            reader.visitIn(fieldRef, new ArrayList<>(literals)))
+                                    .get())
+                    .isEqualTo(bitmap);
+        }
+
+        // test not in
+        for (int i = 0; i < 10; i++) {
+            int size = random.nextInt(5) + 3;
+            Set<Object> literals = new HashSet<>();
+            for (int j = 0; j < size; j++) {
+                literals.add(BinaryString.fromString(prefix + random.nextInt(BOUND)));
+            }
+            RoaringBitmap32 bitmap = new RoaringBitmap32();
+            for (Pair<Integer, BinaryString> pair : pairs) {
+                BinaryString value = pair.getValue();
+                if (value != null && !literals.contains(value)) {
+                    bitmap.add(pair.getKey());
+                }
+            }
+            assertThat(
+                            ((BitmapIndexResult)
+                                            reader.visitNotIn(fieldRef, new ArrayList<>(literals)))
+                                    .get())
+                    .isEqualTo(bitmap);
+        }
+
+        // test is null
+        {
+            RoaringBitmap32 bitmap = new RoaringBitmap32();
+            for (Pair<Integer, BinaryString> pair : pairs) {
+                BinaryString value = pair.getValue();
+                if (value == null) {
+                    bitmap.add(pair.getKey());
+                }
+            }
+            assertThat(((BitmapIndexResult) reader.visitIsNull(fieldRef)).get()).isEqualTo(bitmap);
+        }
+
+        // test is not null
+        {
+            RoaringBitmap32 bitmap = new RoaringBitmap32();
+            for (Pair<Integer, BinaryString> pair : pairs) {
+                BinaryString value = pair.getValue();
+                if (value != null) {
+                    bitmap.add(pair.getKey());
+                }
+            }
+            assertThat(((BitmapIndexResult) reader.visitIsNotNull(fieldRef)).get())
+                    .isEqualTo(bitmap);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
<!-- Linking this pull request to the issue -->

This PR is refer to [PIP-33](https://cwiki.apache.org/confluence/display/PAIMON/PIP-33%3A+Introduce+the+range-bitmap+file+index)

<!-- What is the purpose of the change -->

Introduce an index called range-bitmap.

Must：
1. Supports indexing all the basic data types, particularly STRING, DOUBLE and FLOAT.
2. Supports the EQ and Range predicates evaluation, and Topk/BottomK predicates evaluation in the future.

Should：
1. Good query performance in scenarios with high cardinality.
2. File index size is smaller than the bitmap index.
3. The overall performance of range-bitmap is better than the bsi index.

Benchmarks see: org.apache.paimon.benchmark.bitmap.RangeBitmapIndexBenchmark

### Tests

<!-- List UT and IT cases to verify this change -->
org.apache.paimon.fileindex.rangebitmap.BitSliceIndexBitmapTest
org.apache.paimon.fileindex.rangebitmap.ChunkedDictionaryTest
org.apache.paimon.fileindex.rangebitmap.RangeBitmapFileIndexTest

### API and Format

<!-- Does this change affect API or storage format -->
Nothing.

### Documentation

<!-- Does this change introduce a new feature -->
docs/content/concepts/spec/fileindex.md
