### PR TITLE
[cdc] Fix PostgreSQL DECIMAL type conversion issue

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumSchemaUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/debezium/DebeziumSchemaUtils.java
@@ -167,7 +167,7 @@ public class DebeziumSchemaUtils {
         } else if (("bytes".equals(debeziumType) && className == null)) {
             // MySQL binary, varbinary, blob
             transformed = new String(Base64.getDecoder().decode(rawValue));
-        } else if ("bytes".equals(debeziumType) && decimalLogicalName().equals(className)) {
+        } else if ("bytes".equals(debeziumType) && className.endsWith(decimalLogicalName())) {
             // MySQL numeric, fixed, decimal
             try {
                 new BigDecimal(rawValue);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresRecordParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresRecordParser.java
@@ -179,7 +179,7 @@ public class PostgresRecordParser
             case "string":
                 return DataTypes.STRING();
             case "bytes":
-                if (decimalLogicalName().equals(field.name())) {
+                if (field.name() != null && field.name().endsWith(decimalLogicalName())) {
                     int precision = field.parameters().get("connect.decimal.precision").asInt();
                     int scale = field.parameters().get("scale").asInt();
                     return DataTypes.DECIMAL(precision, scale);
@@ -270,7 +270,8 @@ public class PostgresRecordParser
             } else if (("bytes".equals(postgresSqlType) && className == null)) {
                 // binary, varbinary
                 newValue = new String(Base64.getDecoder().decode(oldValue));
-            } else if ("bytes".equals(postgresSqlType) && decimalLogicalName().equals(className)) {
+            } else if ("bytes".equals(postgresSqlType)
+                    && className.endsWith(decimalLogicalName())) {
                 // numeric, decimal
                 try {
                     new BigDecimal(oldValue);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #6238
When using postgres_sync_table action with Paimon CDC, PostgreSQL DECIMAL fields are incorrectly parsed as BYTES type instead of DECIMAL, causing schema conversion failures.

Error: UnsupportedOperationException: Cannot convert field amount from type DECIMAL(10, 2) NOT NULL to BYTES NOT NULL

DebeziumSchemaUtils.decimalLogicalName() field is org.apache.kafka.connect.data.Decimal, but field name and className is shaded to org.apache.flink.cdc.connectors.shaded.org.apache.kafka.connect.data.Decimal

<img width="1084" height="630" alt="image" src="https://github.com/user-attachments/assets/64d22041-35c5-41b8-8fa1-2909e8b429a3" />

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
