### PR TITLE
[flink] Restart dedicated compact job if schema change is detected

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CompactProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/CompactProcedureITCase.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.flink.CatalogITCaseBase;
+import org.apache.paimon.flink.action.CompactAction;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.DataSplit;
@@ -29,19 +30,24 @@ import org.apache.paimon.utils.BlockingIterator;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.StringUtils;
 
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** IT Case for {@link CompactProcedure}. */
 public class CompactProcedureITCase extends CatalogITCaseBase {
@@ -417,6 +423,52 @@ public class CompactProcedureITCase extends CatalogITCaseBase {
                                         .close())
                 .hasMessageContaining(
                         "The full compact strategy is only supported in batch mode. Please add -Dexecution.runtime-mode=BATCH.");
+    }
+
+    // ----------------------- Schema Evolution -----------------------
+
+    @Test
+    public void testFailWhenSchemaChanged() throws Exception {
+        tEnv.executeSql(
+                "CREATE TABLE T (\n"
+                        + "  pt INT,\n"
+                        + "  k INT,\n"
+                        + "  v INT,\n"
+                        + "  PRIMARY KEY (pt, k) NOT ENFORCED\n"
+                        + ") PARTITIONED BY (pt) WITH (\n"
+                        + "  'bucket' = '1',\n"
+                        + "  'deletion-vectors.enabled' = 'true',\n"
+                        + "  'write-only' = 'true'\n"
+                        + ")");
+        sql("INSERT INTO T VALUES (1, 0, 0), (2, 0, 0)");
+        StreamExecutionEnvironment env =
+                streamExecutionEnvironmentBuilder()
+                        .parallelism(1)
+                        .checkpointIntervalMs(100)
+                        .build();
+        Map<String, String> catalogOptions = new HashMap<>();
+        catalogOptions.put("warehouse", path);
+        CompactAction action = new CompactAction("default", "T", catalogOptions, new HashMap<>());
+        action.withStreamExecutionEnvironment(env);
+        action.build();
+        JobClient jobClient = env.executeAsync();
+        sqlAssertWithRetry(
+                "SELECT * FROM T",
+                result -> result.containsExactlyInAnyOrder(Row.of(1, 0, 0), Row.of(2, 0, 0)));
+
+        sql("ALTER TABLE T ADD v2 INT");
+        sql("INSERT INTO T VALUES (1, 0, 10, 10), (2, 2, 20, 20)");
+        // compact job should fail with new schema
+        assertThatThrownBy(() -> jobClient.getJobExecutionResult().get())
+                .rootCause()
+                .hasMessageContaining("has schema id");
+
+        sql("CALL sys.compact(`table` => 'default.T')");
+        sqlAssertWithRetry(
+                "SELECT * FROM T",
+                result ->
+                        result.containsExactlyInAnyOrder(
+                                Row.of(1, 0, 10, 10), Row.of(2, 0, 0, null), Row.of(2, 2, 20, 20)));
     }
 
     private void checkLatestSnapshot(


### PR DESCRIPTION
### Purpose

Currently, streaming compact job does not deal with schema change. If the user adds a column, it will be ignored by the compact job and this column will be lost.

This PR restarts the compact job if schema change is detected, so new columns will not be lost.

### Tests

* `CompactProcedureITCase#testFailWhenSchemaChanged`

### API and Format

No format changes.

### Documentation

No new feature.
