### PR TITLE
[spark] support using scala 2.13 to build and deploy with paimon-spark

### DIFF
--- a/.github/workflows/publish_snapshot-jdk17.yml
+++ b/.github/workflows/publish_snapshot-jdk17.yml
@@ -64,6 +64,6 @@ jobs:
           echo "</server></servers></settings>" >> $tmp_settings
         
           mvn --settings $tmp_settings clean install -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark4,flink1 -pl org.apache.paimon:paimon-spark-4.0_2.13 -am
-          mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark4,flink1 -pl org.apache.paimon:paimon-spark-common_2.13,org.apache.paimon:paimon-spark4-common_2.13,org.apache.paimon:paimon-spark-4.0_2.13
+          mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark4,flink1 -pl org.apache.paimon:paimon-spark-common_2.13,org.apache.paimon:paimon-spark4-common_2.13,org.apache.paimon:paimon-spark-ut_2.13,org.apache.paimon:paimon-spark-4.0_2.13
 
           rm $tmp_settings

--- a/.github/workflows/publish_snapshot-jdk17.yml
+++ b/.github/workflows/publish_snapshot-jdk17.yml
@@ -63,7 +63,7 @@ jobs:
           echo "<password>$ASF_PASSWORD</password>" >> $tmp_settings
           echo "</server></servers></settings>" >> $tmp_settings
         
-          mvn --settings $tmp_settings clean install -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark4,flink1 -pl org.apache.paimon:paimon-spark-4.0 -am
-          mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark4,flink1 -pl org.apache.paimon:paimon-spark-common_2.13,org.apache.paimon:paimon-spark4-common,org.apache.paimon:paimon-spark-4.0
+          mvn --settings $tmp_settings clean install -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark4,flink1 -pl org.apache.paimon:paimon-spark-4.0_2.13 -am
+          mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark4,flink1 -pl org.apache.paimon:paimon-spark-common_2.13,org.apache.paimon:paimon-spark4-common,org.apache.paimon:paimon-spark-4.0_2.13
 
           rm $tmp_settings

--- a/.github/workflows/publish_snapshot-jdk17.yml
+++ b/.github/workflows/publish_snapshot-jdk17.yml
@@ -64,6 +64,6 @@ jobs:
           echo "</server></servers></settings>" >> $tmp_settings
         
           mvn --settings $tmp_settings clean install -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark4,flink1 -pl org.apache.paimon:paimon-spark-4.0_2.13 -am
-          mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark4,flink1 -pl org.apache.paimon:paimon-spark-common_2.13,org.apache.paimon:paimon-spark4-common,org.apache.paimon:paimon-spark-4.0_2.13
+          mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark4,flink1 -pl org.apache.paimon:paimon-spark-common_2.13,org.apache.paimon:paimon-spark4-common_2.13,org.apache.paimon:paimon-spark-4.0_2.13
 
           rm $tmp_settings

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -66,5 +66,6 @@ jobs:
           echo "</server></servers></settings>" >> $tmp_settings
           
           mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark3,flink1
+          mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark3_2.13,flink1
 
           rm $tmp_settings

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -66,6 +66,6 @@ jobs:
           echo "</server></servers></settings>" >> $tmp_settings
           
           mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark3,flink1
-          mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark3_2.13,flink1
+          mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark3,scala_2.13,flink1
 
           rm $tmp_settings

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -66,6 +66,7 @@ jobs:
           echo "</server></servers></settings>" >> $tmp_settings
           
           mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark3,flink1
-          mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark3,scala_2.13,flink1
+          # deploy for scala 2.13
+          mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark3,scala-2.13,flink1 -pl org.apache.paimon:paimon-spark-common_2.13,org.apache.paimon:paimon-spark3-common_2.13,org.apache.paimon:paimon-spark-3.2_2.13,org.apache.paimon:paimon-spark-3.3_2.13,org.apache.paimon:paimon-spark-3.4_2.13,org.apache.paimon:paimon-spark-3.5_2.13
 
           rm $tmp_settings

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -67,6 +67,6 @@ jobs:
           
           mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark3,flink1
           # deploy for scala 2.13
-          mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark3,scala-2.13,flink1 -pl org.apache.paimon:paimon-spark-common_2.13,org.apache.paimon:paimon-spark3-common_2.13,org.apache.paimon:paimon-spark-3.2_2.13,org.apache.paimon:paimon-spark-3.3_2.13,org.apache.paimon:paimon-spark-3.4_2.13,org.apache.paimon:paimon-spark-3.5_2.13
+          mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark3,scala-2.13,flink1 -pl org.apache.paimon:paimon-spark-common_2.13,org.apache.paimon:paimon-spark3-common_2.13,org.apache.paimon:paimon-spark-ut_2.13,org.apache.paimon:paimon-spark-3.2_2.13,org.apache.paimon:paimon-spark-3.3_2.13,org.apache.paimon:paimon-spark-3.4_2.13,org.apache.paimon:paimon-spark-3.5_2.13
 
           rm $tmp_settings

--- a/.github/workflows/utitcase-jdk11.yml
+++ b/.github/workflows/utitcase-jdk11.yml
@@ -52,7 +52,8 @@ jobs:
           jvm_timezone=$(random_timezone)
           echo "JVM timezone is set to $jvm_timezone"
           test_modules="!paimon-e2e-tests,!org.apache.paimon:paimon-hive-connector-3.1,"
-          for suffix in 3.5 3.4 3.3 3.2 ut; do
+          scala_version=2.12
+          for suffix in ut 3.5_${scala_version} 3.4_${scala_version} 3.3_${scala_version} 3.2_${scala_version}; do
           test_modules+="!org.apache.paimon:paimon-spark-${suffix},"
           done
           test_modules="${test_modules%,}"

--- a/.github/workflows/utitcase-jdk11.yml
+++ b/.github/workflows/utitcase-jdk11.yml
@@ -52,9 +52,8 @@ jobs:
           jvm_timezone=$(random_timezone)
           echo "JVM timezone is set to $jvm_timezone"
           test_modules="!paimon-e2e-tests,!org.apache.paimon:paimon-hive-connector-3.1,"
-          scala_version=2.12
-          for suffix in ut 3.5_${scala_version} 3.4_${scala_version} 3.3_${scala_version} 3.2_${scala_version}; do
-          test_modules+="!org.apache.paimon:paimon-spark-${suffix},"
+          for suffix in ut 3.5 3.4 3.3 3.2; do
+          test_modules+="!org.apache.paimon:paimon-spark-${suffix}_2.12,"
           done
           test_modules="${test_modules%,}"
           mvn -T 1C -B clean install -pl "${test_modules}" -Pflink1,spark3 -Pskip-paimon-flink-tests -Duser.timezone=$jvm_timezone

--- a/.github/workflows/utitcase-spark-3.x.yml
+++ b/.github/workflows/utitcase-spark-3.x.yml
@@ -36,20 +36,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-spark3-2_12:
+  build_test:
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: true
+      matrix:
+        scala_version: [ '2.12', '2.13' ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
       - name: Set up JDK ${{ env.JDK_VERSION }}
         uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: 'temurin'
-      - name: Build Spark 3 with scala 2.12
+
+      - name: Build Spark 3 with ${{ matrix.scala_version }}
         run:  mvn -T 2C -B clean install -DskipTests
-      - name: Test Spark 3 with scala 2.12
+
+      - name: Test Spark 3 with ${{ matrix.scala_version }}
         timeout-minutes: 60
         run: |
           # run tests with random timezone to find out timezone related bugs
@@ -57,39 +63,8 @@ jobs:
           jvm_timezone=$(random_timezone)
           echo "JVM timezone is set to $jvm_timezone"
           test_modules=""
-          scala_version=2.12
-          for suffix in ut 3.5_${scala_version} 3.4_${scala_version} 3.3_${scala_version} 3.2_${scala_version}; do
+          for suffix in ut 3.5_${{ matrix.scala_version }} 3.4_${{ matrix.scala_version }} 3.3_${{ matrix.scala_version }} 3.2_${{ matrix.scala_version }}; do
           test_modules+="org.apache.paimon:paimon-spark-${suffix},"
           done
           test_modules="${test_modules%,}"
-          mvn -T 2C -B verify -pl "${test_modules}" -Duser.timezone=$jvm_timezone
-
-  build-spark3-2_13:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Set up JDK ${{ env.JDK_VERSION }}
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JDK_VERSION }}
-          distribution: 'temurin'
-      - name: Build Spark 3 with scala 2.13
-        run:  mvn -T 2C -B clean install -DskipTests -Pspark3 -Pscala_2.13
-      - name: Test Spark 3 with scala 2.13
-        timeout-minutes: 60
-        run: |
-          # run tests with random timezone to find out timezone related bugs
-          . .github/workflows/utils.sh
-          jvm_timezone=$(random_timezone)
-          echo "JVM timezone is set to $jvm_timezone"
-          test_modules=""
-          scala_version=2.13
-          for suffix in ut 3.5_${scala_version} 3.4_${scala_version} 3.3_${scala_version} 3.2_${scala_version}; do
-          test_modules+="org.apache.paimon:paimon-spark-${suffix},"
-          done
-          test_modules="${test_modules%,}"
-          mvn -T 2C -B verify -pl "${test_modules}" -Duser.timezone=$jvm_timezone -Pspark3 -Pscala_2.13
-        env:
-          MAVEN_OPTS: -Xmx4096m
+          mvn -T 2C -B verify -pl "${test_modules}" -Duser.timezone=$jvm_timezone -Pscala-${{ matrix.scala_version }}

--- a/.github/workflows/utitcase-spark-3.x.yml
+++ b/.github/workflows/utitcase-spark-3.x.yml
@@ -53,7 +53,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Build Spark 3 with ${{ matrix.scala_version }}
-        run:  mvn -T 2C -B clean install -DskipTests
+        run:  mvn -T 2C -B clean install -DskipTests -Pspark3,flink1,scala-${{ matrix.scala_version }}
 
       - name: Test Spark 3 with ${{ matrix.scala_version }}
         timeout-minutes: 60
@@ -67,6 +67,6 @@ jobs:
           test_modules+="org.apache.paimon:paimon-spark-${suffix}_${{ matrix.scala_version }},"
           done
           test_modules="${test_modules%,}"
-          mvn -T 2C -B verify -pl "${test_modules}" -Duser.timezone=$jvm_timezone -Pscala-${{ matrix.scala_version }}
+          mvn -T 2C -B verify -pl "${test_modules}" -Duser.timezone=$jvm_timezone -Pspark3,flink1,scala-${{ matrix.scala_version }}
         env:
           MAVEN_OPTS: -Xmx4096m

--- a/.github/workflows/utitcase-spark-3.x.yml
+++ b/.github/workflows/utitcase-spark-3.x.yml
@@ -36,7 +36,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-spark3-2_12:
     runs-on: ubuntu-latest
 
     steps:
@@ -49,8 +49,6 @@ jobs:
           distribution: 'temurin'
       - name: Build Spark 3 with scala 2.12
         run:  mvn -T 2C -B clean install -DskipTests
-      - name: Build Spark 3 with scala 2.13
-        run:  mvn -T 2C -B clean install -DskipTests -Pspark3_2.13
       - name: Test Spark 3 with scala 2.12
         timeout-minutes: 60
         run: |
@@ -65,6 +63,20 @@ jobs:
           done
           test_modules="${test_modules%,}"
           mvn -T 2C -B verify -pl "${test_modules}" -Duser.timezone=$jvm_timezone
+
+  build-spark3-2_13:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up JDK ${{ env.JDK_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JDK_VERSION }}
+          distribution: 'temurin'
+      - name: Build Spark 3 with scala 2.13
+        run:  mvn -T 2C -B clean install -DskipTests -Pspark3_2.13
       - name: Test Spark 3 with scala 2.13
         timeout-minutes: 60
         run: |

--- a/.github/workflows/utitcase-spark-3.x.yml
+++ b/.github/workflows/utitcase-spark-3.x.yml
@@ -76,7 +76,7 @@ jobs:
           java-version: ${{ env.JDK_VERSION }}
           distribution: 'temurin'
       - name: Build Spark 3 with scala 2.13
-        run:  mvn -T 2C -B clean install -DskipTests -Pspark3_2.13
+        run:  mvn -T 2C -B clean install -DskipTests -Pspark3 -Pscala_2.13
       - name: Test Spark 3 with scala 2.13
         timeout-minutes: 60
         run: |
@@ -90,6 +90,6 @@ jobs:
           test_modules+="org.apache.paimon:paimon-spark-${suffix},"
           done
           test_modules="${test_modules%,}"
-          mvn -T 2C -B verify -pl "${test_modules}" -Duser.timezone=$jvm_timezone -Pspark3_2.13
+          mvn -T 2C -B verify -pl "${test_modules}" -Duser.timezone=$jvm_timezone -Pspark3 -Pscala_2.13
         env:
           MAVEN_OPTS: -Xmx4096m

--- a/.github/workflows/utitcase-spark-3.x.yml
+++ b/.github/workflows/utitcase-spark-3.x.yml
@@ -59,7 +59,8 @@ jobs:
           jvm_timezone=$(random_timezone)
           echo "JVM timezone is set to $jvm_timezone"
           test_modules=""
-          for suffix in ut 3.5 3.4 3.3 3.2; do
+          scala_version=2.12
+          for suffix in ut 3.5_${scala_version} 3.4_${scala_version} 3.3_${scala_version} 3.2_${scala_version}; do
           test_modules+="org.apache.paimon:paimon-spark-${suffix},"
           done
           test_modules="${test_modules%,}"
@@ -72,7 +73,8 @@ jobs:
           jvm_timezone=$(random_timezone)
           echo "JVM timezone is set to $jvm_timezone"
           test_modules=""
-          for suffix in ut 3.5 3.4 3.3 3.2; do
+          scala_version=2.12
+          for suffix in ut 3.5_${scala_version} 3.4_${scala_version} 3.3_${scala_version} 3.2_${scala_version}; do
           test_modules+="org.apache.paimon:paimon-spark-${suffix},"
           done
           test_modules="${test_modules%,}"

--- a/.github/workflows/utitcase-spark-3.x.yml
+++ b/.github/workflows/utitcase-spark-3.x.yml
@@ -63,8 +63,10 @@ jobs:
           jvm_timezone=$(random_timezone)
           echo "JVM timezone is set to $jvm_timezone"
           test_modules=""
-          for suffix in ut 3.5_${{ matrix.scala_version }} 3.4_${{ matrix.scala_version }} 3.3_${{ matrix.scala_version }} 3.2_${{ matrix.scala_version }}; do
-          test_modules+="org.apache.paimon:paimon-spark-${suffix},"
+          for suffix in ut 3.5 3.4 3.3 3.2; do
+          test_modules+="org.apache.paimon:paimon-spark-${suffix}_${{ matrix.scala_version }},"
           done
           test_modules="${test_modules%,}"
           mvn -T 2C -B verify -pl "${test_modules}" -Duser.timezone=$jvm_timezone -Pscala-${{ matrix.scala_version }}
+        env:
+          MAVEN_OPTS: -Xmx4096m

--- a/.github/workflows/utitcase-spark-3.x.yml
+++ b/.github/workflows/utitcase-spark-3.x.yml
@@ -73,7 +73,7 @@ jobs:
           jvm_timezone=$(random_timezone)
           echo "JVM timezone is set to $jvm_timezone"
           test_modules=""
-          scala_version=2.12
+          scala_version=2.13
           for suffix in ut 3.5_${scala_version} 3.4_${scala_version} 3.3_${scala_version} 3.2_${scala_version}; do
           test_modules+="org.apache.paimon:paimon-spark-${suffix},"
           done

--- a/.github/workflows/utitcase-spark-3.x.yml
+++ b/.github/workflows/utitcase-spark-3.x.yml
@@ -47,9 +47,11 @@ jobs:
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: 'temurin'
-      - name: Build Spark
+      - name: Build Spark 3 with scala 2.12
         run:  mvn -T 2C -B clean install -DskipTests
-      - name: Test Spark
+      - name: Build Spark 3 with scala 2.13
+        run:  mvn -T 2C -B clean install -DskipTests -Pspark3_2.13
+      - name: Test Spark 3 with scala 2.12
         timeout-minutes: 60
         run: |
           # run tests with random timezone to find out timezone related bugs
@@ -62,5 +64,18 @@ jobs:
           done
           test_modules="${test_modules%,}"
           mvn -T 2C -B verify -pl "${test_modules}" -Duser.timezone=$jvm_timezone
+      - name: Test Spark 3 with scala 2.13
+        timeout-minutes: 60
+        run: |
+          # run tests with random timezone to find out timezone related bugs
+          . .github/workflows/utils.sh
+          jvm_timezone=$(random_timezone)
+          echo "JVM timezone is set to $jvm_timezone"
+          test_modules=""
+          for suffix in ut 3.5 3.4 3.3 3.2; do
+          test_modules+="org.apache.paimon:paimon-spark-${suffix},"
+          done
+          test_modules="${test_modules%,}"
+          mvn -T 2C -B verify -pl "${test_modules}" -Duser.timezone=$jvm_timezone -Pspark3_2.13
         env:
           MAVEN_OPTS: -Xmx4096m

--- a/.github/workflows/utitcase-spark-4.x.yml
+++ b/.github/workflows/utitcase-spark-4.x.yml
@@ -57,7 +57,8 @@ jobs:
           jvm_timezone=$(random_timezone)
           echo "JVM timezone is set to $jvm_timezone"
           test_modules=""
-          for suffix in ut 4.0; do
+          scala_version=2.13
+          for suffix in ut 4.0_${scala_version}; do
           test_modules+="org.apache.paimon:paimon-spark-${suffix},"
           done
           test_modules="${test_modules%,}"

--- a/.github/workflows/utitcase-spark-4.x.yml
+++ b/.github/workflows/utitcase-spark-4.x.yml
@@ -36,7 +36,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build_test:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/utitcase-spark-4.x.yml
+++ b/.github/workflows/utitcase-spark-4.x.yml
@@ -57,9 +57,8 @@ jobs:
           jvm_timezone=$(random_timezone)
           echo "JVM timezone is set to $jvm_timezone"
           test_modules=""
-          scala_version=2.13
-          for suffix in ut 4.0_${scala_version}; do
-          test_modules+="org.apache.paimon:paimon-spark-${suffix},"
+          for suffix in ut 4.0; do
+          test_modules+="org.apache.paimon:paimon-spark-${suffix}_2.13,"
           done
           test_modules="${test_modules%,}"
           mvn -T 2C -B verify -pl "${test_modules}" -Duser.timezone=$jvm_timezone -Pspark4,flink1

--- a/.github/workflows/utitcase-spark-4.x.yml
+++ b/.github/workflows/utitcase-spark-4.x.yml
@@ -42,13 +42,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
       - name: Set up JDK ${{ env.JDK_VERSION }}
         uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: 'temurin'
+
       - name: Build Spark
         run:  mvn -T 2C -B clean install -DskipTests -Pspark4,flink1
+
       - name: Test Spark
         timeout-minutes: 60
         run: |

--- a/.github/workflows/utitcase.yml
+++ b/.github/workflows/utitcase.yml
@@ -62,9 +62,8 @@ jobs:
           echo "JVM timezone is set to $jvm_timezone"
           
           TEST_MODULES="!paimon-e2e-tests,"
-          scala_version=2.12
-          for suffix in ut 3.5_${scala_version} 3.4_${scala_version} 3.3_${scala_version} 3.2_${scala_version}; do
-            TEST_MODULES+="!org.apache.paimon:paimon-spark-${suffix},"
+          for suffix in ut 3.5 3.4 3.3 3.2; do
+            TEST_MODULES+="!org.apache.paimon:paimon-spark-${suffix}_2.12,"
           done
           TEST_MODULES="${TEST_MODULES%,}"
           mvn -T 2C -B clean install -pl "${TEST_MODULES}" -Pskip-paimon-flink-tests -Duser.timezone=$jvm_timezone

--- a/.github/workflows/utitcase.yml
+++ b/.github/workflows/utitcase.yml
@@ -62,7 +62,8 @@ jobs:
           echo "JVM timezone is set to $jvm_timezone"
           
           TEST_MODULES="!paimon-e2e-tests,"
-          for suffix in 3.5 3.4 3.3 3.2 ut; do
+          scala_version=2.12
+          for suffix in ut 3.5_${scala_version} 3.4_${scala_version} 3.3_${scala_version} 3.2_${scala_version}; do
             TEST_MODULES+="!org.apache.paimon:paimon-spark-${suffix},"
           done
           TEST_MODULES="${TEST_MODULES%,}"

--- a/paimon-spark/paimon-spark-3.2/pom.xml
+++ b/paimon-spark/paimon-spark-3.2/pom.xml
@@ -43,7 +43,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-spark3-common</artifactId>
+            <artifactId>paimon-spark3-common_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -131,7 +131,7 @@ under the License.
                             </filters>
                             <artifactSet>
                                 <includes combine.children="append">
-                                     <include>org.apache.paimon:paimon-spark3-common</include>
+                                     <include>org.apache.paimon:paimon-spark3-common_${scala.binary.version}</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/paimon-spark/paimon-spark-3.2/pom.xml
+++ b/paimon-spark/paimon-spark-3.2/pom.xml
@@ -75,7 +75,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-spark-ut</artifactId>
+            <artifactId>paimon-spark-ut_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>

--- a/paimon-spark/paimon-spark-3.2/pom.xml
+++ b/paimon-spark/paimon-spark-3.2/pom.xml
@@ -28,8 +28,8 @@ under the License.
         <version>1.4-SNAPSHOT</version>
     </parent>
 
-    <artifactId>paimon-spark-3.2</artifactId>
-    <name>Paimon : Spark : 3.2</name>
+    <artifactId>paimon-spark-3.2_${scala.binary.version}</artifactId>
+    <name>Paimon : Spark : 3.2 : ${scala.binary.version}</name>
 
     <properties>
         <spark.version>3.2.4</spark.version>

--- a/paimon-spark/paimon-spark-3.3/pom.xml
+++ b/paimon-spark/paimon-spark-3.3/pom.xml
@@ -43,7 +43,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-spark3-common</artifactId>
+            <artifactId>paimon-spark3-common_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -131,7 +131,7 @@ under the License.
                             </filters>
                             <artifactSet>
                                 <includes combine.children="append">
-                                     <include>org.apache.paimon:paimon-spark3-common</include>
+                                     <include>org.apache.paimon:paimon-spark3-common_${scala.binary.version}</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/paimon-spark/paimon-spark-3.3/pom.xml
+++ b/paimon-spark/paimon-spark-3.3/pom.xml
@@ -75,7 +75,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-spark-ut</artifactId>
+            <artifactId>paimon-spark-ut_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>

--- a/paimon-spark/paimon-spark-3.3/pom.xml
+++ b/paimon-spark/paimon-spark-3.3/pom.xml
@@ -28,8 +28,8 @@ under the License.
         <version>1.4-SNAPSHOT</version>
     </parent>
 
-    <artifactId>paimon-spark-3.3</artifactId>
-    <name>Paimon : Spark : 3.3</name>
+    <artifactId>paimon-spark-3.3_${scala.binary.version}</artifactId>
+    <name>Paimon : Spark : 3.3: ${scala.binary.version}</name>
 
     <properties>
         <spark.version>3.3.4</spark.version>

--- a/paimon-spark/paimon-spark-3.4/pom.xml
+++ b/paimon-spark/paimon-spark-3.4/pom.xml
@@ -43,7 +43,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-spark3-common</artifactId>
+            <artifactId>paimon-spark3-common_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -131,7 +131,7 @@ under the License.
                             </filters>
                             <artifactSet>
                                 <includes combine.children="append">
-                                     <include>org.apache.paimon:paimon-spark3-common</include>
+                                     <include>org.apache.paimon:paimon-spark3-common_${scala.binary.version}</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/paimon-spark/paimon-spark-3.4/pom.xml
+++ b/paimon-spark/paimon-spark-3.4/pom.xml
@@ -75,7 +75,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-spark-ut</artifactId>
+            <artifactId>paimon-spark-ut_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>

--- a/paimon-spark/paimon-spark-3.4/pom.xml
+++ b/paimon-spark/paimon-spark-3.4/pom.xml
@@ -28,8 +28,8 @@ under the License.
         <version>1.4-SNAPSHOT</version>
     </parent>
 
-    <artifactId>paimon-spark-3.4</artifactId>
-    <name>Paimon : Spark : 3.4</name>
+    <artifactId>paimon-spark-3.4_${scala.binary.version}</artifactId>
+    <name>Paimon : Spark : 3.4: ${scala.binary.version}</name>
 
     <properties>
         <spark.version>3.4.3</spark.version>

--- a/paimon-spark/paimon-spark-3.5/pom.xml
+++ b/paimon-spark/paimon-spark-3.5/pom.xml
@@ -43,7 +43,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-spark3-common</artifactId>
+            <artifactId>paimon-spark3-common_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -131,7 +131,7 @@ under the License.
                             </filters>
                             <artifactSet>
                                 <includes combine.children="append">
-                                     <include>org.apache.paimon:paimon-spark3-common</include>
+                                     <include>org.apache.paimon:paimon-spark3-common_${scala.binary.version}</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/paimon-spark/paimon-spark-3.5/pom.xml
+++ b/paimon-spark/paimon-spark-3.5/pom.xml
@@ -75,7 +75,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-spark-ut</artifactId>
+            <artifactId>paimon-spark-ut_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>

--- a/paimon-spark/paimon-spark-3.5/pom.xml
+++ b/paimon-spark/paimon-spark-3.5/pom.xml
@@ -28,8 +28,8 @@ under the License.
         <version>1.4-SNAPSHOT</version>
     </parent>
 
-    <artifactId>paimon-spark-3.5</artifactId>
-    <name>Paimon : Spark : 3.5</name>
+    <artifactId>paimon-spark-3.5_${scala.binary.version}</artifactId>
+    <name>Paimon : Spark : 3.5: ${scala.binary.version}</name>
 
     <properties>
         <spark.version>3.5.6</spark.version>

--- a/paimon-spark/paimon-spark-4.0/pom.xml
+++ b/paimon-spark/paimon-spark-4.0/pom.xml
@@ -28,8 +28,8 @@ under the License.
         <version>1.4-SNAPSHOT</version>
     </parent>
 
-    <artifactId>paimon-spark-4.0_${scala.binary.version}</artifactId>
-    <name>Paimon : Spark : 4.0 : ${scala.binary.version}</name>
+    <artifactId>paimon-spark-4.0_2.13</artifactId>
+    <name>Paimon : Spark : 4.0 : 2.13</name>
 
     <properties>
         <spark.version>4.0.1</spark.version>

--- a/paimon-spark/paimon-spark-4.0/pom.xml
+++ b/paimon-spark/paimon-spark-4.0/pom.xml
@@ -81,7 +81,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-spark-ut</artifactId>
+            <artifactId>paimon-spark-ut_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>

--- a/paimon-spark/paimon-spark-4.0/pom.xml
+++ b/paimon-spark/paimon-spark-4.0/pom.xml
@@ -43,7 +43,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-spark4-common</artifactId>
+            <artifactId>paimon-spark4-common_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -143,7 +143,7 @@ under the License.
                             </filters>
                             <artifactSet>
                                 <includes combine.children="append">
-                                     <include>org.apache.paimon:paimon-spark4-common</include>
+                                     <include>org.apache.paimon:paimon-spark4-common_${scala.binary.version}</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/paimon-spark/paimon-spark-4.0/pom.xml
+++ b/paimon-spark/paimon-spark-4.0/pom.xml
@@ -28,8 +28,8 @@ under the License.
         <version>1.4-SNAPSHOT</version>
     </parent>
 
-    <artifactId>paimon-spark-4.0</artifactId>
-    <name>Paimon : Spark : 4.0</name>
+    <artifactId>paimon-spark-4.0_${scala.binary.version}</artifactId>
+    <name>Paimon : Spark : 4.0 : ${scala.binary.version}</name>
 
     <properties>
         <spark.version>4.0.1</spark.version>

--- a/paimon-spark/paimon-spark-ut/pom.xml
+++ b/paimon-spark/paimon-spark-ut/pom.xml
@@ -28,8 +28,8 @@ under the License.
         <version>1.4-SNAPSHOT</version>
     </parent>
 
-    <artifactId>paimon-spark-ut</artifactId>
-    <name>Paimon : Spark : UT</name>
+    <artifactId>paimon-spark-ut_${scala.binary.version}</artifactId>
+    <name>Paimon : Spark : UT : ${scala.binary.version}</name>
 
     <properties>
         <spark.version>${paimon-spark-common.spark.version}</spark.version>

--- a/paimon-spark/paimon-spark3-common/pom.xml
+++ b/paimon-spark/paimon-spark3-common/pom.xml
@@ -30,8 +30,8 @@ under the License.
 
     <packaging>jar</packaging>
 
-    <artifactId>paimon-spark3-common</artifactId>
-    <name>Paimon : Spark3 : Common</name>
+    <artifactId>paimon-spark3-common_${scala.binary.version}</artifactId>
+    <name>Paimon : Spark3 : Common : ${scala.binary.version}</name>
 
     <properties>
         <spark.version>${paimon-spark-common.spark.version}</spark.version>

--- a/paimon-spark/paimon-spark4-common/pom.xml
+++ b/paimon-spark/paimon-spark4-common/pom.xml
@@ -30,8 +30,8 @@ under the License.
 
     <packaging>jar</packaging>
 
-    <artifactId>paimon-spark4-common</artifactId>
-    <name>Paimon : Spark4 : Common</name>
+    <artifactId>paimon-spark4-common_2.13</artifactId>
+    <name>Paimon : Spark4 : Common : 2.13</name>
 
     <properties>
         <spark.version>${paimon-spark-common.spark.version}</spark.version>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@ under the License.
         <test.mysql.connector.java.version>8.0.27</test.mysql.connector.java.version>
 
         <!-- spark profile properties-->
-        <paimon-sparkx-common>paimon-spark3-common</paimon-sparkx-common>
+        <paimon-sparkx-common>paimon-spark3-common_${scala.binary.version}</paimon-sparkx-common>
         <paimon-spark-common.spark.version>3.5.6</paimon-spark-common.spark.version>
         <test.spark.main.version>3.3</test.spark.main.version>
         <test.spark.version>3.3.0</test.spark.version>
@@ -402,7 +402,7 @@ under the License.
                 <scala.binary.version>2.12</scala.binary.version>
                 <scala.version>${scala212.version}</scala.version>
                 <paimon-spark-common.spark.version>3.5.6</paimon-spark-common.spark.version>
-                <paimon-sparkx-common>paimon-spark3-common</paimon-sparkx-common>
+                <paimon-sparkx-common>paimon-spark3-common_${scala.binary.version}</paimon-sparkx-common>
                 <!-- todo: support the latest spark in paimon e2e test2 -->
                 <test.spark.main.version>3.3</test.spark.main.version>
                 <test.spark.version>3.3.0</test.spark.version>
@@ -427,7 +427,7 @@ under the License.
                 <scala.binary.version>2.13</scala.binary.version>
                 <scala.version>${scala213.version}</scala.version>
                 <paimon-spark-common.spark.version>4.0.1</paimon-spark-common.spark.version>
-                <paimon-sparkx-common>paimon-spark4-common</paimon-sparkx-common>
+                <paimon-sparkx-common>paimon-spark4-common_2.13</paimon-sparkx-common>
                 <test.spark.main.version>4.0</test.spark.main.version>
                 <test.spark.version>4.0.1</test.spark.version>
             </properties>
@@ -484,14 +484,14 @@ under the License.
         </profile>
 
         <profile>
-            <id>scala_2.13</id>
+            <id>scala-2.13</id>
             <properties>
                 <scala.binary.version>2.13</scala.binary.version>
                 <scala.version>${scala213.version}</scala.version>
             </properties>
             <activation>
                 <property>
-                    <name>scala_2.13</name>
+                    <name>scala-2.13</name>
                 </property>
             </activation>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -416,6 +416,31 @@ under the License.
         </profile>
 
         <profile>
+            <id>spark3_2.13</id>
+            <modules>
+                <module>paimon-spark/paimon-spark3-common</module>
+                <module>paimon-spark/paimon-spark-3.5</module>
+                <module>paimon-spark/paimon-spark-3.4</module>
+                <module>paimon-spark/paimon-spark-3.3</module>
+                <module>paimon-spark/paimon-spark-3.2</module>
+            </modules>
+            <properties>
+                <scala.binary.version>2.13</scala.binary.version>
+                <scala.version>${scala213.version}</scala.version>
+                <paimon-spark-common.spark.version>3.5.6</paimon-spark-common.spark.version>
+                <paimon-sparkx-common>paimon-spark3-common</paimon-sparkx-common>
+                <!-- todo: support the latest spark in paimon e2e test2 -->
+                <test.spark.main.version>3.3</test.spark.main.version>
+                <test.spark.version>3.3.0</test.spark.version>
+            </properties>
+            <activation>
+                <property>
+                    <name>spark3_2.13</name>
+                </property>
+            </activation>
+        </profile>
+
+        <profile>
             <id>spark4</id>
             <modules>
                 <module>paimon-spark/paimon-spark4-common</module>
@@ -1025,7 +1050,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M1</version>
+                    <version>3.0.0-M2</version>
                 </plugin>
 
                 <!-- Pin the version of the maven shade plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -1050,7 +1050,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M2</version>
+                    <version>3.0.0-M1</version>
                 </plugin>
 
                 <!-- Pin the version of the maven shade plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -416,31 +416,6 @@ under the License.
         </profile>
 
         <profile>
-            <id>spark3_2.13</id>
-            <modules>
-                <module>paimon-spark/paimon-spark3-common</module>
-                <module>paimon-spark/paimon-spark-3.5</module>
-                <module>paimon-spark/paimon-spark-3.4</module>
-                <module>paimon-spark/paimon-spark-3.3</module>
-                <module>paimon-spark/paimon-spark-3.2</module>
-            </modules>
-            <properties>
-                <scala.binary.version>2.13</scala.binary.version>
-                <scala.version>${scala213.version}</scala.version>
-                <paimon-spark-common.spark.version>3.5.6</paimon-spark-common.spark.version>
-                <paimon-sparkx-common>paimon-spark3-common</paimon-sparkx-common>
-                <!-- todo: support the latest spark in paimon e2e test2 -->
-                <test.spark.main.version>3.3</test.spark.main.version>
-                <test.spark.version>3.3.0</test.spark.version>
-            </properties>
-            <activation>
-                <property>
-                    <name>spark3_2.13</name>
-                </property>
-            </activation>
-        </profile>
-
-        <profile>
             <id>spark4</id>
             <modules>
                 <module>paimon-spark/paimon-spark4-common</module>
@@ -504,6 +479,19 @@ under the License.
             <activation>
                 <property>
                     <name>flink2</name>
+                </property>
+            </activation>
+        </profile>
+
+        <profile>
+            <id>scala_2.13</id>
+            <properties>
+                <scala.binary.version>2.13</scala.binary.version>
+                <scala.version>${scala213.version}</scala.version>
+            </properties>
+            <activation>
+                <property>
+                    <name>scala_2.13</name>
                 </property>
             </activation>
         </profile>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Support the use of scala 2.13 to compile and package the paimon-spark module, as in other projects, if scala 2.13 is used, the paimon jar package must also be packaged using scala 2.13.

<!-- What is the purpose of the change -->

### Tests

Rerun the UT and IT for the spark module package compiled on scala 2.13

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
