### PR TITLE
[flink] Revert method of FileStoreSourceSplitGenerator

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceSplitGenerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceSplitGenerator.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.source;
 
+import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableScan;
 
 import java.util.List;
@@ -35,7 +36,11 @@ public class FileStoreSourceSplitGenerator {
     private final AtomicInteger idCounter = new AtomicInteger(1);
 
     public List<FileStoreSourceSplit> createSplits(TableScan.Plan plan) {
-        return plan.splits().stream()
+        return createSplits(plan.splits());
+    }
+
+    public List<FileStoreSourceSplit> createSplits(List<Split> splits) {
+        return splits.stream()
                 .map(s -> new FileStoreSourceSplit(getNextId(), s))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The method `createSplits(List<Split> splits)` was used by other system.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
