### PR TITLE
[spark] Unify config extraction for maxPartitionBytes and openCostInBytes between paimon and spark

### DIFF
--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/ScanHelperTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/ScanHelperTest.scala
@@ -113,9 +113,38 @@ class ScanHelperTest extends PaimonSparkTestBase {
     Assertions.assertEquals(1, reshuffled.length)
   }
 
+  test("Paimon: set open-file-cost to 0") {
+    withTable("t") {
+      sql("CREATE TABLE t (a INT, b STRING)")
+      for (i <- 1 to 100) {
+        sql(s"INSERT INTO t VALUES ($i, 'a')")
+      }
+
+      def paimonScan() = getPaimonScan("SELECT * FROM t")
+
+      // default openCostInBytes is 4m, so we will get 400 / 128 = 4 partitions
+      withSparkSQLConf("spark.sql.leafNodeDefaultParallelism" -> "1") {
+        assert(paimonScan().lazyInputPartitions.length == 4)
+      }
+
+      withSparkSQLConf(
+        "spark.sql.files.openCostInBytes" -> "0",
+        "spark.sql.leafNodeDefaultParallelism" -> "1") {
+        assert(paimonScan().lazyInputPartitions.length == 1)
+      }
+
+      // Paimon's conf takes precedence over Spark's
+      withSparkSQLConf(
+        "spark.sql.files.openCostInBytes" -> "4194304",
+        "spark.paimon.source.split.open-file-cost" -> "0",
+        "spark.sql.leafNodeDefaultParallelism" -> "1") {
+        assert(paimonScan().lazyInputPartitions.length == 1)
+      }
+    }
+  }
+
   class FakeScan extends ScanHelper {
     override val coreOptions: CoreOptions =
       CoreOptions.fromMap(new JHashMap[String, String]())
   }
-
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

For maxPartitionBytes, paimon has `source.split.target-size`, spark has `spark.sql.files.maxPartitionBytes`

For file openCostInBytes, paimon has `source.split.open-file-cost`, spark has `spark.sql.files.openCostInBytes`

This pr combine them, and make Paimon's conf takes precedence over Spark's if we set them both

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
