### PR TITLE
[core] Add dv conflict detection during commit

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -298,7 +298,10 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                 options.commitMinRetryWait(),
                 options.commitMaxRetryWait(),
                 options.commitStrictModeLastSafeSnapshot().orElse(null),
-                options.rowTrackingEnabled());
+                options.rowTrackingEnabled(),
+                !schema.primaryKeys().isEmpty(),
+                options.deletionVectorsEnabled(),
+                newIndexFileHandler());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/FileEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/FileEntry.java
@@ -22,7 +22,6 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.Filter;
-import org.apache.paimon.utils.Preconditions;
 
 import javax.annotation.Nullable;
 
@@ -40,6 +39,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.paimon.utils.ManifestReadThreadPool.randomlyExecuteSequentialReturn;
 import static org.apache.paimon.utils.ManifestReadThreadPool.sequentialBatchedExecute;
+import static org.apache.paimon.utils.Preconditions.checkState;
 
 /** Entry representing a file. */
 public interface FileEntry {
@@ -77,7 +77,7 @@ public interface FileEntry {
         public final int level;
         public final String fileName;
         public final List<String> extraFiles;
-        @Nullable private final byte[] embeddedIndex;
+        @Nullable public final byte[] embeddedIndex;
         @Nullable public final String externalPath;
 
         /* Cache the hash code for the string */
@@ -190,7 +190,7 @@ public interface FileEntry {
             Identifier identifier = entry.identifier();
             switch (entry.kind()) {
                 case ADD:
-                    Preconditions.checkState(
+                    checkState(
                             !map.containsKey(identifier),
                             "Trying to add file %s which is already added.",
                             identifier);

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/SimpleFileEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/SimpleFileEntry.java
@@ -81,6 +81,21 @@ public class SimpleFileEntry implements FileEntry {
                 entry.externalPath());
     }
 
+    public SimpleFileEntry toDelete() {
+        return new SimpleFileEntry(
+                FileKind.DELETE,
+                partition,
+                bucket,
+                totalBuckets,
+                level,
+                fileName,
+                extraFiles,
+                embeddedIndex,
+                minKey,
+                maxKey,
+                externalPath);
+    }
+
     public static List<SimpleFileEntry> from(List<ManifestEntry> entries) {
         return entries.stream().map(SimpleFileEntry::from).collect(Collectors.toList());
     }
@@ -113,6 +128,11 @@ public class SimpleFileEntry implements FileEntry {
     @Override
     public String fileName() {
         return fileName;
+    }
+
+    @Nullable
+    public byte[] embeddedIndex() {
+        return embeddedIndex;
     }
 
     @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/SimpleFileEntryWithDV.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/SimpleFileEntryWithDV.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.manifest;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+
+/** A {@link FileEntry} contains {@link SimpleFileEntry} and dv file name. */
+public class SimpleFileEntryWithDV extends SimpleFileEntry {
+
+    @Nullable private final String dvFileName;
+
+    public SimpleFileEntryWithDV(SimpleFileEntry entry, @Nullable String dvFileName) {
+        super(
+                entry.kind(),
+                entry.partition(),
+                entry.bucket(),
+                entry.totalBuckets(),
+                entry.level(),
+                entry.fileName(),
+                entry.extraFiles(),
+                entry.embeddedIndex(),
+                entry.minKey(),
+                entry.maxKey(),
+                entry.externalPath());
+        this.dvFileName = dvFileName;
+    }
+
+    public Identifier identifier() {
+        return new IdentifierWithDv(super.identifier(), dvFileName);
+    }
+
+    @Nullable
+    public String dvFileName() {
+        return dvFileName;
+    }
+
+    public SimpleFileEntry toDelete() {
+        return new SimpleFileEntryWithDV(super.toDelete(), dvFileName);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        SimpleFileEntryWithDV that = (SimpleFileEntryWithDV) o;
+        return Objects.equals(dvFileName, that.dvFileName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), dvFileName);
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + ", {dvFileName=" + dvFileName + '}';
+    }
+
+    /**
+     * The same {@link Identifier} indicates that the {@link ManifestEntry} refers to the same data
+     * file.
+     */
+    static class IdentifierWithDv extends Identifier {
+
+        private final String dvFileName;
+
+        public IdentifierWithDv(Identifier identifier, String dvFileName) {
+            super(
+                    identifier.partition,
+                    identifier.bucket,
+                    identifier.level,
+                    identifier.fileName,
+                    identifier.extraFiles,
+                    identifier.embeddedIndex,
+                    identifier.externalPath);
+            this.dvFileName = dvFileName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            if (!super.equals(o)) {
+                return false;
+            }
+            IdentifierWithDv that = (IdentifierWithDv) o;
+            return Objects.equals(dvFileName, that.dvFileName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), dvFileName);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ConflictDeletionUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ConflictDeletionUtils.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.index.DeletionVectorMeta;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.manifest.FileKind;
+import org.apache.paimon.manifest.IndexManifestEntry;
+import org.apache.paimon.manifest.SimpleFileEntry;
+import org.apache.paimon.manifest.SimpleFileEntryWithDV;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.paimon.utils.Preconditions.checkState;
+
+/** Utils for conflict deletion. */
+public class ConflictDeletionUtils {
+
+    public static List<SimpleFileEntry> buildBaseEntriesWithDV(
+            List<SimpleFileEntry> baseEntries, List<IndexManifestEntry> baseIndexEntries) {
+        if (baseEntries.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Map<String, String> fileNameToDVFileName = new HashMap<>();
+        for (IndexManifestEntry indexManifestEntry : baseIndexEntries) {
+            // Should not attach DELETE type dv index for base file.
+            if (!indexManifestEntry.kind().equals(FileKind.DELETE)) {
+                IndexFileMeta indexFile = indexManifestEntry.indexFile();
+                if (indexFile.dvRanges() != null) {
+                    for (DeletionVectorMeta value : indexFile.dvRanges().values()) {
+                        checkState(
+                                !fileNameToDVFileName.containsKey(value.dataFileName()),
+                                "One file should correspond to only one dv entry.");
+                        fileNameToDVFileName.put(value.dataFileName(), indexFile.fileName());
+                    }
+                }
+            }
+        }
+
+        // Attach dv name to file entries.
+        List<SimpleFileEntry> entriesWithDV = new ArrayList<>(baseEntries.size());
+        for (SimpleFileEntry fileEntry : baseEntries) {
+            entriesWithDV.add(
+                    new SimpleFileEntryWithDV(
+                            fileEntry, fileNameToDVFileName.get(fileEntry.fileName())));
+        }
+        return entriesWithDV;
+    }
+
+    public static List<SimpleFileEntry> buildDeltaEntriesWithDV(
+            List<SimpleFileEntry> baseEntries,
+            List<SimpleFileEntry> deltaEntries,
+            List<IndexManifestEntry> deltaIndexEntries) {
+        if (deltaEntries.isEmpty() && deltaIndexEntries.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<SimpleFileEntry> entriesWithDV = new ArrayList<>(deltaEntries.size());
+
+        // One file may correspond to more than one dv entries, for example, delete the old dv, and
+        // create a new one.
+        Map<String, List<IndexManifestEntry>> fileNameToDVEntry = new HashMap<>();
+        for (IndexManifestEntry deltaIndexEntry : deltaIndexEntries) {
+            if (deltaIndexEntry.indexFile().dvRanges() != null) {
+                for (DeletionVectorMeta meta : deltaIndexEntry.indexFile().dvRanges().values()) {
+                    fileNameToDVEntry.putIfAbsent(meta.dataFileName(), new ArrayList<>());
+                    fileNameToDVEntry.get(meta.dataFileName()).add(deltaIndexEntry);
+                }
+            }
+        }
+
+        Set<String> fileNotInDeltaEntries = new HashSet<>(fileNameToDVEntry.keySet());
+        // 1. Attach dv name to delta file entries.
+        for (SimpleFileEntry fileEntry : deltaEntries) {
+            if (fileNameToDVEntry.containsKey(fileEntry.fileName())) {
+                List<IndexManifestEntry> dvs = fileNameToDVEntry.get(fileEntry.fileName());
+                checkState(dvs.size() == 1, "Delta entry only can have one dv file");
+                entriesWithDV.add(
+                        new SimpleFileEntryWithDV(fileEntry, dvs.get(0).indexFile().fileName()));
+                fileNotInDeltaEntries.remove(fileEntry.fileName());
+            } else {
+                entriesWithDV.add(new SimpleFileEntryWithDV(fileEntry, null));
+            }
+        }
+
+        // 2. For file not in delta entries, build entry with dv with baseEntries.
+        if (!fileNotInDeltaEntries.isEmpty()) {
+            Map<String, SimpleFileEntry> fileNameToFileEntry = new HashMap<>();
+            for (SimpleFileEntry baseEntry : baseEntries) {
+                if (baseEntry.kind().equals(FileKind.ADD)) {
+                    fileNameToFileEntry.put(baseEntry.fileName(), baseEntry);
+                }
+            }
+
+            for (String fileName : fileNotInDeltaEntries) {
+                SimpleFileEntryWithDV simpleFileEntry =
+                        (SimpleFileEntryWithDV) fileNameToFileEntry.get(fileName);
+                checkState(
+                        simpleFileEntry != null,
+                        String.format(
+                                "Trying to create deletion vector on file %s which is not previously added.",
+                                fileName));
+                List<IndexManifestEntry> dvEntries = fileNameToDVEntry.get(fileName);
+                // If dv entry's type id DELETE, add DELETE<f, dv>
+                // If dv entry's type id ADD, add ADD<f, dv>
+                for (IndexManifestEntry dvEntry : dvEntries) {
+                    entriesWithDV.add(
+                            new SimpleFileEntryWithDV(
+                                    dvEntry.kind().equals(FileKind.ADD)
+                                            ? simpleFileEntry
+                                            : simpleFileEntry.toDelete(),
+                                    dvEntry.indexFile().fileName()));
+                }
+
+                // If one file correspond to only one dv entry and the type is ADD,
+                // we need to add a DELETE<f, null>.
+                // This happens when create a dv for a file that doesn't have dv before.
+                if (dvEntries.size() == 1 && dvEntries.get(0).kind().equals(FileKind.ADD)) {
+                    entriesWithDV.add(new SimpleFileEntryWithDV(simpleFileEntry.toDelete(), null));
+                }
+            }
+        }
+
+        return entriesWithDV;
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/utils/ConflictDeletionUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/ConflictDeletionUtilsTest.java
@@ -1,0 +1,342 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.index.DeletionVectorMeta;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.manifest.FileEntry;
+import org.apache.paimon.manifest.FileKind;
+import org.apache.paimon.manifest.IndexManifestEntry;
+import org.apache.paimon.manifest.SimpleFileEntry;
+import org.apache.paimon.manifest.SimpleFileEntryWithDV;
+
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import static org.apache.paimon.data.BinaryRow.EMPTY_ROW;
+import static org.apache.paimon.deletionvectors.DeletionVectorsIndexFile.DELETION_VECTORS_INDEX;
+import static org.apache.paimon.manifest.FileKind.ADD;
+import static org.apache.paimon.manifest.FileKind.DELETE;
+import static org.apache.paimon.utils.ConflictDeletionUtils.buildBaseEntriesWithDV;
+import static org.apache.paimon.utils.ConflictDeletionUtils.buildDeltaEntriesWithDV;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ConflictDeletionUtils}. */
+public class ConflictDeletionUtilsTest {
+
+    @Test
+    public void testBuildBaseEntriesWithDV() {
+        {
+            // Scene 1
+            List<SimpleFileEntry> baseEntries = new ArrayList<>();
+            baseEntries.add(createFileEntry("f1", ADD));
+            baseEntries.add(createFileEntry("f2", ADD));
+
+            List<IndexManifestEntry> deltaIndexEntries = new ArrayList<>();
+            deltaIndexEntries.add(createDvIndexEntry("dv1", ADD, Arrays.asList("f2")));
+
+            assertThat(buildBaseEntriesWithDV(baseEntries, deltaIndexEntries))
+                    .containsExactlyInAnyOrder(
+                            createFileEntryWithDV("f1", ADD, null),
+                            createFileEntryWithDV("f2", ADD, "dv1"));
+        }
+
+        {
+            // Scene 2: skip delete dv
+            List<SimpleFileEntry> baseEntries = new ArrayList<>();
+            baseEntries.add(createFileEntry("f1", ADD));
+            baseEntries.add(createFileEntry("f2", ADD));
+
+            List<IndexManifestEntry> deltaIndexEntries = new ArrayList<>();
+            deltaIndexEntries.add(createDvIndexEntry("dv1", DELETE, Arrays.asList("f2")));
+
+            assertThat(buildBaseEntriesWithDV(baseEntries, deltaIndexEntries))
+                    .containsExactlyInAnyOrder(
+                            createFileEntryWithDV("f1", ADD, null),
+                            createFileEntryWithDV("f2", ADD, null));
+        }
+    }
+
+    @Test
+    public void testBuildDeltaEntriesWithDV() {
+        {
+            // Scene 1: update f2's dv
+            List<SimpleFileEntry> baseEntries = new ArrayList<>();
+            baseEntries.add(createFileEntryWithDV("f1", ADD, "dv1"));
+            baseEntries.add(createFileEntryWithDV("f2", ADD, null));
+
+            List<SimpleFileEntry> deltaEntries = new ArrayList<>();
+            deltaEntries.add(createFileEntry("f2", DELETE));
+            deltaEntries.add(createFileEntry("f2_new", ADD));
+
+            List<IndexManifestEntry> deltaIndexEntries = new ArrayList<>();
+            deltaIndexEntries.add(createDvIndexEntry("dv2", ADD, Arrays.asList("f2_new")));
+
+            assertThat(buildDeltaEntriesWithDV(baseEntries, deltaEntries, deltaIndexEntries))
+                    .containsExactlyInAnyOrder(
+                            createFileEntryWithDV("f2", DELETE, null),
+                            createFileEntryWithDV("f2_new", ADD, "dv2"));
+        }
+
+        {
+            // Scene 2: update f2 and merge f1's dv
+            List<SimpleFileEntry> baseEntries = new ArrayList<>();
+            baseEntries.add(createFileEntryWithDV("f1", ADD, "dv1"));
+            baseEntries.add(createFileEntryWithDV("f2", ADD, null));
+
+            List<SimpleFileEntry> deltaEntries = new ArrayList<>();
+            deltaEntries.add(createFileEntry("f2", DELETE));
+            deltaEntries.add(createFileEntry("f2_new", ADD));
+            deltaEntries.add(createFileEntry("f3", ADD));
+
+            List<IndexManifestEntry> deltaIndexEntries = new ArrayList<>();
+            deltaIndexEntries.add(createDvIndexEntry("dv1", DELETE, Arrays.asList("f1")));
+            deltaIndexEntries.add(createDvIndexEntry("dv2", ADD, Arrays.asList("f1", "f2_new")));
+
+            assertThat(buildDeltaEntriesWithDV(baseEntries, deltaEntries, deltaIndexEntries))
+                    .containsExactlyInAnyOrder(
+                            createFileEntryWithDV("f1", DELETE, "dv1"),
+                            createFileEntryWithDV("f1", ADD, "dv2"),
+                            createFileEntryWithDV("f2", DELETE, null),
+                            createFileEntryWithDV("f2_new", ADD, "dv2"),
+                            createFileEntryWithDV("f3", ADD, null));
+        }
+
+        {
+            // Scene 3: update f2 (with dv) and merge f1's dv
+            List<SimpleFileEntry> baseEntries = new ArrayList<>();
+            baseEntries.add(createFileEntryWithDV("f1", ADD, "dv1"));
+            baseEntries.add(createFileEntryWithDV("f2", ADD, "dv2"));
+
+            List<SimpleFileEntry> deltaEntries = new ArrayList<>();
+            deltaEntries.add(createFileEntry("f2", DELETE));
+            deltaEntries.add(createFileEntry("f2_new", ADD));
+            deltaEntries.add(createFileEntry("f3", ADD));
+
+            List<IndexManifestEntry> deltaIndexEntries = new ArrayList<>();
+            deltaIndexEntries.add(createDvIndexEntry("dv1", DELETE, Arrays.asList("f1")));
+            deltaIndexEntries.add(createDvIndexEntry("dv2", DELETE, Arrays.asList("f2")));
+            deltaIndexEntries.add(createDvIndexEntry("dv3", ADD, Arrays.asList("f1", "f2_new")));
+
+            assertThat(buildDeltaEntriesWithDV(baseEntries, deltaEntries, deltaIndexEntries))
+                    .containsExactlyInAnyOrder(
+                            createFileEntryWithDV("f1", DELETE, "dv1"),
+                            createFileEntryWithDV("f1", ADD, "dv3"),
+                            createFileEntryWithDV("f2", DELETE, "dv2"),
+                            createFileEntryWithDV("f2_new", ADD, "dv3"),
+                            createFileEntryWithDV("f3", ADD, null));
+        }
+
+        {
+            // Scene 4: full compact
+            List<SimpleFileEntry> baseEntries = new ArrayList<>();
+            baseEntries.add(createFileEntryWithDV("f1", ADD, null));
+            baseEntries.add(createFileEntryWithDV("f2", ADD, "dv1"));
+            baseEntries.add(createFileEntryWithDV("f3", ADD, "dv1"));
+            baseEntries.add(createFileEntryWithDV("f4", ADD, "dv2"));
+
+            List<SimpleFileEntry> deltaEntries = new ArrayList<>();
+            deltaEntries.add(createFileEntry("f1", DELETE));
+            deltaEntries.add(createFileEntry("f2", DELETE));
+            deltaEntries.add(createFileEntry("f3", DELETE));
+            deltaEntries.add(createFileEntry("f4", DELETE));
+            deltaEntries.add(createFileEntry("f5_compact", ADD));
+
+            List<IndexManifestEntry> deltaIndexEntries = new ArrayList<>();
+            deltaIndexEntries.add(createDvIndexEntry("dv1", DELETE, Arrays.asList("f2", "f3")));
+            deltaIndexEntries.add(createDvIndexEntry("dv2", DELETE, Arrays.asList("f4")));
+
+            assertThat(buildDeltaEntriesWithDV(baseEntries, deltaEntries, deltaIndexEntries))
+                    .containsExactlyInAnyOrder(
+                            createFileEntryWithDV("f1", DELETE, null),
+                            createFileEntryWithDV("f2", DELETE, "dv1"),
+                            createFileEntryWithDV("f3", DELETE, "dv1"),
+                            createFileEntryWithDV("f4", DELETE, "dv2"),
+                            createFileEntryWithDV("f5_compact", ADD, null));
+        }
+
+        {
+            // Scene 5: merge into with update, delete and insert
+            List<SimpleFileEntry> baseEntries = new ArrayList<>();
+            baseEntries.add(createFileEntryWithDV("f1", ADD, null));
+            baseEntries.add(createFileEntryWithDV("f2", ADD, null));
+            baseEntries.add(createFileEntryWithDV("f3", ADD, "dv1"));
+            baseEntries.add(createFileEntryWithDV("f4", ADD, "dv1"));
+            baseEntries.add(createFileEntryWithDV("f5", ADD, "dv2"));
+
+            List<SimpleFileEntry> deltaEntries = new ArrayList<>();
+            deltaEntries.add(createFileEntry("f2", DELETE));
+            deltaEntries.add(createFileEntry("f3", DELETE));
+            deltaEntries.add(createFileEntry("f3_new", ADD));
+            deltaEntries.add(createFileEntry("f7", ADD));
+
+            List<IndexManifestEntry> deltaIndexEntries = new ArrayList<>();
+            deltaIndexEntries.add(createDvIndexEntry("dv1", DELETE, Arrays.asList("f3", "f4")));
+            deltaIndexEntries.add(createDvIndexEntry("dv2", DELETE, Arrays.asList("f5")));
+            deltaIndexEntries.add(createDvIndexEntry("dv3", ADD, Arrays.asList("f1", "f4", "f5")));
+
+            assertThat(buildDeltaEntriesWithDV(baseEntries, deltaEntries, deltaIndexEntries))
+                    .containsExactlyInAnyOrder(
+                            createFileEntryWithDV("f1", DELETE, null),
+                            createFileEntryWithDV("f1", ADD, "dv3"),
+                            createFileEntryWithDV("f2", DELETE, null),
+                            createFileEntryWithDV("f3", DELETE, "dv1"),
+                            createFileEntryWithDV("f3_new", ADD, null),
+                            createFileEntryWithDV("f4", DELETE, "dv1"),
+                            createFileEntryWithDV("f4", ADD, "dv3"),
+                            createFileEntryWithDV("f5", DELETE, "dv2"),
+                            createFileEntryWithDV("f5", ADD, "dv3"),
+                            createFileEntryWithDV("f7", ADD, null));
+        }
+    }
+
+    @Test
+    public void testConflictDeletionWithDV() {
+        {
+            // Scene 1: base -------------> update2 (conflict)
+            //           f1          ^         <f1, +dv2>
+            //                       |
+            //                  update1 (finished)
+            //                    <f1, +dv1>
+            List<SimpleFileEntry> update1Entries = new ArrayList<>();
+            update1Entries.add(createFileEntryWithDV("f1", ADD, "dv1"));
+
+            List<SimpleFileEntry> update2DeltaEntries = new ArrayList<>();
+
+            List<IndexManifestEntry> update2DeltaIndexEntries = new ArrayList<>();
+            update2DeltaIndexEntries.add(createDvIndexEntry("dv2", ADD, Arrays.asList("f1")));
+
+            List<SimpleFileEntry> update2DeltaEntriesWithDV =
+                    buildDeltaEntriesWithDV(
+                            update1Entries, update2DeltaEntries, update2DeltaIndexEntries);
+            assertThat(update2DeltaEntriesWithDV)
+                    .containsExactlyInAnyOrder(
+                            createFileEntryWithDV("f1", DELETE, null),
+                            createFileEntryWithDV("f1", ADD, "dv2"));
+            assertConflict(update1Entries, update2DeltaEntriesWithDV);
+        }
+
+        {
+            // Scene 2: base -------------> update2 (conflict)
+            //         <f1, dv0>     ^        <f1, +dv2>
+            //                       |
+            //                  update1 (finished)
+            //                    <f1, +dv1>
+            List<SimpleFileEntry> update1Entries = new ArrayList<>();
+            update1Entries.add(createFileEntryWithDV("f1", ADD, "dv1"));
+
+            List<SimpleFileEntry> update2DeltaEntries = new ArrayList<>();
+
+            List<IndexManifestEntry> update2DeltaIndexEntries = new ArrayList<>();
+            update2DeltaIndexEntries.add(createDvIndexEntry("dv0", DELETE, Arrays.asList("f1")));
+            update2DeltaIndexEntries.add(createDvIndexEntry("dv2", ADD, Arrays.asList("f1")));
+
+            List<SimpleFileEntry> update2DeltaEntriesWithDV =
+                    buildDeltaEntriesWithDV(
+                            update1Entries, update2DeltaEntries, update2DeltaIndexEntries);
+            assertThat(update2DeltaEntriesWithDV)
+                    .containsExactlyInAnyOrder(
+                            createFileEntryWithDV("f1", DELETE, "dv0"),
+                            createFileEntryWithDV("f1", ADD, "dv2"));
+            assertConflict(update1Entries, update2DeltaEntriesWithDV);
+        }
+
+        {
+            // Scene 3: base -------------> update2 (conflict)
+            //         <f1, dv0>      ^     <-f1, -dv0>, <+f3, null>
+            //                        |
+            //                  update1 (finished)
+            //                 <-f1, -dv0>, <+f2, dv1>
+            List<SimpleFileEntry> update1Entries = new ArrayList<>();
+            update1Entries.add(createFileEntryWithDV("f2", ADD, "dv1"));
+
+            List<SimpleFileEntry> update2DeltaEntries = new ArrayList<>();
+            update2DeltaEntries.add(createFileEntry("f1", DELETE));
+            update2DeltaEntries.add(createFileEntry("f3", ADD));
+
+            List<IndexManifestEntry> update2DeltaIndexEntries = new ArrayList<>();
+            update2DeltaIndexEntries.add(createDvIndexEntry("dv0", DELETE, Arrays.asList("f1")));
+
+            List<SimpleFileEntry> update2DeltaEntriesWithDV =
+                    buildDeltaEntriesWithDV(
+                            update1Entries, update2DeltaEntries, update2DeltaIndexEntries);
+            assertThat(update2DeltaEntriesWithDV)
+                    .containsExactlyInAnyOrder(
+                            createFileEntryWithDV("f1", DELETE, "dv0"),
+                            createFileEntryWithDV("f3", ADD, null));
+            assertConflict(update1Entries, update2DeltaEntriesWithDV);
+        }
+    }
+
+    private SimpleFileEntry createFileEntry(String fileName, FileKind kind) {
+        return new SimpleFileEntry(
+                kind,
+                EMPTY_ROW,
+                0,
+                1,
+                0,
+                fileName,
+                Collections.emptyList(),
+                null,
+                EMPTY_ROW,
+                EMPTY_ROW,
+                null);
+    }
+
+    private SimpleFileEntryWithDV createFileEntryWithDV(
+            String fileName, FileKind kind, @Nullable String dvFileName) {
+        return new SimpleFileEntryWithDV(createFileEntry(fileName, kind), dvFileName);
+    }
+
+    private IndexManifestEntry createDvIndexEntry(
+            String fileName, FileKind kind, List<String> fileNames) {
+        LinkedHashMap<String, DeletionVectorMeta> dvRanges = new LinkedHashMap<>();
+        for (String name : fileNames) {
+            dvRanges.put(name, new DeletionVectorMeta(name, 1, 1, 1L));
+        }
+        return new IndexManifestEntry(
+                kind,
+                EMPTY_ROW,
+                0,
+                new IndexFileMeta(
+                        DELETION_VECTORS_INDEX, fileName, 11, dvRanges.size(), dvRanges, null));
+    }
+
+    private void assertConflict(
+            List<SimpleFileEntry> baseEntries, List<SimpleFileEntry> deltaEntries) {
+        ArrayList<SimpleFileEntry> simpleFileEntryWithDVS = new ArrayList<>(baseEntries);
+        simpleFileEntryWithDVS.addAll(deltaEntries);
+        Collection<SimpleFileEntry> merged = FileEntry.mergeEntries(simpleFileEntryWithDVS);
+        int deleteCount = 0;
+        for (SimpleFileEntry simpleFileEntryWithDV : merged) {
+            if (simpleFileEntryWithDV.kind().equals(FileKind.DELETE)) {
+                deleteCount++;
+            }
+        }
+        assert (deleteCount > 0);
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -18,7 +18,7 @@
 
 package org.apache.paimon.spark.commands
 
-import org.apache.paimon.CoreOptions
+import org.apache.paimon.{CoreOptions, Snapshot}
 import org.apache.paimon.CoreOptions.{PartitionSinkStrategy, WRITE_ONLY}
 import org.apache.paimon.codegen.CodeGenUtils
 import org.apache.paimon.crosspartition.{IndexBootstrap, KeyPartOrRow}
@@ -304,10 +304,11 @@ case class PaimonSparkWriter(table: FileStoreTable, writeRowTracking: Boolean = 
    * deletion vectors; else, one index file will contain all deletion vector with the same partition
    * and bucket.
    */
-  def persistDeletionVectors(deletionVectors: Dataset[SparkDeletionVector]): Seq[CommitMessage] = {
+  def persistDeletionVectors(
+      deletionVectors: Dataset[SparkDeletionVector],
+      snapshot: Snapshot): Seq[CommitMessage] = {
     val sparkSession = deletionVectors.sparkSession
     import sparkSession.implicits._
-    val snapshot = table.snapshotManager().latestSnapshotFromFileSystem()
     val serializedCommits = deletionVectors
       .groupByKey(_.partitionAndBucket)
       .mapGroups {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

### Transaction Isolation Level

1. Snapshot Isolation: For writes to the same file (such as COW or DV writes), the first write to complete wins.
2. Serializability: In addition to level 1, it also checks whether new files generated from reading the snapshot ID to writing the snapshot ID are also applied to the processing logic (for example, newly added files also need to be updated).

Serializability relies on reading the snapshot ID, which is currently not supported by Paimon. Paimon currently achieves snapshot isolation by comparing two consecutive snapshots to see if they conflict.

### This PR 

Enhances snapshot isolation for DV tables. Compared with non-DV table conflict detection, DV table needs to compare <file, db> pair.

non dv table
snapshot t-1 -> base files -> ADD f
snapshot t -> delete files + add files -> ADD f or DELETE f

dv table
snapshot t-1 -> base files + dv files -> ADD <f, dv>
snapshot t -> delete files + new files + delete dv files + new dv files -> ADD <f, dv> or DELETE <f, dv>

Other fix:

Use scan snapshot to persistDeletionVectors in spark row level command with dv table. This can ensure that the snapshot used for DV generation and reading is the same as much as possible. (Although I feel it is not so accurate. Perhaps this can only be achieved if we implement read snapshot id at the table interface level)

### Todo

Since PK table's compact dv index and Non-PK HASH table's dv index entry only contains ADD type, we can't perform conflict detection on them.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
