### PR TITLE
[core] fix NPE and ArrayIndexOutOfBoundsException caused by PartitionExpire

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
@@ -185,7 +185,8 @@ public class PartitionExpire {
         return expiredPartValues.stream()
                 .map(values -> String.join(DELIMITER, values))
                 .sorted()
-                .map(s -> s.split(DELIMITER))
+                // Use split(DELIMITER, -1) to preserve trailing empty strings
+                .map(s -> s.split(DELIMITER, -1))
                 .map(strategy::toPartitionString)
                 .limit(Math.min(expiredPartValues.size(), maxExpireNum))
                 .collect(Collectors.toList());

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionExpireStrategyFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionExpireStrategyFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.partition;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.factories.FactoryUtil;
@@ -30,7 +31,10 @@ import org.apache.paimon.shade.guava30.com.google.common.base.Suppliers;
 public interface PartitionExpireStrategyFactory {
 
     PartitionExpireStrategy create(
-            CatalogLoader catalogLoader, Identifier identifier, RowType partitionType);
+            CatalogLoader catalogLoader,
+            Identifier identifier,
+            CoreOptions options,
+            RowType partitionType);
 
     Supplier<PartitionExpireStrategyFactory> INSTANCE =
             Suppliers.memoize(

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionUpdateTimeExpireStrategy.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionUpdateTimeExpireStrategy.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.partition;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.types.RowType;
@@ -33,8 +34,8 @@ import java.util.stream.Collectors;
  */
 public class PartitionUpdateTimeExpireStrategy extends PartitionExpireStrategy {
 
-    public PartitionUpdateTimeExpireStrategy(RowType partitionType) {
-        super(partitionType);
+    public PartitionUpdateTimeExpireStrategy(CoreOptions options, RowType partitionType) {
+        super(partitionType, options.partitionDefaultName());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/partition/PartitionValuesTimeExpireStrategy.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/PartitionValuesTimeExpireStrategy.java
@@ -48,7 +48,7 @@ public class PartitionValuesTimeExpireStrategy extends PartitionExpireStrategy {
     private final PartitionTimeExtractor timeExtractor;
 
     public PartitionValuesTimeExpireStrategy(CoreOptions options, RowType partitionType) {
-        super(partitionType);
+        super(partitionType, options.partitionDefaultName());
         String timePattern = options.partitionTimestampPattern();
         String timeFormatter = options.partitionTimestampFormatter();
         this.timeExtractor = new PartitionTimeExtractor(timePattern, timeFormatter);

--- a/paimon-core/src/test/java/org/apache/paimon/partition/CustomPartitionExpirationFactory.java
+++ b/paimon-core/src/test/java/org/apache/paimon/partition/CustomPartitionExpirationFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.partition;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.Identifier;
@@ -38,8 +39,11 @@ public class CustomPartitionExpirationFactory implements PartitionExpireStrategy
 
     @Override
     public PartitionExpireStrategy create(
-            CatalogLoader catalogLoader, Identifier identifier, RowType partitionType) {
-        return new PartitionExpireStrategy(partitionType) {
+            CatalogLoader catalogLoader,
+            Identifier identifier,
+            CoreOptions options,
+            RowType partitionType) {
+        return new PartitionExpireStrategy(partitionType, options.partitionDefaultName()) {
             @Override
             public List<PartitionEntry> selectExpiredPartitions(
                     FileStoreScan scan, LocalDateTime expirationTime) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
When executing `PartitionExpire` with partition field `ds` and sub-partition field `hh`, take `$ds` as `partition.timestamp-pattern`, two issues may occur:

1. NullPointerException: When hh=null, a NPE is thrown during partition expiration processing
2. ArrayIndexOutOfBoundsException: When hh="" (empty string), an ArrayIndexOutOfBoundsException occurs due to String.split() discarding trailing empty strings

### Tests

<!-- List UT and IT cases to verify this change -->
PartitionExpireTest#testExpireWithNullOrEmptyPartition

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
