### PR TITLE
[cdc] Optimize SyncDatabaseAction performance by removing listTables calls

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
@@ -38,10 +38,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 import static org.apache.paimon.flink.action.MultiTablesSinkMode.COMBINED;
@@ -218,11 +216,9 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
                         tablePrefix,
                         tableSuffix,
                         tableMapping);
-        Set<String> createdTables;
-        try {
-            createdTables = new HashSet<>(catalog.listTables(database));
-        } catch (Catalog.DatabaseNotExistException e) {
-            throw new RuntimeException(e);
+        List<String> databases = catalog.listDatabases();
+        if (!databases.contains(database)) {
+            throw new RuntimeException(new Catalog.DatabaseNotExistException(database));
         }
         return () ->
                 new RichCdcMultiplexRecordEventParser(
@@ -231,8 +227,7 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
                         tblExcludingPattern,
                         dbIncludingPattern,
                         dbExcludingPattern,
-                        tableNameConverter,
-                        createdTables);
+                        tableNameConverter);
     }
 
     protected abstract boolean requirePrimaryKeys();

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcMultiplexRecordEventParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcMultiplexRecordEventParser.java
@@ -50,7 +50,6 @@ public class RichCdcMultiplexRecordEventParser implements EventParser<RichCdcMul
     @Nullable private final Pattern dbIncludingPattern;
     @Nullable private final Pattern dbExcludingPattern;
     private final TableNameConverter tableNameConverter;
-    private final Set<String> createdTables;
 
     private final Map<String, RichEventParser> parsers = new HashMap<>();
     private final Set<String> includedTables = new HashSet<>();
@@ -66,7 +65,7 @@ public class RichCdcMultiplexRecordEventParser implements EventParser<RichCdcMul
     private RichEventParser currentParser;
 
     public RichCdcMultiplexRecordEventParser(boolean caseSensitive) {
-        this(null, null, null, null, null, new TableNameConverter(caseSensitive), new HashSet<>());
+        this(null, null, null, null, null, new TableNameConverter(caseSensitive));
     }
 
     public RichCdcMultiplexRecordEventParser(
@@ -75,15 +74,13 @@ public class RichCdcMultiplexRecordEventParser implements EventParser<RichCdcMul
             @Nullable Pattern tblExcludingPattern,
             @Nullable Pattern dbIncludingPattern,
             @Nullable Pattern dbExcludingPattern,
-            TableNameConverter tableNameConverter,
-            Set<String> createdTables) {
+            TableNameConverter tableNameConverter) {
         this.schemaBuilder = schemaBuilder;
         this.tblIncludingPattern = tblIncludingPattern;
         this.tblExcludingPattern = tblExcludingPattern;
         this.dbIncludingPattern = dbIncludingPattern;
         this.dbExcludingPattern = dbExcludingPattern;
         this.tableNameConverter = tableNameConverter;
-        this.createdTables = createdTables;
     }
 
     @Override
@@ -201,8 +198,6 @@ public class RichCdcMultiplexRecordEventParser implements EventParser<RichCdcMul
     }
 
     private boolean shouldCreateCurrentTable() {
-        return shouldSynchronizeCurrentTable
-                && !record.cdcSchema().fields().isEmpty()
-                && createdTables.add(parseTableName());
+        return shouldSynchronizeCurrentTable && !record.cdcSchema().fields().isEmpty();
     }
 }


### PR DESCRIPTION
## Purpose
from #5955 

### What is the purpose of the change
Optimize SyncDatabaseAction performance by removing expensive listTables operations during initialization, improving scalability for databases with many tables.

### Brief change log
- Remove `listTables()` call from `RichCdcMultiplexRecordEventParser`
- Implement lazy table creation in `CdcDynamicTableParsingProcessFunction#processElement`
- Remove `createdTables` Set to reduce memory usage

### Verifying this change
- Verified existing functionality remains intact

### Testing
This optimization does not require additional test cases as the existing functionality is already covered by:
- `SyncDatabaseActionBaseTest.testSyncTablesWithoutDbLists()` - validates table filtering logic
- `SyncDatabaseActionBaseTest.testSyncTablesWithDbList()` - validates database filtering logic  
- `SyncDatabaseActionBaseTest.testSycTablesCrossDB()` - validates cross-database filtering scenarios

All these tests create and use RichCdcMultiplexRecordEventParser, ensuring the optimization doesn't break existing functionality.
