### PR TITLE
[core] Log a warning for invalid partition values instead of throwing an exception when enable partition mark done. 

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/listener/PartitionMarkDoneTriggerTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/listener/PartitionMarkDoneTriggerTest.java
@@ -153,7 +153,7 @@ class PartitionMarkDoneTriggerTest {
                         toEpochMillis("2024-02-01"),
                         true);
 
-        assertThat(trigger.extractDateTime("unknown")).isEqualTo(LocalDateTime.MIN);
+        assertThat(trigger.extractDateTime("unknown")).isEmpty();
         trigger.notifyPartition("dt=__DEFAULT_PARTITION__", toEpochMillis("2024-02-01"));
         List<String> partitions = trigger.donePartitions(false, toEpochMillis("2024-02-03"));
         assertThat(partitions).isEmpty();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/listener/PartitionMarkDoneTriggerTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/listener/PartitionMarkDoneTriggerTest.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.flink.sink.listener;
 
 import org.apache.paimon.partition.PartitionTimeExtractor;
-import org.apache.paimon.testutils.assertj.PaimonAssertions;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,7 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PartitionMarkDoneTriggerTest {
 
@@ -155,11 +153,10 @@ class PartitionMarkDoneTriggerTest {
                         toEpochMillis("2024-02-01"),
                         true);
 
-        assertThatThrownBy(() -> trigger.extractDateTime("unknown"))
-                .satisfies(
-                        PaimonAssertions.anyCauseMatches(
-                                RuntimeException.class,
-                                "Can't extract datetime from partition unknown"));
+        assertThat(trigger.extractDateTime("unknown")).isEqualTo(LocalDateTime.MIN);
+        trigger.notifyPartition("dt=__DEFAULT_PARTITION__", toEpochMillis("2024-02-01"));
+        List<String> partitions = trigger.donePartitions(false, toEpochMillis("2024-02-03"));
+        assertThat(partitions).isEmpty();
     }
 
     private long toEpochMillis(String dt) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #5976

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
