### PR TITLE
[spark] Support drop partition from top level

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonAnalysis.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonAnalysis.scala
@@ -21,6 +21,7 @@ package org.apache.paimon.spark.catalyst.analysis
 import org.apache.paimon.spark.{SparkConnectorOptions, SparkTable}
 import org.apache.paimon.spark.catalyst.Compatibility
 import org.apache.paimon.spark.catalyst.analysis.PaimonRelation.isPaimonTable
+import org.apache.paimon.spark.catalyst.plans.logical.PaimonDropPartitions
 import org.apache.paimon.spark.commands.{PaimonAnalyzeTableColumnCommand, PaimonDynamicPartitionOverwriteCommand, PaimonShowColumnsCommand, PaimonTruncateTableCommand}
 import org.apache.paimon.spark.util.OptionUtils
 import org.apache.paimon.table.FileStoreTable
@@ -33,13 +34,13 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.catalyst.util.TypeUtils.toSQLId
 import org.apache.spark.sql.connector.catalog.TableCapability
-import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Implicits, DataSourceV2Relation}
 import org.apache.spark.sql.types._
 
 import scala.collection.mutable
 
 class PaimonAnalysis(session: SparkSession) extends Rule[LogicalPlan] {
-
+  import DataSourceV2Implicits._
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsDown {
 
     case a @ PaimonV2WriteCommand(table) if !paimonWriteResolved(a.query, table) =>
@@ -60,6 +61,11 @@ class PaimonAnalysis(session: SparkSession) extends Rule[LogicalPlan] {
 
     case s @ ShowColumns(PaimonRelation(table), _, _) if s.resolved =>
       PaimonShowColumnsCommand(table)
+
+    case d @ PaimonDropPartitions(ResolvedTable(_, _, table: SparkTable, _), parts, _, _)
+        if d.resolved =>
+      PaimonDropPartitions.validate(table, parts.asResolvedPartitionSpecs)
+      d
   }
 
   private def writeOptions(v2WriteCommand: V2WriteCommand): Map[String, String] = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/plans/logical/PaimonDropPartitions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/plans/logical/PaimonDropPartitions.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.catalyst.plans.logical
+
+import org.apache.paimon.spark.SparkTable
+
+import org.apache.spark.sql.{types, PaimonUtils}
+import org.apache.spark.sql.catalyst.analysis.{PartitionSpec, ResolvedPartitionSpec}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, V2PartitionCommand}
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Implicits.TableHelper
+import org.apache.spark.sql.types.StructType;
+
+/** Drop partitions command. */
+case class PaimonDropPartitions(
+    table: LogicalPlan,
+    parts: Seq[PartitionSpec],
+    ifExists: Boolean,
+    purge: Boolean)
+  extends V2PartitionCommand {
+
+  override def allowPartialPartitionSpec: Boolean = true
+  override protected def withNewChildInternal(newChild: LogicalPlan): PaimonDropPartitions =
+    copy(table = newChild)
+}
+
+/**
+ * If a paimon table has partition spec like (pt1, pt2, pt3), then the drop partition command must
+ * provide all fields or a prefix subset of partition fields. For example, (pt1 = 'v1', pt2 = 'v2')
+ * is valid, but (pt2 = 'v2') is not.
+ */
+object PaimonDropPartitions {
+  def validate(table: SparkTable, partialSpecs: Seq[ResolvedPartitionSpec]): Unit = {
+    val partitionSchema = table.asPartitionable.partitionSchema();
+    partialSpecs.foreach {
+      partialSpec =>
+        if (!partitionSchema.names.toSeq.startsWith(partialSpec.names)) {
+          val values = partialSpec.names.zipWithIndex.map {
+            case (name, ordinal) =>
+              partialSpec.ident.get(ordinal, partitionSchema.apply(name).dataType).toString
+          }
+          val spec = partialSpec.names
+            .zip(values)
+            .map { case (name, value) => s"$name = '$value'" }
+            .mkString(",")
+          throw PaimonUtils.invalidPartitionSpecError(spec, partitionSchema.fieldNames, table.name)
+        }
+    }
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonDropPartitionsExec.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonDropPartitionsExec.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.execution
+
+import org.apache.paimon.spark.SparkTable
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.{NoSuchPartitionsException, ResolvedPartitionSpec}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Implicits.TableHelper
+import org.apache.spark.sql.execution.datasources.v2.LeafV2CommandExec
+
+case class PaimonDropPartitionsExec(
+    table: SparkTable,
+    partSpecs: Seq[ResolvedPartitionSpec],
+    ignoreIfNotExists: Boolean,
+    purge: Boolean,
+    refreshCache: () => Unit)
+  extends LeafV2CommandExec
+  with Logging {
+  override protected def run(): Seq[InternalRow] = {
+    val partitionSchema = table.asPartitionable.partitionSchema()
+    val (partialPartSpecs, fullPartSpecs) =
+      partSpecs.partition(_.ident.numFields != partitionSchema.length)
+
+    val (existsPartIdents, notExistsPartIdents) =
+      fullPartSpecs.map(_.ident).partition(table.partitionExists)
+    if (notExistsPartIdents.nonEmpty && !ignoreIfNotExists) {
+      throw new NoSuchPartitionsException(
+        table.name(),
+        notExistsPartIdents,
+        table.asPartitionable.partitionSchema())
+    }
+    val allExistsPartIdents = existsPartIdents ++ partialPartSpecs.flatMap(expendPartialSpec)
+    logDebug("Try to drop partitions: " + allExistsPartIdents.mkString(","))
+    val isTableAltered = if (allExistsPartIdents.nonEmpty) {
+      allExistsPartIdents
+        .map(
+          partIdent => {
+            if (purge) table.purgePartition(partIdent) else table.dropPartition(partIdent)
+          })
+        .reduce(_ || _)
+    } else false
+
+    if (isTableAltered) refreshCache()
+    Seq.empty
+  }
+
+  private def expendPartialSpec(partialSpec: ResolvedPartitionSpec): Seq[InternalRow] = {
+    table.listPartitionIdentifiers(partialSpec.names.toArray, partialSpec.ident).toSeq
+  }
+
+  override def output: Seq[Attribute] = Seq.empty
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/PaimonUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/PaimonUtils.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.connector.expressions.FieldReference
 import org.apache.spark.sql.connector.expressions.filter.Predicate
+import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Strategy.translateFilterV2WithMapping
 import org.apache.spark.sql.internal.connector.PredicateUtils
@@ -137,5 +138,12 @@ object PaimonUtils {
 
   def classForName(clazz: String): Class[_] = {
     SparkUtils.classForName(clazz)
+  }
+
+  def invalidPartitionSpecError(
+      specKeys: String,
+      partitionColumnNames: Seq[String],
+      tableName: String): Throwable = {
+    QueryCompilationErrors.invalidPartitionSpecError(specKeys, partitionColumnNames, tableName)
   }
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/AbstractPaimonSparkSqlExtensionsParser.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/AbstractPaimonSparkSqlExtensionsParser.scala
@@ -79,7 +79,8 @@ abstract class AbstractPaimonSparkSqlExtensionsParser(val delegate: ParserInterf
   private def parserRules(sparkSession: SparkSession): Seq[Rule[LogicalPlan]] = {
     Seq(
       RewritePaimonViewCommands(sparkSession),
-      RewritePaimonFunctionCommands(sparkSession)
+      RewritePaimonFunctionCommands(sparkSession),
+      RewriteSparkDDLCommands(sparkSession)
     )
   }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/RewriteSparkDDLCommands.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/RewriteSparkDDLCommands.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.parser.extensions
+
+import org.apache.paimon.spark.catalog.SupportView
+import org.apache.paimon.spark.catalyst.plans.logical.{PaimonDropPartitions, ResolvedIdentifier}
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.analysis.UnresolvedIdentifier
+import org.apache.spark.sql.catalyst.plans.logical.{DropPartitions, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.catalog.{CatalogManager, LookupCatalog}
+
+case class RewriteSparkDDLCommands(spark: SparkSession)
+  extends Rule[LogicalPlan]
+  with LookupCatalog {
+
+  protected lazy val catalogManager: CatalogManager = spark.sessionState.catalogManager
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsUp {
+
+    // A new member was added to CreatePaimonView since spark4.0,
+    // unapply pattern matching is not used here to ensure compatibility across multiple spark versions.
+    case DropPartitions(UnresolvedPaimonRelation(aliasedTable), parts, ifExists, purge) =>
+      PaimonDropPartitions(aliasedTable, parts, ifExists, purge)
+
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/UnresolvedPaimonRelation.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/UnresolvedPaimonRelation.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.parser.extensions
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, UnresolvedTable}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.{PaimonLookupCatalog, TableCatalog}
+
+import scala.util.Try
+
+object UnresolvedPaimonRelation extends PaimonLookupCatalog {
+  protected lazy val catalogManager = SparkSession.active.sessionState.catalogManager
+
+  def unapply(plan: LogicalPlan): Option[LogicalPlan] = {
+    EliminateSubqueryAliases(plan) match {
+      case UnresolvedTable(multipartIdentifier, _, _) if isPaimonTable(multipartIdentifier) =>
+        Some(plan)
+      case _ => None
+    }
+  }
+
+  private def isPaimonTable(multipartIdentifier: Seq[String]): Boolean = {
+    multipartIdentifier match {
+      case CatalogAndIdentifier(catalog: TableCatalog, ident) =>
+        Try(catalog.loadTable(ident))
+          .map(t => t.isInstanceOf[org.apache.paimon.spark.SparkTable])
+          .getOrElse(false)
+      case _ => false
+    }
+  }
+
+}

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/extensions/DropPartitionParserTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/extensions/DropPartitionParserTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.extensions;
+
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.spark.SparkCatalog;
+import org.apache.paimon.spark.SparkGenericCatalog;
+import org.apache.paimon.spark.catalyst.plans.logical.PaimonDropPartitions;
+import org.apache.paimon.utils.FileIOUtils;
+
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.parser.ParseException;
+import org.apache.spark.sql.catalyst.parser.ParserInterface;
+import org.apache.spark.sql.catalyst.plans.logical.DropPartitions;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.io.File;
+import java.io.IOException;
+
+import scala.Option;
+
+/** Test for DropPartition parser. */
+public class DropPartitionParserTest {
+
+    private static SparkSession spark = null;
+    private static ParserInterface parser = null;
+    private final String dbName = "test_db";
+    private final String tableName = "test_paimon";
+    private final String hiveTableName = "test_hive";
+    private static Path warehousePath;
+
+    @BeforeAll
+    public static void startSparkSession(@TempDir java.nio.file.Path tempDir) {
+        warehousePath = new Path("file:" + tempDir.toString());
+        // Stops and clears active session to avoid loading previous non-stopped session.
+        Option<SparkSession> optionalSession =
+                SparkSession.getActiveSession().orElse(SparkSession::getDefaultSession);
+        if (!optionalSession.isEmpty()) {
+            optionalSession.get().stop();
+        }
+        SparkSession.clearActiveSession();
+        spark =
+                SparkSession.builder()
+                        .master("local[2]")
+                        .config("spark.sql.catalog.paimon", SparkCatalog.class.getName())
+                        .config("spark.sql.catalog.paimon.warehouse", warehousePath.toString())
+                        .config(
+                                "spark.sql.catalog.spark_catalog",
+                                SparkGenericCatalog.class.getName())
+                        .config(
+                                "spark.sql.catalog.spark_catalog.warehouse.dir",
+                                warehousePath.toString())
+                        .config("spark.sql.warehouse.dir", warehousePath.toString())
+                        .config(
+                                "spark.sql.extensions",
+                                PaimonSparkSessionExtensions.class.getName())
+                        .getOrCreate();
+        parser = spark.sessionState().sqlParser();
+    }
+
+    @AfterAll
+    public static void stopSparkSession() throws IOException {
+        if (spark != null) {
+            FileIOUtils.deleteDirectory(new File(warehousePath.toString()));
+            spark.stop();
+            spark = null;
+            parser = null;
+        }
+    }
+
+    @AfterEach
+    public void clear() {
+        if (spark != null) {
+            spark.sql("DROP TABLE IF EXISTS " + dbName + "." + tableName);
+            spark.sql("DROP TABLE IF EXISTS " + dbName + "." + hiveTableName);
+            spark.sql("DROP DATABASE " + dbName + " CASCADE");
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"false", "true"})
+    public void testOnPaimonCatalog(boolean defaultCatalog)
+            throws ParseException, NoSuchTableException {
+        String catalogName = !defaultCatalog ? "paimon" : "spark_catalog";
+        spark.sql("USE " + catalogName);
+
+        spark.sql("CREATE DATABASE IF NOT EXISTS " + dbName);
+        spark.sql("USE " + dbName);
+        spark.sql(
+                "CREATE TABLE "
+                        + tableName
+                        + " (id INT, name STRING) USING paimon PARTITIONED BY (dt STRING) ");
+        TableCatalog catalog =
+                (TableCatalog) spark.sessionState().catalogManager().currentCatalog();
+        Table table = catalog.loadTable(Identifier.of(new String[] {dbName}, tableName));
+        Assertions.assertNotNull(table);
+        LogicalPlan plan =
+                parser.parsePlan("ALTER TABLE " + tableName + " DROP PARTITION(dt='2024-01-01')");
+        Assertions.assertTrue(plan instanceof PaimonDropPartitions);
+        if (defaultCatalog) {
+            spark.sql(
+                    "CREATE TABLE IF NOT EXISTS "
+                            + hiveTableName
+                            + " (id INT, name STRING) USING parquet PARTITIONED BY (dt STRING) ");
+            plan =
+                    parser.parsePlan(
+                            "ALTER TABLE " + hiveTableName + " DROP PARTITION(dt='2024-01-01')");
+            Assertions.assertFalse(plan instanceof PaimonDropPartitions);
+            Assertions.assertTrue(plan instanceof DropPartitions);
+        }
+    }
+}

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
@@ -24,7 +24,8 @@ import org.apache.paimon.spark.PaimonSparkTestBase
 import org.apache.paimon.types.DataTypes
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.catalyst.analysis.NoSuchPartitionsException
 import org.junit.jupiter.api.Assertions
 
 import java.sql.{Date, Timestamp}
@@ -557,5 +558,41 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
     assert(intercept[Exception] {
       sql("CREATE TABLE t (id INT) USING paimon1")
     }.getMessage.contains("Provider is not supported: paimon1"))
+  }
+
+  test("Paimon DDL: Drop Partition by partial spec") {
+    withTable("tbl") {
+      spark.sql(
+        s"CREATE TABLE tbl (id int, data string) USING paimon " +
+          s"PARTITIONED BY (dt string, hour string, event string) ")
+      spark.sql(s"INSERT INTO tbl VALUES (1, 'a', '2023-01-01', '00', 'event1')")
+      spark.sql(s"INSERT INTO tbl VALUES (1, 'a', '2023-01-02', '00', 'event1')")
+      spark.sql(s"INSERT INTO tbl VALUES (1, 'a', '2023-01-02', '00', 'event2')")
+      spark.sql(s"INSERT INTO tbl VALUES (1, 'a', '2023-01-02', '00', 'event3')")
+      spark.sql(s"INSERT INTO tbl VALUES (1, 'a', '2023-01-02', '02', 'event1')")
+      spark.sql(s"INSERT INTO tbl VALUES (1, 'a', '2023-01-02', '02', 'event2')")
+      spark.sql(s"INSERT INTO tbl VALUES (1, 'a', '2023-01-02', '03', 'event1')")
+      spark.sql(s"INSERT INTO tbl VALUES (1, 'a', '2023-01-03', '00', 'event1')")
+      val query = () => spark.sql("SELECT * FROM tbl")
+      assert(query().count() == 8)
+      // drop full parts level
+      spark.sql("ALTER TABLE tbl DROP PARTITION (dt='2023-01-01', hour='00', event='event1')")
+      assert(query().count() == 7)
+      // drop first + second level
+      spark.sql("ALTER TABLE tbl DROP PARTITION (dt='2023-01-02', hour='00')")
+      assert(query().count() == 4)
+      // drop first level
+      spark.sql("ALTER TABLE tbl DROP PARTITION (dt='2023-01-02')")
+      assert(query().count() == 1)
+      // no effected drop
+      spark.sql("ALTER TABLE tbl DROP PARTITION (dt='2023-01-01')")
+      assert(query().count() == 1)
+      assertThrows[AnalysisException] {
+        spark.sql("ALTER TABLE tbl DROP PARTITION (hour='00', event='event1')")
+      }
+      assertThrows[NoSuchPartitionsException] {
+        spark.sql("ALTER TABLE tbl DROP PARTITION (dt='2023-01-01', hour='00', event='event1')")
+      }
+    }
   }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonPartitionManagementTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonPartitionManagementTest.scala
@@ -149,10 +149,6 @@ class PaimonPartitionManagementTest extends PaimonSparkTestBase {
               "alter table T drop partition (dt=20240101, hh='00'), partition (dt=20240102, hh='00')")
 
             assertThrows[AnalysisException] {
-              spark.sql("alter table T drop partition (dt=20230816)")
-            }
-
-            assertThrows[AnalysisException] {
               spark.sql("alter table T drop partition (hh='1134')")
             }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

To support drop partition from top level in spark if partition spec with one more fields

example:

```
CREATE TABLE tbl (id int, data string) 
USING paimon 
PARTITIONED BY (dt string, hour string, event string);

ALTER TABLE tbl DROP PARTITION (dt='2023-01-01');
```

### Tests

- DDLTestBase.scala
- DropPartitionParserTest.java
- PaimonPartitionManagementTest.scala


### API and Format

No

### Documentation

No
