### PR TITLE
[cdc] Fix cannot be cast to float due to precision loss

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/TypeUtils.java
@@ -144,12 +144,7 @@ public class TypeUtils {
                 } else {
                     // Compatible canal-cdc
                     Float f = Float.valueOf(s);
-                    String floatStr = f.toString();
-                    if (s.contains(".") && !s.contains("E")) {
-                        int decimal = s.length() - s.indexOf(".") - 1;
-                        floatStr = String.format("%." + decimal + "f", f);
-                    }
-                    if (!floatStr.equals(s)) {
+                    if (!f.toString().equals(Double.toString(d))) {
                         throw new NumberFormatException(
                                 s + " cannot be cast to float due to precision loss");
                     } else {

--- a/paimon-common/src/test/java/org/apache/paimon/utils/TypeUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/TypeUtilsTest.java
@@ -198,8 +198,8 @@ public class TypeUtilsTest {
 
     @Test
     public void testFloatCastFromString() {
-        String[] values = {"123.456", "0.00042", "1.00001"};
-        Float[] expected = {123.456f, 0.00042f, 1.00001f};
+        String[] values = {"123.456", "0.00042", "1.00001", "175.26562", "0.00046"};
+        Float[] expected = {123.456f, 0.00042f, 1.00001f, 175.26562f, 0.00046f};
         for (int i = 0; i < values.length; i++) {
             Object result = TypeUtils.castFromCdcValueString(values[i], DataTypes.FLOAT());
             assertThat(result).isEqualTo(expected[i]);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #6289

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
- org.apache.paimon.utils.TypeUtilsTest#testFloatCastFromString

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
