### PR TITLE
[core] Don't check -2 and fixed buckets changes

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -36,7 +36,6 @@ import org.apache.paimon.schema.SchemaChange.UpdateColumnNullability;
 import org.apache.paimon.schema.SchemaChange.UpdateColumnPosition;
 import org.apache.paimon.schema.SchemaChange.UpdateColumnType;
 import org.apache.paimon.schema.SchemaChange.UpdateComment;
-import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
@@ -298,10 +297,7 @@ public class SchemaManager implements Serializable {
                 SetOption setOption = (SetOption) change;
                 if (hasSnapshots.get()) {
                     checkAlterTableOption(
-                            setOption.key(),
-                            oldOptions.get(setOption.key()),
-                            setOption.value(),
-                            false);
+                            setOption.key(), oldOptions.get(setOption.key()), setOption.value());
                 }
                 newOptions.put(setOption.key(), setOption.value());
             } else if (change instanceof RemoveOption) {
@@ -1076,7 +1072,7 @@ public class SchemaManager implements Serializable {
     }
 
     public static void checkAlterTableOption(
-            String key, @Nullable String oldValue, String newValue, boolean fromDynamicOptions) {
+            String key, @Nullable String oldValue, String newValue) {
         if (CoreOptions.IMMUTABLE_OPTIONS.contains(key)) {
             throw new UnsupportedOperationException(
                     String.format("Change '%s' is not supported yet.", key));
@@ -1089,19 +1085,11 @@ public class SchemaManager implements Serializable {
                             : Integer.parseInt(oldValue);
             int newBucket = Integer.parseInt(newValue);
 
-            if (fromDynamicOptions) {
-                throw new UnsupportedOperationException(
-                        "Cannot change bucket number through dynamic options. You might need to rescale bucket.");
-            }
             if (oldBucket == -1) {
                 throw new UnsupportedOperationException("Cannot change bucket when it is -1.");
             }
             if (newBucket == -1) {
                 throw new UnsupportedOperationException("Cannot change bucket to -1.");
-            }
-            if (oldBucket == BucketMode.POSTPONE_BUCKET) {
-                throw new UnsupportedOperationException(
-                        "Cannot change bucket for postpone bucket tables.");
             }
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -318,12 +318,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
                 (k, newValue) -> {
                     String oldValue = oldOptions.get(k);
                     if (!Objects.equals(oldValue, newValue)) {
-                        SchemaManager.checkAlterTableOption(k, oldValue, newValue, true);
-
-                        if (CoreOptions.BUCKET.key().equals(k)) {
-                            throw new UnsupportedOperationException(
-                                    "Cannot change bucket number through dynamic options. You might need to rescale bucket.");
-                        }
+                        SchemaManager.checkAlterTableOption(k, oldValue, newValue);
                     }
                 });
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/AbstractFlinkTableFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/AbstractFlinkTableFactory.java
@@ -198,7 +198,7 @@ public abstract class AbstractFlinkTableFactory
                 (key, newValue) -> {
                     String oldValue = origin.getOptions().get(key);
                     if (!Objects.equals(oldValue, newValue)) {
-                        SchemaManager.checkAlterTableOption(key, oldValue, newValue, true);
+                        SchemaManager.checkAlterTableOption(key, oldValue, newValue);
                     }
                 });
         Map<String, String> newOptions = new HashMap<>();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
I think users shouldn't change bucket number except rescale, and it's common to use dynamic options to change bucket number for developers. So better to loose the check.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
