### PR TITLE
[core] Validate blob type should not be defined solely

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -657,6 +657,9 @@ public class SchemaValidation {
             checkArgument(
                     BlobType.splitBlob(schema.logicalRowType()).getRight().getFieldCount() == 1,
                     "Table with BLOB type column only support one BLOB column.");
+            checkArgument(
+                    schema.fields().size() > 1,
+                    "Table with BLOB type column must have other normal columns.");
         }
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Disable define blob type solely

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
