### PR TITLE
[core] let 'sequence.field' be mutable

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -779,7 +779,6 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Fields that are ignored for comparison while generating -U, +U changelog for the same record. This configuration is only valid for the changelog-producer.row-deduplicate is true.");
 
-    @Immutable
     public static final ConfigOption<String> SEQUENCE_FIELD =
             key("sequence.field")
                     .stringType()

--- a/paimon-flink/paimon-flink-1.16/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-1.16/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
@@ -90,13 +90,5 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
                 .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Change 'merge-engine' is not supported yet.");
-
-        // sequence.field is immutable
-        sql("CREATE TABLE T5 (a STRING, b STRING, c STRING) WITH ('sequence.field' = 'b')");
-        sql("INSERT INTO T5 VALUES ('a', 'b', 'c')");
-        assertThatThrownBy(() -> sql("ALTER TABLE T5 SET ('sequence.field' = 'c')"))
-                .rootCause()
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("Change 'sequence.field' is not supported yet.");
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
@@ -896,14 +896,6 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
                 .rootCause()
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Change 'merge-engine' is not supported yet.");
-
-        // sequence.field is immutable
-        sql("CREATE TABLE T5 (a STRING, b STRING, c STRING) WITH ('sequence.field' = 'b')");
-        sql("INSERT INTO T5 VALUES ('a', 'b', 'c')");
-        assertThatThrownBy(() -> sql("ALTER TABLE T5 SET ('sequence.field' = 'c')"))
-                .rootCause()
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("Change 'sequence.field' is not supported yet.");
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
After https://github.com/apache/incubator-paimon/pull/2945 , changing sequence field has no such big impact to the storage (Completely has no impact on storage format).

Let 'sequence.field' be mutable, after full compaction, we can just change the 'sequence.field'.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
