### PR TITLE
[core] Introduce creation methods to Blob

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -32,8 +32,8 @@ import org.apache.hc.client5.http.classic.methods.HttpDelete;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicHeader;
@@ -43,12 +43,10 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
 
-import static org.apache.paimon.rest.HttpClientUtils.createLoggingBuilder;
+import static org.apache.paimon.rest.HttpClientUtils.DEFAULT_HTTP_CLIENT;
 
 /** Apache HTTP client for REST catalog. */
 public class HttpClient implements RESTClient {
-
-    private static final CloseableHttpClient HTTP_CLIENT = createLoggingBuilder().build();
 
     private final String uri;
 
@@ -136,6 +134,7 @@ public class HttpClient implements RESTClient {
     }
 
     private <T extends RESTResponse> T exec(HttpUriRequestBase request, Class<T> responseType) {
+<<<<<<< HEAD
         try {
             return HTTP_CLIENT.execute(
                     request,
@@ -166,6 +165,34 @@ public class HttpClient implements RESTClient {
                         }
                     });
         } catch (IOException e) {
+=======
+        try (CloseableHttpResponse response = DEFAULT_HTTP_CLIENT.execute(request)) {
+            String responseBodyStr = RESTUtil.extractResponseBodyAsString(response);
+            if (!RESTUtil.isSuccessful(response)) {
+                ErrorResponse error;
+                try {
+                    error = RESTApi.fromJson(responseBodyStr, ErrorResponse.class);
+                } catch (JsonProcessingException e) {
+                    error =
+                            new ErrorResponse(
+                                    null,
+                                    null,
+                                    responseBodyStr != null
+                                            ? responseBodyStr
+                                            : "response body is null",
+                                    response.getCode());
+                }
+                errorHandler.accept(error, getRequestId(response));
+            }
+            if (responseType != null && responseBodyStr != null) {
+                return RESTApi.fromJson(responseBodyStr, responseType);
+            } else if (responseType == null) {
+                return null;
+            } else {
+                throw new RESTException("response body is null.");
+            }
+        } catch (IOException | ParseException e) {
+>>>>>>> 042de11aa (fix)
             throw new RESTException(
                     e, "Error occurred while processing %s request", request.getMethod());
         }

--- a/paimon-api/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -33,7 +33,6 @@ import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.apache.hc.core5.http.ClassicHttpResponse;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicHeader;
@@ -134,9 +133,8 @@ public class HttpClient implements RESTClient {
     }
 
     private <T extends RESTResponse> T exec(HttpUriRequestBase request, Class<T> responseType) {
-<<<<<<< HEAD
         try {
-            return HTTP_CLIENT.execute(
+            return DEFAULT_HTTP_CLIENT.execute(
                     request,
                     response -> {
                         String responseBodyStr = RESTUtil.extractResponseBodyAsString(response);
@@ -165,34 +163,6 @@ public class HttpClient implements RESTClient {
                         }
                     });
         } catch (IOException e) {
-=======
-        try (CloseableHttpResponse response = DEFAULT_HTTP_CLIENT.execute(request)) {
-            String responseBodyStr = RESTUtil.extractResponseBodyAsString(response);
-            if (!RESTUtil.isSuccessful(response)) {
-                ErrorResponse error;
-                try {
-                    error = RESTApi.fromJson(responseBodyStr, ErrorResponse.class);
-                } catch (JsonProcessingException e) {
-                    error =
-                            new ErrorResponse(
-                                    null,
-                                    null,
-                                    responseBodyStr != null
-                                            ? responseBodyStr
-                                            : "response body is null",
-                                    response.getCode());
-                }
-                errorHandler.accept(error, getRequestId(response));
-            }
-            if (responseType != null && responseBodyStr != null) {
-                return RESTApi.fromJson(responseBodyStr, responseType);
-            } else if (responseType == null) {
-                return null;
-            } else {
-                throw new RESTException("response body is null.");
-            }
-        } catch (IOException | ParseException e) {
->>>>>>> 042de11aa (fix)
             throw new RESTException(
                     e, "Error occurred while processing %s request", request.getMethod());
         }

--- a/paimon-common/src/main/java/org/apache/paimon/data/AbstractBinaryWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/AbstractBinaryWriter.java
@@ -196,7 +196,7 @@ abstract class AbstractBinaryWriter implements BinaryWriter {
 
     @Override
     public void writeBlob(int pos, Blob blob) {
-        byte[] bytes = blob.toBytes();
+        byte[] bytes = blob.toData();
         writeBinary(pos, bytes, 0, bytes.length);
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/data/Blob.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/Blob.java
@@ -19,7 +19,10 @@
 package org.apache.paimon.data;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.utils.UriReader;
 
 import java.io.IOException;
 
@@ -31,7 +34,27 @@ import java.io.IOException;
 @Public
 public interface Blob {
 
-    byte[] toBytes();
+    byte[] toData();
 
     SeekableInputStream newInputStream() throws IOException;
+
+    static Blob fromData(byte[] data) {
+        return new BlobData(data);
+    }
+
+    static Blob fromLocal(String file) {
+        return fromFile(LocalFileIO.create(), new BlobDescriptor(file, 0, -1));
+    }
+
+    static Blob fromHttp(String uri) {
+        return fromDescriptor(UriReader.fromHttp(), new BlobDescriptor(uri, 0, -1));
+    }
+
+    static Blob fromFile(FileIO fileIO, BlobDescriptor descriptor) {
+        return fromDescriptor(UriReader.fromFile(fileIO), descriptor);
+    }
+
+    static Blob fromDescriptor(UriReader reader, BlobDescriptor descriptor) {
+        return new BlobRef(reader, descriptor);
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/data/Blob.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/Blob.java
@@ -36,6 +36,8 @@ public interface Blob {
 
     byte[] toData();
 
+    BlobDescriptor toDescriptor();
+
     SeekableInputStream newInputStream() throws IOException;
 
     static Blob fromData(byte[] data) {

--- a/paimon-common/src/main/java/org/apache/paimon/data/Blob.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/Blob.java
@@ -51,7 +51,7 @@ public interface Blob {
     }
 
     static Blob fromFile(FileIO fileIO, String file) {
-        return fromDescriptor(UriReader.fromFile(fileIO), new BlobDescriptor(file, 0, -1));
+        return fromFile(fileIO, file, 0, -1);
     }
 
     static Blob fromFile(FileIO fileIO, String file, long offset, long length) {

--- a/paimon-common/src/main/java/org/apache/paimon/data/Blob.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/Blob.java
@@ -43,15 +43,19 @@ public interface Blob {
     }
 
     static Blob fromLocal(String file) {
-        return fromFile(LocalFileIO.create(), new BlobDescriptor(file, 0, -1));
+        return fromFile(LocalFileIO.create(), file);
     }
 
     static Blob fromHttp(String uri) {
         return fromDescriptor(UriReader.fromHttp(), new BlobDescriptor(uri, 0, -1));
     }
 
-    static Blob fromFile(FileIO fileIO, BlobDescriptor descriptor) {
-        return fromDescriptor(UriReader.fromFile(fileIO), descriptor);
+    static Blob fromFile(FileIO fileIO, String file) {
+        return fromDescriptor(UriReader.fromFile(fileIO), new BlobDescriptor(file, 0, -1));
+    }
+
+    static Blob fromFile(FileIO fileIO, String file, long offset, long length) {
+        return fromDescriptor(UriReader.fromFile(fileIO), new BlobDescriptor(file, offset, length));
     }
 
     static Blob fromDescriptor(UriReader reader, BlobDescriptor descriptor) {

--- a/paimon-common/src/main/java/org/apache/paimon/data/BlobData.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BlobData.java
@@ -49,6 +49,11 @@ public class BlobData implements Blob, Serializable {
     }
 
     @Override
+    public BlobDescriptor toDescriptor() {
+        throw new RuntimeException("Blob data can not convert to descriptor.");
+    }
+
+    @Override
     public SeekableInputStream newInputStream() throws IOException {
         return new ByteArraySeekableStream(data);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/data/BlobData.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BlobData.java
@@ -44,7 +44,7 @@ public class BlobData implements Blob, Serializable {
     }
 
     @Override
-    public byte[] toBytes() {
+    public byte[] toData() {
         return data;
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/data/BlobDescriptor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BlobDescriptor.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.data;
+
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/** Blob descriptor to describe a blob reference. */
+public class BlobDescriptor implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String uri;
+    private final long offset;
+    private final long length;
+
+    public BlobDescriptor(String uri, long offset, long length) {
+        this.uri = uri;
+        this.offset = offset;
+        this.length = length;
+    }
+
+    public String uri() {
+        return uri;
+    }
+
+    public long offset() {
+        return offset;
+    }
+
+    public long length() {
+        return length;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BlobDescriptor that = (BlobDescriptor) o;
+        return offset == that.offset && length == that.length && Objects.equals(uri, that.uri);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uri, offset, length);
+    }
+
+    @Override
+    public String toString() {
+        return "BlobDescriptor{"
+                + "uri='"
+                + uri
+                + '\''
+                + ", offset="
+                + offset
+                + ", length="
+                + length
+                + '}';
+    }
+
+    public byte[] serialize() {
+        byte[] uriBytes = uri.getBytes(UTF_8);
+        int uriLength = uriBytes.length;
+
+        int totalSize = 4 + uriLength + 8 + 8;
+        ByteBuffer buffer = ByteBuffer.allocate(totalSize);
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
+
+        buffer.putInt(uriLength);
+        buffer.put(uriBytes);
+
+        buffer.putLong(offset);
+        buffer.putLong(length);
+
+        return buffer.array();
+    }
+
+    public static BlobDescriptor deserialize(byte[] bytes) {
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
+
+        int uriLength = buffer.getInt();
+        byte[] uriBytes = new byte[uriLength];
+        buffer.get(uriBytes);
+        String uri = new String(uriBytes, StandardCharsets.UTF_8);
+
+        long offset = buffer.getLong();
+        long length = buffer.getLong();
+
+        return new BlobDescriptor(uri, offset, length);
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/data/BlobRef.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BlobRef.java
@@ -53,6 +53,11 @@ public class BlobRef implements Blob {
     }
 
     @Override
+    public BlobDescriptor toDescriptor() {
+        return descriptor;
+    }
+
+    @Override
     public SeekableInputStream newInputStream() throws IOException {
         return new OffsetSeekableInputStream(
                 uriReader.newInputStream(descriptor.uri()),

--- a/paimon-common/src/main/java/org/apache/paimon/fs/LimitedSeekableInputStream.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/LimitedSeekableInputStream.java
@@ -16,35 +16,42 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.data.serializer;
-
-import org.apache.paimon.data.Blob;
-import org.apache.paimon.data.BlobData;
-import org.apache.paimon.io.DataInputView;
-import org.apache.paimon.io.DataOutputView;
+package org.apache.paimon.fs;
 
 import java.io.IOException;
+import java.io.InputStream;
 
-/** Type serializer for {@code Blob}. */
-public class BlobSerializer extends SerializerSingleton<Blob> {
+/** A {@link SeekableInputStream} wrapped {@link InputStream} without seek. */
+public class LimitedSeekableInputStream extends SeekableInputStream {
 
-    private static final long serialVersionUID = 1L;
+    private final InputStream in;
 
-    public static final BlobSerializer INSTANCE = new BlobSerializer();
-
-    @Override
-    public Blob copy(Blob from) {
-        return from;
+    public LimitedSeekableInputStream(InputStream in) {
+        this.in = in;
     }
 
     @Override
-    public void serialize(Blob blob, DataOutputView target) throws IOException {
-        BinarySerializer.INSTANCE.serialize(blob.toData(), target);
+    public void seek(long desired) throws IOException {
+        throw new UnsupportedOperationException();
     }
 
     @Override
-    public Blob deserialize(DataInputView source) throws IOException {
-        byte[] bytes = BinarySerializer.INSTANCE.deserialize(source);
-        return new BlobData(bytes);
+    public long getPos() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int read() throws IOException {
+        return in.read();
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        return in.read(b, off, len);
+    }
+
+    @Override
+    public void close() throws IOException {
+        in.close();
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fs/OffsetSeekableInputStream.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/OffsetSeekableInputStream.java
@@ -35,7 +35,9 @@ public class OffsetSeekableInputStream extends SeekableInputStream {
         this.wrapped = wrapped;
         this.offset = offset;
         this.length = length;
-        wrapped.seek(offset);
+        if (offset != 0) {
+            wrapped.seek(offset);
+        }
     }
 
     @Override
@@ -50,19 +52,23 @@ public class OffsetSeekableInputStream extends SeekableInputStream {
 
     @Override
     public int read() throws IOException {
-        if (getPos() >= length) {
-            return -1;
+        if (length != -1) {
+            if (getPos() >= length) {
+                return -1;
+            }
         }
         return wrapped.read();
     }
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
-        long realLen = Math.min(len, length - getPos());
-        if (realLen == 0) {
-            return -1;
+        if (length != -1) {
+            len = (int) Math.min(len, length - getPos());
+            if (len == 0) {
+                return -1;
+            }
         }
-        return wrapped.read(b, off, (int) realLen);
+        return wrapped.read(b, off, len);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/utils/UriReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/UriReader.java
@@ -32,10 +32,34 @@ public interface UriReader {
     SeekableInputStream newInputStream(String uri) throws IOException;
 
     static UriReader fromFile(FileIO fileIO) {
-        return uri -> fileIO.newInputStream(new Path(uri));
+        return new FileUriReader(fileIO);
     }
 
     static UriReader fromHttp() {
-        return uri -> new LimitedSeekableInputStream(HttpClientUtils.getAsInputStream(uri));
+        return new HttpUriReader();
+    }
+
+    /** A {@link UriReader} uses {@link FileIO} to read file. */
+    class FileUriReader implements UriReader {
+
+        private final FileIO fileIO;
+
+        public FileUriReader(FileIO fileIO) {
+            this.fileIO = fileIO;
+        }
+
+        @Override
+        public SeekableInputStream newInputStream(String uri) throws IOException {
+            return fileIO.newInputStream(new Path(uri));
+        }
+    }
+
+    /** A {@link UriReader} reads http uri. */
+    class HttpUriReader implements UriReader {
+
+        @Override
+        public SeekableInputStream newInputStream(String uri) throws IOException {
+            return new LimitedSeekableInputStream(HttpClientUtils.getAsInputStream(uri));
+        }
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/UriReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/UriReader.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.LimitedSeekableInputStream;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.SeekableInputStream;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/** An interface to read uri as a stream. */
+public interface UriReader {
+
+    SeekableInputStream newInputStream(String uri) throws IOException;
+
+    static UriReader fromFile(FileIO fileIO) {
+        return uri -> fileIO.newInputStream(new Path(uri));
+    }
+
+    static UriReader fromHttp() {
+        return uri -> {
+            URL url = new URL(uri);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(5000);
+            conn.setReadTimeout(5000);
+
+            if (conn.getResponseCode() != 200) {
+                throw new RuntimeException("HTTP error code: " + conn.getResponseCode());
+            }
+
+            return new LimitedSeekableInputStream(conn.getInputStream());
+        };
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/UriReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/UriReader.java
@@ -22,19 +22,12 @@ import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.LimitedSeekableInputStream;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.SeekableInputStream;
-
-import org.apache.hc.client5.http.classic.methods.HttpGet;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.paimon.rest.HttpClientUtils;
 
 import java.io.IOException;
 
-import static org.apache.paimon.rest.HttpClientUtils.createLoggingBuilder;
-
 /** An interface to read uri as a stream. */
 public interface UriReader {
-
-    CloseableHttpClient HTTP_CLIENT = createLoggingBuilder().build();
 
     SeekableInputStream newInputStream(String uri) throws IOException;
 
@@ -43,13 +36,6 @@ public interface UriReader {
     }
 
     static UriReader fromHttp() {
-        return uri -> {
-            HttpGet httpGet = new HttpGet(uri);
-            CloseableHttpResponse response = HTTP_CLIENT.execute(httpGet);
-            if (response.getCode() != 200) {
-                throw new RuntimeException("HTTP error code: " + response.getCode());
-            }
-            return new LimitedSeekableInputStream(response.getEntity().getContent());
-        };
+        return uri -> new LimitedSeekableInputStream(HttpClientUtils.getAsInputStream(uri));
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/UriReaderFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/UriReaderFactory.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** A factory to create and cache {@link UriReader}. */
+public class UriReaderFactory {
+
+    private final CatalogContext context;
+    private final Map<UriKey, UriReader> readers;
+
+    public UriReaderFactory(CatalogContext context) {
+        this.context = context;
+        this.readers = new ConcurrentHashMap<>();
+    }
+
+    public UriReader create(String input) {
+        URI uri = URI.create(input);
+        UriKey key = new UriKey(uri.getScheme(), uri.getAuthority());
+        return readers.computeIfAbsent(key, k -> newReader(k, uri));
+    }
+
+    private UriReader newReader(UriKey key, URI uri) {
+        if ("http".equals(key.scheme) || "https".equals(key.scheme)) {
+            return UriReader.fromHttp();
+        }
+
+        try {
+            FileIO fileIO = FileIO.get(new Path(uri), context);
+            return UriReader.fromFile(fileIO);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static final class UriKey {
+
+        private final @Nullable String scheme;
+        private final @Nullable String authority;
+
+        public UriKey(@Nullable String scheme, @Nullable String authority) {
+            this.scheme = scheme;
+            this.authority = authority;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            UriKey uriKey = (UriKey) o;
+            return Objects.equals(scheme, uriKey.scheme)
+                    && Objects.equals(authority, uriKey.authority);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(scheme, authority);
+        }
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/data/BinaryRowTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/BinaryRowTest.java
@@ -974,7 +974,7 @@ public class BinaryRowTest {
 
         Blob blob0 = row.getBlob(0);
         assertThat(blob0).isInstanceOf(BlobData.class);
-        assertThat(blob0.toBytes()).isEqualTo(new byte[] {1, 3, 1});
+        assertThat(blob0.toData()).isEqualTo(new byte[] {1, 3, 1});
         assertThat(row.isNullAt(1)).isTrue();
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/data/BlobDescriptorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/BlobDescriptorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.data;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link BlobDescriptor}. */
+public class BlobDescriptorTest {
+
+    @Test
+    public void testEquals() {
+        String uri1 = "/test/path1";
+        String uri2 = "/test/path2";
+
+        BlobDescriptor descriptor1 = new BlobDescriptor(uri1, 100L, 200L);
+        BlobDescriptor descriptor2 = new BlobDescriptor(uri1, 100L, 200L);
+        BlobDescriptor descriptor3 = new BlobDescriptor(uri2, 100L, 200L);
+        BlobDescriptor descriptor4 = new BlobDescriptor(uri1, 150L, 200L);
+        BlobDescriptor descriptor5 = new BlobDescriptor(uri1, 100L, 250L);
+
+        assertThat(descriptor1).isEqualTo(descriptor2);
+        assertThat(descriptor1).isNotEqualTo(descriptor3);
+        assertThat(descriptor1).isNotEqualTo(descriptor4);
+        assertThat(descriptor1).isNotEqualTo(descriptor5);
+        assertThat(descriptor1).isNotEqualTo(null);
+        assertThat(descriptor1).isNotEqualTo(new Object());
+    }
+
+    @Test
+    public void testHashCode() {
+        String uri = "/test/path";
+
+        BlobDescriptor descriptor1 = new BlobDescriptor(uri, 100L, 200L);
+        BlobDescriptor descriptor2 = new BlobDescriptor(uri, 100L, 200L);
+
+        assertThat(descriptor1.hashCode()).isEqualTo(descriptor2.hashCode());
+    }
+
+    @Test
+    public void testToString() {
+        String uri = "/test/path";
+        BlobDescriptor descriptor = new BlobDescriptor(uri, 100L, 200L);
+
+        String toString = descriptor.toString();
+        assertThat(toString).contains("uri='/test/path'");
+        assertThat(toString).contains("offset=100");
+        assertThat(toString).contains("length=200");
+    }
+
+    @Test
+    public void testSerializeAndDeserialize() {
+        String uri = "/test/path";
+        long offset = 100L;
+        long length = 200L;
+
+        BlobDescriptor original = new BlobDescriptor(uri, offset, length);
+        byte[] serialized = original.serialize();
+        BlobDescriptor deserialized = BlobDescriptor.deserialize(serialized);
+
+        assertThat(deserialized.uri()).isEqualTo(original.uri());
+        assertThat(deserialized.offset()).isEqualTo(original.offset());
+        assertThat(deserialized.length()).isEqualTo(original.length());
+        assertThat(deserialized).isEqualTo(original);
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/data/BlobTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/BlobTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.data;
+
+import org.apache.paimon.fs.local.LocalFileIO;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link Blob}. */
+public class BlobTest {
+
+    @TempDir java.nio.file.Path tempPath;
+
+    private String file;
+
+    @BeforeEach
+    void beforeEach() throws IOException {
+        file = new File(tempPath.toString(), "test.txt").getAbsolutePath();
+        Files.write(Paths.get(file), "test data".getBytes());
+    }
+
+    @Test
+    public void testFromData() {
+        byte[] testData = "test data".getBytes();
+        Blob blob = Blob.fromData(testData);
+        assertThat(blob).isInstanceOf(BlobData.class);
+        assertThat(blob.toData()).isEqualTo(testData);
+    }
+
+    @Test
+    public void testFromLocal() {
+        Blob blob = Blob.fromLocal(file);
+        assertThat(blob).isInstanceOf(BlobRef.class);
+        assertThat(blob.toData()).isEqualTo("test data".getBytes());
+    }
+
+    @Test
+    public void testFromFile() {
+        BlobDescriptor descriptor = new BlobDescriptor(file, 0, 4);
+        Blob blob = Blob.fromFile(LocalFileIO.create(), descriptor);
+        assertThat(blob).isInstanceOf(BlobRef.class);
+        assertThat(blob.toData()).isEqualTo("test".getBytes());
+    }
+
+    @Test
+    public void testFromHttp() {
+        String uri = "http://example.com/file.txt";
+        Blob blob = Blob.fromHttp(uri);
+        assertThat(blob).isInstanceOf(BlobRef.class);
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/data/BlobTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/BlobTest.java
@@ -61,10 +61,16 @@ public class BlobTest {
 
     @Test
     public void testFromFile() {
-        BlobDescriptor descriptor = new BlobDescriptor(file, 0, 4);
-        Blob blob = Blob.fromFile(LocalFileIO.create(), descriptor);
+        Blob blob = Blob.fromFile(LocalFileIO.create(), file, 0, 4);
         assertThat(blob).isInstanceOf(BlobRef.class);
         assertThat(blob.toData()).isEqualTo("test".getBytes());
+    }
+
+    @Test
+    public void testFromPath() {
+        Blob blob = Blob.fromFile(LocalFileIO.create(), file);
+        assertThat(blob).isInstanceOf(BlobRef.class);
+        assertThat(blob.toData()).isEqualTo("test data".getBytes());
     }
 
     @Test

--- a/paimon-common/src/test/java/org/apache/paimon/fs/OffsetSeekableInputStreamTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/OffsetSeekableInputStreamTest.java
@@ -173,32 +173,4 @@ public class OffsetSeekableInputStreamTest {
             assertThat(stream.getPos()).isEqualTo(10);
         }
     }
-
-    @Test
-    public void testReadByteArrayWithZeroLength() throws IOException {
-        long offset = 5;
-        long length = 10;
-        try (OffsetSeekableInputStream stream =
-                new OffsetSeekableInputStream(wrapped, offset, length)) {
-            byte[] buffer = new byte[0];
-            int bytesRead = stream.read(buffer, 0, 0);
-
-            assertThat(bytesRead).isEqualTo(0);
-        }
-    }
-
-    @Test
-    public void testSeekBeyondLength() throws IOException {
-        long offset = 5;
-        long length = 10;
-        try (OffsetSeekableInputStream stream =
-                new OffsetSeekableInputStream(wrapped, offset, length)) {
-            // Seeking beyond length should be allowed, but reading should return -1
-            stream.seek(15);
-            assertThat(stream.getPos()).isEqualTo(15);
-
-            int result = stream.read();
-            assertThat(result).isEqualTo(-1);
-        }
-    }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/fs/OffsetSeekableInputStreamTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/OffsetSeekableInputStreamTest.java
@@ -25,6 +25,9 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /** Tests for {@link OffsetSeekableInputStream}. */
 public class OffsetSeekableInputStreamTest {
@@ -144,6 +147,58 @@ public class OffsetSeekableInputStreamTest {
             byte[] buffer = new byte[5];
             int bytesRead = stream.read(buffer, 0, 5);
             assertThat(bytesRead).isEqualTo(-1);
+        }
+    }
+
+    @Test
+    public void testClose() throws IOException {
+        SeekableInputStream mockStream = mock(SeekableInputStream.class);
+        OffsetSeekableInputStream offsetStream = new OffsetSeekableInputStream(mockStream, 0, 10);
+        offsetStream.close();
+        verify(mockStream, times(1)).close();
+    }
+
+    @Test
+    public void testReadWithUnlimitedLength() throws IOException {
+        long offset = 5;
+        long length = -1; // Unlimited length
+        try (OffsetSeekableInputStream stream =
+                new OffsetSeekableInputStream(wrapped, offset, length)) {
+            // Should be able to read beyond the original testData length
+            byte[] buffer = new byte[10];
+            int bytesRead = stream.read(buffer, 0, 10);
+
+            assertThat(bytesRead).isEqualTo(10);
+            assertThat(buffer).containsExactly(Arrays.copyOfRange(testData, 5, 15));
+            assertThat(stream.getPos()).isEqualTo(10);
+        }
+    }
+
+    @Test
+    public void testReadByteArrayWithZeroLength() throws IOException {
+        long offset = 5;
+        long length = 10;
+        try (OffsetSeekableInputStream stream =
+                new OffsetSeekableInputStream(wrapped, offset, length)) {
+            byte[] buffer = new byte[0];
+            int bytesRead = stream.read(buffer, 0, 0);
+
+            assertThat(bytesRead).isEqualTo(0);
+        }
+    }
+
+    @Test
+    public void testSeekBeyondLength() throws IOException {
+        long offset = 5;
+        long length = 10;
+        try (OffsetSeekableInputStream stream =
+                new OffsetSeekableInputStream(wrapped, offset, length)) {
+            // Seeking beyond length should be allowed, but reading should return -1
+            stream.seek(15);
+            assertThat(stream.getPos()).isEqualTo(15);
+
+            int result = stream.read();
+            assertThat(result).isEqualTo(-1);
         }
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/utils/UriReaderFactoryTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/UriReaderFactoryTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.utils.UriReader.FileUriReader;
+import org.apache.paimon.utils.UriReader.HttpUriReader;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link UriReaderFactory}. */
+public class UriReaderFactoryTest {
+
+    private final UriReaderFactory factory =
+            new UriReaderFactory(CatalogContext.create(new Options()));
+
+    @Test
+    public void testCreateHttpUriReader() {
+        UriReader reader = factory.create("http://example.com/file.txt");
+        assertThat(reader).isInstanceOf(HttpUriReader.class);
+    }
+
+    @Test
+    public void testCreateHttpsUriReader() {
+        UriReader reader = factory.create("https://example.com/file.txt");
+        assertThat(reader).isInstanceOf(HttpUriReader.class);
+    }
+
+    @Test
+    public void testCreateFileUriReader() {
+        UriReader reader = factory.create("file:///path/to/file.txt");
+        assertThat(reader).isInstanceOf(FileUriReader.class);
+    }
+
+    @Test
+    public void testCreateUriReaderWithAuthority() {
+        UriReader reader1 = factory.create("http://my_bucket1/path/to/file.txt");
+        UriReader reader2 = factory.create("http://my_bucket2/path/to/file.txt");
+        assertThat(reader1).isNotEqualTo(reader2);
+    }
+
+    @Test
+    public void testCachedReadersWithSameSchemeAndAuthority() {
+        UriReader reader1 = factory.create("http://my_bucket/path/to/file1.txt");
+        UriReader reader2 = factory.create("http://my_bucket/path/to/file2.txt");
+        assertThat(reader1).isSameAs(reader2);
+    }
+
+    @Test
+    public void testCachedReadersWithNullAuthority() {
+        UriReader reader1 = factory.create("file:///path/to/file1.txt");
+        UriReader reader2 = factory.create("file:///path/to/file2.txt");
+        assertThat(reader1).isSameAs(reader2);
+    }
+
+    @Test
+    public void testCreateUriReaderWithLocalPath() {
+        UriReader reader = factory.create("/local/path/to/file.txt");
+        assertThat(reader).isInstanceOf(FileUriReader.class);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -80,23 +80,23 @@ public abstract class AbstractCatalog implements Catalog {
 
     protected final FileIO fileIO;
     protected final Map<String, String> tableDefaultOptions;
-    protected final Options catalogOptions;
+    protected final CatalogContext context;
 
     protected AbstractCatalog(FileIO fileIO) {
         this.fileIO = fileIO;
         this.tableDefaultOptions = new HashMap<>();
-        this.catalogOptions = new Options();
+        this.context = CatalogContext.create(new Options());
     }
 
-    protected AbstractCatalog(FileIO fileIO, Options options) {
+    protected AbstractCatalog(FileIO fileIO, CatalogContext context) {
         this.fileIO = fileIO;
-        this.tableDefaultOptions = CatalogUtils.tableDefaultOptions(options.toMap());
-        this.catalogOptions = options;
+        this.tableDefaultOptions = CatalogUtils.tableDefaultOptions(context.options().toMap());
+        this.context = context;
     }
 
     @Override
     public Map<String, String> options() {
-        return catalogOptions.toMap();
+        return context.options().toMap();
     }
 
     public abstract String warehouse();
@@ -114,7 +114,7 @@ public abstract class AbstractCatalog implements Catalog {
             return Optional.empty();
         }
 
-        String lock = catalogOptions.get(LOCK_TYPE);
+        String lock = context.options().get(LOCK_TYPE);
         if (lock == null) {
             return defaultLockFactory();
         }
@@ -129,11 +129,11 @@ public abstract class AbstractCatalog implements Catalog {
     }
 
     public Optional<CatalogLockContext> lockContext() {
-        return Optional.of(CatalogLockContext.fromOptions(catalogOptions));
+        return Optional.of(CatalogLockContext.fromOptions(context.options()));
     }
 
     protected boolean lockEnabled() {
-        return catalogOptions.getOptional(LOCK_ENABLED).orElse(fileIO.isObjectStore());
+        return context.options().getOptional(LOCK_ENABLED).orElse(fileIO.isObjectStore());
     }
 
     protected boolean allowCustomTablePath() {
@@ -474,7 +474,8 @@ public abstract class AbstractCatalog implements Catalog {
                 this::fileIO,
                 this::loadTableMetadata,
                 lockFactory().orElse(null),
-                lockContext().orElse(null));
+                lockContext().orElse(null),
+                context);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
@@ -214,7 +214,8 @@ public class CatalogUtils {
             Function<Path, FileIO> externalFileIO,
             TableMetadata.Loader metadataLoader,
             @Nullable CatalogLockFactory lockFactory,
-            @Nullable CatalogLockContext lockContext)
+            @Nullable CatalogLockContext lockContext,
+            @Nullable CatalogContext catalogContext)
             throws Catalog.TableNotExistException {
         if (SYSTEM_DATABASE_NAME.equals(identifier.getDatabaseName())) {
             return CatalogUtils.createGlobalSystemTable(identifier.getTableName(), catalog);
@@ -258,6 +259,7 @@ public class CatalogUtils {
                         catalog.catalogLoader(),
                         lockFactory,
                         lockContext,
+                        catalogContext,
                         catalog.supportsVersionManagement());
         Path path = new Path(schema.options().get(PATH.key()));
         FileStoreTable table =

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalog.java
@@ -21,7 +21,6 @@ package org.apache.paimon.catalog;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.operation.Lock;
-import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.schema.SchemaManager;
@@ -49,8 +48,8 @@ public class FileSystemCatalog extends AbstractCatalog {
         this.warehouse = warehouse;
     }
 
-    public FileSystemCatalog(FileIO fileIO, Path warehouse, Options options) {
-        super(fileIO, options);
+    public FileSystemCatalog(FileIO fileIO, Path warehouse, CatalogContext context) {
+        super(fileIO, context);
         this.warehouse = warehouse;
     }
 
@@ -198,11 +197,11 @@ public class FileSystemCatalog extends AbstractCatalog {
 
     @Override
     public CatalogLoader catalogLoader() {
-        return new FileSystemCatalogLoader(fileIO, warehouse, catalogOptions);
+        return new FileSystemCatalogLoader(fileIO, warehouse, context);
     }
 
     @Override
     public boolean caseSensitive() {
-        return catalogOptions.getOptional(CASE_SENSITIVE).orElse(true);
+        return context.options().getOptional(CASE_SENSITIVE).orElse(true);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalogFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalogFactory.java
@@ -41,6 +41,6 @@ public class FileSystemCatalogFactory implements CatalogFactory {
                     "Only managed table is supported in File system catalog.");
         }
 
-        return new FileSystemCatalog(fileIO, warehouse, context.options());
+        return new FileSystemCatalog(fileIO, warehouse, context);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalogLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalogLoader.java
@@ -24,7 +24,7 @@ import org.apache.paimon.fs.Path;
 /** Loader to create {@link FileSystemCatalog}. */
 public class FileSystemCatalogLoader implements CatalogLoader {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     private final FileIO fileIO;
     private final Path warehouse;

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalogLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/FileSystemCatalogLoader.java
@@ -20,7 +20,6 @@ package org.apache.paimon.catalog;
 
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
-import org.apache.paimon.options.Options;
 
 /** Loader to create {@link FileSystemCatalog}. */
 public class FileSystemCatalogLoader implements CatalogLoader {
@@ -29,16 +28,16 @@ public class FileSystemCatalogLoader implements CatalogLoader {
 
     private final FileIO fileIO;
     private final Path warehouse;
-    private final Options options;
+    private final CatalogContext context;
 
-    public FileSystemCatalogLoader(FileIO fileIO, Path warehouse, Options options) {
+    public FileSystemCatalogLoader(FileIO fileIO, Path warehouse, CatalogContext context) {
         this.fileIO = fileIO;
         this.warehouse = warehouse;
-        this.options = options;
+        this.context = context;
     }
 
     @Override
     public Catalog load() {
-        return new FileSystemCatalog(fileIO, warehouse, options);
+        return new FileSystemCatalog(fileIO, warehouse, context);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
@@ -20,6 +20,7 @@ package org.apache.paimon.jdbc;
 
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.AbstractCatalog;
+import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.CatalogLockContext;
 import org.apache.paimon.catalog.CatalogLockFactory;
@@ -85,10 +86,11 @@ public class JdbcCatalog extends AbstractCatalog {
     private final Options options;
     private final String warehouse;
 
-    protected JdbcCatalog(FileIO fileIO, String catalogKey, Options options, String warehouse) {
-        super(fileIO, options);
+    protected JdbcCatalog(
+            FileIO fileIO, String catalogKey, CatalogContext context, String warehouse) {
+        super(fileIO, context);
         this.catalogKey = catalogKey;
-        this.options = options;
+        this.options = context.options();
         this.warehouse = warehouse;
         Preconditions.checkNotNull(options, "Invalid catalog properties: null");
         this.connections =
@@ -153,7 +155,7 @@ public class JdbcCatalog extends AbstractCatalog {
 
     @Override
     public CatalogLoader catalogLoader() {
-        return new JdbcCatalogLoader(fileIO, catalogKey, options, warehouse);
+        return new JdbcCatalogLoader(fileIO, catalogKey, context, warehouse);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogFactory.java
@@ -39,6 +39,6 @@ public class JdbcCatalogFactory implements CatalogFactory {
     public Catalog create(FileIO fileIO, Path warehouse, CatalogContext context) {
         Options options = context.options();
         String catalogKey = options.get(JdbcCatalogOptions.CATALOG_KEY);
-        return new JdbcCatalog(fileIO, catalogKey, context.options(), warehouse.toString());
+        return new JdbcCatalog(fileIO, catalogKey, context, warehouse.toString());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogLoader.java
@@ -19,9 +19,9 @@
 package org.apache.paimon.jdbc;
 
 import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.fs.FileIO;
-import org.apache.paimon.options.Options;
 
 /** Loader to create {@link JdbcCatalog}. */
 public class JdbcCatalogLoader implements CatalogLoader {
@@ -30,18 +30,19 @@ public class JdbcCatalogLoader implements CatalogLoader {
 
     private final FileIO fileIO;
     private final String catalogKey;
-    private final Options options;
+    private final CatalogContext context;
     private final String warehouse;
 
-    public JdbcCatalogLoader(FileIO fileIO, String catalogKey, Options options, String warehouse) {
+    public JdbcCatalogLoader(
+            FileIO fileIO, String catalogKey, CatalogContext context, String warehouse) {
         this.fileIO = fileIO;
         this.catalogKey = catalogKey;
-        this.options = options;
+        this.context = context;
         this.warehouse = warehouse;
     }
 
     @Override
     public Catalog load() {
-        return new JdbcCatalog(fileIO, catalogKey, options, warehouse);
+        return new JdbcCatalog(fileIO, catalogKey, context, warehouse);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogLoader.java
@@ -26,7 +26,7 @@ import org.apache.paimon.fs.FileIO;
 /** Loader to create {@link JdbcCatalog}. */
 public class JdbcCatalogLoader implements CatalogLoader {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     private final FileIO fileIO;
     private final String catalogKey;

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -278,7 +278,8 @@ public class RESTCatalog implements Catalog {
                 this::fileIOFromOptions,
                 this::loadTableMetadata,
                 null,
-                null);
+                null,
+                context);
     }
 
     @Override
@@ -426,7 +427,8 @@ public class RESTCatalog implements Catalog {
                     this::fileIOFromOptions,
                     i -> toTableMetadata(db, response),
                     null,
-                    null);
+                    null,
+                    context);
         } catch (TableNotExistException e) {
             throw new RuntimeException(e);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
@@ -43,7 +43,7 @@ import java.util.Optional;
 /** Catalog environment in table which contains log factory, metastore client factory. */
 public class CatalogEnvironment implements Serializable {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     @Nullable private final Identifier identifier;
     @Nullable private final String uuid;

--- a/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
@@ -20,6 +20,7 @@ package org.apache.paimon.table;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.CatalogLockContext;
 import org.apache.paimon.catalog.CatalogLockFactory;
@@ -49,6 +50,7 @@ public class CatalogEnvironment implements Serializable {
     @Nullable private final CatalogLoader catalogLoader;
     @Nullable private final CatalogLockFactory lockFactory;
     @Nullable private final CatalogLockContext lockContext;
+    @Nullable private final CatalogContext catalogContext;
     private final boolean supportsVersionManagement;
 
     public CatalogEnvironment(
@@ -57,17 +59,19 @@ public class CatalogEnvironment implements Serializable {
             @Nullable CatalogLoader catalogLoader,
             @Nullable CatalogLockFactory lockFactory,
             @Nullable CatalogLockContext lockContext,
+            @Nullable CatalogContext catalogContext,
             boolean supportsVersionManagement) {
         this.identifier = identifier;
         this.uuid = uuid;
         this.catalogLoader = catalogLoader;
         this.lockFactory = lockFactory;
         this.lockContext = lockContext;
+        this.catalogContext = catalogContext;
         this.supportsVersionManagement = supportsVersionManagement;
     }
 
     public static CatalogEnvironment empty() {
-        return new CatalogEnvironment(null, null, null, null, null, false);
+        return new CatalogEnvironment(null, null, null, null, null, null, false);
     }
 
     @Nullable
@@ -132,6 +136,11 @@ public class CatalogEnvironment implements Serializable {
         return catalogLoader;
     }
 
+    @Nullable
+    public CatalogContext catalogContext() {
+        return catalogContext;
+    }
+
     public CatalogEnvironment copy(Identifier identifier) {
         return new CatalogEnvironment(
                 identifier,
@@ -139,6 +148,7 @@ public class CatalogEnvironment implements Serializable {
                 catalogLoader,
                 lockFactory,
                 lockContext,
+                catalogContext,
                 supportsVersionManagement);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/FileSystemCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/FileSystemCatalogTest.java
@@ -36,8 +36,9 @@ public class FileSystemCatalogTest extends CatalogTestBase {
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-        Options catalogOptions = new Options();
-        catalog = new FileSystemCatalog(fileIO, new Path(warehouse), catalogOptions);
+        catalog =
+                new FileSystemCatalog(
+                        fileIO, new Path(warehouse), CatalogContext.create(new Options()));
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/data/BlobHttpTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/data/BlobHttpTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.data;
+
+import org.apache.paimon.rest.TestHttpWebServer;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link Blob} http. */
+public class BlobHttpTest {
+
+    private TestHttpWebServer server;
+
+    @Before
+    public void setUp() throws Exception {
+        server = new TestHttpWebServer("/my_path");
+        server.start();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        server.stop();
+    }
+
+    @Test
+    public void testHttp() {
+        String data = "my_data";
+        server.enqueueResponse(data, 200);
+        Blob blob = Blob.fromHttp(server.getBaseUrl());
+        assertThat(blob).isInstanceOf(BlobRef.class);
+        assertThat(new String(blob.toData(), UTF_8)).isEqualTo(data);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcCatalogTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.jdbc;
 
 import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogTestBase;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.options.CatalogOptions;
@@ -63,7 +64,10 @@ public class JdbcCatalogTest extends CatalogTestBase {
         properties.putAll(props);
         JdbcCatalog catalog =
                 new JdbcCatalog(
-                        fileIO, "test-jdbc-catalog", Options.fromMap(properties), warehouse);
+                        fileIO,
+                        "test-jdbc-catalog",
+                        CatalogContext.create(Options.fromMap(properties)),
+                        warehouse);
         assertThat(catalog.warehouse()).isEqualTo(warehouse);
         return catalog;
     }

--- a/paimon-core/src/test/java/org/apache/paimon/jdbc/PostgresqlCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/jdbc/PostgresqlCatalogTest.java
@@ -121,7 +121,7 @@ public class PostgresqlCatalogTest {
                 new JdbcCatalog(
                         fileIO,
                         "test-jdbc-postgres-catalog",
-                        Options.fromMap(properties),
+                        CatalogContext.create(Options.fromMap(properties)),
                         warehouse);
         assertThat(catalog.warehouse()).isEqualTo(warehouse);
         return catalog;

--- a/paimon-core/src/test/java/org/apache/paimon/operation/PartitionExpireTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/PartitionExpireTest.java
@@ -137,7 +137,7 @@ public class PartitionExpireTest {
                 };
 
         CatalogEnvironment env =
-                new CatalogEnvironment(null, null, null, null, null, false) {
+                new CatalogEnvironment(null, null, null, null, null, null, false) {
 
                     @Override
                     public PartitionHandler partitionHandler() {

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -161,6 +161,7 @@ public class RESTCatalogServer {
 
     private final String databaseUri;
 
+    private final CatalogContext catalogContext;
     private final FileSystemCatalog catalog;
     private final MockWebServer server;
 
@@ -190,7 +191,7 @@ public class RESTCatalogServer {
         Options conf = new Options();
         this.configResponse.getDefaults().forEach(conf::setString);
         conf.setString(WAREHOUSE.key(), dataPath);
-        CatalogContext context = CatalogContext.create(conf);
+        this.catalogContext = CatalogContext.create(conf);
         Path warehousePath = new Path(dataPath);
         FileIO fileIO;
         try {
@@ -199,7 +200,7 @@ public class RESTCatalogServer {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-        this.catalog = new FileSystemCatalog(fileIO, warehousePath, context.options());
+        this.catalog = new FileSystemCatalog(fileIO, warehousePath, catalogContext);
         Dispatcher dispatcher = initDispatcher(authProvider);
         MockWebServer mockWebServer = new MockWebServer();
         mockWebServer.setDispatcher(dispatcher);
@@ -2270,6 +2271,7 @@ public class RESTCatalogServer {
                             catalog.catalogLoader(),
                             catalog.lockFactory().orElse(null),
                             catalog.lockContext().orElse(null),
+                            catalogContext,
                             false);
             Path path = new Path(schema.options().get(PATH.key()));
             FileIO dataFileIO = catalog.fileIO();

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/TestAlterTableCatalogFactory.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/TestAlterTableCatalogFactory.java
@@ -43,7 +43,7 @@ public class TestAlterTableCatalogFactory implements CatalogFactory {
 
     @Override
     public Catalog create(FileIO fileIO, Path warehouse, CatalogContext context) {
-        return new FileSystemCatalog(fileIO, warehouse, context.options()) {
+        return new FileSystemCatalog(fileIO, warehouse, context) {
 
             @Override
             public void alterTable(

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatReader.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.format.blob;
 
 import org.apache.paimon.data.Blob;
-import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.FileIO;
@@ -123,13 +122,14 @@ public class BlobFormatReader implements FileRecordReader<InternalRow> {
                     return null;
                 }
 
-                BlobDescriptor descriptor =
-                        new BlobDescriptor(
+                Blob blob =
+                        Blob.fromFile(
+                                fileIO,
                                 filePath.toString(),
                                 blobOffsets[currentPosition] + 4,
                                 blobLengths[currentPosition] - 16);
                 currentPosition++;
-                return GenericRow.of(Blob.fromFile(fileIO, descriptor));
+                return GenericRow.of(blob);
             }
 
             @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatReader.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.format.blob;
 
+import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.FileIO;
@@ -121,14 +123,13 @@ public class BlobFormatReader implements FileRecordReader<InternalRow> {
                     return null;
                 }
 
-                BlobFileRef blobRef =
-                        new BlobFileRef(
-                                fileIO,
-                                filePath,
-                                blobLengths[currentPosition],
-                                blobOffsets[currentPosition]);
+                BlobDescriptor descriptor =
+                        new BlobDescriptor(
+                                filePath.toString(),
+                                blobOffsets[currentPosition] + 4,
+                                blobLengths[currentPosition] - 16);
                 currentPosition++;
-                return GenericRow.of(blobRef);
+                return GenericRow.of(Blob.fromFile(fileIO, descriptor));
             }
 
             @Override

--- a/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
@@ -83,7 +83,7 @@ public class BlobFileFormatTest {
         List<byte[]> result = new ArrayList<>();
         readerFactory
                 .createReader(context)
-                .forEachRemaining(row -> result.add(row.getBlob(0).toBytes()));
+                .forEachRemaining(row -> result.add(row.getBlob(0).toData()));
 
         // assert
         assertThat(result).containsExactlyElementsOf(blobs);
@@ -95,7 +95,7 @@ public class BlobFileFormatTest {
         result.clear();
         readerFactory
                 .createReader(context)
-                .forEachRemaining(row -> result.add(row.getBlob(0).toBytes()));
+                .forEachRemaining(row -> result.add(row.getBlob(0).toData()));
 
         // assert
         assertThat(result).containsOnly(blobs.get(1));

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -164,19 +164,19 @@ public class HiveCatalog extends AbstractCatalog {
     private final LocationHelper locationHelper;
 
     public HiveCatalog(FileIO fileIO, HiveConf hiveConf, String clientClassName, String warehouse) {
-        this(fileIO, hiveConf, clientClassName, new Options(), warehouse);
+        this(fileIO, hiveConf, clientClassName, CatalogContext.create(new Options()), warehouse);
     }
 
     public HiveCatalog(
             FileIO fileIO,
             HiveConf hiveConf,
             String clientClassName,
-            Options options,
+            CatalogContext context,
             String warehouse) {
-        super(fileIO, options);
+        super(fileIO, context);
         this.hiveConf = hiveConf;
         this.clientClassName = clientClassName;
-        this.options = options;
+        this.options = context.options();
         this.warehouse = warehouse;
 
         boolean needLocationInProperties =
@@ -206,7 +206,7 @@ public class HiveCatalog extends AbstractCatalog {
     public Optional<CatalogLockContext> lockContext() {
         return Optional.of(
                 new HiveCatalogLockContext(
-                        new SerializableHiveConf(hiveConf), clientClassName, catalogOptions));
+                        new SerializableHiveConf(hiveConf), clientClassName, options));
     }
 
     @Override
@@ -1202,7 +1202,7 @@ public class HiveCatalog extends AbstractCatalog {
 
     @Override
     public boolean caseSensitive() {
-        return catalogOptions.getOptional(CASE_SENSITIVE).orElse(false);
+        return options.getOptional(CASE_SENSITIVE).orElse(false);
     }
 
     @Override
@@ -1211,7 +1211,7 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     public boolean syncAllProperties() {
-        return catalogOptions.get(SYNC_ALL_PROPERTIES);
+        return options.get(SYNC_ALL_PROPERTIES);
     }
 
     @Override
@@ -1328,7 +1328,7 @@ public class HiveCatalog extends AbstractCatalog {
     @Override
     public CatalogLoader catalogLoader() {
         return new HiveCatalogLoader(
-                fileIO, new SerializableHiveConf(hiveConf), clientClassName, options, warehouse);
+                fileIO, new SerializableHiveConf(hiveConf), clientClassName, context, warehouse);
     }
 
     public Table getHmsTable(Identifier identifier)
@@ -1715,7 +1715,7 @@ public class HiveCatalog extends AbstractCatalog {
                 fileIO,
                 hiveConf,
                 options.get(HiveCatalogOptions.METASTORE_CLIENT_CLASS),
-                options,
+                context,
                 warehouse.toUri().toString());
     }
 

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogLoader.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogLoader.java
@@ -19,9 +19,9 @@
 package org.apache.paimon.hive;
 
 import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.fs.FileIO;
-import org.apache.paimon.options.Options;
 
 /** Loader to create {@link HiveCatalog}. */
 public class HiveCatalogLoader implements CatalogLoader {
@@ -31,24 +31,24 @@ public class HiveCatalogLoader implements CatalogLoader {
     private final FileIO fileIO;
     private final SerializableHiveConf hiveConf;
     private final String clientClassName;
-    private final Options options;
+    private final CatalogContext context;
     private final String warehouse;
 
     public HiveCatalogLoader(
             FileIO fileIO,
             SerializableHiveConf hiveConf,
             String clientClassName,
-            Options options,
+            CatalogContext context,
             String warehouse) {
         this.fileIO = fileIO;
         this.hiveConf = hiveConf;
         this.clientClassName = clientClassName;
-        this.options = options;
+        this.context = context;
         this.warehouse = warehouse;
     }
 
     @Override
     public Catalog load() {
-        return new HiveCatalog(fileIO, hiveConf.conf(), clientClassName, options, warehouse);
+        return new HiveCatalog(fileIO, hiveConf.conf(), clientClassName, context, warehouse);
     }
 }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogLoader.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogLoader.java
@@ -26,7 +26,7 @@ import org.apache.paimon.fs.FileIO;
 /** Loader to create {@link HiveCatalog}. */
 public class HiveCatalogLoader implements CatalogLoader {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     private final FileIO fileIO;
     private final SerializableHiveConf hiveConf;

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.hive;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogTestBase;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.client.ClientPool;
@@ -79,8 +80,8 @@ public class HiveCatalogTest extends CatalogTestBase {
         String metastoreClientClass = "org.apache.hadoop.hive.metastore.HiveMetaStoreClient";
         Options catalogOptions = new Options();
         catalogOptions.set(CatalogOptions.SYNC_ALL_PROPERTIES.key(), "false");
-        catalog =
-                new HiveCatalog(fileIO, hiveConf, metastoreClientClass, catalogOptions, warehouse);
+        CatalogContext context = CatalogContext.create(catalogOptions, hiveConf);
+        catalog = new HiveCatalog(fileIO, hiveConf, metastoreClientClass, context, warehouse);
     }
 
     @Test

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveTableStatsTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveTableStatsTest.java
@@ -64,7 +64,7 @@ public class HiveTableStatsTest {
         CatalogContext catalogContext = CatalogContext.create(catalogOptions);
         FileIO fileIO = FileIO.get(new Path(warehouse), catalogContext);
         catalog =
-                new HiveCatalog(fileIO, hiveConf, metastoreClientClass, catalogOptions, warehouse);
+                new HiveCatalog(fileIO, hiveConf, metastoreClientClass, catalogContext, warehouse);
     }
 
     @Test

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/pool/TestCachedClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/pool/TestCachedClientPool.java
@@ -421,7 +421,7 @@ public class TestCachedClientPool {
                                                         fileIO,
                                                         hiveConf,
                                                         metastoreClientClass,
-                                                        options,
+                                                        CatalogContext.create(options),
                                                         warehouse);
                                             } catch (Exception e) {
                                                 throw new RuntimeException(e);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Introduce util methods:
```java
    static Blob fromData(byte[] data) {
        return new BlobData(data);
    }

    static Blob fromLocal(String file) {
        return fromFile(LocalFileIO.create(), new BlobDescriptor(file, 0, -1));
    }

    static Blob fromHttp(String uri) {
        return fromDescriptor(UriReader.fromHttp(), new BlobDescriptor(uri, 0, -1));
    }

    static Blob fromFile(FileIO fileIO, BlobDescriptor descriptor) {
        return fromDescriptor(UriReader.fromFile(fileIO), descriptor);
    }

    static Blob fromDescriptor(UriReader reader, BlobDescriptor descriptor) {
        return new BlobRef(reader, descriptor);
    }
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
