### PR TITLE
[paimon-flink-cdc] Add skip-corrupt-record configuration for Kafka CDC with PII-safe logging

### DIFF
--- a/docs/content/cdc-ingestion/kafka-cdc.md
+++ b/docs/content/cdc-ingestion/kafka-cdc.md
@@ -288,23 +288,6 @@ There are some useful options to build Flink Kafka Source, but they are not prov
           <td>String</td>
           <td>When configuring "value.format=debezium-avro" which requires using the Confluence schema registry model for Apache Avro serialization, you need to provide the schema registry URL.</td>
         </tr>
-    </tbody>
-</table>
-
-## Error Handling
-
-When consuming CDC data from Kafka, you may encounter corrupt or unparsable records due to schema mismatches, malformed data, or other issues. Paimon provides configuration options to handle such records gracefully without causing job failures.
-
-<table class="table table-bordered">
-    <thead>
-      <tr>
-        <th class="text-left">Key</th>
-        <th class="text-left">Default</th>
-        <th class="text-left">Type</th>
-        <th class="text-left">Description</th>
-      </tr>
-    </thead>
-    <tbody>
         <tr>
           <td>cdc.skip-corrupt-record</td>
           <td>false</td>
@@ -315,18 +298,12 @@ When consuming CDC data from Kafka, you may encounter corrupt or unparsable reco
           <td>cdc.log-corrupt-record</td>
           <td>true</td>
           <td>Boolean</td>
-          <td>Whether to log full details about corrupt records when they are encountered. This includes the topic, partition, offset, and record payload. When false, only topic-level metadata is logged without record details to prevent PII leakage. Set to true only for debugging purposes with appropriate log security measures in place.</td>
+          <td>Whether to log full details about corrupt records when they are encountered. This includes the topic, partition, offset, and record payload. When false, only topic-level metadata is logged without record details to prevent PII leakage. <strong>Security Warning:</strong> When set to true, the full record content will be logged, which may include Personally Identifiable Information (PII) or other sensitive data. Ensure your log storage and access controls comply with your organization's data privacy policies. Set to true only for debugging purposes with appropriate security measures in place.</td>
         </tr>
     </tbody>
 </table>
 
-{{< hint warning >}}
-**Security Warning:** When `cdc.log-corrupt-record=true`, the full record content will be logged, which may include Personally Identifiable Information (PII) or other sensitive data. Ensure your log storage and access controls comply with your organization's data privacy policies. Consider setting this to `false` in production environments or ensure logs are properly secured and have appropriate retention policies.
-{{< /hint >}}
-
-**Note:** These configurations apply to parsing-level errors (e.g., missing required fields, type mismatches). They should be specified via `--kafka_conf`.
-
-**Example:**
+**Example - Skip corrupt records with PII-safe logging:**
 
 ```bash
 <FLINK_HOME>/bin/flink run \
@@ -339,14 +316,6 @@ When consuming CDC data from Kafka, you may encounter corrupt or unparsable reco
     --kafka_conf topic=orders \
     --kafka_conf value.format=debezium-avro \
     --kafka_conf schema.registry.url=http://localhost:8081 \
-    --kafka_conf cdc.skip-corrupt-record=true
+    --kafka_conf cdc.skip-corrupt-record=true \
+    --kafka_conf cdc.log-corrupt-record=false
 ```
-
-When `cdc.skip-corrupt-record=true`, the synchronization job will continue processing even if it encounters records that cannot be parsed. By default, only topic-level metadata (topic name) is logged to prevent PII leakage. Corrupt records are logged as warnings with messages like "Corrupt record detected during record processing from topic: orders".
-
-To enable full record payload logging for debugging (not recommended for production), add:
-```bash
-    --kafka_conf cdc.log-corrupt-record=true
-```
-
-This will log the complete record details including partition, offset, and record content, which may contain sensitive data.

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/CdcSourceRecord.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/CdcSourceRecord.java
@@ -35,10 +35,25 @@ public class CdcSourceRecord implements Serializable {
     // TODO Use generics to support more scenarios.
     private final Object value;
 
-    public CdcSourceRecord(@Nullable String topic, @Nullable Object key, Object value) {
+    @Nullable private final Integer partition;
+
+    @Nullable private final Long offset;
+
+    public CdcSourceRecord(
+            @Nullable String topic,
+            @Nullable Object key,
+            Object value,
+            @Nullable Integer partition,
+            @Nullable Long offset) {
         this.topic = topic;
         this.key = key;
         this.value = value;
+        this.partition = partition;
+        this.offset = offset;
+    }
+
+    public CdcSourceRecord(@Nullable String topic, @Nullable Object key, Object value) {
+        this(topic, key, value, null, null);
     }
 
     public CdcSourceRecord(Object value) {
@@ -59,6 +74,16 @@ public class CdcSourceRecord implements Serializable {
         return value;
     }
 
+    @Nullable
+    public Integer getPartition() {
+        return partition;
+    }
+
+    @Nullable
+    public Long getOffset() {
+        return offset;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof CdcSourceRecord)) {
@@ -68,16 +93,30 @@ public class CdcSourceRecord implements Serializable {
         CdcSourceRecord that = (CdcSourceRecord) o;
         return Objects.equals(topic, that.topic)
                 && Objects.equals(key, that.key)
-                && Objects.equals(value, that.value);
+                && Objects.equals(value, that.value)
+                && Objects.equals(partition, that.partition)
+                && Objects.equals(offset, that.offset);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(topic, key, value);
+        return Objects.hash(topic, key, value, partition, offset);
     }
 
     @Override
     public String toString() {
-        return topic + ": " + key + " " + value;
+        StringBuilder sb = new StringBuilder();
+        if (topic != null) {
+            sb.append("topic=").append(topic);
+        }
+        if (partition != null) {
+            sb.append(", partition=").append(partition);
+        }
+        if (offset != null) {
+            sb.append(", offset=").append(offset);
+        }
+        sb.append("\nkey: ").append(key);
+        sb.append("\nvalue: ").append(value);
+        return sb.toString();
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncJobHandler.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncJobHandler.java
@@ -48,6 +48,8 @@ import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.POSTGRES_C
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.PULSAR_CONF;
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.checkOneRequiredOption;
 import static org.apache.paimon.flink.action.cdc.CdcActionCommonUtils.checkRequiredOptions;
+import static org.apache.paimon.flink.sink.cdc.CdcRecordStoreWriteOperator.LOG_CORRUPT_RECORD;
+import static org.apache.paimon.flink.sink.cdc.CdcRecordStoreWriteOperator.SKIP_CORRUPT_RECORD;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Provide different function according to CDC source type. */
@@ -209,7 +211,13 @@ public class SyncJobHandler {
             case KAFKA:
             case PULSAR:
                 DataFormat dataFormat = provideDataFormat();
-                return dataFormat.createParser(typeMapping, computedColumns);
+                return dataFormat.createParser(
+                        typeMapping,
+                        computedColumns,
+                        cdcSourceConfig.getBoolean(
+                                SKIP_CORRUPT_RECORD.key(), SKIP_CORRUPT_RECORD.defaultValue()),
+                        cdcSourceConfig.getBoolean(
+                                LOG_CORRUPT_RECORD.key(), LOG_CORRUPT_RECORD.defaultValue()));
             case MONGODB:
                 return new MongoDBRecordParser(computedColumns, cdcSourceConfig);
             default:

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/DataFormat.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/format/DataFormat.java
@@ -38,11 +38,32 @@ public interface DataFormat {
      * Creates a new instance of {@link AbstractRecordParser} for this data format with the
      * specified configurations.
      *
+     * @param typeMapping Type mapping options.
      * @param computedColumns List of computed columns to be considered by the parser.
      * @return A new instance of {@link AbstractRecordParser}.
      */
     AbstractRecordParser createParser(
             TypeMapping typeMapping, List<ComputedColumn> computedColumns);
+
+    /**
+     * Creates a new instance of {@link AbstractRecordParser} for this data format with the
+     * specified configurations and corrupt record handling options.
+     *
+     * @param typeMapping Type mapping options.
+     * @param computedColumns List of computed columns to be considered by the parser.
+     * @param skipCorruptRecord Whether to skip corrupt records instead of throwing exceptions.
+     * @param logCorruptRecord Whether to log corrupt record details (may contain PII).
+     * @return A new instance of {@link AbstractRecordParser}.
+     */
+    default AbstractRecordParser createParser(
+            TypeMapping typeMapping,
+            List<ComputedColumn> computedColumns,
+            boolean skipCorruptRecord,
+            boolean logCorruptRecord) {
+        return createParser(typeMapping, computedColumns)
+                .withSkipCorruptRecord(skipCorruptRecord)
+                .withLogCorruptRecord(logCorruptRecord);
+    }
 
     KafkaDeserializationSchema<CdcSourceRecord> createKafkaDeserializer(
             Configuration cdcSourceConfig);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaDebeziumAvroDeserializationSchema.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaDebeziumAvroDeserializationSchema.java
@@ -76,7 +76,7 @@ public class KafkaDebeziumAvroDeserializationSchema
             key = (GenericRecord) keyContainerWithVersion.container();
         }
         GenericRecord value = (GenericRecord) valueContainerWithVersion.container();
-        return new CdcSourceRecord(topic, key, value);
+        return new CdcSourceRecord(topic, key, value, message.partition(), message.offset());
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaDebeziumJsonDeserializationSchema.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/kafka/KafkaDebeziumJsonDeserializationSchema.java
@@ -76,7 +76,8 @@ public class KafkaDebeziumJsonDeserializationSchema
             }
 
             JsonNode valueNode = objectMapper.readValue(message.value(), JsonNode.class);
-            return new CdcSourceRecord(null, keyNode, valueNode);
+            return new CdcSourceRecord(
+                    message.topic(), keyNode, valueNode, message.partition(), message.offset());
         } catch (Exception e) {
             LOG.error("Invalid Json:\n{}", new String(message.value()));
             throw e;


### PR DESCRIPTION
### Purpose

Fixes job failures when Kafka CDC ingestion encounters corrupt or unparsable records. Instead of crashing the job, users can now configure the parser to skip invalid records with PII-safe logging.

This feature is already available for [MySQL sources](https://github.com/apache/paimon/blob/master/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/CdcRecordStoreWriteOperator.java#L64-L75).

<!-- What is the purpose of the change -->

### Tests

It's a difficult thing to test to produce invalid avro messages to a topic but it's been tested with a live job in our cluster.

`2025-10-01 00:04:51,433 [] WARN  org.apache.paimon.flink.action.cdc.format.AbstractRecordParser [] - Skipping corrupt or unparsable source record.`

### Documentation

Docs has been updated.
