### PR TITLE
[flink] Fail fast validation for delete with write-only mode enabled

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DeleteAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DeleteAction.java
@@ -54,7 +54,12 @@ public class DeleteAction extends TableActionBase {
 
     @Override
     public void run() throws Exception {
-        CoreOptions.MergeEngine mergeEngine = CoreOptions.fromMap(table.options()).mergeEngine();
+        CoreOptions coreOptions = CoreOptions.fromMap(table.options());
+        if (coreOptions.writeOnly()) {
+            throw new UnsupportedOperationException(
+                    "DELETE is not supported when 'write-only'='true'. Remove the hint or set it to false for the target table.");
+        }
+        CoreOptions.MergeEngine mergeEngine = coreOptions.mergeEngine();
         if (mergeEngine != DEDUPLICATE) {
             throw new UnsupportedOperationException(
                     String.format(


### PR DESCRIPTION
 - DeleteAction now checks CoreOptions.writeOnly() at the start of run.
 - If 'write-only' = 'true', it throws a clear UnsupportedOperationException.
 - avoids deep FileStoreCommitImpl manifest conflict errors.
 - Added testDeleteActionWriteOnlyRejected to assert the new guard.
 - Related to #6137 