### PR TITLE
[core] Introduce 'compaction.total-size-threshold' to do full compaction

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -733,6 +733,13 @@ public class CoreOptions implements Serializable {
                             "Implying how often to perform an optimization compaction, this configuration is used to "
                                     + "ensure the query timeliness of the read-optimized system table.");
 
+    public static final ConfigOption<MemorySize> COMPACTION_TOTAL_SIZE_THRESHOLD =
+            key("compaction.total-size-threshold")
+                    .memoryType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "When total size is smaller than this threshold, force a full compaction.");
+
     public static final ConfigOption<Integer> COMPACTION_MIN_FILE_NUM =
             key("compaction.min.file-num")
                     .intType()
@@ -2364,6 +2371,11 @@ public class CoreOptions implements Serializable {
         return options.get(COMPACTION_OPTIMIZATION_INTERVAL);
     }
 
+    @Nullable
+    public MemorySize compactionTotalSizeThreshold() {
+        return options.get(COMPACTION_TOTAL_SIZE_THRESHOLD);
+    }
+
     public int numSortedRunStopTrigger() {
         Integer stopTrigger = options.get(NUM_SORTED_RUNS_STOP_TRIGGER);
         if (stopTrigger == null) {
@@ -2416,9 +2428,12 @@ public class CoreOptions implements Serializable {
         return options.get(COMPACTION_SIZE_RATIO);
     }
 
-    public OffPeakHours offPeakHours() {
-        return OffPeakHours.create(
-                options.get(COMPACT_OFFPEAK_START_HOUR), options.get(COMPACT_OFFPEAK_END_HOUR));
+    public int compactOffPeakStartHour() {
+        return options.get(COMPACT_OFFPEAK_START_HOUR);
+    }
+
+    public int compactOffPeakEndHour() {
+        return options.get(COMPACT_OFFPEAK_END_HOUR);
     }
 
     public int compactOffPeakRatio() {

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ForceUpLevel0Compaction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ForceUpLevel0Compaction.java
@@ -21,16 +21,24 @@ package org.apache.paimon.mergetree.compact;
 import org.apache.paimon.compact.CompactUnit;
 import org.apache.paimon.mergetree.LevelSortedRun;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /** A {@link CompactStrategy} to force compacting level 0 files. */
 public class ForceUpLevel0Compaction implements CompactStrategy {
 
     private final UniversalCompaction universal;
+    @Nullable private final Integer maxCompactInterval;
+    @Nullable private final AtomicInteger compactTriggerCount;
 
-    public ForceUpLevel0Compaction(UniversalCompaction universal) {
+    public ForceUpLevel0Compaction(
+            UniversalCompaction universal, @Nullable Integer maxCompactInterval) {
         this.universal = universal;
+        this.maxCompactInterval = maxCompactInterval;
+        this.compactTriggerCount = maxCompactInterval == null ? null : new AtomicInteger(0);
     }
 
     @Override
@@ -40,6 +48,26 @@ public class ForceUpLevel0Compaction implements CompactStrategy {
             return pick;
         }
 
-        return universal.forcePickL0(numLevels, runs);
+        if (maxCompactInterval == null || compactTriggerCount == null) {
+            return universal.forcePickL0(numLevels, runs);
+        }
+
+        compactTriggerCount.getAndIncrement();
+        if (compactTriggerCount.compareAndSet(maxCompactInterval, 0)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "Universal compaction due to max lookup compaction interval {}.",
+                        maxCompactInterval);
+            }
+            return universal.forcePickL0(numLevels, runs);
+        } else {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "Skip universal compaction due to lookup compaction trigger count {} is less than the max interval {}.",
+                        compactTriggerCount.get(),
+                        maxCompactInterval);
+            }
+            return Optional.empty();
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullCompactTrigger.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FullCompactTrigger.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree.compact;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.compact.CompactUnit;
+import org.apache.paimon.mergetree.LevelSortedRun;
+import org.apache.paimon.options.MemorySize;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+/** Trigger full compaction. */
+public class FullCompactTrigger {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FullCompactTrigger.class);
+
+    @Nullable private final Long fullCompactionInterval;
+    @Nullable private final Long totalSizeThreshold;
+
+    @Nullable private Long lastFullCompaction;
+
+    public FullCompactTrigger(
+            @Nullable Long fullCompactionInterval, @Nullable Long totalSizeThreshold) {
+        this.fullCompactionInterval = fullCompactionInterval;
+        this.totalSizeThreshold = totalSizeThreshold;
+    }
+
+    @Nullable
+    public static FullCompactTrigger create(CoreOptions options) {
+        Duration interval = options.optimizedCompactionInterval();
+        MemorySize threshold = options.compactionTotalSizeThreshold();
+        if (interval == null && threshold == null) {
+            return null;
+        }
+        return new FullCompactTrigger(
+                interval == null ? null : interval.toMillis(),
+                threshold == null ? null : threshold.getBytes());
+    }
+
+    public Optional<CompactUnit> tryFullCompact(int numLevels, List<LevelSortedRun> runs) {
+        int maxLevel = numLevels - 1;
+        if (fullCompactionInterval != null) {
+            if (lastFullCompaction == null
+                    || currentTimeMillis() - lastFullCompaction > fullCompactionInterval) {
+                LOG.debug("Universal compaction due to full compaction interval");
+                updateLastFullCompaction();
+                return Optional.of(CompactUnit.fromLevelRuns(maxLevel, runs));
+            }
+        }
+        if (totalSizeThreshold != null) {
+            long totalSize = 0;
+            for (LevelSortedRun run : runs) {
+                totalSize += run.run().totalSize();
+            }
+            if (totalSize < totalSizeThreshold) {
+                return Optional.of(CompactUnit.fromLevelRuns(maxLevel, runs));
+            }
+        }
+        return Optional.empty();
+    }
+
+    public void updateLastFullCompaction() {
+        lastFullCompaction = currentTimeMillis();
+    }
+
+    @VisibleForTesting
+    long currentTimeMillis() {
+        return System.currentTimeMillis();
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -53,12 +53,14 @@ import org.apache.paimon.mergetree.compact.CompactRewriter;
 import org.apache.paimon.mergetree.compact.CompactStrategy;
 import org.apache.paimon.mergetree.compact.ForceUpLevel0Compaction;
 import org.apache.paimon.mergetree.compact.FullChangelogMergeTreeCompactRewriter;
+import org.apache.paimon.mergetree.compact.FullCompactTrigger;
 import org.apache.paimon.mergetree.compact.LookupMergeTreeCompactRewriter;
 import org.apache.paimon.mergetree.compact.LookupMergeTreeCompactRewriter.FirstRowMergeFunctionWrapperFactory;
 import org.apache.paimon.mergetree.compact.LookupMergeTreeCompactRewriter.LookupMergeFunctionWrapperFactory;
 import org.apache.paimon.mergetree.compact.MergeFunctionFactory;
 import org.apache.paimon.mergetree.compact.MergeTreeCompactManager;
 import org.apache.paimon.mergetree.compact.MergeTreeCompactRewriter;
+import org.apache.paimon.mergetree.compact.OffPeakHours;
 import org.apache.paimon.mergetree.compact.UniversalCompaction;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.KeyValueFieldsExtractor;
@@ -220,25 +222,22 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
 
     private CompactStrategy createCompactStrategy(CoreOptions options) {
         if (options.needLookup()) {
-            if (CoreOptions.LookupCompactMode.RADICAL.equals(options.lookupCompact())) {
-                return new ForceUpLevel0Compaction(
-                        new UniversalCompaction(
-                                options.maxSizeAmplificationPercent(),
-                                options.sortedRunSizeRatio(),
-                                options.numSortedRunCompactionTrigger(),
-                                options.optimizedCompactionInterval(),
-                                options.offPeakHours(),
-                                options.compactOffPeakRatio()));
-            } else if (CoreOptions.LookupCompactMode.GENTLE.equals(options.lookupCompact())) {
-                return new UniversalCompaction(
-                        options.maxSizeAmplificationPercent(),
-                        options.sortedRunSizeRatio(),
-                        options.numSortedRunCompactionTrigger(),
-                        options.optimizedCompactionInterval(),
-                        options.lookupCompactMaxInterval(),
-                        options.offPeakHours(),
-                        options.compactOffPeakRatio());
+            Integer compactMaxInterval = null;
+            switch (options.lookupCompact()) {
+                case GENTLE:
+                    compactMaxInterval = options.lookupCompactMaxInterval();
+                    break;
+                case RADICAL:
+                    break;
             }
+            return new ForceUpLevel0Compaction(
+                    new UniversalCompaction(
+                            options.maxSizeAmplificationPercent(),
+                            options.sortedRunSizeRatio(),
+                            options.numSortedRunCompactionTrigger(),
+                            FullCompactTrigger.create(options),
+                            OffPeakHours.create(options)),
+                    compactMaxInterval);
         }
 
         UniversalCompaction universal =
@@ -246,11 +245,10 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                         options.maxSizeAmplificationPercent(),
                         options.sortedRunSizeRatio(),
                         options.numSortedRunCompactionTrigger(),
-                        options.optimizedCompactionInterval(),
-                        options.offPeakHours(),
-                        options.compactOffPeakRatio());
+                        FullCompactTrigger.create(options),
+                        OffPeakHours.create(options));
         if (options.compactionForceUpLevel0()) {
-            return new ForceUpLevel0Compaction(universal);
+            return new ForceUpLevel0Compaction(universal, null);
         } else {
             return universal;
         }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/MergeTreeTestBase.java
@@ -46,7 +46,6 @@ import org.apache.paimon.mergetree.compact.DeduplicateMergeFunction;
 import org.apache.paimon.mergetree.compact.IntervalPartition;
 import org.apache.paimon.mergetree.compact.MergeTreeCompactManager;
 import org.apache.paimon.mergetree.compact.ReducerMergeFunctionWrapper;
-import org.apache.paimon.mergetree.compact.UniversalCompaction;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.reader.RecordReader;
@@ -90,6 +89,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
+import static org.apache.paimon.mergetree.compact.UniversalCompactionTest.ofTesting;
 import static org.apache.paimon.utils.FileStorePathFactoryTest.createNonPartFactory;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -277,7 +277,7 @@ public abstract class MergeTreeTestBase {
                 new MockFailResultCompactionManager(
                         service,
                         new Levels(comparator, dataFileMetas, options.numLevels()),
-                        new UniversalCompaction(
+                        ofTesting(
                                 options.maxSizeAmplificationPercent(),
                                 options.sortedRunSizeRatio(),
                                 options.numSortedRunCompactionTrigger()),
@@ -438,7 +438,7 @@ public abstract class MergeTreeTestBase {
     private MergeTreeCompactManager createCompactManager(
             ExecutorService compactExecutor, List<DataFileMeta> files) {
         CompactStrategy strategy =
-                new UniversalCompaction(
+                ofTesting(
                         options.maxSizeAmplificationPercent(),
                         options.sortedRunSizeRatio(),
                         options.numSortedRunCompactionTrigger());

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/ForceUpLevel0CompactionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/ForceUpLevel0CompactionTest.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Optional;
 
 import static org.apache.paimon.mergetree.compact.UniversalCompactionTest.file;
+import static org.apache.paimon.mergetree.compact.UniversalCompactionTest.ofTesting;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link ForceUpLevel0Compaction}. */
@@ -37,7 +38,7 @@ public class ForceUpLevel0CompactionTest {
     @Test
     public void testForceCompaction0() {
         ForceUpLevel0Compaction compaction =
-                new ForceUpLevel0Compaction(new UniversalCompaction(200, 1, 5));
+                new ForceUpLevel0Compaction(ofTesting(200, 1, 5), null);
 
         Optional<CompactUnit> result = compaction.pick(3, Arrays.asList(run(0, 1), run(0, 1)));
         assertThat(result).isPresent();

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/OffPeakHoursTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/OffPeakHoursTest.java
@@ -16,9 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.offpeak;
-
-import org.apache.paimon.OffPeakHours;
+package org.apache.paimon.mergetree.compact;
 
 import org.junit.jupiter.api.Test;
 
@@ -28,31 +26,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class OffPeakHoursTest {
 
     @Test
-    public void testDisabledInstance() {
-        OffPeakHours disabled = OffPeakHours.DISABLED;
-        for (int hour = 0; hour < 24; hour++) {
-            assertThat(disabled.isOffPeak(hour)).isFalse();
-        }
-    }
-
-    @Test
-    public void testGetInstanceWithDisabledValues() {
-        OffPeakHours offPeakHours = OffPeakHours.create(-1, -1);
-        assertThat(offPeakHours).isSameAs(OffPeakHours.DISABLED);
-    }
-
-    @Test
-    public void testGetInstanceWithSameStartAndEnd() {
-        for (int hour = 0; hour < 24; hour++) {
-            OffPeakHours offPeakHours = OffPeakHours.create(hour, hour);
-            assertThat(offPeakHours).isSameAs(OffPeakHours.DISABLED);
-        }
-    }
-
-    @Test
     public void testNormalRangeOffPeakHours() {
         // Test normal range: 9 AM to 5 PM (9-17)
-        OffPeakHours offPeakHours = OffPeakHours.create(9, 17);
+        OffPeakHours offPeakHours = OffPeakHours.create(9, 17, 0);
 
         // Hours before start should not be off-peak
         for (int hour = 0; hour < 9; hour++) {
@@ -78,7 +54,7 @@ public class OffPeakHoursTest {
 
     @Test
     public void testWrapAroundRangeOffPeakHours() {
-        OffPeakHours offPeakHours = OffPeakHours.create(22, 6);
+        OffPeakHours offPeakHours = OffPeakHours.create(22, 6, 0);
 
         // Hours before end (0-5) should be off-peak
         for (int hour = 0; hour < 6; hour++) {
@@ -105,7 +81,7 @@ public class OffPeakHoursTest {
     @Test
     public void testSingleHourRange() {
         // Test single hour range: 12 to 13
-        OffPeakHours offPeakHours = OffPeakHours.create(12, 13);
+        OffPeakHours offPeakHours = OffPeakHours.create(12, 13, 0);
 
         // Only hour 12 should be off-peak
         for (int hour = 0; hour < 24; hour++) {

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/UniversalCompactionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/UniversalCompactionTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.mergetree.compact;
 
-import org.apache.paimon.OffPeakHours;
 import org.apache.paimon.compact.CompactUnit;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.manifest.FileSource;
@@ -27,7 +26,6 @@ import org.apache.paimon.mergetree.SortedRun;
 
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -42,7 +40,7 @@ public class UniversalCompactionTest {
 
     @Test
     public void testOutputLevel() {
-        UniversalCompaction compaction = new UniversalCompaction(25, 1, 3);
+        UniversalCompaction compaction = ofTesting(25, 1, 3);
         assertThat(compaction.createUnit(createLevels(0, 0, 1, 3, 4), 5, 1).outputLevel())
                 .isEqualTo(1);
         assertThat(compaction.createUnit(createLevels(0, 0, 1, 3, 4), 5, 2).outputLevel())
@@ -57,7 +55,7 @@ public class UniversalCompactionTest {
 
     @Test
     public void testPick() {
-        UniversalCompaction compaction = new UniversalCompaction(25, 1, 3);
+        UniversalCompaction compaction = ofTesting(25, 1, 3);
 
         // by size amplification
         Optional<CompactUnit> pick = compaction.pick(3, level0(1, 2, 3, 3));
@@ -86,14 +84,15 @@ public class UniversalCompactionTest {
     @Test
     public void testOptimizedCompactionInterval() {
         AtomicLong time = new AtomicLong(0);
-        UniversalCompaction compaction =
-                new UniversalCompaction(
-                        100, 1, 3, Duration.ofMillis(1000), OffPeakHours.DISABLED, 0) {
+        FullCompactTrigger fullCompactTrigger =
+                new FullCompactTrigger(1000L, null) {
                     @Override
                     long currentTimeMillis() {
                         return time.get();
                     }
                 };
+        UniversalCompaction compaction =
+                new UniversalCompaction(100, 1, 3, fullCompactTrigger, null);
 
         // first time, force optimized compaction
         Optional<CompactUnit> pick =
@@ -127,8 +126,26 @@ public class UniversalCompactionTest {
     }
 
     @Test
+    public void testTotalSizeThreshold() {
+        FullCompactTrigger fullCompactTrigger = new FullCompactTrigger(null, 10L);
+        UniversalCompaction compaction =
+                new UniversalCompaction(100, 1, 3, fullCompactTrigger, null);
+
+        // total size less than threshold
+        Optional<CompactUnit> pick =
+                compaction.pick(3, Arrays.asList(level(0, 1), level(1, 3), level(2, 5)));
+        assertThat(pick.isPresent()).isTrue();
+        long[] results = pick.get().files().stream().mapToLong(DataFileMeta::fileSize).toArray();
+        assertThat(results).isEqualTo(new long[] {1, 3, 5});
+
+        // total size bigger than threshold
+        pick = compaction.pick(3, Arrays.asList(level(0, 2), level(1, 6), level(2, 10)));
+        assertThat(pick.isPresent()).isFalse();
+    }
+
+    @Test
     public void testNoOutputLevel0() {
-        UniversalCompaction compaction = new UniversalCompaction(25, 1, 3);
+        UniversalCompaction compaction = ofTesting(25, 1, 3);
 
         Optional<CompactUnit> pick =
                 compaction.pick(
@@ -148,7 +165,7 @@ public class UniversalCompactionTest {
 
     @Test
     public void testExtremeCaseNoOutputLevel0() {
-        UniversalCompaction compaction = new UniversalCompaction(200, 1, 5);
+        UniversalCompaction compaction = ofTesting(200, 1, 5);
 
         Optional<CompactUnit> pick =
                 compaction.pick(
@@ -168,7 +185,7 @@ public class UniversalCompactionTest {
 
     @Test
     public void testSizeAmplification() {
-        UniversalCompaction compaction = new UniversalCompaction(25, 0, 1);
+        UniversalCompaction compaction = ofTesting(25, 0, 1);
         long[] sizes = new long[] {1};
         sizes = appendAndPickForSizeAmp(compaction, sizes);
         assertThat(sizes).isEqualTo(new long[] {2});
@@ -208,7 +225,7 @@ public class UniversalCompactionTest {
 
     @Test
     public void testSizeRatio() {
-        UniversalCompaction compaction = new UniversalCompaction(25, 1, 5);
+        UniversalCompaction compaction = ofTesting(25, 1, 5);
         long[] sizes = new long[] {1, 1, 1, 1};
         sizes = appendAndPickForSizeRatio(compaction, sizes);
         assertThat(sizes).isEqualTo(new long[] {5});
@@ -261,16 +278,13 @@ public class UniversalCompactionTest {
     @Test
     public void testSizeRatioThreshold() {
         long[] sizes = new long[] {8, 9, 10};
-        assertThat(pickForSizeRatio(new UniversalCompaction(25, 10, 2), sizes))
-                .isEqualTo(new long[] {8, 9, 10});
-        assertThat(pickForSizeRatio(new UniversalCompaction(25, 20, 2), sizes))
-                .isEqualTo(new long[] {27});
+        assertThat(pickForSizeRatio(ofTesting(25, 10, 2), sizes)).isEqualTo(new long[] {8, 9, 10});
+        assertThat(pickForSizeRatio(ofTesting(25, 20, 2), sizes)).isEqualTo(new long[] {27});
     }
 
     @Test
     public void testLookup() {
-        ForceUpLevel0Compaction compaction =
-                new ForceUpLevel0Compaction(new UniversalCompaction(25, 1, 3));
+        ForceUpLevel0Compaction compaction = new ForceUpLevel0Compaction(ofTesting(25, 1, 3), null);
 
         // level 0 to max level
         Optional<CompactUnit> pick = compaction.pick(3, level0(1, 2, 2, 2));
@@ -297,8 +311,9 @@ public class UniversalCompactionTest {
     @Test
     public void testForcePickL0() {
         int maxInterval = 5;
-        UniversalCompaction compaction =
-                new UniversalCompaction(25, 1, 5, null, maxInterval, OffPeakHours.DISABLED, 0);
+        ForceUpLevel0Compaction compaction =
+                new ForceUpLevel0Compaction(
+                        new UniversalCompaction(25, 1, 5, null, null), maxInterval);
 
         // level 0 to max level
         List<LevelSortedRun> level0ToMax = level0(1, 2, 2, 2);
@@ -324,16 +339,15 @@ public class UniversalCompactionTest {
         List<LevelSortedRun> level0ForcePick = Arrays.asList(level(0, 2), level(1, 2), level(2, 2));
 
         for (int i = 1; i <= maxInterval; i++) {
+            pick = compaction.pick(3, level0ForcePick);
             if (i == maxInterval) {
                 // level 0 force pick triggered
-                pick = compaction.pick(3, level0ForcePick);
                 assertThat(pick.isPresent()).isTrue();
                 results = pick.get().files().stream().mapToLong(DataFileMeta::fileSize).toArray();
                 assertThat(results).isEqualTo(new long[] {2, 2, 2});
                 assertThat(pick.get().outputLevel()).isEqualTo(2);
             } else {
                 // compact skipped
-                pick = compaction.pick(3, level0ForcePick);
                 assertThat(pick.isPresent()).isFalse();
             }
         }
@@ -440,5 +454,10 @@ public class UniversalCompactionTest {
                 FileSource.APPEND,
                 null,
                 null);
+    }
+
+    public static UniversalCompaction ofTesting(
+            int maxSizeAmp, int sizeRatio, int numRunCompactionTrigger) {
+        return new UniversalCompaction(maxSizeAmp, sizeRatio, numRunCompactionTrigger, null, null);
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Introduce 'compaction.total-size-threshold', when total size is smaller than this threshold, force a full compaction.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
