### PR TITLE
[core] Iceberg:  support TINYINT and SMALLINT

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergConversions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergConversions.java
@@ -57,6 +57,14 @@ public class IcebergConversions {
             case INTEGER:
             case DATE:
                 return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(0, (int) value);
+            case TINYINT:
+                return ByteBuffer.allocate(4)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putInt(0, ((byte) value));
+            case SMALLINT:
+                return ByteBuffer.allocate(4)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putInt(0, ((Short) value).intValue());
             case BIGINT:
                 return ByteBuffer.allocate(8)
                         .order(ByteOrder.LITTLE_ENDIAN)

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergDataField.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergDataField.java
@@ -150,6 +150,8 @@ public class IcebergDataField {
             case BOOLEAN:
                 return "boolean";
             case INTEGER:
+            case TINYINT:
+            case SMALLINT:
                 return "int";
             case BIGINT:
                 return "long";

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
@@ -471,6 +471,8 @@ public class IcebergCompatibilityTest {
                 RowType.of(
                         new DataType[] {
                             DataTypes.INT(),
+                            DataTypes.TINYINT(),
+                            DataTypes.SMALLINT(),
                             DataTypes.BOOLEAN(),
                             DataTypes.BIGINT(),
                             DataTypes.FLOAT(),
@@ -485,6 +487,8 @@ public class IcebergCompatibilityTest {
                         },
                         new String[] {
                             "v_int",
+                            "v_tinyint",
+                            "v_smallint",
                             "v_boolean",
                             "v_bigint",
                             "v_float",
@@ -507,6 +511,8 @@ public class IcebergCompatibilityTest {
         GenericRow lowerBounds =
                 GenericRow.of(
                         1,
+                        (byte) 1,
+                        (short) 1,
                         true,
                         10L,
                         100.0f,
@@ -522,6 +528,8 @@ public class IcebergCompatibilityTest {
         GenericRow upperBounds =
                 GenericRow.of(
                         2,
+                        (byte) 3,
+                        (short) 4,
                         true,
                         20L,
                         200.0f,
@@ -583,7 +591,21 @@ public class IcebergCompatibilityTest {
                                     icebergTable ->
                                             IcebergGenerics.read(icebergTable)
                                                     .select(name)
-                                                    .where(Expressions.lessThan(name, upper))
+                                                    .where(
+                                                            // Handle numeric primitive wrappers
+                                                            // that need conversion
+                                                            upper instanceof Short
+                                                                    ? Expressions.lessThan(
+                                                                            name,
+                                                                            ((Short) upper)
+                                                                                    .intValue())
+                                                                    : upper instanceof Byte
+                                                                            ? Expressions.lessThan(
+                                                                                    name,
+                                                                                    ((Byte) upper)
+                                                                                            .intValue())
+                                                                            : Expressions.lessThan(
+                                                                                    name, upper))
                                                     .build(),
                                     Record::toString))
                     .containsExactly("Record(" + expectedLower + ")");
@@ -592,7 +614,25 @@ public class IcebergCompatibilityTest {
                                     icebergTable ->
                                             IcebergGenerics.read(icebergTable)
                                                     .select(name)
-                                                    .where(Expressions.greaterThan(name, lower))
+                                                    .where(
+                                                            // Handle numeric primitive wrappers
+                                                            // that need conversion
+                                                            lower instanceof Short
+                                                                    ? Expressions.greaterThan(
+                                                                            name,
+                                                                            ((Short) lower)
+                                                                                    .intValue())
+                                                                    : lower instanceof Byte
+                                                                            ? Expressions
+                                                                                    .greaterThan(
+                                                                                            name,
+                                                                                            ((Byte)
+                                                                                                            lower)
+                                                                                                    .intValue())
+                                                                            : Expressions
+                                                                                    .greaterThan(
+                                                                                            name,
+                                                                                            lower))
                                                     .build(),
                                     Record::toString))
                     .containsExactly("Record(" + expectedUpper + ")");
@@ -601,7 +641,21 @@ public class IcebergCompatibilityTest {
                                     icebergTable ->
                                             IcebergGenerics.read(icebergTable)
                                                     .select(name)
-                                                    .where(Expressions.lessThan(name, lower))
+                                                    .where(
+                                                            // Handle numeric primitive wrappers
+                                                            // that need conversion
+                                                            lower instanceof Short
+                                                                    ? Expressions.lessThan(
+                                                                            name,
+                                                                            ((Short) lower)
+                                                                                    .intValue())
+                                                                    : lower instanceof Byte
+                                                                            ? Expressions.lessThan(
+                                                                                    name,
+                                                                                    ((Byte) lower)
+                                                                                            .intValue())
+                                                                            : Expressions.lessThan(
+                                                                                    name, lower))
                                                     .build(),
                                     Record::toString))
                     .isEmpty();
@@ -610,7 +664,25 @@ public class IcebergCompatibilityTest {
                                     icebergTable ->
                                             IcebergGenerics.read(icebergTable)
                                                     .select(name)
-                                                    .where(Expressions.greaterThan(name, upper))
+                                                    .where(
+                                                            // Handle numeric primitive wrappers
+                                                            // that need conversion
+                                                            upper instanceof Short
+                                                                    ? Expressions.greaterThan(
+                                                                            name,
+                                                                            ((Short) upper)
+                                                                                    .intValue())
+                                                                    : upper instanceof Byte
+                                                                            ? Expressions
+                                                                                    .greaterThan(
+                                                                                            name,
+                                                                                            ((Byte)
+                                                                                                            upper)
+                                                                                                    .intValue())
+                                                                            : Expressions
+                                                                                    .greaterThan(
+                                                                                            name,
+                                                                                            upper))
                                                     .build(),
                                     Record::toString))
                     .isEmpty();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/iceberg/FlinkIcebergITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/iceberg/FlinkIcebergITCaseBase.java
@@ -191,6 +191,8 @@ public abstract class FlinkIcebergITCaseBase extends AbstractTestBase {
                         + "  pt INT,\n"
                         + "  id INT,"
                         + "  v_int INT,\n"
+                        + "  v_tinyint TINYINT,\n"
+                        + "  v_smallint SMALLINT,\n"
                         + "  v_boolean BOOLEAN,\n"
                         + "  v_bigint BIGINT,\n"
                         + "  v_float FLOAT,\n"
@@ -210,9 +212,9 @@ public abstract class FlinkIcebergITCaseBase extends AbstractTestBase {
                         + ")");
         tEnv.executeSql(
                         "INSERT INTO paimon.`default`.T VALUES "
-                                + "(1, 1, 1, true, 10, CAST(100.0 AS FLOAT), 1000.0, 123.456, 'cat', CAST('B_cat' AS VARBINARY(20)), DATE '2024-10-10', TIMESTAMP '2024-10-10 11:22:33.123456'), "
-                                + "(2, 2, 2, false, 20, CAST(200.0 AS FLOAT), 2000.0, 234.567, 'dog', CAST('B_dog' AS VARBINARY(20)), DATE '2024-10-20', TIMESTAMP '2024-10-20 11:22:33.123456'), "
-                                + "(3, 3, CAST(NULL AS INT), CAST(NULL AS BOOLEAN), CAST(NULL AS BIGINT), CAST(NULL AS FLOAT), CAST(NULL AS DOUBLE), CAST(NULL AS DECIMAL(8, 3)), CAST(NULL AS STRING), CAST(NULL AS VARBINARY(20)), CAST(NULL AS DATE), CAST(NULL AS TIMESTAMP(6)))")
+                                + "(1, 1, 1, CAST(1 AS TINYINT), CAST(1 as SMALLINT), true, 10, CAST(100.0 AS FLOAT), 1000.0, 123.456, 'cat', CAST('B_cat' AS VARBINARY(20)), DATE '2024-10-10', TIMESTAMP '2024-10-10 11:22:33.123456'), "
+                                + "(2, 2, 2, CAST(2 AS TINYINT), CAST(2 as SMALLINT), false, 20, CAST(200.0 AS FLOAT), 2000.0, 234.567, 'dog', CAST('B_dog' AS VARBINARY(20)), DATE '2024-10-20', TIMESTAMP '2024-10-20 11:22:33.123456'), "
+                                + "(3, 3, CAST(NULL AS INT), CAST(NULL AS TINYINT), CAST(NULL AS SMALLINT), CAST(NULL AS BOOLEAN), CAST(NULL AS BIGINT), CAST(NULL AS FLOAT), CAST(NULL AS DOUBLE), CAST(NULL AS DECIMAL(8, 3)), CAST(NULL AS STRING), CAST(NULL AS VARBINARY(20)), CAST(NULL AS DATE), CAST(NULL AS TIMESTAMP(6)))")
                 .await();
 
         tEnv.executeSql(
@@ -228,6 +230,10 @@ public abstract class FlinkIcebergITCaseBase extends AbstractTestBase {
         assertThat(collect(tEnv.executeSql("SELECT id FROM T where pt = 1")))
                 .containsExactly(Row.of(1));
         assertThat(collect(tEnv.executeSql("SELECT id FROM T where v_int = 1")))
+                .containsExactly(Row.of(1));
+        assertThat(collect(tEnv.executeSql("SELECT id FROM T where v_tinyint = 1")))
+                .containsExactly(Row.of(1));
+        assertThat(collect(tEnv.executeSql("SELECT id FROM T where v_smallint = 1")))
                 .containsExactly(Row.of(1));
         assertThat(collect(tEnv.executeSql("SELECT id FROM T where v_boolean = true")))
                 .containsExactly(Row.of(1));
@@ -249,6 +255,10 @@ public abstract class FlinkIcebergITCaseBase extends AbstractTestBase {
                                         "SELECT id FROM T where v_timestamp = TIMESTAMP '2024-10-10 11:22:33.123456'")))
                 .containsExactly(Row.of(1));
         assertThat(collect(tEnv.executeSql("SELECT id FROM T where v_int IS NULL")))
+                .containsExactly(Row.of(3));
+        assertThat(collect(tEnv.executeSql("SELECT id FROM T where v_tinyint IS NULL")))
+                .containsExactly(Row.of(3));
+        assertThat(collect(tEnv.executeSql("SELECT id FROM T where v_smallint IS NULL")))
                 .containsExactly(Row.of(3));
         assertThat(collect(tEnv.executeSql("SELECT id FROM T where v_boolean IS NULL")))
                 .containsExactly(Row.of(3));


### PR DESCRIPTION
### Purpose

Support [TINYINT](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/types/#tinyint) and [SMALLINT](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/types/#smallint) in Iceberg

I need these types because I have them in MySQL clusters and want to ingest them to Paimon and read as Iceberg.

### Tests
UT and IT test cases