### PR TITLE
[core] Fix default value not work for primary key table with bucket -1

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
@@ -171,26 +171,19 @@ public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State
 
     @Nullable
     public SinkRecord writeAndReturn(InternalRow row) throws Exception {
+        return writeAndReturn(row, -1);
+    }
+
+    @Nullable
+    public SinkRecord writeAndReturn(InternalRow row, int bucket) throws Exception {
         checkNullability(row);
         row = wrapDefaultValue(row);
         RowKind rowKind = RowKindGenerator.getRowKind(rowKindGenerator, row);
         if (ignoreDelete && rowKind.isRetract()) {
             return null;
         }
-        SinkRecord record = toSinkRecord(row);
+        SinkRecord record = bucket == -1 ? toSinkRecord(row) : toSinkRecord(row, bucket);
         write.write(record.partition(), record.bucket(), recordExtractor.extract(record, rowKind));
-        return record;
-    }
-
-    @Nullable
-    public SinkRecord writeAndReturn(InternalRow row, int bucket) throws Exception {
-        checkNullability(row);
-        RowKind rowKind = RowKindGenerator.getRowKind(rowKindGenerator, row);
-        if (ignoreDelete && rowKind.isRetract()) {
-            return null;
-        }
-        SinkRecord record = toSinkRecord(row, bucket);
-        write.write(record.partition(), bucket, recordExtractor.extract(record, rowKind));
         return record;
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BranchSqlITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BranchSqlITCase.java
@@ -53,6 +53,15 @@ public class BranchSqlITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testDefaultValueForPkTableDynamicBucket() throws Exception {
+        sql("CREATE TABLE T (a INT PRIMARY KEY NOT ENFORCED, b INT)");
+        sql("CALL sys.alter_column_default_value('default.T', 'b', '5')");
+        sql("INSERT INTO T (a) VALUES (1), (2)");
+        assertThat(collectResult("SELECT * FROM T"))
+                .containsExactlyInAnyOrder("+I[1, 5]", "+I[2, 5]");
+    }
+
+    @Test
     public void testAlterBranchTable() throws Exception {
         sql(
                 "CREATE TABLE T ("


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
