### PR TITLE
[core] Update deprecated HttpClient 5 API calls

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -33,9 +33,8 @@ import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.Header;
-import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicHeader;
 
@@ -137,32 +136,36 @@ public class HttpClient implements RESTClient {
     }
 
     private <T extends RESTResponse> T exec(HttpUriRequestBase request, Class<T> responseType) {
-        try (CloseableHttpResponse response = HTTP_CLIENT.execute(request)) {
-            String responseBodyStr = RESTUtil.extractResponseBodyAsString(response);
-            if (!RESTUtil.isSuccessful(response)) {
-                ErrorResponse error;
-                try {
-                    error = RESTApi.fromJson(responseBodyStr, ErrorResponse.class);
-                } catch (JsonProcessingException e) {
-                    error =
-                            new ErrorResponse(
-                                    null,
-                                    null,
-                                    responseBodyStr != null
-                                            ? responseBodyStr
-                                            : "response body is null",
-                                    response.getCode());
-                }
-                errorHandler.accept(error, getRequestId(response));
-            }
-            if (responseType != null && responseBodyStr != null) {
-                return RESTApi.fromJson(responseBodyStr, responseType);
-            } else if (responseType == null) {
-                return null;
-            } else {
-                throw new RESTException("response body is null.");
-            }
-        } catch (IOException | ParseException e) {
+        try {
+            return HTTP_CLIENT.execute(
+                    request,
+                    response -> {
+                        String responseBodyStr = RESTUtil.extractResponseBodyAsString(response);
+                        if (!RESTUtil.isSuccessful(response)) {
+                            ErrorResponse error;
+                            try {
+                                error = RESTApi.fromJson(responseBodyStr, ErrorResponse.class);
+                            } catch (JsonProcessingException e) {
+                                error =
+                                        new ErrorResponse(
+                                                null,
+                                                null,
+                                                responseBodyStr != null
+                                                        ? responseBodyStr
+                                                        : "response body is null",
+                                                response.getCode());
+                            }
+                            errorHandler.accept(error, getRequestId(response));
+                        }
+                        if (responseType != null && responseBodyStr != null) {
+                            return RESTApi.fromJson(responseBodyStr, responseType);
+                        } else if (responseType == null) {
+                            return null;
+                        } else {
+                            throw new RESTException("response body is null.");
+                        }
+                    });
+        } catch (IOException e) {
             throw new RESTException(
                     e, "Error occurred while processing %s request", request.getMethod());
         }
@@ -194,7 +197,7 @@ public class HttpClient implements RESTClient {
         return uri;
     }
 
-    private static String getRequestId(CloseableHttpResponse response) {
+    private static String getRequestId(ClassicHttpResponse response) {
         Header header = response.getFirstHeader(LoggingInterceptor.REQUEST_ID_KEY);
         return header != null ? header.getValue() : LoggingInterceptor.DEFAULT_REQUEST_ID;
     }

--- a/paimon-api/src/main/java/org/apache/paimon/rest/RESTUtil.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/RESTUtil.java
@@ -27,7 +27,7 @@ import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.shade.guava30.com.google.common.collect.Maps;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
@@ -173,7 +173,7 @@ public class RESTUtil {
         return null;
     }
 
-    public static String extractResponseBodyAsString(CloseableHttpResponse response)
+    public static String extractResponseBodyAsString(ClassicHttpResponse response)
             throws IOException, ParseException {
         if (response.getEntity() == null) {
             return null;
@@ -182,7 +182,7 @@ public class RESTUtil {
         return EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
     }
 
-    public static boolean isSuccessful(CloseableHttpResponse response) {
+    public static boolean isSuccessful(ClassicHttpResponse response) {
         int code = response.getCode();
         return code == HttpStatus.SC_OK
                 || code == HttpStatus.SC_ACCEPTED

--- a/paimon-api/src/main/java/org/apache/paimon/rest/interceptor/LoggingInterceptor.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/interceptor/LoggingInterceptor.java
@@ -40,7 +40,7 @@ public class LoggingInterceptor implements HttpResponseInterceptor {
     @Override
     public void process(
             HttpResponse httpResponse, EntityDetails entityDetails, HttpContext httpContext) {
-        HttpCoreContext coreContext = HttpCoreContext.adapt(httpContext);
+        HttpCoreContext coreContext = HttpCoreContext.cast(httpContext);
         HttpRequest request = coreContext.getRequest();
         Long startTime = (Long) coreContext.getAttribute(REQUEST_START_TIME_KEY);
         long durationMs = System.currentTimeMillis() - startTime;

--- a/paimon-api/src/main/java/org/apache/paimon/rest/interceptor/TimingInterceptor.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/interceptor/TimingInterceptor.java
@@ -35,7 +35,7 @@ public class TimingInterceptor implements HttpRequestInterceptor {
     public void process(
             HttpRequest httpRequest, EntityDetails entityDetails, HttpContext httpContext)
             throws HttpException, IOException {
-        HttpCoreContext coreContext = HttpCoreContext.adapt(httpContext);
+        HttpCoreContext coreContext = HttpCoreContext.cast(httpContext);
         coreContext.setAttribute(REQUEST_START_TIME_KEY, System.currentTimeMillis());
     }
 }


### PR DESCRIPTION
### Purpose

To resolve compile-time warnings and align with Apache HttpClient 5 best practices, this commit refactors parts of the `paimon-api` module.

The main changes include:
- Replacing the deprecated `HttpCoreContext.adapt()` with `HttpCoreContext.cast()`.
- Using the new `execute(request, responseHandler)` method instead of the old `execute(request)` call to ensure safer resource management.

### Tests

CI
