### PR TITLE
[hive] Fix sync-all-properties cannot configurable

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -1054,7 +1054,7 @@ public class HiveCatalog extends AbstractCatalog {
         checkArgument(Options.fromMap(options).get(TYPE) != FORMAT_TABLE);
 
         Map<String, String> tblProperties;
-        if (syncAllProperties()) {
+        if (syncAllProperties(new Options(options))) {
             tblProperties = new HashMap<>(options);
             // add primary-key, partition-key to tblproperties
             tblProperties.putAll(convertToPropertiesTableKey(tableSchema));
@@ -1210,8 +1210,8 @@ public class HiveCatalog extends AbstractCatalog {
         return true;
     }
 
-    public boolean syncAllProperties() {
-        return catalogOptions.get(SYNC_ALL_PROPERTIES);
+    public boolean syncAllProperties(Options tableOptions) {
+        return tableOptions.get(SYNC_ALL_PROPERTIES);
     }
 
     @Override
@@ -1570,12 +1570,12 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     private void updateHmsTablePars(Table table, TableSchema schema, Set<String> removedOptions) {
-        if (syncAllProperties()) {
-            table.getParameters().putAll(schema.options());
+        Map<String, String> options = schema.options();
+        if (syncAllProperties(new Options(options))) {
+            table.getParameters().putAll(options);
             table.getParameters().putAll(convertToPropertiesTableKey(schema));
         } else {
-            table.getParameters()
-                    .putAll(convertToPropertiesPrefixKey(schema.options(), HIVE_PREFIX));
+            table.getParameters().putAll(convertToPropertiesPrefixKey(options, HIVE_PREFIX));
         }
         removedOptions.forEach(table.getParameters()::remove);
     }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -1054,7 +1054,7 @@ public class HiveCatalog extends AbstractCatalog {
         checkArgument(Options.fromMap(options).get(TYPE) != FORMAT_TABLE);
 
         Map<String, String> tblProperties;
-        if (syncAllProperties(new Options(options))) {
+        if (syncAllProperties(options)) {
             tblProperties = new HashMap<>(options);
             // add primary-key, partition-key to tblproperties
             tblProperties.putAll(convertToPropertiesTableKey(tableSchema));
@@ -1210,8 +1210,10 @@ public class HiveCatalog extends AbstractCatalog {
         return true;
     }
 
-    public boolean syncAllProperties(Options tableOptions) {
-        return tableOptions.get(SYNC_ALL_PROPERTIES);
+    public boolean syncAllProperties(Map<String, String> tableOptions) {
+        Map<String, String> merged = new HashMap<>(catalogOptions.toMap());
+        merged.putAll(tableOptions);
+        return new Options(merged).get(SYNC_ALL_PROPERTIES);
     }
 
     @Override
@@ -1571,7 +1573,7 @@ public class HiveCatalog extends AbstractCatalog {
 
     private void updateHmsTablePars(Table table, TableSchema schema, Set<String> removedOptions) {
         Map<String, String> options = schema.options();
-        if (syncAllProperties(new Options(options))) {
+        if (syncAllProperties(options)) {
             table.getParameters().putAll(options);
             table.getParameters().putAll(convertToPropertiesTableKey(schema));
         } else {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

We set `sync-all-properties=false` and find all properties also sync to hms, we should check it by using paimon table options.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
