### PR TITLE
[core] Bug: disable data-evolution manifest filter for now

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
@@ -27,6 +27,7 @@ import org.apache.paimon.operation.AppendOnlyFileStoreScan;
 import org.apache.paimon.operation.BaseAppendFileStoreWrite;
 import org.apache.paimon.operation.BucketSelectConverter;
 import org.apache.paimon.operation.BucketedAppendFileStoreWrite;
+import org.apache.paimon.operation.DataEvolutionFileStoreScan;
 import org.apache.paimon.operation.DataEvolutionSplitRead;
 import org.apache.paimon.operation.RawFileSplitRead;
 import org.apache.paimon.predicate.Predicate;
@@ -167,6 +168,17 @@ public class AppendOnlyFileStore extends AbstractFileStore<InternalRow> {
                     }
                     return Optional.empty();
                 };
+
+        if (options().dataEvolutionEnabled()) {
+            return new DataEvolutionFileStoreScan(
+                    newManifestsReader(),
+                    bucketSelectConverter,
+                    snapshotManager(),
+                    schemaManager,
+                    schema,
+                    manifestFileFactory(),
+                    options.scanManifestParallelism());
+        }
 
         return new AppendOnlyFileStoreScan(
                 newManifestsReader(),

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.operation;
+
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.ManifestFile;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.utils.SnapshotManager;
+
+/** {@link FileStoreScan} for data-evolution enabled table. */
+public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
+
+    public DataEvolutionFileStoreScan(
+            ManifestsReader manifestsReader,
+            BucketSelectConverter bucketSelectConverter,
+            SnapshotManager snapshotManager,
+            SchemaManager schemaManager,
+            TableSchema schema,
+            ManifestFile.Factory manifestFileFactory,
+            Integer scanManifestParallelism) {
+        super(
+                manifestsReader,
+                bucketSelectConverter,
+                snapshotManager,
+                schemaManager,
+                schema,
+                manifestFileFactory,
+                scanManifestParallelism,
+                false);
+    }
+
+    public DataEvolutionFileStoreScan withFilter(Predicate predicate) {
+        return this;
+    }
+
+    /** Note: Keep this thread-safe. */
+    @Override
+    protected boolean filterByStats(ManifestEntry entry) {
+        return true;
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Data evolution file manifest filter is not easy, so disable it for now.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
