### PR TITLE
[spark] Throw exception when using unknown provider

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -455,9 +455,13 @@ public class SparkCatalog extends SparkBaseCatalog
             StructType schema, Transform[] partitions, Map<String, String> properties) {
         Map<String, String> normalizedProperties = new HashMap<>(properties);
         String provider = properties.get(TableCatalog.PROP_PROVIDER);
-        if (!usePaimon(provider) && isFormatTable(provider)) {
-            normalizedProperties.put(TYPE.key(), FORMAT_TABLE.toString());
-            normalizedProperties.put(FILE_FORMAT.key(), provider.toLowerCase());
+        if (!usePaimon(provider)) {
+            if (isFormatTable(provider)) {
+                normalizedProperties.put(TYPE.key(), FORMAT_TABLE.toString());
+                normalizedProperties.put(FILE_FORMAT.key(), provider.toLowerCase());
+            } else {
+                throw new UnsupportedOperationException("Provider is not supported: " + provider);
+            }
         }
         normalizedProperties.remove(TableCatalog.PROP_PROVIDER);
         normalizedProperties.remove(PRIMARY_KEY_IDENTIFIER);

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
@@ -553,4 +553,10 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
       }.getMessage.contains("Only supports operations within the same catalog"))
     }
   }
+
+  test("Paimon DDL: create unsupported table") {
+    assert(intercept[Exception] {
+      sql("CREATE TABLE t (id INT) USING paimon1")
+    }.getMessage.contains("Provider is not supported: paimon1"))
+  }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

```sql
CREATE TABLE t (id INT) USING paimon1");

--  throw exception 'Provider is not supported: paimon1'
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
