### PR TITLE
[core] Support blob set target size

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -63,6 +63,12 @@ under the License.
             <td>Specify the blob field.</td>
         </tr>
         <tr>
+            <td><h5>blob.target-file-size</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>MemorySize</td>
+            <td>Target size of a blob file. Default is value of TARGET_FILE_SIZE.</td>
+        </tr>
+        <tr>
             <td><h5>bucket</h5></td>
             <td style="word-wrap: break-word;">-1</td>
             <td>Integer</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -623,6 +623,16 @@ public class CoreOptions implements Serializable {
                                             text("append table: the default value is 256 MB."))
                                     .build());
 
+    public static final ConfigOption<MemorySize> BLOB_TARGET_FILE_SIZE =
+            key("blob.target-file-size")
+                    .memoryType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Target size of a blob file. Default is value of TARGET_FILE_SIZE.")
+                                    .build());
+
     public static final ConfigOption<Integer> NUM_SORTED_RUNS_COMPACTION_TRIGGER =
             key("num-sorted-run.compaction-trigger")
                     .intType()
@@ -2443,6 +2453,12 @@ public class CoreOptions implements Serializable {
         return options.getOptional(TARGET_FILE_SIZE)
                 .orElse(hasPrimaryKey ? VALUE_128_MB : VALUE_256_MB)
                 .getBytes();
+    }
+
+    public long blobTargetFileSize() {
+        return options.getOptional(BLOB_TARGET_FILE_SIZE)
+                .map(MemorySize::getBytes)
+                .orElse(targetFileSize(false));
     }
 
     public long compactionFileSize(boolean hasPrimaryKey) {

--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -72,6 +72,7 @@ public class AppendOnlyWriter implements BatchRecordWriter, MemoryOwner {
     private final long schemaId;
     private final FileFormat fileFormat;
     private final long targetFileSize;
+    private final long blobTargetFileSize;
     private final RowType writeSchema;
     @Nullable private final List<String> writeCols;
     private final DataFilePathFactory pathFactory;
@@ -102,6 +103,7 @@ public class AppendOnlyWriter implements BatchRecordWriter, MemoryOwner {
             long schemaId,
             FileFormat fileFormat,
             long targetFileSize,
+            long blobTargetFileSize,
             RowType writeSchema,
             @Nullable List<String> writeCols,
             long maxSequenceNumber,
@@ -123,6 +125,7 @@ public class AppendOnlyWriter implements BatchRecordWriter, MemoryOwner {
         this.schemaId = schemaId;
         this.fileFormat = fileFormat;
         this.targetFileSize = targetFileSize;
+        this.blobTargetFileSize = blobTargetFileSize;
         this.writeSchema = writeSchema;
         this.writeCols = writeCols;
         this.pathFactory = pathFactory;
@@ -299,6 +302,7 @@ public class AppendOnlyWriter implements BatchRecordWriter, MemoryOwner {
                     schemaId,
                     fileFormat,
                     targetFileSize,
+                    blobTargetFileSize,
                     writeSchema,
                     pathFactory,
                     seqNumCounter,

--- a/paimon-core/src/main/java/org/apache/paimon/append/RollingBlobFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/RollingBlobFileWriter.java
@@ -89,6 +89,7 @@ public class RollingBlobFileWriter implements RollingFileWriter<InternalRow, Dat
                     RollingFileWriterImpl<InternalRow, DataFileMeta>, List<DataFileMeta>>
             blobWriter;
     private final long targetFileSize;
+    private final long blobTargetFileSize;
 
     // State management
     private final List<FileWriterAbortExecutor> closedWriters;
@@ -103,6 +104,7 @@ public class RollingBlobFileWriter implements RollingFileWriter<InternalRow, Dat
             long schemaId,
             FileFormat fileFormat,
             long targetFileSize,
+            long blobTargetFileSize,
             RowType writeSchema,
             DataFilePathFactory pathFactory,
             LongCounter seqNumCounter,
@@ -115,6 +117,7 @@ public class RollingBlobFileWriter implements RollingFileWriter<InternalRow, Dat
 
         // Initialize basic fields
         this.targetFileSize = targetFileSize;
+        this.blobTargetFileSize = blobTargetFileSize;
         this.results = new ArrayList<>();
         this.closedWriters = new ArrayList<>();
 
@@ -152,7 +155,7 @@ public class RollingBlobFileWriter implements RollingFileWriter<InternalRow, Dat
                         fileSource,
                         asyncFileWrite,
                         statsDenseStore,
-                        targetFileSize);
+                        blobTargetFileSize);
     }
 
     /** Creates a factory for normal data writers. */

--- a/paimon-core/src/main/java/org/apache/paimon/operation/BaseAppendFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/BaseAppendFileStoreWrite.java
@@ -119,6 +119,7 @@ public abstract class BaseAppendFileStoreWrite extends MemoryFileStoreWrite<Inte
                 schemaId,
                 fileFormat,
                 options.targetFileSize(false),
+                options.blobTargetFileSize(),
                 writeType,
                 writeCols,
                 restoredMaxSeqNumber,

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -621,6 +621,7 @@ public class AppendOnlyWriterTest {
                         SCHEMA_ID,
                         fileFormat,
                         targetFileSize,
+                        targetFileSize,
                         AppendOnlyWriterTest.SCHEMA,
                         null,
                         getMaxSequenceNumber(toCompact),

--- a/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
@@ -85,6 +85,7 @@ public class FileFormatSuffixTest extends KeyValueFileReadWriteTest {
                         0,
                         fileFormat,
                         10,
+                        10,
                         SCHEMA,
                         null,
                         0,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Support blob file has it own target file size.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
