### PR TITLE
[arrow] ArrowBatchConverter support reset the reused VectorSchemaRoot

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/converter/ArrowBatchConverter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/converter/ArrowBatchConverter.java
@@ -62,6 +62,9 @@ public abstract class ArrowBatchConverter {
         return root;
     }
 
+    public abstract ArrowBatchConverter copy(
+            VectorSchemaRoot root, ArrowFieldWriter[] fieldWriters);
+
     protected abstract void doWrite(int maxBatchRows);
 
     public void close() {

--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/converter/ArrowPerRowBatchConverter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/converter/ArrowPerRowBatchConverter.java
@@ -37,6 +37,14 @@ public class ArrowPerRowBatchConverter extends ArrowBatchConverter {
     }
 
     @Override
+    public ArrowPerRowBatchConverter copy(VectorSchemaRoot root, ArrowFieldWriter[] fieldWriters) {
+        ArrowPerRowBatchConverter newConverter = new ArrowPerRowBatchConverter(root, fieldWriters);
+        newConverter.iterator = this.iterator;
+        newConverter.currentRow = this.currentRow;
+        return newConverter;
+    }
+
+    @Override
     public void doWrite(int maxBatchRows) {
         int rowIndex = 0;
         while (currentRow != null && rowIndex < maxBatchRows) {

--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/converter/ArrowVectorizedBatchConverter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/converter/ArrowVectorizedBatchConverter.java
@@ -47,6 +47,19 @@ public class ArrowVectorizedBatchConverter extends ArrowBatchConverter {
     }
 
     @Override
+    public ArrowVectorizedBatchConverter copy(
+            VectorSchemaRoot root, ArrowFieldWriter[] fieldWriters) {
+        ArrowVectorizedBatchConverter newConverter =
+                new ArrowVectorizedBatchConverter(root, fieldWriters);
+        newConverter.iterator = this.iterator;
+        newConverter.batch = this.batch;
+        newConverter.pickedInColumn = this.pickedInColumn;
+        newConverter.totalNumRows = this.totalNumRows;
+        newConverter.startIndex = this.startIndex;
+        return newConverter;
+    }
+
+    @Override
     public void doWrite(int maxBatchRows) {
         int batchRows = Math.min(maxBatchRows, totalNumRows - startIndex);
         ColumnVector[] columns = batch.columns;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Currently, the VectorSchemaRoot in ArrowBatchConverter is reused, but when interacting with compute engines, they might clean the returned VSR (thus the FieldVector inner structure might be cleaned), so we should support recreate a new VSR.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
