### PR TITLE
[core] Fix incomplete large file filtering in BucketedAppendCompactManager

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/BucketedAppendCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/BucketedAppendCompactManager.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -263,15 +264,15 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
 
         @Override
         protected CompactResult doCompact() throws Exception {
-            // remove large files
-            while (!forceRewriteAllFiles && !toCompact.isEmpty()) {
-                DataFileMeta file = toCompact.peekFirst();
-                // the data file with deletion file always need to be compacted.
-                if (file.fileSize() >= targetFileSize && !hasDeletionFile(file)) {
-                    toCompact.poll();
-                    continue;
+            // Fix: Use iterator to properly filter all qualifying large files
+            if (!forceRewriteAllFiles) {
+                Iterator<DataFileMeta> iterator = toCompact.iterator();
+                while (iterator.hasNext()) {
+                    DataFileMeta file = iterator.next();
+                    if (file.fileSize() >= targetFileSize && !hasDeletionFile(file)) {
+                        iterator.remove();
+                    }
                 }
-                break;
             }
 
             // do compaction


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

This PR fixes an issue where the compaction logic in `BucketedAppendCompactManager` only filtered the first large file from the queue, leaving subsequent large files in the compaction set

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
