### PR TITLE
[flink] Fix Global Committer metrics missing in UI for filter/commit path

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
@@ -119,6 +119,8 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
             boolean checkAppendFiles,
             boolean partitionMarkDoneRecoverFromState) {
         int committed = commit.filterAndCommitMultiple(globalCommittables, checkAppendFiles);
+        // update bytes/records metrics for filter-and-commit path as well
+        calcNumBytesAndRecordsOut(globalCommittables);
         commitListeners.notifyCommittable(globalCommittables, partitionMarkDoneRecoverFromState);
 
         return committed;


### PR DESCRIPTION
 - Global Committer metrics in Flink UI when committing via filter-and-commit.
 - StoreCommitter.filterAndCommit() didn’t update CommitterMetrics, unlike commit().
 - Updated the same and added a test.
 - Fixes: #5950 