### PR TITLE
[rest] Add more hint message when commit failed because of NoSuchResourceException

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -355,7 +355,7 @@ public class RESTCatalog implements Catalog {
         try {
             return api.commitSnapshot(identifier, tableUuid, snapshot, statistics);
         } catch (NoSuchResourceException e) {
-            throw new TableNotExistException(identifier);
+            throw new TableNotExistException(identifier, e);
         } catch (ForbiddenException e) {
             throw new TableNoPermissionException(identifier, e);
         } catch (BadRequestException e) {


### PR DESCRIPTION
### Purpose
A commit failure with NoSuchResourceException could be due to the table not existing, or due to the table being recreated. We need to surface more detailed error reasons.

### Tests

### API and Format

### Documentation
