### PR TITLE
[spark] Optimize the config reading for load table in SparkSource

### DIFF
--- a/docs/content/spark/dataframe.md
+++ b/docs/content/spark/dataframe.md
@@ -44,13 +44,13 @@ data.write.format("paimon")
 ## Insert
 
 ### Insert Into
-You can achieve INSERT INTO semantics by setting the mode to `append` (by default).
+You can achieve INSERT INTO semantics by setting the mode to `append`.
 
 ```scala
 val data: DataFrame = ...
 
 data.write.format("paimon")
-  .mode("append")         // by default
+  .mode("append")
   .insertInto("test_tbl") // or .saveAsTable("test_tbl") or .save("/path/to/default.db/test_tbl")
 ```
 
@@ -93,5 +93,11 @@ data.write.format("paimon")
 ```scala
 spark.read.format("paimon")
   .table("t") // or .load("/path/to/default.db/test_tbl")
+  .show()
+
+// time travel
+spark.read.format("paimon")
+  .option("scan.snapshot-id", 1)
+  .table("t")
   .show()
 ```

--- a/docs/content/spark/dataframe.md
+++ b/docs/content/spark/dataframe.md
@@ -94,10 +94,28 @@ data.write.format("paimon")
 spark.read.format("paimon")
   .table("t") // or .load("/path/to/default.db/test_tbl")
   .show()
+```
 
+To specify the catalog or database, you can use
+
+```scala
+// recommend
+spark.read.format("paimon")
+  .table("<catalogName>.<databaseName>.<tableName>")
+
+// or
+spark.read.format("paimon")
+  .option("catalog", "<catalogName>")
+  .option("database", "<databaseName>")
+  .option("table", "<tableName>")
+  .load("/path/to/default.db/test_tbl")
+```
+
+You can specify other read configs through option:
+
+```scala
 // time travel
 spark.read.format("paimon")
   .option("scan.snapshot-id", 1)
   .table("t")
-  .show()
 ```

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/OptionUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/OptionUtils.scala
@@ -26,7 +26,7 @@ import org.apache.paimon.table.Table
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.internal.StaticSQLConf
 
-import java.util.{Map => JMap}
+import java.util.{HashMap => JHashMap, Map => JMap}
 import java.util.regex.Pattern
 
 import scala.collection.JavaConverters._
@@ -71,19 +71,21 @@ object OptionUtils extends SQLConfHelper {
     getOptionString(SparkConnectorOptions.EXPLICIT_CAST).toBoolean
   }
 
-  def extractCatalogName(): Option[String] = {
-    val sparkCatalogTemplate = String.format("%s([^.]*)$", SPARK_CATALOG_PREFIX)
-    val sparkCatalogPattern = Pattern.compile(sparkCatalogTemplate)
-    conf.getAllConfs.filterKeys(_.startsWith(SPARK_CATALOG_PREFIX)).foreach {
-      case (key, _) =>
-        val matcher = sparkCatalogPattern.matcher(key)
-        if (matcher.find())
-          return Option(matcher.group(1))
-    }
-    Option.empty
+  private def mergeSQLConf(extraOptions: JMap[String, String]): JMap[String, String] = {
+    val mergedOptions = new JHashMap[String, String](
+      conf.getAllConfs
+        .filterKeys(_.startsWith(PAIMON_OPTION_PREFIX))
+        .map {
+          case (key, value) =>
+            key.stripPrefix(PAIMON_OPTION_PREFIX) -> value
+        }
+        .toMap
+        .asJava)
+    mergedOptions.putAll(extraOptions)
+    mergedOptions
   }
 
-  def mergeSQLConfWithIdentifier(
+  private def mergeSQLConfWithIdentifier(
       extraOptions: JMap[String, String],
       catalogName: String,
       ident: Identifier): JMap[String, String] = {
@@ -106,11 +108,14 @@ object OptionUtils extends SQLConfHelper {
 
   def copyWithSQLConf[T <: Table](
       table: T,
-      catalogName: String,
-      ident: Identifier,
-      extraOptions: JMap[String, String]): T = {
-    val mergedOptions: JMap[String, String] =
+      catalogName: String = null,
+      ident: Identifier = null,
+      extraOptions: JMap[String, String] = new JHashMap[String, String]()): T = {
+    val mergedOptions = if (catalogName != null && ident != null) {
       mergeSQLConfWithIdentifier(extraOptions, catalogName, ident)
+    } else {
+      mergeSQLConf(extraOptions)
+    }
     if (mergedOptions.isEmpty) {
       table
     } else {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonOptionTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonOptionTest.scala
@@ -95,7 +95,7 @@ class PaimonOptionTest extends PaimonSparkTestBase {
     // query with table options
     withSparkSQLConf("spark.paimon.*.*.T.scan.snapshot-id" -> "1") {
       checkAnswer(sql("SELECT * FROM T ORDER BY id"), Row(1))
-      checkAnswer(spark.read.format("paimon").load(table.location().toString), Row(1))
+      checkAnswer(spark.read.format("paimon").table("T"), Row(1))
     }
 
     // query with both global and table options
@@ -103,9 +103,7 @@ class PaimonOptionTest extends PaimonSparkTestBase {
       "spark.paimon.scan.snapshot-id" -> "1",
       "spark.paimon.*.*.T.scan.snapshot-id" -> "2") {
       checkAnswer(sql("SELECT * FROM T ORDER BY id"), Row(1) :: Row(2) :: Nil)
-      checkAnswer(
-        spark.read.format("paimon").load(table.location().toString),
-        Row(1) :: Row(2) :: Nil)
+      checkAnswer(spark.read.format("paimon").table("T"), Row(1) :: Row(2) :: Nil)
     }
   }
 
@@ -129,8 +127,8 @@ class PaimonOptionTest extends PaimonSparkTestBase {
       checkAnswer(
         spark.read
           .format("paimon")
-          .load(table1.location().toString)
-          .join(spark.read.format("paimon").load(table2.location().toString), "id"),
+          .table("T1")
+          .join(spark.read.format("paimon").table("T2"), "id"),
         Row(1)
       )
     }
@@ -141,8 +139,8 @@ class PaimonOptionTest extends PaimonSparkTestBase {
       checkAnswer(
         spark.read
           .format("paimon")
-          .load(table1.location().toString)
-          .join(spark.read.format("paimon").load(table2.location().toString), "id"),
+          .table("T1")
+          .join(spark.read.format("paimon").table("T2"), "id"),
         Row(1)
       )
     }
@@ -157,8 +155,8 @@ class PaimonOptionTest extends PaimonSparkTestBase {
       checkAnswer(
         spark.read
           .format("paimon")
-          .load(table1.location().toString)
-          .join(spark.read.format("paimon").load(table2.location().toString), "id"),
+          .table("T1")
+          .join(spark.read.format("paimon").table("T2"), "id"),
         Row(1) :: Row(2) :: Nil
       )
     }
@@ -170,8 +168,8 @@ class PaimonOptionTest extends PaimonSparkTestBase {
       checkAnswer(
         spark.read
           .format("paimon")
-          .load(table1.location().toString)
-          .join(spark.read.format("paimon").load(table2.location().toString), "id"),
+          .table("T1")
+          .join(spark.read.format("paimon").table("T2"), "id"),
         Row(1)
       )
     }
@@ -183,8 +181,8 @@ class PaimonOptionTest extends PaimonSparkTestBase {
       checkAnswer(
         spark.read
           .format("paimon")
-          .load(table1.location().toString)
-          .join(spark.read.format("paimon").load(table2.location().toString), "id"),
+          .table("T1")
+          .join(spark.read.format("paimon").table("T2"), "id"),
         Row(1)
       )
     }
@@ -198,8 +196,8 @@ class PaimonOptionTest extends PaimonSparkTestBase {
       checkAnswer(
         spark.read
           .format("paimon")
-          .load(table1.location().toString)
-          .join(spark.read.format("paimon").load(table2.location().toString), "id"),
+          .table("T1")
+          .join(spark.read.format("paimon").table("T2"), "id"),
         Row(1) :: Row(2) :: Nil
       )
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

- If only path conf is provided, the catalog configs should not be read.
- Provides catalog, database, and table options, to allow the user to specify the catalog name.
- Fix other options reading, like time travel

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
