### PR TITLE
[core] Introduce data file cache in FileIO

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -206,6 +206,31 @@ public class CoreOptions implements Serializable {
                                     + ExternalPathStrategy.SPECIFIC_FS
                                     + ", should be the prefix scheme of the external path, now supported are s3 and oss.");
 
+    public static final ConfigOption<Boolean> DATA_FILE_LOCAL_CACHE_ENABLED =
+            key("data-file.local-cache.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("");
+
+    public static final ConfigOption<String> DATA_FILE_LOCAL_CACHE_TMP_DIRS =
+            key("data-file.local-cache.tmp.dirs")
+                    .stringType()
+                    .defaultValue(System.getProperty("java.io.tmpdir"))
+                    .withDescription(
+                            "Directories for temporary files, separated by\",\", \"|\", or the system's java.io.File.pathSeparator.");
+
+    public static final ConfigOption<MemorySize> DATA_FILE_LOCAL_CACHE_SIZE =
+            key("data-file.local-cache.size")
+                    .memoryType()
+                    .defaultValue(MemorySize.ofMebiBytes(1024))
+                    .withDescription("");
+
+    public static final ConfigOption<Double> DATA_FILE_LOCAL_CACHE_EVICTION_RATIO =
+            key("data-file.local-cache.eviction-ratio")
+                    .doubleType()
+                    .defaultValue(0.5)
+                    .withDescription("");
+
     public static final ConfigOption<Boolean> COMPACTION_FORCE_REWRITE_ALL_FILES =
             key("compaction.force-rewrite-all-files")
                     .booleanType()
@@ -2681,6 +2706,22 @@ public class CoreOptions implements Serializable {
     @Nullable
     public String externalSpecificFS() {
         return options.get(DATA_FILE_EXTERNAL_PATHS_SPECIFIC_FS);
+    }
+
+    public boolean dataFileLocalCacheEnabled() {
+        return options.get(DATA_FILE_LOCAL_CACHE_ENABLED);
+    }
+
+    public String dataFileLocalCacheTempDirs() {
+        return options.get(DATA_FILE_LOCAL_CACHE_TMP_DIRS);
+    }
+
+    public MemorySize dataFileLocalCacheSize() {
+        return options.get(DATA_FILE_LOCAL_CACHE_SIZE);
+    }
+
+    public double dataFileLocalCacheEvictionRatio() {
+        return options.get(DATA_FILE_LOCAL_CACHE_EVICTION_RATIO);
     }
 
     public Boolean forceRewriteAllFiles() {

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileLocalCachingFileIO.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileLocalCachingFileIO.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.disk.FileIOChannel;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.FileStatus;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.IOUtils;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.paimon.utils.Preconditions.checkState;
+
+/** Cache data file to local. */
+public class DataFileLocalCachingFileIO implements FileIO {
+
+    private static final LRUCache CACHE = new LRUCache(LocalFileIO.create());
+
+    private final LocalFileIO cacheFileIO = LocalFileIO.create();
+
+    private final FileIO targetFileIO;
+    private final String localTempDirs;
+    private final MemorySize localCacheSize;
+    private final double localCacheEvictionRatio;
+
+    private transient IOManager ioManager;
+
+    public DataFileLocalCachingFileIO(
+            FileIO targetFileIO,
+            String localTempDirs,
+            MemorySize localCacheSize,
+            double localCacheEvictionRatio) {
+        this.targetFileIO = targetFileIO;
+        this.localTempDirs = localTempDirs;
+        this.localCacheSize = localCacheSize;
+        this.localCacheEvictionRatio = localCacheEvictionRatio;
+    }
+
+    @Override
+    public boolean isObjectStore() {
+        return false;
+    }
+
+    @Override
+    public void configure(CatalogContext context) {
+        // won't be called currently
+    }
+
+    @Override
+    public void setRuntimeContext(Map<String, String> options) {
+        targetFileIO.setRuntimeContext(options);
+    }
+
+    // TODO: what if the input is very large ?
+    @Override
+    public SeekableInputStream newInputStream(Path path) throws IOException {
+        if (notDataFilePath(path) || cacheFull()) {
+            return targetFileIO.newInputStream(path);
+        }
+
+        Optional<Path> cachePath = getCachePath(path, true);
+        if (cachePath.isPresent()) {
+            return cacheFileIO.newInputStream(cachePath.get());
+        }
+
+        Path newCachePath = newLocalCachePath(path);
+        IOUtils.copyBytes(
+                targetFileIO.newInputStream(path), cacheFileIO.newOutputStream(newCachePath, true));
+        CACHE.put(path, newCachePath, true);
+        return cacheFileIO.newInputStream(newCachePath);
+    }
+
+    @Override
+    public PositionOutputStream newOutputStream(Path path, boolean overwrite) throws IOException {
+        if (notDataFilePath(path)) {
+            return targetFileIO.newOutputStream(path, overwrite);
+        }
+
+        checkState(
+                !getCachePath(path, false).isPresent() && !overwrite,
+                "Data file won't be written after closed.");
+
+        Path cachePath = newLocalCachePath(path);
+        CACHE.put(path, cachePath, false);
+        return cacheFileIO.newOutputStream(cachePath, overwrite);
+    }
+
+    @Override
+    public FileStatus getFileStatus(Path path) throws IOException {
+        // For non-data files, directly get status from target file system
+        if (notDataFilePath(path)) {
+            return targetFileIO.getFileStatus(path);
+        }
+
+        // If file is in cache but not on remote, flush it to remote
+        LRUCache.Node node = CACHE.get(path, false);
+        if (node != null && !node.onRemote()) {
+            CACHE.flushFile(path, targetFileIO);
+        }
+
+        return targetFileIO.getFileStatus(path);
+    }
+
+    @Override
+    public FileStatus[] listStatus(Path path) throws IOException {
+        return targetFileIO.listStatus(path);
+    }
+
+    @Override
+    public boolean exists(Path path) throws IOException {
+        return getCachePath(path, true).isPresent() || targetFileIO.exists(path);
+    }
+
+    @Override
+    public boolean delete(Path path, boolean recursive) throws IOException {
+        LRUCache.Node node = CACHE.invalidate(path);
+        if (node == null || node.onRemote()) {
+            return targetFileIO.delete(path, recursive);
+        }
+
+        // true if invalidating cache successfully
+        return true;
+    }
+
+    @Override
+    public boolean mkdirs(Path path) throws IOException {
+        return targetFileIO.mkdirs(path);
+    }
+
+    @Override
+    public boolean rename(Path src, Path dst) throws IOException {
+        checkState(notDataFilePath(src), "Data file won't be renamed.");
+        return targetFileIO.rename(src, dst);
+    }
+
+    @Override
+    public void close() throws IOException {
+        flush();
+        CACHE.expire(0);
+        cacheFileIO.close();
+        targetFileIO.close();
+    }
+
+    public void flush() throws IOException {
+        CACHE.flush(targetFileIO);
+    }
+
+    public void expire() throws IOException {
+        CACHE.expire((long) (localCacheSize.getBytes() * localCacheEvictionRatio));
+    }
+
+    private boolean cacheFull() {
+        return CACHE.size() >= localCacheSize.getBytes();
+    }
+
+    private boolean notDataFilePath(Path path) {
+        return !path.toString().contains(FileStorePathFactory.BUCKET_PATH_PREFIX);
+    }
+
+    private Path newLocalCachePath(Path origin) {
+        synchronized (this) {
+            if (ioManager == null) {
+                ioManager = IOManager.create(localTempDirs);
+            }
+        }
+
+        FileIOChannel.ID id = ioManager.createChannel(origin.getName() + "-local-cache-");
+        return new Path(id.getPath());
+    }
+
+    private Optional<Path> getCachePath(Path origin, boolean refreshLru) {
+        LRUCache.Node node = CACHE.get(origin, refreshLru);
+        return node == null ? Optional.empty() : Optional.of(node.cachePath());
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/io/LRUCache.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/LRUCache.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.utils.IOUtils;
+import org.apache.paimon.utils.ThreadPoolUtils;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.UncheckedIOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
+
+/** LRU cache implementation for local file caching. */
+public class LRUCache implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Map<Path, Node> fileMap = new ConcurrentHashMap<>();
+    private final LRUList lru = new LRUList();
+    private final ExecutorService executor =
+            ThreadPoolUtils.createCachedThreadPool(
+                    Runtime.getRuntime().availableProcessors(), "LRU-CACHE-FLUSH");
+
+    private final LocalFileIO fileIO;
+
+    public LRUCache(LocalFileIO fileIO) {
+        this.fileIO = fileIO;
+    }
+
+    public synchronized void put(Path path, Path cachePath, boolean onRemote) {
+        Node node = new Node(path, cachePath);
+        if (onRemote) {
+            long fileSize;
+            try {
+                fileSize = fileIO.getFileSize(cachePath);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            node.fileSize = fileSize;
+            node.onRemote = onRemote;
+        }
+
+        fileMap.put(path, node);
+        // always put new value because data file won't be overwritten
+        lru.addToHead(node);
+    }
+
+    @Nullable
+    public synchronized Node get(Path path, boolean refreshLru) {
+        Node node = fileMap.get(path);
+        if (node != null && refreshLru) {
+            lru.moveToHead(node);
+        }
+        return node;
+    }
+
+    public synchronized Node invalidate(Path path) {
+        Node node = fileMap.get(path);
+        if (node == null) {
+            return null;
+        }
+
+        try {
+            fileIO.delete(node.cachePath, false);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        fileMap.remove(path);
+        lru.remove(node);
+        return node;
+    }
+
+    public synchronized void expire(long remainSize) {
+        long cacheSize = size();
+        while (cacheSize > remainSize) {
+            if (lru.isEmpty()) {
+                return;
+            }
+            Node node = lru.tailNode();
+            invalidate(node.path);
+
+            cacheSize -= node.fileSize;
+        }
+    }
+
+    public synchronized long size() {
+        long size = 0;
+        for (Node node : fileMap.values()) {
+            node.setSizeIfNeeded(fileIO);
+            size += node.fileSize;
+        }
+        return size;
+    }
+
+    public synchronized void flush(FileIO targetFileIO) throws IOException {
+        List<Map.Entry<Path, Node>> toFlush =
+                fileMap.entrySet().stream()
+                        .filter(entry -> !entry.getValue().onRemote())
+                        .collect(Collectors.toList());
+
+        ThreadPoolUtils.randomlyOnlyExecute(
+                executor,
+                entry -> {
+                    Node node = entry.getValue();
+                    try {
+                        IOUtils.copyBytes(
+                                fileIO.newInputStream(node.cachePath),
+                                targetFileIO.newOutputStream(entry.getKey(), false));
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                    node.setOnRemote(true);
+                },
+                toFlush);
+    }
+
+    public synchronized void flushFile(Path path, FileIO targetFileIO) throws IOException {
+        Node node = get(path, true);
+        if (node != null && !node.onRemote()) {
+            IOUtils.copyBytes(
+                    fileIO.newInputStream(node.cachePath),
+                    targetFileIO.newOutputStream(path, false));
+            node.setOnRemote(true);
+        }
+    }
+
+    @VisibleForTesting
+    synchronized Iterable<Node> nodesInOrder() {
+        return () ->
+                new Iterator<Node>() {
+                    private Node current = lru.head.next;
+
+                    @Override
+                    public boolean hasNext() {
+                        return current != lru.tail;
+                    }
+
+                    @Override
+                    public Node next() {
+                        if (!hasNext()) {
+                            throw new NoSuchElementException();
+                        }
+                        Node node = current;
+                        current = current.next;
+                        return node;
+                    }
+                };
+    }
+
+    /** Node class for LRU cache. */
+    public static class Node implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final Path path;
+        private final Path cachePath;
+
+        private long fileSize = -1;
+        private boolean onRemote = false;
+
+        private Node prev, next;
+
+        public Node(Path path, Path cachePath) {
+            this.path = path;
+            this.cachePath = cachePath;
+        }
+
+        public void setSizeIfNeeded(FileIO fileIO) {
+            if (fileSize < 0) {
+                try {
+                    fileSize = fileIO.getFileSize(cachePath);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        public Path cachePath() {
+            return cachePath;
+        }
+
+        public Path path() {
+            return path;
+        }
+
+        public boolean onRemote() {
+            return onRemote;
+        }
+
+        public void setOnRemote(boolean onRemote) {
+            this.onRemote = onRemote;
+        }
+    }
+
+    /** LRU list implementation. */
+    private static class LRUList implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final Node head = new Node(null, null);
+        private final Node tail = new Node(null, null);
+
+        LRUList() {
+            head.next = tail;
+            tail.prev = head;
+        }
+
+        void addToHead(Node newNode) {
+            newNode.next = head.next;
+            newNode.prev = head;
+            head.next.prev = newNode;
+            head.next = newNode;
+        }
+
+        void moveToHead(Node oldNode) {
+            if (oldNode.prev == head) {
+                return;
+            }
+            remove(oldNode);
+            addToHead(oldNode);
+        }
+
+        void remove(Node oldNode) {
+            oldNode.prev.next = oldNode.next;
+            oldNode.next.prev = oldNode.prev;
+        }
+
+        boolean isEmpty() {
+            return head.next == tail;
+        }
+
+        Node tailNode() {
+            return tail.prev;
+        }
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/io/DataFileLocalCachingFileIOTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/DataFileLocalCachingFileIOTest.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.FileStatus;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.IOUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link DataFileLocalCachingFileIO}. */
+public class DataFileLocalCachingFileIOTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    private String bucketDir;
+    private String cacheDir;
+    private FileIO localFileIO;
+    private FileIO targetFileIO;
+    private DataFileLocalCachingFileIO cachingFileIO;
+
+    @BeforeEach
+    public void setUp() {
+        bucketDir =
+                tempDir.toString()
+                        + Path.SEPARATOR
+                        + FileStorePathFactory.BUCKET_PATH_PREFIX
+                        + "0/";
+        cacheDir = tempDir.toString() + Path.SEPARATOR + "cache/";
+        localFileIO = LocalFileIO.create();
+        targetFileIO = new LocalFileIO();
+        cachingFileIO =
+                new DataFileLocalCachingFileIO(
+                        targetFileIO,
+                        cacheDir,
+                        new MemorySize(1024 * 1024), // 1MB cache
+                        0.75);
+    }
+
+    @AfterEach
+    public void clear() {
+        localFileIO.deleteDirectoryQuietly(new Path(bucketDir));
+        localFileIO.deleteDirectoryQuietly(new Path(cacheDir));
+    }
+
+    @Test
+    public void testIsObjectStore() {
+        assertThat(cachingFileIO.isObjectStore()).isFalse();
+    }
+
+    @Test
+    public void testNewInputStreamWithDataFile() throws IOException {
+        // Create a data file path (contains bucket path prefix)
+        Path dataFilePath = new Path(bucketDir + "data-file-1.parquet");
+
+        // Write some data to the target file
+        String testData = "test data for caching";
+        try (PositionOutputStream out = targetFileIO.newOutputStream(dataFilePath, false)) {
+            out.write(testData.getBytes());
+        }
+
+        // Read through caching file IO
+        byte[] result = new byte[testData.length()];
+        try (SeekableInputStream in = cachingFileIO.newInputStream(dataFilePath)) {
+            IOUtils.readFully(in, result);
+        }
+
+        assertThat(new String(result)).isEqualTo(testData);
+
+        // Verify that the file is cached locally
+        FileStatus[] tempDirs = localFileIO.listStatus(new Path(cacheDir));
+        assertThat(tempDirs.length).isEqualTo(1);
+        Path cachePath = tempDirs[0].getPath();
+
+        FileStatus[] status = localFileIO.listStatus(cachePath);
+        assertThat(status.length).isEqualTo(1);
+        Path localFile = status[0].getPath();
+        assertThat(localFile.toString()).contains("data-file-1.parquet");
+    }
+
+    @Test
+    public void testNewInputStreamWithNonDataFile() throws IOException {
+        // Create a non-data file path (doesn't contain bucket path prefix)
+        Path nonDataFilePath = new Path(tempDir.toString(), "non-data-file.txt");
+
+        // Write some data to the target file
+        String testData = "test data for non-cached file";
+        try (PositionOutputStream out = targetFileIO.newOutputStream(nonDataFilePath, false)) {
+            out.write(testData.getBytes());
+        }
+
+        // Read through caching file IO
+        byte[] result = new byte[testData.length()];
+        try (SeekableInputStream in = cachingFileIO.newInputStream(nonDataFilePath)) {
+            IOUtils.readFully(in, result);
+        }
+
+        assertThat(new String(result)).isEqualTo(testData);
+
+        // The cache isn't initialized
+        assertThat(localFileIO.exists(new Path(cacheDir))).isFalse();
+    }
+
+    @Test
+    public void testNewOutputStreamWithDataFile() throws IOException {
+        // Create a data file path (contains bucket path prefix)
+        Path dataFilePath = new Path(bucketDir + "data-file-1.parquet");
+
+        // Write through caching file IO
+        String testData = "test output data";
+        try (PositionOutputStream out = cachingFileIO.newOutputStream(dataFilePath, false)) {
+            out.write(testData.getBytes());
+        }
+
+        // Test flush
+        assertThat(localFileIO.exists(dataFilePath)).isFalse();
+        cachingFileIO.flush();
+        assertThat(localFileIO.exists(dataFilePath)).isTrue();
+
+        // Read directly from target file IO to verify
+        byte[] result = new byte[testData.length()];
+        try (SeekableInputStream in = targetFileIO.newInputStream(dataFilePath)) {
+            IOUtils.readFully(in, result);
+        }
+
+        assertThat(new String(result)).isEqualTo(testData);
+    }
+
+    @Test
+    public void testNewOutputStreamWithNonDataFile() throws IOException {
+        // Create a non-data file path (doesn't contain bucket path prefix)
+        Path nonDataFilePath = new Path(tempDir.toString(), "non-data-output-file.txt");
+
+        // Write through caching file IO
+        String testData = "test output data for non-data file";
+        try (PositionOutputStream out = cachingFileIO.newOutputStream(nonDataFilePath, false)) {
+            out.write(testData.getBytes());
+        }
+
+        // For non-data files, data should be immediately written to target file IO
+        // without needing to call flush
+        assertThat(targetFileIO.exists(nonDataFilePath)).isTrue();
+
+        // Read directly from target file IO to verify
+        byte[] result = new byte[testData.length()];
+        try (SeekableInputStream in = targetFileIO.newInputStream(nonDataFilePath)) {
+            IOUtils.readFully(in, result);
+        }
+
+        assertThat(new String(result)).isEqualTo(testData);
+
+        // The cache isn't initialized
+        assertThat(localFileIO.exists(new Path(cacheDir))).isFalse();
+    }
+
+    @Test
+    public void testGetFileStatusWithDataFile() throws IOException {
+        // Create a data file path (contains bucket path prefix)
+        Path dataFilePath = new Path(bucketDir + "data-file-1.parquet");
+
+        // Test case 1: File exists only in target
+        try (PositionOutputStream out = targetFileIO.newOutputStream(dataFilePath, false)) {
+            out.write("test".getBytes());
+        }
+
+        FileStatus status1 = cachingFileIO.getFileStatus(dataFilePath);
+        assertThat(status1).isNotNull();
+        assertThat(status1.getPath().toString()).doesNotContain("cache");
+
+        // Test case 2: File exists only in cache
+        Path dataFilePath2 = new Path(bucketDir + "data-file-2.parquet");
+        try (PositionOutputStream out = cachingFileIO.newOutputStream(dataFilePath2, false)) {
+            out.write("test2".getBytes());
+        }
+
+        // At this point, the file should be in cache but not on remote
+        // getFileStatus should flush the file to remote and return the remote file status
+        FileStatus status2 = cachingFileIO.getFileStatus(dataFilePath2);
+        assertThat(status2.getPath().toString()).doesNotContain("cache");
+
+        // Verify the file now exists on remote
+        assertThat(targetFileIO.exists(dataFilePath2)).isTrue();
+    }
+
+    @Test
+    public void testExistsWithDataFile() throws IOException {
+        // Create a data file path (contains bucket path prefix)
+        Path dataFilePath = new Path(bucketDir + "data-file-1.parquet");
+
+        // Test case 1: File exist in both cache and target
+        try (PositionOutputStream out = cachingFileIO.newOutputStream(dataFilePath, false)) {
+            out.write("test".getBytes());
+        }
+        cachingFileIO.flush();
+        assertThat(targetFileIO.exists(dataFilePath)).isTrue();
+        assertThat(cachingFileIO.exists(dataFilePath)).isTrue();
+
+        cachingFileIO.delete(dataFilePath, false);
+        // Test case 2: File exists only in cache
+        try (PositionOutputStream out = cachingFileIO.newOutputStream(dataFilePath, false)) {
+            out.write("test".getBytes());
+        }
+        assertThat(targetFileIO.exists(dataFilePath)).isFalse();
+        assertThat(cachingFileIO.exists(dataFilePath)).isTrue();
+
+        cachingFileIO.delete(dataFilePath, false);
+        // Test case 3: File exists only in target
+        try (PositionOutputStream out = targetFileIO.newOutputStream(dataFilePath, false)) {
+            out.write("test".getBytes());
+        }
+        assertThat(targetFileIO.exists(dataFilePath)).isTrue();
+        assertThat(cachingFileIO.exists(dataFilePath)).isTrue();
+    }
+
+    @Test
+    public void testExistsWithNonDataFile() throws IOException {
+        // Create a non-data file path (doesn't contain bucket path prefix)
+        Path nonDataFilePath = new Path(tempDir.toString(), "non-data-existing-file");
+
+        // Create the file
+        try (PositionOutputStream out = cachingFileIO.newOutputStream(nonDataFilePath, false)) {
+            out.write("test".getBytes());
+        }
+
+        // It should exist
+        assertThat(cachingFileIO.exists(nonDataFilePath)).isTrue();
+    }
+
+    @Test
+    public void testDeleteWithDataFile() throws IOException {
+        // Create a data file path (contains bucket path prefix)
+        Path dataFilePath = new Path(bucketDir + "data-file-1.parquet");
+
+        // Test case 1: File exists only in cache
+        try (PositionOutputStream out = cachingFileIO.newOutputStream(dataFilePath, false)) {
+            out.write("test".getBytes());
+        }
+        assertThat(targetFileIO.exists(dataFilePath)).isFalse();
+        assertThat(cachingFileIO.exists(dataFilePath)).isTrue();
+
+        boolean deleted1 = cachingFileIO.delete(dataFilePath, false);
+        assertThat(deleted1).isTrue();
+        assertThat(cachingFileIO.exists(dataFilePath)).isFalse();
+
+        // Test case 2: File exists only in target
+        try (PositionOutputStream out = targetFileIO.newOutputStream(dataFilePath, false)) {
+            out.write("test".getBytes());
+        }
+        assertThat(targetFileIO.exists(dataFilePath)).isTrue();
+        assertThat(cachingFileIO.exists(dataFilePath)).isTrue();
+
+        boolean deleted2 = cachingFileIO.delete(dataFilePath, false);
+        assertThat(deleted2).isTrue();
+        assertThat(cachingFileIO.exists(dataFilePath)).isFalse();
+        assertThat(targetFileIO.exists(dataFilePath)).isFalse();
+
+        // Test case 3: File exists in both cache and target
+        try (PositionOutputStream out = cachingFileIO.newOutputStream(dataFilePath, false)) {
+            out.write("test".getBytes());
+        }
+        cachingFileIO.flush();
+        assertThat(targetFileIO.exists(dataFilePath)).isTrue();
+        assertThat(cachingFileIO.exists(dataFilePath)).isTrue();
+
+        boolean deleted3 = cachingFileIO.delete(dataFilePath, false);
+        assertThat(deleted3).isTrue();
+        assertThat(cachingFileIO.exists(dataFilePath)).isFalse();
+        assertThat(targetFileIO.exists(dataFilePath)).isFalse();
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/io/LRUCacheTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/LRUCacheTest.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.utils.Pair;
+import org.apache.paimon.utils.StringUtils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link LRUCache}. */
+public class LRUCacheTest {
+
+    @TempDir private java.nio.file.Path tempDir;
+    private LRUCache cache;
+    private LocalFileIO fileIO;
+
+    @BeforeEach
+    public void setUp() {
+        fileIO = LocalFileIO.create();
+        cache = new LRUCache(fileIO);
+    }
+
+    @Test
+    public void testPutAndGet() {
+        Path path = new Path(tempDir.toString(), "test/path");
+        Path cachePath = new Path(tempDir.toString(), "cache/path");
+
+        // Put a node into the cache
+        cache.put(path, cachePath, false);
+
+        // Get the node from the cache
+        LRUCache.Node node = cache.get(path, true);
+        assertThat(node).isNotNull();
+        assertThat(node.cachePath()).isEqualTo(cachePath);
+        assertThat(node.onRemote()).isFalse();
+    }
+
+    @Test
+    public void testInvalidate() {
+        Path path = new Path(tempDir.toString(), "test/path");
+        Path cachePath = new Path(tempDir.toString(), "cache/path");
+
+        // Put a node into the cache
+        cache.put(path, cachePath, false);
+
+        // Invalidate the node
+        LRUCache.Node node = cache.invalidate(path);
+        assertThat(node).isNotNull();
+        assertThat(node.cachePath()).isEqualTo(cachePath);
+
+        // Try to get the node again, should return null
+        LRUCache.Node node2 = cache.get(path, true);
+        assertThat(node2).isNull();
+    }
+
+    @Test
+    public void testFlush() throws IOException {
+        // Create a mock target FileIO
+        LocalFileIO targetFileIO = LocalFileIO.create();
+
+        // Create multiple cache files
+        Path cacheFile1 = writeCacheFile().getLeft();
+        Path cacheFile2 = writeCacheFile().getLeft();
+        Path cacheFile3 = writeCacheFile().getLeft();
+
+        // Create remote files
+        Path remoteFile1 = new Path(tempDir.toString(), "remote/file1");
+        Path remoteFile2 = new Path(tempDir.toString(), "remote/file2");
+        Path remoteFile3 = new Path(tempDir.toString(), "remote/file3");
+
+        // Add nodes to cache with onRemote = false
+        cache.put(remoteFile1, cacheFile1, false);
+        cache.put(remoteFile2, cacheFile2, false);
+        cache.put(remoteFile3, cacheFile3, false);
+
+        // Verify all nodes are not on remote
+        assertThat(targetFileIO.exists(remoteFile1)).isFalse();
+        assertThat(targetFileIO.exists(remoteFile2)).isFalse();
+        assertThat(targetFileIO.exists(remoteFile3)).isFalse();
+
+        // Flush the cache using thread pool
+        cache.flush(targetFileIO);
+
+        // Verify all nodes are now on remote
+        assertThat(cache.get(remoteFile1, true).onRemote()).isTrue();
+        assertThat(cache.get(remoteFile2, true).onRemote()).isTrue();
+        assertThat(cache.get(remoteFile3, true).onRemote()).isTrue();
+
+        // Verify remote files exist
+        assertThat(targetFileIO.exists(remoteFile1)).isTrue();
+        assertThat(targetFileIO.exists(remoteFile2)).isTrue();
+        assertThat(targetFileIO.exists(remoteFile3)).isTrue();
+    }
+
+    @Test
+    public void testExpire() throws IOException {
+        // Create cache files first since onRemote=true requires real files
+        Pair<Path, Long> cacheFile1 = writeCacheFile();
+        Pair<Path, Long> cacheFile2 = writeCacheFile();
+        Pair<Path, Long> cacheFile3 = writeCacheFile();
+
+        // remote file paths
+        Path path1 = new Path(tempDir.toString(), "test/path1");
+        Path path2 = new Path(tempDir.toString(), "test/path2");
+        Path path3 = new Path(tempDir.toString(), "test/path3");
+
+        // Add to the cache
+        cache.put(path1, cacheFile1.getLeft(), true);
+        cache.put(path2, cacheFile2.getLeft(), true);
+        cache.put(path3, cacheFile3.getLeft(), true);
+
+        // Test expire with 0 size, should remove all nodes and files
+        cache.expire(0);
+
+        // All nodes should be removed
+        assertThat(cache.get(path1, true)).isNull();
+        assertThat(cache.get(path2, true)).isNull();
+        assertThat(cache.get(path3, true)).isNull();
+
+        // All cache files should also be deleted
+        assertThat(fileIO.exists(cacheFile1.getLeft())).isFalse();
+        assertThat(fileIO.exists(cacheFile2.getLeft())).isFalse();
+        assertThat(fileIO.exists(cacheFile3.getLeft())).isFalse();
+
+        // Re-create cache files for next test
+        cacheFile1 = writeCacheFile();
+        cacheFile2 = writeCacheFile();
+        cacheFile3 = writeCacheFile();
+
+        cache.put(path1, cacheFile1.getLeft(), true);
+        cache.put(path2, cacheFile2.getLeft(), true);
+        cache.put(path3, cacheFile3.getLeft(), true);
+
+        // In this case, file1 will be expired
+        long boundarySize =
+                cacheFile1.getRight() + cacheFile2.getRight() + cacheFile3.getRight() - 1;
+        cache.expire(boundarySize);
+
+        assertThat(cache.get(path1, true)).isNull();
+        assertThat(cache.get(path2, true)).isNotNull();
+        assertThat(cache.get(path3, true)).isNotNull();
+
+        assertThat(fileIO.exists(cacheFile1.getLeft())).isFalse();
+        assertThat(fileIO.exists(cacheFile2.getLeft())).isTrue();
+        assertThat(fileIO.exists(cacheFile3.getLeft())).isTrue();
+
+        // Re-create cache files for next test
+        cacheFile1 = writeCacheFile();
+        cacheFile2 = writeCacheFile();
+        cacheFile3 = writeCacheFile();
+
+        cache.put(path1, cacheFile1.getLeft(), true);
+        cache.put(path2, cacheFile2.getLeft(), true);
+        cache.put(path3, cacheFile3.getLeft(), true);
+
+        // Test with large size, should keep all nodes
+        long largeSize = cacheFile1.getRight() + cacheFile2.getRight() + cacheFile3.getRight() + 1;
+        cache.expire(largeSize);
+
+        // All nodes should remain
+        assertThat(cache.get(path1, true)).isNotNull();
+        assertThat(cache.get(path2, true)).isNotNull();
+        assertThat(cache.get(path3, true)).isNotNull();
+
+        // Cache files should still exist
+        assertThat(fileIO.exists(cacheFile1.getLeft())).isTrue();
+        assertThat(fileIO.exists(cacheFile2.getLeft())).isTrue();
+        assertThat(fileIO.exists(cacheFile3.getLeft())).isTrue();
+    }
+
+    @Test
+    public void testSize() throws IOException {
+        // Size should be 0 initially
+        assertThat(cache.size()).isEqualTo(0);
+
+        // Create cache file
+        Pair<Path, Long> cacheFile = writeCacheFile();
+
+        Path path = new Path(tempDir.toString(), "test/path");
+
+        // Put a node into the cache
+        cache.put(path, cacheFile.getLeft(), false);
+
+        // Size should equal the cache file size
+        assertThat(cache.size()).isEqualTo(cacheFile.getRight());
+    }
+
+    @Test
+    public void testLRUNodesOrder() throws IOException {
+        // Put initial nodes
+        Pair<Path, Long> cacheFile1 = writeCacheFile();
+        Pair<Path, Long> cacheFile2 = writeCacheFile();
+        Pair<Path, Long> cacheFile3 = writeCacheFile();
+
+        Path path1 = new Path(tempDir.toString(), "test/path1");
+        Path path2 = new Path(tempDir.toString(), "test/path2");
+        Path path3 = new Path(tempDir.toString(), "test/path3");
+
+        cache.put(path1, cacheFile1.getLeft(), false);
+        cache.put(path2, cacheFile2.getLeft(), false);
+        cache.put(path3, cacheFile3.getLeft(), false);
+
+        // Check initial LRU order (most recent first): path3, path2, path1
+        List<LRUCache.Node> initialOrder = new ArrayList<>();
+        for (LRUCache.Node node : cache.nodesInOrder()) {
+            initialOrder.add(node);
+        }
+        assertThat(initialOrder).hasSize(3);
+        assertThat(initialOrder.get(0).path()).isEqualTo(path3);
+        assertThat(initialOrder.get(1).path()).isEqualTo(path2);
+        assertThat(initialOrder.get(2).path()).isEqualTo(path1);
+
+        // Access the first node to move it to the front
+        cache.get(path1, true);
+
+        // Check LRU order after accessing path1: path1, path3, path2
+        List<LRUCache.Node> orderAfterAccess1 = new ArrayList<>();
+        for (LRUCache.Node node : cache.nodesInOrder()) {
+            orderAfterAccess1.add(node);
+        }
+        assertThat(orderAfterAccess1).hasSize(3);
+        assertThat(orderAfterAccess1.get(0).path()).isEqualTo(path1);
+        assertThat(orderAfterAccess1.get(1).path()).isEqualTo(path3);
+        assertThat(orderAfterAccess1.get(2).path()).isEqualTo(path2);
+
+        // Access the second node
+        cache.get(path2, true);
+
+        // Check LRU order after accessing path2: path2, path1, path3
+        List<LRUCache.Node> orderAfterAccess2 = new ArrayList<>();
+        for (LRUCache.Node node : cache.nodesInOrder()) {
+            orderAfterAccess2.add(node);
+        }
+        assertThat(orderAfterAccess2).hasSize(3);
+        assertThat(orderAfterAccess2.get(0).path()).isEqualTo(path2);
+        assertThat(orderAfterAccess2.get(1).path()).isEqualTo(path1);
+        assertThat(orderAfterAccess2.get(2).path()).isEqualTo(path3);
+
+        // Add another node (create a fourth file)
+        Pair<Path, Long> cacheFile4 = writeCacheFile();
+        Path path4 = new Path(tempDir.toString(), "test/path4");
+        cache.put(path4, cacheFile4.getLeft(), false);
+
+        // Check LRU order after adding path4: path4, path2, path1, path3
+        List<LRUCache.Node> orderAfterAdding4 = new ArrayList<>();
+        for (LRUCache.Node node : cache.nodesInOrder()) {
+            orderAfterAdding4.add(node);
+        }
+        assertThat(orderAfterAdding4).hasSize(4);
+        assertThat(orderAfterAdding4.get(0).path()).isEqualTo(path4);
+        assertThat(orderAfterAdding4.get(1).path()).isEqualTo(path2);
+        assertThat(orderAfterAdding4.get(2).path()).isEqualTo(path1);
+        assertThat(orderAfterAdding4.get(3).path()).isEqualTo(path3);
+
+        // Test LRU order - expire to keep only 3 nodes
+        // Should remove the least recently used (path3)
+        cache.expire(cacheFile4.getRight() + cacheFile2.getRight() + cacheFile1.getRight());
+
+        // Check LRU order after expiration: path4, path2, path1
+        List<LRUCache.Node> orderAfterExpiration = new ArrayList<>();
+        for (LRUCache.Node node : cache.nodesInOrder()) {
+            orderAfterExpiration.add(node);
+        }
+        assertThat(orderAfterExpiration).hasSize(3);
+        assertThat(orderAfterExpiration.get(0).path()).isEqualTo(path4);
+        assertThat(orderAfterExpiration.get(1).path()).isEqualTo(path2);
+        assertThat(orderAfterExpiration.get(2).path()).isEqualTo(path1);
+    }
+
+    private Pair<Path, Long> writeCacheFile() throws IOException {
+        Path cachePath = new Path(tempDir.toString(), "cache/" + UUID.randomUUID());
+        try (PositionOutputStream out = fileIO.newOutputStream(cachePath, false)) {
+            out.write(
+                    StringUtils.getRandomString(ThreadLocalRandom.current(), 10, 1000).getBytes());
+        }
+        return Pair.of(cachePath, fileIO.getFileSize(cachePath));
+    }
+}

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperator.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreMultiWriteOperator.java
@@ -31,6 +31,7 @@ import org.apache.paimon.flink.sink.StoreSinkWriteImpl;
 import org.apache.paimon.flink.sink.StoreSinkWriteState;
 import org.apache.paimon.flink.sink.StoreSinkWriteStateImpl;
 import org.apache.paimon.flink.utils.RuntimeContextUtils;
+import org.apache.paimon.io.DataFileLocalCachingFileIO;
 import org.apache.paimon.memory.HeapMemorySegmentPool;
 import org.apache.paimon.memory.MemoryPoolFactory;
 import org.apache.paimon.options.Options;
@@ -273,6 +274,11 @@ public class CdcRecordStoreMultiWriteOperator
                 throw new IOException("Failed to prepare commit for table: " + key.toString(), e);
             }
         }
+
+        for (FileStoreTable table : tables.values()) {
+            flushDataFileCache(table, waitCompaction);
+        }
+
         return committables;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/AppendTableCompactor.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/AppendTableCompactor.java
@@ -227,4 +227,13 @@ public class AppendTableCompactor {
             writeRefresher.tryRefresh();
         }
     }
+
+    /**
+     * Get the table associated with this compactor.
+     *
+     * @return the table
+     */
+    public FileStoreTable table() {
+        return table;
+    }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendCompactWorkerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendCompactWorkerOperator.java
@@ -22,6 +22,7 @@ import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.append.AppendCompactTask;
 import org.apache.paimon.flink.compact.AppendTableCompactor;
 import org.apache.paimon.flink.source.AppendTableCompactSource;
+import org.apache.paimon.io.DataFileLocalCachingFileIO;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
@@ -87,6 +88,8 @@ public abstract class AppendCompactWorkerOperator<IN>
         List<Committable> committables =
                 this.unawareBucketCompactor.prepareCommit(waitCompaction, checkpointId);
         this.unawareBucketCompactor.tryRefreshWrite();
+        flushDataFileCache(table, waitCompaction);
+
         return committables;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendOnlyMultiTableCompactionWorkerOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/AppendOnlyMultiTableCompactionWorkerOperator.java
@@ -24,6 +24,7 @@ import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.compact.AppendTableCompactor;
+import org.apache.paimon.io.DataFileLocalCachingFileIO;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.utils.ExceptionUtils;
@@ -104,6 +105,11 @@ public class AppendOnlyMultiTableCompactionWorkerOperator
                                 committable.kind(),
                                 committable.wrappedCommittable()));
             }
+        }
+
+        for (AppendTableCompactor compactor : compactorContainer.values()) {
+            FileStoreTable table = compactor.table();
+            flushDataFileCache(table, waitCompaction);
         }
 
         return result;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSink.java
@@ -225,6 +225,7 @@ public abstract class FlinkSink<T> implements Serializable {
                                     committerOperator,
                             table);
         }
+
         SingleOutputStreamOperator<?> committed =
                 written.transform(
                                 GLOBAL_COMMITTER_NAME + " : " + table.name(),

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
@@ -24,6 +24,7 @@ import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.flink.utils.RuntimeContextUtils;
+import org.apache.paimon.io.DataFileLocalCachingFileIO;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFileMetaSerializer;
 import org.apache.paimon.options.Options;
@@ -196,6 +197,11 @@ public class MultiTablesStoreCompactOperator
                                             MultiTableCommittable.fromCommittable(key, committable))
                             .collect(Collectors.toList()));
         }
+
+        for (FileStoreTable table : tables.values()) {
+            flushDataFileCache(table, waitCompaction);
+        }
+
         return committables;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCompactOperator.java
@@ -22,6 +22,7 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.flink.utils.RuntimeContextUtils;
+import org.apache.paimon.io.DataFileLocalCachingFileIO;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFileMetaSerializer;
 import org.apache.paimon.options.Options;
@@ -175,6 +176,7 @@ public class StoreCompactOperator extends PrepareCommitOperator<RowData, Committ
 
         List<Committable> committables = write.prepareCommit(waitCompaction, checkpointId);
 
+        flushDataFileCache(table, waitCompaction);
         tryRefreshWrite();
         return committables;
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/TableWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/TableWriteOperator.java
@@ -23,6 +23,7 @@ import org.apache.paimon.flink.sink.StoreSinkWriteState.StateValueFilter;
 import org.apache.paimon.flink.sink.coordinator.CoordinatedWriteRestore;
 import org.apache.paimon.flink.sink.coordinator.WriteOperatorCoordinator;
 import org.apache.paimon.flink.utils.RuntimeContextUtils;
+import org.apache.paimon.io.DataFileLocalCachingFileIO;
 import org.apache.paimon.operation.WriteRestore;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
@@ -148,7 +149,9 @@ public abstract class TableWriteOperator<IN> extends PrepareCommitOperator<IN, C
     @Override
     protected List<Committable> prepareCommit(boolean waitCompaction, long checkpointId)
             throws IOException {
-        return write.prepareCommit(waitCompaction, checkpointId);
+        List<Committable> committables = write.prepareCommit(waitCompaction, checkpointId);
+        flushDataFileCache(table, waitCompaction);
+        return committables;
     }
 
     @VisibleForTesting

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -957,4 +957,13 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
                                 "SELECT * FROM T /*+ OPTIONS('scan.dedicated-split-generation'='true') */"))
                 .hasSize(0);
     }
+
+    @Test
+    public void testDataFileCache() {
+        sql("CREATE TABLE test (a int, b string) WITH ('data-file.local-cache.enabled'='true')");
+
+        sql("INSERT INTO test VALUES (1, 'A')");
+
+        assertThat(sql("SELECT * FROM test")).containsExactly(Row.of(1, "A"));
+    }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
If input is very small, a data file cache is useful to reduce remote filesystem access times.
Note that this is not useful for all scenarios, please enable this feature carefully.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
