### PR TITLE
[hotfix] Fix useless cases in StartupModeTest

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/table/source/StartupModeTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/StartupModeTest.java
@@ -262,14 +262,7 @@ public class StartupModeTest extends ScannerTestBase {
         // streaming Mode
         StreamTableScan dataTableScan = table.newStreamScan();
         TableScan.Plan firstPlan = dataTableScan.plan();
-
-        long startTime = System.currentTimeMillis();
         TableScan.Plan secondPlan = dataTableScan.plan();
-        long endTime = System.currentTimeMillis();
-        long duration = endTime - startTime;
-
-        // without delay read test
-        assertThat(duration).isLessThan(100);
 
         assertThat(firstPlan.splits()).isEmpty();
         assertThat(secondPlan.splits())


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->
The useless cases may cause the workflow runs error.

See https://github.com/apache/paimon/actions/runs/16743242901/job/47395798363?pr=6028

```text
Error:  Failures: 
Error:    StartupModeTest.testStartFromSnapshotWithoutDelayDuration:272 
Expecting actual:
  117L
to be less than:
  100L 
[INFO] 
Error:  Tests run: 2083, Failures: 1, Errors: 0, Skipped: 2
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
