### PR TITLE
[Python] Change pyarrow version

### DIFF
--- a/paimon-python/dev/requirements.txt
+++ b/paimon-python/dev/requirements.txt
@@ -34,7 +34,7 @@ polars==0.9.12; python_version<"3.8"
 polars==1.8.0; python_version=="3.8"
 polars==1.32.0; python_version>"3.8"
 pyarrow==6.0.1; python_version < "3.8"
-pyarrow>=16; python_version >= "3.8"
+pyarrow==16; python_version >= "3.8"
 readerwriterlock==1.0.9
 zstandard==0.19.0; python_version<"3.9"
 zstandard==0.24.0; python_version>="3.9"


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

In a clean python environment, Python 3.10 will default to downloading the latest pyarrow package, which may result in write failure. It is necessary to specify the version of the pyarrow package.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
