### PR TITLE
[core] Fix that cannot read binlog table with projection

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/system/BinlogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/BinlogTable.java
@@ -131,7 +131,7 @@ public class BinlogTable extends AuditLogTable {
                         (row1, row2) ->
                                 new AuditLogRow(
                                         readProjection, convertToArray(row1, row2, fieldGetters)),
-                        wrapped.rowType());
+                        this.wrappedReadType);
             } else {
                 return dataRead.createReader(split)
                         .transform(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
For example, the test will throw exception:
```
Caused by: java.lang.IllegalArgumentException: Row arity: 1, but serializer arity: 2
	at org.apache.paimon.data.serializer.InternalRowSerializer.copy(InternalRowSerializer.java:75)
	at org.apache.paimon.reader.PackChangelogReader$InternRecordIterator.next(PackChangelogReader.java:91)
	at org.apache.paimon.reader.PackChangelogReader$InternRecordIterator.next(PackChangelogReader.java:63)
	at org.apache.paimon.flink.source.FileStoreSourceSplitReader$FileStoreRecordIterator.next(FileStoreSourceSplitReader.java:299)
	at org.apache.paimon.flink.source.FlinkRecordsWithSplitIds.emitRecord(FlinkRecordsWithSplitIds.java:128)
	at org.apache.paimon.flink.source.FileStoreSourceReader.lambda$new$1(FileStoreSourceReader.java:67)
	at org.apache.flink.connector.base.source.reader.SourceReaderBase.pollNext(SourceReaderBase.java:203)
	at org.apache.flink.streaming.api.operators.SourceOperator.emitNext(SourceOperator.java:443)
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
