### PR TITLE
[core] Support limit pushdown to the DataFile

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bitmap/BitmapIndexResult.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bitmap/BitmapIndexResult.java
@@ -59,6 +59,10 @@ public class BitmapIndexResult extends LazyField<RoaringBitmap32> implements Fil
         return new BitmapIndexResult(() -> RoaringBitmap32.andNot(get(), deletion));
     }
 
+    public FileIndexResult limit(int limit) {
+        return new BitmapIndexResult(() -> get().limit(limit));
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
@@ -272,7 +272,7 @@ public class KeyValueFileReaderFactory implements FileReaderFactory<KeyValue> {
                     finalReadKeyType,
                     readValueType,
                     new FormatReaderMapping.Builder(
-                            formatDiscover, readTableFields, fieldsExtractor, filters, null),
+                            formatDiscover, readTableFields, fieldsExtractor, filters, null, null),
                     pathFactory.createDataFilePathFactory(partition, bucket),
                     options.fileReaderAsyncThreshold().getBytes(),
                     partition,

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
@@ -126,6 +126,7 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
                         readRowType.getFields(),
                         schema -> rowTypeWithRowLineage(schema.logicalRowType(), true).getFields(),
                         null,
+                        null,
                         null);
 
         List<List<DataFileMeta>> splitByRowId = DataEvolutionSplitGenerator.split(files);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/RawFileSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/RawFileSplitRead.java
@@ -83,6 +83,7 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
     private RowType readRowType;
     @Nullable private List<Predicate> filters;
     @Nullable private TopN topN;
+    @Nullable private Integer limit;
 
     public RawFileSplitRead(
             FileIO fileIO,
@@ -135,6 +136,12 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
     }
 
     @Override
+    public SplitRead<InternalRow> withLimit(@Nullable Integer limit) {
+        this.limit = limit;
+        return this;
+    }
+
+    @Override
     public RecordReader<InternalRow> createReader(DataSplit split) throws IOException {
         if (!split.beforeFiles().isEmpty()) {
             LOG.info("Ignore split before files: {}", split.beforeFiles());
@@ -172,7 +179,8 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
                             return schema.fields();
                         },
                         filters,
-                        topN);
+                        topN,
+                        limit);
 
         for (DataFileMeta file : files) {
             suppliers.add(
@@ -230,6 +238,7 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
                             formatReaderMapping.getDataSchema(),
                             formatReaderMapping.getDataFilters(),
                             formatReaderMapping.getTopN(),
+                            formatReaderMapping.getLimit(),
                             dataFilePathFactory,
                             file,
                             deletionVector);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/SplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/SplitRead.java
@@ -49,6 +49,10 @@ public interface SplitRead<T> {
         return this;
     }
 
+    default SplitRead<T> withLimit(@Nullable Integer limit) {
+        return this;
+    }
+
     /** Create a {@link RecordReader} from split. */
     RecordReader<T> createReader(DataSplit split) throws IOException;
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AppendTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AppendTableRead.java
@@ -47,6 +47,7 @@ public final class AppendTableRead extends AbstractDataTableRead {
     @Nullable private RowType readType = null;
     private Predicate predicate = null;
     private TopN topN = null;
+    private Integer limit = null;
 
     public AppendTableRead(
             List<Function<SplitReadConfig, SplitReadProvider>> providerFactories,
@@ -74,6 +75,7 @@ public final class AppendTableRead extends AbstractDataTableRead {
         }
         read.withFilter(predicate);
         read.withTopN(topN);
+        read.withLimit(limit);
     }
 
     @Override
@@ -93,6 +95,13 @@ public final class AppendTableRead extends AbstractDataTableRead {
     public InnerTableRead withTopN(TopN topN) {
         initialized().forEach(r -> r.withTopN(topN));
         this.topN = topN;
+        return this;
+    }
+
+    @Override
+    public InnerTableRead withLimit(int limit) {
+        initialized().forEach(r -> r.withLimit(limit));
+        this.limit = limit;
         return this;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableRead.java
@@ -55,6 +55,10 @@ public interface InnerTableRead extends TableRead {
         return this;
     }
 
+    default InnerTableRead withLimit(int limit) {
+        return this;
+    }
+
     default InnerTableRead forceKeepDelete() {
         return this;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
@@ -56,6 +56,7 @@ public final class KeyValueTableRead extends AbstractDataTableRead {
     private Predicate predicate = null;
     private IOManager ioManager = null;
     @Nullable private TopN topN = null;
+    @Nullable private Integer limit = null;
 
     public KeyValueTableRead(
             Supplier<MergeFileSplitRead> mergeReadSupplier,
@@ -91,6 +92,9 @@ public final class KeyValueTableRead extends AbstractDataTableRead {
         if (topN != null) {
             read = read.withTopN(topN);
         }
+        if (limit != null) {
+            read = read.withLimit(limit);
+        }
         read.withFilter(predicate).withIOManager(ioManager);
     }
 
@@ -118,6 +122,13 @@ public final class KeyValueTableRead extends AbstractDataTableRead {
     public InnerTableRead withTopN(TopN topN) {
         initialized().forEach(r -> r.withTopN(topN));
         this.topN = topN;
+        return this;
+    }
+
+    @Override
+    public InnerTableRead withLimit(int limit) {
+        initialized().forEach(r -> r.withLimit(limit));
+        this.limit = limit;
         return this;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -214,6 +214,9 @@ public class ReadBuilderImpl implements ReadBuilder {
         if (topN != null) {
             read.withTopN(topN);
         }
+        if (limit != null) {
+            read.withLimit(limit);
+        }
         return read;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/utils/FormatReaderMapping.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/FormatReaderMapping.java
@@ -64,6 +64,7 @@ public class FormatReaderMapping {
     private final List<Predicate> dataFilters;
     private final Map<String, Integer> systemFields;
     @Nullable private final TopN topN;
+    @Nullable private final Integer limit;
 
     public FormatReaderMapping(
             @Nullable int[] indexMapping,
@@ -74,7 +75,8 @@ public class FormatReaderMapping {
             TableSchema dataSchema,
             List<Predicate> dataFilters,
             Map<String, Integer> systemFields,
-            @Nullable TopN topN) {
+            @Nullable TopN topN,
+            @Nullable Integer limit) {
         this.indexMapping = combine(indexMapping, trimmedKeyMapping);
         this.castMapping = castMapping;
         this.readerFactory = readerFactory;
@@ -83,6 +85,7 @@ public class FormatReaderMapping {
         this.dataFilters = dataFilters;
         this.systemFields = systemFields;
         this.topN = topN;
+        this.limit = limit;
     }
 
     private int[] combine(@Nullable int[] indexMapping, @Nullable int[] trimmedKeyMapping) {
@@ -141,6 +144,11 @@ public class FormatReaderMapping {
         return topN;
     }
 
+    @Nullable
+    public Integer getLimit() {
+        return limit;
+    }
+
     /** Builder for {@link FormatReaderMapping}. */
     public static class Builder {
 
@@ -149,18 +157,21 @@ public class FormatReaderMapping {
         private final Function<TableSchema, List<DataField>> fieldsExtractor;
         @Nullable private final List<Predicate> filters;
         @Nullable private final TopN topN;
+        @Nullable private final Integer limit;
 
         public Builder(
                 FileFormatDiscover formatDiscover,
                 List<DataField> readFields,
                 Function<TableSchema, List<DataField>> fieldsExtractor,
                 @Nullable List<Predicate> filters,
-                @Nullable TopN topN) {
+                @Nullable TopN topN,
+                @Nullable Integer limit) {
             this.formatDiscover = formatDiscover;
             this.readFields = readFields;
             this.fieldsExtractor = fieldsExtractor;
             this.filters = filters;
             this.topN = topN;
+            this.limit = limit;
         }
 
         /**
@@ -223,7 +234,8 @@ public class FormatReaderMapping {
                     dataSchema,
                     readFilters,
                     systemFields,
-                    evolutionTopN(tableSchema, dataSchema));
+                    evolutionTopN(tableSchema, dataSchema),
+                    limit);
         }
 
         @Nullable

--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlySimpleTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlySimpleTableTest.java
@@ -36,6 +36,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.io.BundleRecords;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.Equal;
 import org.apache.paimon.predicate.FieldRef;
@@ -68,6 +69,7 @@ import org.apache.paimon.utils.RoaringBitmap32;
 
 import org.apache.paimon.shade.org.apache.parquet.hadoop.ParquetOutputFormat;
 
+import org.apache.commons.math3.random.RandomDataGenerator;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -96,6 +98,7 @@ import static org.apache.paimon.CoreOptions.FILE_FORMAT;
 import static org.apache.paimon.CoreOptions.FILE_FORMAT_PARQUET;
 import static org.apache.paimon.CoreOptions.FILE_INDEX_IN_MANIFEST_THRESHOLD;
 import static org.apache.paimon.CoreOptions.METADATA_STATS_MODE;
+import static org.apache.paimon.CoreOptions.SOURCE_SPLIT_TARGET_SIZE;
 import static org.apache.paimon.CoreOptions.WRITE_ONLY;
 import static org.apache.paimon.io.DataFileTestUtils.row;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -942,6 +945,57 @@ public class AppendOnlySimpleTableTest extends SimpleTableTestBase {
             AtomicInteger cnt = new AtomicInteger(0);
             reader.forEachRemaining(row -> cnt.incrementAndGet());
             assertThat(cnt.get()).isEqualTo(rowCount);
+            reader.close();
+        }
+    }
+
+    @Test
+    public void testLimitPushDown() throws Exception {
+        RowType rowType = RowType.builder().field("id", DataTypes.INT()).build();
+        Consumer<Options> configure =
+                options -> {
+                    options.set(FILE_FORMAT, FILE_FORMAT_PARQUET);
+                    options.set(WRITE_ONLY, true);
+                    options.set(SOURCE_SPLIT_TARGET_SIZE, MemorySize.ofBytes(1));
+                    options.set(ParquetOutputFormat.BLOCK_SIZE, "1048576");
+                    options.set(ParquetOutputFormat.MIN_ROW_COUNT_FOR_PAGE_SIZE_CHECK, "100");
+                    options.set(ParquetOutputFormat.PAGE_ROW_COUNT_LIMIT, "300");
+                };
+        // in unaware-bucket mode, we split files into splits all the time
+        FileStoreTable table = createUnawareBucketFileStoreTable(rowType, configure);
+
+        int rowCount = 10000;
+        StreamTableWrite write = table.newWrite(commitUser);
+        StreamTableCommit commit = table.newCommit(commitUser);
+        for (int i = 0; i < rowCount; i++) {
+            write.write(GenericRow.of(i));
+        }
+        commit.commit(0, write.prepareCommit(true, 0));
+
+        for (int i = 0; i < rowCount; i++) {
+            write.write(GenericRow.of(i));
+        }
+        commit.commit(1, write.prepareCommit(true, 1));
+
+        for (int i = 0; i < rowCount; i++) {
+            write.write(GenericRow.of(i));
+        }
+        commit.commit(2, write.prepareCommit(true, 2));
+
+        write.close();
+        commit.close();
+
+        // test limit push down
+        {
+            int limit = new RandomDataGenerator().nextInt(1, 1000);
+            TableScan.Plan plan = table.newScan().withLimit(limit).plan();
+            assertThat(plan.splits()).hasSize(1);
+
+            RecordReader<InternalRow> reader =
+                    table.newRead().withLimit(limit).createReader(plan.splits());
+            AtomicInteger cnt = new AtomicInteger(0);
+            reader.forEachRemaining(row -> cnt.incrementAndGet());
+            assertThat(cnt.get()).isEqualTo(limit);
             reader.close();
         }
     }

--- a/paimon-core/src/test/java/org/apache/paimon/utils/FormatReaderMappingTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/FormatReaderMappingTest.java
@@ -136,6 +136,7 @@ public class FormatReaderMappingTest {
                         null,
                         null,
                         Collections.emptyMap(),
+                        null,
                         null);
 
         Assertions.assertThat(formatReaderMapping.getIndexMapping())

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonPushDownTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonPushDownTestBase.scala
@@ -224,6 +224,7 @@ abstract class PaimonPushDownTestBase extends PaimonSparkTestBase {
 
               sql("INSERT INTO T SELECT id FROM range (1, 50000)")
               sql("DELETE FROM T WHERE id % 13 = 0")
+              Assertions.assertEquals(100, spark.sql("SELECT * FROM T LIMIT 100").count())
 
               val withoutLimit = getScanBuilder().build().asInstanceOf[PaimonScan].getOriginSplits
               assert(withoutLimit.length == 10)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

For now, `selection` can push down to filter the DataFile's rowgroups and pages, and the `limit` can trim the `selection`, then more rowgroups and pages will be filtered out.

1. support append-only table, append-only/primary-key table in deletion-vector mode.
2. limit can not using with `TopN` and `Predicate Filter`.

Benchmarks:
Before
```text
limit:                                                                                               Best/Avg Time(ms)    Row Rate(K/s)      Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
OPERATORTEST_limit_300000-1000                                                                             498 /  498           2007.2            498.2       1.0X
```

After
```text
limit:                                                                                               Best/Avg Time(ms)    Row Rate(K/s)      Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
OPERATORTEST_limit_300000-1000                                                                              27 /   27          37500.0             26.7       1.0X
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
