### PR TITLE
[test] Fix flaky test for CloneActionITCase

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/CloneActionITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/CloneActionITCase.java
@@ -914,7 +914,7 @@ public class CloneActionITCase extends ActionITCaseBase {
         return (FileStoreTable) catalog.getTable(table);
     }
 
-        private List<Row> sql(TableEnvironment tEnv, String query, Object... args) {
+    private List<Row> sql(TableEnvironment tEnv, String query, Object... args) {
         String formattedQuery = String.format(query, args);
         Exception lastException = null;
 


### PR DESCRIPTION
 - testMigrateOneNonPartitionedTable occasionally fails with "Broken pipe" HMS connectivity errors
 - Network/timing issues in CI cause transient Thrift connection failures
 - Simple retry with backoff gives HMS time to recover from temporary issues
 - Fixes: #6002 