### PR TITLE
[spark] Support partial insert for data evolution merge into

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonMergeIntoBase.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonMergeIntoBase.scala
@@ -110,9 +110,9 @@ trait PaimonMergeIntoBase
         u.copy(assignments = alignAssignments(targetOutput, assignments))
 
       case i @ InsertAction(_, assignments) =>
-        if (assignments.length != targetOutput.length && dataEvolutionEnabled) {
-          throw new RuntimeException("Can't align the table's columns in insert clause.")
-        }
+//        if (assignments.length != targetOutput.length && dataEvolutionEnabled) {
+//          throw new RuntimeException("Can't align the table's columns in insert clause.")
+//        }
         i.copy(assignments = alignAssignments(targetOutput, assignments))
 
       case _: UpdateStarAction =>

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -31,7 +31,7 @@ import org.apache.paimon.table.source.DataSplit
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils._
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer.resolver
-import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, Literal}
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftOuter}
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -258,7 +258,13 @@ case class MergeIntoPaimonDataEvolutionTable(
         case insertAction: InsertAction =>
           Keep(
             insertAction.condition.getOrElse(TrueLiteral),
-            insertAction.assignments.map(a => a.value))
+            insertAction.assignments.map(
+              a =>
+                if (!a.value.isInstanceOf[AttributeReference]) a.value
+                else if (joinPlan.output.exists(attr => attr.toString().equals(a.value.toString())))
+                  a.value
+                else Literal(null))
+          )
       }.toSeq,
       notMatchedBySourceInstructions = Nil,
       checkCardinality = false,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Support data evolution mode merge into partial columns exist.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
