### PR TITLE
[core] Fix the commit kind when performing row-level changes on non-pk table

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/Snapshot.java
+++ b/paimon-api/src/main/java/org/apache/paimon/Snapshot.java
@@ -496,13 +496,16 @@ public class Snapshot implements Serializable {
     /** Type of changes in this snapshot. */
     public enum CommitKind {
 
-        /** Changes flushed from the mem table. */
+        /** New data files are appended to the table and no data file is deleted. */
         APPEND,
 
         /** Changes by compacting existing data files. */
         COMPACT,
 
-        /** Changes that clear up the whole partition and then add new records. */
+        /**
+         * New data files are added to overwrite existing data files or just delete existing data
+         * files.
+         */
         OVERWRITE,
 
         /** Collect statistics. */

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
@@ -50,7 +50,7 @@ public interface FileStoreCommit extends AutoCloseable {
      *     note that this partition does not necessarily equal to the partitions of the newly added
      *     key-values. This is just the partition to be cleaned up.
      */
-    int overwrite(
+    int overwritePartition(
             Map<String, String> partition,
             ManifestCommittable committable,
             Map<String, String> properties);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -747,7 +747,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     .newIndexFiles()
                     .forEach(
                             m ->
-                                    appendIndexFiles.add(
+                                    compactIndexFiles.add(
                                             new IndexManifestEntry(
                                                     FileKind.ADD,
                                                     commitMessage.partition(),
@@ -758,7 +758,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     .deletedIndexFiles()
                     .forEach(
                             m ->
-                                    appendIndexFiles.add(
+                                    compactIndexFiles.add(
                                             new IndexManifestEntry(
                                                     FileKind.DELETE,
                                                     commitMessage.partition(),

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -25,7 +25,6 @@ import org.apache.paimon.catalog.SnapshotCommit;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.FileIO;
-import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFilePathFactory;
 import org.apache.paimon.manifest.FileEntry;
@@ -88,7 +87,6 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static org.apache.paimon.deletionvectors.DeletionVectorsIndexFile.DELETION_VECTORS_INDEX;
-import static org.apache.paimon.index.HashIndexFile.HASH_INDEX;
 import static org.apache.paimon.manifest.ManifestEntry.recordCount;
 import static org.apache.paimon.manifest.ManifestEntry.recordCountAdd;
 import static org.apache.paimon.manifest.ManifestEntry.recordCountDelete;
@@ -296,24 +294,24 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
         List<ManifestEntry> appendTableFiles = new ArrayList<>();
         List<ManifestEntry> appendChangelog = new ArrayList<>();
+        List<IndexManifestEntry> appendIndexFiles = new ArrayList<>();
         List<ManifestEntry> compactTableFiles = new ArrayList<>();
         List<ManifestEntry> compactChangelog = new ArrayList<>();
-        List<IndexManifestEntry> appendHashIndexFiles = new ArrayList<>();
-        List<IndexManifestEntry> compactDvIndexFiles = new ArrayList<>();
+        List<IndexManifestEntry> compactIndexFiles = new ArrayList<>();
         collectChanges(
                 committable.fileCommittables(),
                 appendTableFiles,
                 appendChangelog,
+                appendIndexFiles,
                 compactTableFiles,
                 compactChangelog,
-                appendHashIndexFiles,
-                compactDvIndexFiles);
+                compactIndexFiles);
         try {
             List<SimpleFileEntry> appendSimpleEntries = SimpleFileEntry.from(appendTableFiles);
             if (!ignoreEmptyCommit
                     || !appendTableFiles.isEmpty()
                     || !appendChangelog.isEmpty()
-                    || !appendHashIndexFiles.isEmpty()) {
+                    || !appendIndexFiles.isEmpty()) {
                 // Optimization for common path.
                 // Step 1:
                 // Read manifest entries from changed partitions here and check for conflicts.
@@ -322,6 +320,10 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 // This optimization is mainly used to decrease the number of times we read from
                 // files.
                 latestSnapshot = snapshotManager.latestSnapshot();
+                boolean hasDelete = hasDelete(appendSimpleEntries, appendIndexFiles);
+                Snapshot.CommitKind commitKind =
+                        hasDelete ? Snapshot.CommitKind.OVERWRITE : Snapshot.CommitKind.APPEND;
+
                 if (latestSnapshot != null && checkAppendFiles) {
                     // it is possible that some partitions only have compact changes,
                     // so we need to contain all changes
@@ -332,7 +334,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                             latestSnapshot.commitUser(),
                             baseEntries,
                             appendSimpleEntries,
-                            Snapshot.CommitKind.APPEND);
+                            commitKind);
                     safeLatestSnapshotId = latestSnapshot.id();
                 }
 
@@ -340,20 +342,20 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         tryCommit(
                                 appendTableFiles,
                                 appendChangelog,
-                                appendHashIndexFiles,
+                                appendIndexFiles,
                                 committable.identifier(),
                                 committable.watermark(),
                                 committable.logOffsets(),
                                 committable.properties(),
-                                Snapshot.CommitKind.APPEND,
-                                noConflictCheck(),
+                                commitKind,
+                                hasDelete ? mustConflictCheck() : noConflictCheck(),
                                 null);
                 generatedSnapshot += 1;
             }
 
             if (!compactTableFiles.isEmpty()
                     || !compactChangelog.isEmpty()
-                    || !compactDvIndexFiles.isEmpty()) {
+                    || !compactIndexFiles.isEmpty()) {
                 // Optimization for common path.
                 // Step 2:
                 // Add appendChanges to the manifest entries read above and check for conflicts.
@@ -376,7 +378,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         tryCommit(
                                 compactTableFiles,
                                 compactChangelog,
-                                compactDvIndexFiles,
+                                compactIndexFiles,
                                 committable.identifier(),
                                 committable.watermark(),
                                 committable.logOffsets(),
@@ -426,8 +428,23 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         commitMetrics.reportCommit(commitStats);
     }
 
+    private boolean hasDelete(
+            List<SimpleFileEntry> appendSimpleEntries, List<IndexManifestEntry> appendIndexFiles) {
+        for (SimpleFileEntry appendSimpleEntry : appendSimpleEntries) {
+            if (appendSimpleEntry.kind().equals(FileKind.DELETE)) {
+                return true;
+            }
+        }
+        for (IndexManifestEntry appendIndexFile : appendIndexFiles) {
+            if (appendIndexFile.indexFile().indexType().equals(DELETION_VECTORS_INDEX)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
-    public int overwrite(
+    public int overwritePartition(
             Map<String, String> partition,
             ManifestCommittable committable,
             Map<String, String> properties) {
@@ -448,18 +465,18 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         int attempts = 0;
         List<ManifestEntry> appendTableFiles = new ArrayList<>();
         List<ManifestEntry> appendChangelog = new ArrayList<>();
+        List<IndexManifestEntry> appendIndexFiles = new ArrayList<>();
         List<ManifestEntry> compactTableFiles = new ArrayList<>();
         List<ManifestEntry> compactChangelog = new ArrayList<>();
-        List<IndexManifestEntry> appendHashIndexFiles = new ArrayList<>();
-        List<IndexManifestEntry> compactDvIndexFiles = new ArrayList<>();
+        List<IndexManifestEntry> compactIndexFiles = new ArrayList<>();
         collectChanges(
                 committable.fileCommittables(),
                 appendTableFiles,
                 appendChangelog,
+                appendIndexFiles,
                 compactTableFiles,
                 compactChangelog,
-                appendHashIndexFiles,
-                compactDvIndexFiles);
+                compactIndexFiles);
 
         if (!appendChangelog.isEmpty() || !compactChangelog.isEmpty()) {
             StringBuilder warnMessage =
@@ -493,7 +510,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     partitionFilter = PartitionPredicate.fromMultiple(partitionType, partitions);
                 }
             } else {
-                // partition may be partial partition fields, so here must to use predicate way.
+                // partition may be partial partition fields, so here must use predicate way.
                 Predicate partitionPredicate =
                         createPartitionPredicate(partition, partitionType, partitionDefaultName);
                 partitionFilter =
@@ -516,10 +533,10 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             // overwrite new files
             if (!skipOverwrite) {
                 attempts +=
-                        tryOverwrite(
+                        tryOverwritePartition(
                                 partitionFilter,
                                 appendTableFiles,
-                                appendHashIndexFiles,
+                                appendIndexFiles,
                                 committable.identifier(),
                                 committable.watermark(),
                                 committable.logOffsets(),
@@ -527,12 +544,12 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 generatedSnapshot += 1;
             }
 
-            if (!compactTableFiles.isEmpty() || !compactDvIndexFiles.isEmpty()) {
+            if (!compactTableFiles.isEmpty() || !compactIndexFiles.isEmpty()) {
                 attempts +=
                         tryCommit(
                                 compactTableFiles,
                                 emptyList(),
-                                compactDvIndexFiles,
+                                compactIndexFiles,
                                 committable.identifier(),
                                 committable.watermark(),
                                 committable.logOffsets(),
@@ -590,7 +607,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             partitionFilter = PartitionPredicate.fromPredicate(partitionType, predicate);
         }
 
-        tryOverwrite(
+        tryOverwritePartition(
                 partitionFilter,
                 emptyList(),
                 emptyList(),
@@ -602,7 +619,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
     @Override
     public void truncateTable(long commitIdentifier) {
-        tryOverwrite(
+        tryOverwritePartition(
                 null,
                 emptyList(),
                 emptyList(),
@@ -666,10 +683,10 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             List<CommitMessage> commitMessages,
             List<ManifestEntry> appendTableFiles,
             List<ManifestEntry> appendChangelog,
+            List<IndexManifestEntry> appendIndexFiles,
             List<ManifestEntry> compactTableFiles,
             List<ManifestEntry> compactChangelog,
-            List<IndexManifestEntry> appendHashIndexFiles,
-            List<IndexManifestEntry> compactDvIndexFiles) {
+            List<IndexManifestEntry> compactIndexFiles) {
         for (CommitMessage message : commitMessages) {
             CommitMessageImpl commitMessage = (CommitMessageImpl) message;
             commitMessage
@@ -688,6 +705,29 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     .changelogFiles()
                     .forEach(m -> appendChangelog.add(makeEntry(FileKind.ADD, commitMessage, m)));
             commitMessage
+                    .newFilesIncrement()
+                    .newIndexFiles()
+                    .forEach(
+                            m ->
+                                    appendIndexFiles.add(
+                                            new IndexManifestEntry(
+                                                    FileKind.ADD,
+                                                    commitMessage.partition(),
+                                                    commitMessage.bucket(),
+                                                    m)));
+            commitMessage
+                    .newFilesIncrement()
+                    .deletedIndexFiles()
+                    .forEach(
+                            m ->
+                                    appendIndexFiles.add(
+                                            new IndexManifestEntry(
+                                                    FileKind.DELETE,
+                                                    commitMessage.partition(),
+                                                    commitMessage.bucket(),
+                                                    m)));
+
+            commitMessage
                     .compactIncrement()
                     .compactBefore()
                     .forEach(
@@ -702,53 +742,28 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     .compactIncrement()
                     .changelogFiles()
                     .forEach(m -> compactChangelog.add(makeEntry(FileKind.ADD, commitMessage, m)));
-
-            // todo: split them
-            List<IndexFileMeta> newIndexFiles =
-                    new ArrayList<>(commitMessage.newFilesIncrement().newIndexFiles());
-            newIndexFiles.addAll(commitMessage.compactIncrement().newIndexFiles());
-            newIndexFiles.forEach(
-                    f -> {
-                        switch (f.indexType()) {
-                            case HASH_INDEX:
-                                appendHashIndexFiles.add(
-                                        new IndexManifestEntry(
-                                                FileKind.ADD,
-                                                commitMessage.partition(),
-                                                commitMessage.bucket(),
-                                                f));
-                                break;
-                            case DELETION_VECTORS_INDEX:
-                                compactDvIndexFiles.add(
-                                        new IndexManifestEntry(
-                                                FileKind.ADD,
-                                                commitMessage.partition(),
-                                                commitMessage.bucket(),
-                                                f));
-                                break;
-                            default:
-                                throw new RuntimeException("Unknown index type: " + f.indexType());
-                        }
-                    });
-
-            // todo: split them
-            List<IndexFileMeta> deletedIndexFiles =
-                    new ArrayList<>(commitMessage.newFilesIncrement().deletedIndexFiles());
-            deletedIndexFiles.addAll(commitMessage.compactIncrement().deletedIndexFiles());
-            deletedIndexFiles.forEach(
-                    f -> {
-                        if (f.indexType().equals(DELETION_VECTORS_INDEX)) {
-                            compactDvIndexFiles.add(
-                                    new IndexManifestEntry(
-                                            FileKind.DELETE,
-                                            commitMessage.partition(),
-                                            commitMessage.bucket(),
-                                            f));
-                        } else {
-                            throw new RuntimeException(
-                                    "This index type is not supported to delete: " + f.indexType());
-                        }
-                    });
+            commitMessage
+                    .compactIncrement()
+                    .newIndexFiles()
+                    .forEach(
+                            m ->
+                                    appendIndexFiles.add(
+                                            new IndexManifestEntry(
+                                                    FileKind.ADD,
+                                                    commitMessage.partition(),
+                                                    commitMessage.bucket(),
+                                                    m)));
+            commitMessage
+                    .compactIncrement()
+                    .deletedIndexFiles()
+                    .forEach(
+                            m ->
+                                    appendIndexFiles.add(
+                                            new IndexManifestEntry(
+                                                    FileKind.DELETE,
+                                                    commitMessage.partition(),
+                                                    commitMessage.bucket(),
+                                                    m)));
         }
         if (!commitMessages.isEmpty()) {
             List<String> msg = new ArrayList<>();
@@ -758,17 +773,17 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             if (!appendChangelog.isEmpty()) {
                 msg.add(appendChangelog.size() + " append Changelogs");
             }
+            if (!appendIndexFiles.isEmpty()) {
+                msg.add(appendIndexFiles.size() + " append index files");
+            }
             if (!compactTableFiles.isEmpty()) {
                 msg.add(compactTableFiles.size() + " compact table files");
             }
             if (!compactChangelog.isEmpty()) {
                 msg.add(compactChangelog.size() + " compact Changelogs");
             }
-            if (!appendHashIndexFiles.isEmpty()) {
-                msg.add(appendHashIndexFiles.size() + " append hash index files");
-            }
-            if (!compactDvIndexFiles.isEmpty()) {
-                msg.add(compactDvIndexFiles.size() + " compact dv index files");
+            if (!compactIndexFiles.isEmpty()) {
+                msg.add(compactIndexFiles.size() + " compact index files");
             }
             LOG.info("Finished collecting changes, including: {}", String.join(", ", msg));
         }
@@ -836,7 +851,13 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         return retryCount + 1;
     }
 
-    private int tryOverwrite(
+    /**
+     * Try to overwrite partition.
+     *
+     * @param partitionFilter Partition filter indicating which partitions to overwrite, if {@code
+     *     null}, overwrites the entire table.
+     */
+    private int tryOverwritePartition(
             @Nullable PartitionPredicate partitionFilter,
             List<ManifestEntry> changes,
             List<IndexManifestEntry> indexFiles,

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
@@ -248,7 +248,8 @@ public class TableCommitImpl implements InnerTableCommit {
                 committable = new ManifestCommittable(Long.MAX_VALUE);
             }
             int newSnapshots =
-                    commit.overwrite(overwritePartition, committable, Collections.emptyMap());
+                    commit.overwritePartition(
+                            overwritePartition, committable, Collections.emptyMap());
             maintain(
                     committable.identifier(),
                     maintainExecutor,

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -263,7 +263,7 @@ public class TestFileStore extends KeyValueFileStore {
                 null,
                 Collections.emptyList(),
                 (commit, committable) ->
-                        commit.overwrite(partition, committable, Collections.emptyMap()));
+                        commit.overwritePartition(partition, committable, Collections.emptyMap()));
     }
 
     public Snapshot dropPartitions(List<Map<String, String>> partitions) {

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
@@ -154,13 +154,13 @@ public class FileDeletionTest {
         FileStoreCommitImpl commit = store.newCommit();
         Map<String, String> partitionSpec = new HashMap<>();
         partitionSpec.put("dt", "0401");
-        commit.overwrite(
+        commit.overwritePartition(
                 partitionSpec, new ManifestCommittable(commitIdentifier++), Collections.emptyMap());
 
         // step 3: generate snapshot 3 by cleaning partition dt=0402/hr=10
         partitionSpec.put("dt", "0402");
         partitionSpec.put("hr", "8");
-        commit.overwrite(
+        commit.overwritePartition(
                 partitionSpec, new ManifestCommittable(commitIdentifier++), Collections.emptyMap());
         commit.close();
 

--- a/paimon-core/src/test/java/org/apache/paimon/operation/TestCommitThread.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/TestCommitThread.java
@@ -169,7 +169,7 @@ public class TestCommitThread extends Thread {
         runWithRetry(
                 committable,
                 () ->
-                        commit.overwrite(
+                        commit.overwritePartition(
                                 TestKeyValueGenerator.toPartitionMap(partition, MULTI_PARTITIONED),
                                 committable,
                                 Collections.emptyMap()));

--- a/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTest.scala
+++ b/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTest.scala
@@ -32,8 +32,10 @@ class MergeIntoPrimaryKeyNonBucketTableTest
 
 class MergeIntoAppendBucketedTableTest
   extends MergeIntoTableTestBase
+  with MergeIntoAppendTableTest
   with PaimonAppendBucketedTableTest {}
 
 class MergeIntoAppendNonBucketedTableTest
   extends MergeIntoTableTestBase
+  with MergeIntoAppendTableTest
   with PaimonAppendNonBucketTableTest {}

--- a/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTest.scala
+++ b/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTest.scala
@@ -32,8 +32,10 @@ class MergeIntoPrimaryKeyNonBucketTableTest
 
 class MergeIntoAppendBucketedTableTest
   extends MergeIntoTableTestBase
+  with MergeIntoAppendTableTest
   with PaimonAppendBucketedTableTest {}
 
 class MergeIntoAppendNonBucketedTableTest
   extends MergeIntoTableTestBase
+  with MergeIntoAppendTableTest
   with PaimonAppendNonBucketTableTest {}

--- a/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTest.scala
+++ b/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTest.scala
@@ -34,10 +34,12 @@ class MergeIntoPrimaryKeyNonBucketTableTest
 
 class MergeIntoAppendBucketedTableTest
   extends MergeIntoTableTestBase
+  with MergeIntoAppendTableTest
   with MergeIntoNotMatchedBySourceTest
   with PaimonAppendBucketedTableTest {}
 
 class MergeIntoAppendNonBucketedTableTest
   extends MergeIntoTableTestBase
+  with MergeIntoAppendTableTest
   with MergeIntoNotMatchedBySourceTest
   with PaimonAppendNonBucketTableTest {}

--- a/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTest.scala
+++ b/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTest.scala
@@ -34,10 +34,12 @@ class MergeIntoPrimaryKeyNonBucketTableTest
 
 class MergeIntoAppendBucketedTableTest
   extends MergeIntoTableTestBase
+  with MergeIntoAppendTableTest
   with MergeIntoNotMatchedBySourceTest
   with PaimonAppendBucketedTableTest {}
 
 class MergeIntoAppendNonBucketedTableTest
   extends MergeIntoTableTestBase
+  with MergeIntoAppendTableTest
   with MergeIntoNotMatchedBySourceTest
   with PaimonAppendNonBucketTableTest {}

--- a/paimon-spark/paimon-spark-4.0/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTest.scala
+++ b/paimon-spark/paimon-spark-4.0/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTest.scala
@@ -34,10 +34,12 @@ class MergeIntoPrimaryKeyNonBucketTableTest
 
 class MergeIntoAppendBucketedTableTest
   extends MergeIntoTableTestBase
+  with MergeIntoAppendTableTest
   with MergeIntoNotMatchedBySourceTest
   with PaimonAppendBucketedTableTest {}
 
 class MergeIntoAppendNonBucketedTableTest
   extends MergeIntoTableTestBase
+  with MergeIntoAppendTableTest
   with MergeIntoNotMatchedBySourceTest
   with PaimonAppendNonBucketTableTest {}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Currently, there are some issues with the commit kind for non-PK tables under row-level commands:

- UPDATE, DELETE, and MERGE operations that remove old files should be classified as OVERWRITE, not APPEND.
- For non-PK DV (Deletion Vector) tables, only a single snapshot commit is needed (no need two), and it should also be of type OVERWRITE.


Here is a brief summary of commit kinds after modifcation:

- APPEND: 
  - insert into table
  - place data to PK table's level 0 (e.g. the first step of PK tables' DV generation).
- COMPACT:
  - Compact non-PK tables (e.g. merge small files)
  - Compact PK tables (e.g. triggered by LSM tree compaction)
  - Compact PK DV tables (e.g. triggered by DV generation)
- OVERWRITE:
  - insert overwrite (partition) table
  - drop partition
  - delete, update, and merge on non-PK tables (Note: this commit kind applies to both DV and non-DV tables) (Note: if this operation does not delete any old files, it will be classified as an APPEND. e.g. a merge can be considered as APPEND when it only insert condition matched)
- ANALYZE: 
  - analyze table

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
