### PR TITLE
[core] fix that branch can't be streamingly read if setting fallback branch

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
@@ -464,18 +464,21 @@ public class FallbackReadFileStoreTable extends DelegatedFileStoreTable {
 
         @Override
         public RecordReader<InternalRow> createReader(Split split) throws IOException {
-            FallbackDataSplit dataSplit = (FallbackDataSplit) split;
-            if (dataSplit.isFallback) {
-                try {
-                    return fallbackRead.createReader(dataSplit);
-                } catch (Exception ignored) {
-                    LOG.error(
-                            "Reading from fallback branch has problems for files: {}",
-                            dataSplit.dataFiles().stream()
-                                    .map(DataFileMeta::fileName)
-                                    .collect(Collectors.joining(", ")));
+            if (split instanceof FallbackDataSplit) {
+                FallbackDataSplit fallbackDataSplit = (FallbackDataSplit) split;
+                if (fallbackDataSplit.isFallback) {
+                    try {
+                        return fallbackRead.createReader(fallbackDataSplit);
+                    } catch (Exception ignored) {
+                        LOG.error(
+                                "Reading from fallback branch has problems for files: {}",
+                                fallbackDataSplit.dataFiles().stream()
+                                        .map(DataFileMeta::fileName)
+                                        .collect(Collectors.joining(", ")));
+                    }
                 }
             }
+            DataSplit dataSplit = (DataSplit) split;
             return mainRead.createReader(dataSplit);
         }
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BranchSqlITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BranchSqlITCase.java
@@ -26,7 +26,9 @@ import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.shade.org.apache.commons.lang3.StringUtils;
 
 import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
+import org.assertj.core.api.AssertionsForInterfaceTypes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -352,6 +354,32 @@ public class BranchSqlITCase extends CatalogITCaseBase {
         assertThat(collectResult("SELECT v, k FROM `t$branch_pk`"))
                 .containsExactlyInAnyOrder(
                         "+I[cat, 20]", "+I[dog, 30]", "+I[lion, 10]", "+I[wolf, 20]");
+    }
+
+    @Test
+    public void testFallbackBranchStreamRead() throws Exception {
+        sql(
+                "CREATE TABLE t ( pt INT NOT NULL, k INT NOT NULL, v STRING ) PARTITIONED BY (pt) WITH ( 'bucket' = '-1' )");
+        sql("INSERT INTO t VALUES (1, 10, 'apple'), (1, 20, 'banana')");
+
+        sql("CALL sys.create_branch('default.t', 'pk')");
+        sql("ALTER TABLE `t$branch_pk` SET ( 'primary-key' = 'pt, k', 'bucket' = '2' )");
+        sql("ALTER TABLE t SET ( 'scan.fallback-branch' = 'pk' )");
+
+        sql("INSERT INTO `t$branch_pk` VALUES (2, 20, 'cat'), (2, 30, 'dog')");
+
+        // read main branch in batch
+        assertThat(collectResult("SELECT v, k FROM t"))
+                .containsExactlyInAnyOrder(
+                        "+I[apple, 10]", "+I[banana, 20]", "+I[cat, 20]", "+I[dog, 30]");
+
+        // read main branch streamingly
+        try (BlockingIterator<Row, Row> iter = streamSqlBlockIter("SELECT * FROM t")) {
+            AssertionsForInterfaceTypes.assertThat(iter.collect(2))
+                    .containsExactlyInAnyOrder(
+                            Row.ofKind(RowKind.INSERT, 1, 10, "apple"),
+                            Row.ofKind(RowKind.INSERT, 1, 20, "banana"));
+        }
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
```
Caused by: java.lang.ClassCastException: org.apache.paimon.table.source.DataSplit cannot be cast to org.apache.paimon.table.FallbackReadFileStoreTable$FallbackDataSplit
```
An exception would be thrown when attempting to read a branch configured with the `scan.fallback-branch` property. This occurs because the `FallbackReadFileStoreTable` class does not implement the `newStreamScan()` method. As a result, the data splits generated in streaming mode are instances of `DataSplit` rather than `FallbackDataSplit`, leading to a ClassCastException.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
