### PR TITLE
[spark] Disable v2 write in v1 append location unit tests

### DIFF
--- a/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/PaimonSinkTest.scala
+++ b/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/PaimonSinkTest.scala
@@ -29,51 +29,55 @@ import java.sql.Date
 class PaimonSinkTest extends PaimonSparkTestBase with StreamTest {
 
   override protected def sparkConf: SparkConf = {
-    super.sparkConf.set("spark.sql.catalog.paimon.cache-enabled", "false")
+    super.sparkConf
+      .set("spark.sql.catalog.paimon.cache-enabled", "false")
+      .set("spark.paimon.write.use-v2-write", "false")
   }
 
   import testImplicits._
 
   test("Paimon Sink: forEachBatch") {
-    failAfter(streamingTimeout) {
-      withTempDir {
-        checkpointDir =>
-          // define a pk table and test `forEachBatch` api
-          spark.sql(s"""
-                       |CREATE TABLE T (a INT, b STRING)
-                       |TBLPROPERTIES ('primary-key'='a', 'bucket'='3')
-                       |""".stripMargin)
-          val location = loadTable("T").location().toString
+    withSparkSQLConf(("spark.paimon.write.use-v2-write", "false")) {
+      failAfter(streamingTimeout) {
+        withTempDir {
+          checkpointDir =>
+            // define a pk table and test `forEachBatch` api
+            spark.sql(s"""
+                         |CREATE TABLE T (a INT, b STRING)
+                         |TBLPROPERTIES ('primary-key'='a', 'bucket'='3')
+                         |""".stripMargin)
+            val location = loadTable("T").location().toString
 
-          val inputData = MemoryStream[(Int, String)]
-          val stream = inputData
-            .toDS()
-            .toDF("a", "b")
-            .writeStream
-            .option("checkpointLocation", checkpointDir.getCanonicalPath)
-            .foreachBatch {
-              (batch: Dataset[Row], id: Long) =>
-                batch.write.format("paimon").mode("append").save(location)
+            val inputData = MemoryStream[(Int, String)]
+            val stream = inputData
+              .toDS()
+              .toDF("a", "b")
+              .writeStream
+              .option("checkpointLocation", checkpointDir.getCanonicalPath)
+              .foreachBatch {
+                (batch: Dataset[Row], id: Long) =>
+                  batch.write.format("paimon").mode("append").save(location)
+              }
+              .start()
+
+            val query = () => spark.sql("SELECT * FROM T ORDER BY a")
+
+            try {
+              inputData.addData((1, "a"))
+              stream.processAllAvailable()
+              checkAnswer(query(), Row(1, "a") :: Nil)
+
+              inputData.addData((2, "b"))
+              stream.processAllAvailable()
+              checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
+
+              inputData.addData((2, "b2"))
+              stream.processAllAvailable()
+              checkAnswer(query(), Row(1, "a") :: Row(2, "b2") :: Nil)
+            } finally {
+              stream.stop()
             }
-            .start()
-
-          val query = () => spark.sql("SELECT * FROM T ORDER BY a")
-
-          try {
-            inputData.addData((1, "a"))
-            stream.processAllAvailable()
-            checkAnswer(query(), Row(1, "a") :: Nil)
-
-            inputData.addData((2, "b"))
-            stream.processAllAvailable()
-            checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
-
-            inputData.addData((2, "b2"))
-            stream.processAllAvailable()
-            checkAnswer(query(), Row(1, "a") :: Row(2, "b2") :: Nil)
-          } finally {
-            stream.stop()
-          }
+        }
       }
     }
   }

--- a/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/RollbackProcedureTest.scala
+++ b/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/RollbackProcedureTest.scala
@@ -29,68 +29,70 @@ class RollbackProcedureTest extends PaimonSparkTestBase with StreamTest {
   import testImplicits._
 
   test("Paimon Procedure: rollback to snapshot and tag") {
-    failAfter(streamingTimeout) {
-      withTempDir {
-        checkpointDir =>
-          // define a pk table and test `forEachBatch` api
-          spark.sql(s"""
-                       |CREATE TABLE T (a INT, b STRING)
-                       |TBLPROPERTIES ('primary-key'='a', 'bucket'='3')
-                       |""".stripMargin)
-          val location = loadTable("T").location().toString
+    withSparkSQLConf(("spark.paimon.write.use-v2-write", "false")) {
+      failAfter(streamingTimeout) {
+        withTempDir {
+          checkpointDir =>
+            // define a pk table and test `forEachBatch` api
+            spark.sql(s"""
+                         |CREATE TABLE T (a INT, b STRING)
+                         |TBLPROPERTIES ('primary-key'='a', 'bucket'='3')
+                         |""".stripMargin)
+            val location = loadTable("T").location().toString
 
-          val inputData = MemoryStream[(Int, String)]
-          val stream = inputData
-            .toDS()
-            .toDF("a", "b")
-            .writeStream
-            .option("checkpointLocation", checkpointDir.getCanonicalPath)
-            .foreachBatch {
-              (batch: Dataset[Row], _: Long) =>
-                batch.write.format("paimon").mode("append").save(location)
+            val inputData = MemoryStream[(Int, String)]
+            val stream = inputData
+              .toDS()
+              .toDF("a", "b")
+              .writeStream
+              .option("checkpointLocation", checkpointDir.getCanonicalPath)
+              .foreachBatch {
+                (batch: Dataset[Row], _: Long) =>
+                  batch.write.format("paimon").mode("append").save(location)
+              }
+              .start()
+
+            val table = loadTable("T")
+            val query = () => spark.sql("SELECT * FROM T ORDER BY a")
+
+            try {
+              // snapshot-1
+              inputData.addData((1, "a"))
+              stream.processAllAvailable()
+              checkAnswer(query(), Row(1, "a") :: Nil)
+
+              checkAnswer(
+                spark.sql(
+                  "CALL paimon.sys.create_tag(table => 'test.T', tag => 'test_tag', snapshot => 1)"),
+                Row(true) :: Nil)
+
+              // snapshot-2
+              inputData.addData((2, "b"))
+              stream.processAllAvailable()
+              checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
+
+              // snapshot-3
+              inputData.addData((2, "b2"))
+              stream.processAllAvailable()
+              checkAnswer(query(), Row(1, "a") :: Row(2, "b2") :: Nil)
+              assertThrows[RuntimeException] {
+                spark.sql("CALL paimon.sys.rollback(table => 'test.T_exception', version =>  '2')")
+              }
+              // rollback to snapshot
+              checkAnswer(
+                spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '2')"),
+                Row(table.latestSnapshot().get().id, 2) :: Nil)
+              checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
+
+              // rollback to tag
+              checkAnswer(
+                spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => 'test_tag')"),
+                Row(table.latestSnapshot().get().id, 1) :: Nil)
+              checkAnswer(query(), Row(1, "a") :: Nil)
+            } finally {
+              stream.stop()
             }
-            .start()
-
-          val table = loadTable("T")
-          val query = () => spark.sql("SELECT * FROM T ORDER BY a")
-
-          try {
-            // snapshot-1
-            inputData.addData((1, "a"))
-            stream.processAllAvailable()
-            checkAnswer(query(), Row(1, "a") :: Nil)
-
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.create_tag(table => 'test.T', tag => 'test_tag', snapshot => 1)"),
-              Row(true) :: Nil)
-
-            // snapshot-2
-            inputData.addData((2, "b"))
-            stream.processAllAvailable()
-            checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
-
-            // snapshot-3
-            inputData.addData((2, "b2"))
-            stream.processAllAvailable()
-            checkAnswer(query(), Row(1, "a") :: Row(2, "b2") :: Nil)
-            assertThrows[RuntimeException] {
-              spark.sql("CALL paimon.sys.rollback(table => 'test.T_exception', version =>  '2')")
-            }
-            // rollback to snapshot
-            checkAnswer(
-              spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => '2')"),
-              Row(table.latestSnapshot().get().id, 2) :: Nil)
-            checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
-
-            // rollback to tag
-            checkAnswer(
-              spark.sql("CALL paimon.sys.rollback(table => 'test.T', version => 'test_tag')"),
-              Row(table.latestSnapshot().get().id, 1) :: Nil)
-            checkAnswer(query(), Row(1, "a") :: Nil)
-          } finally {
-            stream.stop()
-          }
+        }
       }
     }
   }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/PaimonSourceTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/PaimonSourceTest.scala
@@ -20,6 +20,7 @@ package org.apache.paimon.spark
 
 import org.apache.paimon.spark.sources.PaimonSourceOffset
 
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.streaming.{StreamingQueryException, StreamTest, Trigger}
 import org.junit.jupiter.api.Assertions
@@ -27,6 +28,11 @@ import org.junit.jupiter.api.Assertions
 import java.util.concurrent.TimeUnit
 
 class PaimonSourceTest extends PaimonSparkTestBase with StreamTest {
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.paimon.write.use-v2-write", "false")
+  }
 
   import testImplicits._
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/BranchProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/BranchProcedureTest.scala
@@ -28,120 +28,122 @@ class BranchProcedureTest extends PaimonSparkTestBase with StreamTest {
 
   import testImplicits._
   test("Paimon Procedure: create, query, write and delete branch") {
-    failAfter(streamingTimeout) {
-      withTempDir {
-        checkpointDir =>
-          // define a change-log table and test `forEachBatch` api
-          spark.sql(s"""
-                       |CREATE TABLE T (a INT, b STRING)
-                       |TBLPROPERTIES ('primary-key'='a', 'bucket'='3')
-                       |""".stripMargin)
-          val location = loadTable("T").location().toString
+    withSparkSQLConf(("spark.paimon.write.use-v2-write", "false")) {
+      failAfter(streamingTimeout) {
+        withTempDir {
+          checkpointDir =>
+            // define a change-log table and test `forEachBatch` api
+            spark.sql(s"""
+                         |CREATE TABLE T (a INT, b STRING)
+                         |TBLPROPERTIES ('primary-key'='a', 'bucket'='3')
+                         |""".stripMargin)
+            val location = loadTable("T").location().toString
 
-          val inputData = MemoryStream[(Int, String)]
-          val stream = inputData
-            .toDS()
-            .toDF("a", "b")
-            .writeStream
-            .option("checkpointLocation", checkpointDir.getCanonicalPath)
-            .foreachBatch {
-              (batch: Dataset[Row], _: Long) =>
-                batch.write.format("paimon").mode("append").save(location)
+            val inputData = MemoryStream[(Int, String)]
+            val stream = inputData
+              .toDS()
+              .toDF("a", "b")
+              .writeStream
+              .option("checkpointLocation", checkpointDir.getCanonicalPath)
+              .foreachBatch {
+                (batch: Dataset[Row], _: Long) =>
+                  batch.write.format("paimon").mode("append").save(location)
+              }
+              .start()
+
+            val query = () => spark.sql("SELECT * FROM T ORDER BY a")
+
+            try {
+              // snapshot-1
+              inputData.addData((1, "a"))
+              stream.processAllAvailable()
+              checkAnswer(query(), Row(1, "a") :: Nil)
+
+              // snapshot-2
+              inputData.addData((2, "b"))
+              stream.processAllAvailable()
+              checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
+
+              // snapshot-3
+              inputData.addData((2, "b2"))
+              stream.processAllAvailable()
+              checkAnswer(query(), Row(1, "a") :: Row(2, "b2") :: Nil)
+
+              // create tags
+              checkAnswer(
+                spark.sql(
+                  "CALL paimon.sys.create_tag(table => 'test.T', tag => 'test_tag', snapshot => 2)"),
+                Row(true) :: Nil)
+              checkAnswer(
+                spark.sql("SELECT tag_name FROM paimon.test.`T$tags`"),
+                Row("test_tag") :: Nil)
+
+              // create branch with tag
+              checkAnswer(
+                spark.sql(
+                  "CALL paimon.sys.create_branch(table => 'test.T', branch => 'test_branch', tag => 'test_tag')"),
+                Row(true) :: Nil)
+              val table = loadTable("T")
+              val branchManager = table.branchManager()
+              assert(branchManager.branchExists("test_branch"))
+
+              // query from branch
+              checkAnswer(
+                spark.sql("SELECT * FROM `T$branch_test_branch` ORDER BY a"),
+                Row(1, "a") :: Row(2, "b") :: Nil
+              )
+              checkAnswer(
+                spark.read.format("paimon").option("branch", "test_branch").table("T").orderBy("a"),
+                Row(1, "a") :: Row(2, "b") :: Nil
+              )
+
+              // update branch
+              spark.sql("INSERT INTO `T$branch_test_branch` VALUES (3, 'c')")
+              checkAnswer(
+                spark.sql("SELECT * FROM `T$branch_test_branch` ORDER BY a"),
+                Row(1, "a") :: Row(2, "b") :: Row(3, "c") :: Nil
+              )
+              // create tags
+              checkAnswer(
+                spark.sql(
+                  "CALL paimon.sys.create_tag(table => 'test.`T$branch_test_branch`', tag => 'test_tag2', snapshot => 3)"),
+                Row(true) :: Nil)
+
+              // create branch from another branch.
+              checkAnswer(
+                spark.sql(
+                  "CALL paimon.sys.create_branch(table => 'test.`T$branch_test_branch`', branch => 'test_branch2', tag => 'test_tag2')"),
+                Row(true) :: Nil)
+              checkAnswer(
+                spark.sql("SELECT * FROM `T$branch_test_branch2` ORDER BY a"),
+                Row(1, "a") :: Row(2, "b") :: Row(3, "c") :: Nil
+              )
+
+              // create empty branch
+              checkAnswer(
+                spark.sql(
+                  "CALL paimon.sys.create_branch(table => 'test.T', branch => 'empty_branch')"),
+                Row(true) :: Nil)
+              assert(branchManager.branchExists("empty_branch"))
+              checkAnswer(
+                spark.sql("SELECT * FROM `T$branch_empty_branch` ORDER BY a"),
+                Nil
+              )
+
+              // delete branch
+              checkAnswer(
+                spark.sql(
+                  "CALL paimon.sys.delete_branch(table => 'test.T', branch => 'test_branch')"),
+                Row(true) :: Nil)
+              assert(!branchManager.branchExists("test_branch"))
+              intercept[Exception] {
+                spark.sql("SELECT * FROM `T$branch_test_branch` ORDER BY a")
+              }
+
+            } finally {
+              stream.stop()
             }
-            .start()
-
-          val query = () => spark.sql("SELECT * FROM T ORDER BY a")
-
-          try {
-            // snapshot-1
-            inputData.addData((1, "a"))
-            stream.processAllAvailable()
-            checkAnswer(query(), Row(1, "a") :: Nil)
-
-            // snapshot-2
-            inputData.addData((2, "b"))
-            stream.processAllAvailable()
-            checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
-
-            // snapshot-3
-            inputData.addData((2, "b2"))
-            stream.processAllAvailable()
-            checkAnswer(query(), Row(1, "a") :: Row(2, "b2") :: Nil)
-
-            // create tags
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.create_tag(table => 'test.T', tag => 'test_tag', snapshot => 2)"),
-              Row(true) :: Nil)
-            checkAnswer(
-              spark.sql("SELECT tag_name FROM paimon.test.`T$tags`"),
-              Row("test_tag") :: Nil)
-
-            // create branch with tag
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.create_branch(table => 'test.T', branch => 'test_branch', tag => 'test_tag')"),
-              Row(true) :: Nil)
-            val table = loadTable("T")
-            val branchManager = table.branchManager()
-            assert(branchManager.branchExists("test_branch"))
-
-            // query from branch
-            checkAnswer(
-              spark.sql("SELECT * FROM `T$branch_test_branch` ORDER BY a"),
-              Row(1, "a") :: Row(2, "b") :: Nil
-            )
-            checkAnswer(
-              spark.read.format("paimon").option("branch", "test_branch").table("T").orderBy("a"),
-              Row(1, "a") :: Row(2, "b") :: Nil
-            )
-
-            // update branch
-            spark.sql("INSERT INTO `T$branch_test_branch` VALUES (3, 'c')")
-            checkAnswer(
-              spark.sql("SELECT * FROM `T$branch_test_branch` ORDER BY a"),
-              Row(1, "a") :: Row(2, "b") :: Row(3, "c") :: Nil
-            )
-            // create tags
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.create_tag(table => 'test.`T$branch_test_branch`', tag => 'test_tag2', snapshot => 3)"),
-              Row(true) :: Nil)
-
-            // create branch from another branch.
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.create_branch(table => 'test.`T$branch_test_branch`', branch => 'test_branch2', tag => 'test_tag2')"),
-              Row(true) :: Nil)
-            checkAnswer(
-              spark.sql("SELECT * FROM `T$branch_test_branch2` ORDER BY a"),
-              Row(1, "a") :: Row(2, "b") :: Row(3, "c") :: Nil
-            )
-
-            // create empty branch
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.create_branch(table => 'test.T', branch => 'empty_branch')"),
-              Row(true) :: Nil)
-            assert(branchManager.branchExists("empty_branch"))
-            checkAnswer(
-              spark.sql("SELECT * FROM `T$branch_empty_branch` ORDER BY a"),
-              Nil
-            )
-
-            // delete branch
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.delete_branch(table => 'test.T', branch => 'test_branch')"),
-              Row(true) :: Nil)
-            assert(!branchManager.branchExists("test_branch"))
-            intercept[Exception] {
-              spark.sql("SELECT * FROM `T$branch_test_branch` ORDER BY a")
-            }
-
-          } finally {
-            stream.stop()
-          }
+        }
       }
     }
   }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
@@ -90,213 +90,219 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
   // ----------------------- Sort Compact -----------------------
 
   test("Paimon Procedure: sort compact") {
-    failAfter(streamingTimeout) {
-      withTempDir {
-        checkpointDir =>
-          spark.sql(s"""
-                       |CREATE TABLE T (a INT, b INT)
-                       |TBLPROPERTIES ('bucket'='-1')
-                       |""".stripMargin)
-          val location = loadTable("T").location().toString
+    withSparkSQLConf(("spark.paimon.write.use-v2-write", "false")) {
 
-          val inputData = MemoryStream[(Int, Int)]
-          val stream = inputData
-            .toDS()
-            .toDF("a", "b")
-            .writeStream
-            .option("checkpointLocation", checkpointDir.getCanonicalPath)
-            .foreachBatch {
-              (batch: Dataset[Row], _: Long) =>
-                batch.write.format("paimon").mode("append").save(location)
-            }
-            .start()
+      failAfter(streamingTimeout) {
+        withTempDir {
+          checkpointDir =>
+            spark.sql(s"""
+                         |CREATE TABLE T (a INT, b INT)
+                         |TBLPROPERTIES ('bucket'='-1')
+                         |""".stripMargin)
+            val location = loadTable("T").location().toString
 
-          val query = () => spark.sql("SELECT * FROM T")
-
-          try {
-            // test zorder sort
-            inputData.addData((0, 0))
-            inputData.addData((0, 1))
-            inputData.addData((0, 2))
-            inputData.addData((1, 0))
-            inputData.addData((1, 1))
-            inputData.addData((1, 2))
-            inputData.addData((2, 0))
-            inputData.addData((2, 1))
-            inputData.addData((2, 2))
-            stream.processAllAvailable()
-
-            val result = new util.ArrayList[Row]()
-            for (a <- 0 until 3) {
-              for (b <- 0 until 3) {
-                result.add(Row(a, b))
+            val inputData = MemoryStream[(Int, Int)]
+            val stream = inputData
+              .toDS()
+              .toDF("a", "b")
+              .writeStream
+              .option("checkpointLocation", checkpointDir.getCanonicalPath)
+              .foreachBatch {
+                (batch: Dataset[Row], _: Long) =>
+                  batch.write.format("paimon").mode("append").save(location)
               }
+              .start()
+
+            val query = () => spark.sql("SELECT * FROM T")
+
+            try {
+              // test zorder sort
+              inputData.addData((0, 0))
+              inputData.addData((0, 1))
+              inputData.addData((0, 2))
+              inputData.addData((1, 0))
+              inputData.addData((1, 1))
+              inputData.addData((1, 2))
+              inputData.addData((2, 0))
+              inputData.addData((2, 1))
+              inputData.addData((2, 2))
+              stream.processAllAvailable()
+
+              val result = new util.ArrayList[Row]()
+              for (a <- 0 until 3) {
+                for (b <- 0 until 3) {
+                  result.add(Row(a, b))
+                }
+              }
+              Assertions.assertThat(query().collect()).containsExactlyElementsOf(result)
+
+              checkAnswer(
+                spark.sql(
+                  "CALL paimon.sys.compact(table => 'T', order_strategy => 'zorder', order_by => 'a,b')"),
+                Row(true) :: Nil)
+
+              val result2 = new util.ArrayList[Row]()
+              result2.add(0, Row(0, 0))
+              result2.add(1, Row(0, 1))
+              result2.add(2, Row(1, 0))
+              result2.add(3, Row(1, 1))
+              result2.add(4, Row(0, 2))
+              result2.add(5, Row(1, 2))
+              result2.add(6, Row(2, 0))
+              result2.add(7, Row(2, 1))
+              result2.add(8, Row(2, 2))
+
+              Assertions.assertThat(query().collect()).containsExactlyElementsOf(result2)
+
+              // test hilbert sort
+              val result3 = new util.ArrayList[Row]()
+              result3.add(0, Row(0, 0))
+              result3.add(1, Row(0, 1))
+              result3.add(2, Row(1, 1))
+              result3.add(3, Row(1, 0))
+              result3.add(4, Row(2, 0))
+              result3.add(5, Row(2, 1))
+              result3.add(6, Row(2, 2))
+              result3.add(7, Row(1, 2))
+              result3.add(8, Row(0, 2))
+
+              checkAnswer(
+                spark.sql(
+                  "CALL paimon.sys.compact(table => 'T', order_strategy => 'hilbert', order_by => 'a,b')"),
+                Row(true) :: Nil)
+
+              Assertions.assertThat(query().collect()).containsExactlyElementsOf(result3)
+
+              // test order sort
+              checkAnswer(
+                spark.sql(
+                  "CALL paimon.sys.compact(table => 'T', order_strategy => 'order', order_by => 'a,b')"),
+                Row(true) :: Nil)
+              Assertions.assertThat(query().collect()).containsExactlyElementsOf(result)
+            } finally {
+              stream.stop()
             }
-            Assertions.assertThat(query().collect()).containsExactlyElementsOf(result)
-
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.compact(table => 'T', order_strategy => 'zorder', order_by => 'a,b')"),
-              Row(true) :: Nil)
-
-            val result2 = new util.ArrayList[Row]()
-            result2.add(0, Row(0, 0))
-            result2.add(1, Row(0, 1))
-            result2.add(2, Row(1, 0))
-            result2.add(3, Row(1, 1))
-            result2.add(4, Row(0, 2))
-            result2.add(5, Row(1, 2))
-            result2.add(6, Row(2, 0))
-            result2.add(7, Row(2, 1))
-            result2.add(8, Row(2, 2))
-
-            Assertions.assertThat(query().collect()).containsExactlyElementsOf(result2)
-
-            // test hilbert sort
-            val result3 = new util.ArrayList[Row]()
-            result3.add(0, Row(0, 0))
-            result3.add(1, Row(0, 1))
-            result3.add(2, Row(1, 1))
-            result3.add(3, Row(1, 0))
-            result3.add(4, Row(2, 0))
-            result3.add(5, Row(2, 1))
-            result3.add(6, Row(2, 2))
-            result3.add(7, Row(1, 2))
-            result3.add(8, Row(0, 2))
-
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.compact(table => 'T', order_strategy => 'hilbert', order_by => 'a,b')"),
-              Row(true) :: Nil)
-
-            Assertions.assertThat(query().collect()).containsExactlyElementsOf(result3)
-
-            // test order sort
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.compact(table => 'T', order_strategy => 'order', order_by => 'a,b')"),
-              Row(true) :: Nil)
-            Assertions.assertThat(query().collect()).containsExactlyElementsOf(result)
-          } finally {
-            stream.stop()
-          }
+        }
       }
     }
   }
 
   test("Paimon Procedure: sort compact with partition") {
-    failAfter(streamingTimeout) {
-      withTempDir {
-        checkpointDir =>
-          spark.sql(s"""
-                       |CREATE TABLE T (p INT, a INT, b INT)
-                       |TBLPROPERTIES ('bucket'='-1')
-                       |PARTITIONED BY (p)
-                       |""".stripMargin)
-          val location = loadTable("T").location().toString
+    withSparkSQLConf(("spark.paimon.write.use-v2-write", "false")) {
 
-          val inputData = MemoryStream[(Int, Int, Int)]
-          val stream = inputData
-            .toDS()
-            .toDF("p", "a", "b")
-            .writeStream
-            .option("checkpointLocation", checkpointDir.getCanonicalPath)
-            .foreachBatch {
-              (batch: Dataset[Row], _: Long) =>
-                batch.write.format("paimon").mode("append").save(location)
-            }
-            .start()
+      failAfter(streamingTimeout) {
+        withTempDir {
+          checkpointDir =>
+            spark.sql(s"""
+                         |CREATE TABLE T (p INT, a INT, b INT)
+                         |TBLPROPERTIES ('bucket'='-1')
+                         |PARTITIONED BY (p)
+                         |""".stripMargin)
+            val location = loadTable("T").location().toString
 
-          val query0 = () => spark.sql("SELECT * FROM T WHERE p=0")
-          val query1 = () => spark.sql("SELECT * FROM T WHERE p=1")
-
-          try {
-            // test zorder sort
-            inputData.addData((0, 0, 0))
-            inputData.addData((0, 0, 1))
-            inputData.addData((0, 0, 2))
-            inputData.addData((0, 1, 0))
-            inputData.addData((0, 1, 1))
-            inputData.addData((0, 1, 2))
-            inputData.addData((0, 2, 0))
-            inputData.addData((0, 2, 1))
-            inputData.addData((0, 2, 2))
-
-            inputData.addData((1, 0, 0))
-            inputData.addData((1, 0, 1))
-            inputData.addData((1, 0, 2))
-            inputData.addData((1, 1, 0))
-            inputData.addData((1, 1, 1))
-            inputData.addData((1, 1, 2))
-            inputData.addData((1, 2, 0))
-            inputData.addData((1, 2, 1))
-            inputData.addData((1, 2, 2))
-            stream.processAllAvailable()
-
-            val result0 = new util.ArrayList[Row]()
-            for (a <- 0 until 3) {
-              for (b <- 0 until 3) {
-                result0.add(Row(0, a, b))
+            val inputData = MemoryStream[(Int, Int, Int)]
+            val stream = inputData
+              .toDS()
+              .toDF("p", "a", "b")
+              .writeStream
+              .option("checkpointLocation", checkpointDir.getCanonicalPath)
+              .foreachBatch {
+                (batch: Dataset[Row], _: Long) =>
+                  batch.write.format("paimon").mode("append").save(location)
               }
-            }
-            val result1 = new util.ArrayList[Row]()
-            for (a <- 0 until 3) {
-              for (b <- 0 until 3) {
-                result1.add(Row(1, a, b))
+              .start()
+
+            val query0 = () => spark.sql("SELECT * FROM T WHERE p=0")
+            val query1 = () => spark.sql("SELECT * FROM T WHERE p=1")
+
+            try {
+              // test zorder sort
+              inputData.addData((0, 0, 0))
+              inputData.addData((0, 0, 1))
+              inputData.addData((0, 0, 2))
+              inputData.addData((0, 1, 0))
+              inputData.addData((0, 1, 1))
+              inputData.addData((0, 1, 2))
+              inputData.addData((0, 2, 0))
+              inputData.addData((0, 2, 1))
+              inputData.addData((0, 2, 2))
+
+              inputData.addData((1, 0, 0))
+              inputData.addData((1, 0, 1))
+              inputData.addData((1, 0, 2))
+              inputData.addData((1, 1, 0))
+              inputData.addData((1, 1, 1))
+              inputData.addData((1, 1, 2))
+              inputData.addData((1, 2, 0))
+              inputData.addData((1, 2, 1))
+              inputData.addData((1, 2, 2))
+              stream.processAllAvailable()
+
+              val result0 = new util.ArrayList[Row]()
+              for (a <- 0 until 3) {
+                for (b <- 0 until 3) {
+                  result0.add(Row(0, a, b))
+                }
               }
+              val result1 = new util.ArrayList[Row]()
+              for (a <- 0 until 3) {
+                for (b <- 0 until 3) {
+                  result1.add(Row(1, a, b))
+                }
+              }
+              Assertions.assertThat(query0().collect()).containsExactlyElementsOf(result0)
+              Assertions.assertThat(query1().collect()).containsExactlyElementsOf(result1)
+
+              checkAnswer(
+                spark.sql(
+                  "CALL paimon.sys.compact(table => 'T', partitions => 'p=0',  order_strategy => 'zorder', order_by => 'a,b')"),
+                Row(true) :: Nil)
+
+              val result2 = new util.ArrayList[Row]()
+              result2.add(0, Row(0, 0, 0))
+              result2.add(1, Row(0, 0, 1))
+              result2.add(2, Row(0, 1, 0))
+              result2.add(3, Row(0, 1, 1))
+              result2.add(4, Row(0, 0, 2))
+              result2.add(5, Row(0, 1, 2))
+              result2.add(6, Row(0, 2, 0))
+              result2.add(7, Row(0, 2, 1))
+              result2.add(8, Row(0, 2, 2))
+
+              Assertions.assertThat(query0().collect()).containsExactlyElementsOf(result2)
+              Assertions.assertThat(query1().collect()).containsExactlyElementsOf(result1)
+
+              // test hilbert sort
+              val result3 = new util.ArrayList[Row]()
+              result3.add(0, Row(0, 0, 0))
+              result3.add(1, Row(0, 0, 1))
+              result3.add(2, Row(0, 1, 1))
+              result3.add(3, Row(0, 1, 0))
+              result3.add(4, Row(0, 2, 0))
+              result3.add(5, Row(0, 2, 1))
+              result3.add(6, Row(0, 2, 2))
+              result3.add(7, Row(0, 1, 2))
+              result3.add(8, Row(0, 0, 2))
+
+              checkAnswer(
+                spark.sql(
+                  "CALL paimon.sys.compact(table => 'T', partitions => 'p=0',  order_strategy => 'hilbert', order_by => 'a,b')"),
+                Row(true) :: Nil)
+
+              Assertions.assertThat(query0().collect()).containsExactlyElementsOf(result3)
+              Assertions.assertThat(query1().collect()).containsExactlyElementsOf(result1)
+
+              // test order sort
+              checkAnswer(
+                spark.sql(
+                  "CALL paimon.sys.compact(table => 'T', partitions => 'p=0',  order_strategy => 'order', order_by => 'a,b')"),
+                Row(true) :: Nil)
+              Assertions.assertThat(query0().collect()).containsExactlyElementsOf(result0)
+              Assertions.assertThat(query1().collect()).containsExactlyElementsOf(result1)
+            } finally {
+              stream.stop()
             }
-            Assertions.assertThat(query0().collect()).containsExactlyElementsOf(result0)
-            Assertions.assertThat(query1().collect()).containsExactlyElementsOf(result1)
-
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.compact(table => 'T', partitions => 'p=0',  order_strategy => 'zorder', order_by => 'a,b')"),
-              Row(true) :: Nil)
-
-            val result2 = new util.ArrayList[Row]()
-            result2.add(0, Row(0, 0, 0))
-            result2.add(1, Row(0, 0, 1))
-            result2.add(2, Row(0, 1, 0))
-            result2.add(3, Row(0, 1, 1))
-            result2.add(4, Row(0, 0, 2))
-            result2.add(5, Row(0, 1, 2))
-            result2.add(6, Row(0, 2, 0))
-            result2.add(7, Row(0, 2, 1))
-            result2.add(8, Row(0, 2, 2))
-
-            Assertions.assertThat(query0().collect()).containsExactlyElementsOf(result2)
-            Assertions.assertThat(query1().collect()).containsExactlyElementsOf(result1)
-
-            // test hilbert sort
-            val result3 = new util.ArrayList[Row]()
-            result3.add(0, Row(0, 0, 0))
-            result3.add(1, Row(0, 0, 1))
-            result3.add(2, Row(0, 1, 1))
-            result3.add(3, Row(0, 1, 0))
-            result3.add(4, Row(0, 2, 0))
-            result3.add(5, Row(0, 2, 1))
-            result3.add(6, Row(0, 2, 2))
-            result3.add(7, Row(0, 1, 2))
-            result3.add(8, Row(0, 0, 2))
-
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.compact(table => 'T', partitions => 'p=0',  order_strategy => 'hilbert', order_by => 'a,b')"),
-              Row(true) :: Nil)
-
-            Assertions.assertThat(query0().collect()).containsExactlyElementsOf(result3)
-            Assertions.assertThat(query1().collect()).containsExactlyElementsOf(result1)
-
-            // test order sort
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.compact(table => 'T', partitions => 'p=0',  order_strategy => 'order', order_by => 'a,b')"),
-              Row(true) :: Nil)
-            Assertions.assertThat(query0().collect()).containsExactlyElementsOf(result0)
-            Assertions.assertThat(query1().collect()).containsExactlyElementsOf(result1)
-          } finally {
-            stream.stop()
-          }
+        }
       }
     }
   }
@@ -343,53 +349,55 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
   }
 
   test("Paimon Procedure: compact for pk") {
-    failAfter(streamingTimeout) {
-      withTempDir {
-        checkpointDir =>
-          spark.sql(s"""
-                       |CREATE TABLE T (a INT, b INT)
-                       |TBLPROPERTIES ('primary-key'='a,b', 'bucket'='1')
-                       |""".stripMargin)
-          val location = loadTable("T").location().toString
+    withSparkSQLConf(("spark.paimon.write.use-v2-write", "false")) {
+      failAfter(streamingTimeout) {
+        withTempDir {
+          checkpointDir =>
+            spark.sql(s"""
+                         |CREATE TABLE T (a INT, b INT)
+                         |TBLPROPERTIES ('primary-key'='a,b', 'bucket'='1')
+                         |""".stripMargin)
+            val location = loadTable("T").location().toString
 
-          val inputData = MemoryStream[(Int, Int)]
-          val stream = inputData
-            .toDS()
-            .toDF("a", "b")
-            .writeStream
-            .option("checkpointLocation", checkpointDir.getCanonicalPath)
-            .foreachBatch {
-              (batch: Dataset[Row], _: Long) =>
-                batch.write.format("paimon").mode("append").save(location)
-            }
-            .start()
-
-          val query = () => spark.sql("SELECT * FROM T")
-
-          try {
-            inputData.addData((0, 0))
-            inputData.addData((0, 1))
-            inputData.addData((0, 2))
-            inputData.addData((1, 0))
-            inputData.addData((1, 1))
-            inputData.addData((1, 2))
-            inputData.addData((2, 0))
-            inputData.addData((2, 1))
-            inputData.addData((2, 2))
-            stream.processAllAvailable()
-
-            val result = new util.ArrayList[Row]()
-            for (a <- 0 until 3) {
-              for (b <- 0 until 3) {
-                result.add(Row(a, b))
+            val inputData = MemoryStream[(Int, Int)]
+            val stream = inputData
+              .toDS()
+              .toDF("a", "b")
+              .writeStream
+              .option("checkpointLocation", checkpointDir.getCanonicalPath)
+              .foreachBatch {
+                (batch: Dataset[Row], _: Long) =>
+                  batch.write.format("paimon").mode("append").save(location)
               }
+              .start()
+
+            val query = () => spark.sql("SELECT * FROM T")
+
+            try {
+              inputData.addData((0, 0))
+              inputData.addData((0, 1))
+              inputData.addData((0, 2))
+              inputData.addData((1, 0))
+              inputData.addData((1, 1))
+              inputData.addData((1, 2))
+              inputData.addData((2, 0))
+              inputData.addData((2, 1))
+              inputData.addData((2, 2))
+              stream.processAllAvailable()
+
+              val result = new util.ArrayList[Row]()
+              for (a <- 0 until 3) {
+                for (b <- 0 until 3) {
+                  result.add(Row(a, b))
+                }
+              }
+              Assertions.assertThat(query().collect()).containsExactlyElementsOf(result)
+              checkAnswer(spark.sql("CALL paimon.sys.compact(table => 'T')"), Row(true) :: Nil)
+              Assertions.assertThat(query().collect()).containsExactlyElementsOf(result)
+            } finally {
+              stream.stop()
             }
-            Assertions.assertThat(query().collect()).containsExactlyElementsOf(result)
-            checkAnswer(spark.sql("CALL paimon.sys.compact(table => 'T')"), Row(true) :: Nil)
-            Assertions.assertThat(query().collect()).containsExactlyElementsOf(result)
-          } finally {
-            stream.stop()
-          }
+        }
       }
     }
   }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CreateAndDeleteTagProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CreateAndDeleteTagProcedureTest.scala
@@ -29,161 +29,162 @@ class CreateAndDeleteTagProcedureTest extends PaimonSparkTestBase with StreamTes
   import testImplicits._
 
   test("Paimon Procedure: create and delete tag") {
-    failAfter(streamingTimeout) {
-      withTempDir {
-        checkpointDir =>
-          // define a change-log table and test `forEachBatch` api
-          spark.sql(s"""
-                       |CREATE TABLE T (a INT, b STRING)
-                       |TBLPROPERTIES ('primary-key'='a', 'bucket'='3')
-                       |""".stripMargin)
-          val location = loadTable("T").location().toString
+    withSparkSQLConf(("spark.paimon.write.use-v2-write", "false")) {
 
-          val inputData = MemoryStream[(Int, String)]
-          val stream = inputData
-            .toDS()
-            .toDF("a", "b")
-            .writeStream
-            .option("checkpointLocation", checkpointDir.getCanonicalPath)
-            .foreachBatch {
-              (batch: Dataset[Row], _: Long) =>
-                batch.write.format("paimon").mode("append").save(location)
-            }
-            .start()
+      failAfter(streamingTimeout) {
+        withTempDir {
+          checkpointDir =>
+            // define a change-log table and test `forEachBatch` api
+            spark.sql(s"""
+                         |CREATE TABLE T (a INT, b STRING)
+                         |TBLPROPERTIES ('primary-key'='a', 'bucket'='3')
+                         |""".stripMargin)
+            val location = loadTable("T").location().toString
 
-          val query = () => spark.sql("SELECT * FROM T ORDER BY a")
+            val inputData = MemoryStream[(Int, String)]
+            val stream = inputData
+              .toDS()
+              .toDF("a", "b")
+              .writeStream
+              .option("checkpointLocation", checkpointDir.getCanonicalPath)
+              .foreachBatch {
+                (batch: Dataset[Row], _: Long) =>
+                  batch.write.format("paimon").mode("append").save(location)
+              }
+              .start()
 
-          try {
-            // snapshot-1
-            inputData.addData((1, "a"))
-            stream.processAllAvailable()
-            checkAnswer(query(), Row(1, "a") :: Nil)
+            val query = () => spark.sql("SELECT * FROM T ORDER BY a")
 
-            // snapshot-2
-            inputData.addData((2, "b"))
-            stream.processAllAvailable()
-            checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
+            try {
+              // snapshot-1
+              inputData.addData((1, "a"))
+              stream.processAllAvailable()
+              checkAnswer(query(), Row(1, "a") :: Nil)
 
-            // snapshot-3
-            inputData.addData((2, "b2"))
-            stream.processAllAvailable()
-            checkAnswer(query(), Row(1, "a") :: Row(2, "b2") :: Nil)
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.create_tag(" +
+              // snapshot-2
+              inputData.addData((2, "b"))
+              stream.processAllAvailable()
+              checkAnswer(query(), Row(1, "a") :: Row(2, "b") :: Nil)
+
+              // snapshot-3
+              inputData.addData((2, "b2"))
+              stream.processAllAvailable()
+              checkAnswer(query(), Row(1, "a") :: Row(2, "b2") :: Nil)
+              checkAnswer(
+                spark.sql("CALL paimon.sys.create_tag(" +
                   "table => 'test.T', tag => 'test_tag', time_retained => '5 d', snapshot => 2)"),
-              Row(true) :: Nil)
-            checkAnswer(
-              spark.sql("SELECT tag_name FROM paimon.test.`T$tags`"),
-              Row("test_tag") :: Nil)
-            checkAnswer(
-              spark.sql("CALL paimon.sys.delete_tag(table => 'test.T', tag => 'test_tag')"),
-              Row(true) :: Nil)
-            checkAnswer(spark.sql("SELECT tag_name FROM paimon.test.`T$tags`"), Nil)
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.create_tag(table => 'test.T', tag => 'test_latestSnapshot_tag')"),
-              Row(true) :: Nil)
-            checkAnswer(
-              spark.sql("SELECT tag_name FROM paimon.test.`T$tags`"),
-              Row("test_latestSnapshot_tag") :: Nil)
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.delete_tag(table => 'test.T', tag => 'test_latestSnapshot_tag')"),
-              Row(true) :: Nil)
-            checkAnswer(spark.sql("SELECT tag_name FROM paimon.test.`T$tags`"), Nil)
+                Row(true) :: Nil)
+              checkAnswer(
+                spark.sql("SELECT tag_name FROM paimon.test.`T$tags`"),
+                Row("test_tag") :: Nil)
+              checkAnswer(
+                spark.sql("CALL paimon.sys.delete_tag(table => 'test.T', tag => 'test_tag')"),
+                Row(true) :: Nil)
+              checkAnswer(spark.sql("SELECT tag_name FROM paimon.test.`T$tags`"), Nil)
+              checkAnswer(
+                spark.sql(
+                  "CALL paimon.sys.create_tag(table => 'test.T', tag => 'test_latestSnapshot_tag')"),
+                Row(true) :: Nil)
+              checkAnswer(
+                spark.sql("SELECT tag_name FROM paimon.test.`T$tags`"),
+                Row("test_latestSnapshot_tag") :: Nil)
+              checkAnswer(
+                spark.sql(
+                  "CALL paimon.sys.delete_tag(table => 'test.T', tag => 'test_latestSnapshot_tag')"),
+                Row(true) :: Nil)
+              checkAnswer(spark.sql("SELECT tag_name FROM paimon.test.`T$tags`"), Nil)
 
-            // create test_tag_1 and test_tag_2
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.create_tag(" +
+              // create test_tag_1 and test_tag_2
+              checkAnswer(
+                spark.sql("CALL paimon.sys.create_tag(" +
                   "table => 'test.T', tag => 'test_tag_1', snapshot => 1)"),
-              Row(true) :: Nil)
+                Row(true) :: Nil)
 
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.create_tag(" +
+              checkAnswer(
+                spark.sql("CALL paimon.sys.create_tag(" +
                   "table => 'test.T', tag => 'test_tag_2', snapshot => 2)"),
-              Row(true) :: Nil)
+                Row(true) :: Nil)
 
-            checkAnswer(
-              spark.sql("SELECT tag_name FROM paimon.test.`T$tags`"),
-              Row("test_tag_1") :: Row("test_tag_2") :: Nil)
+              checkAnswer(
+                spark.sql("SELECT tag_name FROM paimon.test.`T$tags`"),
+                Row("test_tag_1") :: Row("test_tag_2") :: Nil)
 
-            // test rename_tag
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.rename_tag(table => 'test.T', tag => 'test_tag_1', target_tag => 'test_tag_3')"),
-              Row(true) :: Nil
-            )
-            checkAnswer(
-              spark.sql("SELECT tag_name FROM paimon.test.`T$tags`"),
-              Row("test_tag_2") :: Row("test_tag_3") :: Nil)
+              // test rename_tag
+              checkAnswer(
+                spark.sql(
+                  "CALL paimon.sys.rename_tag(table => 'test.T', tag => 'test_tag_1', target_tag => 'test_tag_3')"),
+                Row(true) :: Nil
+              )
+              checkAnswer(
+                spark.sql("SELECT tag_name FROM paimon.test.`T$tags`"),
+                Row("test_tag_2") :: Row("test_tag_3") :: Nil)
 
-            // delete test_tag_2 and test_tag_3
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.delete_tag(table => 'test.T', tag => 'test_tag_2,test_tag_3')"),
-              Row(true) :: Nil)
+              // delete test_tag_2 and test_tag_3
+              checkAnswer(
+                spark.sql(
+                  "CALL paimon.sys.delete_tag(table => 'test.T', tag => 'test_tag_2,test_tag_3')"),
+                Row(true) :: Nil)
 
-            checkAnswer(spark.sql("SELECT tag_name FROM paimon.test.`T$tags`"), Nil)
+              checkAnswer(spark.sql("SELECT tag_name FROM paimon.test.`T$tags`"), Nil)
 
-          } finally {
-            stream.stop()
-          }
+            } finally {
+              stream.stop()
+            }
+        }
       }
     }
   }
 
   test("Paimon Procedure: create same tag with same snapshot") {
-    failAfter(streamingTimeout) {
-      withTempDir {
-        checkpointDir =>
-          // define a change-log table and test `forEachBatch` api
-          spark.sql(s"""
-                       |CREATE TABLE T (a INT, b STRING)
-                       |TBLPROPERTIES ('primary-key'='a', 'bucket'='3')
-                       |""".stripMargin)
-          val location = loadTable("T").location().toString
+    withSparkSQLConf(("spark.paimon.write.use-v2-write", "false")) {
 
-          val inputData = MemoryStream[(Int, String)]
-          val stream = inputData
-            .toDS()
-            .toDF("a", "b")
-            .writeStream
-            .option("checkpointLocation", checkpointDir.getCanonicalPath)
-            .foreachBatch {
-              (batch: Dataset[Row], _: Long) =>
-                batch.write.format("paimon").mode("append").save(location)
-            }
-            .start()
+      failAfter(streamingTimeout) {
+        withTempDir {
+          checkpointDir =>
+            // define a change-log table and test `forEachBatch` api
+            spark.sql(s"""
+                         |CREATE TABLE T (a INT, b STRING)
+                         |TBLPROPERTIES ('primary-key'='a', 'bucket'='3')
+                         |""".stripMargin)
+            val location = loadTable("T").location().toString
 
-          val query = () => spark.sql("SELECT * FROM T ORDER BY a")
+            val inputData = MemoryStream[(Int, String)]
+            val stream = inputData
+              .toDS()
+              .toDF("a", "b")
+              .writeStream
+              .option("checkpointLocation", checkpointDir.getCanonicalPath)
+              .foreachBatch {
+                (batch: Dataset[Row], _: Long) =>
+                  batch.write.format("paimon").mode("append").save(location)
+              }
+              .start()
 
-          try {
-            // snapshot-1
-            inputData.addData((1, "a"))
-            stream.processAllAvailable()
-            checkAnswer(query(), Row(1, "a") :: Nil)
+            val query = () => spark.sql("SELECT * FROM T ORDER BY a")
 
-            checkAnswer(
-              spark.sql(
-                "CALL paimon.sys.create_tag(" +
+            try {
+              // snapshot-1
+              inputData.addData((1, "a"))
+              stream.processAllAvailable()
+              checkAnswer(query(), Row(1, "a") :: Nil)
+
+              checkAnswer(
+                spark.sql("CALL paimon.sys.create_tag(" +
                   "table => 'test.T', tag => 'test_tag', snapshot => 1)"),
-              Row(true) :: Nil)
-            checkAnswer(
-              spark.sql("SELECT count(*) FROM paimon.test.`T$tags` where tag_name = 'test_tag'"),
-              Row(1) :: Nil)
+                Row(true) :: Nil)
+              checkAnswer(
+                spark.sql("SELECT count(*) FROM paimon.test.`T$tags` where tag_name = 'test_tag'"),
+                Row(1) :: Nil)
 
-            // throw exception "Tag test_tag already exists"
-            assertThrows[IllegalArgumentException] {
-              spark.sql(
-                "CALL paimon.sys.create_tag(" +
+              // throw exception "Tag test_tag already exists"
+              assertThrows[IllegalArgumentException] {
+                spark.sql("CALL paimon.sys.create_tag(" +
                   "table => 'test.T', tag => 'test_tag', time_retained => '5 d', snapshot => 1)")
+              }
+            } finally {
+              stream.stop()
             }
-          } finally {
-            stream.stop()
-          }
+        }
       }
     }
   }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/ExpirePartitionsProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/ExpirePartitionsProcedureTest.scala
@@ -20,6 +20,7 @@ package org.apache.paimon.spark.procedure
 
 import org.apache.paimon.spark.PaimonSparkTestBase
 
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.{Dataset, Row}
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.streaming.StreamTest
@@ -27,6 +28,11 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 
 /** IT Case for [[ExpirePartitionsProcedure]]. */
 class ExpirePartitionsProcedureTest extends PaimonSparkTestBase with StreamTest {
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.paimon.write.use-v2-write", "false")
+  }
 
   import testImplicits._
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/ExpireSnapshotsProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/ExpireSnapshotsProcedureTest.scala
@@ -21,6 +21,7 @@ package org.apache.paimon.spark.procedure
 import org.apache.paimon.spark.PaimonSparkTestBase
 import org.apache.paimon.utils.SnapshotManager
 
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.{Dataset, Row}
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.streaming.StreamTest
@@ -29,6 +30,11 @@ import org.assertj.core.api.Assertions.{assertThat, assertThatIllegalArgumentExc
 import java.sql.Timestamp
 
 class ExpireSnapshotsProcedureTest extends PaimonSparkTestBase with StreamTest {
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.paimon.write.use-v2-write", "false")
+  }
 
   import testImplicits._
 


### PR DESCRIPTION
### Purpose

Disable v2 write in v1 append location unit tests

The operation ```batch.write.format("paimon").mode("append").save(location)``` throws an exception when v2 write is enabled. Therefore, it is necessary to explicitly disable v2 write in the relevant unit tests.

### Tests

CI
