### PR TITLE
[spark] Disable compaction for data evolution table

### DIFF
--- a/docs/content/append-table/data-evolution.md
+++ b/docs/content/append-table/data-evolution.md
@@ -67,7 +67,7 @@ ON t.id = s.id
 WHEN MATCHED THEN UPDATE SET t.b = s.b
 WHEN NOT MATCHED THEN INSERT (id, b, c) VALUES (id, b, 0);
 
-SELECT * FROM my_table;
+SELECT * FROM target_table;
 +----+----+----+
 | id | b  | c  |
 +----+----+----+
@@ -80,7 +80,7 @@ This statement updates only the `b` column in the target table `target_table` ba
 `source_table`. The `id` column and `c` column remain unchanged, and new records are inserted with the specified values. The difference between this and table those are not enabled with data evolution is that only the `b` column data is written to new files.
 
 Note that: 
-* Data Evolution Table does not support 'Delete' statement yet.
+* Data Evolution Table does not support 'Delete', 'Update', or 'Compact' statement yet.
 * Merge Into for Data Evolution Table does not support 'WHEN NOT MATCHED BY SOURCE' clause.
 
 ## Spec

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -182,6 +182,9 @@ public class CompactProcedure extends BaseProcedure {
                 table -> {
                     checkArgument(table instanceof FileStoreTable);
                     checkArgument(
+                            !((FileStoreTable) table).coreOptions().dataEvolutionEnabled(),
+                            "Compact operation is not supported when data evolution is enabled yet.");
+                    checkArgument(
                             sortColumns.stream().noneMatch(table.partitionKeys()::contains),
                             "order_by should not contain partition cols, because it is meaningless, your order_by cols are %s, and partition cols are %s",
                             sortColumns,

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
@@ -329,6 +329,23 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase {
     }
   }
 
+  test("Data Evolution: compact table throws exception") {
+    withTable("t") {
+      sql(
+        "CREATE TABLE t (id INT, b INT) TBLPROPERTIES ('row-tracking.enabled' = 'true', 'data-evolution.enabled' = 'true')")
+      sql("INSERT INTO t VALUES (1, 11), (2, 22)")
+      sql("INSERT INTO t VALUES (3, 33)")
+      sql("INSERT INTO t VALUES (4, 44)")
+      sql("INSERT INTO t VALUES (5, 55)")
+      sql("INSERT INTO t VALUES (6, 66)")
+      assert(
+        intercept[RuntimeException] {
+          sql("CALL sys.compact(table => 't')")
+        }.getMessage
+          .contains("Compact operation is not supported when data evolution is enabled yet."))
+    }
+  }
+
   test("Data Evolution: delete table throws exception") {
     withTable("t") {
       sql(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Spark data evolution table can appear inconsistent before and after compaction. Example:

```sql
CREATE TABLE s (id INT, b INT);
INSERT INTO s VALUES (1, 11), (2, 22);

CREATE TABLE t (id INT, b INT, c INT) TBLPROPERTIES ('row-tracking.enabled' = 'true', 'data-evolution.enabled' = 'true');
INSERT INTO t VALUES (2, 2, 2), (3, 3, 3);
MERGE INTO t
USING s
ON t.id = s.id
WHEN MATCHED THEN UPDATE SET t.b = s.b
WHEN NOT MATCHED THEN INSERT (id, b, c) VALUES (id, b, 0);
select *, _ROW_ID, _SEQUENCE_NUMBER from t order by _ROW_ID asc;
CALL sys.compact(table => 't');
select *, _ROW_ID, _SEQUENCE_NUMBER from t order by _ROW_ID asc;
```

before compaction:
```text
+----+----+---+---------+------------------+
| id |  b | c | _ROW_ID | _SEQUENCE_NUMBER |
+----+----+---+---------+------------------+
|  2 | 22 | 2 |       0 |                2 |
|  3 |  3 | 3 |       1 |                2 |
|  1 | 11 | 0 |       2 |                2 |
+----+----+---+---------+------------------+
```
after compaction:
```text
+--------+----+--------+---------+------------------+
|     id |  b |      c | _ROW_ID | _SEQUENCE_NUMBER |
+--------+----+--------+---------+------------------+
| <NULL> | 22 | <NULL> |       0 |                2 |
|      2 |  2 |      2 |       0 |                1 |
| <NULL> |  3 | <NULL> |       1 |                2 |
|      3 |  3 |      3 |       1 |                1 |
|      1 | 11 |      0 |       2 |                2 |
+--------+----+--------+---------+------------------+
```
Disable compaction in Spark to align with Flink behavior (#6112).

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
