### PR TITLE
[arrow] Optimize Arrow string write performance

### DIFF
--- a/paimon-benchmark/paimon-micro-benchmarks/pom.xml
+++ b/paimon-benchmark/paimon-micro-benchmarks/pom.xml
@@ -146,6 +146,12 @@ under the License.
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-arrow</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- Test -->
 
         <dependency>

--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/arrow/ArrowWriteBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/arrow/ArrowWriteBenchmark.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.benchmark.arrow;
+
+import org.apache.paimon.arrow.vector.ArrowFormatWriter;
+import org.apache.paimon.benchmark.Benchmark;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/** Benchmark for arrow write. */
+public class ArrowWriteBenchmark {
+
+    @Test
+    public void testWrite() {
+        int batch = 1024 * 20;
+        Benchmark benchmark =
+                new Benchmark("read", batch * batch)
+                        .setNumWarmupIters(1)
+                        .setOutputPerIteration(true);
+        RowType rowType =
+                RowType.of(
+                        DataTypes.STRING(),
+                        DataTypes.STRING(),
+                        DataTypes.STRING(),
+                        DataTypes.STRING());
+        ThreadLocalRandom rnd = ThreadLocalRandom.current();
+        byte[] bytes = new byte[100];
+        rnd.nextBytes(bytes);
+        BinaryString binaryString = BinaryString.fromBytes(bytes, 1, 99);
+        GenericRow row = GenericRow.of(binaryString, binaryString, binaryString, binaryString);
+        benchmark.addCase(
+                "write",
+                1,
+                () -> {
+                    try (ArrowFormatWriter writer = new ArrowFormatWriter(rowType, batch, true)) {
+                        for (int i = 0; i < batch; i++) {
+                            writer.reset();
+                            for (int j = 0; j < batch; j++) {
+                                writer.write(row);
+                            }
+                        }
+                    }
+                });
+        benchmark.run();
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
See `ArrowWriteBenchmark`.


Before optimization:
```
OpenJDK 64-Bit Server VM 1.8.0_432-b06 on Mac OS X 15.6.1
Apple M4 Pro
read:                                                                                                Best/Avg Time(ms)    Row Rate(K/s)      Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
OPERATORTEST_read_write                                                                                 33458 / 33458          12536.1             79.8       1.0X
```


After optimization:
```
OpenJDK 64-Bit Server VM 1.8.0_432-b06 on Mac OS X 15.6.1
Apple M4 Pro
read:                                                                                                Best/Avg Time(ms)    Row Rate(K/s)      Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
OPERATORTEST_read_write                                                                                 26029 / 26029          16114.3             62.1       1.0X
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
