### PR TITLE
[flink] Support starting Flink job for all actions

### DIFF
--- a/docs/content/flink/action-jars.md
+++ b/docs/content/flink/action-jars.md
@@ -305,3 +305,21 @@ For more information of 'rewrite_file_index', see
     /path/to/paimon-flink-action-{{< version >}}.jar \
     rewrite_file_index --help
 ```
+
+## Force Start Flink Job
+
+Some actions, like `create_tag`, are lightweight and by default will not be submitted as a job to Flink cluster. If you
+have the need to unify the experience regardless of actions, you can use the `--force_start_flink_job` flag to make sure
+submitting them as jobs. For example,
+
+```bash
+<FLINK_HOME>/bin/flink run \
+    /path/to/paimon-flink-action-{{< version >}}.jar \
+    drop_partition \
+    --warehouse <warehouse-path> \
+    --database <database-name> \
+    --table <table-name> \
+    [--partition <partition_spec> [--partition <partition_spec> ...]] \
+    [--catalog_conf <paimon-catalog-conf> [--catalog_conf <paimon-catalog-conf> ...]]
+    --force_start_flink_job
+```

--- a/paimon-flink/paimon-flink-common/pom.xml
+++ b/paimon-flink/paimon-flink-common/pom.xml
@@ -217,6 +217,20 @@ under the License.
             <version>${apache.hc.client.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.10.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>9.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ActionBase.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ActionBase.java
@@ -28,13 +28,19 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeCasts;
 
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.util.Collector;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -43,15 +49,22 @@ import java.util.stream.Collectors;
 import static org.apache.paimon.options.CatalogOptions.CACHE_ENABLED;
 
 /** Abstract base of {@link Action} for table. */
-public abstract class ActionBase implements Action {
+public abstract class ActionBase implements Action, Serializable {
 
     protected final Options catalogOptions;
-    protected final Catalog catalog;
-    protected final FlinkCatalog flinkCatalog;
+    protected transient Catalog catalog;
+    protected transient FlinkCatalog flinkCatalog;
     protected final String catalogName = "paimon-" + UUID.randomUUID();
 
-    protected StreamExecutionEnvironment env;
-    protected StreamTableEnvironment batchTEnv;
+    /**
+     * Forces LocalAction to run as a Flink job instead of local execution. This field only has
+     * effect on {@link LocalAction} implementations. For non-LocalAction implementations, this
+     * field is ignored.
+     */
+    protected boolean forceStartFlinkJob = false;
+
+    protected transient StreamExecutionEnvironment env;
+    protected transient StreamTableEnvironment batchTEnv;
 
     public ActionBase(Map<String, String> catalogConfig) {
         catalogOptions = Options.fromMap(catalogConfig);
@@ -61,11 +74,27 @@ public abstract class ActionBase implements Action {
             catalogOptions.set(CACHE_ENABLED, false);
         }
 
-        catalog = initPaimonCatalog();
-        flinkCatalog = initFlinkCatalog();
+        initCatalog();
 
         // use the default env if user doesn't pass one
         initFlinkEnv(StreamExecutionEnvironment.getExecutionEnvironment());
+    }
+
+    void initCatalog() {
+        catalog = initPaimonCatalog();
+        flinkCatalog = initFlinkCatalog();
+    }
+
+    /**
+     * Forces this action to run as a Flink job instead of local execution. This method only has
+     * effect on {@link LocalAction} implementations. For non-LocalAction implementations, this
+     * method has no effect.
+     *
+     * @return this ActionBase for method chaining
+     */
+    public ActionBase forceStartFlinkJob() {
+        this.forceStartFlinkJob = true;
+        return this;
     }
 
     public ActionBase withStreamExecutionEnvironment(StreamExecutionEnvironment env) {
@@ -137,5 +166,52 @@ public abstract class ActionBase implements Action {
     @VisibleForTesting
     public Map<String, String> catalogConfig() {
         return catalogOptions.toMap();
+    }
+
+    @Override
+    public void run() throws Exception {
+        if (LocalAction.class.isAssignableFrom(this.getClass())) {
+            if (forceStartFlinkJob) {
+                env.fromSequence(0, 0)
+                        .flatMap(new LocalActionExecutor<>(this))
+                        .setParallelism(1)
+                        .sinkTo(new DiscardingSink<>());
+                execute(this.getClass().getSimpleName());
+            } else {
+                ((LocalAction) this).executeLocally();
+            }
+        } else {
+            build();
+            execute(this.getClass().getSimpleName());
+        }
+    }
+
+    /**
+     * A {@link org.apache.flink.api.common.functions.FlatMapFunction} that wraps {@link
+     * LocalAction} into a Flink operator.
+     */
+    private static class LocalActionExecutor<T extends ActionBase & LocalAction>
+            extends RichFlatMapFunction<Long, Object> {
+        private final T action;
+
+        @SuppressWarnings("unchecked")
+        private LocalActionExecutor(ActionBase action) {
+            this.action = (T) action;
+        }
+
+        // @Override is skipped for compatibility between Flink versions
+        public void open(Configuration parameters) {
+            action.initCatalog();
+        }
+
+        // @Override is skipped for compatibility between Flink versions
+        public void open(OpenContext openContext) {
+            action.initCatalog();
+        }
+
+        @Override
+        public void flatMap(Long aLong, Collector<Object> collector) throws Exception {
+            action.executeLocally();
+        }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ActionFactory.java
@@ -60,6 +60,13 @@ public interface ActionFactory extends Factory {
     String MINOR = "minor";
     String FULL = "full";
 
+    /**
+     * Forces the action to run as a Flink job instead of local execution. This parameter only
+     * affects {@link LocalAction} implementations. For non-LocalAction implementations, this
+     * parameter has no effect.
+     */
+    String FORCE_START_FLINK_JOB = "force_start_flink_job";
+
     Optional<Action> create(MultipleParameterToolAdapter params);
 
     static Optional<Action> createAction(String[] args) {
@@ -92,7 +99,23 @@ public interface ActionFactory extends Factory {
                             PATH, CATALOG_CONF, CatalogOptions.WAREHOUSE.key(), DATABASE, TABLE));
         }
 
-        return actionFactory.create(params);
+        Optional<Action> optionalAction = actionFactory.create(params);
+
+        if (params.has(FORCE_START_FLINK_JOB)) {
+            optionalAction =
+                    optionalAction.map(
+                            a -> {
+                                if (!(a instanceof ActionBase)) {
+                                    throw new UnsupportedOperationException(
+                                            String.format(
+                                                    "Action %s does not support %s.",
+                                                    action, FORCE_START_FLINK_JOB));
+                                }
+                                return ((ActionBase) a).forceStartFlinkJob();
+                            });
+        }
+
+        return optionalAction;
     }
 
     void printHelp();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ClearConsumerAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ClearConsumerAction.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 /** Clear consumers action for Flink. */
-public class ClearConsumerAction extends TableActionBase {
+public class ClearConsumerAction extends TableActionBase implements LocalAction {
 
     private String includingConsumers;
     private String excludingConsumers;
@@ -49,7 +49,7 @@ public class ClearConsumerAction extends TableActionBase {
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() {
         FileStoreTable dataTable = (FileStoreTable) table;
         ConsumerManager consumerManager =
                 new ConsumerManager(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactAction.java
@@ -53,6 +53,7 @@ import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
 import org.apache.flink.table.data.RowData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -282,7 +283,12 @@ public class CompactAction extends TableActionBase {
                         .withBucket(BucketMode.POSTPONE_BUCKET)
                         .partitions();
         if (partitions.isEmpty()) {
-            return false;
+            if (this.forceStartFlinkJob) {
+                env.fromSequence(0, 0).name("Placeholder Source").sinkTo(new DiscardingSink<>());
+                return true;
+            } else {
+                return false;
+            }
         }
 
         InternalRowPartitionComputer partitionComputer =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateBranchAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateBranchAction.java
@@ -23,7 +23,7 @@ import org.apache.paimon.shade.org.apache.commons.lang3.StringUtils;
 import java.util.Map;
 
 /** Create branch action for Flink. */
-public class CreateBranchAction extends TableActionBase {
+public class CreateBranchAction extends TableActionBase implements LocalAction {
     private final String branchName;
     private final String tagName;
 
@@ -39,7 +39,7 @@ public class CreateBranchAction extends TableActionBase {
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() {
         if (!StringUtils.isBlank(tagName)) {
             table.createBranch(branchName, tagName);
         } else {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateTagAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateTagAction.java
@@ -24,7 +24,7 @@ import java.time.Duration;
 import java.util.Map;
 
 /** Create tag action for Flink. */
-public class CreateTagAction extends TableActionBase {
+public class CreateTagAction extends TableActionBase implements LocalAction {
 
     private final String tagName;
     private final @Nullable Long snapshotId;
@@ -44,7 +44,7 @@ public class CreateTagAction extends TableActionBase {
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() {
         if (snapshotId == null) {
             table.createTag(tagName, timeRetained);
         } else {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateTagFromTimestampAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateTagFromTimestampAction.java
@@ -25,7 +25,7 @@ import org.apache.flink.table.procedure.DefaultProcedureContext;
 import java.util.Map;
 
 /** Create tag from timestamp action for Flink. */
-public class CreateTagFromTimestampAction extends ActionBase {
+public class CreateTagFromTimestampAction extends ActionBase implements LocalAction {
 
     private final String database;
     private final String table;
@@ -49,7 +49,7 @@ public class CreateTagFromTimestampAction extends ActionBase {
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() throws Exception {
         CreateTagFromTimestampProcedure createTagFromTimestampProcedure =
                 new CreateTagFromTimestampProcedure();
         createTagFromTimestampProcedure.withCatalog(catalog);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateTagFromWatermarkAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateTagFromWatermarkAction.java
@@ -20,12 +20,10 @@ package org.apache.paimon.flink.action;
 
 import org.apache.paimon.flink.procedure.CreateTagFromWatermarkProcedure;
 
-import org.apache.flink.table.procedure.DefaultProcedureContext;
-
 import java.util.Map;
 
 /** Create tag from watermark action for Flink. */
-public class CreateTagFromWatermarkAction extends ActionBase {
+public class CreateTagFromWatermarkAction extends ActionBase implements LocalAction {
 
     private final String database;
     private final String table;
@@ -49,15 +47,11 @@ public class CreateTagFromWatermarkAction extends ActionBase {
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() throws Exception {
         CreateTagFromWatermarkProcedure createTagFromWatermarkProcedure =
                 new CreateTagFromWatermarkProcedure();
         createTagFromWatermarkProcedure.withCatalog(catalog);
         createTagFromWatermarkProcedure.call(
-                new DefaultProcedureContext(env),
-                database + "." + table,
-                tag,
-                watermark,
-                timeRetained);
+                null, database + "." + table, tag, watermark, timeRetained);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DeleteBranchAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DeleteBranchAction.java
@@ -21,7 +21,7 @@ package org.apache.paimon.flink.action;
 import java.util.Map;
 
 /** Delete branch action for Flink. */
-public class DeleteBranchAction extends TableActionBase {
+public class DeleteBranchAction extends TableActionBase implements LocalAction {
 
     private final String branchNames;
 
@@ -35,7 +35,7 @@ public class DeleteBranchAction extends TableActionBase {
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() {
         table.deleteBranches(branchNames);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DropPartitionAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DropPartitionAction.java
@@ -25,10 +25,9 @@ import java.util.List;
 import java.util.Map;
 
 /** Table drop partition action for Flink. */
-public class DropPartitionAction extends TableActionBase {
+public class DropPartitionAction extends TableActionBase implements LocalAction {
 
     private final List<Map<String, String>> partitions;
-    private final BatchTableCommit commit;
 
     public DropPartitionAction(
             String databaseName,
@@ -44,11 +43,11 @@ public class DropPartitionAction extends TableActionBase {
         }
 
         this.partitions = partitions;
-        this.commit = table.newBatchWriteBuilder().newCommit();
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() throws Exception {
+        BatchTableCommit commit = table.newBatchWriteBuilder().newCommit();
         commit.truncatePartitions(partitions);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireChangelogsAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireChangelogsAction.java
@@ -20,12 +20,10 @@ package org.apache.paimon.flink.action;
 
 import org.apache.paimon.flink.procedure.ExpireChangelogsProcedure;
 
-import org.apache.flink.table.procedure.DefaultProcedureContext;
-
 import java.util.Map;
 
 /** Expire changelogs action for Flink. */
-public class ExpireChangelogsAction extends ActionBase {
+public class ExpireChangelogsAction extends ActionBase implements LocalAction {
     private final String database;
     private final String table;
     private final Integer retainMax;
@@ -53,11 +51,11 @@ public class ExpireChangelogsAction extends ActionBase {
         this.deleteAll = deleteAll;
     }
 
-    public void run() throws Exception {
+    public void executeLocally() throws Exception {
         ExpireChangelogsProcedure expireChangelogsProcedure = new ExpireChangelogsProcedure();
         expireChangelogsProcedure.withCatalog(catalog);
         expireChangelogsProcedure.call(
-                new DefaultProcedureContext(env),
+                null,
                 database + "." + table,
                 retainMax,
                 retainMin,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireSnapshotsAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireSnapshotsAction.java
@@ -20,12 +20,10 @@ package org.apache.paimon.flink.action;
 
 import org.apache.paimon.flink.procedure.ExpireSnapshotsProcedure;
 
-import org.apache.flink.table.procedure.DefaultProcedureContext;
-
 import java.util.Map;
 
 /** Expire snapshots action for Flink. */
-public class ExpireSnapshotsAction extends ActionBase {
+public class ExpireSnapshotsAction extends ActionBase implements LocalAction {
 
     private final String database;
     private final String table;
@@ -54,16 +52,10 @@ public class ExpireSnapshotsAction extends ActionBase {
         this.options = options;
     }
 
-    public void run() throws Exception {
+    public void executeLocally() throws Exception {
         ExpireSnapshotsProcedure expireSnapshotsProcedure = new ExpireSnapshotsProcedure();
         expireSnapshotsProcedure.withCatalog(catalog);
         expireSnapshotsProcedure.call(
-                new DefaultProcedureContext(env),
-                database + "." + table,
-                retainMax,
-                retainMin,
-                olderThan,
-                maxDeletes,
-                options);
+                null, database + "." + table, retainMax, retainMin, olderThan, maxDeletes, options);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireTagsAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireTagsAction.java
@@ -20,12 +20,10 @@ package org.apache.paimon.flink.action;
 
 import org.apache.paimon.flink.procedure.ExpireTagsProcedure;
 
-import org.apache.flink.table.procedure.DefaultProcedureContext;
-
 import java.util.Map;
 
 /** Expire tags action for Flink. */
-public class ExpireTagsAction extends ActionBase {
+public class ExpireTagsAction extends ActionBase implements LocalAction {
 
     private final String database;
     private final String table;
@@ -40,10 +38,9 @@ public class ExpireTagsAction extends ActionBase {
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() throws Exception {
         ExpireTagsProcedure expireTagsProcedure = new ExpireTagsProcedure();
         expireTagsProcedure.withCatalog(catalog);
-        expireTagsProcedure.call(
-                new DefaultProcedureContext(env), database + "." + table, olderThan);
+        expireTagsProcedure.call(null, database + "." + table, olderThan);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/FastForwardAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/FastForwardAction.java
@@ -21,7 +21,7 @@ package org.apache.paimon.flink.action;
 import java.util.Map;
 
 /** Fast Forward action for Flink. */
-public class FastForwardAction extends TableActionBase {
+public class FastForwardAction extends TableActionBase implements LocalAction {
     private final String branchName;
 
     public FastForwardAction(
@@ -34,7 +34,7 @@ public class FastForwardAction extends TableActionBase {
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() throws Exception {
         table.fastForward(branchName);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/LocalAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/LocalAction.java
@@ -18,24 +18,12 @@
 
 package org.apache.paimon.flink.action;
 
-import java.util.Map;
+import java.io.Serializable;
 
-/** Delete tag action for Flink. */
-public class DeleteTagAction extends TableActionBase implements LocalAction {
-
-    private final String tagNameStr;
-
-    public DeleteTagAction(
-            String databaseName,
-            String tableName,
-            Map<String, String> catalogConfig,
-            String tagNameStr) {
-        super(databaseName, tableName, catalogConfig);
-        this.tagNameStr = tagNameStr;
-    }
-
-    @Override
-    public void executeLocally() throws Exception {
-        table.deleteTags(tagNameStr);
-    }
+/**
+ * Interface for {@link Action}s that are recommended to be executed locally without starting a
+ * Flink job.
+ */
+public interface LocalAction extends Action, Serializable {
+    void executeLocally() throws Exception;
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MarkPartitionDoneAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MarkPartitionDoneAction.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import static org.apache.paimon.flink.sink.listener.PartitionMarkDoneListener.markDone;
 
 /** Table partition mark done action for Flink. */
-public class MarkPartitionDoneAction extends TableActionBase {
+public class MarkPartitionDoneAction extends TableActionBase implements LocalAction {
 
     private final FileStoreTable fileStoreTable;
     private final List<Map<String, String>> partitions;
@@ -52,7 +52,7 @@ public class MarkPartitionDoneAction extends TableActionBase {
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() throws Exception {
         List<PartitionMarkDoneAction> actions =
                 PartitionMarkDoneAction.createActions(
                         getClass().getClassLoader(), fileStoreTable, fileStoreTable.coreOptions());

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateDatabaseAction.java
@@ -20,12 +20,10 @@ package org.apache.paimon.flink.action;
 
 import org.apache.paimon.flink.procedure.MigrateDatabaseProcedure;
 
-import org.apache.flink.table.procedure.DefaultProcedureContext;
-
 import java.util.Map;
 
 /** Migrate from external all hive table in database to paimon table. */
-public class MigrateDatabaseAction extends ActionBase {
+public class MigrateDatabaseAction extends ActionBase implements LocalAction {
     private final String connector;
     private final String hiveDatabaseName;
     private final String tableProperties;
@@ -45,14 +43,10 @@ public class MigrateDatabaseAction extends ActionBase {
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() throws Exception {
         MigrateDatabaseProcedure migrateDatabaseProcedure = new MigrateDatabaseProcedure();
         migrateDatabaseProcedure.withCatalog(catalog);
         migrateDatabaseProcedure.call(
-                new DefaultProcedureContext(env),
-                connector,
-                hiveDatabaseName,
-                tableProperties,
-                parallelism);
+                null, connector, hiveDatabaseName, tableProperties, parallelism);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateIcebergTableAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateIcebergTableAction.java
@@ -20,12 +20,10 @@ package org.apache.paimon.flink.action;
 
 import org.apache.paimon.flink.procedure.MigrateIcebergTableProcedure;
 
-import org.apache.flink.table.procedure.DefaultProcedureContext;
-
 import java.util.Map;
 
 /** Migrate from iceberg table to paimon table. */
-public class MigrateIcebergTableAction extends ActionBase {
+public class MigrateIcebergTableAction extends ActionBase implements LocalAction {
 
     private final String sourceTableFullName;
     private final String tableProperties;
@@ -47,15 +45,11 @@ public class MigrateIcebergTableAction extends ActionBase {
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() throws Exception {
         MigrateIcebergTableProcedure migrateIcebergTableProcedure =
                 new MigrateIcebergTableProcedure();
         migrateIcebergTableProcedure.withCatalog(catalog);
         migrateIcebergTableProcedure.call(
-                new DefaultProcedureContext(env),
-                sourceTableFullName,
-                icebergProperties,
-                tableProperties,
-                parallelism);
+                null, sourceTableFullName, icebergProperties, tableProperties, parallelism);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateTableAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateTableAction.java
@@ -20,12 +20,10 @@ package org.apache.paimon.flink.action;
 
 import org.apache.paimon.flink.procedure.MigrateTableProcedure;
 
-import org.apache.flink.table.procedure.DefaultProcedureContext;
-
 import java.util.Map;
 
 /** Migrate from external hive table to paimon table. */
-public class MigrateTableAction extends ActionBase {
+public class MigrateTableAction extends ActionBase implements LocalAction {
 
     private final String connector;
     private final String hiveTableFullName;
@@ -46,16 +44,10 @@ public class MigrateTableAction extends ActionBase {
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() throws Exception {
         MigrateTableProcedure migrateTableProcedure = new MigrateTableProcedure();
         migrateTableProcedure.withCatalog(catalog);
         migrateTableProcedure.call(
-                new DefaultProcedureContext(env),
-                connector,
-                hiveTableFullName,
-                null,
-                tableProperties,
-                parallelism,
-                null);
+                null, connector, hiveTableFullName, null, tableProperties, parallelism, null);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RenameTagAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RenameTagAction.java
@@ -23,7 +23,7 @@ import org.apache.paimon.utils.StringUtils;
 import java.util.Map;
 
 /** Rename Tag action for Flink. */
-public class RenameTagAction extends TableActionBase {
+public class RenameTagAction extends TableActionBase implements LocalAction {
     private final String tagName;
     private final String targetTagName;
 
@@ -39,7 +39,7 @@ public class RenameTagAction extends TableActionBase {
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() throws Exception {
         if (StringUtils.isEmpty(tagName) || StringUtils.isEmpty(targetTagName)) {
             throw new RuntimeException(
                     String.format(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RepairAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RepairAction.java
@@ -20,12 +20,10 @@ package org.apache.paimon.flink.action;
 
 import org.apache.paimon.flink.procedure.RepairProcedure;
 
-import org.apache.flink.table.procedure.DefaultProcedureContext;
-
 import java.util.Map;
 
 /** Repair action for Flink. */
-public class RepairAction extends ActionBase {
+public class RepairAction extends ActionBase implements LocalAction {
 
     private final String identifier;
 
@@ -35,9 +33,9 @@ public class RepairAction extends ActionBase {
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() throws Exception {
         RepairProcedure repairProcedure = new RepairProcedure();
         repairProcedure.withCatalog(catalog);
-        repairProcedure.call(new DefaultProcedureContext(env), identifier);
+        repairProcedure.call(null, identifier);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ReplaceTagAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ReplaceTagAction.java
@@ -24,7 +24,7 @@ import java.time.Duration;
 import java.util.Map;
 
 /** Replace tag action for Flink. */
-public class ReplaceTagAction extends TableActionBase {
+public class ReplaceTagAction extends TableActionBase implements LocalAction {
 
     private final String tagName;
     private final @Nullable Long snapshotId;
@@ -44,7 +44,7 @@ public class ReplaceTagAction extends TableActionBase {
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() throws Exception {
         table.replaceTag(tagName, snapshotId, timeRetained);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ResetConsumerAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ResetConsumerAction.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /** Reset consumer action for Flink. */
-public class ResetConsumerAction extends TableActionBase {
+public class ResetConsumerAction extends TableActionBase implements LocalAction {
 
     private final String consumerId;
     private Long nextSnapshotId;
@@ -46,7 +46,7 @@ public class ResetConsumerAction extends TableActionBase {
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() throws Exception {
         FileStoreTable dataTable = (FileStoreTable) table;
         ConsumerManager consumerManager =
                 new ConsumerManager(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RollbackToAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RollbackToAction.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Map;
 
 /** Rollback to specific version action for Flink. */
-public class RollbackToAction extends TableActionBase {
+public class RollbackToAction extends TableActionBase implements LocalAction {
 
     private static final Logger LOG = LoggerFactory.getLogger(RollbackToAction.class);
 
@@ -42,7 +42,7 @@ public class RollbackToAction extends TableActionBase {
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() throws Exception {
         LOG.debug("Run rollback-to action with snapshot id '{}'.", version);
 
         if (!(table instanceof DataTable)) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RollbackToTimestampAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RollbackToTimestampAction.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Map;
 
 /** Rollback to specific timestamp action for Flink. */
-public class RollbackToTimestampAction extends TableActionBase {
+public class RollbackToTimestampAction extends TableActionBase implements LocalAction {
 
     private static final Logger LOG = LoggerFactory.getLogger(RollbackToTimestampAction.class);
 
@@ -45,7 +45,7 @@ public class RollbackToTimestampAction extends TableActionBase {
     }
 
     @Override
-    public void run() throws Exception {
+    public void executeLocally() throws Exception {
         LOG.debug("Run rollback-to-timestamp action with timestamp '{}'.", timestamp);
 
         if (!(table instanceof DataTable)) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ActionJobCoverageTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ActionJobCoverageTest.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.reflections.Reflections;
+import org.reflections.scanners.Scanners;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/** Test to verify that all Flink Actions support starting Flink jobs. */
+public class ActionJobCoverageTest {
+    private static final Logger LOG = LoggerFactory.getLogger(ActionJobCoverageTest.class);
+
+    @Test
+    public void testAllActionSupportsFlinkJob() throws Exception {
+        // Get all Action subclasses using reflections
+        Reflections reflections =
+                new Reflections(
+                        new ConfigurationBuilder()
+                                .setUrls(ClasspathHelper.forPackage("org.apache.paimon.flink"))
+                                .setScanners(Scanners.SubTypes));
+
+        Set<Class<? extends Action>> actionClasses =
+                reflections.getSubTypesOf(Action.class).stream()
+                        .filter(x -> !Modifier.isAbstract(x.getModifiers()) && !x.isInterface())
+                        .collect(Collectors.toSet());
+
+        assertThat(actionClasses).isNotEmpty();
+
+        // In order for an action to support flink job, it should satisfy any of the following
+        // requirements.
+        for (Class<? extends Action> actionClass : actionClasses) {
+            // 1. it implements LocalAction.
+            if (LocalAction.class.isAssignableFrom(actionClass)) {
+                continue;
+            }
+
+            Method runMethod = actionClass.getMethod("run");
+
+            // 2. Its run() method body has env.execute() calls.
+            if (haveEnvExecutePattern(runMethod)) {
+                continue;
+            }
+
+            fail(String.format("Action %s might not support starting Flink jobs.", actionClass));
+        }
+    }
+
+    private boolean haveEnvExecutePattern(Method runMethod) throws IOException {
+        // Use ASM to analyze the bytecode of the run() method
+        String className = runMethod.getDeclaringClass().getName().replace('.', '/');
+        String methodName = runMethod.getName();
+        String methodDesc = org.objectweb.asm.Type.getMethodDescriptor(runMethod);
+
+        InputStream classFile =
+                runMethod.getDeclaringClass().getResourceAsStream("/" + className + ".class");
+        if (classFile == null) {
+            LOG.warn("Failed to load class file for {}", className);
+            return false;
+        }
+
+        ClassReader classReader = new ClassReader(classFile);
+        EnvExecuteMethodVisitor visitor = new EnvExecuteMethodVisitor(methodName, methodDesc);
+        classReader.accept(visitor, 0);
+
+        return visitor.hasEnvExecuteCall();
+    }
+
+    /** ASM visitor to check if a method contains env.execute() calls. */
+    private static class EnvExecuteMethodVisitor extends ClassVisitor {
+        private final String targetMethodName;
+        private final String targetMethodDesc;
+        private boolean hasEnvExecuteCall = false;
+
+        private static final List<Tuple2<String, String>> VALID_OWNER_AND_NAMES =
+                Arrays.asList(
+                        Tuple2.of(
+                                "org/apache/flink/streaming/api/environment/StreamExecutionEnvironment",
+                                "execute"),
+                        Tuple2.of("org/apache/flink/table/api/TableResult", "await"),
+                        Tuple2.of(
+                                "org/apache/flink/table/procedure/DefaultProcedureContext",
+                                "<init>"),
+                        Tuple2.of(
+                                "org/apache/paimon/flink/orphan/FlinkOrphanFilesClean",
+                                "executeDatabaseOrphanFiles"));
+
+        private static final List<Tuple2<String, String>> VALID_OWNER_PATTERN_AND_NAMES =
+                Collections.singletonList(
+                        Tuple2.of(
+                                "org/apache/paimon/flink/action/.*".replace("/", "\\/"),
+                                "execute"));
+
+        public EnvExecuteMethodVisitor(String methodName, String methodDesc) {
+            super(Opcodes.ASM9);
+            this.targetMethodName = methodName;
+            this.targetMethodDesc = methodDesc;
+        }
+
+        @Override
+        public MethodVisitor visitMethod(
+                int access, String name, String descriptor, String signature, String[] exceptions) {
+            if (name.equals(targetMethodName) && descriptor.equals(targetMethodDesc)) {
+                return new MethodVisitor(Opcodes.ASM9) {
+                    @Override
+                    public void visitMethodInsn(
+                            int opcode,
+                            String owner,
+                            String name,
+                            String descriptor,
+                            boolean isInterface) {
+                        // Check for env.execute() calls
+                        if (!hasEnvExecuteCall) {
+                            for (Tuple2<String, String> validOwnerAndName : VALID_OWNER_AND_NAMES) {
+                                if (owner.equals(validOwnerAndName.f0)
+                                        && name.equals(validOwnerAndName.f1)) {
+                                    hasEnvExecuteCall = true;
+                                    break;
+                                }
+                            }
+
+                            for (Tuple2<String, String> validOwnerPatternAndName :
+                                    VALID_OWNER_PATTERN_AND_NAMES) {
+                                if (owner.matches(validOwnerPatternAndName.f0)
+                                        && name.equals(validOwnerPatternAndName.f1)) {
+                                    hasEnvExecuteCall = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+                    }
+                };
+            }
+            return super.visitMethod(access, name, descriptor, signature, exceptions);
+        }
+
+        public boolean hasEnvExecuteCall() {
+            return hasEnvExecuteCall;
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ConsumerActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ConsumerActionITCase.java
@@ -28,12 +28,14 @@ import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.BlockingIterator;
 
+import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.types.Row;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -50,7 +52,7 @@ public class ConsumerActionITCase extends ActionITCaseBase {
 
     @ParameterizedTest
     @Timeout(60)
-    @ValueSource(strings = {"action", "procedure_indexed", "procedure_named"})
+    @ValueSource(strings = {"action", "action_job", "procedure_indexed", "procedure_named"})
     public void testResetConsumer(String invoker) throws Exception {
         init(warehouse);
 
@@ -114,6 +116,11 @@ public class ConsumerActionITCase extends ActionITCaseBase {
             case "action":
                 createAction(ResetConsumerAction.class, args).run();
                 break;
+            case "action_job":
+                args = new ArrayList<>(args);
+                args.add("--force_start_flink_job");
+                createAction(ResetConsumerAction.class, args).run();
+                break;
             case "procedure_indexed":
                 executeSQL(
                         String.format(
@@ -137,6 +144,11 @@ public class ConsumerActionITCase extends ActionITCaseBase {
         switch (invoker) {
             case "action":
                 createAction(ResetConsumerAction.class, args.subList(0, 9)).run();
+                break;
+            case "action_job":
+                List<String> subArgs = args.subList(0, 9);
+                subArgs.add("--force_start_flink_job");
+                createAction(ResetConsumerAction.class, subArgs).run();
                 break;
             case "procedure_indexed":
                 executeSQL(
@@ -175,6 +187,13 @@ public class ConsumerActionITCase extends ActionITCaseBase {
                         RuntimeException.class,
                         () -> createAction(ResetConsumerAction.class, args1).run());
                 break;
+            case "action_job":
+                List<String> args2 = new ArrayList<>(args1);
+                args2.add("--force_start_flink_job");
+                assertThrows(
+                        JobExecutionException.class,
+                        () -> createAction(ResetConsumerAction.class, args2).run());
+                break;
             case "procedure_indexed":
                 assertThrows(
                         TableException.class,
@@ -200,7 +219,7 @@ public class ConsumerActionITCase extends ActionITCaseBase {
 
     @ParameterizedTest
     @Timeout(60)
-    @ValueSource(strings = {"action", "procedure_indexed", "procedure_named"})
+    @ValueSource(strings = {"action", "action_job", "procedure_indexed", "procedure_named"})
     public void testResetBranchConsumer(String invoker) throws Exception {
         init(warehouse);
 
@@ -270,6 +289,11 @@ public class ConsumerActionITCase extends ActionITCaseBase {
             case "action":
                 createAction(ResetConsumerAction.class, args).run();
                 break;
+            case "action_job":
+                args = new ArrayList<>(args);
+                args.add("--force_start_flink_job");
+                createAction(ResetConsumerAction.class, args).run();
+                break;
             case "procedure_indexed":
                 executeSQL(
                         String.format(
@@ -294,6 +318,11 @@ public class ConsumerActionITCase extends ActionITCaseBase {
             case "action":
                 createAction(ResetConsumerAction.class, args.subList(0, 9)).run();
                 break;
+            case "action_job":
+                List<String> subArgs = args.subList(0, 9);
+                subArgs.add("--force_start_flink_job");
+                createAction(ResetConsumerAction.class, subArgs).run();
+                break;
             case "procedure_indexed":
                 executeSQL(
                         String.format(
@@ -315,7 +344,7 @@ public class ConsumerActionITCase extends ActionITCaseBase {
 
     @ParameterizedTest
     @Timeout(120)
-    @ValueSource(strings = {"action", "procedure_indexed", "procedure_named"})
+    @ValueSource(strings = {"action", "action_job", "procedure_indexed", "procedure_named"})
     public void testClearConsumers(String invoker) throws Exception {
         init(warehouse);
 
@@ -415,6 +444,11 @@ public class ConsumerActionITCase extends ActionITCaseBase {
             case "action":
                 createAction(ClearConsumerAction.class, args).run();
                 break;
+            case "action_job":
+                args = new ArrayList<>(args);
+                args.add("--force_start_flink_job");
+                createAction(ClearConsumerAction.class, args).run();
+                break;
             case "procedure_indexed":
                 executeSQL(
                         String.format(
@@ -455,6 +489,11 @@ public class ConsumerActionITCase extends ActionITCaseBase {
             case "action":
                 createAction(ClearConsumerAction.class, args).run();
                 break;
+            case "action_job":
+                args = new ArrayList<>(args);
+                args.add("--force_start_flink_job");
+                createAction(ClearConsumerAction.class, args).run();
+                break;
             case "procedure_indexed":
                 executeSQL(
                         String.format(
@@ -482,6 +521,11 @@ public class ConsumerActionITCase extends ActionITCaseBase {
         switch (invoker) {
             case "action":
                 createAction(ClearConsumerAction.class, args.subList(0, 7)).run();
+                break;
+            case "action_job":
+                List<String> subArgs = args.subList(0, 7);
+                subArgs.add("--force_start_flink_job");
+                createAction(ClearConsumerAction.class, subArgs).run();
                 break;
             case "procedure_indexed":
                 executeSQL(String.format("CALL sys.clear_consumers('%s.%s')", database, tableName));

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/DropPartitionActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/DropPartitionActionITCase.java
@@ -55,7 +55,8 @@ public class DropPartitionActionITCase extends ActionITCaseBase {
     public void testDropPartitionWithSinglePartitionKey(boolean hasPk) throws Exception {
         FileStoreTable table = prepareTable(hasPk);
 
-        if (ThreadLocalRandom.current().nextBoolean()) {
+        int mode = ThreadLocalRandom.current().nextInt(3);
+        if (mode == 0) {
 
             createAction(
                             DropPartitionAction.class,
@@ -68,6 +69,20 @@ public class DropPartitionActionITCase extends ActionITCaseBase {
                             tableName,
                             "--partition",
                             "partKey0=0")
+                    .run();
+        } else if (mode == 1) {
+            createAction(
+                            DropPartitionAction.class,
+                            "drop_partition",
+                            "--warehouse",
+                            warehouse,
+                            "--database",
+                            database,
+                            "--table",
+                            tableName,
+                            "--partition",
+                            "partKey0=0",
+                            "--force_start_flink_job")
                     .run();
         } else {
             executeSQL(
@@ -120,7 +135,8 @@ public class DropPartitionActionITCase extends ActionITCaseBase {
         partitions1.put("partKey0", "1");
         partitions1.put("partKey1", "0");
 
-        if (ThreadLocalRandom.current().nextBoolean()) {
+        int mode = ThreadLocalRandom.current().nextInt(3);
+        if (mode == 0) {
             createAction(
                             DropPartitionAction.class,
                             "drop_partition",
@@ -134,6 +150,22 @@ public class DropPartitionActionITCase extends ActionITCaseBase {
                             "partKey0=0,partKey1=1",
                             "--partition",
                             "partKey0=1,partKey1=0")
+                    .run();
+        } else if (mode == 1) {
+            createAction(
+                            DropPartitionAction.class,
+                            "drop_partition",
+                            "--warehouse",
+                            warehouse,
+                            "--database",
+                            database,
+                            "--table",
+                            tableName,
+                            "--partition",
+                            "partKey0=0,partKey1=1",
+                            "--partition",
+                            "partKey0=1,partKey1=0",
+                            "--force_start_flink_job")
                     .run();
         } else {
             executeSQL(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MarkPartitionDoneActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MarkPartitionDoneActionITCase.java
@@ -67,6 +67,8 @@ public class MarkPartitionDoneActionITCase extends ActionITCaseBase {
         return Stream.of(
                 Arguments.of(true, "action"),
                 Arguments.of(false, "action"),
+                Arguments.of(true, "action_job"),
+                Arguments.of(false, "action_job"),
                 Arguments.of(true, "procedure_indexed"),
                 Arguments.of(false, "procedure_indexed"),
                 Arguments.of(true, "procedure_named"),
@@ -92,6 +94,21 @@ public class MarkPartitionDoneActionITCase extends ActionITCaseBase {
                                 tableName,
                                 "--partition",
                                 "partKey0=0")
+                        .run();
+                break;
+            case "action_job":
+                createAction(
+                                MarkPartitionDoneAction.class,
+                                "mark_partition_done",
+                                "--warehouse",
+                                warehouse,
+                                "--database",
+                                database,
+                                "--table",
+                                tableName,
+                                "--partition",
+                                "partKey0=0",
+                                "--force_start_flink_job")
                         .run();
                 break;
             case "procedure_indexed":
@@ -136,6 +153,23 @@ public class MarkPartitionDoneActionITCase extends ActionITCaseBase {
                                 "partKey0=0,partKey1=1",
                                 "--partition",
                                 "partKey0=1,partKey1=0")
+                        .run();
+                break;
+            case "action_job":
+                createAction(
+                                MarkPartitionDoneAction.class,
+                                "mark_partition_done",
+                                "--warehouse",
+                                warehouse,
+                                "--database",
+                                database,
+                                "--table",
+                                tableName,
+                                "--partition",
+                                "partKey0=0,partKey1=1",
+                                "--partition",
+                                "partKey0=1,partKey1=0",
+                                "--force_start_flink_job")
                         .run();
                 break;
             case "procedure_indexed":
@@ -192,6 +226,23 @@ public class MarkPartitionDoneActionITCase extends ActionITCaseBase {
                                 "partKey0=0,partKey1=1",
                                 "--partition",
                                 "partKey0=1,partKey1=0")
+                        .run();
+                break;
+            case "action_job":
+                createAction(
+                                MarkPartitionDoneAction.class,
+                                "mark_partition_done",
+                                "--warehouse",
+                                warehouse,
+                                "--database",
+                                database,
+                                "--table",
+                                tableName,
+                                "--partition",
+                                "partKey0=0,partKey1=1",
+                                "--partition",
+                                "partKey0=1,partKey1=0",
+                                "--force_start_flink_job")
                         .run();
                 break;
             case "procedure_indexed":
@@ -257,6 +308,23 @@ public class MarkPartitionDoneActionITCase extends ActionITCaseBase {
                                     "partKey0=0,partKey1=1",
                                     "--partition",
                                     "partKey0=1,partKey1=0")
+                            .run();
+                    break;
+                case "action_job":
+                    createAction(
+                                    MarkPartitionDoneAction.class,
+                                    "mark_partition_done",
+                                    "--warehouse",
+                                    warehouse,
+                                    "--database",
+                                    database,
+                                    "--table",
+                                    tableName,
+                                    "--partition",
+                                    "partKey0=0,partKey1=1",
+                                    "--partition",
+                                    "partKey0=1,partKey1=0",
+                                    "--force_start_flink_job")
                             .run();
                     break;
                 case "procedure_indexed":

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/RollbackToActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/RollbackToActionITCase.java
@@ -50,7 +50,7 @@ public class RollbackToActionITCase extends ActionITCaseBase {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"action", "procedure_named", "procedure_indexed"})
+    @ValueSource(strings = {"action", "action_job", "procedure_named", "procedure_indexed"})
     public void rollbackToSnapshotTest(String invoker) throws Exception {
         FileStoreTable table =
                 createFileStoreTable(
@@ -83,6 +83,21 @@ public class RollbackToActionITCase extends ActionITCaseBase {
                                 "2")
                         .run();
                 break;
+            case "action_job":
+                createAction(
+                                RollbackToAction.class,
+                                "rollback_to",
+                                "--warehouse",
+                                warehouse,
+                                "--database",
+                                database,
+                                "--table",
+                                tableName,
+                                "--version",
+                                "2",
+                                "--force_start_flink_job")
+                        .run();
+                break;
             case "procedure_indexed":
                 executeSQL(
                         String.format(
@@ -105,7 +120,7 @@ public class RollbackToActionITCase extends ActionITCaseBase {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"action", "procedure_named", "procedure_indexed"})
+    @ValueSource(strings = {"action", "action_job", "procedure_named", "procedure_indexed"})
     public void rollbackToTagTest(String invoker) throws Exception {
         FileStoreTable table =
                 createFileStoreTable(
@@ -141,6 +156,21 @@ public class RollbackToActionITCase extends ActionITCaseBase {
                                 "tag2")
                         .run();
                 break;
+            case "action_job":
+                createAction(
+                                RollbackToAction.class,
+                                "rollback_to",
+                                "--warehouse",
+                                warehouse,
+                                "--database",
+                                database,
+                                "--table",
+                                tableName,
+                                "--version",
+                                "tag2",
+                                "--force_start_flink_job")
+                        .run();
+                break;
             case "procedure_indexed":
                 executeSQL(
                         String.format(
@@ -162,7 +192,7 @@ public class RollbackToActionITCase extends ActionITCaseBase {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"action", "procedure_named", "procedure_indexed"})
+    @ValueSource(strings = {"action", "action_job", "procedure_named", "procedure_indexed"})
     public void rollbackToTimestampTest(String invoker) throws Exception {
         FileStoreTable table =
                 createFileStoreTable(
@@ -193,6 +223,21 @@ public class RollbackToActionITCase extends ActionITCaseBase {
                                 tableName,
                                 "--timestamp",
                                 timestamp + "")
+                        .run();
+                break;
+            case "action_job":
+                createAction(
+                                RollbackToTimestampAction.class,
+                                "rollback_to_timestamp",
+                                "--warehouse",
+                                warehouse,
+                                "--database",
+                                database,
+                                "--table",
+                                tableName,
+                                "--timestamp",
+                                timestamp + "",
+                                "--force_start_flink_job")
                         .run();
                 break;
             case "procedure_indexed":

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/TagActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/TagActionITCase.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.stream.Stream;
 
 import static org.apache.paimon.flink.util.ReadWriteTableTestUtil.init;
 import static org.apache.paimon.flink.util.ReadWriteTableTestUtil.testBatchRead;
@@ -41,12 +40,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** IT cases for tag management actions. */
 public class TagActionITCase extends ActionITCaseBase {
 
-    private static Stream<String> testData() {
-        return Stream.of("action", "procedure_indexed", "procedure_named");
-    }
-
     @ParameterizedTest(name = "{0}")
-    @ValueSource(strings = {"action", "procedure_indexed", "procedure_named"})
+    @ValueSource(strings = {"action", "action_job", "procedure_indexed", "procedure_named"})
     public void testCreateAndDeleteTag(String invoker) throws Exception {
         init(warehouse);
 
@@ -74,6 +69,23 @@ public class TagActionITCase extends ActionITCaseBase {
         TagManager tagManager = new TagManager(table.fileIO(), table.location());
 
         switch (invoker) {
+            case "action_job":
+                createAction(
+                                CreateTagAction.class,
+                                "create_tag",
+                                "--warehouse",
+                                warehouse,
+                                "--database",
+                                database,
+                                "--table",
+                                tableName,
+                                "--tag_name",
+                                "tag2",
+                                "--snapshot",
+                                "2",
+                                "--force_start_flink_job")
+                        .run();
+                break;
             case "action":
                 createAction(
                                 CreateTagAction.class,
@@ -126,6 +138,21 @@ public class TagActionITCase extends ActionITCaseBase {
                                 "tag2")
                         .run();
                 break;
+            case "action_job":
+                createAction(
+                                DeleteTagAction.class,
+                                "delete_tag",
+                                "--warehouse",
+                                warehouse,
+                                "--database",
+                                database,
+                                "--table",
+                                tableName,
+                                "--tag_name",
+                                "tag2",
+                                "--force_start_flink_job")
+                        .run();
+                break;
             case "procedure_indexed":
                 executeSQL(
                         String.format("CALL sys.delete_tag('%s.%s', 'tag2')", database, tableName));
@@ -157,6 +184,23 @@ public class TagActionITCase extends ActionITCaseBase {
                                 "tag1",
                                 "--snapshot",
                                 "1")
+                        .run();
+                break;
+            case "action_job":
+                createAction(
+                                CreateTagAction.class,
+                                "create_tag",
+                                "--warehouse",
+                                warehouse,
+                                "--database",
+                                database,
+                                "--table",
+                                tableName,
+                                "--tag_name",
+                                "tag1",
+                                "--snapshot",
+                                "1",
+                                "--force_start_flink_job")
                         .run();
                 break;
             case "procedure_indexed":
@@ -192,6 +236,23 @@ public class TagActionITCase extends ActionITCaseBase {
                                 "3")
                         .run();
                 break;
+            case "action_job":
+                createAction(
+                                CreateTagAction.class,
+                                "create_tag",
+                                "--warehouse",
+                                warehouse,
+                                "--database",
+                                database,
+                                "--table",
+                                tableName,
+                                "--tag_name",
+                                "tag3",
+                                "--snapshot",
+                                "3",
+                                "--force_start_flink_job")
+                        .run();
+                break;
             case "procedure_indexed":
                 executeSQL(
                         String.format(
@@ -222,6 +283,21 @@ public class TagActionITCase extends ActionITCaseBase {
                                 "tag1,tag3")
                         .run();
                 break;
+            case "action_job":
+                createAction(
+                                DeleteTagAction.class,
+                                "delete_tag",
+                                "--warehouse",
+                                warehouse,
+                                "--database",
+                                database,
+                                "--table",
+                                tableName,
+                                "--tag_name",
+                                "tag1,tag3",
+                                "--force_start_flink_job")
+                        .run();
+                break;
             case "procedure_indexed":
                 executeSQL(
                         String.format(
@@ -241,7 +317,7 @@ public class TagActionITCase extends ActionITCaseBase {
     }
 
     @ParameterizedTest(name = "{0}")
-    @ValueSource(strings = {"action", "procedure_indexed", "procedure_named"})
+    @ValueSource(strings = {"action", "action_job", "procedure_indexed", "procedure_named"})
     public void testRenameTag(String invoker) throws Exception {
         init(warehouse);
 
@@ -282,6 +358,21 @@ public class TagActionITCase extends ActionITCaseBase {
                                 "tag2")
                         .run();
                 break;
+            case "action_job":
+                createAction(
+                                CreateTagAction.class,
+                                "create_tag",
+                                "--warehouse",
+                                warehouse,
+                                "--database",
+                                database,
+                                "--table",
+                                tableName,
+                                "--tag_name",
+                                "tag2",
+                                "--force_start_flink_job")
+                        .run();
+                break;
             case "procedure_indexed":
                 executeSQL(
                         String.format(
@@ -315,6 +406,23 @@ public class TagActionITCase extends ActionITCaseBase {
                                 "tag3")
                         .run();
                 break;
+            case "action_job":
+                createAction(
+                                RenameTagAction.class,
+                                "rename_tag",
+                                "--warehouse",
+                                warehouse,
+                                "--database",
+                                database,
+                                "--table",
+                                tableName,
+                                "--tag_name",
+                                "tag2",
+                                "--target_tag_name",
+                                "tag3",
+                                "--force_start_flink_job")
+                        .run();
+                break;
             case "procedure_indexed":
                 executeSQL(
                         String.format(
@@ -336,7 +444,7 @@ public class TagActionITCase extends ActionITCaseBase {
     }
 
     @ParameterizedTest(name = "{0}")
-    @ValueSource(strings = {"action", "procedure_indexed", "procedure_named"})
+    @ValueSource(strings = {"action", "action_job", "procedure_indexed", "procedure_named"})
     public void testCreateLatestTag(String invoker) throws Exception {
         init(warehouse);
 
@@ -376,6 +484,21 @@ public class TagActionITCase extends ActionITCaseBase {
                                 tableName,
                                 "--tag_name",
                                 "tag2")
+                        .run();
+                break;
+            case "action_job":
+                createAction(
+                                CreateTagAction.class,
+                                "create_tag",
+                                "--warehouse",
+                                warehouse,
+                                "--database",
+                                database,
+                                "--table",
+                                tableName,
+                                "--tag_name",
+                                "tag2",
+                                "--force_start_flink_job")
                         .run();
                 break;
             case "procedure_indexed":

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateDatabaseProcedureITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateDatabaseProcedureITCase.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.HashMap;
 import java.util.List;
@@ -214,8 +213,8 @@ public class MigrateDatabaseProcedureITCase extends ActionITCaseBase {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"orc", "parquet", "avro"})
-    public void testMigrateDatabaseAction(String format) throws Exception {
+    @MethodSource("testArguments")
+    public void testMigrateDatabaseAction(String format, boolean startFlinkJob) throws Exception {
         TableEnvironment tEnv = tableEnvironmentBuilder().batchMode().build();
         tEnv.executeSql("CREATE CATALOG HIVE WITH ('type'='hive')");
         tEnv.useCatalog("HIVE");
@@ -255,6 +254,9 @@ public class MigrateDatabaseProcedureITCase extends ActionITCaseBase {
                 "warehouse", System.getProperty(HiveConf.ConfVars.METASTOREWAREHOUSE.varname));
         MigrateDatabaseAction migrateDatabaseAction =
                 new MigrateDatabaseAction("hive", "my_database", catalogConf, "", 6);
+        if (startFlinkJob) {
+            migrateDatabaseAction.forceStartFlinkJob();
+        }
         migrateDatabaseAction.run();
 
         tEnv.executeSql(

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateIcebergTableProcedureITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateIcebergTableProcedureITCase.java
@@ -35,15 +35,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Stream;
 
 /** Tests for {@link MigrateIcebergTableProcedure}. */
 public class MigrateIcebergTableProcedureITCase extends ActionITCaseBase {
@@ -57,6 +61,16 @@ public class MigrateIcebergTableProcedureITCase extends ActionITCaseBase {
 
     @TempDir java.nio.file.Path iceTempDir;
     @TempDir java.nio.file.Path paiTempDir;
+
+    public static Stream<Arguments> actionArguments() {
+        List<Arguments> argumentsList = new ArrayList<>();
+        for (boolean isPartitioned : Arrays.asList(false, true)) {
+            for (boolean startFlinkJob : Arrays.asList(false, true)) {
+                argumentsList.add(Arguments.of(isPartitioned, startFlinkJob));
+            }
+        }
+        return argumentsList.stream();
+    }
 
     @BeforeEach
     public void beforeEach() {
@@ -145,8 +159,9 @@ public class MigrateIcebergTableProcedureITCase extends ActionITCaseBase {
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {false, true})
-    public void testMigrateIcebergTableAction(boolean isPartitioned) throws Exception {
+    @MethodSource("actionArguments")
+    public void testMigrateIcebergTableAction(boolean isPartitioned, boolean startFlinkJob)
+            throws Exception {
         TableEnvironment tEnv =
                 TableEnvironmentImpl.create(
                         EnvironmentSettings.newInstance().inBatchMode().build());
@@ -186,6 +201,9 @@ public class MigrateIcebergTableProcedureITCase extends ActionITCaseBase {
         MigrateIcebergTableAction migrateIcebergTableAction =
                 new MigrateIcebergTableAction(
                         "default." + icebergTable, catalogConf, icebergOptions, "", 6);
+        if (startFlinkJob) {
+            migrateIcebergTableAction.forceStartFlinkJob();
+        }
         migrateIcebergTableAction.run();
 
         tEnv.executeSql(paimonCatalogDdl(true));

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateTableProcedureITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/MigrateTableProcedureITCase.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.HashMap;
 import java.util.List;
@@ -59,12 +58,22 @@ public class MigrateTableProcedureITCase extends ActionITCaseBase {
         TEST_HIVE_METASTORE.stop();
     }
 
-    private static Stream<Arguments> testArguments() {
+    private static Stream<Arguments> testProcedureArguments() {
         return Stream.of(Arguments.of("orc"), Arguments.of("avro"), Arguments.of("parquet"));
     }
 
+    private static Stream<Arguments> testActionArguments() {
+        return Stream.of(
+                Arguments.of("orc", false),
+                Arguments.of("avro", false),
+                Arguments.of("parquet", false),
+                Arguments.of("orc", true),
+                Arguments.of("avro", true),
+                Arguments.of("parquet", true));
+    }
+
     @ParameterizedTest
-    @MethodSource("testArguments")
+    @MethodSource("testProcedureArguments")
     public void testMigrateProcedure(String format) throws Exception {
         testUpgradeNonPartitionTable(format);
         resetMetastore();
@@ -142,8 +151,8 @@ public class MigrateTableProcedureITCase extends ActionITCaseBase {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"orc", "parquet", "avro"})
-    public void testMigrateAction(String format) throws Exception {
+    @MethodSource("testActionArguments")
+    public void testMigrateAction(String format, boolean startFlinkJob) throws Exception {
         TableEnvironment tEnv = tableEnvironmentBuilder().batchMode().build();
         tEnv.executeSql("CREATE CATALOG HIVE WITH ('type'='hive')");
         tEnv.useCatalog("HIVE");
@@ -165,6 +174,9 @@ public class MigrateTableProcedureITCase extends ActionITCaseBase {
                 "warehouse", System.getProperty(HiveConf.ConfVars.METASTOREWAREHOUSE.varname));
         MigrateTableAction migrateTableAction =
                 new MigrateTableAction("hive", "default.hivetable", catalogConf, "", 6);
+        if (startFlinkJob) {
+            migrateTableAction.forceStartFlinkJob();
+        }
         migrateTableAction.run();
 
         tEnv.executeSql(

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/RepairActionITCase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/procedure/RepairActionITCase.java
@@ -29,7 +29,8 @@ import org.apache.flink.types.Row;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.HashMap;
 import java.util.List;
@@ -54,8 +55,9 @@ public class RepairActionITCase extends ActionITCaseBase {
         TEST_HIVE_METASTORE.stop();
     }
 
-    @Test
-    public void testRepairTableAction() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testRepairTableAction(boolean startFlinkJob) throws Exception {
         TableEnvironment tEnv = tableEnvironmentBuilder().batchMode().build();
         tEnv.executeSql(
                 "CREATE CATALOG PAIMON WITH ('type'='paimon', 'metastore' = 'hive', 'uri' = 'thrift://localhost:"
@@ -86,6 +88,9 @@ public class RepairActionITCase extends ActionITCaseBase {
         catalogConf.put(
                 "warehouse", System.getProperty(HiveConf.ConfVars.METASTOREWAREHOUSE.varname));
         RepairAction repairAction = new RepairAction("test_db.t_repair_hive", catalogConf);
+        if (startFlinkJob) {
+            repairAction.forceStartFlinkJob();
+        }
         repairAction.run();
 
         List<Row> ret =


### PR DESCRIPTION
### Purpose

Currently Flink actions do not provide a unified experience for users. Some actions like CompactAction will start a Flink job, but others like CreateTagAction are lightweight and will not start a Flink job. This brings more complexity when DevOps are trying to integrate Flink Actions to their platforms, because they need to provide multiple execution pipelines for different Actions.

In order to solve this problem, this PR proposes to introduce the parameter `force_start_flink_job` and the method `ActionBase#forceStartFlinkJob` to support all actions to execute within a Flink job. This PR mainly includes the following changes:

* Adds `LocalAction` interface and uses it to mark actions that does not natively need a flink job.
* Makes `LocalAction` serializable, as a prerequisite to wrap them into Flink operators.
* Adds a common implementation in `ActionBase` to execute `LocalAction`s in Flink job.
* Introduces the parameter `force_start_flink_job` and the method `ActionBase#forceStartFlinkJob` as user interface.

### Tests

* Existing action unit tests are modified to test the flink job mode, for example `BranchActionITCase`.
* `ActionJobCoverageTest` is introduced to make sure all actions have provided a Flink job execution mode. This test case will also remind developers to support this feature when new actions are introduced in future.

### API and Format

This PR introduces the parameter `force_start_flink_job` and the method `ActionBase#forceStartFlinkJob` to support all actions to execute within a Flink job.

### Documentation

The new feature is documented in the Flink Actions section.
