### PR TITLE
[clone] support specifying target prefer file format

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CloneAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CloneAction.java
@@ -20,9 +20,11 @@ package org.apache.paimon.flink.action;
 
 import org.apache.paimon.catalog.CachingCatalog;
 import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.flink.clone.CloneFileFormatUtils;
 import org.apache.paimon.flink.clone.CloneHiveTableUtils;
 import org.apache.paimon.flink.clone.ClonePaimonTableUtils;
 import org.apache.paimon.hive.HiveCatalog;
+import org.apache.paimon.utils.StringUtils;
 
 import javax.annotation.Nullable;
 
@@ -44,6 +46,7 @@ public class CloneAction extends ActionBase {
     @Nullable private final String whereSql;
     @Nullable private final List<String> includedTables;
     @Nullable private final List<String> excludedTables;
+    @Nullable private final String preferFileFormat;
     private final String cloneFrom;
 
     public CloneAction(
@@ -57,6 +60,7 @@ public class CloneAction extends ActionBase {
             @Nullable String whereSql,
             @Nullable List<String> includedTables,
             @Nullable List<String> excludedTables,
+            @Nullable String preferFileFormat,
             String cloneFrom) {
         super(sourceCatalogConfig);
 
@@ -84,6 +88,11 @@ public class CloneAction extends ActionBase {
         this.whereSql = whereSql;
         this.includedTables = includedTables;
         this.excludedTables = excludedTables;
+        CloneFileFormatUtils.validateFileFormat(preferFileFormat);
+        this.preferFileFormat =
+                StringUtils.isNullOrWhitespaceOnly(preferFileFormat)
+                        ? preferFileFormat
+                        : preferFileFormat.toLowerCase();
         this.cloneFrom = cloneFrom;
     }
 
@@ -103,7 +112,8 @@ public class CloneAction extends ActionBase {
                         parallelism,
                         whereSql,
                         includedTables,
-                        excludedTables);
+                        excludedTables,
+                        preferFileFormat);
                 break;
             case "paimon":
                 ClonePaimonTableUtils.build(
@@ -118,7 +128,8 @@ public class CloneAction extends ActionBase {
                         parallelism,
                         whereSql,
                         includedTables,
-                        excludedTables);
+                        excludedTables,
+                        preferFileFormat);
                 break;
         }
     }
@@ -128,4 +139,6 @@ public class CloneAction extends ActionBase {
         build();
         execute("Clone job");
     }
+
+    private void validateFileFormat(String preferFileFormat) {}
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CloneActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CloneActionFactory.java
@@ -38,6 +38,7 @@ public class CloneActionFactory implements ActionFactory {
     private static final String WHERE = "where";
     private static final String INCLUDED_TABLES = "included_tables";
     private static final String EXCLUDED_TABLES = "excluded_tables";
+    private static final String PREFER_FILE_FORMAT = "prefer_file_format";
     private static final String CLONE_FROM = "clone_from";
 
     @Override
@@ -74,7 +75,7 @@ public class CloneActionFactory implements ActionFactory {
         if (StringUtils.isNullOrWhitespaceOnly(cloneFrom)) {
             cloneFrom = "hive";
         }
-
+        String preferFileFormat = params.get(PREFER_FILE_FORMAT);
         CloneAction cloneAction =
                 new CloneAction(
                         params.get(DATABASE),
@@ -87,6 +88,7 @@ public class CloneActionFactory implements ActionFactory {
                         params.get(WHERE),
                         includedTables,
                         excludedTables,
+                        preferFileFormat,
                         cloneFrom);
 
         return Optional.of(cloneAction);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/CloneFileFormatUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/CloneFileFormatUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.clone;
+
+import org.apache.paimon.flink.action.CloneAction;
+import org.apache.paimon.utils.StringUtils;
+
+/** Utils for file format in {@link CloneAction}. */
+public class CloneFileFormatUtils {
+
+    public static void validateFileFormat(String fileFormat) {
+        if (StringUtils.isNullOrWhitespaceOnly(fileFormat)) {
+            return;
+        }
+        String fileFormatLower = fileFormat.toLowerCase();
+        String[] supportedFileFormat = new String[] {"parquet", "orc", "avro"};
+        for (String supportedFormat : supportedFileFormat) {
+            if (fileFormatLower.equals(supportedFormat)) {
+                return;
+            }
+        }
+        throw new IllegalArgumentException(
+                "Unsupported file format: "
+                        + fileFormat
+                        + ". Supported file formats are: "
+                        + String.join(", ", supportedFileFormat));
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/CloneHiveTableUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/CloneHiveTableUtils.java
@@ -155,7 +155,8 @@ public class CloneHiveTableUtils {
             int parallelism,
             @Nullable String whereSql,
             @Nullable List<String> includedTables,
-            @Nullable List<String> excludedTables)
+            @Nullable List<String> excludedTables,
+            @Nullable String preferFileFormat)
             throws Exception {
         // list source tables
         DataStream<Tuple2<Identifier, Identifier>> source =
@@ -178,7 +179,7 @@ public class CloneHiveTableUtils {
                 partitionedSource
                         .process(
                                 new CloneHiveSchemaFunction(
-                                        sourceCatalogConfig, targetCatalogConfig))
+                                        sourceCatalogConfig, targetCatalogConfig, preferFileFormat))
                         .name("Clone Schema")
                         .setParallelism(parallelism);
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/ClonePaimonTableUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/ClonePaimonTableUtils.java
@@ -137,7 +137,8 @@ public class ClonePaimonTableUtils {
             int parallelism,
             @Nullable String whereSql,
             @Nullable List<String> includedTables,
-            @Nullable List<String> excludedTables)
+            @Nullable List<String> excludedTables,
+            @Nullable String preferFileFormat)
             throws Exception {
         // list source tables
         DataStream<Tuple2<Identifier, Identifier>> source =
@@ -160,7 +161,7 @@ public class ClonePaimonTableUtils {
                 partitionedSource
                         .process(
                                 new ClonePaimonSchemaFunction(
-                                        sourceCatalogConfig, targetCatalogConfig))
+                                        sourceCatalogConfig, targetCatalogConfig, preferFileFormat))
                         .name("Clone Schema")
                         .setParallelism(parallelism);
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/schema/ClonePaimonSchemaFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/schema/ClonePaimonSchemaFunction.java
@@ -18,11 +18,13 @@
 
 package org.apache.paimon.flink.clone.schema;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.Table;
+import org.apache.paimon.utils.StringUtils;
 
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -45,14 +47,18 @@ public class ClonePaimonSchemaFunction
 
     private final Map<String, String> sourceCatalogConfig;
     private final Map<String, String> targetCatalogConfig;
+    private final String preferFileFormat;
 
     private transient Catalog sourceCatalog;
     private transient Catalog targetCatalog;
 
     public ClonePaimonSchemaFunction(
-            Map<String, String> sourceCatalogConfig, Map<String, String> targetCatalogConfig) {
+            Map<String, String> sourceCatalogConfig,
+            Map<String, String> targetCatalogConfig,
+            String preferFileFormat) {
         this.sourceCatalogConfig = sourceCatalogConfig;
         this.targetCatalogConfig = targetCatalogConfig;
+        this.preferFileFormat = preferFileFormat;
     }
 
     /**
@@ -109,6 +115,10 @@ public class ClonePaimonSchemaFunction
         } else {
             // for primary key table, only postpone bucket supports clone
             builder.option(BUCKET.key(), "-2");
+        }
+
+        if (!StringUtils.isNullOrWhitespaceOnly(preferFileFormat)) {
+            builder.option(CoreOptions.FILE_FORMAT.key(), preferFileFormat);
         }
 
         targetCatalog.createTable(tuple.f1, builder.build(), true);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CloneProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CloneProcedure.java
@@ -67,6 +67,10 @@ public class CloneProcedure extends ProcedureBase {
                         type = @DataTypeHint("STRING"),
                         isOptional = true),
                 @ArgumentHint(
+                        name = "prefer_file_format",
+                        type = @DataTypeHint("STRING"),
+                        isOptional = true),
+                @ArgumentHint(
                         name = "clone_from",
                         type = @DataTypeHint("STRING"),
                         isOptional = true)
@@ -83,6 +87,7 @@ public class CloneProcedure extends ProcedureBase {
             String where,
             String includedTablesStr,
             String excludedTablesStr,
+            String preferFileFormat,
             String cloneFrom)
             throws Exception {
         Map<String, String> sourceCatalogConfig =
@@ -112,6 +117,7 @@ public class CloneProcedure extends ProcedureBase {
                         where,
                         includedTables,
                         excludedTables,
+                        preferFileFormat,
                         cloneFrom);
         return execute(procedureContext, action, "Clone Job");
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->
Support specifying target prefer file format when migrating orc/csv/json tables to parquet tables

### Tests

<!-- List UT and IT cases to verify this change -->
org.apache.paimon.hive.procedure.CloneActionITCase#testMigrateWithPreferFileFormat

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
