### PR TITLE
[hotfix] fix format table read filter bug

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatReadBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatReadBuilder.java
@@ -151,7 +151,7 @@ public class FormatReadBuilder implements ReadBuilder {
 
     @Override
     public TableRead newRead() {
-        return new FormatTableRead(readType(), this, filter, limit);
+        return new FormatTableRead(readType(), table.rowType(), this, filter, limit);
     }
 
     protected RecordReader<InternalRow> createReader(FormatDataSplit dataSplit) throws IOException {

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableRead.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class FormatTableRead implements TableRead {
 
     private final RowType readType;
+    private final RowType tableRowType;
     private final Predicate predicate;
     private final FormatReadBuilder read;
     private final Integer limit;
@@ -44,7 +45,12 @@ public class FormatTableRead implements TableRead {
     private boolean executeFilter = false;
 
     public FormatTableRead(
-            RowType readType, FormatReadBuilder read, Predicate predicate, Integer limit) {
+            RowType readType,
+            RowType tableRowType,
+            FormatReadBuilder read,
+            Predicate predicate,
+            Integer limit) {
+        this.tableRowType = tableRowType;
         this.readType = readType;
         this.read = read;
         this.predicate = predicate;
@@ -88,7 +94,7 @@ public class FormatTableRead implements TableRead {
 
         Predicate predicate = this.predicate;
         if (readType != null) {
-            int[] projection = readType.getFieldIndices(readType.getFieldNames());
+            int[] projection = tableRowType.getFieldIndices(readType.getFieldNames());
             Optional<Predicate> optional =
                     predicate.visit(new PredicateProjectionConverter(projection));
             if (!optional.isPresent()) {

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -651,8 +651,8 @@ public abstract class CatalogTestBase {
             catalog.createTable(identifier, schemaBuilder.build(), true);
             FormatTable table = (FormatTable) catalog.getTable(identifier);
             int[] projection = new int[] {1, 2};
-            PredicateBuilder builder = new PredicateBuilder(table.rowType().project(projection));
-            Predicate predicate = builder.greaterOrEqual(0, 10);
+            PredicateBuilder builder = new PredicateBuilder(table.rowType());
+            Predicate predicate = builder.greaterOrEqual(1, 10);
             int size = 2000;
             int checkSize = 3;
             InternalRow[] datas = new InternalRow[size];


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

User use the table 's row type to init predicate, so we need use the same when executeFilter

<!-- What is the purpose of the change -->

### Tests
- CatalogTestBase#testFormatTableReadAndWrite

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
