### PR TITLE
[core]fix: filter contains partition filter

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
@@ -208,7 +208,7 @@ public class PredicateBuilder {
         return result;
     }
 
-    public static Pair<List<Predicate>, List<Predicate>> splitAndForPartitionAndNonPartitionFilter(
+    public static Pair<List<Predicate>, List<Predicate>> splitAndByPartition(
             Predicate predicate, int[] fieldIdxToPartitionIdx) {
         List<Predicate> partitionFilters = new ArrayList<>();
         List<Predicate> nonPartitionFilters = new ArrayList<>();

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
@@ -72,7 +72,7 @@ import static org.apache.paimon.Snapshot.FIRST_SNAPSHOT_ID;
 import static org.apache.paimon.deletionvectors.DeletionVectorsIndexFile.DELETION_VECTORS_INDEX;
 import static org.apache.paimon.operation.FileStoreScan.Plan.groupByPartFiles;
 import static org.apache.paimon.partition.PartitionPredicate.createPartitionPredicate;
-import static org.apache.paimon.predicate.PredicateBuilder.splitAndForPartitionAndNonPartitionFilter;
+import static org.apache.paimon.predicate.PredicateBuilder.splitAndByPartition;
 
 /** Implementation of {@link SnapshotReader}. */
 public class SnapshotReaderImpl implements SnapshotReader {
@@ -222,15 +222,15 @@ public class SnapshotReaderImpl implements SnapshotReader {
                 PredicateBuilder.fieldIdxToPartitionIdx(
                         tableSchema.logicalRowType(), tableSchema.partitionKeys());
         Pair<List<Predicate>, List<Predicate>> partitionAndNonPartitionFilter =
-                splitAndForPartitionAndNonPartitionFilter(predicate, fieldIdxToPartitionIdx);
+                splitAndByPartition(predicate, fieldIdxToPartitionIdx);
         List<Predicate> partitionFilters = partitionAndNonPartitionFilter.getLeft();
-        List<Predicate> unPartitionFilters = partitionAndNonPartitionFilter.getRight();
+        List<Predicate> nonPartitionFilters = partitionAndNonPartitionFilter.getRight();
         if (partitionFilters.size() > 0) {
             scan.withPartitionFilter(PredicateBuilder.and(partitionFilters));
         }
 
-        if (unPartitionFilters.size() > 0) {
-            nonPartitionFilterConsumer.accept(scan, PredicateBuilder.and(unPartitionFilters));
+        if (nonPartitionFilters.size() > 0) {
+            nonPartitionFilterConsumer.accept(scan, PredicateBuilder.and(nonPartitionFilters));
         }
         return this;
     }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -685,6 +685,14 @@ public abstract class CatalogTestBase {
             List<InternalRow> readLimitData =
                     read(table, predicate, projection, partitionSpec, limit);
             assertThat(readLimitData).hasSize(limit);
+            if (partitioned) {
+                PredicateBuilder partitionFilterBuilder = new PredicateBuilder(table.rowType());
+                Predicate partitionFilterPredicate =
+                        partitionFilterBuilder.equal(2, partitionValue);
+                List<InternalRow> readPartitionAndNoPartitionFilterData =
+                        read(table, partitionFilterPredicate, projection, null, null);
+                assertThat(readPartitionAndNoPartitionFilterData).hasSize(size);
+            }
             catalog.dropTable(Identifier.create(dbName, format), true);
         }
     }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -661,7 +661,6 @@ public abstract class CatalogTestBase {
                         diffPartitionPathFactory.newPath(),
                         compressionType.value(),
                         dataWithDiffPartition);
-                size = size + 1;
                 partitionSpec = new HashMap<>();
                 partitionSpec.put("dt", "" + partitionValue);
             } else {
@@ -679,13 +678,13 @@ public abstract class CatalogTestBase {
             List<InternalRow> readFilterData =
                     read(table, predicate, projection, partitionSpec, null);
             assertThat(readFilterData).containsExactlyInAnyOrder(checkDatas);
-            List<InternalRow> readAllData = read(table, null, null, null, null);
-            assertThat(readAllData).hasSize(size);
             int limit = checkSize - 1;
             List<InternalRow> readLimitData =
                     read(table, predicate, projection, partitionSpec, limit);
             assertThat(readLimitData).hasSize(limit);
             if (partitioned) {
+                List<InternalRow> readAllData = read(table, null, null, null, null);
+                assertThat(readAllData).hasSize(size + 1);
                 PredicateBuilder partitionFilterBuilder = new PredicateBuilder(table.rowType());
                 Predicate partitionFilterPredicate =
                         partitionFilterBuilder.equal(2, partitionValue);
@@ -749,11 +748,11 @@ public abstract class CatalogTestBase {
             readBuilder.withProjection(projection);
         }
         readBuilder.withPartitionFilter(partitionSpec);
-        TableScan scan = readBuilder.newScan();
         readBuilder.withFilter(predicate);
         if (limit != null) {
             readBuilder.withLimit(limit);
         }
+        TableScan scan = readBuilder.newScan();
         try (RecordReader<InternalRow> reader =
                 readBuilder.newRead().executeFilter().createReader(scan.plan())) {
             InternalRowSerializer serializer = new InternalRowSerializer(readBuilder.readType());


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

For the format table: a user may define partition filters in filters, so we need to get partition filters from filters when a user defines filters for reading

<!-- What is the purpose of the change -->

### Tests
- CatalogTestBase#testFormatTableRead

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
