### PR TITLE
[flink] Local TZ convert parity for Paimon / Hive

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
@@ -98,6 +98,12 @@ public class ParquetFileFormat extends FileFormat {
                     ParquetOutputFormat.BLOCK_SIZE, String.valueOf(blockSize.getBytes()));
         }
 
+        if (context.options().containsKey(ParquetOptions.TIMESTAMP_INT96_ADJUST_ZONE)) {
+            parquetOptions.set(
+                    ParquetOptions.TIMESTAMP_INT96_ADJUST_ZONE,
+                    context.options().get(ParquetOptions.TIMESTAMP_INT96_ADJUST_ZONE));
+        }
+
         return parquetOptions;
     }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetOptions.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetOptions.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.format.parquet;
 
 import org.apache.paimon.options.ConfigOption;
+import org.apache.paimon.options.Options;
 
 import static org.apache.paimon.options.ConfigOptions.key;
 
@@ -31,4 +32,16 @@ public class ParquetOptions {
                     .noDefaultValue()
                     .withDescription(
                             "Specify the variant shredding schema for writing parquet files.");
+
+    public static final String TIMESTAMP_INT96_ADJUST_ZONE = "parquet.timestamp-int96-adjust-zone";
+
+    private final Options options;
+
+    public ParquetOptions(Options options) {
+        this.options = options;
+    }
+
+    public boolean timestampInt96AdjustZone() {
+        return options.getBoolean(TIMESTAMP_INT96_ADJUST_ZONE, false);
+    }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
@@ -96,6 +96,7 @@ public class ParquetReaderFactory implements FormatReaderFactory {
                                 context.fileIO(), context.filePath(), context.fileSize()),
                         builder.build(),
                         context.selection());
+
         MessageType fileSchema = reader.getFileMetaData().getSchema();
         MessageType requestedSchema = clipParquetSchema(fileSchema);
 
@@ -115,8 +116,17 @@ public class ParquetReaderFactory implements FormatReaderFactory {
         MessageColumnIO columnIO = new ColumnIOFactory().getColumnIO(requestedSchema);
         List<ParquetField> fields = buildFieldsList(readFields, columnIO, shreddingSchemas);
 
+        ParquetOptions po = new ParquetOptions(conf);
+        boolean adjustInt96Timestamp = po.timestampInt96AdjustZone();
+
         return new VectorizedParquetRecordReader(
-                context.filePath(), reader, fileSchema, fields, writableVectors, batchSize);
+                context.filePath(),
+                reader,
+                fileSchema,
+                fields,
+                writableVectors,
+                batchSize,
+                adjustInt96Timestamp);
     }
 
     private void setReadOptions(ParquetReadOptions.Builder builder) {

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedParquetRecordReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedParquetRecordReader.java
@@ -129,7 +129,6 @@ public class VectorizedParquetRecordReader implements FileRecordReader<InternalR
         this.batchSize = batchSize;
         this.rowIndexGenerator = new RowIndexGenerator();
 
-        // Initialize INT96 timestamp adjustment parameter
         this.adjustInt96Timestamp = adjustInt96Timestamp;
 
         // fetch writer version from file metadata
@@ -177,6 +176,7 @@ public class VectorizedParquetRecordReader implements FileRecordReader<InternalR
                     break;
                 case TIMESTAMP_WITHOUT_TIME_ZONE:
                     if (adjustInt96Timestamp && isInt96Timestamp(fields.get(i))) {
+                        // Request tz conversion
                         vectors[i] = new ParquetTimestampVector(writableVectors[i], true);
                     } else {
                         vectors[i] = new ParquetTimestampVector(writableVectors[i], false);

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedParquetRecordReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedParquetRecordReader.java
@@ -46,6 +46,8 @@ import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/clone/HiveCloneUtils.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/clone/HiveCloneUtils.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.hive.clone;
 
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.format.parquet.ParquetOptions;
 import org.apache.paimon.fs.FileStatus;
 import org.apache.paimon.hive.HiveCatalog;
 import org.apache.paimon.partition.PartitionPredicate;
@@ -128,10 +129,17 @@ public class HiveCloneUtils {
 
     public static Schema hiveTableToPaimonSchema(HiveCatalog hiveCatalog, Identifier identifier)
             throws Exception {
+        return hiveTableToPaimonSchema(hiveCatalog, identifier, true);
+    }
+
+    public static Schema hiveTableToPaimonSchema(
+            HiveCatalog hiveCatalog, Identifier identifier, boolean enableTimezoneConversion)
+            throws Exception {
         String database = identifier.getDatabaseName();
         String table = identifier.getObjectName();
 
         IMetaStoreClient client = hiveCatalog.getHmsClient();
+
         // check primary key
         PrimaryKeysRequest primaryKeysRequest = new PrimaryKeysRequest(database, table);
         try {
@@ -148,6 +156,19 @@ public class HiveCloneUtils {
         List<FieldSchema> fields = extractor.extractSchema(client, hiveTable, database, table);
         List<String> partitionKeys = extractor.extractPartitionKeys(hiveTable);
         Map<String, String> options = extractor.extractOptions(hiveTable);
+
+        if (enableTimezoneConversion
+                && hasTimestampColumns(hiveTable)
+                && "parquet".equals(parseFormat(hiveTable))
+                && !options.containsKey(ParquetOptions.TIMESTAMP_INT96_ADJUST_ZONE)) {
+            options.put(ParquetOptions.TIMESTAMP_INT96_ADJUST_ZONE, "true");
+            LOG.debug(
+                    "Enabled {} for {}.{} (Parquet).",
+                    ParquetOptions.TIMESTAMP_INT96_ADJUST_ZONE,
+                    database,
+                    table);
+        }
+
         Schema.Builder schemaBuilder =
                 Schema.newBuilder()
                         .comment(options.get("comment"))
@@ -212,5 +233,14 @@ public class HiveCloneUtils {
             throw new UnsupportedOperationException("Unknown partition format: " + partition);
         }
         return format;
+    }
+
+    /** Check if the table has timestamp columns that need timezone conversion. */
+    public static boolean hasTimestampColumns(Table hiveTable) {
+        List<FieldSchema> allCols = new ArrayList<>(hiveTable.getSd().getCols());
+        allCols.addAll(hiveTable.getPartitionKeys());
+
+        return allCols.stream()
+                .anyMatch(field -> field.getType().toLowerCase().contains("timestamp"));
     }
 }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/clone/HiveCloneUtils.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/clone/HiveCloneUtils.java
@@ -235,7 +235,6 @@ public class HiveCloneUtils {
         return format;
     }
 
-    /** Check if the table has timestamp columns that need timezone conversion. */
     public static boolean hasTimestampColumns(Table hiveTable) {
         List<FieldSchema> allCols = new ArrayList<>(hiveTable.getSd().getCols());
         allCols.addAll(hiveTable.getPartitionKeys());

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/HiveTimestampTimezoneIssueITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/HiveTimestampTimezoneIssueITCase.java
@@ -43,7 +43,7 @@ import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** IT to reproduce timestamp skew after Hive -> Paimon clone (parquet). */
+/** Tests the local timezone conversion for Parquet files */
 public class HiveTimestampTimezoneIssueITCase extends ActionITCaseBase {
 
     private static final TestHiveMetastore HMS = new TestHiveMetastore();
@@ -93,7 +93,6 @@ public class HiveTimestampTimezoneIssueITCase extends ActionITCaseBase {
         return LocalDateTime.parse(iso);
     }
 
-    // Holds random db/table identifiers for each test run
     private static class TableIds {
         final String db = "hivedb" + StringUtils.randomNumericString(10);
         final String tbl = "hivetable" + StringUtils.randomNumericString(10);

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/HiveTimestampTimezoneIssueITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/HiveTimestampTimezoneIssueITCase.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.hive.procedure;
+
+import org.apache.paimon.flink.action.ActionITCaseBase;
+import org.apache.paimon.flink.action.CloneAction;
+import org.apache.paimon.hive.TestHiveMetastore;
+import org.apache.paimon.utils.StringUtils;
+
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
+
+import org.apache.flink.table.api.SqlDialect;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.ServerSocket;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** IT to reproduce timestamp skew after Hive -> Paimon clone (parquet). */
+public class HiveTimestampTimezoneIssueITCase extends ActionITCaseBase {
+
+    private static final TestHiveMetastore HMS = new TestHiveMetastore();
+    private static final int PORT = findFreePort();
+
+    private static int findFreePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        } catch (Exception e) {
+            throw new RuntimeException("Could not find a free port", e);
+        }
+    }
+
+    private static final TimeZone ORIGINAL_TZ = TimeZone.getDefault();
+    private static final ZoneId TEST_ZONE = ZoneId.of("Asia/Shanghai");
+
+    @TempDir Path warehouse;
+
+    @BeforeAll
+    public static void beforeAll() {
+        HMS.start(PORT);
+        TimeZone.setDefault(TimeZone.getTimeZone(TEST_ZONE));
+        // set JVM timezone to Asia/Shanghai for this test run
+    }
+
+    @AfterAll
+    public static void afterAll() throws Exception {
+        HMS.stop();
+        TimeZone.setDefault(ORIGINAL_TZ);
+    }
+
+    private static List<Row> sql(TableEnvironment env, String q, Object... args) {
+        try (CloseableIterator<Row> it = env.executeSql(String.format(q, args)).collect()) {
+            return ImmutableList.copyOf(it);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static LocalDateTime parseTs(String s) {
+        String iso = s.replace(' ', 'T');
+        int p = Math.max(iso.indexOf('+'), Math.max(iso.indexOf('-', 19), iso.indexOf('Z')));
+        if (p > 19) {
+            iso = iso.substring(0, p);
+        }
+        return LocalDateTime.parse(iso);
+    }
+
+    // Holds random db/table identifiers for each test run
+    private static class TableIds {
+        final String db = "hivedb" + StringUtils.randomNumericString(10);
+        final String tbl = "hivetable" + StringUtils.randomNumericString(10);
+    }
+
+    private TableEnvironment freshEnv() {
+        TableEnvironment tEnv = tableEnvironmentBuilder().batchMode().build();
+        tEnv.getConfig().setLocalTimeZone(TEST_ZONE);
+
+        tEnv.executeSql("CREATE CATALOG HIVE WITH ('type'='hive')");
+        tEnv.executeSql(
+                "CREATE CATALOG PAIMON WITH ('type'='paimon', 'warehouse'='" + warehouse + "')");
+        return tEnv;
+    }
+
+    @Test
+    public void clonePreservesTimestamp_parquetHiveToPaimon() throws Exception {
+        TableEnvironment tEnv = freshEnv();
+        TableIds s = new TableIds();
+        tEnv.useCatalog("HIVE");
+        tEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
+        tEnv.executeSql("CREATE DATABASE " + s.db);
+        sql(tEnv, "CREATE TABLE %s.%s (`a` INT, `ts` TIMESTAMP) STORED AS PARQUET", s.db, s.tbl);
+        sql(tEnv, "INSERT INTO %s.%s VALUES (1, '2025-06-03 16:00:00')", s.db, s.tbl);
+
+        tEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
+        List<Row> hiveRows =
+                sql(tEnv, "SELECT a, CAST(ts AS STRING) AS ts_str FROM HIVE.%s.%s", s.db, s.tbl);
+        assertThat(hiveRows).hasSize(1);
+
+        assertThat(hiveRows.get(0).getField(0)).isEqualTo(1);
+        String hiveTsStr = hiveRows.get(0).getField(1).toString();
+        LocalDateTime hiveTs = parseTs(hiveTsStr);
+
+        createAction(
+                        CloneAction.class,
+                        "clone",
+                        "--database",
+                        s.db,
+                        "--table",
+                        s.tbl,
+                        "--catalog_conf",
+                        "metastore=hive",
+                        "--catalog_conf",
+                        "uri=thrift://localhost:" + PORT,
+                        "--target_database",
+                        "test",
+                        "--target_table",
+                        "test_table",
+                        "--target_catalog_conf",
+                        "warehouse=" + warehouse.toString())
+                .run();
+        tEnv.useCatalog("PAIMON");
+        List<Row> paimonRows =
+                sql(tEnv, "SELECT a, CAST(ts AS STRING) AS ts_str FROM test.test_table");
+        assertThat(paimonRows).hasSize(1);
+        assertThat(paimonRows.get(0).getField(0)).isEqualTo(1);
+        String paimonTsStr = paimonRows.get(0).getField(1).toString();
+
+        LocalDateTime paimonTs = parseTs(paimonTsStr);
+
+        assertThat(paimonTs).isEqualTo(hiveTs);
+    }
+}

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/HiveTimestampTimezoneIssueITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/HiveTimestampTimezoneIssueITCase.java
@@ -43,7 +43,7 @@ import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Tests the local timezone conversion for Parquet files */
+/** Tests the local timezone conversion for Parquet files. */
 public class HiveTimestampTimezoneIssueITCase extends ActionITCaseBase {
 
     private static final TestHiveMetastore HMS = new TestHiveMetastore();


### PR DESCRIPTION
 - When reading parquet, hive converts the TZ to local timezone while querying which causes result mismatch against paimon
 - Add support to do the same when querying through paimon behind a feature flag. Behaviour will be enabled if user enables the config.
 - Fixes: #5722 