### PR TITLE
[core] Add name for catalog

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/catalog/CatalogContext.java
+++ b/paimon-common/src/main/java/org/apache/paimon/catalog/CatalogContext.java
@@ -48,18 +48,21 @@ public class CatalogContext implements Serializable {
     private final SerializableConfiguration hadoopConf;
     @Nullable private final FileIOLoader preferIOLoader;
     @Nullable private final FileIOLoader fallbackIOLoader;
+    @Nullable final String catalogName;
 
     private CatalogContext(
             Options options,
             @Nullable Configuration hadoopConf,
             @Nullable FileIOLoader preferIOLoader,
-            @Nullable FileIOLoader fallbackIOLoader) {
+            @Nullable FileIOLoader fallbackIOLoader,
+            @Nullable String catalogName) {
         this.options = checkNotNull(options);
         this.hadoopConf =
                 new SerializableConfiguration(
                         hadoopConf == null ? getHadoopConfiguration(options) : hadoopConf);
         this.preferIOLoader = preferIOLoader;
         this.fallbackIOLoader = fallbackIOLoader;
+        this.catalogName = catalogName;
     }
 
     public static CatalogContext create(Path warehouse) {
@@ -69,28 +72,40 @@ public class CatalogContext implements Serializable {
     }
 
     public static CatalogContext create(Options options) {
-        return new CatalogContext(options, null, null, null);
+        return new CatalogContext(options, null, null, null, null);
     }
 
     public static CatalogContext create(Options options, Configuration hadoopConf) {
-        return new CatalogContext(options, hadoopConf, null, null);
-    }
-
-    public static CatalogContext create(Options options, FileIOLoader fallbackIOLoader) {
-        return new CatalogContext(options, null, null, fallbackIOLoader);
+        return new CatalogContext(options, hadoopConf, null, null, null);
     }
 
     public static CatalogContext create(
-            Options options, FileIOLoader preferIOLoader, FileIOLoader fallbackIOLoader) {
-        return new CatalogContext(options, null, preferIOLoader, fallbackIOLoader);
+            Options options, Configuration hadoopConf, String catalogName) {
+        return new CatalogContext(options, hadoopConf, null, null, catalogName);
+    }
+
+    public static CatalogContext create(Options options, FileIOLoader fallbackIOLoader) {
+        return new CatalogContext(options, null, null, fallbackIOLoader, null);
+    }
+
+    public static CatalogContext create(
+            Options options, FileIOLoader fallbackIOLoader, String catalogName) {
+        return new CatalogContext(options, null, null, fallbackIOLoader, catalogName);
     }
 
     public static CatalogContext create(
             Options options,
             Configuration hadoopConf,
             FileIOLoader preferIOLoader,
-            FileIOLoader fallbackIOLoader) {
-        return new CatalogContext(options, hadoopConf, preferIOLoader, fallbackIOLoader);
+            FileIOLoader fallbackIOLoader,
+            String catalogName) {
+        return new CatalogContext(
+                options, hadoopConf, preferIOLoader, fallbackIOLoader, catalogName);
+    }
+
+    @Nullable
+    public String catalogName() {
+        return catalogName;
     }
 
     public Options options() {

--- a/paimon-common/src/main/java/org/apache/paimon/fs/ResolvingFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/ResolvingFileIO.java
@@ -64,7 +64,11 @@ public class ResolvingFileIO implements FileIO {
         options.set(RESOLVING_FILE_IO_ENABLED, false);
         this.context =
                 CatalogContext.create(
-                        options, context.hadoopConf(), context.preferIO(), context.fallbackIO());
+                        options,
+                        context.hadoopConf(),
+                        context.preferIO(),
+                        context.fallbackIO(),
+                        context.catalogName());
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
@@ -176,7 +176,8 @@ public class RESTTokenFileIO implements FileIO {
                             options,
                             catalogContext.hadoopConf(),
                             catalogContext.preferIO(),
-                            catalogContext.fallbackIO());
+                            catalogContext.fallbackIO(),
+                            catalogContext.catalogName());
             try {
                 fileIO = FileIO.get(path, context);
             } catch (IOException e) {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -81,17 +81,25 @@ public abstract class AbstractCatalog implements Catalog {
     protected final FileIO fileIO;
     protected final Map<String, String> tableDefaultOptions;
     protected final Options catalogOptions;
+    @Nullable protected final String name;
 
     protected AbstractCatalog(FileIO fileIO) {
         this.fileIO = fileIO;
         this.tableDefaultOptions = new HashMap<>();
         this.catalogOptions = new Options();
+        this.name = null;
     }
 
-    protected AbstractCatalog(FileIO fileIO, Options options) {
+    protected AbstractCatalog(FileIO fileIO, Options options, @Nullable String name) {
         this.fileIO = fileIO;
         this.tableDefaultOptions = CatalogUtils.tableDefaultOptions(options.toMap());
         this.catalogOptions = options;
+        this.name = name;
+    }
+
+    @Override
+    public String name() {
+        return name;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -940,6 +940,11 @@ public interface Catalog extends AutoCloseable {
 
     // ==================== Catalog Information ==========================
 
+    /** The name of this catalog. */
+    default String name() {
+        return toString();
+    }
+
     /** Catalog options for re-creating this catalog. */
     Map<String, String> options();
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogFactory.java
@@ -63,8 +63,8 @@ public interface CatalogFactory extends Factory {
      * If the ClassLoader is not specified, using the context ClassLoader of current thread as
      * default.
      */
-    static Catalog createCatalog(CatalogContext options) {
-        return createCatalog(options, CatalogFactory.class.getClassLoader());
+    static Catalog createCatalog(CatalogContext context) {
+        return createCatalog(context, CatalogFactory.class.getClassLoader());
     }
 
     static Catalog createCatalog(CatalogContext context, ClassLoader classLoader) {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
@@ -237,6 +237,7 @@ public class CatalogUtils {
 
         CatalogEnvironment catalogEnv =
                 new CatalogEnvironment(
+                        catalog.name(),
                         tableIdentifier,
                         metadata.uuid(),
                         catalog.catalogLoader(),

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -52,6 +52,11 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
+    public String name() {
+        return wrapped.name();
+    }
+
+    @Override
     public boolean caseSensitive() {
         return wrapped.caseSensitive();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
@@ -50,7 +50,11 @@ public class FileSystemCatalog extends AbstractCatalog {
     }
 
     public FileSystemCatalog(FileIO fileIO, Path warehouse, Options options) {
-        super(fileIO, options);
+        this(fileIO, warehouse, options, null);
+    }
+
+    public FileSystemCatalog(FileIO fileIO, Path warehouse, Options options, String name) {
+        super(fileIO, options, name);
         this.warehouse = warehouse;
     }
 
@@ -198,7 +202,7 @@ public class FileSystemCatalog extends AbstractCatalog {
 
     @Override
     public CatalogLoader catalogLoader() {
-        return new FileSystemCatalogLoader(fileIO, warehouse, catalogOptions);
+        return new FileSystemCatalogLoader(fileIO, warehouse, catalogOptions, name);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalogFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalogFactory.java
@@ -41,6 +41,6 @@ public class FileSystemCatalogFactory implements CatalogFactory {
                     "Only managed table is supported in File system catalog.");
         }
 
-        return new FileSystemCatalog(fileIO, warehouse, context.options());
+        return new FileSystemCatalog(fileIO, warehouse, context.options(), context.catalogName());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalogLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalogLoader.java
@@ -30,15 +30,17 @@ public class FileSystemCatalogLoader implements CatalogLoader {
     private final FileIO fileIO;
     private final Path warehouse;
     private final Options options;
+    private final String name;
 
-    public FileSystemCatalogLoader(FileIO fileIO, Path warehouse, Options options) {
+    public FileSystemCatalogLoader(FileIO fileIO, Path warehouse, Options options, String name) {
         this.fileIO = fileIO;
         this.warehouse = warehouse;
         this.options = options;
+        this.name = name;
     }
 
     @Override
     public Catalog load() {
-        return new FileSystemCatalog(fileIO, warehouse, options);
+        return new FileSystemCatalog(fileIO, warehouse, options, name);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
@@ -46,6 +46,8 @@ import org.apache.paimon.shade.guava30.com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
@@ -85,8 +87,13 @@ public class JdbcCatalog extends AbstractCatalog {
     private final Options options;
     private final String warehouse;
 
-    protected JdbcCatalog(FileIO fileIO, String catalogKey, Options options, String warehouse) {
-        super(fileIO, options);
+    protected JdbcCatalog(
+            FileIO fileIO,
+            String catalogKey,
+            Options options,
+            String warehouse,
+            @Nullable String name) {
+        super(fileIO, options, name);
         this.catalogKey = catalogKey;
         this.options = options;
         this.warehouse = warehouse;
@@ -153,7 +160,7 @@ public class JdbcCatalog extends AbstractCatalog {
 
     @Override
     public CatalogLoader catalogLoader() {
-        return new JdbcCatalogLoader(fileIO, catalogKey, options, warehouse);
+        return new JdbcCatalogLoader(fileIO, catalogKey, options, warehouse, name);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogFactory.java
@@ -39,6 +39,7 @@ public class JdbcCatalogFactory implements CatalogFactory {
     public Catalog create(FileIO fileIO, Path warehouse, CatalogContext context) {
         Options options = context.options();
         String catalogKey = options.get(JdbcCatalogOptions.CATALOG_KEY);
-        return new JdbcCatalog(fileIO, catalogKey, context.options(), warehouse.toString());
+        return new JdbcCatalog(
+                fileIO, catalogKey, context.options(), warehouse.toString(), context.catalogName());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogLoader.java
@@ -32,16 +32,19 @@ public class JdbcCatalogLoader implements CatalogLoader {
     private final String catalogKey;
     private final Options options;
     private final String warehouse;
+    private final String name;
 
-    public JdbcCatalogLoader(FileIO fileIO, String catalogKey, Options options, String warehouse) {
+    public JdbcCatalogLoader(
+            FileIO fileIO, String catalogKey, Options options, String warehouse, String name) {
         this.fileIO = fileIO;
         this.catalogKey = catalogKey;
         this.options = options;
         this.warehouse = warehouse;
+        this.name = name;
     }
 
     @Override
     public Catalog load() {
-        return new JdbcCatalog(fileIO, catalogKey, options, warehouse);
+        return new JdbcCatalog(fileIO, catalogKey, options, warehouse, name);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/partition/actions/HttpReportMarkDoneAction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/partition/actions/HttpReportMarkDoneAction.java
@@ -65,7 +65,10 @@ public class HttpReportMarkDoneAction implements PartitionMarkDoneAction {
 
         this.params = options.httpReportMarkDoneActionParams();
         this.url = options.httpReportMarkDoneActionUrl();
-        this.tableName = fileStoreTable.fullName();
+        // just for compatibility with the old behavior
+        String fullName = fileStoreTable.fullName();
+        String[] parts = fullName.split("\\.");
+        this.tableName = parts.length == 3 ? parts[1] + "." + parts[2] : fullName;
         this.location = fileStoreTable.location().toString();
 
         this.mapper = new ObjectMapper();

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -92,6 +92,7 @@ public class RESTCatalog implements Catalog {
     private final RESTApi api;
     private final CatalogContext context;
     private final boolean dataTokenEnabled;
+    @Nullable private final String name;
 
     public RESTCatalog(CatalogContext context) {
         this(context, true);
@@ -104,8 +105,15 @@ public class RESTCatalog implements Catalog {
                         api.options(),
                         context.hadoopConf(),
                         context.preferIO(),
-                        context.fallbackIO());
+                        context.fallbackIO(),
+                        context.catalogName());
         this.dataTokenEnabled = api.options().get(RESTTokenFileIO.DATA_TOKEN_ENABLED);
+        this.name = context.catalogName();
+    }
+
+    @Override
+    public String name() {
+        return name;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -171,7 +171,10 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
 
     @Override
     public String fullName() {
-        return identifier().getFullName();
+        String catalogName = catalogEnvironment.catalogName();
+        return catalogName == null
+                ? identifier().getFullName()
+                : String.format("%s.%s", catalogName, identifier().getFullName());
     }
 
     public Identifier identifier() {

--- a/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
@@ -44,6 +44,7 @@ public class CatalogEnvironment implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    @Nullable private final String catalogName;
     @Nullable private final Identifier identifier;
     @Nullable private final String uuid;
     @Nullable private final CatalogLoader catalogLoader;
@@ -52,12 +53,14 @@ public class CatalogEnvironment implements Serializable {
     private final boolean supportsVersionManagement;
 
     public CatalogEnvironment(
+            @Nullable String catalogName,
             @Nullable Identifier identifier,
             @Nullable String uuid,
             @Nullable CatalogLoader catalogLoader,
             @Nullable CatalogLockFactory lockFactory,
             @Nullable CatalogLockContext lockContext,
             boolean supportsVersionManagement) {
+        this.catalogName = catalogName;
         this.identifier = identifier;
         this.uuid = uuid;
         this.catalogLoader = catalogLoader;
@@ -67,7 +70,12 @@ public class CatalogEnvironment implements Serializable {
     }
 
     public static CatalogEnvironment empty() {
-        return new CatalogEnvironment(null, null, null, null, null, false);
+        return new CatalogEnvironment(null, null, null, null, null, null, false);
+    }
+
+    @Nullable
+    public String catalogName() {
+        return catalogName;
     }
 
     @Nullable
@@ -134,6 +142,7 @@ public class CatalogEnvironment implements Serializable {
 
     public CatalogEnvironment copy(Identifier identifier) {
         return new CatalogEnvironment(
+                catalogName,
                 identifier,
                 uuid,
                 catalogLoader,

--- a/paimon-core/src/main/java/org/apache/paimon/table/Table.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/Table.java
@@ -54,7 +54,10 @@ public interface Table extends Serializable {
     /** A name to identify this table. */
     String name();
 
-    /** Full name of the table, default is database.tableName. */
+    /**
+     * Full name of the table, default is database.tableName or catalog.database.tableName if
+     * catalog is present.
+     */
     default String fullName() {
         return name();
     }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogFactoryTest.java
@@ -93,7 +93,7 @@ public class CatalogFactoryTest {
         conf.set("my_key", "my_value");
         CatalogContext context =
                 CatalogContext.create(
-                        new Options(), conf, new TestFileIOLoader(), new TestFileIOLoader());
+                        new Options(), conf, new TestFileIOLoader(), new TestFileIOLoader(), null);
         context = InstantiationUtil.clone(context);
         assertThat(context.hadoopConf().get("my_key")).isEqualTo(conf.get("my_key"));
     }

--- a/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcCatalogTest.java
@@ -63,7 +63,7 @@ public class JdbcCatalogTest extends CatalogTestBase {
         properties.putAll(props);
         JdbcCatalog catalog =
                 new JdbcCatalog(
-                        fileIO, "test-jdbc-catalog", Options.fromMap(properties), warehouse);
+                        fileIO, "test-jdbc-catalog", Options.fromMap(properties), warehouse, null);
         assertThat(catalog.warehouse()).isEqualTo(warehouse);
         return catalog;
     }

--- a/paimon-core/src/test/java/org/apache/paimon/jdbc/PostgresqlCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/jdbc/PostgresqlCatalogTest.java
@@ -122,7 +122,8 @@ public class PostgresqlCatalogTest {
                         fileIO,
                         "test-jdbc-postgres-catalog",
                         Options.fromMap(properties),
-                        warehouse);
+                        warehouse,
+                        null);
         assertThat(catalog.warehouse()).isEqualTo(warehouse);
         return catalog;
     }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/PartitionExpireTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/PartitionExpireTest.java
@@ -137,7 +137,7 @@ public class PartitionExpireTest {
                 };
 
         CatalogEnvironment env =
-                new CatalogEnvironment(null, null, null, null, null, false) {
+                new CatalogEnvironment(null, null, null, null, null, null, false) {
 
                     @Override
                     public PartitionHandler partitionHandler() {

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -2228,6 +2228,7 @@ public class RESTCatalogServer {
             TableSchema schema = tableMetadata.schema();
             CatalogEnvironment catalogEnv =
                     new CatalogEnvironment(
+                            catalog.name(),
                             identifier,
                             tableMetadata.uuid(),
                             catalog.catalogLoader(),

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalogFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalogFactory.java
@@ -53,7 +53,9 @@ public class FlinkCatalogFactory implements org.apache.flink.table.factories.Cat
         return createCatalog(
                 context.getName(),
                 CatalogContext.create(
-                        Options.fromMap(context.getOptions()), new FlinkFileIOLoader()),
+                        Options.fromMap(context.getOptions()),
+                        new FlinkFileIOLoader(),
+                        context.getName()),
                 context.getClassLoader());
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkGenericCatalogFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkGenericCatalogFactory.java
@@ -93,7 +93,7 @@ public class FlinkGenericCatalogFactory implements CatalogFactory {
         FlinkCatalog paimon =
                 new FlinkCatalog(
                         org.apache.paimon.catalog.CatalogFactory.createCatalog(
-                                CatalogContext.create(options, new FlinkFileIOLoader()), cl),
+                                CatalogContext.create(options, new FlinkFileIOLoader(), name), cl),
                         name,
                         options.get(DEFAULT_DATABASE),
                         cl,

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MarkPartitionDoneActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MarkPartitionDoneActionITCase.java
@@ -175,7 +175,6 @@ public class MarkPartitionDoneActionITCase extends ActionITCaseBase {
                 MockCustomPartitionMarkDoneAction.class.getName());
 
         FileStoreTable table = prepareTable(hasPk, options);
-        String fullTableName = table.fullName();
 
         switch (invoker) {
             case "action":
@@ -220,8 +219,8 @@ public class MarkPartitionDoneActionITCase extends ActionITCaseBase {
 
         assertThat(MockCustomPartitionMarkDoneAction.getMarkedDonePartitions())
                 .containsExactlyInAnyOrder(
-                        "table=" + fullTableName + ",partition=partKey0=0/partKey1=1/",
-                        "table=" + fullTableName + ",partition=partKey0=1/partKey1=0/");
+                        "table=" + tableName + ",partition=partKey0=0/partKey1=1/",
+                        "table=" + tableName + ",partition=partKey0=1/partKey1=0/");
     }
 
     @ParameterizedTest

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/listener/CustomPartitionMarkDoneActionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/listener/CustomPartitionMarkDoneActionTest.java
@@ -100,6 +100,6 @@ public class CustomPartitionMarkDoneActionTest extends TableTestBase {
         assertThat(table2.fileIO().exists(successFile)).isEqualTo(true);
 
         assertThat(MockCustomPartitionMarkDoneAction.getMarkedDonePartitions().iterator().next())
-                .isEqualTo("table=default.T,partition=a=0/");
+                .isEqualTo("table=T,partition=a=0/");
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/listener/MockCustomPartitionMarkDoneAction.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/listener/MockCustomPartitionMarkDoneAction.java
@@ -35,7 +35,7 @@ public class MockCustomPartitionMarkDoneAction implements PartitionMarkDoneActio
 
     @Override
     public void open(FileStoreTable fileStoreTable, CoreOptions options) {
-        this.tableName = fileStoreTable.fullName();
+        this.tableName = fileStoreTable.name();
     }
 
     @Override

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -164,7 +164,7 @@ public class HiveCatalog extends AbstractCatalog {
     private final LocationHelper locationHelper;
 
     public HiveCatalog(FileIO fileIO, HiveConf hiveConf, String clientClassName, String warehouse) {
-        this(fileIO, hiveConf, clientClassName, new Options(), warehouse);
+        this(fileIO, hiveConf, clientClassName, new Options(), warehouse, null);
     }
 
     public HiveCatalog(
@@ -172,8 +172,9 @@ public class HiveCatalog extends AbstractCatalog {
             HiveConf hiveConf,
             String clientClassName,
             Options options,
-            String warehouse) {
-        super(fileIO, options);
+            String warehouse,
+            @Nullable String name) {
+        super(fileIO, options, name);
         this.hiveConf = hiveConf;
         this.clientClassName = clientClassName;
         this.options = options;
@@ -1328,7 +1329,12 @@ public class HiveCatalog extends AbstractCatalog {
     @Override
     public CatalogLoader catalogLoader() {
         return new HiveCatalogLoader(
-                fileIO, new SerializableHiveConf(hiveConf), clientClassName, options, warehouse);
+                fileIO,
+                new SerializableHiveConf(hiveConf),
+                clientClassName,
+                options,
+                warehouse,
+                name);
     }
 
     public Table getHmsTable(Identifier identifier)
@@ -1716,7 +1722,8 @@ public class HiveCatalog extends AbstractCatalog {
                 hiveConf,
                 options.get(HiveCatalogOptions.METASTORE_CLIENT_CLASS),
                 options,
-                warehouse.toUri().toString());
+                warehouse.toUri().toString(),
+                context.catalogName());
     }
 
     public static HiveConf createHiveConf(CatalogContext context) {

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogLoader.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogLoader.java
@@ -47,7 +47,7 @@ public class HiveCatalogLoader implements CatalogLoader {
         this.clientClassName = clientClassName;
         this.options = options;
         this.warehouse = warehouse;
-        this.name = null;
+        this.name = name;
     }
 
     @Override

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogLoader.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogLoader.java
@@ -33,22 +33,25 @@ public class HiveCatalogLoader implements CatalogLoader {
     private final String clientClassName;
     private final Options options;
     private final String warehouse;
+    private final String name;
 
     public HiveCatalogLoader(
             FileIO fileIO,
             SerializableHiveConf hiveConf,
             String clientClassName,
             Options options,
-            String warehouse) {
+            String warehouse,
+            String name) {
         this.fileIO = fileIO;
         this.hiveConf = hiveConf;
         this.clientClassName = clientClassName;
         this.options = options;
         this.warehouse = warehouse;
+        this.name = null;
     }
 
     @Override
     public Catalog load() {
-        return new HiveCatalog(fileIO, hiveConf.conf(), clientClassName, options, warehouse);
+        return new HiveCatalog(fileIO, hiveConf.conf(), clientClassName, options, warehouse, name);
     }
 }

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -80,7 +80,8 @@ public class HiveCatalogTest extends CatalogTestBase {
         Options catalogOptions = new Options();
         catalogOptions.set(CatalogOptions.SYNC_ALL_PROPERTIES.key(), "false");
         catalog =
-                new HiveCatalog(fileIO, hiveConf, metastoreClientClass, catalogOptions, warehouse);
+                new HiveCatalog(
+                        fileIO, hiveConf, metastoreClientClass, catalogOptions, warehouse, null);
     }
 
     @Test

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveTableStatsTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveTableStatsTest.java
@@ -64,7 +64,8 @@ public class HiveTableStatsTest {
         CatalogContext catalogContext = CatalogContext.create(catalogOptions);
         FileIO fileIO = FileIO.get(new Path(warehouse), catalogContext);
         catalog =
-                new HiveCatalog(fileIO, hiveConf, metastoreClientClass, catalogOptions, warehouse);
+                new HiveCatalog(
+                        fileIO, hiveConf, metastoreClientClass, catalogOptions, warehouse, null);
     }
 
     @Test

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/pool/TestCachedClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/pool/TestCachedClientPool.java
@@ -422,7 +422,8 @@ public class TestCachedClientPool {
                                                         hiveConf,
                                                         metastoreClientClass,
                                                         options,
-                                                        warehouse);
+                                                        warehouse,
+                                                        null);
                                             } catch (Exception e) {
                                                 throw new RuntimeException(e);
                                             }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -133,7 +133,9 @@ public class SparkCatalog extends SparkBaseCatalog
         this.catalogName = name;
         CatalogContext catalogContext =
                 CatalogContext.create(
-                        Options.fromMap(options), sparkSession.sessionState().newHadoopConf());
+                        Options.fromMap(options),
+                        sparkSession.sessionState().newHadoopConf(),
+                        name);
         this.catalog = CatalogFactory.createCatalog(catalogContext);
         this.defaultDatabase =
                 options.getOrDefault(DEFAULT_DATABASE.key(), DEFAULT_DATABASE.defaultValue());

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTestBase.scala
@@ -55,7 +55,9 @@ abstract class DDLWithHiveCatalogTestBase extends PaimonHiveTestBase {
                 val fileStoreTable = getPaimonScan("SELECT * FROM paimon_db.paimon_tbl").table
                   .asInstanceOf[FileStoreTable]
                 Assertions.assertEquals("paimon_tbl", fileStoreTable.name())
-                Assertions.assertEquals("paimon_db.paimon_tbl", fileStoreTable.fullName())
+                Assertions.assertEquals(
+                  s"$catalogName.paimon_db.paimon_tbl",
+                  fileStoreTable.fullName())
               }
             }
         }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DescribeTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DescribeTableTestBase.scala
@@ -156,4 +156,11 @@ abstract class DescribeTableTestBase extends PaimonSparkTestBase {
     // check comment in schema
     Assertions.assertTrue(Objects.equals(comment, loadTable(tableName).schema().comment()))
   }
+
+  test("Paimon describe: table full name") {
+    withTable("t") {
+      sql("CREATE TABLE t (a INT, b STRING)")
+      assert(loadTable("t").fullName().equals("paimon.test.t"))
+    }
+  }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/V2WriteRequireDistributionTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/V2WriteRequireDistributionTest.scala
@@ -49,7 +49,7 @@ class V2WriteRequireDistributionTest extends PaimonSparkTestBase with AdaptiveSp
         val node1 = nodes(0)
         assert(
           node1.isInstanceOf[AppendDataExec] &&
-            node1.toString.contains("PaimonWrite(table=test.t1"),
+            node1.toString.contains("PaimonWrite(table=paimon.test.t1"),
           s"Expected AppendDataExec with specific paimon write, but got: $node1"
         )
 
@@ -92,7 +92,7 @@ class V2WriteRequireDistributionTest extends PaimonSparkTestBase with AdaptiveSp
         val node1 = nodes(0)
         assert(
           node1.isInstanceOf[AppendDataExec] &&
-            node1.toString.contains("PaimonWrite(table=test.t1"),
+            node1.toString.contains("PaimonWrite(table=paimon.test.t1"),
           s"Expected AppendDataExec with specific paimon write, but got: $node1"
         )
 
@@ -136,7 +136,7 @@ class V2WriteRequireDistributionTest extends PaimonSparkTestBase with AdaptiveSp
         val node1 = nodes(0)
         assert(
           node1.isInstanceOf[AppendDataExecV1] &&
-            node1.toString.contains("AppendDataExecV1 PrimaryKeyFileStoreTable[test.t1]"),
+            node1.toString.contains("AppendDataExecV1 PrimaryKeyFileStoreTable[paimon.test.t1]"),
           s"Expected AppendDataExec with specific paimon write, but got: $node1"
         )
       }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

1. Add `name` in interface `Catalog`

2. Make fileStoreTable's `fullName` return `catalog.db.table` if catalogName if present. 
  - This is beneficial for systems like Kyuubi to obtain the catalogName for authorization purposes.
  - Enables more comprehensive representation in the UI.

<img width="258" height="211" alt="image" src="https://github.com/user-attachments/assets/200ce3c7-7b06-4cbf-82e8-ab155c302c08" />



### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
