### PR TITLE
[spark] Fix Lance format UT

### DIFF
--- a/paimon-spark/pom.xml
+++ b/paimon-spark/pom.xml
@@ -277,6 +277,13 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-arrow</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-lance</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>


### PR DESCRIPTION
### Purpose
- Lance format: read and write *** FAILED ***
  org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 0.0 failed 1 times, most recent failure: Lost task 0.0 in stage 0.0 (TID 0) (runnervmf4ws1.rxdzavhu1oberabbgijsmh0pqd.gx.internal.cloudapp.net executor driver): java.lang.NoClassDefFoundError: Could not initialize class org.apache.arrow.memory.RootAllocator
	at org.apache.paimon.arrow.vector.ArrowFormatWriter.<init>(ArrowFormatWriter.java:59)
	at org.apache.paimon.format.lance.LanceFileFormat.lambda$createWriterFactory$0(LanceFileFormat.java:84)
	at org.apache.paimon.format.lance.LanceWriterFactory.create(LanceWriterFactory.java:59)
	at org.apache.paimon.io.SingleFileWriter.<init>(SingleFileWriter.java:73)
	at org.apache.paimon.io.StatsCollectingSingleFileWriter.<init>(StatsCollectingSingleFileWriter.java:52)
	at org.apache.paimon.io.RowDataFileWriter.<init>(RowDataFileWriter.java:68)
	at org.apache.paimon.io.RowDataRollingFileWriter.lambda$new$0(RowDataRollingFileWriter.java:71)
	at org.apache.paimon.io.RollingFileWriter.openCurrentWriter(RollingFileWriter.java:122)
	at org.apache.paimon.io.RollingFileWriter.write(RollingFileWriter.java:77)
	at org.apache.paimon.utils.SinkWriter$DirectSinkWriter.write(SinkWriter.java:75)
	at org.apache.paimon.append.AppendOnlyWriter.write(AppendOnlyWriter.java:176)
	at org.apache.paimon.append.AppendOnlyWriter.write(AppendOnlyWriter.java:66)
	at org.apache.paimon.operation.AbstractFileStoreWrite.write(AbstractFileStoreWrite.java:155)
	at org.apache.paimon.table.sink.TableWriteImpl.writeAndReturn(TableWriteImpl.java:185)
	at org.apache.paimon.table.sink.TableWriteImpl.writeAndReturn(TableWriteImpl.java:173)
	at org.apache.paimon.table.sink.TableWriteImpl.write(TableWriteImpl.java:151)
	at org.apache.paimon.spark.SparkTableWrite.write(SparkTableWrite.scala:55)

### Tests
CI
