### PR TITLE
[core] The TopN predicate for range-bitmap supports multiple sort keys

### DIFF
--- a/docs/content/concepts/spec/fileindex.md
+++ b/docs/content/concepts/spec/fileindex.md
@@ -268,7 +268,7 @@ SELECT * FROM TABLE WHERE dt = '20250801' ORDER BY score ASC LIMIT 10;
 
 SELECT * FROM TABLE WHERE dt = '20250801' ORDER BY score DESC LIMIT 10;
 
--- support multi sort keys, and the first sort key must be created with range-bitmap.
+-- if there are multiple sort keys, the first sort key must be created with range-bitmap.
 SELECT * FROM TABLE WHERE dt = '20250801' ORDER BY score ASC, col DESC LIMIT 10;
 SELECT * FROM TABLE WHERE dt = '20250801' ORDER BY score DESC, col ASC LIMIT 10;
 ```

--- a/docs/content/concepts/spec/fileindex.md
+++ b/docs/content/concepts/spec/fileindex.md
@@ -267,6 +267,10 @@ For now, the `TOPN` predicate optimization can not using with other predicates, 
 SELECT * FROM TABLE WHERE dt = '20250801' ORDER BY score ASC LIMIT 10;
 
 SELECT * FROM TABLE WHERE dt = '20250801' ORDER BY score DESC LIMIT 10;
+
+-- support multi sort keys, and the first sort key must be created with range-bitmap.
+SELECT * FROM TABLE WHERE dt = '20250801' ORDER BY score ASC, col DESC LIMIT 10;
+SELECT * FROM TABLE WHERE dt = '20250801' ORDER BY score DESC, col ASC LIMIT 10;
 ```
 
 <pre>

--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/bitmap/RangeBitmapIndexPushDownBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/bitmap/RangeBitmapIndexPushDownBenchmark.java
@@ -239,17 +239,25 @@ public class RangeBitmapIndexPushDownBenchmark {
 
     private void benchmarkMultipleTopN(Map<String, Table> tables, int bound, int k) {
         Benchmark benchmark =
-                new Benchmark("multiple-topn", ROW_COUNT).setNumWarmupIters(1).setOutputPerIteration(false);
+                new Benchmark("multiple-topn", ROW_COUNT)
+                        .setNumWarmupIters(1)
+                        .setOutputPerIteration(false);
         for (String name : tables.keySet()) {
             benchmark.addCase(
                     name + "-" + bound + "-" + k,
                     1,
                     () -> {
                         Table table = tables.get(name);
-                        List<SortValue> orders = Arrays.asList(
-                                new SortValue(new FieldRef(0, "k", DataTypes.INT()), DESCENDING, NULLS_LAST),
-                                new SortValue(new FieldRef(1, "f1", DataTypes.STRING()), ASCENDING, NULLS_LAST)
-                        );
+                        List<SortValue> orders =
+                                Arrays.asList(
+                                        new SortValue(
+                                                new FieldRef(0, "k", DataTypes.INT()),
+                                                DESCENDING,
+                                                NULLS_LAST),
+                                        new SortValue(
+                                                new FieldRef(1, "f1", DataTypes.STRING()),
+                                                ASCENDING,
+                                                NULLS_LAST));
                         TopN topN = new TopN(orders, k);
                         List<Split> splits = table.newReadBuilder().newScan().plan().splits();
                         AtomicLong readCount = new AtomicLong(0);

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexPredicate.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexPredicate.java
@@ -92,12 +92,6 @@ public class FileIndexPredicate implements Closeable {
             return result;
         }
 
-        // for now we only support single column.
-        List<SortValue> orders = topN.orders();
-        if (orders.size() != 1) {
-            return result;
-        }
-
         int k = topN.limit();
         if (result instanceof BitmapIndexResult) {
             long cardinality = ((BitmapIndexResult) result).get().getCardinality();
@@ -106,6 +100,7 @@ public class FileIndexPredicate implements Closeable {
             }
         }
 
+        List<SortValue> orders = topN.orders();
         String requiredName = orders.get(0).field().name();
         Set<FileIndexReader> readers = reader.readColumnIndex(requiredName);
         for (FileIndexReader reader : readers) {

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/BitSliceIndexBitmap.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/BitSliceIndexBitmap.java
@@ -152,6 +152,16 @@ public class BitSliceIndexBitmap {
         return gt(code - 1);
     }
 
+    /**
+     * Find k rows with largest values in a BSI.
+     *
+     * <p>Refer to algorithm 4.1 in the paper <a
+     * href="https://www.cs.umb.edu/~poneil/SIGBSTMH.pdf">Bit-Sliced Index Arithmetic</a>
+     *
+     * @param k K largest values.
+     * @param foundSet the selection.
+     * @param strict if true, the result will be trimmed; otherwise, it will not be.
+     */
     public RoaringBitmap32 topK(int k, @Nullable RoaringBitmap32 foundSet, boolean strict) {
         if (k == 0 || (foundSet != null && foundSet.isEmpty())) {
             return new RoaringBitmap32();
@@ -187,6 +197,7 @@ public class BitSliceIndexBitmap {
             return f;
         }
 
+        // return k rows
         long n = f.getCardinality() - k;
         if (n > 0) {
             Iterator<Integer> iterator = e.iterator();
@@ -198,6 +209,13 @@ public class BitSliceIndexBitmap {
         return f;
     }
 
+    /**
+     * Find k rows with smallest values in a BSI.
+     *
+     * @param k K smallest values.
+     * @param foundSet the selection.
+     * @param strict if true, the result will be trimmed; otherwise, it will not be.
+     */
     public RoaringBitmap32 bottomK(int k, @Nullable RoaringBitmap32 foundSet, boolean strict) {
         if (k == 0 || (foundSet != null && foundSet.isEmpty())) {
             return new RoaringBitmap32();
@@ -234,6 +252,7 @@ public class BitSliceIndexBitmap {
             return f;
         }
 
+        // return k rows
         long n = f.getCardinality() - k;
         if (n > 0) {
             Iterator<Integer> iterator = e.iterator();

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndex.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndex.java
@@ -155,18 +155,14 @@ public class RangeBitmapFileIndex implements FileIndexer {
 
         @Override
         public FileIndexResult visitTopN(TopN topN, FileIndexResult result) {
-            List<SortValue> orders = topN.orders();
-
-            // If multiple columns, use first column with strict=false (allow duplicates)
-            boolean strict = orders.size() == 1;
-            SortValue sort = orders.get(0);
-
             RoaringBitmap32 foundSet =
                     result instanceof BitmapIndexResult ? ((BitmapIndexResult) result).get() : null;
 
             int limit = topN.limit();
+            List<SortValue> orders = topN.orders();
+            SortValue sort = orders.get(0);
             SortValue.NullOrdering nullOrdering = sort.nullOrdering();
-
+            boolean strict = orders.size() == 1;
             if (ASCENDING.equals(sort.direction())) {
                 return new BitmapIndexResult(
                         () -> bitmap.bottomK(limit, nullOrdering, foundSet, strict));

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/TopN.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/TopN.java
@@ -20,12 +20,14 @@ package org.apache.paimon.predicate;
 
 import org.apache.paimon.predicate.SortValue.NullOrdering;
 import org.apache.paimon.predicate.SortValue.SortDirection;
-import org.apache.paimon.utils.Preconditions;
 
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.apache.paimon.utils.ListUtils.isNullOrEmpty;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Represents the TopN predicate. */
 public class TopN implements Serializable {
@@ -36,7 +38,8 @@ public class TopN implements Serializable {
     private final int limit;
 
     public TopN(List<SortValue> orders, int limit) {
-        this.orders = Preconditions.checkNotNull(orders);
+        checkArgument(!isNullOrEmpty(orders), "orders should not be null or empty");
+        this.orders = orders;
         this.limit = limit;
     }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
@@ -104,37 +104,39 @@ class PaimonScanBuilder(table: InnerTable)
       return false
     }
 
-    if (orders.length != 1) {
-      return false
-    }
+    val sorts: List[SortValue] = orders
+      .map(
+        order => {
+          val fieldName = order.expression() match {
+            case nr: NamedReference => nr.fieldNames.mkString(".")
+            case _ => return false
+          }
 
-    val fieldName = orders.head.expression() match {
-      case nr: NamedReference => nr.fieldNames.mkString(".")
-      case _ => return false
-    }
+          val rowType = table.rowType()
+          if (rowType.notContainsField(fieldName)) {
+            return false
+          }
 
-    val rowType = table.rowType()
-    if (rowType.notContainsField(fieldName)) {
-      return false
-    }
+          val field = rowType.getField(fieldName)
+          val ref = new FieldRef(field.id(), field.name(), field.`type`())
 
-    val field = rowType.getField(fieldName)
-    val ref = new FieldRef(field.id(), field.name(), field.`type`())
+          val nullOrdering = order.nullOrdering() match {
+            case expressions.NullOrdering.NULLS_LAST => NullOrdering.NULLS_LAST
+            case expressions.NullOrdering.NULLS_FIRST => NullOrdering.NULLS_FIRST
+            case _ => return false
+          }
 
-    val nullOrdering = orders.head.nullOrdering() match {
-      case expressions.NullOrdering.NULLS_LAST => NullOrdering.NULLS_LAST
-      case expressions.NullOrdering.NULLS_FIRST => NullOrdering.NULLS_FIRST
-      case _ => return false
-    }
+          val direction = order.direction() match {
+            case expressions.SortDirection.DESCENDING => SortDirection.DESCENDING
+            case expressions.SortDirection.ASCENDING => SortDirection.ASCENDING
+            case _ => return false
+          }
 
-    val direction = orders.head.direction() match {
-      case expressions.SortDirection.DESCENDING => SortDirection.DESCENDING
-      case expressions.SortDirection.ASCENDING => SortDirection.ASCENDING
-      case _ => return false
-    }
+          new SortValue(ref, direction, nullOrdering)
+        })
+      .toList
 
-    val sort = new SortValue(ref, direction, nullOrdering)
-    pushDownTopN = Some(new TopN(Collections.singletonList(sort), limit))
+    pushDownTopN = Some(new TopN(sorts.asJava, limit))
 
     // just make the best effort to push down TopN
     false


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

Wrap up #6178

Suppose the `id` has created with `range-bitmap`.
position | id | price
--|--|--|
0|10 | 100
1|20 | 100
2|20 | 200
3|20 | 300
4|30 | 100

`SELECT * FROM id DESC LIMIT 2` will return
position | id | price
--|--|--|
3|20 | 300
4|30 | 100

`SELECT * FROM id DESC, price LIMIT 2` will return this. And the compute engine will rerank the result.
position | id | price
--|--|--|
1|20 | 100
2|20 | 200
3|20 | 300
4|30 | 100


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
