### PR TITLE
[fs] Set credentials provider in JindoFileIO

### DIFF
--- a/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
+++ b/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.jindo;
 
+import com.aliyun.jindodata.oss.auth.SimpleCredentialsProvider;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.options.Options;
@@ -96,6 +97,7 @@ public class JindoFileIO extends HadoopCompliantFileIO {
 
         // Misalignment can greatly affect performance, so the maximum buffer is set here
         hadoopOptions.set("fs.oss.read.position.buffer.size", "8388608");
+        hadoopOptions.set("fs.oss.credentials.provider", SimpleCredentialsProvider.NAME);
 
         // read all configuration with prefix 'CONFIG_PREFIXES'
         for (String key : context.options().keySet()) {

--- a/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
+++ b/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.jindo;
 
-import com.aliyun.jindodata.oss.auth.SimpleCredentialsProvider;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.options.Options;
@@ -28,6 +27,7 @@ import org.apache.paimon.utils.Pair;
 import com.aliyun.jindodata.common.JindoHadoopSystem;
 import com.aliyun.jindodata.dls.JindoDlsFileSystem;
 import com.aliyun.jindodata.oss.JindoOssFileSystem;
+import com.aliyun.jindodata.oss.auth.SimpleCredentialsProvider;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.slf4j.Logger;


### PR DESCRIPTION
### Purpose
Set SimpleCredentialsProvider as default credentials provider for JindoFileIO to use right token to access OSS.
### Tests

### API and Format

### Documentation
