### PR TITLE
[core][spark] Support reading row lineage metadata column

### DIFF
--- a/docs/content/spark/sql-query.md
+++ b/docs/content/spark/sql-query.md
@@ -43,6 +43,8 @@ Paimon also supports reading some hidden metadata columns, currently supporting 
 - `__paimon_partition`: the partition of the record.
 - `__paimon_bucket`: the bucket of the record.
 - `__paimon_row_index`: the row index of the record.
+- `_ROW_ID`: the unique row id of the record (valid only when `row-tracking.enabled` is set to true).
+- `_SEQUENCE_NUMBER`: the sequence number of the record (valid only when `row-tracking.enabled` is set to true).
 
 ```sql
 -- read all columns and the corresponding file path, partition, bucket, rowIndex of the record

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
@@ -23,7 +23,6 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
-import org.apache.paimon.table.Table;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
 
@@ -119,7 +118,7 @@ public interface ReadBuilder extends Serializable {
     /**
      * Push read row type to the reader, support nested row pruning.
      *
-     * @param readType read row type, can be a pruned type from {@link Table#rowType()}
+     * @param readType read row type
      * @since 1.0.0
      */
     ReadBuilder withReadType(RowType readType);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -110,12 +110,6 @@ public class ReadBuilderImpl implements ReadBuilder {
 
     @Override
     public ReadBuilder withReadType(RowType readType) {
-        RowType tableRowType = table.rowType();
-        checkState(
-                readType.isPrunedFrom(tableRowType),
-                "read row type must be a pruned type from table row type, read row type: %s, table row type: %s",
-                readType,
-                tableRowType);
         this.readType = readType;
         return this;
     }

--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -19,7 +19,7 @@
 package org.apache.paimon.spark
 
 import org.apache.paimon.predicate.Predicate
-import org.apache.paimon.table.Table
+import org.apache.paimon.table.InnerTable
 
 import org.apache.spark.sql.PaimonUtils.fieldReference
 import org.apache.spark.sql.connector.expressions.NamedReference
@@ -30,7 +30,7 @@ import org.apache.spark.sql.types.StructType
 import scala.collection.JavaConverters._
 
 case class PaimonScan(
-    table: Table,
+    table: InnerTable,
     requiredSchema: StructType,
     filters: Seq[Predicate],
     reservedFilters: Seq[Filter],

--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
@@ -19,14 +19,14 @@
 package org.apache.paimon.spark
 
 import org.apache.paimon.predicate.{PartitionPredicateVisitor, Predicate}
-import org.apache.paimon.table.Table
+import org.apache.paimon.table.InnerTable
 
 import org.apache.spark.sql.connector.read.SupportsPushDownFilters
 import org.apache.spark.sql.sources.Filter
 
 import scala.collection.mutable
 
-class PaimonScanBuilder(table: Table)
+class PaimonScanBuilder(table: InnerTable)
   extends PaimonBaseScanBuilder(table)
   with SupportsPushDownFilters {
 

--- a/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -19,7 +19,7 @@
 package org.apache.paimon.spark
 
 import org.apache.paimon.predicate.Predicate
-import org.apache.paimon.table.{BucketMode, FileStoreTable, Table}
+import org.apache.paimon.table.{BucketMode, FileStoreTable, InnerTable}
 import org.apache.paimon.table.source.{DataSplit, Split}
 
 import org.apache.spark.sql.PaimonUtils.fieldReference
@@ -32,7 +32,7 @@ import org.apache.spark.sql.types.StructType
 import scala.collection.JavaConverters._
 
 case class PaimonScan(
-    table: Table,
+    table: InnerTable,
     requiredSchema: StructType,
     filters: Seq[Predicate],
     reservedFilters: Seq[Filter],

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/ColumnPruningAndPushDown.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/ColumnPruningAndPushDown.scala
@@ -18,24 +18,38 @@
 
 package org.apache.paimon.spark
 
+import org.apache.paimon.CoreOptions
 import org.apache.paimon.predicate.{Predicate, PredicateBuilder}
 import org.apache.paimon.spark.schema.PaimonMetadataColumn
-import org.apache.paimon.table.Table
+import org.apache.paimon.table.{InnerTable, SpecialFields}
 import org.apache.paimon.table.source.ReadBuilder
-import org.apache.paimon.types.RowType
+import org.apache.paimon.types.{DataField, RowType}
 import org.apache.paimon.utils.Preconditions.checkState
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.types.StructType
 
+import java.util.{ArrayList => JArrayList}
+
 trait ColumnPruningAndPushDown extends Scan with Logging {
-  def table: Table
+  def table: InnerTable
   def requiredSchema: StructType
   def filters: Seq[Predicate]
   def pushDownLimit: Option[Int] = None
 
-  lazy val tableRowType: RowType = table.rowType
+  lazy val tableRowType: RowType = {
+    val coreOptions: CoreOptions = CoreOptions.fromMap(table.options())
+    if (coreOptions.rowTrackingEnabled()) {
+      val fields = new JArrayList[DataField](table.rowType().getFields)
+      fields.add(SpecialFields.ROW_ID)
+      fields.add(SpecialFields.SEQUENCE_NUMBER)
+      new RowType(fields)
+    } else {
+      table.rowType()
+    }
+  }
+
   lazy val tableSchema: StructType = SparkTypeUtils.fromPaimonRowType(tableRowType)
 
   final def partitionType: StructType = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/ColumnPruningAndPushDown.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/ColumnPruningAndPushDown.scala
@@ -23,14 +23,12 @@ import org.apache.paimon.predicate.{Predicate, PredicateBuilder}
 import org.apache.paimon.spark.schema.PaimonMetadataColumn
 import org.apache.paimon.table.{InnerTable, SpecialFields}
 import org.apache.paimon.table.source.ReadBuilder
-import org.apache.paimon.types.{DataField, RowType}
+import org.apache.paimon.types.RowType
 import org.apache.paimon.utils.Preconditions.checkState
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.types.StructType
-
-import java.util.{ArrayList => JArrayList}
 
 trait ColumnPruningAndPushDown extends Scan with Logging {
   def table: InnerTable
@@ -41,10 +39,7 @@ trait ColumnPruningAndPushDown extends Scan with Logging {
   lazy val tableRowType: RowType = {
     val coreOptions: CoreOptions = CoreOptions.fromMap(table.options())
     if (coreOptions.rowTrackingEnabled()) {
-      val fields = new JArrayList[DataField](table.rowType().getFields)
-      fields.add(SpecialFields.ROW_ID)
-      fields.add(SpecialFields.SEQUENCE_NUMBER)
-      new RowType(fields)
+      SpecialFields.rowTypeWithRowLineage(table.rowType())
     } else {
       table.rowType()
     }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScanBuilder.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScanBuilder.scala
@@ -19,14 +19,14 @@
 package org.apache.paimon.spark
 
 import org.apache.paimon.predicate.Predicate
-import org.apache.paimon.table.Table
+import org.apache.paimon.table.InnerTable
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownRequiredColumns}
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 
-abstract class PaimonBaseScanBuilder(table: Table)
+abstract class PaimonBaseScanBuilder(table: InnerTable)
   extends ScanBuilder
   with SupportsPushDownRequiredColumns
   with Logging {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -21,7 +21,7 @@ package org.apache.paimon.spark
 import org.apache.paimon.CoreOptions.BucketFunctionType
 import org.apache.paimon.predicate.Predicate
 import org.apache.paimon.spark.commands.BucketExpression.quote
-import org.apache.paimon.table.{BucketMode, FileStoreTable, Table}
+import org.apache.paimon.table.{BucketMode, FileStoreTable, InnerTable, Table}
 import org.apache.paimon.table.source.{DataSplit, Split}
 
 import org.apache.spark.sql.PaimonUtils.fieldReference
@@ -35,7 +35,7 @@ import org.apache.spark.sql.types.StructType
 import scala.collection.JavaConverters._
 
 case class PaimonScan(
-    table: Table,
+    table: InnerTable,
     requiredSchema: StructType,
     filters: Seq[Predicate],
     reservedFilters: Seq[Filter],

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
@@ -20,7 +20,7 @@ package org.apache.paimon.spark
 
 import org.apache.paimon.predicate.{PartitionPredicateVisitor, Predicate, PredicateBuilder}
 import org.apache.paimon.spark.aggregate.{AggregatePushDownUtils, LocalAggregator}
-import org.apache.paimon.table.{FileStoreTable, Table}
+import org.apache.paimon.table.{FileStoreTable, InnerTable, Table}
 import org.apache.paimon.table.source.DataSplit
 
 import org.apache.spark.sql.PaimonUtils
@@ -32,7 +32,7 @@ import org.apache.spark.sql.sources.Filter
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
-class PaimonScanBuilder(table: Table)
+class PaimonScanBuilder(table: InnerTable)
   extends PaimonBaseScanBuilder(table)
   with SupportsPushDownV2Filters
   with SupportsPushDownLimit

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonSplitScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonSplitScan.scala
@@ -20,7 +20,7 @@ package org.apache.paimon.spark
 
 import org.apache.paimon.CoreOptions
 import org.apache.paimon.predicate.Predicate
-import org.apache.paimon.table.{KnownSplitsTable, Table}
+import org.apache.paimon.table.{InnerTable, KnownSplitsTable}
 import org.apache.paimon.table.source.{DataSplit, Split}
 
 import org.apache.spark.sql.connector.read.{Batch, Scan}
@@ -34,7 +34,7 @@ class PaimonSplitScanBuilder(table: KnownSplitsTable) extends PaimonScanBuilder(
 
 /** For internal use only. */
 case class PaimonSplitScan(
-    table: Table,
+    table: InnerTable,
     dataSplits: Array[DataSplit],
     requiredSchema: StructType,
     filters: Seq[Predicate])
@@ -61,7 +61,7 @@ case class PaimonSplitScan(
 }
 
 object PaimonSplitScan {
-  def apply(table: Table, dataSplits: Array[DataSplit]): PaimonSplitScan = {
+  def apply(table: InnerTable, dataSplits: Array[DataSplit]): PaimonSplitScan = {
     val requiredSchema = SparkTypeUtils.fromPaimonRowType(table.rowType)
     new PaimonSplitScan(table, dataSplits, requiredSchema, Seq.empty)
   }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/aggregate/LocalAggregator.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/aggregate/LocalAggregator.scala
@@ -18,9 +18,7 @@
 
 package org.apache.paimon.spark.aggregate
 
-import org.apache.paimon.CoreOptions
 import org.apache.paimon.data.BinaryRow
-import org.apache.paimon.schema.SchemaManager
 import org.apache.paimon.spark.SparkTypeUtils
 import org.apache.paimon.spark.data.SparkInternalRow
 import org.apache.paimon.stats.SimpleStatsEvolutions
@@ -46,10 +44,7 @@ class LocalAggregator(table: FileStoreTable) {
   private var aggFuncEvaluatorGetter: () => Seq[AggFuncEvaluator[_]] = _
   private var isInitialized = false
   private lazy val simpleStatsEvolutions = {
-    val schemaManager = new SchemaManager(
-      table.fileIO(),
-      table.location(),
-      CoreOptions.branch(table.schema().options()))
+    val schemaManager = table.schemaManager()
     new SimpleStatsEvolutions(sid => schemaManager.schema(sid).fields(), table.schema().id())
   }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
@@ -28,7 +28,7 @@ import org.apache.paimon.spark.catalyst.analysis.expressions.ExpressionHelper
 import org.apache.paimon.spark.commands.SparkDataFileMeta.convertToSparkDataFileMeta
 import org.apache.paimon.spark.schema.PaimonMetadataColumn
 import org.apache.paimon.spark.schema.PaimonMetadataColumn._
-import org.apache.paimon.table.{BucketMode, FileStoreTable, KnownSplitsTable}
+import org.apache.paimon.table.{BucketMode, InnerTable, KnownSplitsTable}
 import org.apache.paimon.table.sink.{CommitMessage, CommitMessageImpl}
 import org.apache.paimon.table.source.DataSplit
 import org.apache.paimon.utils.SerializationUtils
@@ -36,7 +36,7 @@ import org.apache.paimon.utils.SerializationUtils
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils.createDataset
 import org.apache.spark.sql.catalyst.SQLConfHelper
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
 import org.apache.spark.sql.catalyst.plans.logical.{Filter => FilterLogicalNode, LogicalPlan, Project}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -160,9 +160,9 @@ trait PaimonCommand extends WithFileStoreTable with ExpressionHelper with SQLCon
       relation: DataSourceV2Relation): DataSourceV2Relation = {
     assert(relation.table.isInstanceOf[SparkTable])
     val sparkTable = relation.table.asInstanceOf[SparkTable]
-    assert(sparkTable.table.isInstanceOf[FileStoreTable])
+    assert(sparkTable.table.isInstanceOf[InnerTable])
     val knownSplitsTable =
-      KnownSplitsTable.create(sparkTable.table.asInstanceOf[FileStoreTable], splits.toArray)
+      KnownSplitsTable.create(sparkTable.table.asInstanceOf[InnerTable], splits.toArray)
     val outputNames = relation.outputSet.map(_.name)
     def isOutputColumn(colName: String) = {
       val resolve = conf.resolver

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/schema/PaimonMetadataColumn.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/schema/PaimonMetadataColumn.scala
@@ -19,6 +19,7 @@
 package org.apache.paimon.spark.schema
 
 import org.apache.paimon.spark.SparkTypeUtils
+import org.apache.paimon.table.SpecialFields
 import org.apache.paimon.types.DataField
 
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
@@ -47,11 +48,14 @@ object PaimonMetadataColumn {
   val FILE_PATH_COLUMN = "__paimon_file_path"
   val PARTITION_COLUMN = "__paimon_partition"
   val BUCKET_COLUMN = "__paimon_bucket"
+
   val SUPPORTED_METADATA_COLUMNS: Seq[String] = Seq(
     ROW_INDEX_COLUMN,
     FILE_PATH_COLUMN,
     PARTITION_COLUMN,
-    BUCKET_COLUMN
+    BUCKET_COLUMN,
+    SpecialFields.ROW_ID.name(),
+    SpecialFields.SEQUENCE_NUMBER.name()
   )
 
   val ROW_INDEX: PaimonMetadataColumn =
@@ -63,6 +67,10 @@ object PaimonMetadataColumn {
   }
   val BUCKET: PaimonMetadataColumn =
     PaimonMetadataColumn(Int.MaxValue - 103, BUCKET_COLUMN, IntegerType)
+  val ROW_ID: PaimonMetadataColumn =
+    PaimonMetadataColumn(Int.MaxValue - 104, SpecialFields.ROW_ID.name(), LongType)
+  val SEQUENCE_NUMBER: PaimonMetadataColumn =
+    PaimonMetadataColumn(Int.MaxValue - 105, SpecialFields.SEQUENCE_NUMBER.name(), LongType)
 
   def get(metadataColumn: String, partitionType: StructType): PaimonMetadataColumn = {
     metadataColumn match {
@@ -70,6 +78,8 @@ object PaimonMetadataColumn {
       case FILE_PATH_COLUMN => FILE_PATH
       case PARTITION_COLUMN => PARTITION(partitionType)
       case BUCKET_COLUMN => BUCKET
+      case ROW_ID.name => ROW_ID
+      case SEQUENCE_NUMBER.name => SEQUENCE_NUMBER
       case _ =>
         throw new IllegalArgumentException(s"$metadataColumn metadata column is not supported.")
     }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowLineageTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowLineageTest.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+import org.apache.paimon.spark.PaimonSparkTestBase
+
+import org.apache.spark.sql.Row
+
+class RowLineageTest extends PaimonSparkTestBase {
+
+  test("Row Lineage: read row lineage") {
+    withTable("t") {
+      sql("CREATE TABLE t (id INT, data STRING) TBLPROPERTIES ('row-tracking.enabled' = 'true')")
+      sql("INSERT INTO t VALUES (11, 'a'), (22, 'b')")
+
+      checkAnswer(
+        sql("SELECT *, _ROW_ID, _SEQUENCE_NUMBER FROM t"),
+        Seq(Row(11, "a", 0, 1), Row(22, "b", 1, 1))
+      )
+      checkAnswer(
+        sql("SELECT _ROW_ID, data, _SEQUENCE_NUMBER, id FROM t"),
+        Seq(Row(0, "a", 1, 11), Row(1, "b", 1, 22))
+      )
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

In this PR:

1. ~~add `metadataRowType()` and `fullRowType()` in `interface InnerTable`~~ remove the schema checker in `withReadType(RowType readType)`
3. make spark scan accpet `InnerTable` instead of `Table`
4. add `_ROW_ID` and `_SEQUENCE_NUMBER` metadata column in spark scan

```sql
SELECT *, _ROW_ID, _SEQUENCE_NUMBER FROM t
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
