### PR TITLE
[hotfix] Fix bug of comparing string and int in row_key_extractor

### DIFF
--- a/paimon-python/pypaimon/write/row_key_extractor.py
+++ b/paimon-python/pypaimon/write/row_key_extractor.py
@@ -101,7 +101,7 @@ class UnawareBucketRowKeyExtractor(RowKeyExtractor):
 
     def __init__(self, table_schema: TableSchema):
         super().__init__(table_schema)
-        num_buckets = table_schema.options.get(CoreOptions.BUCKET, -1)
+        num_buckets = int(table_schema.options.get(CoreOptions.BUCKET, -1))
 
         if num_buckets != -1:
             raise ValueError(f"Unaware bucket mode requires bucket = -1, got {num_buckets}")
@@ -118,7 +118,7 @@ class DynamicBucketRowKeyExtractor(RowKeyExtractor):
 
     def __init__(self, table_schema: 'TableSchema'):
         super().__init__(table_schema)
-        num_buckets = table_schema.options.get(CoreOptions.BUCKET, -1)
+        num_buckets = int(table_schema.options.get(CoreOptions.BUCKET, -1))
 
         if num_buckets != -1:
             raise ValueError(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
fix bug of comparing string and int in row_key_extractor.py

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
add ut test_with_shard_ao_unaware_bucket_manual: test with setting bucket -1 manually

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
