### PR TITLE
[python] Support ignore_if_exists param for database and table

### DIFF
--- a/paimon-python/pypaimon/tests/predicates_test.py
+++ b/paimon-python/pypaimon/tests/predicates_test.py
@@ -26,6 +26,7 @@ import pyarrow as pa
 from pypaimon import CatalogFactory
 from pypaimon import Schema
 
+
 def _check_filtered_result(read_builder, expected_df):
     scan = read_builder.new_scan()
     read = read_builder.new_read()
@@ -33,8 +34,10 @@ def _check_filtered_result(read_builder, expected_df):
     pd.testing.assert_frame_equal(
         actual_df.reset_index(drop=True), expected_df.reset_index(drop=True))
 
+
 def _random_format():
     return random.choice(['parquet', 'avro', 'orc'])
+
 
 class PredicateTest(unittest.TestCase):
 

--- a/paimon-python/pypaimon/tests/predicates_test.py
+++ b/paimon-python/pypaimon/tests/predicates_test.py
@@ -26,7 +26,6 @@ import pyarrow as pa
 from pypaimon import CatalogFactory
 from pypaimon import Schema
 
-
 def _check_filtered_result(read_builder, expected_df):
     scan = read_builder.new_scan()
     read = read_builder.new_read()
@@ -34,10 +33,8 @@ def _check_filtered_result(read_builder, expected_df):
     pd.testing.assert_frame_equal(
         actual_df.reset_index(drop=True), expected_df.reset_index(drop=True))
 
-
 def _random_format():
     return random.choice(['parquet', 'avro', 'orc'])
-
 
 class PredicateTest(unittest.TestCase):
 
@@ -81,14 +78,14 @@ class PredicateTest(unittest.TestCase):
 
         cls.df = df
 
-    def testWrongFieldName(self):
+    def test_wrong_field_name(self):
         table = self.catalog.get_table('default.test_append')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         with self.assertRaises(ValueError) as e:
             predicate_builder.equal('f2', 'a')
         self.assertEqual(str(e.exception), "The field f2 is not in field list ['f0', 'f1'].")
 
-    def testAppendWithDuplicate(self):
+    def test_append_with_duplicate(self):
         pa_schema = pa.schema([
             ('f0', pa.int64()),
             ('f1', pa.string()),
@@ -121,7 +118,7 @@ class PredicateTest(unittest.TestCase):
         actual_df = read.to_pandas(scan.plan().splits())
         self.assertEqual(len(actual_df), 0)
 
-    def testAllFieldTypesWithEqual(self):
+    def test_all_field_types_with_equal(self):
         pa_schema = pa.schema([
             # int
             ('_tinyint', pa.int8()),
@@ -194,169 +191,169 @@ class PredicateTest(unittest.TestCase):
         predicate = predicate_builder.equal('_boolean', True)
         _check_filtered_result(table.new_read_builder().with_filter(predicate), df.loc[[0]])
 
-    def testEqualPk(self):
+    def test_equal_pk(self):
         table = self.catalog.get_table('default.test_pk')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.equal('f0', 1)
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[[0]])
 
-    def testNotEqualAppend(self):
+    def test_not_equal_append(self):
         table = self.catalog.get_table('default.test_append')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.not_equal('f0', 1)
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[1:4])
 
-    def testNotEqualPk(self):
+    def test_not_equal_pk(self):
         table = self.catalog.get_table('default.test_pk')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.not_equal('f0', 1)
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[1:4])
 
-    def testLessThanAppend(self):
+    def test_less_than_append(self):
         table = self.catalog.get_table('default.test_append')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.less_than('f0', 3)
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[0:1])
 
-    def testLessThanPk(self):
+    def test_less_than_pk(self):
         table = self.catalog.get_table('default.test_pk')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.less_than('f0', 3)
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[0:1])
 
-    def testLessOrEqualAppend(self):
+    def test_less_or_equal_append(self):
         table = self.catalog.get_table('default.test_append')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.less_or_equal('f0', 3)
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[0:2])
 
-    def testLessOrEqualPk(self):
+    def test_less_or_equal_pk(self):
         table = self.catalog.get_table('default.test_pk')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.less_or_equal('f0', 3)
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[0:2])
 
-    def testGreaterThanAppend(self):
+    def test_greater_than_append(self):
         table = self.catalog.get_table('default.test_append')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.greater_than('f0', 3)
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[3:4])
 
-    def testGreaterThanPk(self):
+    def test_greater_than_pk(self):
         table = self.catalog.get_table('default.test_pk')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.greater_than('f0', 3)
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[3:4])
 
-    def testGreaterOrEqualAppend(self):
+    def test_greater_or_equal_append(self):
         table = self.catalog.get_table('default.test_append')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.greater_or_equal('f0', 3)
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[2:4])
 
-    def testGreaterOrEqualPk(self):
+    def test_greater_or_equal_pk(self):
         table = self.catalog.get_table('default.test_pk')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.greater_or_equal('f0', 3)
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[2:4])
 
-    def testIsNullAppend(self):
+    def test_is_null_append(self):
         table = self.catalog.get_table('default.test_append')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.is_null('f1')
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[[4]])
 
-    def testIsNullPk(self):
+    def test_is_null_pk(self):
         table = self.catalog.get_table('default.test_pk')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.is_null('f1')
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[[4]])
 
-    def testIsNotNullAppend(self):
+    def test_is_not_null_append(self):
         table = self.catalog.get_table('default.test_append')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.is_not_null('f1')
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[0:3])
 
-    def testIsNotNullPk(self):
+    def test_is_not_null_pk(self):
         table = self.catalog.get_table('default.test_pk')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.is_not_null('f1')
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[0:3])
 
-    def testStartswithAppend(self):
+    def test_startswith_append(self):
         table = self.catalog.get_table('default.test_append')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.startswith('f1', 'ab')
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[0:1])
 
-    def testStartswithPk(self):
+    def test_startswith_pk(self):
         table = self.catalog.get_table('default.test_pk')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.startswith('f1', 'ab')
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[0:1])
 
-    def testEndswithAppend(self):
+    def test_endswith_append(self):
         table = self.catalog.get_table('default.test_append')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.endswith('f1', 'bc')
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[0:2])
 
-    def testEndswithPk(self):
+    def test_endswith_pk(self):
         table = self.catalog.get_table('default.test_pk')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.endswith('f1', 'bc')
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[0:2])
 
-    def testContainsAppend(self):
+    def test_contains_append(self):
         table = self.catalog.get_table('default.test_append')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.contains('f1', 'bb')
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[[1]])
 
-    def testContainsPk(self):
+    def test_contains_pk(self):
         table = self.catalog.get_table('default.test_pk')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.contains('f1', 'bb')
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[[1]])
 
-    def testIsInAppend(self):
+    def test_is_in_append(self):
         table = self.catalog.get_table('default.test_append')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.is_in('f0', [1, 2])
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[0:1])
 
-    def testIsInPk(self):
+    def test_is_in_pk(self):
         table = self.catalog.get_table('default.test_pk')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.is_in('f1', ['abc', 'd'])
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[[0, 3]])
 
-    def testIsNotInAppend(self):
+    def test_is_not_in_append(self):
         table = self.catalog.get_table('default.test_append')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.is_not_in('f0', [1, 2])
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[2:4])
 
-    def testIsNotInPk(self):
+    def test_is_not_in_pk(self):
         table = self.catalog.get_table('default.test_pk')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.is_not_in('f1', ['abc', 'abbc'])
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[2:4])
 
-    def testBetweenAppend(self):
+    def test_between_append(self):
         table = self.catalog.get_table('default.test_append')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.between('f0', 1, 3)
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[0:2])
 
-    def testBetweenPk(self):
+    def test_between_pk(self):
         table = self.catalog.get_table('default.test_pk')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.between('f0', 1, 3)
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[0:2])
 
-    def testAndPredicates(self):
+    def test_and_predicates(self):
         table = self.catalog.get_table('default.test_append')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate1 = predicate_builder.greater_than('f0', 1)
@@ -364,7 +361,7 @@ class PredicateTest(unittest.TestCase):
         predicate = predicate_builder.and_predicates([predicate1, predicate2])
         _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[[1]])
 
-    def testOrPredicates(self):
+    def test_or_predicates(self):
         table = self.catalog.get_table('default.test_append')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate1 = predicate_builder.greater_than('f0', 3)
@@ -373,7 +370,7 @@ class PredicateTest(unittest.TestCase):
         _check_filtered_result(table.new_read_builder().with_filter(predicate),
                                self.df.loc[[0, 3, 4]])
 
-    def testPkReaderWithFilter(self):
+    def test_pk_reader_with_filter(self):
         pa_schema = pa.schema([
             pa.field('key1', pa.int32(), nullable=False),
             pa.field('key2', pa.string(), nullable=False),

--- a/paimon-python/pypaimon/tests/pvfs_test.py
+++ b/paimon-python/pypaimon/tests/pvfs_test.py
@@ -26,9 +26,6 @@ import pandas
 from pypaimon import PaimonVirtualFileSystem
 from pypaimon.api.api_response import ConfigResponse
 from pypaimon.api.auth import BearTokenAuthProvider
-from pypaimon.catalog.rest.table_metadata import TableMetadata
-from pypaimon.schema.data_types import AtomicType, DataField
-from pypaimon.schema.table_schema import TableSchema
 from pypaimon.tests.rest.api_test import RESTCatalogServer
 
 
@@ -67,17 +64,6 @@ class PVFSTest(unittest.TestCase):
         self.test_databases = {
             self.database: self.server.mock_database(self.database, {"k1": "v1", "k2": "v2"}),
         }
-        data_fields = [
-            DataField(0, "id", AtomicType('INT'), 'id'),
-            DataField(1, "name", AtomicType('STRING'), 'name')
-        ]
-        schema = TableSchema(TableSchema.CURRENT_VERSION, len(data_fields), data_fields, len(data_fields),
-                             [], [], {}, "")
-        self.server.database_store.update(self.test_databases)
-        self.test_tables = {
-            f"{self.database}.{self.table}": TableMetadata(uuid=str(uuid.uuid4()), is_external=True, schema=schema),
-        }
-        self.server.table_metadata_store.update(self.test_tables)
 
     def tearDown(self):
         if self.temp_path.exists():

--- a/paimon-python/pypaimon/tests/rest/rest_simple_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_simple_test.py
@@ -21,6 +21,8 @@ import os
 import pyarrow as pa
 
 from pypaimon import Schema
+from pypaimon.catalog.catalog_exception import DatabaseAlreadyExistException, TableAlreadyExistException, \
+    DatabaseNotExistException, TableNotExistException
 from pypaimon.tests.rest.rest_base_test import RESTBaseTest
 from pypaimon.write.row_key_extractor import FixedBucketRowKeyExtractor, DynamicBucketRowKeyExtractor
 
@@ -558,3 +560,56 @@ class RESTSimpleTest(RESTBaseTest):
         splits = read_builder.new_scan().plan().splits()
         actual = table_read.to_arrow(splits)
         self.assertTrue(not actual)
+
+    def test_create_drop_database_table(self):
+        # test create database
+        self.rest_catalog.create_database("db1", False)
+
+        with self.assertRaises(DatabaseAlreadyExistException) as context:
+            self.rest_catalog.create_database("db1", False)
+
+        self.assertEqual("db1", context.exception.database)
+
+        try:
+            self.rest_catalog.create_database("db1", True)
+        except DatabaseAlreadyExistException:
+            self.fail("create_database with ignore_if_exists=True should not raise DatabaseAlreadyExistException")
+
+        # test create table
+        self.rest_catalog.create_table("db1.tbl1",
+                                       Schema.from_pyarrow_schema(self.pa_schema, partition_keys=['dt']),
+                                       False)
+        with self.assertRaises(TableAlreadyExistException) as context:
+            self.rest_catalog.create_table("db1.tbl1",
+                                           Schema.from_pyarrow_schema(self.pa_schema, partition_keys=['dt']),
+                                           False)
+        self.assertEqual("db1.tbl1", context.exception.identifier.get_full_name())
+
+        try:
+            self.rest_catalog.create_table("db1.tbl1",
+                                           Schema.from_pyarrow_schema(self.pa_schema, partition_keys=['dt']),
+                                           True)
+        except TableAlreadyExistException:
+            self.fail("create_table with ignore_if_exists=True should not raise TableAlreadyExistException")
+
+        # test drop table
+        self.rest_catalog.drop_table("db1.tbl1", False)
+        with self.assertRaises(TableNotExistException) as context:
+            self.rest_catalog.drop_table("db1.tbl1", False)
+        self.assertEqual("db1.tbl1", context.exception.identifier.get_full_name())
+
+        try:
+            self.rest_catalog.drop_table("db1.tbl1", True)
+        except TableNotExistException:
+            self.fail("drop_table with ignore_if_exists=True should not raise TableNotExistException")
+
+        # test drop database
+        self.rest_catalog.drop_database("db1", False)
+        with self.assertRaises(DatabaseNotExistException) as context:
+            self.rest_catalog.drop_database("db1", False)
+        self.assertEqual("db1", context.exception.database)
+
+        try:
+            self.rest_catalog.drop_database("db1", True)
+        except DatabaseNotExistException:
+            self.fail("drop_database with ignore_if_exists=True should not raise DatabaseNotExistException")

--- a/paimon-python/pypaimon/tests/serializable_test.py
+++ b/paimon-python/pypaimon/tests/serializable_test.py
@@ -54,7 +54,7 @@ class SerializableTest(unittest.TestCase):
     def tearDownClass(cls):
         shutil.rmtree(cls.tempdir, ignore_errors=True)
 
-    def testPickleSerializable(self):
+    def test_pickle_serializable(self):
         schema = Schema.from_pyarrow_schema(self.pa_schema,
                                             partition_keys=['dt'],
                                             primary_keys=['user_id', 'dt'],


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Support ignore_if_exists param when create and drop a database and table.

### Tests

- RESTSimpleTest.test_create_drop_database_table()

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
