### PR TITLE
[core]support prune read partition for format table

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatReadBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatReadBuilder.java
@@ -171,7 +171,7 @@ public class FormatReadBuilder implements ReadBuilder {
 
         Pair<int[], RowType> partitionMapping =
                 PartitionUtils.getPartitionMapping(
-                        table.partitionKeys(), table.rowType().getFields(), table.partitionType());
+                        table.partitionKeys(), readType().getFields(), table.partitionType());
 
         return new DataFileRecordReader(
                 readType(),

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/table/PaimonFormatTableTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/table/PaimonFormatTableTest.scala
@@ -50,10 +50,10 @@ class PaimonFormatTableTest extends PaimonSparkTestWithRestCatalogBase {
         new Path(
           table.location(),
           s"ds=$partition/part-00000-0a28422e-68ba-4713-8870-2fde2d36ed06-c001.csv")
-      table.fileIO().writeFile(csvFile, "1|2｜asfasdfsdf|11111\n3|4｜asfasdfsdf", false)
+      table.fileIO().writeFile(csvFile, "1|asfasdfsdf\n2|asfasdfsdf", false)
       checkAnswer(
         sql(s"SELECT * FROM $tableName"),
-        Seq(Row(1, "2｜asfasdfsdf|11111", partition), Row(3, "4｜asfasdfsdf", partition)))
+        Seq(Row(1, "asfasdfsdf", partition), Row(2, "asfasdfsdf", partition)))
     }
   }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Support prune read partition for format table.

### Tests
- CatalogTestBase#testCsvFormatTableDataHasFieldDelimiter
- PaimonSparkTestBase#test("PaimonFormatTableRead table: csv with field-delimiter")

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
