### PR TITLE
[common] Minor fix for range-bitmap

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/BitSliceIndexBitmap.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/BitSliceIndexBitmap.java
@@ -236,7 +236,8 @@ public class BitSliceIndexBitmap {
             this.min = min;
             this.max = max;
             this.ebm = new RoaringBitmap32();
-            this.slices = new RoaringBitmap32[Long.SIZE - Long.numberOfLeadingZeros(max)];
+            this.slices =
+                    new RoaringBitmap32[Math.max(Long.SIZE - Long.numberOfLeadingZeros(max), 1)];
             for (int i = 0; i < slices.length; i++) {
                 slices[i] = new RoaringBitmap32();
             }

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/chunked/ChunkedDictionary.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/dictionary/chunked/ChunkedDictionary.java
@@ -193,13 +193,13 @@ public class ChunkedDictionary implements Dictionary {
                 throw new IllegalArgumentException("key should not be null");
             }
 
-            if (this.key != null && comparator.compare(this.key, key) > 0) {
+            if (this.key != null && comparator.compare(this.key, key) >= 0) {
                 throw new IllegalArgumentException("key can not out of order");
             } else {
                 this.key = key;
             }
 
-            if (this.code != null && this.code.compareTo(code) > 0) {
+            if (this.code != null && this.code.compareTo(code) >= 0) {
                 throw new IllegalArgumentException("code can not out of order");
             } else {
                 this.code = code;

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/rangebitmap/ChunkedDictionaryTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/rangebitmap/ChunkedDictionaryTest.java
@@ -24,6 +24,7 @@ import org.apache.paimon.fileindex.rangebitmap.dictionary.chunked.KeyFactory;
 import org.apache.paimon.fs.ByteArraySeekableStream;
 
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -52,6 +53,18 @@ public class ChunkedDictionaryTest {
 
         testVariableLengthChunkedDictionary(0); // test no chunked
         testVariableLengthChunkedDictionary(512); // test chunked
+    }
+
+    @Test
+    public void testBuildEmpty() throws IOException {
+        KeyFactory.IntKeyFactory factory = new KeyFactory.IntKeyFactory();
+        ChunkedDictionary.Appender appender = new ChunkedDictionary.Appender(factory, 0);
+        ChunkedDictionary dictionary =
+                new ChunkedDictionary(
+                        new ByteArraySeekableStream(appender.serialize()), 0, factory);
+        assertThat(dictionary.find(new Integer(0))).isEqualTo(-1);
+        assertThat(dictionary.find(new Integer(1))).isEqualTo(-1);
+        assertThat(dictionary.find(new Integer(3))).isEqualTo(-1);
     }
 
     private void testFixedLengthChunkedDictionary(int limitedSize) throws IOException {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

Fix the following two issues:
1. An unexpected error will be thrown when building the range-bitmap if all the values are NULL.
2. If the cardinality of a value is 1, an unexpected exception will be thrown when reading the range-bitmap's bsi.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
