### PR TITLE
[hotfix] Fix that VariantType doesn't have default constructor

### DIFF
--- a/paimon-flink/paimon-flink-2.0/src/main/java/org/apache/flink/table/types/logical/VariantType.java
+++ b/paimon-flink/paimon-flink-2.0/src/main/java/org/apache/flink/table/types/logical/VariantType.java
@@ -32,6 +32,10 @@ import java.util.List;
 @PublicEvolving
 public class VariantType extends LogicalType {
 
+    public VariantType() {
+        this(true);
+    }
+
     public VariantType(boolean isNullable) {
         super(isNullable, LogicalTypeRoot.UNRESOLVED);
     }

--- a/paimon-flink/paimon-flink1-common/src/main/java/org/apache/flink/table/types/logical/VariantType.java
+++ b/paimon-flink/paimon-flink1-common/src/main/java/org/apache/flink/table/types/logical/VariantType.java
@@ -32,6 +32,10 @@ import java.util.List;
 @PublicEvolving
 public class VariantType extends LogicalType {
 
+    public VariantType() {
+        this(true);
+    }
+
     public VariantType(boolean isNullable) {
         super(isNullable, LogicalTypeRoot.UNRESOLVED);
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
