### PR TITLE
[core] Support TopN pushdown to pick the DataSplits

### DIFF
--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/bitmap/RangeBitmapIndexPushDownBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/bitmap/RangeBitmapIndexPushDownBenchmark.java
@@ -32,7 +32,6 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
-import org.apache.paimon.predicate.SortValue;
 import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.Schema;
@@ -213,8 +212,7 @@ public class RangeBitmapIndexPushDownBenchmark {
                     () -> {
                         Table table = tables.get(name);
                         FieldRef ref = new FieldRef(0, "k", DataTypes.INT());
-                        SortValue sort = new SortValue(ref, DESCENDING, NULLS_LAST);
-                        TopN topN = new TopN(Collections.singletonList(sort), k);
+                        TopN topN = new TopN(ref, DESCENDING, NULLS_LAST, k);
                         List<Split> splits = table.newReadBuilder().newScan().plan().splits();
                         AtomicLong readCount = new AtomicLong(0);
                         try {

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/TopN.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/TopN.java
@@ -18,13 +18,18 @@
 
 package org.apache.paimon.predicate;
 
+import org.apache.paimon.predicate.SortValue.NullOrdering;
+import org.apache.paimon.predicate.SortValue.SortDirection;
 import org.apache.paimon.utils.Preconditions;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-/** Represents the TopN predicate. */
+/**
+ * Represents the TopN predicate.
+ */
 public class TopN implements Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -34,6 +39,12 @@ public class TopN implements Serializable {
 
     public TopN(List<SortValue> orders, int limit) {
         this.orders = Preconditions.checkNotNull(orders);
+        this.limit = limit;
+    }
+
+    public TopN(FieldRef ref, SortDirection direction, NullOrdering nullOrdering, int limit) {
+        SortValue order = new SortValue(ref, direction, nullOrdering);
+        this.orders = Collections.singletonList(order);
         this.limit = limit;
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/TopN.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/TopN.java
@@ -27,9 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-/**
- * Represents the TopN predicate.
- */
+/** Represents the TopN predicate. */
 public class TopN implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndexTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndexTest.java
@@ -25,7 +25,6 @@ import org.apache.paimon.fileindex.bitmap.BitmapIndexResult;
 import org.apache.paimon.fs.ByteArraySeekableStream;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.FieldRef;
-import org.apache.paimon.predicate.SortValue;
 import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.VarCharType;
@@ -36,7 +35,6 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -283,11 +281,7 @@ public class RangeBitmapFileIndexTest {
             RoaringBitmap32 expected = new RoaringBitmap32();
 
             // test NULL_LAST without found set
-            TopN topN =
-                    new TopN(
-                            Collections.singletonList(
-                                    new SortValue(fieldRef, ASCENDING, NULLS_LAST)),
-                            k);
+            TopN topN = new TopN(fieldRef, ASCENDING, NULLS_LAST, k);
             pairs.stream()
                     .sorted(nullLastCompactor)
                     .limit(k)
@@ -298,11 +292,7 @@ public class RangeBitmapFileIndexTest {
 
             // test NULL_LAST with found set
             expected.clear();
-            topN =
-                    new TopN(
-                            Collections.singletonList(
-                                    new SortValue(fieldRef, ASCENDING, NULLS_LAST)),
-                            k);
+            topN = new TopN(fieldRef, ASCENDING, NULLS_LAST, k);
             pairs.stream()
                     .filter(pair -> foundSet.contains(pair.getKey()))
                     .sorted(nullLastCompactor)
@@ -317,11 +307,7 @@ public class RangeBitmapFileIndexTest {
 
             // test NULL_FIRST without found set
             expected.clear();
-            topN =
-                    new TopN(
-                            Collections.singletonList(
-                                    new SortValue(fieldRef, ASCENDING, NULLS_FIRST)),
-                            k);
+            topN = new TopN(fieldRef, ASCENDING, NULLS_FIRST, k);
             pairs.stream()
                     .sorted(nullFirstCompactor)
                     .limit(k)
@@ -332,11 +318,7 @@ public class RangeBitmapFileIndexTest {
 
             // test NULL_FIRST with found set
             expected.clear();
-            topN =
-                    new TopN(
-                            Collections.singletonList(
-                                    new SortValue(fieldRef, ASCENDING, NULLS_FIRST)),
-                            k);
+            topN = new TopN(fieldRef, ASCENDING, NULLS_FIRST, k);
             pairs.stream()
                     .filter(pair -> foundSet.contains(pair.getKey()))
                     .sorted(nullFirstCompactor)
@@ -406,38 +388,26 @@ public class RangeBitmapFileIndexTest {
         // test bottomK
         BitmapIndexResult result =
                 new BitmapIndexResult(() -> RoaringBitmap32.bitmapOf(0, 3, 4, 5));
-        TopN bottomNullFirst =
-                new TopN(
-                        Collections.singletonList(new SortValue(fieldRef, ASCENDING, NULLS_FIRST)),
-                        3);
+        TopN bottomNullFirst = new TopN(fieldRef, ASCENDING, NULLS_FIRST, 3);
         assertThat(((BitmapIndexResult) reader.visitTopN(bottomNullFirst, null)).get())
                 .isEqualTo(RoaringBitmap32.bitmapOf(0, 5, 6));
         assertThat(((BitmapIndexResult) reader.visitTopN(bottomNullFirst, result)).get())
                 .isEqualTo(RoaringBitmap32.bitmapOf(0, 3, 5));
 
-        TopN bottomNullLast =
-                new TopN(
-                        Collections.singletonList(new SortValue(fieldRef, ASCENDING, NULLS_LAST)),
-                        3);
+        TopN bottomNullLast = new TopN(fieldRef, ASCENDING, NULLS_LAST, 3);
         assertThat(((BitmapIndexResult) reader.visitTopN(bottomNullLast, null)).get())
                 .isEqualTo(RoaringBitmap32.bitmapOf(0, 1, 2));
         assertThat(((BitmapIndexResult) reader.visitTopN(bottomNullLast, result)).get())
                 .isEqualTo(RoaringBitmap32.bitmapOf(0, 3, 4));
 
         // test topK
-        TopN topNullFirst =
-                new TopN(
-                        Collections.singletonList(new SortValue(fieldRef, DESCENDING, NULLS_FIRST)),
-                        3);
+        TopN topNullFirst = new TopN(fieldRef, DESCENDING, NULLS_FIRST, 3);
         assertThat(((BitmapIndexResult) reader.visitTopN(topNullFirst, null)).get())
                 .isEqualTo(RoaringBitmap32.bitmapOf(5, 6, 7));
         assertThat(((BitmapIndexResult) reader.visitTopN(topNullFirst, result)).get())
                 .isEqualTo(RoaringBitmap32.bitmapOf(3, 4, 5));
 
-        TopN topNullLast =
-                new TopN(
-                        Collections.singletonList(new SortValue(fieldRef, DESCENDING, NULLS_LAST)),
-                        3);
+        TopN topNullLast = new TopN(fieldRef, DESCENDING, NULLS_LAST, 3);
         assertThat(((BitmapIndexResult) reader.visitTopN(topNullLast, null)).get())
                 .isEqualTo(RoaringBitmap32.bitmapOf(3, 4, 7));
         assertThat(((BitmapIndexResult) reader.visitTopN(topNullLast, result)).get())

--- a/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
@@ -34,6 +34,7 @@ import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.source.DataFilePlan;
@@ -363,6 +364,13 @@ public class FallbackReadFileStoreTable extends DelegatedFileStoreTable {
         public FallbackReadScan withMetricRegistry(MetricRegistry metricRegistry) {
             mainScan.withMetricRegistry(metricRegistry);
             fallbackScan.withMetricRegistry(metricRegistry);
+            return this;
+        }
+
+        @Override
+        public InnerTableScan withTopN(TopN topN) {
+            mainScan.withTopN(topN);
+            fallbackScan.withTopN(topN);
             return this;
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
@@ -78,7 +78,7 @@ abstract class AbstractDataTableScan implements DataTableScan {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractDataTableScan.class);
 
-    private final TableSchema schema;
+    protected final TableSchema schema;
     private final CoreOptions options;
     protected final SnapshotReader snapshotReader;
     private final TableQueryAuth queryAuth;

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.source;
 
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFileMeta08Serializer;
@@ -34,6 +35,7 @@ import org.apache.paimon.predicate.CompareUtils;
 import org.apache.paimon.stats.SimpleStatsEvolution;
 import org.apache.paimon.stats.SimpleStatsEvolutions;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.utils.FunctionWithIOException;
 import org.apache.paimon.utils.InternalRowUtils;
 import org.apache.paimon.utils.SerializationUtils;
@@ -189,6 +191,22 @@ public class DataSplit implements Split {
             }
         }
         return maxValue;
+    }
+
+    public Long nullCount(int fieldIndex, SimpleStatsEvolutions evolutions) {
+        long sum = 0L;
+        for (DataFileMeta dataFile : dataFiles) {
+            SimpleStatsEvolution evolution = evolutions.getOrCreate(dataFile.schemaId());
+            InternalArray nullCounts =
+                    evolution.evolution(
+                            dataFile.valueStats().nullCounts(),
+                            dataFile.rowCount(),
+                            dataFile.valueStatsCols());
+            Long nullCount =
+                    (Long) InternalRowUtils.get(nullCounts, fieldIndex, DataTypes.BIGINT());
+            sum += nullCount == null ? 0 : nullCount;
+        }
+        return sum;
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableScan.java
@@ -22,6 +22,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
 
@@ -74,6 +75,10 @@ public interface InnerTableScan extends TableScan {
     @Override
     default InnerTableScan withMetricRegistry(MetricRegistry metricRegistry) {
         // do nothing, should implement this if need
+        return this;
+    }
+
+    default InnerTableScan withTopN(TopN topN) {
         return this;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -167,6 +167,9 @@ public class ReadBuilderImpl implements ReadBuilder {
         if (limit != null) {
             tableScan.withLimit(limit);
         }
+        if (topN != null) {
+            tableScan.withTopN(topN);
+        }
         return tableScan;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/TopNDataSplitEvaluator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/TopNDataSplitEvaluator.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source;
+
+import org.apache.paimon.predicate.CompareUtils;
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.SortValue;
+import org.apache.paimon.predicate.TopN;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.stats.SimpleStatsEvolutions;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.utils.Pair;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.predicate.SortValue.NullOrdering.NULLS_FIRST;
+import static org.apache.paimon.predicate.SortValue.NullOrdering.NULLS_LAST;
+import static org.apache.paimon.predicate.SortValue.SortDirection.ASCENDING;
+import static org.apache.paimon.predicate.SortValue.SortDirection.DESCENDING;
+
+/** Evaluate DataSplit TopN result. */
+public class TopNDataSplitEvaluator {
+
+    private final TableSchema schema;
+
+    public TopNDataSplitEvaluator(TableSchema schema) {
+        this.schema = schema;
+    }
+
+    public List<DataSplit> evaluate(TopN topN, List<DataSplit> splits) {
+        // todo: we can support all the sort columns.
+        List<SortValue> orders = topN.orders();
+        if (orders.size() != 1) {
+            return splits;
+        }
+
+        int limit = topN.limit();
+        if (limit >= splits.size()) {
+            return splits;
+        }
+
+        SortValue order = orders.get(0);
+        return getTopNSplits(order, limit, splits);
+    }
+
+    private List<DataSplit> getTopNSplits(SortValue order, int limit, List<DataSplit> splits) {
+        FieldRef ref = order.field();
+        SortValue.SortDirection direction = order.direction();
+        SortValue.NullOrdering nullOrdering = order.nullOrdering();
+
+        int index = ref.index();
+        DataField field = schema.fields().get(index);
+        SimpleStatsEvolutions evolutions =
+                new SimpleStatsEvolutions((id) -> schema.fields(), schema.id());
+
+        // extract the stats
+        List<DataSplit> results = new ArrayList<>();
+        List<Pair<Stats, DataSplit>> pairs = new ArrayList<>();
+        for (DataSplit split : splits) {
+            if (!split.rawConvertible()) {
+                return splits;
+            }
+
+            Object min = split.minValue(index, field, evolutions);
+            Object max = split.maxValue(index, field, evolutions);
+            Long nullCount = split.nullCount(index, evolutions);
+            Stats stats = new Stats(min, max, nullCount);
+
+            if (stats.isEmpty()) {
+                results.add(split);
+            } else {
+                pairs.add(Pair.of(stats, split));
+            }
+        }
+
+        // pick the TopN splits
+        if (NULLS_FIRST.equals(nullOrdering)) {
+            results.addAll(pickNullFirstSplits(pairs, ref, direction, limit));
+        } else if (NULLS_LAST.equals(nullOrdering)) {
+            results.addAll(pickNullLastSplits(pairs, ref, direction, limit));
+        } else {
+            return splits;
+        }
+
+        return results;
+    }
+
+    private List<DataSplit> pickNullFirstSplits(
+            List<Pair<Stats, DataSplit>> pairs,
+            FieldRef field,
+            SortValue.SortDirection direction,
+            int limit) {
+        Comparator<Pair<Stats, DataSplit>> comparator;
+        if (ASCENDING.equals(direction)) {
+            comparator =
+                    (x, y) -> {
+                        Stats left = x.getKey();
+                        Stats right = y.getKey();
+                        int result = -Long.compare(left.nullCount, right.nullCount);
+                        if (result == 0) {
+                            result = CompareUtils.compareLiteral(field.type(), left.min, right.min);
+                        }
+                        return result;
+                    };
+        } else if (DESCENDING.equals(direction)) {
+            comparator =
+                    (x, y) -> {
+                        Stats left = x.getKey();
+                        Stats right = y.getKey();
+                        int result = -Long.compare(left.nullCount, right.nullCount);
+                        if (result == 0) {
+                            result =
+                                    -CompareUtils.compareLiteral(field.type(), left.max, right.max);
+                        }
+                        return result;
+                    };
+        } else {
+            return pairs.stream().map(Pair::getValue).collect(Collectors.toList());
+        }
+        pairs.sort(comparator);
+
+        long scanned = 0;
+        List<DataSplit> splits = new ArrayList<>();
+        for (Pair<Stats, DataSplit> pair : pairs) {
+            Stats stats = pair.getKey();
+            DataSplit split = pair.getValue();
+            splits.add(split);
+            scanned += Math.max(stats.nullCount, 1);
+            if (scanned >= limit) {
+                break;
+            }
+        }
+        return splits;
+    }
+
+    private List<DataSplit> pickNullLastSplits(
+            List<Pair<Stats, DataSplit>> pairs,
+            FieldRef field,
+            SortValue.SortDirection direction,
+            int limit) {
+        Comparator<Pair<Stats, DataSplit>> comparator;
+        if (ASCENDING.equals(direction)) {
+            comparator =
+                    (x, y) -> {
+                        Stats left = x.getKey();
+                        Stats right = y.getKey();
+                        int result = CompareUtils.compareLiteral(field.type(), left.min, right.min);
+                        if (result == 0) {
+                            result = -Long.compare(left.nullCount, right.nullCount);
+                        }
+                        return result;
+                    };
+        } else if (DESCENDING.equals(direction)) {
+            comparator =
+                    (x, y) -> {
+                        Stats left = x.getKey();
+                        Stats right = y.getKey();
+                        int result =
+                                -CompareUtils.compareLiteral(field.type(), left.max, right.max);
+                        if (result == 0) {
+                            result = -Long.compare(left.nullCount, right.nullCount);
+                        }
+                        return result;
+                    };
+        } else {
+            return pairs.stream().map(Pair::getValue).collect(Collectors.toList());
+        }
+
+        return pairs.stream()
+                .sorted(comparator)
+                .map(Pair::getValue)
+                .limit(limit)
+                .collect(Collectors.toList());
+    }
+
+    /** The DataSplit's stats. */
+    private static class Stats {
+        Object min;
+        Object max;
+        Long nullCount;
+
+        public Stats(Object min, Object max, Long nullCount) {
+            this.min = min;
+            this.max = max;
+            this.nullCount = nullCount;
+        }
+
+        public boolean isEmpty() {
+            return min == null || max == null || nullCount == null;
+        }
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeySimpleTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeySimpleTableTest.java
@@ -44,7 +44,6 @@ import org.apache.paimon.postpone.PostponeBucketWriter;
 import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
-import org.apache.paimon.predicate.SortValue;
 import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.Schema;
@@ -142,6 +141,8 @@ import static org.apache.paimon.Snapshot.CommitKind.COMPACT;
 import static org.apache.paimon.data.DataFormatTestUtil.internalRowToString;
 import static org.apache.paimon.io.DataFileTestUtils.row;
 import static org.apache.paimon.predicate.PredicateBuilder.and;
+import static org.apache.paimon.predicate.SortValue.NullOrdering.NULLS_LAST;
+import static org.apache.paimon.predicate.SortValue.SortDirection.ASCENDING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -1256,12 +1257,8 @@ public class PrimaryKeySimpleTableTest extends SimpleTableTestBase {
             int k = new Random().nextInt(100);
             RoaringBitmap32 bitmap = RoaringBitmap32.bitmapOfRange(min, min + k);
             DataField field = table.schema().nameToFieldMap().get(indexColumnName);
-            SortValue sort =
-                    new SortValue(
-                            new FieldRef(field.id(), field.name(), field.type()),
-                            SortValue.SortDirection.ASCENDING,
-                            SortValue.NullOrdering.NULLS_LAST);
-            TopN topN = new TopN(Collections.singletonList(sort), k);
+            FieldRef ref = new FieldRef(field.id(), field.name(), field.type());
+            TopN topN = new TopN(ref, ASCENDING, NULLS_LAST, k);
             TableScan.Plan plan = table.newScan().plan();
             RecordReader<InternalRow> reader =
                     table.newRead().withTopN(topN).createReader(plan.splits());
@@ -1282,12 +1279,8 @@ public class PrimaryKeySimpleTableTest extends SimpleTableTestBase {
             int k = new Random().nextInt(100);
             RoaringBitmap32 bitmap = RoaringBitmap32.bitmapOfRange(max - k, max);
             DataField field = table.schema().nameToFieldMap().get(indexColumnName);
-            SortValue sort =
-                    new SortValue(
-                            new FieldRef(field.id(), field.name(), field.type()),
-                            SortValue.SortDirection.DESCENDING,
-                            SortValue.NullOrdering.NULLS_LAST);
-            TopN topN = new TopN(Collections.singletonList(sort), k);
+            FieldRef ref = new FieldRef(field.id(), field.name(), field.type());
+            TopN topN = new TopN(ref, ASCENDING, NULLS_LAST, k);
             TableScan.Plan plan = table.newScan().plan();
             RecordReader<InternalRow> reader =
                     table.newRead().withTopN(topN).createReader(plan.splits());

--- a/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeySimpleTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/PrimaryKeySimpleTableTest.java
@@ -143,6 +143,7 @@ import static org.apache.paimon.io.DataFileTestUtils.row;
 import static org.apache.paimon.predicate.PredicateBuilder.and;
 import static org.apache.paimon.predicate.SortValue.NullOrdering.NULLS_LAST;
 import static org.apache.paimon.predicate.SortValue.SortDirection.ASCENDING;
+import static org.apache.paimon.predicate.SortValue.SortDirection.DESCENDING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -1280,7 +1281,7 @@ public class PrimaryKeySimpleTableTest extends SimpleTableTestBase {
             RoaringBitmap32 bitmap = RoaringBitmap32.bitmapOfRange(max - k, max);
             DataField field = table.schema().nameToFieldMap().get(indexColumnName);
             FieldRef ref = new FieldRef(field.id(), field.name(), field.type());
-            TopN topN = new TopN(ref, ASCENDING, NULLS_LAST, k);
+            TopN topN = new TopN(ref, DESCENDING, NULLS_LAST, k);
             TableScan.Plan plan = table.newScan().plan();
             RecordReader<InternalRow> reader =
                     table.newRead().withTopN(topN).createReader(plan.splits());

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/TableScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/TableScanTest.java
@@ -18,16 +18,27 @@
 
 package org.apache.paimon.table.source;
 
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.TopN;
+import org.apache.paimon.stats.SimpleStatsEvolutions;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
 import org.apache.paimon.table.source.snapshot.ScannerTestBase;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.utils.SnapshotManager;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
+import static org.apache.paimon.predicate.SortValue.NullOrdering.NULLS_FIRST;
+import static org.apache.paimon.predicate.SortValue.NullOrdering.NULLS_LAST;
+import static org.apache.paimon.predicate.SortValue.SortDirection.ASCENDING;
+import static org.apache.paimon.predicate.SortValue.SortDirection.DESCENDING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -94,6 +105,181 @@ public class TableScanTest extends ScannerTestBase {
         // with limit4
         TableScan.Plan plan3 = table.newScan().withLimit(4).plan();
         assertThat(plan3.splits().size()).isEqualTo(4);
+
+        write.close();
+        commit.close();
+    }
+
+    @Test
+    public void testPushDownTopN() throws Exception {
+        createAppendOnlyTable();
+
+        StreamTableWrite write = table.newWrite(commitUser);
+        StreamTableCommit commit = table.newCommit(commitUser);
+
+        write.write(rowData(1, 10, 100L));
+        write.write(rowData(2, 20, 200L));
+        write.write(rowData(3, 30, 300L));
+        commit.commit(0, write.prepareCommit(true, 0));
+
+        write.write(rowData(4, 40, 400L));
+        write.write(rowData(5, 50, 500L));
+        commit.commit(1, write.prepareCommit(true, 1));
+
+        write.write(rowData(6, null, 600L));
+        write.write(rowData(6, null, 600L));
+        write.write(rowData(6, 60, 600L));
+        write.write(rowData(7, null, 700L));
+        write.write(rowData(7, null, 700L));
+        write.write(rowData(7, 70, 700L));
+        commit.commit(2, write.prepareCommit(true, 2));
+        write.close();
+        commit.close();
+
+        // disable stats
+        FileStoreTable disableStatsTable =
+                table.copy(Collections.singletonMap("metadata.stats-mode", "none"));
+        write = disableStatsTable.newWrite(commitUser);
+        commit = disableStatsTable.newCommit(commitUser);
+
+        write.write(rowData(8, 80, 800L));
+        write.write(rowData(9, 90, 900L));
+        commit.commit(3, write.prepareCommit(true, 3));
+
+        // no TopN pushed down
+        TableScan.Plan plan1 = table.newScan().plan();
+        assertThat(plan1.splits().size()).isEqualTo(9);
+
+        DataField field = table.schema().fields().get(1);
+        FieldRef ref = new FieldRef(field.id(), field.name(), field.type());
+        SimpleStatsEvolutions evolutions =
+                new SimpleStatsEvolutions((id) -> table.schema().fields(), table.schema().id());
+
+        // with bottom1 null first
+        TableScan.Plan plan2 =
+                table.newScan().withTopN(new TopN(ref, ASCENDING, NULLS_FIRST, 1)).plan();
+        List<Split> splits2 = plan2.splits();
+        assertThat(splits2.size()).isEqualTo(3);
+        assertThat(((DataSplit) splits2.get(0)).minValue(field.id(), field, evolutions))
+                .isEqualTo(null);
+        assertThat(((DataSplit) splits2.get(1)).minValue(field.id(), field, evolutions))
+                .isEqualTo(null);
+        assertThat(((DataSplit) splits2.get(2)).minValue(field.id(), field, evolutions))
+                .isEqualTo(60);
+        assertThat(((DataSplit) splits2.get(2)).nullCount(field.id(), evolutions)).isEqualTo(2);
+
+        // with bottom1 null last
+        TableScan.Plan plan3 =
+                table.newScan().withTopN(new TopN(ref, ASCENDING, NULLS_LAST, 1)).plan();
+        List<Split> splits3 = plan3.splits();
+        assertThat(splits3.size()).isEqualTo(3);
+        assertThat(((DataSplit) splits3.get(0)).minValue(field.id(), field, evolutions))
+                .isEqualTo(null);
+        assertThat(((DataSplit) splits3.get(1)).minValue(field.id(), field, evolutions))
+                .isEqualTo(null);
+        assertThat(((DataSplit) splits3.get(2)).minValue(field.id(), field, evolutions))
+                .isEqualTo(10);
+
+        // with bottom5 null first
+        TableScan.Plan plan4 =
+                table.newScan().withTopN(new TopN(ref, ASCENDING, NULLS_FIRST, 5)).plan();
+        List<Split> splits4 = plan4.splits();
+        assertThat(splits4.size()).isEqualTo(5);
+        assertThat(((DataSplit) splits4.get(0)).minValue(field.id(), field, evolutions))
+                .isEqualTo(null);
+        assertThat(((DataSplit) splits4.get(1)).minValue(field.id(), field, evolutions))
+                .isEqualTo(null);
+        assertThat(((DataSplit) splits4.get(2)).minValue(field.id(), field, evolutions))
+                .isEqualTo(60);
+        assertThat(((DataSplit) splits4.get(2)).nullCount(field.id(), evolutions)).isEqualTo(2);
+        assertThat(((DataSplit) splits4.get(3)).minValue(field.id(), field, evolutions))
+                .isEqualTo(70);
+        assertThat(((DataSplit) splits4.get(3)).nullCount(field.id(), evolutions)).isEqualTo(2);
+        assertThat(((DataSplit) splits4.get(4)).minValue(field.id(), field, evolutions))
+                .isEqualTo(10);
+
+        // with bottom5 null last
+        TableScan.Plan plan5 =
+                table.newScan().withTopN(new TopN(ref, ASCENDING, NULLS_LAST, 5)).plan();
+        List<Split> splits5 = plan5.splits();
+        assertThat(splits5.size()).isEqualTo(7);
+        assertThat(((DataSplit) splits5.get(0)).minValue(field.id(), field, evolutions))
+                .isEqualTo(null);
+        assertThat(((DataSplit) splits5.get(1)).minValue(field.id(), field, evolutions))
+                .isEqualTo(null);
+        assertThat(((DataSplit) splits5.get(2)).minValue(field.id(), field, evolutions))
+                .isEqualTo(10);
+        assertThat(((DataSplit) splits5.get(3)).minValue(field.id(), field, evolutions))
+                .isEqualTo(20);
+        assertThat(((DataSplit) splits5.get(4)).minValue(field.id(), field, evolutions))
+                .isEqualTo(30);
+        assertThat(((DataSplit) splits5.get(5)).minValue(field.id(), field, evolutions))
+                .isEqualTo(40);
+        assertThat(((DataSplit) splits5.get(6)).minValue(field.id(), field, evolutions))
+                .isEqualTo(50);
+
+        // with top1 null first
+        TableScan.Plan plan6 =
+                table.newScan().withTopN(new TopN(ref, DESCENDING, NULLS_FIRST, 1)).plan();
+        List<Split> splits6 = plan6.splits();
+        assertThat(splits6.size()).isEqualTo(3);
+        assertThat(((DataSplit) splits6.get(0)).maxValue(field.id(), field, evolutions))
+                .isEqualTo(null);
+        assertThat(((DataSplit) splits6.get(1)).maxValue(field.id(), field, evolutions))
+                .isEqualTo(null);
+        assertThat(((DataSplit) splits6.get(2)).maxValue(field.id(), field, evolutions))
+                .isEqualTo(70);
+        assertThat(((DataSplit) splits6.get(2)).nullCount(field.id(), evolutions)).isEqualTo(2);
+
+        // with top1 null last
+        TableScan.Plan plan7 =
+                table.newScan().withTopN(new TopN(ref, DESCENDING, NULLS_LAST, 1)).plan();
+        List<Split> splits7 = plan7.splits();
+        assertThat(splits7.size()).isEqualTo(3);
+        assertThat(((DataSplit) splits7.get(0)).maxValue(field.id(), field, evolutions))
+                .isEqualTo(null);
+        assertThat(((DataSplit) splits7.get(1)).maxValue(field.id(), field, evolutions))
+                .isEqualTo(null);
+        assertThat(((DataSplit) splits7.get(2)).maxValue(field.id(), field, evolutions))
+                .isEqualTo(70);
+
+        // with top5 null first
+        TableScan.Plan plan8 =
+                table.newScan().withTopN(new TopN(ref, DESCENDING, NULLS_FIRST, 5)).plan();
+        List<Split> splits8 = plan8.splits();
+        assertThat(splits8.size()).isEqualTo(5);
+        assertThat(((DataSplit) splits8.get(0)).maxValue(field.id(), field, evolutions))
+                .isEqualTo(null);
+        assertThat(((DataSplit) splits8.get(1)).maxValue(field.id(), field, evolutions))
+                .isEqualTo(null);
+        assertThat(((DataSplit) splits8.get(2)).maxValue(field.id(), field, evolutions))
+                .isEqualTo(70);
+        assertThat(((DataSplit) splits8.get(2)).nullCount(field.id(), evolutions)).isEqualTo(2);
+        assertThat(((DataSplit) splits8.get(3)).maxValue(field.id(), field, evolutions))
+                .isEqualTo(60);
+        assertThat(((DataSplit) splits8.get(3)).nullCount(field.id(), evolutions)).isEqualTo(2);
+        assertThat(((DataSplit) splits8.get(4)).maxValue(field.id(), field, evolutions))
+                .isEqualTo(50);
+
+        // with top5 null last
+        TableScan.Plan plan9 =
+                table.newScan().withTopN(new TopN(ref, DESCENDING, NULLS_LAST, 5)).plan();
+        List<Split> splits9 = plan9.splits();
+        assertThat(splits9.size()).isEqualTo(7);
+        assertThat(((DataSplit) splits9.get(0)).maxValue(field.id(), field, evolutions))
+                .isEqualTo(null);
+        assertThat(((DataSplit) splits9.get(1)).maxValue(field.id(), field, evolutions))
+                .isEqualTo(null);
+        assertThat(((DataSplit) splits9.get(2)).maxValue(field.id(), field, evolutions))
+                .isEqualTo(70);
+        assertThat(((DataSplit) splits9.get(3)).maxValue(field.id(), field, evolutions))
+                .isEqualTo(60);
+        assertThat(((DataSplit) splits9.get(4)).maxValue(field.id(), field, evolutions))
+                .isEqualTo(50);
+        assertThat(((DataSplit) splits9.get(5)).maxValue(field.id(), field, evolutions))
+                .isEqualTo(40);
+        assertThat(((DataSplit) splits9.get(6)).maxValue(field.id(), field, evolutions))
+                .isEqualTo(30);
 
         write.close();
         commit.close();

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/ColumnPruningAndPushDown.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/ColumnPruningAndPushDown.scala
@@ -73,7 +73,13 @@ trait ColumnPruningAndPushDown extends Scan with Logging {
     }
     pushDownLimit.foreach(_readBuilder.withLimit)
     pushDownTopN.foreach(_readBuilder.withTopN)
-    _readBuilder.dropStats()
+
+    // when TopN is not empty, we need the stats to pick the TopN DataSplits
+    if (pushDownTopN.nonEmpty) {
+      _readBuilder
+    } else {
+      _readBuilder.dropStats()
+    }
   }
 
   final def metadataColumns: Seq[PaimonMetadataColumn] = {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

TopN can be applied in the scan phase to pick the DataSplits.
1. the N can >= 1.
2. for now, only support single sort column.
3. only support for append-only table, and can not in deletion-vector mode.
4. please pay attention that `dropStats` will not execute when TopN is not empty.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
