### PR TITLE
[core] Row-tracking row should keep their row_id and sequence_number in compaction

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/table/SpecialFields.java
+++ b/paimon-api/src/main/java/org/apache/paimon/table/SpecialFields.java
@@ -102,9 +102,6 @@ public class SpecialFields {
                             ROW_ID.name())
                     .collect(Collectors.toSet());
 
-    public static final Set<String> ROW_LINEAGE_FIELD_NAMES =
-            Stream.of(ROW_ID.name(), SEQUENCE_NUMBER.name()).collect(Collectors.toSet());
-
     public static boolean isSystemField(int fieldId) {
         return fieldId >= SYSTEM_FIELD_ID_START;
     }
@@ -142,11 +139,12 @@ public class SpecialFields {
                 + depth;
     }
 
-    public static RowType fieldsWithRowLineage(RowType rowType) {
+    public static RowType rowTypeWithRowLineage(RowType rowType) {
         List<DataField> fieldsWithRowLineage = new ArrayList<>(rowType.getFields());
+
         fieldsWithRowLineage.forEach(
                 f -> {
-                    if (ROW_LINEAGE_FIELD_NAMES.contains(f.name())) {
+                    if (ROW_ID.name().equals(f.name()) || SEQUENCE_NUMBER.name().equals(f.name())) {
                         throw new IllegalArgumentException(
                                 "Row lineage field name '"
                                         + f.name()

--- a/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
@@ -33,6 +33,7 @@ import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.CatalogEnvironment;
+import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.types.RowType;
 
 import javax.annotation.Nullable;
@@ -96,9 +97,13 @@ public class AppendOnlyFileStore extends AbstractFileStore<InternalRow> {
                         ? DeletionVectorsMaintainer.factory(newIndexFileHandler())
                         : null;
         if (bucketMode() == BucketMode.BUCKET_UNAWARE) {
+            RawFileSplitRead readForCompact = newRead();
+            if (options.rowTrackingEnabled()) {
+                readForCompact.withReadType(SpecialFields.fieldsWithRowLineage(rowType));
+            }
             return new AppendFileStoreWrite(
                     fileIO,
-                    newRead(),
+                    readForCompact,
                     schema.id(),
                     rowType,
                     partitionType,

--- a/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
@@ -99,7 +99,7 @@ public class AppendOnlyFileStore extends AbstractFileStore<InternalRow> {
         if (bucketMode() == BucketMode.BUCKET_UNAWARE) {
             RawFileSplitRead readForCompact = newRead();
             if (options.rowTrackingEnabled()) {
-                readForCompact.withReadType(SpecialFields.fieldsWithRowLineage(rowType));
+                readForCompact.withReadType(SpecialFields.rowTypeWithRowLineage(rowType));
             }
             return new AppendFileStoreWrite(
                     fileIO,

--- a/paimon-core/src/main/java/org/apache/paimon/operation/BaseAppendFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/BaseAppendFileStoreWrite.java
@@ -155,7 +155,7 @@ public abstract class BaseAppendFileStoreWrite extends MemoryFileStoreWrite<Inte
         }
         RowType writeSchema =
                 options.rowTrackingEnabled()
-                        ? SpecialFields.fieldsWithRowLineage(rowType)
+                        ? SpecialFields.rowTypeWithRowLineage(rowType)
                         : rowType;
         Exception collectedExceptions = null;
         RowDataRollingFileWriter rewriter =

--- a/paimon-core/src/main/java/org/apache/paimon/operation/BaseAppendFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/BaseAppendFileStoreWrite.java
@@ -35,6 +35,7 @@ import org.apache.paimon.io.RowDataRollingFileWriter;
 import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.reader.RecordReaderIterator;
 import org.apache.paimon.statistics.SimpleColStatsCollector;
+import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.CommitIncrement;
 import org.apache.paimon.utils.ExceptionUtils;
@@ -43,7 +44,6 @@ import org.apache.paimon.utils.IOExceptionSupplier;
 import org.apache.paimon.utils.LongCounter;
 import org.apache.paimon.utils.RecordWriter;
 import org.apache.paimon.utils.SnapshotManager;
-import org.apache.paimon.utils.StatsCollectorFactories;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,6 +59,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 
 import static org.apache.paimon.format.FileFormat.fileFormat;
+import static org.apache.paimon.utils.StatsCollectorFactories.createStatsFactories;
 
 /** {@link FileStoreWrite} for {@link AppendOnlyFileStore}. */
 public abstract class BaseAppendFileStoreWrite extends MemoryFileStoreWrite<InternalRow>
@@ -67,7 +68,7 @@ public abstract class BaseAppendFileStoreWrite extends MemoryFileStoreWrite<Inte
     private static final Logger LOG = LoggerFactory.getLogger(BaseAppendFileStoreWrite.class);
 
     private final FileIO fileIO;
-    private final RawFileSplitRead read;
+    private final RawFileSplitRead readForCompact;
     private final long schemaId;
     private final RowType rowType;
     private final FileFormat fileFormat;
@@ -79,7 +80,7 @@ public abstract class BaseAppendFileStoreWrite extends MemoryFileStoreWrite<Inte
 
     public BaseAppendFileStoreWrite(
             FileIO fileIO,
-            RawFileSplitRead read,
+            RawFileSplitRead readForCompact,
             long schemaId,
             RowType rowType,
             RowType partitionType,
@@ -91,15 +92,14 @@ public abstract class BaseAppendFileStoreWrite extends MemoryFileStoreWrite<Inte
             String tableName) {
         super(snapshotManager, scan, options, partitionType, null, dvMaintainerFactory, tableName);
         this.fileIO = fileIO;
-        this.read = read;
+        this.readForCompact = readForCompact;
         this.schemaId = schemaId;
         this.rowType = rowType;
         this.fileFormat = fileFormat(options);
         this.pathFactory = pathFactory;
 
         this.statsCollectors =
-                StatsCollectorFactories.createStatsFactories(
-                        options.statsMode(), options, rowType.getFieldNames());
+                createStatsFactories(options.statsMode(), options, rowType.getFieldNames());
         this.fileIndexOptions = options.indexColumnsOptions();
     }
 
@@ -153,10 +153,17 @@ public abstract class BaseAppendFileStoreWrite extends MemoryFileStoreWrite<Inte
         if (toCompact.isEmpty()) {
             return Collections.emptyList();
         }
+        RowType writeSchema =
+                options.rowTrackingEnabled()
+                        ? SpecialFields.fieldsWithRowLineage(rowType)
+                        : rowType;
         Exception collectedExceptions = null;
         RowDataRollingFileWriter rewriter =
                 createRollingFileWriter(
-                        partition, bucket, new LongCounter(toCompact.get(0).minSequenceNumber()));
+                        partition,
+                        bucket,
+                        new LongCounter(toCompact.get(0).minSequenceNumber()),
+                        writeSchema);
         List<IOExceptionSupplier<DeletionVector>> dvFactories = null;
         if (dvFactory != null) {
             dvFactories = new ArrayList<>(toCompact.size());
@@ -182,17 +189,20 @@ public abstract class BaseAppendFileStoreWrite extends MemoryFileStoreWrite<Inte
     }
 
     private RowDataRollingFileWriter createRollingFileWriter(
-            BinaryRow partition, int bucket, LongCounter seqNumCounter) {
+            BinaryRow partition, int bucket, LongCounter seqNumCounter, RowType writeSchema) {
         return new RowDataRollingFileWriter(
                 fileIO,
                 schemaId,
                 fileFormat,
                 options.targetFileSize(false),
-                rowType,
+                writeSchema,
                 pathFactory.createDataFilePathFactory(partition, bucket),
                 seqNumCounter,
                 options.fileCompression(),
-                statsCollectors,
+                writeSchema.equals(rowType)
+                        ? statsCollectors
+                        : createStatsFactories(
+                                options.statsMode(), options, writeSchema.getFieldNames()),
                 fileIndexOptions,
                 FileSource.COMPACT,
                 options.asyncFileWrite(),
@@ -205,7 +215,8 @@ public abstract class BaseAppendFileStoreWrite extends MemoryFileStoreWrite<Inte
             List<DataFileMeta> files,
             @Nullable List<IOExceptionSupplier<DeletionVector>> dvFactories)
             throws IOException {
-        return new RecordReaderIterator<>(read.createReader(partition, bucket, files, dvFactories));
+        return new RecordReaderIterator<>(
+                readForCompact.createReader(partition, bucket, files, dvFactories));
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -1183,6 +1183,9 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 long rowCount = entry.file().rowCount();
                 rowIdAssigned.add(entry.assignFirstRowId(start));
                 start += rowCount;
+            } else {
+                // for compact file, do not assign first row id.
+                rowIdAssigned.add(entry);
             }
         }
         return start;

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/RowLineageTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/RowLineageTable.java
@@ -101,7 +101,7 @@ public class RowLineageTable implements DataTable, ReadonlyTable {
 
     @Override
     public RowType rowType() {
-        return SpecialFields.fieldsWithRowLineage(wrapped.rowType());
+        return SpecialFields.rowTypeWithRowLineage(wrapped.rowType());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/RowLineageTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/RowLineageTable.java
@@ -36,7 +36,6 @@ import org.apache.paimon.table.source.DataTableScan;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.StreamDataTableScan;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
-import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.ChangelogManager;
@@ -44,7 +43,6 @@ import org.apache.paimon.utils.SimpleFileReader;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -103,10 +101,7 @@ public class RowLineageTable implements DataTable, ReadonlyTable {
 
     @Override
     public RowType rowType() {
-        List<DataField> fields = new ArrayList<>(wrapped.rowType().getFields());
-        fields.add(SpecialFields.ROW_ID);
-        fields.add(SpecialFields.SEQUENCE_NUMBER);
-        return new RowType(fields);
+        return SpecialFields.fieldsWithRowLineage(wrapped.rowType());
     }
 
     @Override


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Row id and Sequence number should be kept their origin value during compaction.
<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
