### PR TITLE
[common] Correct the range-bitmap's dictionary return results

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmap.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmap.java
@@ -142,7 +142,9 @@ public class RangeBitmap {
         }
 
         int code = getDictionary().find(key);
-        return code < 0 ? getBitSliceIndexBitmap().gte(-code) : getBitSliceIndexBitmap().gte(code);
+        return code < 0
+                ? getBitSliceIndexBitmap().gte(-code - 1)
+                : getBitSliceIndexBitmap().gte(code);
     }
 
     public RoaringBitmap32 gt(Object key) {
@@ -155,7 +157,9 @@ public class RangeBitmap {
         }
 
         int code = getDictionary().find(key);
-        return code < 0 ? getBitSliceIndexBitmap().gte(-code) : getBitSliceIndexBitmap().gt(code);
+        return code < 0
+                ? getBitSliceIndexBitmap().gte(-code - 1)
+                : getBitSliceIndexBitmap().gt(code);
     }
 
     public RoaringBitmap32 in(List<Object> keys) {

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/chunked/AbstractChunk.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/chunked/AbstractChunk.java
@@ -36,6 +36,7 @@ public abstract class AbstractChunk implements Chunk {
         }
         int low = 0;
         int high = size() - 1;
+        int base = code() + 1;
         while (low <= high) {
             int mid = (low + high) >>> 1;
             int result = comparator.compare(get(mid), key);
@@ -44,10 +45,10 @@ public abstract class AbstractChunk implements Chunk {
             } else if (result < 0) {
                 low = mid + 1;
             } else {
-                return code() + mid + 1;
+                return base + mid;
             }
         }
-        return -(code() + low + 1);
+        return -(base + low + 1);
     }
 
     @Override
@@ -57,6 +58,9 @@ public abstract class AbstractChunk implements Chunk {
             return key();
         }
         int index = code - current - 1;
+        if (index < 0 || index >= size()) {
+            throw new IndexOutOfBoundsException("invalid code: " + code);
+        }
         return get(index);
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/chunked/ChunkedDictionary.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/chunked/ChunkedDictionary.java
@@ -86,11 +86,18 @@ public class ChunkedDictionary implements Dictionary {
                 return found.code();
             }
         }
+        // key not found
+        if (low == 0) {
+            return -(low + 1);
+        }
         return get(low - 1).find(key);
     }
 
     @Override
     public Object find(int code) {
+        if (code < 0) {
+            throw new IndexOutOfBoundsException("invalid code: " + code);
+        }
         int low = 0;
         int high = size - 1;
         while (low <= high) {

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/rangebitmap/ChunkedDictionaryTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/rangebitmap/ChunkedDictionaryTest.java
@@ -37,6 +37,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test case for {@link ChunkedDictionary}. */
 public class ChunkedDictionaryTest {
@@ -80,19 +81,26 @@ public class ChunkedDictionaryTest {
             Integer value = expected.get(i);
 
             // find code by key
-            assertThat(dictionary.find(value)).isEqualTo(i);
+            int result = dictionary.find(value);
+            assertThat(result).isEqualTo(i);
+            assertThat(result).isEqualTo(Collections.binarySearch(expected, value));
 
             // find key by code
             assertThat(dictionary.find(i)).isEqualTo(value);
         }
 
+        // find key by code out of range
+        assertThatThrownBy(() -> dictionary.find(-1)).isInstanceOf(IndexOutOfBoundsException.class);
+        assertThatThrownBy(() -> dictionary.find(expected.size()))
+                .isInstanceOf(IndexOutOfBoundsException.class);
+
         // not exists
         for (int i = 0; i < 10; i++) {
             Integer value = random.nextInt(BOUND) + BOUND;
             // find code by key
-            assertThat(dictionary.find(value)).isNegative();
-            assertThat(dictionary.find(value))
-                    .isEqualTo(Collections.binarySearch(expected, value) + 1);
+            int result = dictionary.find(value);
+            assertThat(result).isNegative();
+            assertThat(result).isEqualTo(Collections.binarySearch(expected, value));
         }
     }
 
@@ -116,19 +124,26 @@ public class ChunkedDictionaryTest {
             BinaryString value = expected.get(i);
 
             // find code by key
-            assertThat(dictionary.find(value)).isEqualTo(i);
+            int result = dictionary.find(value);
+            assertThat(result).isEqualTo(i);
+            assertThat(result).isEqualTo(Collections.binarySearch(expected, value));
 
             // find key by code
             assertThat(dictionary.find(i)).isEqualTo(value);
         }
 
+        // find key by code out of range
+        assertThatThrownBy(() -> dictionary.find(-1)).isInstanceOf(IndexOutOfBoundsException.class);
+        assertThatThrownBy(() -> dictionary.find(expected.size()))
+                .isInstanceOf(IndexOutOfBoundsException.class);
+
         // not exists
         for (int i = 0; i < 10; i++) {
             BinaryString value = BinaryString.fromString(UUID.randomUUID().toString() + i);
             // find code by key
-            assertThat(dictionary.find(value)).isNegative();
-            assertThat(dictionary.find(value))
-                    .isEqualTo(Collections.binarySearch(expected, value) + 1);
+            int result = dictionary.find(value);
+            assertThat(result).isNegative();
+            assertThat(result).isEqualTo(Collections.binarySearch(expected, value));
         }
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

The `Dictionary#find(java.lang.Object)` result is same as the `Collections.binarySearch`. 
Return the code by the search key if it is contained in the dictionary; otherwise, `(-(insertion point) - 1)` instead.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
