### PR TITLE
[spark] Resolve function after all args have been resolved

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonFunctionResolver.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonFunctionResolver.scala
@@ -34,7 +34,7 @@ case class PaimonFunctionResolver(spark: SparkSession) extends Rule[LogicalPlan]
     plan.resolveOperatorsUpWithPruning(_.containsAnyPattern(UNRESOLVED_FUNCTION)) {
       case l: LogicalPlan =>
         l.transformExpressionsWithPruning(_.containsAnyPattern(UNRESOLVED_FUNCTION)) {
-          case u: UnResolvedPaimonV1Function =>
+          case u: UnResolvedPaimonV1Function if u.arguments.forall(_.resolved) =>
             u.funcIdent.catalog match {
               case Some(catalog) =>
                 catalogManager.catalog(catalog) match {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonV1FunctionTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonV1FunctionTestBase.scala
@@ -214,6 +214,23 @@ abstract class PaimonV1FunctionTestBase extends PaimonSparkTestWithRestCatalogBa
       }
     }
   }
+
+  test("Paimon V1 Function: select with view") {
+    withUserDefinedFunction("udf_add2" -> false) {
+      sql(s"""
+             |CREATE FUNCTION udf_add2 AS '$UDFExampleAdd2Class'
+             |USING JAR '$testUDFJarPath'
+             |""".stripMargin)
+      withTable("t") {
+        withView("v") {
+          sql("CREATE TABLE t (a INT, b INT)")
+          sql("INSERT INTO t VALUES (1, 2), (3, 4)")
+          sql("CREATE VIEW v AS SELECT udf_add2(a, b) AS c1 FROM t")
+          checkAnswer(sql("SELECT * FROM v"), Seq(Row(3), Row(7)))
+        }
+      }
+    }
+  }
 }
 
 class DisablePaimonV1FunctionTest extends PaimonSparkTestWithRestCatalogBase {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Fix this

```
CREATE VIEW v AS SELECT udf_add2(a, b) AS c1 FROM t;
SELECT * FROM v;
```

```
No handler for UDF/UDAF/UDTF 'org.apache.hadoop.hive.contrib.udf.example.UDFExampleAdd2': org.apache.spark.sql.catalyst.analysis.UnresolvedException: Invalid call to dataType on unresolved object
org.apache.spark.sql.AnalysisException: No handler for UDF/UDAF/UDTF 'org.apache.hadoop.hive.contrib.udf.example.UDFExampleAdd2': org.apache.spark.sql.catalyst.analysis.UnresolvedException: Invalid call to dataType on unresolved object
	at org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute.dataType(unresolved.scala:264)
	at org.apache.spark.sql.hive.HiveSimpleUDFEvaluator.$anonfun$method$1(hiveUDFEvaluators.scala:74)
	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:286)
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
