### PR TITLE
[spark] Ensure compatibility of resolveFilter in lower version spark3.4

### DIFF
--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/catalyst/analysis/expressions/ExpressionHelper.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/catalyst/analysis/expressions/ExpressionHelper.scala
@@ -23,11 +23,7 @@ import org.apache.paimon.spark.SparkFilterConverter
 import org.apache.paimon.types.RowType
 
 import org.apache.spark.sql.PaimonUtils.{normalizeExprs, translateFilter}
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
-import org.apache.spark.sql.catalyst.optimizer.ConstantFolding
-import org.apache.spark.sql.catalyst.plans.logical.Filter
-import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 
 trait ExpressionHelper extends ExpressionHelperBase {
 
@@ -54,25 +50,6 @@ trait ExpressionHelper extends ExpressionHelperBase {
       None
     } else {
       Some(PredicateBuilder.and(predicates: _*))
-    }
-  }
-
-  def resolveFilter(
-      spark: SparkSession,
-      relation: DataSourceV2Relation,
-      conditionSql: String): Expression = {
-    val unResolvedExpression = spark.sessionState.sqlParser.parseExpression(conditionSql)
-    val filter = Filter(unResolvedExpression, relation)
-    spark.sessionState.analyzer.execute(filter) match {
-      case filter: Filter =>
-        try {
-          ConstantFolding.apply(filter).asInstanceOf[Filter].condition
-        } catch {
-          case _: Throwable => filter.condition
-        }
-      case _ =>
-        throw new RuntimeException(
-          s"Could not resolve expression $conditionSql in relation: $relation")
     }
   }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

We found that resolveFilter has compatibility issure in spark3.4.2,

```
org.apache.spark.sql.catalyst.QueryPlanningTracker$.$lessinit$greater$default$1()Lscala/Option;
java.lang.NoSuchMethodError: org.apache.spark.sql.catalyst.QueryPlanningTracker$.$lessinit$greater$default$1()Lscala/Option;
	at org.apache.paimon.spark.catalyst.analysis.expressions.ExpressionHelper.resolveFilter(ExpressionHelper.scala:79)
	at org.apache.paimon.spark.catalyst.analysis.expressions.ExpressionHelper.resolveFilter$(ExpressionHelper.scala:73)
	at org.apache.paimon.spark.catalyst.analysis.expressions.ExpressionUtils$.resolveFilter(ExpressionUtils.scala:22)
	at org.apache.paimon.spark.catalyst.analysis.expressions.ExpressionUtils.resolveFilter(ExpressionUtils.scala)
	at org.apache.paimon.spark.procedure.CompactProcedure.lambda$call$0(CompactProcedure.java:192)
	at org.apache.paimon.spark.procedure.BaseProcedure.execute(BaseProcedure.java:89)
	at org.apache.paimon.spark.procedure.BaseProcedure.modifyPaimonTable(BaseProcedure.java:79)
	at org.apache.paimon.spark.procedure.CompactProcedure.call(CompactProcedure.java:180)
	at org.apache.paimon.spark.execution.PaimonCallExec.run(PaimonCallExec.scala:32)
	at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.result$lzycompute(V2CommandExec.scala:43)
	at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.result(V2CommandExec.scala:43)
	at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.executeCollect(V2CommandExec.scala:49)
	at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.$anonfun$applyOrElse$
```

So choose to use `spark.sessionState.analyzer.execute` instead of `spark.sessionState.analyzer.executeAndCheck`

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
