### PR TITLE
[core] Make ManifestEntry and DataFileMeta to interfaces

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta08Serializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta08Serializer.java
@@ -116,7 +116,7 @@ public class DataFileMeta08Serializer implements Serializable {
         byte[] bytes = new byte[in.readInt()];
         in.readFully(bytes);
         SafeBinaryRow row = new SafeBinaryRow(rowSerializer.getArity(), bytes, 0);
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 row.getString(0).toString(),
                 row.getLong(1),
                 row.getLong(2),

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta09Serializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta09Serializer.java
@@ -122,7 +122,7 @@ public class DataFileMeta09Serializer implements Serializable {
         byte[] bytes = new byte[in.readInt()];
         in.readFully(bytes);
         SafeBinaryRow row = new SafeBinaryRow(rowSerializer.getArity(), bytes, 0);
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 row.getString(0).toString(),
                 row.getLong(1),
                 row.getLong(2),

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta10LegacySerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta10LegacySerializer.java
@@ -127,7 +127,7 @@ public class DataFileMeta10LegacySerializer implements Serializable {
         byte[] bytes = new byte[in.readInt()];
         in.readFully(bytes);
         SafeBinaryRow row = new SafeBinaryRow(rowSerializer.getArity(), bytes, 0);
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 row.getString(0).toString(),
                 row.getLong(1),
                 row.getLong(2),

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta12LegacySerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta12LegacySerializer.java
@@ -129,7 +129,7 @@ public class DataFileMeta12LegacySerializer implements Serializable {
         byte[] bytes = new byte[in.readInt()];
         in.readFully(bytes);
         SafeBinaryRow row = new SafeBinaryRow(rowSerializer.getArity(), bytes, 0);
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 row.getString(0).toString(),
                 row.getLong(1),
                 row.getLong(2),

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMetaSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMetaSerializer.java
@@ -66,7 +66,7 @@ public class DataFileMetaSerializer extends ObjectSerializer<DataFileMeta> {
 
     @Override
     public DataFileMeta fromRow(InternalRow row) {
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 row.getString(0).toString(),
                 row.getLong(1),
                 row.getLong(2),

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueDataFileWriter.java
@@ -159,7 +159,7 @@ public abstract class KeyValueDataFileWriter
                         : dataFileIndexWriter.result();
 
         String externalPath = isExternalPath ? path.toString() : null;
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 path.getName(),
                 fileSize,
                 recordCount(),

--- a/paimon-core/src/main/java/org/apache/paimon/io/PojoDataFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/PojoDataFileMeta.java
@@ -1,0 +1,541 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.manifest.FileSource;
+import org.apache.paimon.stats.SimpleStats;
+
+import javax.annotation.Nullable;
+
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.apache.paimon.stats.SimpleStats.EMPTY_STATS;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** A {@link DataFileMeta} using pojo objects. */
+public class PojoDataFileMeta implements DataFileMeta {
+
+    private final String fileName;
+    private final long fileSize;
+
+    // total number of rows (including add & delete) in this file
+    private final long rowCount;
+
+    private final BinaryRow minKey;
+    private final BinaryRow maxKey;
+    private final SimpleStats keyStats;
+    private final SimpleStats valueStats;
+
+    // As for row-lineage table, this will be reassigned while committing
+    private final long minSequenceNumber;
+    private final long maxSequenceNumber;
+    private final long schemaId;
+    private final int level;
+
+    private final List<String> extraFiles;
+    private final Timestamp creationTime;
+
+    // rowCount = addRowCount + deleteRowCount
+    // Why don't we keep addRowCount and deleteRowCount?
+    // Because in previous versions of DataFileMeta, we only keep rowCount.
+    // We have to keep the compatibility.
+    private final @Nullable Long deleteRowCount;
+
+    // file index filter bytes, if it is small, store in data file meta
+    private final @Nullable byte[] embeddedIndex;
+
+    private final @Nullable FileSource fileSource;
+
+    private final @Nullable List<String> valueStatsCols;
+
+    /** external path of file, if it is null, it is in the default warehouse path. */
+    private final @Nullable String externalPath;
+
+    private final @Nullable Long firstRowId;
+
+    private final @Nullable List<String> writeCols;
+
+    public PojoDataFileMeta(
+            String fileName,
+            long fileSize,
+            long rowCount,
+            BinaryRow minKey,
+            BinaryRow maxKey,
+            SimpleStats keyStats,
+            SimpleStats valueStats,
+            long minSequenceNumber,
+            long maxSequenceNumber,
+            long schemaId,
+            int level,
+            List<String> extraFiles,
+            Timestamp creationTime,
+            @Nullable Long deleteRowCount,
+            @Nullable byte[] embeddedIndex,
+            @Nullable FileSource fileSource,
+            @Nullable List<String> valueStatsCols,
+            @Nullable String externalPath,
+            @Nullable Long firstRowId,
+            @Nullable List<String> writeCols) {
+        this.fileName = fileName;
+        this.fileSize = fileSize;
+
+        this.rowCount = rowCount;
+
+        this.embeddedIndex = embeddedIndex;
+        this.minKey = minKey;
+        this.maxKey = maxKey;
+        this.keyStats = keyStats;
+        this.valueStats = valueStats;
+
+        this.minSequenceNumber = minSequenceNumber;
+        this.maxSequenceNumber = maxSequenceNumber;
+        this.level = level;
+        this.schemaId = schemaId;
+        this.extraFiles = Collections.unmodifiableList(extraFiles);
+        this.creationTime = creationTime;
+
+        this.deleteRowCount = deleteRowCount;
+        this.fileSource = fileSource;
+        this.valueStatsCols = valueStatsCols;
+        this.externalPath = externalPath;
+        this.firstRowId = firstRowId;
+        this.writeCols = writeCols;
+    }
+
+    @Override
+    public String fileName() {
+        return fileName;
+    }
+
+    @Override
+    public long fileSize() {
+        return fileSize;
+    }
+
+    @Override
+    public long rowCount() {
+        return rowCount;
+    }
+
+    @Override
+    public Optional<Long> deleteRowCount() {
+        return Optional.ofNullable(deleteRowCount);
+    }
+
+    @Override
+    public byte[] embeddedIndex() {
+        return embeddedIndex;
+    }
+
+    @Override
+    public BinaryRow minKey() {
+        return minKey;
+    }
+
+    @Override
+    public BinaryRow maxKey() {
+        return maxKey;
+    }
+
+    @Override
+    public SimpleStats keyStats() {
+        return keyStats;
+    }
+
+    @Override
+    public SimpleStats valueStats() {
+        return valueStats;
+    }
+
+    @Override
+    public long minSequenceNumber() {
+        return minSequenceNumber;
+    }
+
+    @Override
+    public long maxSequenceNumber() {
+        return maxSequenceNumber;
+    }
+
+    @Override
+    public long schemaId() {
+        return schemaId;
+    }
+
+    @Override
+    public int level() {
+        return level;
+    }
+
+    @Override
+    public List<String> extraFiles() {
+        return extraFiles;
+    }
+
+    @Override
+    public Timestamp creationTime() {
+        return creationTime;
+    }
+
+    @Override
+    public long creationTimeEpochMillis() {
+        return creationTime
+                .toLocalDateTime()
+                .atZone(ZoneId.systemDefault())
+                .toInstant()
+                .toEpochMilli();
+    }
+
+    @Override
+    public String fileFormat() {
+        String[] split = fileName.split("\\.");
+        if (split.length == 1) {
+            throw new RuntimeException("Can't find format from file: " + fileName());
+        }
+        return split[split.length - 1];
+    }
+
+    @Override
+    public Optional<String> externalPath() {
+        return Optional.ofNullable(externalPath);
+    }
+
+    @Override
+    public Optional<String> externalPathDir() {
+        return Optional.ofNullable(externalPath)
+                .map(Path::new)
+                .map(p -> p.getParent().toUri().toString());
+    }
+
+    @Override
+    public Optional<FileSource> fileSource() {
+        return Optional.ofNullable(fileSource);
+    }
+
+    @Nullable
+    public List<String> valueStatsCols() {
+        return valueStatsCols;
+    }
+
+    @Nullable
+    public Long firstRowId() {
+        return firstRowId;
+    }
+
+    @Nullable
+    public List<String> writeCols() {
+        return writeCols;
+    }
+
+    @Override
+    public PojoDataFileMeta upgrade(int newLevel) {
+        checkArgument(newLevel > this.level);
+        return new PojoDataFileMeta(
+                fileName,
+                fileSize,
+                rowCount,
+                minKey,
+                maxKey,
+                keyStats,
+                valueStats,
+                minSequenceNumber,
+                maxSequenceNumber,
+                schemaId,
+                newLevel,
+                extraFiles,
+                creationTime,
+                deleteRowCount,
+                embeddedIndex,
+                fileSource,
+                valueStatsCols,
+                externalPath,
+                firstRowId,
+                writeCols);
+    }
+
+    @Override
+    public PojoDataFileMeta rename(String newFileName) {
+        String newExternalPath = externalPathDir().map(dir -> dir + "/" + newFileName).orElse(null);
+        return new PojoDataFileMeta(
+                newFileName,
+                fileSize,
+                rowCount,
+                minKey,
+                maxKey,
+                keyStats,
+                valueStats,
+                minSequenceNumber,
+                maxSequenceNumber,
+                schemaId,
+                level,
+                extraFiles,
+                creationTime,
+                deleteRowCount,
+                embeddedIndex,
+                fileSource,
+                valueStatsCols,
+                newExternalPath,
+                firstRowId,
+                writeCols);
+    }
+
+    @Override
+    public PojoDataFileMeta copyWithoutStats() {
+        return new PojoDataFileMeta(
+                fileName,
+                fileSize,
+                rowCount,
+                minKey,
+                maxKey,
+                keyStats,
+                EMPTY_STATS,
+                minSequenceNumber,
+                maxSequenceNumber,
+                schemaId,
+                level,
+                extraFiles,
+                creationTime,
+                deleteRowCount,
+                embeddedIndex,
+                fileSource,
+                Collections.emptyList(),
+                externalPath,
+                firstRowId,
+                writeCols);
+    }
+
+    @Override
+    public PojoDataFileMeta assignSequenceNumber(long minSequenceNumber, long maxSequenceNumber) {
+        return new PojoDataFileMeta(
+                fileName,
+                fileSize,
+                rowCount,
+                minKey,
+                maxKey,
+                keyStats,
+                valueStats,
+                minSequenceNumber,
+                maxSequenceNumber,
+                schemaId,
+                level,
+                extraFiles,
+                creationTime,
+                deleteRowCount,
+                embeddedIndex,
+                fileSource,
+                valueStatsCols,
+                externalPath,
+                firstRowId,
+                writeCols);
+    }
+
+    @Override
+    public PojoDataFileMeta assignFirstRowId(long firstRowId) {
+        return new PojoDataFileMeta(
+                fileName,
+                fileSize,
+                rowCount,
+                minKey,
+                maxKey,
+                keyStats,
+                valueStats,
+                minSequenceNumber,
+                maxSequenceNumber,
+                schemaId,
+                level,
+                extraFiles,
+                creationTime,
+                deleteRowCount,
+                embeddedIndex,
+                fileSource,
+                valueStatsCols,
+                externalPath,
+                firstRowId,
+                writeCols);
+    }
+
+    @Override
+    public PojoDataFileMeta copy(List<String> newExtraFiles) {
+        return new PojoDataFileMeta(
+                fileName,
+                fileSize,
+                rowCount,
+                minKey,
+                maxKey,
+                keyStats,
+                valueStats,
+                minSequenceNumber,
+                maxSequenceNumber,
+                schemaId,
+                level,
+                newExtraFiles,
+                creationTime,
+                deleteRowCount,
+                embeddedIndex,
+                fileSource,
+                valueStatsCols,
+                externalPath,
+                firstRowId,
+                writeCols);
+    }
+
+    @Override
+    public PojoDataFileMeta newExternalPath(String newExternalPath) {
+        return new PojoDataFileMeta(
+                fileName,
+                fileSize,
+                rowCount,
+                minKey,
+                maxKey,
+                keyStats,
+                valueStats,
+                minSequenceNumber,
+                maxSequenceNumber,
+                schemaId,
+                level,
+                extraFiles,
+                creationTime,
+                deleteRowCount,
+                embeddedIndex,
+                fileSource,
+                valueStatsCols,
+                newExternalPath,
+                firstRowId,
+                writeCols);
+    }
+
+    @Override
+    public PojoDataFileMeta copy(byte[] newEmbeddedIndex) {
+        return new PojoDataFileMeta(
+                fileName,
+                fileSize,
+                rowCount,
+                minKey,
+                maxKey,
+                keyStats,
+                valueStats,
+                minSequenceNumber,
+                maxSequenceNumber,
+                schemaId,
+                level,
+                extraFiles,
+                creationTime,
+                deleteRowCount,
+                newEmbeddedIndex,
+                fileSource,
+                valueStatsCols,
+                externalPath,
+                firstRowId,
+                writeCols);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof DataFileMeta)) {
+            return false;
+        }
+        DataFileMeta that = (DataFileMeta) o;
+        return Objects.equals(fileName, that.fileName())
+                && fileSize == that.fileSize()
+                && rowCount == that.rowCount()
+                && Arrays.equals(embeddedIndex, that.embeddedIndex())
+                && Objects.equals(minKey, that.minKey())
+                && Objects.equals(maxKey, that.maxKey())
+                && Objects.equals(keyStats, that.keyStats())
+                && Objects.equals(valueStats, that.valueStats())
+                && minSequenceNumber == that.minSequenceNumber()
+                && maxSequenceNumber == that.maxSequenceNumber()
+                && schemaId == that.schemaId()
+                && level == that.level()
+                && Objects.equals(extraFiles, that.extraFiles())
+                && Objects.equals(creationTime, that.creationTime())
+                && Objects.equals(deleteRowCount, that.deleteRowCount().orElse(null))
+                && Objects.equals(fileSource, that.fileSource().orElse(null))
+                && Objects.equals(valueStatsCols, that.valueStatsCols())
+                && Objects.equals(externalPath, that.externalPath().orElse(null))
+                && Objects.equals(firstRowId, that.firstRowId())
+                && Objects.equals(writeCols, that.writeCols());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                fileName,
+                fileSize,
+                rowCount,
+                Arrays.hashCode(embeddedIndex),
+                minKey,
+                maxKey,
+                keyStats,
+                valueStats,
+                minSequenceNumber,
+                maxSequenceNumber,
+                schemaId,
+                level,
+                extraFiles,
+                creationTime,
+                deleteRowCount,
+                fileSource,
+                valueStatsCols,
+                externalPath,
+                firstRowId,
+                writeCols);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "{fileName: %s, fileSize: %d, rowCount: %d, embeddedIndex: %s, "
+                        + "minKey: %s, maxKey: %s, keyStats: %s, valueStats: %s, "
+                        + "minSequenceNumber: %d, maxSequenceNumber: %d, "
+                        + "schemaId: %d, level: %d, extraFiles: %s, creationTime: %s, "
+                        + "deleteRowCount: %d, fileSource: %s, valueStatsCols: %s, externalPath: %s, firstRowId: %s, writeCols: %s}",
+                fileName,
+                fileSize,
+                rowCount,
+                Arrays.toString(embeddedIndex),
+                minKey,
+                maxKey,
+                keyStats,
+                valueStats,
+                minSequenceNumber,
+                maxSequenceNumber,
+                schemaId,
+                level,
+                extraFiles,
+                creationTime,
+                deleteRowCount,
+                fileSource,
+                valueStatsCols,
+                externalPath,
+                firstRowId,
+                writeCols);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/FilteredManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/FilteredManifestEntry.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.manifest;
 
 /** Wrap a {@link ManifestEntry} to contain {@link #selected}. */
-public class FilteredManifestEntry extends ManifestEntry {
+public class FilteredManifestEntry extends PojoManifestEntry {
 
     private final boolean selected;
 

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntry.java
@@ -26,12 +26,9 @@ import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.TinyIntType;
 
-import javax.annotation.Nullable;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 import static org.apache.paimon.utils.SerializationUtils.newBytesType;
 
@@ -41,9 +38,9 @@ import static org.apache.paimon.utils.SerializationUtils.newBytesType;
  * @since 0.9.0
  */
 @Public
-public class ManifestEntry implements FileEntry {
+public interface ManifestEntry extends FileEntry {
 
-    public static final RowType SCHEMA =
+    RowType SCHEMA =
             new RowType(
                     false,
                     Arrays.asList(
@@ -53,158 +50,36 @@ public class ManifestEntry implements FileEntry {
                             new DataField(3, "_TOTAL_BUCKETS", new IntType(false)),
                             new DataField(4, "_FILE", DataFileMeta.SCHEMA)));
 
-    private final FileKind kind;
-    // for tables without partition this field should be a row with 0 columns (not null)
-    private final BinaryRow partition;
-    private final int bucket;
-    private final int totalBuckets;
-    private final DataFileMeta file;
-
-    public ManifestEntry(
+    static ManifestEntry create(
             FileKind kind, BinaryRow partition, int bucket, int totalBuckets, DataFileMeta file) {
-        this.kind = kind;
-        this.partition = partition;
-        this.bucket = bucket;
-        this.totalBuckets = totalBuckets;
-        this.file = file;
+        return new PojoManifestEntry(kind, partition, bucket, totalBuckets, file);
     }
 
-    @Override
-    public FileKind kind() {
-        return kind;
-    }
+    DataFileMeta file();
 
-    @Override
-    public BinaryRow partition() {
-        return partition;
-    }
+    ManifestEntry copyWithoutStats();
 
-    @Override
-    public int bucket() {
-        return bucket;
-    }
+    ManifestEntry assignSequenceNumber(long minSequenceNumber, long maxSequenceNumber);
 
-    @Override
-    public int level() {
-        return file.level();
-    }
+    ManifestEntry assignFirstRowId(long firstRowId);
 
-    @Override
-    public String fileName() {
-        return file.fileName();
-    }
+    byte[] toBytes() throws IOException;
 
-    @Nullable
-    @Override
-    public String externalPath() {
-        return file.externalPath().orElse(null);
-    }
-
-    @Override
-    public BinaryRow minKey() {
-        return file.minKey();
-    }
-
-    @Override
-    public BinaryRow maxKey() {
-        return file.maxKey();
-    }
-
-    @Override
-    public List<String> extraFiles() {
-        return file.extraFiles();
-    }
-
-    @Override
-    public int totalBuckets() {
-        return totalBuckets;
-    }
-
-    public DataFileMeta file() {
-        return file;
-    }
-
-    @Override
-    public Identifier identifier() {
-        return new Identifier(
-                partition,
-                bucket,
-                file.level(),
-                file.fileName(),
-                file.extraFiles(),
-                file.embeddedIndex(),
-                externalPath());
-    }
-
-    public ManifestEntry copyWithoutStats() {
-        return new ManifestEntry(kind, partition, bucket, totalBuckets, file.copyWithoutStats());
-    }
-
-    public ManifestEntry assignSequenceNumber(long minSequenceNumber, long maxSequenceNumber) {
-        return new ManifestEntry(
-                kind,
-                partition,
-                bucket,
-                totalBuckets,
-                file.assignSequenceNumber(minSequenceNumber, maxSequenceNumber));
-    }
-
-    public ManifestEntry assignFirstRowId(long firstRowId) {
-        return new ManifestEntry(
-                kind, partition, bucket, totalBuckets, file.assignFirstRowId(firstRowId));
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (!(o instanceof ManifestEntry)) {
-            return false;
-        }
-        ManifestEntry that = (ManifestEntry) o;
-        return Objects.equals(kind, that.kind)
-                && Objects.equals(partition, that.partition)
-                && bucket == that.bucket
-                && totalBuckets == that.totalBuckets
-                && Objects.equals(file, that.file);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(kind, partition, bucket, totalBuckets, file);
-    }
-
-    @Override
-    public String toString() {
-        return String.format("{%s, %s, %d, %d, %s}", kind, partition, bucket, totalBuckets, file);
-    }
-
-    public static long recordCount(List<ManifestEntry> manifestEntries) {
+    static long recordCount(List<ManifestEntry> manifestEntries) {
         return manifestEntries.stream().mapToLong(manifest -> manifest.file().rowCount()).sum();
     }
 
-    public static long recordCountAdd(List<ManifestEntry> manifestEntries) {
+    static long recordCountAdd(List<ManifestEntry> manifestEntries) {
         return manifestEntries.stream()
                 .filter(manifestEntry -> FileKind.ADD.equals(manifestEntry.kind()))
                 .mapToLong(manifest -> manifest.file().rowCount())
                 .sum();
     }
 
-    public static long recordCountDelete(List<ManifestEntry> manifestEntries) {
+    static long recordCountDelete(List<ManifestEntry> manifestEntries) {
         return manifestEntries.stream()
                 .filter(manifestEntry -> FileKind.DELETE.equals(manifestEntry.kind()))
                 .mapToLong(manifest -> manifest.file().rowCount())
                 .sum();
-    }
-
-    // ----------------------- Serialization -----------------------------
-
-    private static final ThreadLocal<ManifestEntrySerializer> SERIALIZER_THREAD_LOCAL =
-            ThreadLocal.withInitial(ManifestEntrySerializer::new);
-
-    public byte[] toBytes() throws IOException {
-        return SERIALIZER_THREAD_LOCAL.get().serializeToBytes(this);
-    }
-
-    public ManifestEntry fromBytes(byte[] bytes) throws IOException {
-        return SERIALIZER_THREAD_LOCAL.get().deserializeFromBytes(bytes);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntrySerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntrySerializer.java
@@ -69,7 +69,7 @@ public class ManifestEntrySerializer extends VersionedObjectSerializer<ManifestE
             }
             throw new IllegalArgumentException("Unsupported version: " + version);
         }
-        return new ManifestEntry(
+        return ManifestEntry.create(
                 FileKind.fromByteValue(row.getByte(0)),
                 deserializeBinaryRow(row.getBinary(1)),
                 row.getInt(2),

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/PojoManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/PojoManifestEntry.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.manifest;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.io.DataFileMeta;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/** A {@link ManifestEntry} using pojo objects. */
+public class PojoManifestEntry implements ManifestEntry {
+
+    private static final ThreadLocal<ManifestEntrySerializer> SERIALIZER_THREAD_LOCAL =
+            ThreadLocal.withInitial(ManifestEntrySerializer::new);
+
+    private final FileKind kind;
+    // for tables without partition this field should be a row with 0 columns (not null)
+    private final BinaryRow partition;
+    private final int bucket;
+    private final int totalBuckets;
+    private final DataFileMeta file;
+
+    public PojoManifestEntry(
+            FileKind kind, BinaryRow partition, int bucket, int totalBuckets, DataFileMeta file) {
+        this.kind = kind;
+        this.partition = partition;
+        this.bucket = bucket;
+        this.totalBuckets = totalBuckets;
+        this.file = file;
+    }
+
+    @Override
+    public FileKind kind() {
+        return kind;
+    }
+
+    @Override
+    public BinaryRow partition() {
+        return partition;
+    }
+
+    @Override
+    public int bucket() {
+        return bucket;
+    }
+
+    @Override
+    public int level() {
+        return file.level();
+    }
+
+    @Override
+    public String fileName() {
+        return file.fileName();
+    }
+
+    @Nullable
+    @Override
+    public String externalPath() {
+        return file.externalPath().orElse(null);
+    }
+
+    @Override
+    public BinaryRow minKey() {
+        return file.minKey();
+    }
+
+    @Override
+    public BinaryRow maxKey() {
+        return file.maxKey();
+    }
+
+    @Override
+    public List<String> extraFiles() {
+        return file.extraFiles();
+    }
+
+    @Override
+    public int totalBuckets() {
+        return totalBuckets;
+    }
+
+    @Override
+    public DataFileMeta file() {
+        return file;
+    }
+
+    @Override
+    public Identifier identifier() {
+        return new Identifier(
+                partition,
+                bucket,
+                file.level(),
+                file.fileName(),
+                file.extraFiles(),
+                file.embeddedIndex(),
+                externalPath());
+    }
+
+    @Override
+    public PojoManifestEntry copyWithoutStats() {
+        return new PojoManifestEntry(
+                kind, partition, bucket, totalBuckets, file.copyWithoutStats());
+    }
+
+    @Override
+    public PojoManifestEntry assignSequenceNumber(long minSequenceNumber, long maxSequenceNumber) {
+        return new PojoManifestEntry(
+                kind,
+                partition,
+                bucket,
+                totalBuckets,
+                file.assignSequenceNumber(minSequenceNumber, maxSequenceNumber));
+    }
+
+    @Override
+    public PojoManifestEntry assignFirstRowId(long firstRowId) {
+        return new PojoManifestEntry(
+                kind, partition, bucket, totalBuckets, file.assignFirstRowId(firstRowId));
+    }
+
+    @Override
+    public byte[] toBytes() throws IOException {
+        return SERIALIZER_THREAD_LOCAL.get().serializeToBytes(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ManifestEntry)) {
+            return false;
+        }
+        ManifestEntry that = (ManifestEntry) o;
+        return Objects.equals(kind, that.kind())
+                && Objects.equals(partition, that.partition())
+                && bucket == that.bucket()
+                && totalBuckets == that.totalBuckets()
+                && Objects.equals(file, that.file());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(kind, partition, bucket, totalBuckets, file);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("{%s, %s, %d, %d, %s}", kind, partition, bucket, totalBuckets, file);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -774,7 +774,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             totalBuckets = numBucket;
         }
 
-        return new ManifestEntry(
+        return ManifestEntry.create(
                 kind, commitMessage.partition(), commitMessage.bucket(), totalBuckets, file);
     }
 
@@ -853,7 +853,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             List<ManifestEntry> currentEntries = scan.plan().files();
             for (ManifestEntry entry : currentEntries) {
                 changesWithOverwrite.add(
-                        new ManifestEntry(
+                        ManifestEntry.create(
                                 FileKind.DELETE,
                                 entry.partition(),
                                 entry.bucket(),

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/CommitMessageLegacyV2Serializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/CommitMessageLegacyV2Serializer.java
@@ -139,7 +139,7 @@ public class CommitMessageLegacyV2Serializer {
 
         @Override
         public DataFileMeta fromRow(InternalRow row) {
-            return new DataFileMeta(
+            return DataFileMeta.create(
                     row.getString(0).toString(),
                     row.getLong(1),
                     row.getLong(2),

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendCompactCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendCompactCoordinatorTest.java
@@ -245,7 +245,7 @@ public class AppendCompactCoordinatorTest {
     }
 
     private DataFileMeta newFile(long fileSize) {
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 UUID.randomUUID().toString(),
                 fileSize,
                 100,

--- a/paimon-core/src/test/java/org/apache/paimon/crosspartition/IndexBootstrapTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/crosspartition/IndexBootstrapTest.java
@@ -140,7 +140,7 @@ public class IndexBootstrapTest extends TableTestBase {
     }
 
     private static DataFileMeta newFile(long timeMillis) {
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 "",
                 1,
                 1,

--- a/paimon-core/src/test/java/org/apache/paimon/io/DataFileTestDataGenerator.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/DataFileTestDataGenerator.java
@@ -150,7 +150,7 @@ public class DataFileTestDataGenerator {
         return new Data(
                 partition,
                 bucket,
-                new DataFileMeta(
+                DataFileMeta.create(
                         "data-" + UUID.randomUUID(),
                         totalSize,
                         kvs.size(),

--- a/paimon-core/src/test/java/org/apache/paimon/io/DataFileTestUtils.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/DataFileTestUtils.java
@@ -40,7 +40,7 @@ public class DataFileTestUtils {
     }
 
     public static DataFileMeta newFile(long minSeq, long maxSeq) {
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 "",
                 maxSeq - minSeq + 1,
                 0L,
@@ -64,7 +64,7 @@ public class DataFileTestUtils {
     }
 
     public static DataFileMeta newFile() {
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 "",
                 0,
                 0,
@@ -91,7 +91,7 @@ public class DataFileTestUtils {
 
     public static DataFileMeta newFile(
             String name, int level, int minKey, int maxKey, long maxSequence, Long deleteRowCount) {
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 name,
                 maxKey - minKey + 1,
                 maxKey - minKey + 1,

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestCommittableSerializerCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestCommittableSerializerCompatibilityTest.java
@@ -58,7 +58,7 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         singleColumn("max_value"),
                         fromLongArray(new Long[] {0L}));
         DataFileMeta dataFile =
-                new DataFileMeta(
+                DataFileMeta.create(
                         "my_file",
                         1024 * 1024,
                         1024,
@@ -135,7 +135,7 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         singleColumn("max_value"),
                         fromLongArray(new Long[] {0L}));
         DataFileMeta dataFile =
-                new DataFileMeta(
+                DataFileMeta.create(
                         "my_file",
                         1024 * 1024,
                         1024,
@@ -211,7 +211,7 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         singleColumn("max_value"),
                         fromLongArray(new Long[] {0L}));
         DataFileMeta dataFile =
-                new DataFileMeta(
+                DataFileMeta.create(
                         "my_file",
                         1024 * 1024,
                         1024,
@@ -285,7 +285,7 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         singleColumn("max_value"),
                         fromLongArray(new Long[] {0L}));
         DataFileMeta dataFile =
-                new DataFileMeta(
+                DataFileMeta.create(
                         "my_file",
                         1024 * 1024,
                         1024,
@@ -359,7 +359,7 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         singleColumn("max_value"),
                         fromLongArray(new Long[] {0L}));
         DataFileMeta dataFile =
-                new DataFileMeta(
+                DataFileMeta.create(
                         "my_file",
                         1024 * 1024,
                         1024,
@@ -432,7 +432,7 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         singleColumn("max_value"),
                         fromLongArray(new Long[] {0L}));
         DataFileMeta dataFile =
-                new DataFileMeta(
+                DataFileMeta.create(
                         "my_file",
                         1024 * 1024,
                         1024,
@@ -506,7 +506,7 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         singleColumn("max_value"),
                         fromLongArray(new Long[] {0L}));
         DataFileMeta dataFile =
-                new DataFileMeta(
+                DataFileMeta.create(
                         "my_file",
                         1024 * 1024,
                         1024,
@@ -580,7 +580,7 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         singleColumn("max_value"),
                         fromLongArray(new Long[] {0L}));
         DataFileMeta dataFile =
-                new DataFileMeta(
+                DataFileMeta.create(
                         "my_file",
                         1024 * 1024,
                         1024,
@@ -654,7 +654,7 @@ public class ManifestCommittableSerializerCompatibilityTest {
                         singleColumn("max_value"),
                         fromLongArray(new Long[] {0L}));
         DataFileMeta dataFile =
-                new DataFileMeta(
+                DataFileMeta.create(
                         "my_file",
                         1024 * 1024,
                         1024,

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestCommittableSerializerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestCommittableSerializerTest.java
@@ -101,7 +101,7 @@ public class ManifestCommittableSerializerTest {
     }
 
     public static DataFileMeta newFile(int name, int level) {
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 String.valueOf(name),
                 0,
                 1,

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTestBase.java
@@ -73,12 +73,12 @@ public abstract class ManifestFileMetaTestBase {
             binaryRow = BinaryRow.EMPTY_ROW;
         }
 
-        return new ManifestEntry(
+        return ManifestEntry.create(
                 isAdd ? FileKind.ADD : FileKind.DELETE,
                 binaryRow,
                 0, // not used
                 0, // not used
-                new DataFileMeta(
+                DataFileMeta.create(
                         fileName,
                         0, // not used
                         0, // not used
@@ -262,12 +262,12 @@ public abstract class ManifestFileMetaTestBase {
 
     public static ManifestEntry makeEntry(
             FileKind fileKind, int partition, int bucket, long rowCount) {
-        return new ManifestEntry(
+        return ManifestEntry.create(
                 fileKind,
                 row(partition),
                 bucket,
                 0, // not used
-                new DataFileMeta(
+                DataFileMeta.create(
                         "", // not used
                         0, // not used
                         rowCount,

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestTestDataGenerator.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestTestDataGenerator.java
@@ -74,7 +74,7 @@ public class ManifestTestDataGenerator {
         List<DataFileTestDataGenerator.Data> level = bucketLevels.get(file.meta.level());
         level.add(file);
         bufferedResults.push(
-                new ManifestEntry(
+                ManifestEntry.create(
                         FileKind.ADD, file.partition, file.bucket, numBuckets, file.meta));
         mergeLevelsIfNeeded(file.partition, file.bucket);
 
@@ -144,7 +144,7 @@ public class ManifestTestDataGenerator {
 
             for (DataFileTestDataGenerator.Data file : currentLevel) {
                 bufferedResults.push(
-                        new ManifestEntry(
+                        ManifestEntry.create(
                                 FileKind.DELETE, partition, bucket, numBuckets, file.meta));
                 kvs.addAll(file.content);
             }
@@ -152,7 +152,7 @@ public class ManifestTestDataGenerator {
 
             for (DataFileTestDataGenerator.Data file : nextLevel) {
                 bufferedResults.push(
-                        new ManifestEntry(
+                        ManifestEntry.create(
                                 FileKind.DELETE, partition, bucket, numBuckets, file.meta));
                 kvs.addAll(file.content);
             }
@@ -164,7 +164,8 @@ public class ManifestTestDataGenerator {
             nextLevel.addAll(merged);
             for (DataFileTestDataGenerator.Data file : nextLevel) {
                 bufferedResults.push(
-                        new ManifestEntry(FileKind.ADD, partition, bucket, numBuckets, file.meta));
+                        ManifestEntry.create(
+                                FileKind.ADD, partition, bucket, numBuckets, file.meta));
             }
 
             lastModifiedLevel += 1;

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/LevelsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/LevelsTest.java
@@ -69,7 +69,7 @@ public class LevelsTest {
     }
 
     public static DataFileMeta newFile(int level) {
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 UUID.randomUUID().toString(),
                 0,
                 1,

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/IntervalPartitionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/IntervalPartitionTest.java
@@ -167,7 +167,7 @@ public class IntervalPartitionTest {
         maxWriter.writeInt(0, right);
         maxWriter.complete();
 
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 "DUMMY",
                 100,
                 25,

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/UniversalCompactionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/UniversalCompactionTest.java
@@ -442,7 +442,7 @@ public class UniversalCompactionTest {
     }
 
     static DataFileMeta file(long size) {
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 "",
                 size,
                 1,

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -266,7 +266,7 @@ public class ExpireSnapshotsTest {
         // create DataFileMeta and ManifestEntry
         List<String> extraFiles = Arrays.asList("extra1", "extra2");
         DataFileMeta dataFile =
-                new DataFileMeta(
+                DataFileMeta.create(
                         "myDataFile",
                         1,
                         1,
@@ -287,8 +287,8 @@ public class ExpireSnapshotsTest {
                         null,
                         null,
                         null);
-        ManifestEntry add = new ManifestEntry(FileKind.ADD, partition, 0, 1, dataFile);
-        ManifestEntry delete = new ManifestEntry(FileKind.DELETE, partition, 0, 1, dataFile);
+        ManifestEntry add = ManifestEntry.create(FileKind.ADD, partition, 0, 1, dataFile);
+        ManifestEntry delete = ManifestEntry.create(FileKind.DELETE, partition, 0, 1, dataFile);
 
         // expire
         expire.snapshotDeletion()
@@ -329,7 +329,7 @@ public class ExpireSnapshotsTest {
         // create DataFileMeta and ManifestEntry
         List<String> extraFiles = Arrays.asList("extra1", "extra2");
         DataFileMeta dataFile =
-                new DataFileMeta(
+                DataFileMeta.create(
                         fileName,
                         1,
                         1,
@@ -350,8 +350,8 @@ public class ExpireSnapshotsTest {
                         myDataFile.toString(),
                         null,
                         null);
-        ManifestEntry add = new ManifestEntry(FileKind.ADD, partition, 0, 1, dataFile);
-        ManifestEntry delete = new ManifestEntry(FileKind.DELETE, partition, 0, 1, dataFile);
+        ManifestEntry add = ManifestEntry.create(FileKind.ADD, partition, 0, 1, dataFile);
+        ManifestEntry delete = ManifestEntry.create(FileKind.DELETE, partition, 0, 1, dataFile);
 
         // expire
         expire.snapshotDeletion()

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
@@ -912,7 +912,7 @@ public class FileDeletionTest {
                 bucketEntries.stream()
                         .map(
                                 entry ->
-                                        new ManifestEntry(
+                                        ManifestEntry.create(
                                                 FileKind.DELETE,
                                                 partition,
                                                 bucket,

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/DataEvolutionSplitGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/DataEvolutionSplitGeneratorTest.java
@@ -37,7 +37,7 @@ public class DataEvolutionSplitGeneratorTest {
 
     private static DataFileMeta createFile(
             String name, @Nullable Long firstRowId, long maxSequence) {
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 name,
                 10000L,
                 1,

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/SplitGeneratorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/SplitGeneratorTest.java
@@ -44,7 +44,7 @@ public class SplitGeneratorTest {
 
     public static DataFileMeta newFileFromSequence(
             String name, int fileSize, long minSequence, long maxSequence) {
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 name,
                 fileSize,
                 1,

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/SplitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/SplitTest.java
@@ -198,7 +198,7 @@ public class SplitTest {
                         fromLongArray(new Long[] {0L}));
 
         DataFileMeta dataFile =
-                new DataFileMeta(
+                DataFileMeta.create(
                         "my_file",
                         1024 * 1024,
                         1024,
@@ -263,7 +263,7 @@ public class SplitTest {
                         fromLongArray(new Long[] {0L}));
 
         DataFileMeta dataFile =
-                new DataFileMeta(
+                DataFileMeta.create(
                         "my_file",
                         1024 * 1024,
                         1024,
@@ -328,7 +328,7 @@ public class SplitTest {
                         fromLongArray(new Long[] {0L}));
 
         DataFileMeta dataFile =
-                new DataFileMeta(
+                DataFileMeta.create(
                         "my_file",
                         1024 * 1024,
                         1024,
@@ -397,7 +397,7 @@ public class SplitTest {
                         fromLongArray(new Long[] {0L}));
 
         DataFileMeta dataFile =
-                new DataFileMeta(
+                DataFileMeta.create(
                         "my_file",
                         1024 * 1024,
                         1024,
@@ -466,7 +466,7 @@ public class SplitTest {
                         fromLongArray(new Long[] {0L}));
 
         DataFileMeta dataFile =
-                new DataFileMeta(
+                DataFileMeta.create(
                         "my_file",
                         1024 * 1024,
                         1024,
@@ -535,7 +535,7 @@ public class SplitTest {
                         fromLongArray(new Long[] {0L}));
 
         DataFileMeta dataFile =
-                new DataFileMeta(
+                DataFileMeta.create(
                         "my_file",
                         1024 * 1024,
                         1024,
@@ -605,7 +605,7 @@ public class SplitTest {
                         fromLongArray(new Long[] {0L}));
 
         DataFileMeta dataFile =
-                new DataFileMeta(
+                DataFileMeta.create(
                         "my_file",
                         1024 * 1024,
                         1024,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/copy/CopyManifestFileOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/copy/CopyManifestFileOperator.java
@@ -150,7 +150,7 @@ public class CopyManifestFileOperator extends AbstractStreamOperator<CopyFileInf
                 // path is null
                 for (ManifestEntry manifestEntry : manifestEntries) {
                     ManifestEntry newManifestEntry =
-                            new ManifestEntry(
+                            ManifestEntry.create(
                                     manifestEntry.kind(),
                                     manifestEntry.partition(),
                                     manifestEntry.bucket(),

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/changelog/ChangelogCompactSortOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/changelog/ChangelogCompactSortOperatorTest.java
@@ -180,7 +180,7 @@ public class ChangelogCompactSortOperatorTest {
     }
 
     private DataFileMeta createDataFileMeta(int mb, long creationMillis) {
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 UUID.randomUUID().toString(),
                 MemorySize.ofMebiBytes(mb).getBytes(),
                 0,

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/changelog/ChangelogCompactTaskSerializerTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/compact/changelog/ChangelogCompactTaskSerializerTest.java
@@ -86,7 +86,7 @@ public class ChangelogCompactTaskSerializerTest {
     }
 
     private DataFileMeta newFile() {
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 UUID.randomUUID().toString(),
                 0,
                 1,

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CompactionTaskSimpleSerializerTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CompactionTaskSimpleSerializerTest.java
@@ -64,7 +64,7 @@ public class CompactionTaskSimpleSerializerTest {
     }
 
     private DataFileMeta newFile() {
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 UUID.randomUUID().toString(),
                 0,
                 1,

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitGeneratorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitGeneratorTest.java
@@ -101,7 +101,7 @@ public class FileStoreSourceSplitGeneratorTest {
         List<DataFileMeta> metas = new ArrayList<>();
         for (String fileName : fileNames) {
             metas.add(
-                    new DataFileMeta(
+                    DataFileMeta.create(
                             fileName,
                             0, // not used
                             0, // not used

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitSerializerTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitSerializerTest.java
@@ -74,7 +74,7 @@ public class FileStoreSourceSplitSerializerTest {
     // ------------------------------------------------------------------------
 
     public static DataFileMeta newFile(int level) {
-        return new DataFileMeta(
+        return DataFileMeta.create(
                 "",
                 0,
                 1,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Afterwards, we can consider introducing row-based `ManifestEntry` to significantly reduce its serialization and deserialization overhead.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
