### PR TITLE
[python] Add totalRecordCount and deltaRecordCount in Snapshot

### DIFF
--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -67,7 +67,9 @@ class FileStoreCommit:
 
         if latest_snapshot:
             existing_manifest_files = self.manifest_list_manager.read_all_manifest_files(latest_snapshot)
-            total_record_count += latest_snapshot.total_record_count
+            previous_record_count = latest_snapshot.total_record_count
+            if previous_record_count:
+                total_record_count += previous_record_count
 
         new_manifest_files.extend(existing_manifest_files)
         manifest_list = self.manifest_list_manager.write(new_manifest_files)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

Fixes #6138

Fix: the total number of rows in the table and the number of rows added in python commit are empty.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
