### PR TITLE
[python] Add _VALUE_STATS_COLS param to fix parse wrong bytes

### DIFF
--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -15,10 +15,9 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import fastavro
 from io import BytesIO
 from typing import List
-
-import fastavro
 
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import (MANIFEST_ENTRY_SCHEMA,
@@ -66,8 +65,8 @@ class ManifestFileManager:
             elif not file_dict.get('_VALUE_STATS_COLS'):
                 fields = []
             value_stats = SimpleStats(
-                min_values=BinaryRowDeserializer.from_bytes(value_dict['_MIN_VALUES'], fields),
-                max_values=BinaryRowDeserializer.from_bytes(value_dict['_MAX_VALUES'], fields),
+                min_values=GenericRowDeserializer.from_bytes(value_dict['_MIN_VALUES'], fields),
+                max_values=GenericRowDeserializer.from_bytes(value_dict['_MAX_VALUES'], fields),
                 null_counts=value_dict['_NULL_COUNTS'],
             )
             file_meta = DataFileMeta(

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -61,11 +61,13 @@ class ManifestFileManager:
                 null_counts=key_dict['_NULL_COUNTS'],
             )
             value_dict = dict(file_dict['_VALUE_STATS'])
+            if file_dict.get('_VALUE_STATS_COLS') is None:
+                fields = self.table.table_schema.fields
+            elif not file_dict.get('_VALUE_STATS_COLS'):
+                fields = []
             value_stats = SimpleStats(
-                min_values=GenericRowDeserializer.from_bytes(value_dict['_MIN_VALUES'],
-                                                             self.table.table_schema.fields),
-                max_values=GenericRowDeserializer.from_bytes(value_dict['_MAX_VALUES'],
-                                                             self.table.table_schema.fields),
+                min_values=BinaryRowDeserializer.from_bytes(value_dict['_MIN_VALUES'], fields),
+                max_values=BinaryRowDeserializer.from_bytes(value_dict['_MAX_VALUES'], fields),
                 null_counts=value_dict['_NULL_COUNTS'],
             )
             file_meta = DataFileMeta(
@@ -85,6 +87,7 @@ class ManifestFileManager:
                 delete_row_count=file_dict['_DELETE_ROW_COUNT'],
                 embedded_index=file_dict['_EMBEDDED_FILE_INDEX'],
                 file_source=file_dict['_FILE_SOURCE'],
+                value_stats_cols=file_dict.get('_VALUE_STATS_COLS'),
             )
             entry = ManifestEntry(
                 kind=record['_KIND'],
@@ -132,6 +135,7 @@ class ManifestFileManager:
                     "_DELETE_ROW_COUNT": entry.file.delete_row_count,
                     "_EMBEDDED_FILE_INDEX": entry.file.embedded_index,
                     "_FILE_SOURCE": entry.file.file_source,
+                    "_VALUE_STATS_COLS": entry.file.value_stats_cols,
                 }
             }
             avro_records.append(avro_record)

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -64,6 +64,8 @@ class ManifestFileManager:
                 fields = self.table.table_schema.fields
             elif not file_dict.get('_VALUE_STATS_COLS'):
                 fields = []
+            else:
+                raise RuntimeError("_VALUE_STATS_COLS should be None or empty. We don't support other values now.")
             value_stats = SimpleStats(
                 min_values=GenericRowDeserializer.from_bytes(value_dict['_MIN_VALUES'], fields),
                 max_values=GenericRowDeserializer.from_bytes(value_dict['_MAX_VALUES'], fields),

--- a/paimon-python/pypaimon/manifest/schema/data_file_meta.py
+++ b/paimon-python/pypaimon/manifest/schema/data_file_meta.py
@@ -84,5 +84,8 @@ DATA_FILE_META_SCHEMA = {
         {"name": "_DELETE_ROW_COUNT", "type": ["null", "long"], "default": None},
         {"name": "_EMBEDDED_FILE_INDEX", "type": ["null", "bytes"], "default": None},
         {"name": "_FILE_SOURCE", "type": ["null", "int"], "default": None},
+        {"name": "_VALUE_STATS_COLS",
+         "type": ["null", {"type": "array", "items": "string"}],
+         "default": None},
     ]
 }

--- a/paimon-python/pypaimon/tests/py36/ao_read_write_test.py
+++ b/paimon-python/pypaimon/tests/py36/ao_read_write_test.py
@@ -421,10 +421,6 @@ class RESTTableReadWritePy36Test(RESTCatalogBaseTest):
 
         # Create test data with _KIND=1
         # For _KIND=1, value_stats should have empty BinaryRow for min_values and max_values
-        partition_fields = table.table_schema.get_partition_key_fields()
-        primary_key_fields = table.table_schema.get_trimmed_primary_key_fields()
-        all_fields = table.table_schema.fields
-
         # Create empty BinaryRows for _KIND=1 case
         empty_binary_row = BinaryRow([], [])
 

--- a/paimon-python/pypaimon/tests/py36/ao_read_write_test.py
+++ b/paimon-python/pypaimon/tests/py36/ao_read_write_test.py
@@ -34,10 +34,11 @@ from pypaimon.schema.schema import Schema
 from pypaimon.tests.py36.pyarrow_compat import table_sort_by
 from pypaimon.tests.rest_catalog_base_test import RESTCatalogBaseTest
 from pypaimon.manifest.manifest_file_manager import ManifestFileManager
-from pypaimon.table.row.binary_row import BinaryRow
 from pypaimon.manifest.schema.simple_stats import SimpleStats
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
+
+
 class RESTTableReadWritePy36Test(RESTCatalogBaseTest):
 
     def test_overwrite(self):

--- a/paimon-python/pypaimon/tests/reader_basic_test.py
+++ b/paimon-python/pypaimon/tests/reader_basic_test.py
@@ -249,10 +249,6 @@ class ReaderBasicTest(unittest.TestCase):
 
         # Create test data with _KIND=1
         # For _KIND=1, value_stats should have empty BinaryRow for min_values and max_values
-        partition_fields = table.table_schema.get_partition_key_fields()
-        primary_key_fields = table.table_schema.get_trimmed_primary_key_fields()
-        all_fields = table.table_schema.fields
-
         # Create empty BinaryRows for _KIND=1 case
         empty_binary_row = BinaryRow([], [])
 

--- a/paimon-python/pypaimon/tests/reader_basic_test.py
+++ b/paimon-python/pypaimon/tests/reader_basic_test.py
@@ -23,9 +23,8 @@ import unittest
 
 import pandas as pd
 import pyarrow as pa
-from pypaimon.table.row.row_kind import RowKind
 
-from pypaimon.table.row.generic_row import GenericRow, GenericRowSerializer, GenericRowDeserializer
+from pypaimon.table.row.generic_row import GenericRow
 
 from pypaimon.schema.data_types import DataField, AtomicType
 
@@ -202,75 +201,106 @@ class ReaderBasicTest(unittest.TestCase):
         expect = pd.DataFrame(self.raw_data)
         pd.testing.assert_frame_equal(actual.reset_index(drop=True), expect.reset_index(drop=True))
 
-    def test_to_bytes_with_long_string(self):
-        """Test serialization of strings longer than 7 bytes which require variable part storage."""
-        # Create fields with a long string value
-        fields = [
-            DataField(0, "long_string", AtomicType("STRING")),
-        ]
-
-        # String longer than 7 bytes will be stored in variable part
-        long_string = "This is a long string that exceeds 7 bytes"
-        values = [long_string]
-
-        binary_row = GenericRow(values, fields, RowKind.INSERT)
-        serialized_bytes = GenericRowSerializer.to_bytes(binary_row)
-
-        # Verify the last 6 bytes are 0
-        # This is because the variable part data is rounded to the nearest word (8 bytes)
-        # The last 6 bytes check is to ensure proper padding
-        self.assertEqual(serialized_bytes[-6:], b'\x00\x00\x00\x00\x00\x00')
-        self.assertEqual(serialized_bytes[20:62].decode('utf-8'), long_string)
-        # Deserialize to verify
-        deserialized_row = GenericRowDeserializer.from_bytes(serialized_bytes, fields)
-
-        self.assertEqual(deserialized_row.values[0], long_string)
-        self.assertEqual(deserialized_row.row_kind, RowKind.INSERT)
-
-    def test_manifest_entry_kind_1(self):
-        """Test ManifestEntry with _KIND=1, which should create empty BinaryRow for value_stats."""
+    def test_value_stats_cols_logic(self):
+        """Test _VALUE_STATS_COLS logic in ManifestFileManager."""
         # Create a catalog and table
         catalog = CatalogFactory.create({
             "warehouse": self.warehouse
         })
         catalog.create_database("test_db", False)
 
-        # Define schema
+        # Define schema with multiple fields
         pa_schema = pa.schema([
             ('id', pa.int64()),
             ('name', pa.string()),
-            ('price', pa.float64())
+            ('price', pa.float64()),
+            ('category', pa.string())
         ])
         schema = Schema.from_pyarrow_schema(pa_schema)
-        catalog.create_table("test_db.test_table", schema, False)
-        table = catalog.get_table("test_db.test_table")
+        catalog.create_table("test_db.test_value_stats_cols", schema, False)
+        table = catalog.get_table("test_db.test_value_stats_cols")
 
         # Create a ManifestFileManager
         manifest_manager = ManifestFileManager(table)
 
-        # Create test data with _KIND=1
-        # For _KIND=1, value_stats should have empty BinaryRow for min_values and max_values
-        # Create empty BinaryRows for _KIND=1 case
-        empty_binary_row = BinaryRow([], [])
-
-        # Create value_stats with empty BinaryRows for _KIND=1
-        value_stats = SimpleStats(
-            min_values=empty_binary_row,  # Empty for _KIND=1
-            max_values=empty_binary_row,  # Empty for _KIND=1
-            null_counts=[0, 0, 0]  # Null counts for each field
+        # Test case 1: _VALUE_STATS_COLS is None (should use all table fields)
+        self._test_value_stats_cols_case(
+            manifest_manager,
+            table,
+            value_stats_cols=None,
+            expected_fields_count=4,  # All 4 fields
+            test_name="none_case"
         )
 
-        # Create key_stats with actual data
-        # For this test, we'll use empty rows for key stats as well to keep it simple
+        # Test case 2: _VALUE_STATS_COLS is empty list (should use empty fields)
+        self._test_value_stats_cols_case(
+            manifest_manager,
+            table,
+            value_stats_cols=[],
+            expected_fields_count=0,  # No fields
+            test_name="empty_case"
+        )
+
+        # Test case 3: _VALUE_STATS_COLS has specific columns (should raise RuntimeError)
+        with self.assertRaises(RuntimeError) as context:
+            self._test_value_stats_cols_case(
+                manifest_manager,
+                table,
+                value_stats_cols=['id', 'name'],
+                expected_fields_count=2,  # Only 2 specified fields
+                test_name="specific_case"
+            )
+        self.assertEqual("_VALUE_STATS_COLS should be None or empty. We don't support other values now.",
+                         str(context.exception))
+
+    def _test_value_stats_cols_case(self, manifest_manager, table, value_stats_cols, expected_fields_count, test_name):
+        """Helper method to test a specific _VALUE_STATS_COLS case."""
+
+        # Create test data based on expected_fields_count
+        if expected_fields_count == 0:
+            # Empty fields case
+            test_fields = []
+            min_values = []
+            max_values = []
+            null_counts = []
+        elif expected_fields_count == 2:
+            # Specific fields case (id, name)
+            test_fields = [
+                DataField(0, "id", AtomicType("BIGINT")),
+                DataField(1, "name", AtomicType("STRING"))
+            ]
+            min_values = [1, "apple"]
+            max_values = [100, "zebra"]
+            null_counts = [0, 0]
+        else:
+            # All fields case
+            test_fields = table.table_schema.fields
+            min_values = [1, "apple", 10.5, "electronics"]
+            max_values = [100, "zebra", 999.9, "toys"]
+            null_counts = [0, 0, 0, 0]
+
+        # Create BinaryRows for min/max values
+        min_binary_row = GenericRow(min_values, test_fields) if test_fields else GenericRow([], [])
+        max_binary_row = GenericRow(max_values, test_fields) if test_fields else GenericRow([], [])
+
+        # Create value_stats
+        value_stats = SimpleStats(
+            min_values=min_binary_row,
+            max_values=max_binary_row,
+            null_counts=null_counts
+        )
+
+        # Create key_stats (empty for simplicity)
+        empty_binary_row = GenericRow([], [])
         key_stats = SimpleStats(
             min_values=empty_binary_row,
             max_values=empty_binary_row,
-            null_counts=[0, 0, 0]
+            null_counts=[]
         )
 
-        # Create a DataFileMeta
+        # Create DataFileMeta with value_stats_cols
         file_meta = DataFileMeta(
-            file_name="test-file.parquet",
+            file_name=f"test-file-{test_name}.parquet",
             file_size=1024,
             row_count=100,
             min_key=empty_binary_row,
@@ -285,12 +315,14 @@ class ReaderBasicTest(unittest.TestCase):
             creation_time=1234567890,
             delete_row_count=0,
             embedded_index=None,
-            file_source=None
+            file_source=None,
+            value_stats_cols=value_stats_cols,  # This is the key field we're testing
+            external_path=None
         )
 
-        # Create a ManifestEntry with _KIND=1
+        # Create ManifestEntry
         entry = ManifestEntry(
-            kind=1,  # _KIND=1
+            kind=0,  # Normal entry
             partition=empty_binary_row,
             bucket=0,
             total_buckets=1,
@@ -298,7 +330,7 @@ class ReaderBasicTest(unittest.TestCase):
         )
 
         # Write the manifest entry
-        manifest_file_name = "manifest-test-kind-1"
+        manifest_file_name = f"manifest-test-{test_name}"
         manifest_manager.write(manifest_file_name, [entry])
 
         # Read the manifest entry back
@@ -310,14 +342,29 @@ class ReaderBasicTest(unittest.TestCase):
         # Get the entry
         read_entry = entries[0]
 
-        # Verify _KIND is 1
-        self.assertEqual(read_entry.kind, 1)
+        # Verify value_stats_cols is preserved correctly
+        self.assertEqual(read_entry.file.value_stats_cols, value_stats_cols)
 
-        # Verify value_stats has empty BinaryRows for min_values and max_values when _KIND=1
-        self.assertIsInstance(read_entry.file.value_stats.min_values, BinaryRow)
-        self.assertIsInstance(read_entry.file.value_stats.max_values, BinaryRow)
-        self.assertEqual(len(read_entry.file.value_stats.min_values.values), 0)
-        self.assertEqual(len(read_entry.file.value_stats.max_values.values), 0)
+        # Verify value_stats structure based on the logic
+        if value_stats_cols is None:
+            # Should use all table fields - verify we have data for all fields
+            self.assertEqual(len(read_entry.file.value_stats.min_values.values), expected_fields_count)
+            self.assertEqual(len(read_entry.file.value_stats.max_values.values), expected_fields_count)
+            self.assertEqual(len(read_entry.file.value_stats.null_counts), expected_fields_count)
+        elif not value_stats_cols:  # Empty list
+            # Should use empty fields - verify we have no field data
+            self.assertEqual(len(read_entry.file.value_stats.min_values.values), 0)
+            self.assertEqual(len(read_entry.file.value_stats.max_values.values), 0)
+            self.assertEqual(len(read_entry.file.value_stats.null_counts), 0)
+        else:
+            # Should use specified fields - verify we have data for specified fields only
+            self.assertEqual(len(read_entry.file.value_stats.min_values.values), expected_fields_count)
+            self.assertEqual(len(read_entry.file.value_stats.max_values.values), expected_fields_count)
+            self.assertEqual(len(read_entry.file.value_stats.null_counts), expected_fields_count)
 
-        # Verify null_counts are preserved
-        self.assertEqual(read_entry.file.value_stats.null_counts, [0, 0, 0])
+        # Verify the actual values match what we expect
+        if expected_fields_count > 0:
+            self.assertEqual(read_entry.file.value_stats.min_values.values, min_values)
+            self.assertEqual(read_entry.file.value_stats.max_values.values, max_values)
+
+        self.assertEqual(read_entry.file.value_stats.null_counts, null_counts)

--- a/paimon-python/pypaimon/tests/reader_basic_test.py
+++ b/paimon-python/pypaimon/tests/reader_basic_test.py
@@ -31,8 +31,11 @@ from pypaimon.schema.data_types import DataField, AtomicType
 
 from pypaimon.catalog.catalog_factory import CatalogFactory
 from pypaimon.schema.schema import Schema
-
-
+from pypaimon.manifest.manifest_file_manager import ManifestFileManager
+from pypaimon.table.row.binary_row import BinaryRow
+from pypaimon.manifest.schema.simple_stats import SimpleStats
+from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+from pypaimon.manifest.schema.manifest_entry import ManifestEntry
 class ReaderBasicTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -222,3 +225,102 @@ class ReaderBasicTest(unittest.TestCase):
 
         self.assertEqual(deserialized_row.values[0], long_string)
         self.assertEqual(deserialized_row.row_kind, RowKind.INSERT)
+
+    def test_manifest_entry_kind_1(self):
+        """Test ManifestEntry with _KIND=1, which should create empty BinaryRow for value_stats."""
+        # Create a catalog and table
+        catalog = CatalogFactory.create({
+            "warehouse": self.warehouse
+        })
+        catalog.create_database("test_db", False)
+
+        # Define schema
+        pa_schema = pa.schema([
+            ('id', pa.int64()),
+            ('name', pa.string()),
+            ('price', pa.float64())
+        ])
+        schema = Schema.from_pyarrow_schema(pa_schema)
+        catalog.create_table("test_db.test_table", schema, False)
+        table = catalog.get_table("test_db.test_table")
+
+        # Create a ManifestFileManager
+        manifest_manager = ManifestFileManager(table)
+
+        # Create test data with _KIND=1
+        # For _KIND=1, value_stats should have empty BinaryRow for min_values and max_values
+        partition_fields = table.table_schema.get_partition_key_fields()
+        primary_key_fields = table.table_schema.get_trimmed_primary_key_fields()
+        all_fields = table.table_schema.fields
+
+        # Create empty BinaryRows for _KIND=1 case
+        empty_binary_row = BinaryRow([], [])
+
+        # Create value_stats with empty BinaryRows for _KIND=1
+        value_stats = SimpleStats(
+            min_values=empty_binary_row,  # Empty for _KIND=1
+            max_values=empty_binary_row,  # Empty for _KIND=1
+            null_counts=[0, 0, 0]  # Null counts for each field
+        )
+
+        # Create key_stats with actual data
+        # For this test, we'll use empty rows for key stats as well to keep it simple
+        key_stats = SimpleStats(
+            min_values=empty_binary_row,
+            max_values=empty_binary_row,
+            null_counts=[0, 0, 0]
+        )
+
+        # Create a DataFileMeta
+        file_meta = DataFileMeta(
+            file_name="test-file.parquet",
+            file_size=1024,
+            row_count=100,
+            min_key=empty_binary_row,
+            max_key=empty_binary_row,
+            key_stats=key_stats,
+            value_stats=value_stats,
+            min_sequence_number=1,
+            max_sequence_number=100,
+            schema_id=0,
+            level=0,
+            extra_files=[],
+            creation_time=1234567890,
+            delete_row_count=0,
+            embedded_index=None,
+            file_source=None
+        )
+
+        # Create a ManifestEntry with _KIND=1
+        entry = ManifestEntry(
+            kind=1,  # _KIND=1
+            partition=empty_binary_row,
+            bucket=0,
+            total_buckets=1,
+            file=file_meta
+        )
+
+        # Write the manifest entry
+        manifest_file_name = "manifest-test-kind-1"
+        manifest_manager.write(manifest_file_name, [entry])
+
+        # Read the manifest entry back
+        entries = manifest_manager.read(manifest_file_name)
+
+        # Verify we have exactly one entry
+        self.assertEqual(len(entries), 1)
+
+        # Get the entry
+        read_entry = entries[0]
+
+        # Verify _KIND is 1
+        self.assertEqual(read_entry.kind, 1)
+
+        # Verify value_stats has empty BinaryRows for min_values and max_values when _KIND=1
+        self.assertIsInstance(read_entry.file.value_stats.min_values, BinaryRow)
+        self.assertIsInstance(read_entry.file.value_stats.max_values, BinaryRow)
+        self.assertEqual(len(read_entry.file.value_stats.min_values.values), 0)
+        self.assertEqual(len(read_entry.file.value_stats.max_values.values), 0)
+
+        # Verify null_counts are preserved
+        self.assertEqual(read_entry.file.value_stats.null_counts, [0, 0, 0])

--- a/paimon-python/pypaimon/tests/reader_basic_test.py
+++ b/paimon-python/pypaimon/tests/reader_basic_test.py
@@ -32,10 +32,11 @@ from pypaimon.schema.data_types import DataField, AtomicType
 from pypaimon.catalog.catalog_factory import CatalogFactory
 from pypaimon.schema.schema import Schema
 from pypaimon.manifest.manifest_file_manager import ManifestFileManager
-from pypaimon.table.row.binary_row import BinaryRow
 from pypaimon.manifest.schema.simple_stats import SimpleStats
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
+
+
 class ReaderBasicTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/paimon-python/pypaimon/write/writer/data_writer.py
+++ b/paimon-python/pypaimon/write/writer/data_writer.py
@@ -15,14 +15,13 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import pyarrow as pa
+import pyarrow.compute as pc
 import uuid
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
-
-import pyarrow as pa
-import pyarrow.compute as pc
 
 from pypaimon.common.core_options import CoreOptions
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
@@ -166,6 +165,7 @@ class DataWriter(ABC):
             extra_files=[],
             creation_time=datetime.now(),
             delete_row_count=0,
+            value_stats_cols=None,  # None means all columns have statistics
             file_path=str(file_path),
         ))
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
- test_value_stats_cols_logic()
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
