### PR TITLE
[core] Clearly distinguish between OOM and interrupts

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/codegen/CodeGenUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/codegen/CodeGenUtils.java
@@ -135,7 +135,7 @@ public class CodeGenUtils {
                     Thread.sleep(5_000);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
-                    throw error;
+                    throw new RuntimeException("Thread interrupted while generating class", e);
                 }
                 toThrow = error;
             }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Clearly distinguish OOM from interrupts, so that the upper level can better distinguish the reasons for failure.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
