### PR TITLE
[flink] Automatically detect changes of external-paths strategy

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -435,6 +435,12 @@ under the License.
             <td>Optional endInput check partition expire used in case of batch mode or bounded stream.</td>
         </tr>
         <tr>
+            <td><h5>external-paths.detect-config.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to auto detected the change of data-file.external-paths when streaming writing.</td>
+        </tr>
+        <tr>
             <td><h5>fields.default-aggregate-function</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -206,6 +206,13 @@ public class CoreOptions implements Serializable {
                                     + ExternalPathStrategy.SPECIFIC_FS
                                     + ", should be the prefix scheme of the external path, now supported are s3 and oss.");
 
+    public static final ConfigOption<Boolean> AUTO_DETECT_DATA_FILE_EXTERNAL_PATHS =
+            key("external-paths.detect-config.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to auto detected the change of data-file.external-paths when streaming writing.");
+
     public static final ConfigOption<Boolean> COMPACTION_FORCE_REWRITE_ALL_FILES =
             key("compaction.force-rewrite-all-files")
                     .booleanType()
@@ -2673,6 +2680,19 @@ public class CoreOptions implements Serializable {
     @Nullable
     public String dataFileExternalPaths() {
         return options.get(DATA_FILE_EXTERNAL_PATHS);
+    }
+
+    public boolean autoDetectDataFileExternalPaths() {
+        return options.get(AUTO_DETECT_DATA_FILE_EXTERNAL_PATHS);
+    }
+
+    public Map<String, String> dataFileExternalPathConfig() {
+        Map<String, String> externalPathsConfig = new HashMap<>();
+        externalPathsConfig.put(DATA_FILE_EXTERNAL_PATHS.key(), dataFileExternalPaths());
+        externalPathsConfig.put(
+                DATA_FILE_EXTERNAL_PATHS_STRATEGY.key(), externalPathStrategy().toString());
+        externalPathsConfig.put(DATA_FILE_EXTERNAL_PATHS_SPECIFIC_FS.key(), externalSpecificFS());
+        return externalPathsConfig;
     }
 
     public ExternalPathStrategy externalPathStrategy() {

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcAppendTableWriteOperator.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcAppendTableWriteOperator.java
@@ -54,6 +54,13 @@ public class CdcAppendTableWriteOperator extends CdcRecordStoreWriteOperator {
     }
 
     @Override
+    protected String getCommitUser(StateInitializationContext context) throws Exception {
+        // No conflicts will occur in append only unaware bucket writer, so
+        // commitUser does not matter.
+        return commitUser == null ? initialCommitUser : commitUser;
+    }
+
+    @Override
     public void processElement(StreamRecord<CdcRecord> element) throws Exception {
         // only accepts INSERT record
         if (element.getValue().kind() == RowKind.INSERT) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DynamicBucketRowWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DynamicBucketRowWriteOperator.java
@@ -27,6 +27,9 @@ import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
+import java.io.IOException;
+import java.util.List;
+
 /**
  * A {@link PrepareCommitOperator} to write {@link InternalRow} with bucket. Record schema is fixed.
  */
@@ -52,6 +55,15 @@ public class DynamicBucketRowWriteOperator
     public void processElement(StreamRecord<Tuple2<InternalRow, Integer>> element)
             throws Exception {
         write.write(element.getValue().f0, element.getValue().f1);
+    }
+
+    @Override
+    protected List<Committable> prepareCommit(boolean waitCompaction, long checkpointId)
+            throws IOException {
+        List<Committable> committables = super.prepareCommit(waitCompaction, checkpointId);
+
+        updateWriteWithNewSchema(table, write);
+        return committables;
     }
 
     /** {@link StreamOperatorFactory} of {@link DynamicBucketRowWriteOperator}. */

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DynamicBucketRowWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DynamicBucketRowWriteOperator.java
@@ -62,7 +62,7 @@ public class DynamicBucketRowWriteOperator
             throws IOException {
         List<Committable> committables = super.prepareCommit(waitCompaction, checkpointId);
 
-        updateWriteWithNewSchema(table, write);
+        updateWriteWithNewSchema(table, write, state.getSubtaskId());
         return committables;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkWriteSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkWriteSink.java
@@ -93,14 +93,6 @@ public abstract class FlinkWriteSink<T> extends FlinkSink<T> {
                         // is needed.
                         return new NoopStoreSinkWriteState(subtaskId);
                     }
-
-                    @Override
-                    protected String getCommitUser(StateInitializationContext context)
-                            throws Exception {
-                        // No conflicts will occur in append only unaware bucket writer, so
-                        // commitUser does not matter.
-                        return commitUser;
-                    }
                 };
             }
         };

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkWriteSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkWriteSink.java
@@ -93,6 +93,14 @@ public abstract class FlinkWriteSink<T> extends FlinkSink<T> {
                         // is needed.
                         return new NoopStoreSinkWriteState(subtaskId);
                     }
+
+                    @Override
+                    protected String getCommitUser(StateInitializationContext context)
+                            throws Exception {
+                        // No conflicts will occur in append only unaware bucket writer, so
+                        // commitUser does not matter.
+                        return commitUser == null ? initialCommitUser : commitUser;
+                    }
                 };
             }
         };

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataStoreWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataStoreWriteOperator.java
@@ -221,6 +221,8 @@ public class RowDataStoreWriteOperator extends TableWriteOperator<InternalRow> {
                                                     new LogOffsetCommittable(k, v))));
         }
 
+        updateWriteWithNewSchema(table, write);
+
         return committables;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataStoreWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RowDataStoreWriteOperator.java
@@ -221,7 +221,7 @@ public class RowDataStoreWriteOperator extends TableWriteOperator<InternalRow> {
                                                     new LogOffsetCommittable(k, v))));
         }
 
-        updateWriteWithNewSchema(table, write);
+        updateWriteWithNewSchema(table, write, state.getSubtaskId());
 
         return committables;
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCompactOperator.java
@@ -170,7 +170,7 @@ public class StoreCompactOperator extends PrepareCommitOperator<RowData, Committ
 
         List<Committable> committables = write.prepareCommit(waitCompaction, checkpointId);
 
-        updateWriteWithNewSchema(table, write);
+        updateWriteWithNewSchema(table, write, state.getSubtaskId());
         return committables;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCompactOperator.java
@@ -58,7 +58,7 @@ public class StoreCompactOperator extends PrepareCommitOperator<RowData, Committ
 
     private static final Logger LOG = LoggerFactory.getLogger(StoreCompactOperator.class);
 
-    private final FileStoreTable table;
+    private FileStoreTable table;
     private final StoreSinkWrite.Provider storeSinkWriteProvider;
     private final String initialCommitUser;
     private final boolean fullCompaction;
@@ -167,7 +167,11 @@ public class StoreCompactOperator extends PrepareCommitOperator<RowData, Committ
             throw new RuntimeException("Exception happens while executing compaction.", e);
         }
         waitToCompact.clear();
-        return write.prepareCommit(waitCompaction, checkpointId);
+
+        List<Committable> committables = write.prepareCommit(waitCompaction, checkpointId);
+
+        updateWriteWithNewSchema(table, write);
+        return committables;
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendOnlyTableITCase.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.fs.local.LocalFileIOLoader;
 import org.apache.paimon.utils.BlockingIterator;
 import org.apache.paimon.utils.TraceableFileIO;
@@ -28,6 +29,7 @@ import org.apache.paimon.utils.TraceableFileIO;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.util.CloseableIterator;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -35,9 +37,11 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -255,6 +259,78 @@ public class AppendOnlyTableITCase extends CatalogITCaseBase {
         assertThat(rows)
                 .containsExactlyInAnyOrder(
                         Row.of(1, "AAA"), Row.of(2, "BBB"), Row.of(3, "CCC"), Row.of(4, "DDD"));
+    }
+
+    @Test
+    public void testTableReadWriteWithChangedExternalPath() throws Exception {
+        String externalPaths1 = TraceableFileIO.SCHEME + "://" + tempExternalPath1.toString();
+        String externalPaths2 = TraceableFileIO.SCHEME + "://" + tempExternalPath2.toString();
+
+        int bucket = ThreadLocalRandom.current().nextBoolean() ? 1 : -1;
+        String bucketKey = bucket == 1 ? "'bucket-key' = 'k'," : "";
+        sEnv.executeSql(
+                "CREATE TABLE T2 ( k INT, v INT) "
+                        + "WITH ( "
+                        + "'bucket' = '"
+                        + bucket
+                        + "',"
+                        + bucketKey
+                        + "'external-paths.detect-config.enabled' = 'true',"
+                        + "'data-file.external-paths' = '"
+                        + externalPaths1
+                        + "',"
+                        + "'data-file.external-paths.strategy' = 'round-robin'"
+                        + ")");
+
+        // Create a datagen source table
+        sEnv.executeSql(
+                "CREATE TEMPORARY TABLE datagen_source (k INT, v INT) WITH ("
+                        + "'connector' = 'datagen', "
+                        + "'rows-per-second' = '1', "
+                        + "'fields.k.kind' = 'sequence', "
+                        + "'fields.k.start' = '1', "
+                        + "'fields.k.end' = '5', "
+                        + "'fields.v.kind' = 'sequence', "
+                        + "'fields.v.start' = '1', "
+                        + "'fields.v.end' = '5'"
+                        + ")");
+
+        CloseableIterator<Row> it = streamSqlIter("SELECT * FROM T2");
+
+        // Insert data from datagen source into T2
+        sEnv.executeSql("INSERT INTO T2 SELECT * FROM datagen_source");
+        sEnv.executeSql(
+                "ALTER TABLE T2 SET ( "
+                        + "'data-file.external-paths' = '"
+                        + externalPaths2
+                        + "'"
+                        + ")");
+
+        // Read and verify the data
+        List<String> resultRows = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            resultRows.add(it.next().toString());
+        }
+
+        assertThat(resultRows)
+                .containsExactlyInAnyOrder(
+                        "+I[1, 1]", "+I[2, 2]", "+I[3, 3]", "+I[4, 4]", "+I[5, 5]");
+
+        LocalFileIO fileIO = LocalFileIO.create();
+        assertThat(fileIO.exists(new org.apache.paimon.fs.Path(tempExternalPath1.toString())))
+                .isTrue();
+        assertThat(fileIO.exists(new org.apache.paimon.fs.Path(tempExternalPath2.toString())))
+                .isTrue();
+        assertThat(
+                        fileIO.listStatus(
+                                        new org.apache.paimon.fs.Path(tempExternalPath1.toString()))
+                                .length)
+                .isGreaterThanOrEqualTo(1);
+        assertThat(
+                        fileIO.listStatus(
+                                        new org.apache.paimon.fs.Path(tempExternalPath2.toString()))
+                                .length)
+                .isGreaterThanOrEqualTo(1);
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PrimaryKeyFileStoreTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/PrimaryKeyFileStoreTableITCase.java
@@ -479,6 +479,76 @@ public class PrimaryKeyFileStoreTableITCase extends AbstractTestBase {
     }
 
     @Test
+    public void testTableReadWriteWithChangedExternalPath() throws Exception {
+        TableEnvironment sEnv =
+                tableEnvironmentBuilder()
+                        .streamingMode()
+                        .checkpointIntervalMs(ThreadLocalRandom.current().nextInt(900) + 100)
+                        .parallelism(1)
+                        .build();
+
+        sEnv.executeSql(createCatalogSql("testCatalog", path + "/warehouse"));
+        sEnv.executeSql("USE CATALOG testCatalog");
+        String externalPaths1 = TraceableFileIO.SCHEME + "://" + externalPath1.toString();
+        String externalPaths2 = LocalFileIOLoader.SCHEME + "://" + externalPath2.toString();
+
+        int bucket = ThreadLocalRandom.current().nextBoolean() ? 1 : -1;
+        sEnv.executeSql(
+                "CREATE TABLE T2 ( k INT, v INT, PRIMARY KEY (k) NOT ENFORCED ) "
+                        + "WITH ( "
+                        + "'bucket' = '"
+                        + bucket
+                        + "',"
+                        + "'external-paths.detect-config.enabled' = 'true',"
+                        + "'data-file.external-paths' = '"
+                        + externalPaths1
+                        + "',"
+                        + "'data-file.external-paths.strategy' = 'round-robin'"
+                        + ")");
+
+        // Create a datagen source table
+        sEnv.executeSql(
+                "CREATE TEMPORARY TABLE datagen_source (k INT, v INT) WITH ("
+                        + "'connector' = 'datagen', "
+                        + "'rows-per-second' = '1', "
+                        + "'fields.k.kind' = 'sequence', "
+                        + "'fields.k.start' = '1', "
+                        + "'fields.k.end' = '5', "
+                        + "'fields.v.kind' = 'sequence', "
+                        + "'fields.v.start' = '1', "
+                        + "'fields.v.end' = '5'"
+                        + ")");
+
+        CloseableIterator<Row> it = collect(sEnv.executeSql("SELECT * FROM T2"));
+
+        // Insert data from datagen source into T2
+        sEnv.executeSql("INSERT INTO T2 SELECT * FROM datagen_source");
+
+        sEnv.executeSql(
+                "ALTER TABLE T2 SET ( "
+                        + "'data-file.external-paths' = '"
+                        + externalPaths2
+                        + "'"
+                        + ")");
+
+        // Read and verify the data
+        List<String> resultRows = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            resultRows.add(it.next().toString());
+        }
+
+        assertThat(resultRows)
+                .containsExactlyInAnyOrder(
+                        "+I[1, 1]", "+I[2, 2]", "+I[3, 3]", "+I[4, 4]", "+I[5, 5]");
+
+        LocalFileIO fileIO = LocalFileIO.create();
+        assertThat(fileIO.exists(new Path(externalPath1))).isTrue();
+        assertThat(fileIO.exists(new Path(externalPath2))).isTrue();
+        assertThat(fileIO.listStatus(new Path(externalPath1)).length).isGreaterThanOrEqualTo(1);
+        assertThat(fileIO.listStatus(new Path(externalPath2)).length).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
     public void testTableReadWriteBranch() throws Exception {
         TableEnvironment sEnv =
                 tableEnvironmentBuilder()


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
The Flink job needs to be restarted for changes to take effect when changing the configration of external-paths. With rapid data lake growth and frequent storage expansions, external-paths changes occur often,  therefore some users require updates without restarting flink streaming job.

This pr checks latest schema every checkpoint, and if the schema has changed, it'll try update the `write` with the latest external-paths config. You can configure 'external-paths.detect-config.enabled' = 'true' to enable this feature. Cause it tries to read latest schema every chekpoint, it'll bring extra IO cost.

Currently, this feature takes affects for flink streaming writing  job and table-level dedicated compaction job.


### Tests

<!-- List UT and IT cases to verify this change -->
Streaming write:

1. AppendOnlyTableITCase#testTableReadWriteWithChangedExternalPath
2. PrimaryKeyFileStoreTableITCase#testTableReadWriteWithChangedExternalPath

table-level dedicated compaction:

1. CompactActionITCase#testStreamingCompactWithChangedExternalPath
2. CompactActionITCase#testUnawareBucketStreamingCompactWithChangedExternalPath

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
