### PR TITLE
[WIP][common] Fix that casting timestamp with local timezone to numeric doesn't consider zone

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/casting/TimestampToNumericPrimitiveCastRule.java
+++ b/paimon-common/src/main/java/org/apache/paimon/casting/TimestampToNumericPrimitiveCastRule.java
@@ -24,6 +24,9 @@ import org.apache.paimon.types.DataTypeFamily;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.utils.DateTimeUtils;
 
+import java.time.Instant;
+import java.time.ZoneId;
+
 /**
  * {@link DataTypeRoot#TIMESTAMP_WITHOUT_TIME_ZONE}/{@link
  * DataTypeRoot#TIMESTAMP_WITH_LOCAL_TIME_ZONE} to {@link DataTypeFamily#NUMERIC} cast rule.
@@ -55,13 +58,19 @@ public class TimestampToNumericPrimitiveCastRule extends AbstractCastRule<Timest
             if (targetType.is(DataTypeRoot.BIGINT)) {
                 return value ->
                         DateTimeUtils.unixTimestamp(
-                                Timestamp.fromLocalDateTime(value.toLocalDateTime())
+                                Timestamp.fromLocalDateTime(
+                                                Instant.ofEpochMilli(value.getMillisecond())
+                                                        .atZone(ZoneId.systemDefault())
+                                                        .toLocalDateTime())
                                         .getMillisecond());
             } else if (targetType.is(DataTypeRoot.INTEGER)) {
                 return value ->
                         (int)
                                 DateTimeUtils.unixTimestamp(
-                                        Timestamp.fromLocalDateTime(value.toLocalDateTime())
+                                        Timestamp.fromLocalDateTime(
+                                                        Instant.ofEpochMilli(value.getMillisecond())
+                                                                .atZone(ZoneId.systemDefault())
+                                                                .toLocalDateTime())
                                                 .getMillisecond());
             }
         }

--- a/paimon-common/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -317,7 +317,7 @@ public class CastExecutorTest {
 
         compareCastResult(
                 CastExecutors.resolve(new LocalZonedTimestampType(3), new BigIntType(false)),
-                timestamp2,
+                timestamp1,
                 DateTimeUtils.unixTimestamp(millisecond1));
 
         compareCastResult(
@@ -327,7 +327,7 @@ public class CastExecutorTest {
 
         compareCastResult(
                 CastExecutors.resolve(new LocalZonedTimestampType(3), new IntType(false)),
-                timestamp2,
+                timestamp1,
                 (int) DateTimeUtils.unixTimestamp(millisecond1));
 
         // cast from BigIntType or IntType to TimestampType


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Currently, it will cast 1970-01-01 00:00:00 with local timezone to 0, but we expected to add timezone offset.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
