### PR TITLE
[core] #5875 Add required Field IDs to support ID-based column pruning for Apache Iceberg

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestEntry.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.iceberg.manifest;
 
+import org.apache.paimon.iceberg.metadata.IcebergPartitionField;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
@@ -111,14 +112,32 @@ public class IcebergManifestEntry {
     }
 
     public static RowType schema(RowType partitionType) {
+
+        RowType icebergPartition = icebergPartitionType(partitionType);
+
         List<DataField> fields = new ArrayList<>();
         fields.add(new DataField(0, "status", DataTypes.INT().notNull()));
         fields.add(new DataField(1, "snapshot_id", DataTypes.BIGINT()));
         fields.add(new DataField(3, "sequence_number", DataTypes.BIGINT()));
         fields.add(new DataField(4, "file_sequence_number", DataTypes.BIGINT()));
         fields.add(
-                new DataField(2, "data_file", IcebergDataFileMeta.schema(partitionType).notNull()));
+                new DataField(
+                        2, "data_file", IcebergDataFileMeta.schema(icebergPartition).notNull()));
         return new RowType(false, fields);
+    }
+
+    // Add required Field IDs to support ID-based column pruning.
+    // https://iceberg.apache.org/spec/#avro
+    public static RowType icebergPartitionType(RowType partitionType) {
+        List<DataField> fields = new ArrayList<>();
+        for (int i = 0; i < partitionType.getFields().size(); i++) {
+            fields.add(
+                    partitionType
+                            .getFields()
+                            .get(i)
+                            .newId(IcebergPartitionField.FIRST_FIELD_ID + i));
+        }
+        return partitionType.copy(fields);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestFile.java
@@ -103,7 +103,17 @@ public class IcebergManifestFile extends ObjectsFile<IcebergManifestEntry> {
                 "avro.row-name-mapping",
                 "org.apache.paimon.avro.generated.record:manifest_entry,"
                         + "manifest_entry_data_file:r2,"
-                        + "r2_partition:r102");
+                        + "r2_partition:r102,"
+                        + "kv_r2_null_value_counts:k121_v122,"
+                        + "k_r2_null_value_counts:121,"
+                        + "v_r2_null_value_counts:122,"
+                        + "kv_r2_lower_bounds:k126_v127,"
+                        + "k_r2_lower_bounds:126,"
+                        + "v_r2_lower_bounds:127,"
+                        + "kv_r2_upper_bounds:k129_v130,"
+                        + "k_r2_upper_bounds:129,"
+                        + "v_r2_upper_bounds:130,"
+                        + "iceberg:true");
         FileFormat manifestFileAvro = FileFormat.fromIdentifier("avro", avroOptions);
         return new IcebergManifestFile(
                 table.fileIO(),

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestFileMeta.java
@@ -186,7 +186,7 @@ public class IcebergManifestFileMeta {
         fields.add(new DataField(514, "deleted_rows_count", DataTypes.BIGINT().notNull()));
         fields.add(
                 new DataField(
-                        508, "partitions", DataTypes.ARRAY(IcebergPartitionSummary.schema())));
+                        507, "partitions", DataTypes.ARRAY(IcebergPartitionSummary.schema())));
         return new RowType(false, fields);
     }
 
@@ -209,7 +209,7 @@ public class IcebergManifestFileMeta {
         fields.add(new DataField(514, "deleted_rows_count", DataTypes.BIGINT().notNull()));
         fields.add(
                 new DataField(
-                        508, "partitions", DataTypes.ARRAY(IcebergPartitionSummary.schema())));
+                        507, "partitions", DataTypes.ARRAY(IcebergPartitionSummary.schema())));
         return new RowType(false, fields);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestList.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestList.java
@@ -63,7 +63,9 @@ public class IcebergManifestList extends ObjectsFile<IcebergManifestFileMeta> {
         avroOptions.set(
                 "avro.row-name-mapping",
                 "org.apache.paimon.avro.generated.record:manifest_file,"
-                        + "manifest_file_partitions:r508");
+                        + "manifest_file_partitions:r508,"
+                        + "array_r508:508,"
+                        + "iceberg:true");
         FileFormat fileFormat = FileFormat.fromIdentifier("avro", avroOptions);
         RowType manifestType =
                 IcebergManifestFileMeta.schema(

--- a/paimon-format/src/main/java/org/apache/paimon/format/avro/AvroSchemaConverter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/avro/AvroSchemaConverter.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.format.avro;
 
 import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.DecimalType;
@@ -33,12 +34,16 @@ import org.apache.paimon.types.TimestampType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
+import org.apache.avro.SchemaBuilder.ArrayBuilder;
+import org.apache.avro.SchemaBuilder.FieldBuilder;
 
-import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /** Converts an Avro schema into Paimon's type information. */
 public class AvroSchemaConverter {
+
+    private static final String ICEBERG = "iceberg";
 
     private AvroSchemaConverter() {
         // private
@@ -163,20 +168,25 @@ public class AvroSchemaConverter {
                 return nullable ? nullableSchema(decimal) : decimal;
             case ROW:
                 RowType rowType = (RowType) dataType;
-                List<String> fieldNames = rowType.getFieldNames();
                 // we have to make sure the record name is different in a Schema
                 SchemaBuilder.FieldAssembler<Schema> builder =
                         SchemaBuilder.builder().record(rowName).fields();
-                for (int i = 0; i < rowType.getFieldCount(); i++) {
-                    String fieldName = fieldNames.get(i);
-                    DataType fieldType = rowType.getTypeAt(i);
+                for (DataField dataField : rowType.getFields()) {
+                    String fieldName = dataField.name();
+                    DataType fieldType = dataField.type();
+
+                    FieldBuilder<Schema> name = builder.name(fieldName);
+
+                    // Add required Field IDs to support ID-based column pruning.
+                    // https://iceberg.apache.org/spec/#avro
+                    if (rowNameMapping.containsKey(ICEBERG)) {
+                        name.prop("field-id", dataField.id());
+                    }
+
                     SchemaBuilder.GenericDefault<Schema> fieldBuilder =
-                            builder.name(fieldName)
-                                    .type(
-                                            convertToSchema(
-                                                    fieldType,
-                                                    rowName + "_" + fieldName,
-                                                    rowNameMapping));
+                            name.type(
+                                    convertToSchema(
+                                            fieldType, rowName + "_" + fieldName, rowNameMapping));
 
                     if (fieldType.isNullable()) {
                         builder = fieldBuilder.withDefault(null);
@@ -195,19 +205,44 @@ public class AvroSchemaConverter {
                     // Avro only natively support map with string key.
                     // To represent a map with non-string key, we use an array containing several
                     // rows. The first field of a row is the key, and the second field is the value.
-                    SchemaBuilder.GenericDefault<Schema> kvBuilder =
-                            SchemaBuilder.builder()
-                                    .record(rowName)
-                                    .fields()
-                                    .name("key")
-                                    .type(
-                                            convertToSchema(
-                                                    keyType, rowName + "_key", rowNameMapping))
+
+                    // Add required Field IDs to support ID-based column pruning.
+                    // https://iceberg.apache.org/spec/#avro
+                    String origianlRowName = rowName;
+                    if (rowNameMapping.containsKey(ICEBERG)) {
+                        rowName =
+                                Optional.ofNullable(rowNameMapping.get("kv_" + origianlRowName))
+                                        .orElse(rowName);
+                    }
+
+                    FieldBuilder<Schema> key =
+                            SchemaBuilder.builder().record(rowName).fields().name("key");
+
+                    // Add required Field IDs to support ID-based column pruning.
+                    // https://iceberg.apache.org/spec/#avro
+                    if (rowNameMapping.containsKey(ICEBERG)) {
+                        Optional.ofNullable(rowNameMapping.get("k_" + origianlRowName))
+                                .map(Integer::valueOf)
+                                .ifPresent(fieldId -> key.prop("field-id", fieldId));
+                    }
+
+                    FieldBuilder<Schema> value =
+                            key.type(convertToSchema(keyType, rowName + "_key", rowNameMapping))
                                     .noDefault()
-                                    .name("value")
-                                    .type(
-                                            convertToSchema(
-                                                    valueType, rowName + "_value", rowNameMapping));
+                                    .name("value");
+
+                    // Add required Field IDs to support ID-based column pruning.
+                    // https://iceberg.apache.org/spec/#avro
+                    if (rowNameMapping.containsKey(ICEBERG)) {
+                        Optional.ofNullable(rowNameMapping.get("v_" + origianlRowName))
+                                .map(Integer::valueOf)
+                                .ifPresent(fieldId -> value.prop("field-id", fieldId));
+                    }
+
+                    SchemaBuilder.GenericDefault<Schema> kvBuilder =
+                            value.type(
+                                    convertToSchema(valueType, rowName + "_value", rowNameMapping));
+
                     SchemaBuilder.FieldAssembler<Schema> assembler =
                             valueType.isNullable()
                                     ? kvBuilder.withDefault(null)
@@ -226,14 +261,20 @@ public class AvroSchemaConverter {
                 return nullable ? nullableSchema(map) : map;
             case ARRAY:
                 ArrayType arrayType = (ArrayType) dataType;
+                DataType elementType = arrayType.getElementType();
+
+                ArrayBuilder<Schema> arrayBuilder = SchemaBuilder.builder().array();
+
+                // Add required Field IDs to support ID-based column pruning.
+                // https://iceberg.apache.org/spec/#avro
+                if (rowNameMapping.containsKey(ICEBERG)) {
+                    Optional.ofNullable(rowNameMapping.get("array_" + rowName))
+                            .map(Integer::valueOf)
+                            .ifPresent(elementId -> arrayBuilder.prop("element-id", elementId));
+                }
+
                 Schema array =
-                        SchemaBuilder.builder()
-                                .array()
-                                .items(
-                                        convertToSchema(
-                                                arrayType.getElementType(),
-                                                rowName,
-                                                rowNameMapping));
+                        arrayBuilder.items(convertToSchema(elementType, rowName, rowNameMapping));
                 return nullable ? nullableSchema(array) : array;
             default:
                 throw new UnsupportedOperationException(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5875

Iceberg manifest and manifest lists don't include Field IDs required by the Avro specification, which causes critical issues with Google BigQuery Iceberg support as well as reading issues with Python libraries such as Polars.
### Tests

This is a draft PR to get guidance

### API and Format

This is a draft PR to get guidance
### Documentation

This is a draft PR to get guidance