### PR TITLE
[fix Bug] NullPointException when readHadoopXml apache/paimon#6282

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/HadoopUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/HadoopUtils.java
@@ -221,13 +221,19 @@ public class HadoopUtils {
         }
         for (int i = 0; i < propertyNodes.getLength(); i++) {
             Node propertyNode = propertyNodes.item(i);
-            if (propertyNode.getNodeType() == 1) {
+            if (1 == propertyNode.getNodeType()) {
                 Element propertyElement = (Element) propertyNode;
-                String key = propertyElement.getElementsByTagName("name").item(0).getTextContent();
-                String value =
-                        propertyElement.getElementsByTagName("value").item(0).getTextContent();
-                if (!StringUtils.isNullOrWhitespaceOnly(value)) {
-                    conf.set(key, value);
+                if (null != propertyElement.getElementsByTagName("name")
+                        && null != propertyElement.getElementsByTagName("name").item(0)
+                        && null != propertyElement.getElementsByTagName("value")
+                        && null != propertyElement.getElementsByTagName("value").item(0)) {
+                    String key =
+                            propertyElement.getElementsByTagName("name").item(0).getTextContent();
+                    String value =
+                            propertyElement.getElementsByTagName("value").item(0).getTextContent();
+                    if (!StringUtils.isNullOrWhitespaceOnly(value)) {
+                        conf.set(key, value);
+                    }
                 }
             }
         }

--- a/paimon-common/src/test/java/org/apache/paimon/utils/HadoopUtilsITCase.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/HadoopUtilsITCase.java
@@ -70,4 +70,24 @@ public class HadoopUtilsITCase {
             return LocalFileIO.create();
         }
     }
+
+    @Test
+    public void testReadHadoopXml() {
+        String xml =
+                "<configuration><property>"
+                        + "<name>paimon.test.key0</name>"
+                        + "</property>"
+                        + "<property>"
+                        + "<name>paimon.test.key1</name>"
+                        + "<value/>"
+                        + "</property>"
+                        + "<property>"
+                        + "<name>paimon.test.key2</name>"
+                        + "<value>test.value</value>"
+                        + "</property>"
+                        + "</configuration>";
+        Configuration conf = new Configuration();
+        HadoopUtils.readHadoopXml(xml, conf);
+        assertThat(conf.get("paimon.test.key2")).isEqualTo("test.value");
+    }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

fix bug: NullPointException when readHadoopXml 
https://github.com/apache/paimon/issues/6282

### Tests
org.apache.paimon.utils.HadoopUtilsITCase#testReadHadoopXml  passed.

<img width="1252" height="806" alt="image" src="https://github.com/user-attachments/assets/189779bc-6bc9-4220-b9de-bc23764eeebf" />


### API and Format
not involve


### Documentation
not involve

<!-- Does this change introduce a new feature -->
