### PR TITLE
[core] Load RocksDB library in advance and catch exceptions

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/lookup/rocksdb/RocksDBStateFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/lookup/rocksdb/RocksDBStateFactory.java
@@ -29,6 +29,8 @@ import org.rocksdb.Options;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.TtlDB;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -38,6 +40,8 @@ import java.time.Duration;
 
 /** Factory to create state. */
 public class RocksDBStateFactory implements StateFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RocksDBStateFactory.class);
 
     public static final String MERGE_OPERATOR_NAME = "stringappendtest";
 
@@ -50,6 +54,13 @@ public class RocksDBStateFactory implements StateFactory {
     public RocksDBStateFactory(
             String path, org.apache.paimon.options.Options conf, @Nullable Duration ttlSecs)
             throws IOException {
+        try {
+            RocksDB.loadLibrary();
+        } catch (Throwable e) {
+            LOG.error("Fail to load RocksDB library.", e);
+            throw new IOException("Fail to load RocksDB library.", e);
+        }
+
         DBOptions dbOptions =
                 RocksDBOptions.createDBOptions(
                         new DBOptions()

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/RocksDBListStateTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/RocksDBListStateTest.java
@@ -33,12 +33,17 @@ import org.apache.paimon.types.RowType;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.rocksdb.RocksDB;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link RocksDBListState}. */
 public class RocksDBListStateTest {
@@ -69,6 +74,53 @@ public class RocksDBListStateTest {
         assertThat(getString(listState.get(key))).containsExactlyInAnyOrder("1", "2,3", "1");
         assertThat(listState.get(row("bbb"))).isEmpty();
         factory.close();
+    }
+
+    @Test
+    void testRocksDBLibraryLoadSuccess() throws Exception {
+        // Test that RocksDBStateFactory can be created successfully when RocksDB library loads
+        // properly
+        RocksDBStateFactory factory =
+                new RocksDBStateFactory(tempDir.toString(), new Options(), null);
+
+        // Verify that the factory is created and can be used
+        assertThat(factory).isNotNull();
+        assertThat(factory.db()).isNotNull();
+        assertThat(factory.path()).isEqualTo(tempDir.toString());
+
+        factory.close();
+    }
+
+    @Test
+    void testRocksDBLibraryLoadFailure() {
+        // Test that IOException is thrown when RocksDB library fails to load
+        try (MockedStatic<RocksDB> mockedRocksDB = Mockito.mockStatic(RocksDB.class)) {
+            mockedRocksDB
+                    .when(RocksDB::loadLibrary)
+                    .thenThrow(new RuntimeException("Failed to load RocksDB library"));
+
+            assertThatThrownBy(
+                            () -> new RocksDBStateFactory(tempDir.toString(), new Options(), null))
+                    .isInstanceOf(IOException.class)
+                    .hasMessage("Fail to load RocksDB library.")
+                    .hasCauseInstanceOf(RuntimeException.class);
+        }
+    }
+
+    @Test
+    void testRocksDBLibraryLoadWithDifferentExceptionTypes() {
+        // Test that IOException is thrown for different types of exceptions during library loading
+        try (MockedStatic<RocksDB> mockedRocksDB = Mockito.mockStatic(RocksDB.class)) {
+            mockedRocksDB
+                    .when(RocksDB::loadLibrary)
+                    .thenThrow(new UnsatisfiedLinkError("Native library not found"));
+
+            assertThatThrownBy(
+                            () -> new RocksDBStateFactory(tempDir.toString(), new Options(), null))
+                    .isInstanceOf(IOException.class)
+                    .hasMessage("Fail to load RocksDB library.")
+                    .hasCauseInstanceOf(UnsatisfiedLinkError.class);
+        }
     }
 
     public GenericRow row(String value) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
```java
public RocksDBStateFactory(
            String path, org.apache.paimon.options.Options conf, @Nullable Duration ttlSecs)
            throws IOException {
    DBOptions dbOptions =
            RocksDBOptions.createDBOptions(
                    new DBOptions()
                            .setUseFsync(false)
                            .setStatsDumpPeriodSec(0)
                            .setCreateIfMissing(true),
                    conf);
    // ignore
}

public class DBOptions extends RocksObject
    implements DBOptionsInterface<DBOptions>,
    MutableDBOptionsInterface<DBOptions> {
  static {
    RocksDB.loadLibrary();
  }
  // ignore
}
```
When init `RocksDBStateFactory`, `RocksDB.loadLibrary()` will be invoked in static segments of `DBOptions.class`, and if some exceptions or errors occured when loading library, we can not get detailed information about the exception. This pr will load library in advance and catch the exception or error.


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
