### PR TITLE
[python] Support mutual conversion between paimon DataField and pyarrow Field

### DIFF
--- a/paimon-python/pypaimon/schema/data_types.py
+++ b/paimon-python/pypaimon/schema/data_types.py
@@ -15,7 +15,6 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-import json
 import re
 import threading
 from abc import ABC, abstractmethod

--- a/paimon-python/pypaimon/schema/schema.py
+++ b/paimon-python/pypaimon/schema/schema.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from typing import Optional, List, Dict
 
 import pyarrow as pa
-from pypaimon.schema.data_types import DataField
+from pypaimon.schema.data_types import DataField, PyarrowFieldParse
 from pypaimon.common.rest_json import json_field
 
 
@@ -31,11 +31,23 @@ class Schema:
     FIELD_OPTIONS = "options"
     FIELD_COMMENT = "comment"
 
-    pa_schema: Optional[pa.Schema] = None
     fields: List[DataField] = json_field(FIELD_FIELDS, default_factory=list)
-    partition_keys: List[str] = json_field(
-        FIELD_PARTITION_KEYS, default_factory=list)
-    primary_keys: List[str] = json_field(
-        FIELD_PRIMARY_KEYS, default_factory=list)
+    partition_keys: List[str] = json_field(FIELD_PARTITION_KEYS, default_factory=list)
+    primary_keys: List[str] = json_field(FIELD_PRIMARY_KEYS, default_factory=list)
     options: Dict[str, str] = json_field(FIELD_OPTIONS, default_factory=dict)
     comment: Optional[str] = json_field(FIELD_COMMENT, default=None)
+
+    def __init__(self, fields: Optional[List[DataField]] = None, partition_keys: Optional[List[str]] = None,
+                 primary_keys: Optional[List[str]] = None,
+                 options: Optional[Dict[str, str]] = None, comment: Optional[str] = None):
+        self.fields = fields if fields is not None else []
+        self.partition_keys = partition_keys if partition_keys is not None else []
+        self.primary_keys = primary_keys if primary_keys is not None else []
+        self.options = options if options is not None else {}
+        self.comment = comment
+
+    @staticmethod
+    def build_from_pyarrow_schema(pa_schema: pa.Schema, partition_keys: Optional[List[str]] = None,
+                                  primary_keys: Optional[List[str]] = None, options: Optional[Dict[str, str]] = None,
+                                  comment: Optional[str] = None):
+        return Schema(PyarrowFieldParse.parse_pyarrow_schema(pa_schema), partition_keys, primary_keys, options, comment)

--- a/paimon-python/pypaimon/schema/table_schema.py
+++ b/paimon-python/pypaimon/schema/table_schema.py
@@ -22,11 +22,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Dict, Optional
 
-import pyarrow
 
 from pypaimon import Schema
 from pypaimon.common.rest_json import json_field
-from pypaimon.schema import data_types
 from pypaimon.common.core_options import CoreOptions
 from pypaimon.common.file_io import FileIO
 from pypaimon.schema.data_types import DataField

--- a/paimon-python/pypaimon/schema/table_schema.py
+++ b/paimon-python/pypaimon/schema/table_schema.py
@@ -74,13 +74,6 @@ class TableSchema:
         self.time_millis = time_millis if time_millis is not None else int(time.time() * 1000)
 
     def to_schema(self) -> Schema:
-        try:
-            pa_fields = []
-            for field in self.fields:
-                pa_fields.append(field.to_pyarrow_field())
-            pyarrow.schema(pa_fields)
-        except Exception as e:
-            raise e
         return Schema(
             fields=self.fields,
             partition_keys=self.partition_keys,
@@ -133,12 +126,10 @@ class TableSchema:
     @staticmethod
     def from_schema(schema_id: int, schema: Schema) -> "TableSchema":
         fields: List[DataField] = schema.fields
-        if not schema.fields:
-            fields = data_types.parse_data_fields_from_pyarrow_schema(schema.pa_schema)
         partition_keys: List[str] = schema.partition_keys
         primary_keys: List[str] = schema.primary_keys
         options: Dict[str, str] = schema.options
-        highest_field_id: int = None  # max(field.id for field in fields)
+        highest_field_id: int = max(field.id for field in fields)
 
         return TableSchema(
             TableSchema.CURRENT_VERSION,

--- a/paimon-python/pypaimon/schema/table_schema.py
+++ b/paimon-python/pypaimon/schema/table_schema.py
@@ -80,7 +80,7 @@ class TableSchema:
                 pa_fields.append(field.to_pyarrow_field())
             pyarrow.schema(pa_fields)
         except Exception as e:
-            print(e)
+            raise e
         return Schema(
             fields=self.fields,
             partition_keys=self.partition_keys,

--- a/paimon-python/pypaimon/tests/api_test.py
+++ b/paimon-python/pypaimon/tests/api_test.py
@@ -122,23 +122,6 @@ class ApiTestCase(unittest.TestCase):
         self.assertEqual(value_type.fields[0].type.type, 'BIGINT')
         self.assertEqual(value_type.fields[1].type.type, 'DOUBLE')
 
-    def test_types(self):
-        """Example usage of RESTCatalogServer"""
-        # Setup logging
-        logging.basicConfig(level=logging.INFO)
-        data_fields = [
-            DataField(0, "name", AtomicType('INT'), 'desc  name'),
-            DataField(1, "arr11", ArrayType(True, AtomicType('INT')), 'desc  arr11'),
-            DataField(2, "map11",
-                      MapType(False, AtomicType('INT'), MapType(False, AtomicType('INT'), AtomicType('INT'))),
-                      'desc  arr11'),
-        ]
-        table_schema = TableSchema(TableSchema.CURRENT_VERSION, len(data_fields), data_fields, len(data_fields),
-                                   [], [], {}, "")
-        schema = table_schema.to_schema()
-        print("\n")
-        print(schema)
-
     def test_api(self):
         """Example usage of RESTCatalogServer"""
         # Setup logging

--- a/paimon-python/pypaimon/tests/api_test.py
+++ b/paimon-python/pypaimon/tests/api_test.py
@@ -122,6 +122,23 @@ class ApiTestCase(unittest.TestCase):
         self.assertEqual(value_type.fields[0].type.type, 'BIGINT')
         self.assertEqual(value_type.fields[1].type.type, 'DOUBLE')
 
+    def test_types(self):
+        """Example usage of RESTCatalogServer"""
+        # Setup logging
+        logging.basicConfig(level=logging.INFO)
+        data_fields = [
+            DataField(0, "name", AtomicType('INT'), 'desc  name'),
+            DataField(1, "arr11", ArrayType(True, AtomicType('INT')), 'desc  arr11'),
+            DataField(2, "map11",
+                      MapType(False, AtomicType('INT'), MapType(False, AtomicType('INT'), AtomicType('INT'))),
+                      'desc  arr11'),
+        ]
+        table_schema = TableSchema(TableSchema.CURRENT_VERSION, len(data_fields), data_fields, len(data_fields),
+                                   [], [], {}, "")
+        schema = table_schema.to_schema()
+        print("\n")
+        print(schema)
+
     def test_api(self):
         """Example usage of RESTCatalogServer"""
         # Setup logging

--- a/paimon-python/pypaimon/tests/schema_test.py
+++ b/paimon-python/pypaimon/tests/schema_test.py
@@ -1,0 +1,59 @@
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+
+import pyarrow
+
+from pypaimon import Schema
+from pypaimon.schema.table_schema import TableSchema
+from pypaimon.schema.data_types import AtomicType, ArrayType, MapType, DataField, PyarrowFieldParse
+
+
+class SchemaTestCase(unittest.TestCase):
+    def test_types(self):
+        data_fields = [
+            DataField(0, "name", AtomicType('INT'), 'desc  name'),
+            DataField(1, "arr", ArrayType(True, AtomicType('INT')), 'desc arr1'),
+            DataField(2, "map1",
+                      MapType(False, AtomicType('INT'), MapType(False, AtomicType('INT'), AtomicType('INT'))),
+                      'desc map1'),
+        ]
+        table_schema = TableSchema(TableSchema.CURRENT_VERSION, len(data_fields), data_fields,
+                                   max(field.id for field in data_fields),
+                                   [], [], {}, "")
+        pa_fields = []
+        for field in table_schema.fields:
+            pa_field = PyarrowFieldParse.to_pyarrow_field(field)
+            pa_fields.append(pa_field)
+        schema = Schema.build_from_pyarrow_schema(
+            pa_schema=pyarrow.schema(pa_fields),
+            partition_keys=table_schema.partition_keys,
+            primary_keys=table_schema.primary_keys,
+            options=table_schema.options,
+            comment=table_schema.comment
+        )
+        table_schema2 = TableSchema.from_schema(len(data_fields), schema)
+        # print("table_schema2:", table_schema2)
+        l1 = []
+        for field in table_schema.fields:
+            l1.append(field.to_dict())
+        l2 = []
+        for field in table_schema2.fields:
+            l2.append(field.to_dict())
+        self.assertEqual(l1, l2)

--- a/paimon-python/pypaimon/write/row_key_extractor.py
+++ b/paimon-python/pypaimon/write/row_key_extractor.py
@@ -58,7 +58,6 @@ class RowKeyExtractor(ABC):
     @abstractmethod
     def _extract_buckets_batch(self, table: pa.RecordBatch) -> List[int]:
         """Extract bucket numbers for all rows. Must be implemented by subclasses."""
-        pass
 
 
 class FixedBucketRowKeyExtractor(RowKeyExtractor):


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
- Support partial mutual conversion between nested paimon DataField and pyarrow Field, including list and map.
- Support create Schema from pyarrow Schema
<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
schema_test.SchemaTestCase.test_types()
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
