### PR TITLE
[test] Fix FlinkRestCatalogITCase ut failed in idea

### DIFF
--- a/paimon-flink/paimon-flink-common/pom.xml
+++ b/paimon-flink/paimon-flink-common/pom.xml
@@ -210,6 +210,13 @@ under the License.
             <version>${okhttp.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>${apache.hc.client.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 


### PR DESCRIPTION
### Purpose
Fix the failure of FlinkRestCatalogITCase in IDEA, as httpcomponents is relocated in the paimon-api module, and IDEA cannot recognize this scenario. The dependency should be explicitly defined.

### Tests

### API and Format

### Documentation