### PR TITLE
[csv] Add csv prefix to CsvOptions

### DIFF
--- a/docs/content/concepts/table-types.md
+++ b/docs/content/concepts/table-types.md
@@ -157,7 +157,7 @@ CREATE TABLE my_csv_table (
 ) WITH (
     'type'='format-table',
     'file.format'='csv',
-    'field-delimiter'=','
+    'csv.field-delimiter'=','
 )
 ```
 {{< /tab >}}
@@ -168,7 +168,7 @@ CREATE TABLE my_csv_table (
 CREATE TABLE my_csv_table (
     a INT,
     b STRING
-) USING csv OPTIONS ('field-delimiter' ',')
+) USING csv OPTIONS ('csv.field-delimiter' ',')
 ```
 
 {{< /tab >}}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FormatCatalogTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FormatCatalogTable.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.flink;
 
-import org.apache.paimon.format.csv.CsvOptions;
 import org.apache.paimon.table.FormatTable;
 
 import org.apache.flink.table.api.Schema;
@@ -99,9 +98,8 @@ public class FormatCatalogTable implements CatalogTable {
                             cachedOptions.put(k, v);
                         }
                     });
-            if (options.containsKey(CsvOptions.FIELD_DELIMITER.key())) {
-                cachedOptions.put(
-                        "csv.field-delimiter", options.get(CsvOptions.FIELD_DELIMITER.key()));
+            if (options.containsKey("field-delimiter")) {
+                cachedOptions.put("csv.field-delimiter", "field-delimiter");
             }
             cachedOptions.put(CONNECTOR.key(), "filesystem");
             cachedOptions.put(PATH.key(), table.location());

--- a/paimon-format/src/main/java/org/apache/paimon/format/csv/CsvOptions.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/csv/CsvOptions.java
@@ -26,37 +26,38 @@ import org.apache.paimon.options.Options;
 public class CsvOptions {
 
     public static final ConfigOption<String> FIELD_DELIMITER =
-            ConfigOptions.key("field-delimiter")
+            ConfigOptions.key("csv.field-delimiter")
                     .stringType()
                     .defaultValue(",")
+                    .withFallbackKeys("field-delimiter")
                     .withDescription("The field delimiter for CSV or TXT format");
 
     public static final ConfigOption<String> LINE_DELIMITER =
-            ConfigOptions.key("line-delimiter")
+            ConfigOptions.key("csv.line-delimiter")
                     .stringType()
                     .defaultValue("\n")
                     .withDescription("The line delimiter for CSV format");
 
     public static final ConfigOption<String> QUOTE_CHARACTER =
-            ConfigOptions.key("quote-character")
+            ConfigOptions.key("csv.quote-character")
                     .stringType()
                     .defaultValue("\"")
                     .withDescription("The quote character for CSV format");
 
     public static final ConfigOption<String> ESCAPE_CHARACTER =
-            ConfigOptions.key("escape-character")
+            ConfigOptions.key("csv.escape-character")
                     .stringType()
                     .defaultValue("\\")
                     .withDescription("The escape character for CSV format");
 
     public static final ConfigOption<Boolean> INCLUDE_HEADER =
-            ConfigOptions.key("include-header")
+            ConfigOptions.key("csv.include-header")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription("Whether to include header in CSV files");
 
     public static final ConfigOption<String> NULL_LITERAL =
-            ConfigOptions.key("null-literal")
+            ConfigOptions.key("csv.null-literal")
                     .stringType()
                     .defaultValue("null")
                     .withDescription("The literal for null values in CSV format");

--- a/paimon-hive/paimon-hive-catalog/pom.xml
+++ b/paimon-hive/paimon-hive-catalog/pom.xml
@@ -43,6 +43,13 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-format</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-hive-common</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -128,13 +135,6 @@ under the License.
             <version>${project.version}</version>
             <scope>test</scope>
             <type>test-jar</type>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-format</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -114,6 +114,7 @@ import static org.apache.paimon.catalog.CatalogUtils.checkNotSystemTable;
 import static org.apache.paimon.catalog.CatalogUtils.isSystemDatabase;
 import static org.apache.paimon.catalog.CatalogUtils.listPartitionsFromFileSystem;
 import static org.apache.paimon.catalog.Identifier.DEFAULT_MAIN_BRANCH;
+import static org.apache.paimon.format.csv.CsvOptions.FIELD_DELIMITER;
 import static org.apache.paimon.hive.HiveCatalogOptions.HADOOP_CONF_DIR;
 import static org.apache.paimon.hive.HiveCatalogOptions.HIVE_CONF_DIR;
 import static org.apache.paimon.hive.HiveCatalogOptions.IDENTIFIER;
@@ -1487,11 +1488,10 @@ public class HiveCatalog extends AbstractCatalog {
             @Nullable FormatTable.Format provider, Map<String, String> tableParameters) {
         Map<String, String> param = new HashMap<>();
         if (provider == FormatTable.Format.CSV) {
-            String delimiterKey = "field-delimiter";
             param.put(
                     FIELD_DELIM,
                     tableParameters.getOrDefault(
-                            delimiterKey, options.getString(delimiterKey, ",")));
+                            FIELD_DELIMITER.key(), options.get(FIELD_DELIMITER)));
         }
         return param;
     }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveTableUtils.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveTableUtils.java
@@ -37,6 +37,7 @@ import static org.apache.paimon.CoreOptions.PATH;
 import static org.apache.paimon.CoreOptions.TYPE;
 import static org.apache.paimon.TableType.FORMAT_TABLE;
 import static org.apache.paimon.catalog.Catalog.COMMENT_PROP;
+import static org.apache.paimon.format.csv.CsvOptions.FIELD_DELIMITER;
 import static org.apache.paimon.hive.HiveCatalog.HIVE_FIELD_DELIM_DEFAULT;
 import static org.apache.paimon.hive.HiveCatalog.isView;
 
@@ -77,7 +78,7 @@ class HiveTableUtils {
             } else {
                 format = Format.CSV;
                 options.set(
-                        "field-delimiter",
+                        FIELD_DELIMITER,
                         serdeInfo
                                 .getParameters()
                                 .getOrDefault(FIELD_DELIM, HIVE_FIELD_DELIM_DEFAULT));

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogFormatTableITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogFormatTableITCaseBase.java
@@ -158,7 +158,7 @@ public abstract class HiveCatalogFormatTableITCaseBase {
     @Test
     public void testFlinkCreateFormatTableWithDelimiter() throws Exception {
         tEnv.executeSql(
-                "CREATE TABLE flink_csv_table_delimiter (a INT COMMENT 'comment a', b STRING COMMENT 'comment b') with ('type'='format-table', 'file.format'='csv', 'field-delimiter'=';')");
+                "CREATE TABLE flink_csv_table_delimiter (a INT COMMENT 'comment a', b STRING COMMENT 'comment b') with ('type'='format-table', 'file.format'='csv', 'csv.field-delimiter'=';')");
         doTestCSVFormatTable("flink_csv_table_delimiter");
     }
 

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithHiveTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithHiveTest.java
@@ -89,7 +89,7 @@ public class SparkCatalogWithHiveTest {
             // test csv table
 
             spark.sql(
-                    "CREATE TABLE IF NOT EXISTS table_csv (a INT, bb INT, c STRING) USING csv OPTIONS ('field-delimiter' ',')");
+                    "CREATE TABLE IF NOT EXISTS table_csv (a INT, bb INT, c STRING) USING csv OPTIONS ('csv.field-delimiter' ',')");
             spark.sql("INSERT INTO table_csv VALUES (1, 1, '1'), (2, 2, '2')").collect();
             assertThat(spark.sql("DESCRIBE FORMATTED table_csv").collectAsList().toString())
                     .contains("sep=,");

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/FormatTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/FormatTableTestBase.scala
@@ -35,7 +35,7 @@ abstract class FormatTableTestBase extends PaimonHiveTestBase {
 
   test("Format table: csv with field-delimiter") {
     withTable("t") {
-      sql(s"CREATE TABLE t (f0 INT, f1 INT) USING CSV OPTIONS ('field-delimiter' ';')")
+      sql(s"CREATE TABLE t (f0 INT, f1 INT) USING CSV OPTIONS ('csv.field-delimiter' ';')")
       val table =
         paimonCatalog.getTable(Identifier.create(hiveDbName, "t")).asInstanceOf[FormatTable]
       val csvFile =
@@ -132,9 +132,9 @@ abstract class FormatTableTestBase extends PaimonHiveTestBase {
 
   test("Format table: field delimiter in HMS") {
     withTable("t1") {
-      sql("CREATE TABLE t1 (id INT, p1 INT, p2 INT) USING csv OPTIONS ('field-delimiter' ';')")
+      sql("CREATE TABLE t1 (id INT, p1 INT, p2 INT) USING csv OPTIONS ('csv.field-delimiter' ';')")
       val row = sql("SHOW CREATE TABLE t1").collect()(0)
-      assert(row.toString().contains("'field-delimiter' = ';'"))
+      assert(row.toString().contains("'csv.field-delimiter' = ';'"))
     }
   }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Same to parquet, avro and orc, add prefix to CsvOptions.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
