### PR TITLE
[core] Fix manifest file not cleaned if compact_manifest failed

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -1283,7 +1283,13 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         latestSnapshot.properties(),
                         latestSnapshot.nextRowId());
 
-        return commitSnapshotImpl(newSnapshot, emptyList());
+        boolean success = commitSnapshotImpl(newSnapshot, emptyList());
+        if (!success) {
+            LOG.info("Commit failed for compact manifest, will be retried again.");
+            manifestList.delete(deltaManifestList.getLeft());
+            cleanUpNoReuseTmpManifests(baseManifestList, mergeBeforeManifests, mergeAfterManifests);
+        }
+        return success;
     }
 
     private boolean commitSnapshotImpl(Snapshot newSnapshot, List<PartitionEntry> deltaStatistics) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -1285,7 +1285,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
         boolean success = commitSnapshotImpl(newSnapshot, emptyList());
         if (!success) {
-            LOG.info("Commit failed for compact manifest, will be retried again.");
+            LOG.info(
+                    "Commit failed for compact manifest, clean unused legacy manifest files, commit will be retried.");
             manifestList.delete(deltaManifestList.getLeft());
             cleanUpNoReuseTmpManifests(baseManifestList, mergeBeforeManifests, mergeAfterManifests);
         }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactManifestProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactManifestProcedure.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.spark.procedure;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.utils.ProcedureUtils;
@@ -42,6 +43,8 @@ import static org.apache.spark.sql.types.DataTypes.StringType;
  * </code></pre>
  */
 public class CompactManifestProcedure extends BaseProcedure {
+
+    private static final String COMMIT_USER = "Compact-Manifest-Procedure-Committer";
 
     private static final ProcedureParameter[] PARAMETERS =
             new ProcedureParameter[] {
@@ -77,6 +80,8 @@ public class CompactManifestProcedure extends BaseProcedure {
 
         Table table = loadSparkTable(tableIdent).getTable();
         HashMap<String, String> dynamicOptions = new HashMap<>();
+        ProcedureUtils.putIfNotEmpty(
+                dynamicOptions, CoreOptions.COMMIT_USER_PREFIX.key(), COMMIT_USER);
         ProcedureUtils.putAllOptions(dynamicOptions, options);
         table = table.copy(dynamicOptions);
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

- In paimon 1.0, if compact_manifest failed, legacy manifest files will be deleted, pr https://github.com/apache/paimon/pull/5776 remove this deletion.
- Add default commit user-prefix for spark procedure.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
