### PR TITLE
[spark] Replace collect with toLocalIterator to reduce peak memory usage on the Driver

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -294,7 +294,8 @@ case class PaimonSparkWriter(table: FileStoreTable, writeRowLineage: Boolean = f
     }
 
     written
-      .collect()
+      .toLocalIterator
+      .asScala
       .map(deserializeCommitMessage(serializer, _))
       .toSeq
   }
@@ -352,8 +353,10 @@ case class PaimonSparkWriter(table: FileStoreTable, writeRowLineage: Boolean = f
           serializer.serialize(commitMessage)
       }
     serializedCommits
-      .collect()
+      .toLocalIterator
+      .asScala
       .map(deserializeCommitMessage(serializer, _))
+      .toSeq
   }
 
   def commit(commitMessages: Seq[CommitMessage]): Unit = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -293,9 +293,7 @@ case class PaimonSparkWriter(table: FileStoreTable, writeRowLineage: Boolean = f
         throw new UnsupportedOperationException(s"Spark doesn't support $bucketMode mode.")
     }
 
-    written
-      .toLocalIterator
-      .asScala
+    written.toLocalIterator.asScala
       .map(deserializeCommitMessage(serializer, _))
       .toSeq
   }
@@ -352,9 +350,7 @@ case class PaimonSparkWriter(table: FileStoreTable, writeRowLineage: Boolean = f
           val serializer = new CommitMessageSerializer
           serializer.serialize(commitMessage)
       }
-    serializedCommits
-      .toLocalIterator
-      .asScala
+    serializedCommits.toLocalIterator.asScala
       .map(deserializeCommitMessage(serializer, _))
       .toSeq
   }


### PR DESCRIPTION
### Purpose

Replace collect with toLocalIterator to reduce peak memory usage on the Driver

### Tests

UT and IT cases 

