### PR TITLE
[vfs] Support Mkdir in non-existing table

### DIFF
--- a/paimon-vfs/paimon-vfs-hadoop/src/main/java/org/apache/paimon/vfs/hadoop/PaimonVirtualFileSystem.java
+++ b/paimon-vfs/paimon-vfs-hadoop/src/main/java/org/apache/paimon/vfs/hadoop/PaimonVirtualFileSystem.java
@@ -402,10 +402,11 @@ public class PaimonVirtualFileSystem extends FileSystem {
             VFSTableObjectIdentifier identifier = (VFSTableObjectIdentifier) vfsIdentifier;
             VFSTableInfo tableInfo = identifier.tableInfo();
             if (tableInfo == null) {
-                throw new IOException(
-                        "Cannot mkdirs for virtual path "
-                                + f
-                                + " which is not in an existing table");
+                vfsOperations.createObjectTable(identifier.databaseName(), identifier.tableName());
+                identifier =
+                        (VFSTableObjectIdentifier)
+                                vfsOperations.getVFSIdentifier(getVirtualPath(f));
+                tableInfo = identifier.tableInfo();
             }
             return tableInfo.fileIO().mkdirs(identifier.filePath());
         }

--- a/paimon-vfs/paimon-vfs-hadoop/src/test/java/org/apache/paimon/vfs/hadoop/VirtualFileSystemTest.java
+++ b/paimon-vfs/paimon-vfs-hadoop/src/test/java/org/apache/paimon/vfs/hadoop/VirtualFileSystemTest.java
@@ -139,11 +139,11 @@ public abstract class VirtualFileSystemTest {
         // Mkdir in non-existing table
         tableName = "object_table2";
         vfsPath = new Path(vfsRoot, databaseName + "/" + tableName + "/test_dir");
-        try {
-            vfs.mkdirs(vfsPath);
-            Assert.fail();
-        } catch (IOException e) {
-        }
+        Assert.assertTrue(vfs.mkdirs(vfsPath));
+        Table table = catalog.getTable(new Identifier(databaseName, tableName));
+        assertThat(table).isInstanceOf(ObjectTable.class);
+        fileStatus = vfs.getFileStatus(vfsPath);
+        Assert.assertEquals(vfsPath.toString(), fileStatus.getPath().toString());
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
We should also support recursive mkdir, if the table does not exist, it should be automatically created.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
