### PR TITLE
[core][flink] Remove withMemoryPool in TableWriteImpl

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreWrite.java
@@ -25,7 +25,6 @@ import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.index.DynamicBucketIndexMaintainer;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.memory.MemoryPoolFactory;
-import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.SinkRecord;
@@ -56,15 +55,6 @@ public interface FileStoreWrite<T> extends Restorable<List<FileStoreWrite.State<
     /** Specified the write rowType. */
     default void withWriteType(RowType writeType) {
         throw new UnsupportedOperationException();
-    }
-
-    /**
-     * With memory pool for the current file store write.
-     *
-     * @param memoryPool the given memory pool.
-     */
-    default FileStoreWrite<T> withMemoryPool(MemorySegmentPool memoryPool) {
-        return withMemoryPoolFactory(new MemoryPoolFactory(memoryPool));
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWrite.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.io.BundleRecords;
+import org.apache.paimon.memory.MemoryPoolFactory;
 import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.table.Table;
@@ -43,7 +44,11 @@ public interface TableWrite extends AutoCloseable {
     TableWrite withWriteType(RowType writeType);
 
     /** With {@link MemorySegmentPool} for the current table write. */
-    TableWrite withMemoryPool(MemorySegmentPool memoryPool);
+    default TableWrite withMemoryPool(MemorySegmentPool memoryPool) {
+        return withMemoryPoolFactory(new MemoryPoolFactory(memoryPool));
+    }
+
+    TableWrite withMemoryPoolFactory(MemoryPoolFactory memoryPoolFactory);
 
     /** Calculate which partition {@code row} belongs to. */
     BinaryRow getPartition(InternalRow row);

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableWriteImpl.java
@@ -27,7 +27,6 @@ import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.io.BundleRecords;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.memory.MemoryPoolFactory;
-import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.operation.BundleFileStoreWriter;
 import org.apache.paimon.operation.FileStoreWrite;
@@ -120,11 +119,6 @@ public class TableWriteImpl<T> implements InnerTableWrite, Restorable<List<State
     }
 
     @Override
-    public TableWriteImpl<T> withMemoryPool(MemorySegmentPool memoryPool) {
-        write.withMemoryPool(memoryPool);
-        return this;
-    }
-
     public TableWriteImpl<T> withMemoryPoolFactory(MemoryPoolFactory memoryPoolFactory) {
         write.withMemoryPoolFactory(memoryPoolFactory);
         return this;

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
@@ -91,7 +91,7 @@ public class FlinkCdcMultiTableSink implements Serializable {
         this.tableFilter = tableFilter;
     }
 
-    private StoreSinkWrite.WithWriteBufferProvider createWriteProvider() {
+    private StoreSinkWrite.Provider createWriteProvider() {
         // for now, no compaction for multiplexed sink
         return (table, commitUser, state, ioManager, memoryPoolFactory, metricGroup) ->
                 new StoreSinkWriteImpl(
@@ -118,7 +118,7 @@ public class FlinkCdcMultiTableSink implements Serializable {
     public DataStreamSink<?> sinkFrom(
             DataStream<CdcMultiplexRecord> input,
             String commitUser,
-            StoreSinkWrite.WithWriteBufferProvider sinkProvider) {
+            StoreSinkWrite.Provider sinkProvider) {
         StreamExecutionEnvironment env = input.getExecutionEnvironment();
         assertStreamingConfiguration(env);
         MultiTableCommittableTypeInfo typeInfo = new MultiTableCommittableTypeInfo();
@@ -151,8 +151,7 @@ public class FlinkCdcMultiTableSink implements Serializable {
     }
 
     protected OneInputStreamOperatorFactory<CdcMultiplexRecord, MultiTableCommittable>
-            createWriteOperator(
-                    StoreSinkWrite.WithWriteBufferProvider writeProvider, String commitUser) {
+            createWriteOperator(StoreSinkWrite.Provider writeProvider, String commitUser) {
         return new CdcRecordStoreMultiWriteOperator.Factory(
                 catalogLoader, writeProvider, commitUser, new Options());
     }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreWriteOperatorTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreWriteOperatorTest.java
@@ -256,7 +256,7 @@ public class CdcRecordStoreWriteOperatorTest {
         CdcRecordStoreWriteOperator.Factory operatorFactory =
                 new CdcRecordStoreWriteOperator.Factory(
                         table,
-                        (t, commitUser, state, ioManager, memoryPool, metricGroup) ->
+                        (t, commitUser, state, ioManager, memoryPoolFactory, metricGroup) ->
                                 new StoreSinkWriteImpl(
                                         t,
                                         commitUser,
@@ -265,7 +265,7 @@ public class CdcRecordStoreWriteOperatorTest {
                                         false,
                                         false,
                                         true,
-                                        memoryPool,
+                                        memoryPoolFactory,
                                         metricGroup),
                         commitUser);
         TypeSerializer<CdcRecord> inputSerializer = new JavaSerializer<>();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/GlobalFullCompactionSinkWrite.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/GlobalFullCompactionSinkWrite.java
@@ -21,7 +21,7 @@ package org.apache.paimon.flink.sink;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.memory.MemorySegmentPool;
+import org.apache.paimon.memory.MemoryPoolFactory;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.SinkRecord;
 import org.apache.paimon.utils.SnapshotManager;
@@ -74,7 +74,7 @@ public class GlobalFullCompactionSinkWrite extends StoreSinkWriteImpl {
             boolean waitCompaction,
             int deltaCommits,
             boolean isStreaming,
-            @Nullable MemorySegmentPool memoryPool,
+            MemoryPoolFactory memoryPoolFactory,
             MetricGroup metricGroup) {
         super(
                 table,
@@ -84,7 +84,7 @@ public class GlobalFullCompactionSinkWrite extends StoreSinkWriteImpl {
                 ignorePreviousFiles,
                 waitCompaction,
                 isStreaming,
-                memoryPool,
+                memoryPoolFactory,
                 metricGroup);
 
         this.deltaCommits = deltaCommits;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/LookupSinkWrite.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/LookupSinkWrite.java
@@ -19,14 +19,12 @@
 package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.memory.MemorySegmentPool;
+import org.apache.paimon.memory.MemoryPoolFactory;
 import org.apache.paimon.operation.AbstractFileStoreWrite;
 import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
-
-import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,7 +46,7 @@ public class LookupSinkWrite extends StoreSinkWriteImpl {
             boolean ignorePreviousFiles,
             boolean waitCompaction,
             boolean isStreaming,
-            @Nullable MemorySegmentPool memoryPool,
+            MemoryPoolFactory memoryPoolFactory,
             MetricGroup metricGroup) {
         super(
                 table,
@@ -58,7 +56,7 @@ public class LookupSinkWrite extends StoreSinkWriteImpl {
                 ignorePreviousFiles,
                 waitCompaction,
                 isStreaming,
-                memoryPool,
+                memoryPoolFactory,
                 metricGroup);
 
         this.tableName = table.name();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/MultiTablesStoreCompactOperator.java
@@ -165,7 +165,7 @@ public class MultiTablesStoreCompactOperator
                                         commitUser,
                                         state,
                                         getContainingTask().getEnvironment().getIOManager(),
-                                        memoryPool,
+                                        memoryPoolFactory,
                                         getMetricGroup()));
 
         if (write.streamingMode()) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCompactOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCompactOperator.java
@@ -117,7 +117,7 @@ public class StoreCompactOperator extends PrepareCommitOperator<RowData, Committ
                         commitUser,
                         state,
                         getContainingTask().getEnvironment().getIOManager(),
-                        memoryPool,
+                        memoryPoolFactory,
                         getMetricGroup());
         this.writeRefresher = WriterRefresher.create(write.streamingMode(), table, write::replace);
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/TableWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/TableWriteOperator.java
@@ -94,7 +94,7 @@ public abstract class TableWriteOperator<IN> extends PrepareCommitOperator<IN, C
                         getCommitUser(context),
                         state,
                         getContainingTask().getEnvironment().getIOManager(),
-                        memoryPool,
+                        memoryPoolFactory,
                         getMetricGroup());
         if (writeRestore != null) {
             write.setWriteRestore(writeRestore);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CompactorSinkITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/CompactorSinkITCase.java
@@ -19,11 +19,6 @@
 package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.catalog.Catalog;
-import org.apache.paimon.catalog.CatalogLoader;
-import org.apache.paimon.catalog.Identifier;
-import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.data.BinaryRowWriter;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.flink.FlinkConnectorOptions;
@@ -31,7 +26,6 @@ import org.apache.paimon.flink.source.CompactorSourceBuilder;
 import org.apache.paimon.flink.util.AbstractTestBase;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
-import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
@@ -49,13 +43,8 @@ import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.SnapshotManager;
 
-import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
-import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
-import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,7 +59,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 
-import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** IT cases for {@link CompactorSinkBuilder} and {@link CompactorSink}. */
@@ -215,99 +203,5 @@ public class CompactorSinkITCase extends AbstractTestBase {
                                 Collections.singletonMap("bucket", "1"),
                                 ""));
         return FileStoreTableFactory.create(LocalFileIO.create(), tablePath, tableSchema);
-    }
-
-    private FileStoreTable createCatalogTable(Catalog catalog, Identifier tableIdentifier)
-            throws Exception {
-        Schema tableSchema =
-                new Schema(
-                        ROW_TYPE.getFields(),
-                        Collections.emptyList(),
-                        Collections.singletonList("k"),
-                        Collections.singletonMap("bucket", "1"),
-                        "");
-        catalog.createTable(tableIdentifier, tableSchema, false);
-        return (FileStoreTable) catalog.getTable(tableIdentifier);
-    }
-
-    private OneInputStreamOperatorTestHarness<RowData, Committable> createTestHarness(
-            OneInputStreamOperator<RowData, Committable> operator) throws Exception {
-        TypeSerializer<Committable> serializer =
-                new CommittableTypeInfo().createSerializer(new ExecutionConfig());
-        OneInputStreamOperatorTestHarness<RowData, Committable> harness =
-                new OneInputStreamOperatorTestHarness<>(operator);
-        harness.setup(serializer);
-        return harness;
-    }
-
-    private OneInputStreamOperatorTestHarness<RowData, MultiTableCommittable>
-            createMultiTablesTestHarness(
-                    OneInputStreamOperator<RowData, MultiTableCommittable> operator)
-                    throws Exception {
-        TypeSerializer<MultiTableCommittable> serializer =
-                new MultiTableCommittableTypeInfo().createSerializer(new ExecutionConfig());
-        OneInputStreamOperatorTestHarness<RowData, MultiTableCommittable> harness =
-                new OneInputStreamOperatorTestHarness<>(operator);
-        harness.setup(serializer);
-        return harness;
-    }
-
-    protected StoreCompactOperator.Factory createCompactOperator(FileStoreTable table) {
-        return new StoreCompactOperator.Factory(
-                table,
-                (t, commitUser, state, ioManager, memoryPool, metricGroup) ->
-                        new StoreSinkWriteImpl(
-                                t,
-                                commitUser,
-                                state,
-                                ioManager,
-                                false,
-                                false,
-                                false,
-                                memoryPool,
-                                metricGroup),
-                "test",
-                true);
-    }
-
-    protected MultiTablesStoreCompactOperator.Factory createMultiTablesCompactOperator(
-            CatalogLoader catalogLoader) throws Exception {
-        return new MultiTablesStoreCompactOperator.Factory(
-                catalogLoader,
-                commitUser,
-                new CheckpointConfig(),
-                false,
-                false,
-                true,
-                new Options());
-    }
-
-    private static byte[] partition(String dt, int hh) {
-        BinaryRow row = new BinaryRow(2);
-        BinaryRowWriter writer = new BinaryRowWriter(row);
-        writer.writeString(0, BinaryString.fromString(dt));
-        writer.writeInt(1, hh);
-        writer.complete();
-        return serializeBinaryRow(row);
-    }
-
-    private void prepareDataFile(FileStoreTable table) throws Exception {
-        StreamWriteBuilder streamWriteBuilder =
-                table.newStreamWriteBuilder().withCommitUser(commitUser);
-        StreamTableWrite write = streamWriteBuilder.newWrite();
-        StreamTableCommit commit = streamWriteBuilder.newCommit();
-
-        write.write(rowData(1, 100, 15, BinaryString.fromString("20221208")));
-        write.write(rowData(1, 100, 16, BinaryString.fromString("20221208")));
-        write.write(rowData(1, 100, 15, BinaryString.fromString("20221209")));
-        commit.commit(0, write.prepareCommit(true, 0));
-
-        write.write(rowData(2, 200, 15, BinaryString.fromString("20221208")));
-        write.write(rowData(2, 200, 16, BinaryString.fromString("20221208")));
-        write.write(rowData(2, 200, 15, BinaryString.fromString("20221209")));
-        commit.commit(1, write.prepareCommit(true, 1));
-
-        write.close();
-        commit.close();
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreCompactOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/StoreCompactOperatorTest.java
@@ -55,7 +55,7 @@ public class StoreCompactOperatorTest extends TableTestBase {
         StoreCompactOperator.Factory operatorFactory =
                 new StoreCompactOperator.Factory(
                         getTableDefault(),
-                        (table, commitUser, state, ioManager, memoryPool, metricGroup) ->
+                        (table, commitUser, state, ioManager, memoryPoolFactory, metricGroup) ->
                                 compactRememberStoreWrite,
                         "10086",
                         !streamingMode);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/WriterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/WriterOperatorTest.java
@@ -550,7 +550,7 @@ public class WriterOperatorTest {
         return new RowDataStoreWriteOperator.Factory(
                 fileStoreTable,
                 null,
-                (table, commitUser, state, ioManager, memoryPool, metricGroup) ->
+                (table, commitUser, state, ioManager, memoryPoolFactory, metricGroup) ->
                         new LookupSinkWrite(
                                 table,
                                 commitUser,
@@ -559,7 +559,7 @@ public class WriterOperatorTest {
                                 false,
                                 waitCompaction,
                                 true,
-                                memoryPool,
+                                memoryPoolFactory,
                                 metricGroup),
                 commitUser);
     }


### PR DESCRIPTION
### Purpose

Currently, `TableWriteImpl` can use either `MemoryPool` or `MemoryPoolFactory` from the outside. However, `MemoryPoolFactory` are always preferrable, because it can share memory even between writers from different `TableWriteImpl` instances. This is useful for multi-table writes such as the database compact action.

This PR removes `withMemoryPool` in `TableWriteImpl`. From now on we should only use `withMemoryPoolFactory`.

### Tests

This PR is a refactor and has no specific test.

### API and Format

No format changes.

### Documentation

No new feature.
