### PR TITLE
[core] fix RESTCatalog#listViews for system database

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -68,6 +68,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -844,7 +845,9 @@ public class RESTCatalog implements Catalog {
     @Override
     public List<String> listViews(String databaseName) throws DatabaseNotExistException {
         try {
-            return api.listViews(databaseName);
+            return CatalogUtils.isSystemDatabase(databaseName)
+                    ? Collections.emptyList()
+                    : api.listViews(databaseName);
         } catch (NoSuchResourceException e) {
             throw new DatabaseNotExistException(databaseName);
         }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -840,6 +840,8 @@ public abstract class CatalogTestBase {
                 .containsExactlyInAnyOrder(
                         AllTableOptionsTable.ALL_TABLE_OPTIONS,
                         CatalogOptionsTable.CATALOG_OPTIONS);
+
+        assertThat(catalog.listViews(SYSTEM_DATABASE_NAME)).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
### Purpose

When Flink invokes listTables for system database, it would invoke Paimon's both listTables and listViews method(#5910). Thus for REST catalog, it needs to also handle listViews for system database, instead of just handling listTables(#5274).

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
