### PR TITLE
[hotfix] Fix npe when init TagManager with empty branch

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -96,7 +96,7 @@ public class TagManager {
             @Nullable TagPeriodHandler tagPeriodHandler) {
         this.fileIO = fileIO;
         this.tablePath = tablePath;
-        this.branch = branch;
+        this.branch = BranchManager.normalizeBranch(branch);
         this.tagPeriodHandler = tagPeriodHandler;
     }
 


### PR DESCRIPTION
### Purpose
Fix npe when init TagManager with empty branch, org.apache.paimon.utils.BranchManager#isMainBranch may reduce npe

### Tests

### API and Format

### Documentation
