### PR TITLE
[core] Fix checkpoint recovery failure for compacted changelog files

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/CompactedChangelogPathResolver.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/CompactedChangelogPathResolver.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.fs.Path;
+
+/**
+ * Utility class for resolving compacted changelog file paths.
+ *
+ * <p>This class provides functionality to resolve fake compacted changelog file paths to their real
+ * file paths, following the same protocol as CompactedChangelogFormatReaderFactory.
+ */
+public class CompactedChangelogPathResolver {
+
+    /**
+     * Resolves compacted changelog file path to its real file path. Handles both real and fake
+     * compacted changelog file names as described in CompactedChangelogFormatReaderFactory.
+     *
+     * @param path the file path to resolve
+     * @return the resolved real file path
+     */
+    public static Path resolveCompactedChangelogPath(Path path) {
+        // Check if this is a compacted changelog file by its .cc- extension
+        String[] nameAndFormat = path.getName().split("\\.");
+        if (nameAndFormat.length < 2 || !nameAndFormat[1].startsWith("cc-")) {
+            return path;
+        }
+
+        String[] names = nameAndFormat[0].split("\\$");
+        String[] split = names[1].split("-");
+        if (split.length == 2) {
+            // Real file: compacted-changelog-xxx$bid-len.cc-format
+            return path;
+        } else {
+            // Fake file: compacted-changelog-xxx$bid-len-off-len2.cc-format
+            // Resolve to real file: bucket-bid/compacted-changelog-xxx$bid-len.cc-format
+            return new Path(
+                    path.getParent().getParent(),
+                    "bucket-"
+                            + split[0]
+                            + "/"
+                            + names[0]
+                            + "$"
+                            + split[0]
+                            + "-"
+                            + split[1]
+                            + "."
+                            + nameAndFormat[1]);
+        }
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/utils/CompactedChangelogPathResolverTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/CompactedChangelogPathResolverTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.fs.Path;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link CompactedChangelogPathResolver}. */
+public class CompactedChangelogPathResolverTest {
+
+    @Test
+    public void testResolveNonCompactedChangelogFile() {
+        // Test regular changelog file - should return unchanged
+        Path regularFile =
+                new Path(
+                        "/path/to/table/bucket-0/changelog-25b05ab0-6f90-4865-a984-8d9629bac735-1426.parquet");
+        Path resolved = CompactedChangelogPathResolver.resolveCompactedChangelogPath(regularFile);
+        assertThat(resolved).isEqualTo(regularFile);
+    }
+
+    @Test
+    public void testResolveRealCompactedChangelogFile() {
+        // Test real compacted changelog file - should return unchanged
+        Path realFile =
+                new Path(
+                        "/path/to/table/bucket-0/compacted-changelog-8e049c65-5ce4-4ce7-b1b0-78ce694ab351$0-39253.cc-parquet");
+        Path resolved = CompactedChangelogPathResolver.resolveCompactedChangelogPath(realFile);
+        assertThat(resolved).isEqualTo(realFile);
+    }
+
+    @Test
+    public void testResolveFakeCompactedChangelogFile() {
+        // Test fake compacted changelog file - should resolve to real path
+        Path fakeFile =
+                new Path(
+                        "/path/to/table/bucket-1/compacted-changelog-8e049c65-5ce4-4ce7-b1b0-78ce694ab351$0-39253-39253-35699.cc-parquet");
+        Path resolved = CompactedChangelogPathResolver.resolveCompactedChangelogPath(fakeFile);
+
+        Path expectedRealFile =
+                new Path(
+                        "/path/to/table/bucket-0/compacted-changelog-8e049c65-5ce4-4ce7-b1b0-78ce694ab351$0-39253.cc-parquet");
+        assertThat(resolved).isEqualTo(expectedRealFile);
+    }
+
+    @Test
+    public void testResolveWithDifferentFormats() {
+        // Test with different file formats
+        Path fakeOrcFile =
+                new Path(
+                        "/path/to/table/bucket-2/compacted-changelog-8e049c65-5ce4-4ce7-b1b0-78ce694ab351$0-1024-1024-512.cc-orc");
+        Path resolvedOrc =
+                CompactedChangelogPathResolver.resolveCompactedChangelogPath(fakeOrcFile);
+        Path expectedOrcFile =
+                new Path(
+                        "/path/to/table/bucket-0/compacted-changelog-8e049c65-5ce4-4ce7-b1b0-78ce694ab351$0-1024.cc-orc");
+        assertThat(resolvedOrc).isEqualTo(expectedOrcFile);
+
+        Path fakeAvroFile =
+                new Path(
+                        "/path/to/table/bucket-5/compacted-changelog-8e049c65-5ce4-4ce7-b1b0-78ce694ab351$2-2048-2048-1024.cc-avro");
+        Path resolvedAvro =
+                CompactedChangelogPathResolver.resolveCompactedChangelogPath(fakeAvroFile);
+        Path expectedAvroFile =
+                new Path(
+                        "/path/to/table/bucket-2/compacted-changelog-8e049c65-5ce4-4ce7-b1b0-78ce694ab351$2-2048.cc-avro");
+        assertThat(resolvedAvro).isEqualTo(expectedAvroFile);
+    }
+
+    @Test
+    public void testResolveFileWithoutExtension() {
+        // Test file without file extension - should return unchanged
+        Path fileWithoutExt = new Path("/path/to/table/file");
+        Path resolved =
+                CompactedChangelogPathResolver.resolveCompactedChangelogPath(fileWithoutExt);
+        assertThat(resolved).isEqualTo(fileWithoutExt);
+    }
+}


### PR DESCRIPTION
[core] Fix checkpoint recovery failure for compacted changelog files

  ### Purpose

  Fixes checkpoint recovery failures when using precommit-compact functionality introduced in commit [flink] add coordinate and worker operator for small changelog files compaction (#4380).

  **Root Cause:**
  Compacted changelog files have two types of file names:
  1. Real files: `compacted-changelog-xxx$bid-len.cc-format`
  2. Fake files: `compacted-changelog-xxx$bid-len-off-len2.cc-format`

  Fake file names point to segments of real files but don't exist in the filesystem. The `checkFilesExistence` method was directly checking these fake file paths, causing recovery failures.

  **Solution:**
  - Created `CompactedChangelogPathResolver` utility class to resolve fake file paths to real file paths
  - Modified `TableCommitImpl.checkFilesExistence()` to resolve all paths before checking existence
  - Added deduplication logic since multiple fake files may resolve to the same real file
  - Path resolution rules:
    - Real files (`xxx$bid-len.cc-format`): return original path
    - Fake files (`xxx$bid-len-off-len2.cc-format`): resolve to `bucket-bid/xxx$bid-len.cc-format`

  ### Tests

  - Added unit tests in `CompactedChangelogPathResolverTest` to verify path resolution logic
  - Existing checkpoint recovery tests should now pass with compacted changelog files

  ### API and Format

  No changes to public API or storage format. This is an internal fix for file path resolution.

  ### Documentation

  No new features introduced. This is a bug fix for existing precommit-compact functionality.