### PR TITLE
[core] check exists before open file

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/HintFileUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/HintFileUtils.java
@@ -71,7 +71,9 @@ public class HintFileUtils {
         int retryNumber = 0;
         while (retryNumber++ < READ_HINT_RETRY_NUM) {
             try {
-                return fileIO.readOverwrittenFileUtf8(path).map(Long::parseLong).orElse(null);
+                if (fileIO.exists(path)) {
+                    return fileIO.readOverwrittenFileUtf8(path).map(Long::parseLong).orElse(null);
+                }
             } catch (Exception ignored) {
             }
             try {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

When writing an empty table, in the commit stage, some exceptions of FileNotFoundException are always thrown, although it does not affect the final execution result.

```
Caused by: org.apache.hadoop.ipc.RemoteException(java.io.FileNotFoundException): File does not exist: /user/hive/warehouse/xx.db/xxx/snapshot/EARLIEST
```

```
Caused by: org.apache.hadoop.ipc.RemoteException(java.io.FileNotFoundException): File does not exist: /user/hive/warehouse/xx.db/xxx/snapshot/LATEST
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
