### PR TITLE
[Format] fix parquet visitOr error comment

### DIFF
--- a/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
+++ b/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
@@ -131,7 +131,7 @@ public class ParquetFilters {
         @Override
         public FilterPredicate visitOr(List<FilterPredicate> children) {
             if (children.size() != 2) {
-                throw new RuntimeException("Illegal and children: " + children.size());
+                throw new RuntimeException("Illegal or children: " + children.size());
             }
 
             return FilterApi.or(children.get(0), children.get(1));


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

fix parquet parquetfilters  error comment 

```
   @Override
        public FilterPredicate visitOr(List<FilterPredicate> children) {
            if (children.size() != 2) {
                throw new RuntimeException("Illegal and children: " + children.size());
            }

            return FilterApi.or(children.get(0), children.get(1));
        }
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
