### PR TITLE
[wip][flink] filter by directory for orphan file clean to reduce memory usage

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -85,7 +85,7 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
     }
 
     public LocalOrphanFilesClean(FileStoreTable table, long olderThanMillis, boolean dryRun) {
-        super(table, olderThanMillis, dryRun);
+        super(table, olderThanMillis, dryRun, false);
         this.deleteFiles = new ArrayList<>();
         this.executor =
                 createCachedThreadPool(

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
@@ -97,6 +97,7 @@ public class RemoveOrphanFilesProcedure extends ProcedureBase {
                                     catalog,
                                     olderThanMillis(olderThan),
                                     dryRun,
+                                    false,
                                     parallelism,
                                     databaseName,
                                     tableName);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RemoveOrphanFilesAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RemoveOrphanFilesAction.java
@@ -34,6 +34,7 @@ public class RemoveOrphanFilesAction extends ActionBase {
 
     private String olderThan = null;
     private boolean dryRun = false;
+    private boolean folderBasedCheck = false;
 
     public RemoveOrphanFilesAction(
             String databaseName,
@@ -54,6 +55,10 @@ public class RemoveOrphanFilesAction extends ActionBase {
         this.dryRun = true;
     }
 
+    public void folderBasedCheck() {
+        this.folderBasedCheck = true;
+    }
+
     @Override
     public void run() throws Exception {
         executeDatabaseOrphanFiles(
@@ -61,6 +66,7 @@ public class RemoveOrphanFilesAction extends ActionBase {
                 catalog,
                 olderThanMillis(olderThan),
                 dryRun,
+                folderBasedCheck,
                 parallelism == null ? null : Integer.parseInt(parallelism),
                 databaseName,
                 tableName);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RemoveOrphanFilesActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RemoveOrphanFilesActionFactory.java
@@ -26,6 +26,7 @@ public class RemoveOrphanFilesActionFactory implements ActionFactory {
     public static final String IDENTIFIER = "remove_orphan_files";
     private static final String OLDER_THAN = "older_than";
     private static final String DRY_RUN = "dry_run";
+    private static final String FOLDER_BASED_CHECK = "folder_based_check";
     private static final String PARALLELISM = "parallelism";
 
     @Override
@@ -48,6 +49,11 @@ public class RemoveOrphanFilesActionFactory implements ActionFactory {
 
         if (params.has(DRY_RUN) && Boolean.parseBoolean(params.get(DRY_RUN))) {
             action.dryRun();
+        }
+
+        if (params.has(FOLDER_BASED_CHECK)
+                && Boolean.parseBoolean(params.get(FOLDER_BASED_CHECK))) {
+            action.folderBasedCheck();
         }
 
         return Optional.of(action);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
@@ -81,8 +81,9 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
             FileStoreTable table,
             long olderThanMillis,
             boolean dryRun,
+            boolean folderBasedCheck,
             @Nullable Integer parallelism) {
-        super(table, olderThanMillis, dryRun);
+        super(table, olderThanMillis, dryRun, folderBasedCheck);
         this.parallelism = parallelism;
     }
 
@@ -372,10 +373,13 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
             Catalog catalog,
             long olderThanMillis,
             boolean dryRun,
+            boolean folderBasedCheck,
             @Nullable Integer parallelism,
             String databaseName,
             @Nullable String tableName)
             throws Catalog.DatabaseNotExistException, Catalog.TableNotExistException {
+        LOG.info("execute orphan file clean using folderBasedCheck:{}", folderBasedCheck);
+
         List<String> tableNames = Collections.singletonList(tableName);
         if (tableName == null || "*".equals(tableName)) {
             tableNames = catalog.listTables(databaseName);
@@ -393,7 +397,11 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
 
             DataStream<CleanOrphanFilesResult> clean =
                     new FlinkOrphanFilesClean(
-                                    (FileStoreTable) table, olderThanMillis, dryRun, parallelism)
+                                    (FileStoreTable) table,
+                                    olderThanMillis,
+                                    dryRun,
+                                    folderBasedCheck,
+                                    parallelism)
                             .doOrphanClean(env);
             if (clean != null) {
                 orphanFilesCleans.add(clean);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/RemoveOrphanFilesProcedure.java
@@ -85,6 +85,7 @@ public class RemoveOrphanFilesProcedure extends ProcedureBase {
                                     catalog,
                                     olderThanMillis(olderThan),
                                     dryRun != null && dryRun,
+                                    false,
                                     parallelism,
                                     databaseName,
                                     tableName);

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
@@ -26,7 +26,6 @@ import org.apache.paimon.operation.{CleanOrphanFilesResult, OrphanFilesClean}
 import org.apache.paimon.operation.OrphanFilesClean.retryReadingFiles
 import org.apache.paimon.table.FileStoreTable
 import org.apache.paimon.utils.FileStorePathFactory.BUCKET_PATH_PREFIX
-import org.apache.paimon.utils.SerializableConsumer
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{functions, Dataset, PaimonSparkSession, SparkSession}
@@ -47,7 +46,7 @@ case class SparkOrphanFilesClean(
     parallelism: Int,
     dryRunPara: Boolean,
     @transient spark: SparkSession)
-  extends OrphanFilesClean(specifiedTable, specifiedOlderThanMillis, dryRunPara)
+  extends OrphanFilesClean(specifiedTable, specifiedOlderThanMillis, dryRunPara, false)
   with SQLConfHelper
   with Logging {
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
When trying to list all paimon file directories for orphan file cleaning, the memory usage can become quite high if there are too many directories. This pr introduced a new configration `'folder_based_check'` to limit the directories loading to memory. With this cofigured to true, only old directories will be loaded, but this may lead to some old orphan files not being cleaned up properly.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
