### PR TITLE
[spark] Only read necessary meta columns when building new scan plan

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DeleteFromPaimonTableCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DeleteFromPaimonTableCommand.scala
@@ -142,8 +142,9 @@ case class DeleteFromPaimonTableCommand(
         findTouchedFiles(candidateDataSplits, condition, relation, sparkSession)
 
       // Step3: the smallest range of data files that need to be rewritten.
-      val (touchedFiles, newRelation) =
-        createNewRelation(touchedFilePaths, dataFilePathToMeta, relation)
+      val (touchedFiles, touchedSplits) =
+        extractFilesAndBuildSplits(touchedFilePaths, dataFilePathToMeta)
+      val newRelation = createNewScanPlan(touchedSplits, relation)
 
       // Step4: build a dataframe that contains the unchanged data, and write out them.
       val toRewriteScanRelation = Filter(Not(condition), newRelation)

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCommand.scala
@@ -23,12 +23,11 @@ import org.apache.paimon.deletionvectors.{Bitmap64DeletionVector, BitmapDeletion
 import org.apache.paimon.fs.Path
 import org.apache.paimon.index.IndexFileMeta
 import org.apache.paimon.io.{CompactIncrement, DataFileMeta, DataIncrement, IndexIncrement}
-import org.apache.paimon.spark.SparkTable
 import org.apache.paimon.spark.catalyst.analysis.expressions.ExpressionHelper
 import org.apache.paimon.spark.commands.SparkDataFileMeta.convertToSparkDataFileMeta
-import org.apache.paimon.spark.schema.PaimonMetadataColumn
 import org.apache.paimon.spark.schema.PaimonMetadataColumn._
-import org.apache.paimon.table.{BucketMode, InnerTable, KnownSplitsTable}
+import org.apache.paimon.spark.util.ScanPlanHelper
+import org.apache.paimon.table.BucketMode
 import org.apache.paimon.table.sink.{CommitMessage, CommitMessageImpl}
 import org.apache.paimon.table.source.DataSplit
 import org.apache.paimon.utils.SerializationUtils
@@ -38,7 +37,6 @@ import org.apache.spark.sql.PaimonUtils.createDataset
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
-import org.apache.spark.sql.catalyst.plans.logical.{Filter => FilterLogicalNode, LogicalPlan, Project}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 
 import java.net.URI
@@ -47,7 +45,11 @@ import java.util.Collections
 import scala.collection.JavaConverters._
 
 /** Helper trait for all paimon commands. */
-trait PaimonCommand extends WithFileStoreTable with ExpressionHelper with SQLConfHelper {
+trait PaimonCommand
+  extends WithFileStoreTable
+  with ExpressionHelper
+  with ScanPlanHelper
+  with SQLConfHelper {
 
   lazy val dvSafeWriter: PaimonSparkWriter = {
     if (table.primaryKeys().isEmpty && table.bucketMode() == BucketMode.HASH_FIXED) {
@@ -102,7 +104,7 @@ trait PaimonCommand extends WithFileStoreTable with ExpressionHelper with SQLCon
       }
     }
 
-    val filteredRelation = createNewScanPlan(candidateDataSplits, condition, relation)
+    val filteredRelation = createNewScanPlan(candidateDataSplits, relation, Some(condition))
     findTouchedFiles(createDataset(sparkSession, filteredRelation), sparkSession)
   }
 
@@ -119,63 +121,15 @@ trait PaimonCommand extends WithFileStoreTable with ExpressionHelper with SQLCon
       .map(relativePath)
   }
 
-  protected def createNewScanPlan(
-      candidateDataSplits: Seq[DataSplit],
-      condition: Expression,
-      relation: DataSourceV2Relation,
-      metadataColumns: Seq[PaimonMetadataColumn]): LogicalPlan = {
-    val newRelation = createNewScanPlan(candidateDataSplits, condition, relation)
-    val resolvedMetadataColumns = metadataColumns.map {
-      col =>
-        val attr = newRelation.resolve(col.name :: Nil, conf.resolver)
-        assert(attr.isDefined)
-        attr.get
-    }
-    Project(relation.output ++ resolvedMetadataColumns, newRelation)
-  }
-
-  protected def createNewScanPlan(
-      candidateDataSplits: Seq[DataSplit],
-      condition: Expression,
-      relation: DataSourceV2Relation): LogicalPlan = {
-    val newRelation = createNewRelation(candidateDataSplits, relation)
-    FilterLogicalNode(condition, newRelation)
-  }
-
-  protected def createNewRelation(
+  protected def extractFilesAndBuildSplits(
       filePaths: Array[String],
-      filePathToMeta: Map[String, SparkDataFileMeta],
-      relation: DataSourceV2Relation): (Array[SparkDataFileMeta], DataSourceV2Relation) = {
+      filePathToMeta: Map[String, SparkDataFileMeta])
+      : (Array[SparkDataFileMeta], Array[DataSplit]) = {
     val files = filePaths.map(
       file => filePathToMeta.getOrElse(file, throw new RuntimeException(s"Missing file: $file")))
     val touchedDataSplits =
       SparkDataFileMeta.convertToDataSplits(files, rawConvertible = true, fileStore.pathFactory())
-    val newRelation = createNewRelation(touchedDataSplits, relation)
-    (files, newRelation)
-  }
-
-  protected def createNewRelation(
-      splits: Seq[DataSplit],
-      relation: DataSourceV2Relation): DataSourceV2Relation = {
-    assert(relation.table.isInstanceOf[SparkTable])
-    val sparkTable = relation.table.asInstanceOf[SparkTable]
-    assert(sparkTable.table.isInstanceOf[InnerTable])
-    val knownSplitsTable =
-      KnownSplitsTable.create(sparkTable.table.asInstanceOf[InnerTable], splits.toArray)
-    val outputNames = relation.outputSet.map(_.name)
-    def isOutputColumn(colName: String) = {
-      val resolve = conf.resolver
-      outputNames.exists(resolve(colName, _))
-    }
-    val appendMetaColumns = sparkTable.metadataColumns
-      .map(_.asInstanceOf[PaimonMetadataColumn].toAttribute)
-      .filter(col => !isOutputColumn(col.name))
-    // We re-plan the relation to skip analyze phase, so we should append needed
-    // metadata columns manually and let Spark do column pruning during optimization.
-    relation.copy(
-      table = relation.table.asInstanceOf[SparkTable].copy(table = knownSplitsTable),
-      output = relation.output ++ appendMetaColumns
-    )
+    (files, touchedDataSplits)
   }
 
   /** Notice that, the key is a relative path, not just the file name. */
@@ -196,7 +150,8 @@ trait PaimonCommand extends WithFileStoreTable with ExpressionHelper with SQLCon
       condition: Expression,
       relation: DataSourceV2Relation,
       sparkSession: SparkSession): Dataset[SparkDeletionVector] = {
-    val filteredRelation = createNewScanPlan(candidateDataSplits, condition, relation)
+    val filteredRelation =
+      createNewScanPlan(candidateDataSplits, relation, Some(condition), Some(dvMetaCols))
     val dataWithMetadataColumns = createDataset(sparkSession, filteredRelation)
     collectDeletionVectors(dataFilePathToMeta, dataWithMetadataColumns, sparkSession)
   }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/schema/PaimonMetadataColumn.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/schema/PaimonMetadataColumn.scala
@@ -72,6 +72,10 @@ object PaimonMetadataColumn {
   val SEQUENCE_NUMBER: PaimonMetadataColumn =
     PaimonMetadataColumn(Int.MaxValue - 105, SpecialFields.SEQUENCE_NUMBER.name(), LongType)
 
+  def dvMetaCols: Seq[PaimonMetadataColumn] = Seq(FILE_PATH, ROW_INDEX)
+
+  def rowLineageMetaCols: Seq[PaimonMetadataColumn] = Seq(ROW_ID, SEQUENCE_NUMBER)
+
   def get(metadataColumn: String, partitionType: StructType): PaimonMetadataColumn = {
     metadataColumn match {
       case ROW_INDEX_COLUMN => ROW_INDEX

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/ScanPlanHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/ScanPlanHelper.scala
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.util
+
+import org.apache.paimon.spark.SparkTable
+import org.apache.paimon.spark.schema.PaimonMetadataColumn
+import org.apache.paimon.table.{InnerTable, KnownSplitsTable}
+import org.apache.paimon.table.source.DataSplit
+
+import org.apache.spark.sql.catalyst.SQLConfHelper
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
+import org.apache.spark.sql.catalyst.plans.logical.{Filter => FilterLogicalNode, LogicalPlan, Project}
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+
+trait ScanPlanHelper extends SQLConfHelper {
+
+  /**
+   * Create a new scan plan from a relation with the given data splits, condition(optional) and
+   * metadata columns(optional).
+   */
+  def createNewScanPlan(
+      dataSplits: Seq[DataSplit],
+      relation: DataSourceV2Relation,
+      condition: Option[Expression] = None,
+      metadataColumns: Option[Seq[PaimonMetadataColumn]] = None): LogicalPlan = {
+    val newRelation = createNewRelation(dataSplits, relation)
+
+    val filteredNewRelation = condition match {
+      case Some(c) if c != TrueLiteral => FilterLogicalNode(c, newRelation)
+      case _ => newRelation
+    }
+
+    metadataColumns match {
+      case Some(cols) =>
+        val resolvedMetadataColumns = cols.map {
+          col =>
+            val attr = filteredNewRelation.resolve(col.name :: Nil, conf.resolver)
+            assert(attr.isDefined)
+            attr.get
+        }
+        Project(relation.output ++ resolvedMetadataColumns, filteredNewRelation)
+      case None => filteredNewRelation
+    }
+  }
+
+  private def createNewRelation(
+      splits: Seq[DataSplit],
+      relation: DataSourceV2Relation): DataSourceV2Relation = {
+    assert(relation.table.isInstanceOf[SparkTable])
+    val sparkTable = relation.table.asInstanceOf[SparkTable]
+    assert(sparkTable.table.isInstanceOf[InnerTable])
+    val knownSplitsTable =
+      KnownSplitsTable.create(sparkTable.table.asInstanceOf[InnerTable], splits.toArray)
+    val outputNames = relation.outputSet.map(_.name)
+
+    def isOutputColumn(colName: String) = {
+      val resolve = conf.resolver
+      outputNames.exists(resolve(colName, _))
+    }
+
+    val appendMetaColumns = sparkTable.metadataColumns
+      .map(_.asInstanceOf[PaimonMetadataColumn].toAttribute)
+      .filter(col => isOutputColumn(col.name))
+
+    // We re-plan the relation to skip analyze phase, so we should append needed
+    // metadata columns manually and let Spark do column pruning during optimization.
+    relation.copy(
+      table = relation.table.asInstanceOf[SparkTable].copy(table = knownSplitsTable),
+      output = relation.output ++ appendMetaColumns
+    )
+  }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Only read necessary meta columns when building new scan plan

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
