### PR TITLE
[format] Introduce 'write.batch-memory' to control memory in arrow

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -1243,6 +1243,12 @@ If the data size allocated for the sorting task is uneven,which may lead to perf
             <td>If set to true, compactions and snapshot expiration will be skipped. This option is used along with dedicated compact jobs.</td>
         </tr>
         <tr>
+            <td><h5>write.batch-memory</h5></td>
+            <td style="word-wrap: break-word;">128 mb</td>
+            <td>MemorySize</td>
+            <td>Write batch memory for any file format if it supports.</td>
+        </tr>
+        <tr>
             <td><h5>write.batch-size</h5></td>
             <td style="word-wrap: break-word;">1024</td>
             <td>Integer</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1172,6 +1172,12 @@ public class CoreOptions implements Serializable {
                     .withFallbackKeys("orc.write.batch-size")
                     .withDescription("Write batch size for any file format if it supports.");
 
+    public static final ConfigOption<MemorySize> WRITE_BATCH_MEMORY =
+            key("write.batch-memory")
+                    .memoryType()
+                    .defaultValue(MemorySize.parse("128 mb"))
+                    .withDescription("Write batch memory for any file format if it supports.");
+
     public static final ConfigOption<String> CONSUMER_ID =
             key("consumer-id")
                     .stringType()

--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatCWriter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatCWriter.java
@@ -27,6 +27,8 @@ import org.apache.arrow.c.ArrowSchema;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 
+import javax.annotation.Nullable;
+
 /**
  * This writer could flush to c struct, but you need to release it, except it has been released in c
  * code.
@@ -38,12 +40,20 @@ public class ArrowFormatCWriter implements AutoCloseable {
     private final ArrowFormatWriter realWriter;
 
     public ArrowFormatCWriter(RowType rowType, int writeBatchSize, boolean caseSensitive) {
-        this(new ArrowFormatWriter(rowType, writeBatchSize, caseSensitive));
+        this(new ArrowFormatWriter(rowType, writeBatchSize, caseSensitive, null));
+    }
+
+    public ArrowFormatCWriter(
+            RowType rowType,
+            int writeBatchSize,
+            boolean caseSensitive,
+            @Nullable Long memoryUsedMaxInVSR) {
+        this(new ArrowFormatWriter(rowType, writeBatchSize, caseSensitive, memoryUsedMaxInVSR));
     }
 
     public ArrowFormatCWriter(
             RowType rowType, int writeBatchSize, boolean caseSensitive, BufferAllocator allocator) {
-        this(new ArrowFormatWriter(rowType, writeBatchSize, caseSensitive, allocator));
+        this(new ArrowFormatWriter(rowType, writeBatchSize, caseSensitive, allocator, null));
     }
 
     private ArrowFormatCWriter(ArrowFormatWriter arrowFormatWriter) {

--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatWriter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/vector/ArrowFormatWriter.java
@@ -26,7 +26,6 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -105,9 +104,7 @@ public class ArrowFormatWriter implements AutoCloseable {
         for (int i = 0; i < currentRow.getFieldCount(); i++) {
             try {
                 fieldWriters[i].write(rowId, currentRow, i);
-            } catch (OversizedAllocationException
-                    | IndexOutOfBoundsException
-                    | OutOfMemoryException e) {
+            } catch (OversizedAllocationException | IndexOutOfBoundsException e) {
                 // maybe out of memory
                 LOG.warn("Arrow field writer failed while writing", e);
                 return false;

--- a/paimon-arrow/src/test/java/org/apache/paimon/arrow/vector/ArrowFormatWriterTest.java
+++ b/paimon-arrow/src/test/java/org/apache/paimon/arrow/vector/ArrowFormatWriterTest.java
@@ -169,7 +169,6 @@ public class ArrowFormatWriterTest {
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
     public void testWriteWithMemoryLimit(boolean limitMemory) {
-        System.out.println("limit memory: " + limitMemory);
         RowType rowType =
                 new RowType(
                         Arrays.asList(
@@ -194,7 +193,7 @@ public class ArrowFormatWriterTest {
             writer.reset();
 
             if (limitMemory) {
-                for (int i = 0; i < 60; i++) {
+                for (int i = 0; i < 64; i++) {
                     Assertions.assertThat(writer.write(genericRow)).isTrue();
                 }
                 Assertions.assertThat(writer.write(genericRow)).isFalse();

--- a/paimon-arrow/src/test/java/org/apache/paimon/arrow/vector/ArrowFormatWriterTest.java
+++ b/paimon-arrow/src/test/java/org/apache/paimon/arrow/vector/ArrowFormatWriterTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
@@ -162,6 +163,60 @@ public class ArrowFormatWriterTest {
                 }
             }
             vectorSchemaRoot.close();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testWriteWithMemoryLimit(boolean limitMemory) {
+        System.out.println("limit memory: " + limitMemory);
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "f0", DataTypes.BYTES()),
+                                new DataField(1, "f1", DataTypes.BYTES())));
+        Long memoryLimit = limitMemory ? 100 * 1024 * 1024L : null;
+        try (ArrowFormatWriter writer = new ArrowFormatWriter(rowType, 4096, true, memoryLimit)) {
+
+            GenericRow genericRow = new GenericRow(2);
+            genericRow.setField(0, randomBytes(1024 * 1024, 1024 * 1024));
+            genericRow.setField(1, randomBytes(1024 * 1024, 1024 * 1024));
+
+            // normal write
+            for (int i = 0; i < 200; i++) {
+                boolean success = writer.write(genericRow);
+                if (!success) {
+                    writer.flush();
+                    writer.reset();
+                    writer.write(genericRow);
+                }
+            }
+            writer.reset();
+
+            if (limitMemory) {
+                for (int i = 0; i < 60; i++) {
+                    Assertions.assertThat(writer.write(genericRow)).isTrue();
+                }
+                Assertions.assertThat(writer.write(genericRow)).isFalse();
+            }
+            writer.reset();
+
+            // Write batch records
+            for (int i = 0; i < 2000; i++) {
+                boolean success = writer.write(genericRow);
+                if (!success) {
+                    writer.flush();
+                    writer.reset();
+                    writer.write(genericRow);
+                }
+            }
+
+            if (limitMemory) {
+                Assertions.assertThat(writer.memoryUsed()).isLessThan(memoryLimit);
+                Assertions.assertThat(writer.getAllocator().getAllocatedMemory())
+                        .isGreaterThan(memoryLimit)
+                        .isLessThan(2 * memoryLimit);
+            }
         }
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
@@ -84,6 +84,7 @@ public abstract class FileFormat {
                         options,
                         options.get(CoreOptions.READ_BATCH_SIZE),
                         options.get(CoreOptions.WRITE_BATCH_SIZE),
+                        options.get(CoreOptions.WRITE_BATCH_MEMORY),
                         options.get(CoreOptions.FILE_COMPRESSION_ZSTD_LEVEL),
                         options.get(CoreOptions.FILE_BLOCK_SIZE)));
     }

--- a/paimon-common/src/main/java/org/apache/paimon/format/FileFormatFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FileFormatFactory.java
@@ -37,23 +37,35 @@ public interface FileFormatFactory {
         private final Options options;
         private final int readBatchSize;
         private final int writeBatchSize;
+        private final MemorySize writeBatchMemory;
         private final int zstdLevel;
         @Nullable private final MemorySize blockSize;
 
         @VisibleForTesting
         public FormatContext(Options options, int readBatchSize, int writeBatchSize) {
-            this(options, readBatchSize, writeBatchSize, 1, null);
+            this(options, readBatchSize, writeBatchSize, MemorySize.VALUE_128_MB, 1, null);
+        }
+
+        @VisibleForTesting
+        public FormatContext(
+                Options options,
+                int readBatchSize,
+                int writeBatchSize,
+                MemorySize writeBatchMemory) {
+            this(options, readBatchSize, writeBatchSize, writeBatchMemory, 1, null);
         }
 
         public FormatContext(
                 Options options,
                 int readBatchSize,
                 int writeBatchSize,
+                MemorySize writeBatchMemory,
                 int zstdLevel,
                 @Nullable MemorySize blockSize) {
             this.options = options;
             this.readBatchSize = readBatchSize;
             this.writeBatchSize = writeBatchSize;
+            this.writeBatchMemory = writeBatchMemory;
             this.zstdLevel = zstdLevel;
             this.blockSize = blockSize;
         }
@@ -68,6 +80,10 @@ public interface FileFormatFactory {
 
         public int writeBatchSize() {
             return writeBatchSize;
+        }
+
+        public MemorySize writeBatchMemory() {
+            return writeBatchMemory;
         }
 
         public int zstdLevel() {

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFileFormatTest.java
@@ -22,6 +22,7 @@ import org.apache.paimon.format.FileFormatFactory.FormatContext;
 import org.apache.paimon.format.parquet.writer.RowDataParquetBuilder;
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
+import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
@@ -48,7 +49,8 @@ public class ParquetFileFormatTest {
         Options options = new Options();
         options.set(parquetKey, "hello");
         options.set(otherKey, "test");
-        FormatContext context = new FormatContext(options, 1024, 1024, 2, null);
+        FormatContext context =
+                new FormatContext(options, 1024, 1024, MemorySize.VALUE_128_MB, 2, null);
 
         Options actual = new ParquetFileFormat(context).getOptions();
         assertThat(actual.get(parquetKey)).isEqualTo("hello");

--- a/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceFileFormat.java
+++ b/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceFileFormat.java
@@ -75,7 +75,12 @@ public class LanceFileFormat extends FileFormat {
     @Override
     public FormatWriterFactory createWriterFactory(RowType type) {
         return new LanceWriterFactory(
-                () -> new ArrowFormatWriter(type, formatContext.writeBatchSize(), true));
+                () ->
+                        new ArrowFormatWriter(
+                                type,
+                                formatContext.writeBatchSize(),
+                                true,
+                                formatContext.writeBatchMemory().getBytes()));
     }
 
     @Override


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
If every record is too big to put into one batch, then write.batch-size may be useless.
Introduce a new config write.batch-memory for this situation.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
