### PR TITLE
[iceberg] Preserve table properties during Iceberg to Paimon migration

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergRef.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergRef.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 /**
  * Iceberg's ref metadata.
  *
- * <p>See <a href="https://iceberg.apache.org/spec/#refs">Iceberg spec</a>.
+ * <p>See <a href="https://iceberg.apache.org/spec/#snapshot-references">Iceberg spec</a>.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class IcebergRef {

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/migrate/IcebergMigrator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/migrate/IcebergMigrator.java
@@ -291,6 +291,10 @@ public class IcebergMigrator implements Migrator {
     }
 
     private List<TableSchema> icebergSchemasToPaimonSchemas(IcebergMetadata icebergMetadata) {
+        Map<String, String> options =
+                icebergMetadata.properties() == null
+                        ? Collections.emptyMap()
+                        : icebergMetadata.properties();
         return icebergMetadata.schemas().stream()
                 .map(
                         icebergSchema -> {
@@ -299,12 +303,13 @@ public class IcebergMigrator implements Migrator {
                                     icebergSchema.schemaId());
                             return TableSchema.create(
                                     icebergSchema.schemaId(),
-                                    icebergSchemaToPaimonSchema(icebergSchema));
+                                    icebergSchemaToPaimonSchema(icebergSchema, options));
                         })
                 .collect(Collectors.toList());
     }
 
-    private Schema icebergSchemaToPaimonSchema(IcebergSchema icebergSchema) {
+    private Schema icebergSchemaToPaimonSchema(
+            IcebergSchema icebergSchema, Map<String, String> options) {
 
         // get iceberg current partition spec
         int currentPartitionSpecId = icebergMetadata.defaultSpecId();
@@ -321,8 +326,7 @@ public class IcebergMigrator implements Migrator {
                         .map(IcebergPartitionField::name)
                         .collect(Collectors.toList());
 
-        return new Schema(
-                dataFields, partitionKeys, Collections.emptyList(), Collections.emptyMap(), null);
+        return new Schema(dataFields, partitionKeys, Collections.emptyList(), options, null);
     }
 
     private void checkAndFilterManifestFiles(


### PR DESCRIPTION
### Purpose
Pass table properties from Iceberg metadata to Paimon schema during migration.