### PR TITLE
[pvfs] Some minor fix for PVFS Java SDK in file status and input stream

### DIFF
--- a/paimon-vfs/paimon-vfs-hadoop/src/main/java/org/apache/paimon/vfs/hadoop/VFSInputStream.java
+++ b/paimon-vfs/paimon-vfs-hadoop/src/main/java/org/apache/paimon/vfs/hadoop/VFSInputStream.java
@@ -77,4 +77,9 @@ public class VFSInputStream extends FSInputStream {
         }
         return (n == -1) ? -1 : oneByteBuf[0] & 0xff;
     }
+
+    @Override
+    public void close() throws IOException {
+        in.close();
+    }
 }

--- a/paimon-vfs/paimon-vfs-hadoop/src/test/java/org/apache/paimon/vfs/hadoop/VirtualFileSystemTest.java
+++ b/paimon-vfs/paimon-vfs-hadoop/src/test/java/org/apache/paimon/vfs/hadoop/VirtualFileSystemTest.java
@@ -137,6 +137,7 @@ public abstract class VirtualFileSystemTest {
         FileStatus fileStatus = vfs.getFileStatus(vfsPath);
         Assert.assertEquals(vfsPath.toString(), fileStatus.getPath().toString());
         Assert.assertTrue(fileStatus.isDirectory());
+        Assert.assertEquals(0, fileStatus.getBlockSize());
 
         // Mkdir in non-existing table
         tableName = "object_table2";
@@ -195,6 +196,7 @@ public abstract class VirtualFileSystemTest {
         Assert.assertEquals(vfsPath.toString(), fileStatus.getPath().toString());
         Assert.assertTrue(fileStatus.isFile());
         Assert.assertEquals(5, fileStatus.getLen());
+        Assert.assertEquals(128 * 1024 * 1024L, fileStatus.getBlockSize());
 
         FSDataInputStream in = vfs.open(vfsPath);
         byte[] buffer = new byte[5];


### PR DESCRIPTION

### Purpose

1. Set a proper block size in PVFS file status, which may affect splitting in some cases such as Hive
2. Implement close method in input stream to make sure stream can be properly closed
