### PR TITLE
[core] Ignore beforeFiles on initial refresh for LocalTableQuery

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/query/LocalTableQuery.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/query/LocalTableQuery.java
@@ -115,9 +115,7 @@ public class LocalTableQuery implements TableQuery {
         LookupLevels<KeyValue> lookupLevels =
                 tableView.computeIfAbsent(partition, k -> new HashMap<>()).get(bucket);
         if (lookupLevels == null) {
-            Preconditions.checkArgument(
-                    beforeFiles.isEmpty(),
-                    "The before file should be empty for the initial phase.");
+            // Initial phase: ignore beforeFiles as they represent deletions from previous state
             newLookupLevels(partition, bucket, dataFiles);
         } else {
             lookupLevels.getLevels().update(beforeFiles, dataFiles);


### PR DESCRIPTION
 - Fixes a bug where localtablequery throws an error:
 ```
Caused by: java.lang.IllegalArgumentException: The before file should be empty for the initial phase.
at org.apache.paimon.utils.Preconditions.checkArgument(Preconditions.java:127)
at org.apache.paimon.table.query.LocalTableQuery.refreshFiles(LocalTableQuery.java:118)
```
 - Beforefiles may be expected in the FILE_MONITOR mode and not populated for changelog/compact_delta modes. 
 - Removed the check, ideally this should be only added to the changelog log/compact_delta modes, but the LocalTableQuery is not aware of the modes, and the check does not add much value. 
 - This fix will unblock querying but in the future, the higher level apis can be extended to be more aware of the mode and pass it to LocalTableQuery which can enforce the check for the correct conditions.
 -  Fixes: #6080