### PR TITLE
[fix] Fix hive metastore address already in use

### DIFF
--- a/paimon-iceberg/src/test/java/org/apache/paimon/flink/CloneActionForIcebergITCase.java
+++ b/paimon-iceberg/src/test/java/org/apache/paimon/flink/CloneActionForIcebergITCase.java
@@ -43,7 +43,7 @@ public class CloneActionForIcebergITCase extends ActionITCaseBase {
 
     private static final TestHiveMetastore TEST_HIVE_METASTORE = new TestHiveMetastore();
 
-    private static final int PORT = 9089;
+    private static final int PORT = 9090;
 
     @TempDir java.nio.file.Path iceTempDir;
 


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->

`CloneActionForHudiITCase` and `CloneActionForIcebergITCase` should use different METASTORE ports to avoid port conflicts.

<img width="649" height="311" alt="image" src="https://github.com/user-attachments/assets/e555f047-3005-488e-b008-01051336f346" />


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
