### PR TITLE
[core] Introduce DeltaVarintCompressor to length array compress

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/DeltaVarintCompressor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/DeltaVarintCompressor.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+/**
+ * Combining Delta Encoding and Varints Encoding, suitable for integer sequences that are increasing
+ * or not significantly different.
+ */
+public class DeltaVarintCompressor {
+
+    // Compresses a long array using delta encoding, ZigZag transformation, and Varints encoding
+    public static byte[] compress(long[] data) {
+        if (data == null || data.length == 0) {
+            return new byte[0];
+        }
+
+        LongArrayList deltas = new LongArrayList(data.length);
+        // Store the first element
+        deltas.add(data[0]);
+        for (int i = 1; i < data.length; i++) {
+            // Compute delta
+            deltas.add(data[i] - data[i - 1]);
+        }
+
+        // Pre-allocate space
+        ByteArrayOutputStream out = new ByteArrayOutputStream(data.length * 10);
+        for (int i = 0; i < deltas.size(); i++) {
+            // Apply ZigZag and Varints
+            encodeVarint(deltas.get(i), out);
+        }
+        return out.toByteArray();
+    }
+
+    // Decompresses a byte array back to the original long array
+    public static long[] decompress(byte[] compressed) {
+        if (compressed == null || compressed.length == 0) {
+            return new long[0];
+        }
+
+        ByteArrayInputStream in = new ByteArrayInputStream(compressed);
+        // Pre-allocate space
+        LongArrayList deltas = new LongArrayList(compressed.length);
+        while (in.available() > 0) {
+            // Decode Varints and reverse ZigZag
+            deltas.add(decodeVarint(in));
+        }
+
+        long[] result = new long[deltas.size()];
+        // Restore the first element
+        result[0] = deltas.get(0);
+        for (int i = 1; i < result.length; i++) {
+            // Reconstruct using deltas
+            result[i] = result[i - 1] + deltas.get(i);
+        }
+        return result;
+    }
+
+    // Encodes a long value using ZigZag and Varints
+    private static void encodeVarint(long value, ByteArrayOutputStream out) {
+        // ZigZag transformation for long
+        long tmp = (value << 1) ^ (value >> 63);
+        // Check if multiple bytes are needed
+        while ((tmp & ~0x7FL) != 0) {
+            // Set MSB to 1 (continuation)
+            out.write(((int) tmp & 0x7F) | 0x80);
+            // Unsigned right shift
+            tmp >>>= 7;
+        }
+        // Final byte with MSB set to 0
+        out.write((byte) tmp);
+    }
+
+    // Decodes a Varints-encoded value and reverses ZigZag transformation
+    private static long decodeVarint(ByteArrayInputStream in) {
+        long result = 0;
+        int shift = 0;
+        while (true) {
+            long b = in.read();
+            if (b == -1) {
+                throw new RuntimeException("Unexpected end of input");
+            }
+            // Extract 7 bits
+            result |= (b & 0x7F) << shift;
+            // MSB is 0, end of encoding
+            if ((b & 0x80) == 0) {
+                break;
+            }
+            shift += 7;
+            if (shift > 63) {
+                throw new RuntimeException("Varint overflow");
+            }
+        }
+        // Reverse ZigZag transformation
+        long zigzag = result >>> 1;
+        return (result & 1) == 0 ? zigzag : (~zigzag);
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/LongArrayList.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/LongArrayList.java
@@ -42,6 +42,11 @@ public class LongArrayList {
         return true;
     }
 
+    public long get(int index) {
+        rangeCheck(index);
+        return array[index];
+    }
+
     public long removeLong(int index) {
         if (index >= size) {
             throw new IndexOutOfBoundsException(
@@ -75,5 +80,10 @@ public class LongArrayList {
             System.arraycopy(array, 0, t, 0, size);
             array = t;
         }
+    }
+
+    private void rangeCheck(int index) {
+        if (index >= size)
+            throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/utils/DeltaVarintCompressorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/DeltaVarintCompressorTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DeltaVarintCompressorTest {
+
+    // Test case for normal compression and decompression
+    @Test
+    void testNormalCase1() {
+        long[] original = {80L, 50L, 90L, 80L, 70L};
+        byte[] compressed = DeltaVarintCompressor.compress(original);
+        long[] decompressed = DeltaVarintCompressor.decompress(compressed);
+
+        assertArrayEquals(original, decompressed); // Verify data integrity
+        assertEquals(6, compressed.length); // Optimized size for small deltas
+    }
+
+    @Test
+    void testNormalCase2() {
+        long[] original = {100L, 50L, 150L, 100L, 200L};
+        byte[] compressed = DeltaVarintCompressor.compress(original);
+        long[] decompressed = DeltaVarintCompressor.decompress(compressed);
+
+        assertArrayEquals(original, decompressed); // Verify data integrity
+        assertEquals(8, compressed.length); // Optimized size for small deltas
+    }
+
+    @RepeatedTest(10000)
+    void testRandom() {
+        long[] original = new long[100];
+        ThreadLocalRandom rnd = ThreadLocalRandom.current();
+        for (int i = 0; i < original.length; i++) {
+            original[i] = rnd.nextLong();
+        }
+        byte[] compressed = DeltaVarintCompressor.compress(original);
+        long[] decompressed = DeltaVarintCompressor.decompress(compressed);
+
+        assertArrayEquals(original, decompressed); // Verify data integrity
+    }
+
+    // Test case for empty array
+    @Test
+    void testEmptyArray() {
+        long[] original = {};
+        byte[] compressed = DeltaVarintCompressor.compress(original);
+        long[] decompressed = DeltaVarintCompressor.decompress(compressed);
+
+        assertArrayEquals(original, decompressed);
+        assertEquals(0, compressed.length);
+    }
+
+    // Test case for single-element array
+    @Test
+    void testSingleElement() {
+        long[] original = {42L};
+        byte[] compressed = DeltaVarintCompressor.compress(original);
+        long[] decompressed = DeltaVarintCompressor.decompress(compressed);
+
+        assertArrayEquals(original, decompressed);
+        // Calculate expected size: Varint encoding for 42 (0x2A -> 1 byte)
+        assertEquals(1, compressed.length);
+    }
+
+    // Test case for extreme values (Long.MIN_VALUE and MAX_VALUE)
+    @Test
+    void testExtremeValues() {
+        long[] original = {Long.MIN_VALUE, Long.MAX_VALUE};
+        byte[] compressed = DeltaVarintCompressor.compress(original);
+        long[] decompressed = DeltaVarintCompressor.decompress(compressed);
+
+        assertArrayEquals(original, decompressed);
+        // Expected size: 10 bytes (MIN_VALUE) + 9 bytes (delta) = 19 bytes
+        assertEquals(11, compressed.length);
+    }
+
+    // Test case for negative deltas with ZigZag optimization
+    @Test
+    void testNegativeDeltas() {
+        long[] original = {100L, -50L, -150L, -100L}; // Negative values
+        byte[] compressed = DeltaVarintCompressor.compress(original);
+        long[] decompressed = DeltaVarintCompressor.decompress(compressed);
+
+        assertArrayEquals(original, decompressed);
+        // Verify ZigZag optimization: -1 → 1 (1 byte)
+        // Delta sequence: [100, -150, -100, 50] → ZigZag →
+        // Each encoded in 1-2 bytes
+        assertTrue(compressed.length <= 8); // Optimized size
+    }
+
+    // Test case for unsorted data (worse compression ratio)
+    @Test
+    void testUnsortedData() {
+        long[] original = {1000L, 5L, 9999L, 12345L, 6789L};
+        byte[] compressed = DeltaVarintCompressor.compress(original);
+        long[] decompressed = DeltaVarintCompressor.decompress(compressed);
+
+        assertArrayEquals(original, decompressed);
+        // Larger deltas → more bytes (e.g., 9994 → 3 bytes)
+        assertTrue(compressed.length > 5); // Worse than sorted case
+    }
+
+    // Test case for corrupted input (invalid Varint)
+    @Test
+    void testCorruptedInput() {
+        // Invalid Varint (all continuation flags)
+        byte[] corrupted = new byte[] {(byte) 0x80, (byte) 0x80, (byte) 0x80};
+        assertThrows(
+                RuntimeException.class,
+                () -> {
+                    DeltaVarintCompressor.decompress(corrupted);
+                });
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
For integer dense scenes, ZigZag+Varints is the optimal solution that balances speed and space.
<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
