### PR TITLE
[feature] Force auto-tag creation ignore delay option

### DIFF
--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -165,9 +165,10 @@ This section introduce all available spark procedures about paimon.
       <td>trigger_tag_automatic_creation</td>
       <td>
          Trigger the tag automatic creation. Arguments:
-            <li>table: the target table identifier. Cannot be empty.</li>
+            <li>table: the target table identifier. Cannot be empty.</li> 
       </td>
       <td>
+         set `spark.paimon.tag.automatic-creation-without-delay`=true; -- enable automatic creation without delay<br/><br/>
          CALL sys.trigger_tag_automatic_creation(table => 'default.T')
       </td>
     </tr>

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -1195,6 +1195,12 @@ If the data size allocated for the sorting task is uneven,which may lead to perf
             <td>Whether to automatically complete missing tags.</td>
         </tr>
         <tr>
+            <td><h5>tag.automatic-creation-without-delay</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to ignore delay when creating tag automatically.</td>
+        </tr>
+        <tr>
             <td><h5>tag.automatic-creation</h5></td>
             <td style="word-wrap: break-word;">none</td>
             <td><p>Enum</p></td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1531,8 +1531,8 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Whether to create tag automatically. And how to generate tags.");
 
-    public static final ConfigOption<Boolean> TAG_AUTOMATIC_CREATION_IGNORE_DELAY =
-            key("tag.automatic-creation-ignore-delay")
+    public static final ConfigOption<Boolean> TAG_AUTOMATIC_CREATION_WITHOUT_DELAY =
+            key("tag.automatic-creation-without-delay")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription("Whether to ignore delay when creating tag automatically");
@@ -2851,8 +2851,8 @@ public class CoreOptions implements Serializable {
         return options.get(TAG_AUTOMATIC_CREATION);
     }
 
-    public Boolean tagAutoCreateIgnoreDelay() {
-        return options.get(TAG_AUTOMATIC_CREATION_IGNORE_DELAY);
+    public Boolean tagAutoCreateWithoutDelay() {
+        return options.get(TAG_AUTOMATIC_CREATION_WITHOUT_DELAY);
     }
 
     public TagCreationPeriod tagCreationPeriod() {

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1531,6 +1531,12 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Whether to create tag automatically. And how to generate tags.");
 
+    public static final ConfigOption<Boolean> TAG_AUTOMATIC_CREATION_IGNORE_DELAY =
+            key("tag.automatic-creation-ignore-delay")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether to ignore delay when creating tag automatically");
+
     public static final ConfigOption<Boolean> TAG_CREATE_SUCCESS_FILE =
             key("tag.create-success-file")
                     .booleanType()
@@ -2843,6 +2849,10 @@ public class CoreOptions implements Serializable {
 
     public TagCreationMode tagCreationMode() {
         return options.get(TAG_AUTOMATIC_CREATION);
+    }
+
+    public Boolean tagAutoCreateIgnoreDelay() {
+        return options.get(TAG_AUTOMATIC_CREATION_IGNORE_DELAY);
     }
 
     public TagCreationPeriod tagCreationPeriod() {

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoCreation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoCreation.java
@@ -54,7 +54,6 @@ public class TagAutoCreation {
     private final TagDeletion tagDeletion;
     private final TagTimeExtractor timeExtractor;
     private final TagPeriodHandler periodHandler;
-    private final Boolean ignoreDelay;
     private final Duration delay;
     @Nullable private final Integer numRetainedMax;
     @Nullable private final Duration defaultTimeRetained;
@@ -71,7 +70,7 @@ public class TagAutoCreation {
             TagDeletion tagDeletion,
             TagTimeExtractor timeExtractor,
             TagPeriodHandler periodHandler,
-            Boolean ignoreDelay,
+            Boolean withoutDelay,
             Duration delay,
             @Nullable Integer numRetainedMax,
             @Nullable Duration defaultTimeRetained,
@@ -83,8 +82,7 @@ public class TagAutoCreation {
         this.tagDeletion = tagDeletion;
         this.timeExtractor = timeExtractor;
         this.periodHandler = periodHandler;
-        this.ignoreDelay = ignoreDelay;
-        this.delay = ignoreDelay ? Duration.ZERO : delay;
+        this.delay = withoutDelay ? Duration.ZERO : delay;
         this.numRetainedMax = numRetainedMax;
         this.defaultTimeRetained = defaultTimeRetained;
         this.callbacks = callbacks;
@@ -228,7 +226,7 @@ public class TagAutoCreation {
                 tagDeletion,
                 extractor,
                 TagPeriodHandler.create(options),
-                options.tagAutoCreateIgnoreDelay(),
+                options.tagAutoCreateWithoutDelay(),
                 options.tagCreationDelay(),
                 options.tagNumRetainedMax(),
                 options.tagDefaultTimeRetained(),

--- a/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoCreation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/TagAutoCreation.java
@@ -54,6 +54,7 @@ public class TagAutoCreation {
     private final TagDeletion tagDeletion;
     private final TagTimeExtractor timeExtractor;
     private final TagPeriodHandler periodHandler;
+    private final Boolean ignoreDelay;
     private final Duration delay;
     @Nullable private final Integer numRetainedMax;
     @Nullable private final Duration defaultTimeRetained;
@@ -70,6 +71,7 @@ public class TagAutoCreation {
             TagDeletion tagDeletion,
             TagTimeExtractor timeExtractor,
             TagPeriodHandler periodHandler,
+            Boolean ignoreDelay,
             Duration delay,
             @Nullable Integer numRetainedMax,
             @Nullable Duration defaultTimeRetained,
@@ -81,7 +83,8 @@ public class TagAutoCreation {
         this.tagDeletion = tagDeletion;
         this.timeExtractor = timeExtractor;
         this.periodHandler = periodHandler;
-        this.delay = delay;
+        this.ignoreDelay = ignoreDelay;
+        this.delay = ignoreDelay ? Duration.ZERO : delay;
         this.numRetainedMax = numRetainedMax;
         this.defaultTimeRetained = defaultTimeRetained;
         this.callbacks = callbacks;
@@ -225,6 +228,7 @@ public class TagAutoCreation {
                 tagDeletion,
                 extractor,
                 TagPeriodHandler.create(options),
+                options.tagAutoCreateIgnoreDelay(),
                 options.tagCreationDelay(),
                 options.tagNumRetainedMax(),
                 options.tagDefaultTimeRetained(),

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/TriggerTagAutomaticCreationProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/TriggerTagAutomaticCreationProcedure.java
@@ -28,6 +28,8 @@ import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
+import java.util.Collections;
+
 import static org.apache.spark.sql.types.DataTypes.StringType;
 
 /** A procedure to trigger the tag automatic creation for a table. */
@@ -63,7 +65,11 @@ public class TriggerTagAutomaticCreationProcedure extends BaseProcedure {
                 tableIdent,
                 table -> {
                     try {
-                        ((FileStoreTable) table).newTagAutoManager().run();
+                        FileStoreTable fsTable = (FileStoreTable) table;
+                        // Force a empty commit to make sure a snapshot exists
+                        fsTable.newBatchWriteBuilder().newCommit().commit(Collections.emptyList());
+
+                        fsTable.newTagAutoManager().run();
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/TriggerTagAutomaticCreationProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/TriggerTagAutomaticCreationProcedureTest.scala
@@ -60,6 +60,7 @@ class TriggerTagAutomaticCreationProcedureTest extends PaimonSparkTestBase {
                 |USING PAIMON
                 |TBLPROPERTIES (
                 |'primary-key'='id',
+                |'snapshot.ignore-empty-commit'='false',
                 |'tag.automatic-creation'='process-time',
                 |'tag.creation-period'='daily',
                 |'tag.creation-delay'='10 m',

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/TriggerTagAutomaticCreationProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/TriggerTagAutomaticCreationProcedureTest.scala
@@ -26,37 +26,37 @@ import org.assertj.core.api.Assertions.assertThat
 class TriggerTagAutomaticCreationProcedureTest extends PaimonSparkTestBase {
 
   test("Paimon procedure: trigger tag automatic creation test") {
-    spark.sql("""CREATE TABLE T (id INT, name STRING)
+    spark.sql("""CREATE TABLE T_FORCE_AUTO_TAG (id INT, name STRING)
                 |USING PAIMON
                 |TBLPROPERTIES (
                 |'primary-key'='id'
                 |)""".stripMargin)
 
-    spark.sql("insert into T values(1, 'a')")
+    spark.sql("insert into T_FORCE_AUTO_TAG values(1, 'a')")
 
-    val table = loadTable("T")
+    val table = loadTable("T_FORCE_AUTO_TAG")
     assertResult(1)(table.snapshotManager().snapshotCount())
 
-    assertResult(0)(spark.sql("show tags T").count())
+    assertResult(0)(spark.sql("show tags T_FORCE_AUTO_TAG").count())
 
-    spark.sql("""alter table T set tblproperties(
+    spark.sql("""alter table T_FORCE_AUTO_TAG set tblproperties(
                 |'tag.automatic-creation'='process-time',
                 |'tag.creation-period'='daily',
                 |'tag.creation-delay'='10 m',
                 |'tag.num-retained-max'='90'
                 |)""".stripMargin)
 
-    spark.sql("CALL paimon.sys.trigger_tag_automatic_creation(table => 'test.T')")
-    assertResult(1)(spark.sql("show tags T").count())
+    spark.sql("CALL paimon.sys.trigger_tag_automatic_creation(table => 'test.T_FORCE_AUTO_TAG')")
+    assertResult(1)(spark.sql("show tags T_FORCE_AUTO_TAG").count())
     assertResult(
       spark
         .sql("select date_format(date_sub(current_date(), 1), 'yyyy-MM-dd')")
         .head()
-        .getString(0))(loadTable("T").tagManager().tagObjects().get(0).getRight)
+        .getString(0))(loadTable("T_FORCE_AUTO_TAG").tagManager().tagObjects().get(0).getRight)
   }
 
   test("Paimon procedure: trigger tag automatic creation without snapshot test") {
-    spark.sql("""CREATE TABLE T (id INT, name STRING)
+    spark.sql("""CREATE TABLE T_FORCE_AUTO_TAG_NS (id INT, name STRING)
                 |USING PAIMON
                 |TBLPROPERTIES (
                 |'primary-key'='id',
@@ -66,18 +66,18 @@ class TriggerTagAutomaticCreationProcedureTest extends PaimonSparkTestBase {
                 |'tag.num-retained-max'='90'
                 |)""".stripMargin)
 
-    val table = loadTable("T")
+    val table = loadTable("T_FORCE_AUTO_TAG_NS")
     assertResult(0)(table.snapshotManager().snapshotCount())
-    assertResult(0)(spark.sql("show tags T").count())
+    assertResult(0)(spark.sql("show tags T_FORCE_AUTO_TAG_NS").count())
 
-    spark.sql("CALL paimon.sys.trigger_tag_automatic_creation(table => 'test.T')")
+    spark.sql("CALL paimon.sys.trigger_tag_automatic_creation(table => 'test.T_FORCE_AUTO_TAG_NS')")
     assertResult(1)(table.snapshotManager().snapshotCount())
-    assertResult(1)(spark.sql("show tags T").count())
+    assertResult(1)(spark.sql("show tags T_FORCE_AUTO_TAG_NS").count())
     assertResult(
       spark
         .sql("select date_format(date_sub(current_date(), 1), 'yyyy-MM-dd')")
         .head()
-        .getString(0))(loadTable("T").tagManager().tagObjects().get(0).getRight)
+        .getString(0))(loadTable("T_FORCE_AUTO_TAG_NS").tagManager().tagObjects().get(0).getRight)
   }
 
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/TriggerTagAutomaticCreationProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/TriggerTagAutomaticCreationProcedureTest.scala
@@ -72,7 +72,7 @@ class TriggerTagAutomaticCreationProcedureTest extends PaimonSparkTestBase {
     spark.sql("""alter table T_FORCE_AUTO_TAG_IGNORE_DELAY set tblproperties(
                 |'tag.automatic-creation'='process-time',
                 |'tag.creation-period'='daily',
-                |'tag.creation-delay'='2 d',
+                |'tag.creation-delay'='1 d',
                 |'tag.num-retained-max'='90'
                 |)""".stripMargin)
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/TriggerTagAutomaticCreationProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/TriggerTagAutomaticCreationProcedureTest.scala
@@ -69,13 +69,12 @@ class TriggerTagAutomaticCreationProcedureTest extends PaimonSparkTestBase {
 
     assertResult(0)(spark.sql("show tags T_FORCE_AUTO_TAG_IGNORE_DELAY").count())
 
-    spark.sql(
-      """alter table T_FORCE_AUTO_TAG_IGNORE_DELAY set tblproperties(
-        |'tag.automatic-creation'='process-time',
-        |'tag.creation-period'='daily',
-        |'tag.creation-delay'='2 d',
-        |'tag.num-retained-max'='90'
-        |)""".stripMargin)
+    spark.sql("""alter table T_FORCE_AUTO_TAG_IGNORE_DELAY set tblproperties(
+                |'tag.automatic-creation'='process-time',
+                |'tag.creation-period'='daily',
+                |'tag.creation-delay'='2 d',
+                |'tag.num-retained-max'='90'
+                |)""".stripMargin)
 
     // Triggering before delay should create no auto-tag
     spark.sql(

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/TriggerTagAutomaticCreationProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/TriggerTagAutomaticCreationProcedureTest.scala
@@ -73,7 +73,7 @@ class TriggerTagAutomaticCreationProcedureTest extends PaimonSparkTestBase {
       """alter table T_FORCE_AUTO_TAG_IGNORE_DELAY set tblproperties(
         |'tag.automatic-creation'='process-time',
         |'tag.creation-period'='daily',
-        |'tag.creation-delay'='2 d',  -- make sure it's before delay when triggering auto tag creation
+        |'tag.creation-delay'='2 d',
         |'tag.num-retained-max'='90'
         |)""".stripMargin)
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/TriggerTagAutomaticCreationProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/TriggerTagAutomaticCreationProcedureTest.scala
@@ -72,7 +72,7 @@ class TriggerTagAutomaticCreationProcedureTest extends PaimonSparkTestBase {
     spark.sql("""alter table T_FORCE_AUTO_TAG_IGNORE_DELAY set tblproperties(
                 |'tag.automatic-creation'='process-time',
                 |'tag.creation-period'='daily',
-                |'tag.creation-delay'='1 d',
+                |'tag.creation-delay'='86399999',
                 |'tag.num-retained-max'='90'
                 |)""".stripMargin)
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/TriggerTagAutomaticCreationProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/TriggerTagAutomaticCreationProcedureTest.scala
@@ -55,6 +55,46 @@ class TriggerTagAutomaticCreationProcedureTest extends PaimonSparkTestBase {
         .getString(0))(loadTable("T_FORCE_AUTO_TAG").tagManager().tagObjects().get(0).getRight)
   }
 
+  test("Paimon procedure: trigger tag automatic creation ignoring delay test") {
+    spark.sql("""CREATE TABLE T_FORCE_AUTO_TAG_IGNORE_DELAY (id INT, name STRING)
+                |USING PAIMON
+                |TBLPROPERTIES (
+                |'primary-key'='id'
+                |)""".stripMargin)
+
+    spark.sql("insert into T_FORCE_AUTO_TAG_IGNORE_DELAY values(1, 'a')")
+
+    val table = loadTable("T_FORCE_AUTO_TAG_IGNORE_DELAY")
+    assertResult(1)(table.snapshotManager().snapshotCount())
+
+    assertResult(0)(spark.sql("show tags T_FORCE_AUTO_TAG_IGNORE_DELAY").count())
+
+    spark.sql(
+      """alter table T_FORCE_AUTO_TAG_IGNORE_DELAY set tblproperties(
+        |'tag.automatic-creation'='process-time',
+        |'tag.creation-period'='daily',
+        |'tag.creation-delay'='2 d',  -- make sure it's before delay when triggering auto tag creation
+        |'tag.num-retained-max'='90'
+        |)""".stripMargin)
+
+    // Triggering before delay should create no auto-tag
+    spark.sql(
+      "CALL paimon.sys.trigger_tag_automatic_creation(table => 'test.T_FORCE_AUTO_TAG_IGNORE_DELAY')")
+    assertResult(0)(spark.sql("show tags T_FORCE_AUTO_TAG_IGNORE_DELAY").count())
+
+    // Triggering with ignoring delay should create an auto-tag
+    spark.sql("set `spark.paimon.tag.automatic-creation-ignore-delay`=true")
+    spark.sql(
+      "CALL paimon.sys.trigger_tag_automatic_creation(table => 'test.T_FORCE_AUTO_TAG_IGNORE_DELAY')")
+    assertResult(1)(spark.sql("show tags T_FORCE_AUTO_TAG_IGNORE_DELAY").count())
+    assertResult(
+      spark
+        .sql("select date_format(date_sub(current_date(), 1), 'yyyy-MM-dd')")
+        .head()
+        .getString(0))(
+      loadTable("T_FORCE_AUTO_TAG_IGNORE_DELAY").tagManager().tagObjects().get(0).getRight)
+  }
+
   test("Paimon procedure: trigger tag automatic creation without snapshot test") {
     spark.sql("""CREATE TABLE T_FORCE_AUTO_TAG_NS (id INT, name STRING)
                 |USING PAIMON


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #6450 

<!-- What is the purpose of the change -->
Make sure the expected auto-tag created while calling the procedure of trigger_tag_automatic_creation 
### Tests

<!-- List UT and IT cases to verify this change -->
```
org.apache.paimon.spark.procedure.TriggerTagAutomaticCreationProcedureTest
```

### API and Format

<!-- Does this change affect API or storage format -->
No

### Documentation

<!-- Does this change introduce a new feature -->
Provided