### PR TITLE
[flink] Change filesystem.job-level-settings.enabled default value to true and add doc

### DIFF
--- a/docs/content/flink/quick-start.md
+++ b/docs/content/flink/quick-start.md
@@ -270,11 +270,7 @@ SELECT * FROM ....;
 
 ## Setting dynamic options
 
-When interacting with the Paimon table, table options can be tuned without changing the options in the table or catalog. 
-Paimon will extract job-level dynamic options from Flink config and take effect in the current session. There are two ways to achieve it.
-
-### Set table options
-
+When interacting with the Paimon table, table options can be tuned without changing the options in the catalog. Paimon will extract job-level dynamic options and take effect in the current session.
 The dynamic table option's key format is `paimon.${catalogName}.${dbName}.${tableName}.${config_key}`. The catalogName/dbName/tableName can be `*`, which means matching all the specific parts. 
 The dynamic global option's key format is `${config_key}`. Global options will take effect for all the tables. Table options will override global options if there are conflicts.
 
@@ -299,9 +295,3 @@ SET 'paimon.mycatalog.default.T1.scan.timestamp-millis' = '1697018249000';
 SET 'scan.timestamp-millis' = '1697018249001';
 SELECT * FROM T1 JOIN T2 ON xxxx;
 ```
-
-### Set catalog filesystem options
-
-The Flink config will be passed to FileIO, but currently Paimon's FileIOs didn't handle the options. You can use custom 
-FileIO and handle the runtime config by your self. If you want to disable this feature for a table, set table option 
-`filesystem.job-level-settings.enabled` = `false`.

--- a/docs/content/flink/quick-start.md
+++ b/docs/content/flink/quick-start.md
@@ -270,7 +270,11 @@ SELECT * FROM ....;
 
 ## Setting dynamic options
 
-When interacting with the Paimon table, table options can be tuned without changing the options in the catalog. Paimon will extract job-level dynamic options and take effect in the current session.
+When interacting with the Paimon table, table options can be tuned without changing the options in the table or catalog. 
+Paimon will extract job-level dynamic options from Flink config and take effect in the current session. There are two ways to achieve it.
+
+### Set table options
+
 The dynamic table option's key format is `paimon.${catalogName}.${dbName}.${tableName}.${config_key}`. The catalogName/dbName/tableName can be `*`, which means matching all the specific parts. 
 The dynamic global option's key format is `${config_key}`. Global options will take effect for all the tables. Table options will override global options if there are conflicts.
 
@@ -295,3 +299,9 @@ SET 'paimon.mycatalog.default.T1.scan.timestamp-millis' = '1697018249000';
 SET 'scan.timestamp-millis' = '1697018249001';
 SELECT * FROM T1 JOIN T2 ON xxxx;
 ```
+
+### Set catalog filesystem options
+
+The Flink config will be passed to FileIO, but currently Paimon's FileIOs didn't handle the options. You can use custom 
+FileIO and handle the runtime config by your self. If you want to disable this feature for a table, set table option 
+`filesystem.job-level-settings.enabled` = `false`.

--- a/docs/layouts/shortcodes/generated/flink_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/flink_connector_configuration.html
@@ -46,7 +46,7 @@ under the License.
         </tr>
         <tr>
             <td><h5>filesystem.job-level-settings.enabled</h5></td>
-            <td style="word-wrap: break-word;">false</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Enable pass job level filesystem settings to table file IO.</td>
         </tr>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -527,7 +527,7 @@ public class FlinkConnectorOptions {
     public static final ConfigOption<Boolean> FILESYSTEM_JOB_LEVEL_SETTINGS_ENABLED =
             key("filesystem.job-level-settings.enabled")
                     .booleanType()
-                    .defaultValue(false)
+                    .defaultValue(true)
                     .withDescription("Enable pass job level filesystem settings to table file IO.");
 
     public static List<ConfigOption<?>> getOptions() {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
FileIO runtime context should be implemented by user, so if user have implemented it, of course he wants this feature. So adjust the default value for convenience.


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
