### PR TITLE
[core] Fix endian spec for BloomFilter index reader

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bloomfilter/BloomFilterFileIndex.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bloomfilter/BloomFilterFileIndex.java
@@ -117,7 +117,7 @@ public class BloomFilterFileIndex implements FileIndexer {
         private final FastHash hashFunction;
 
         public Reader(DataType type, byte[] serializedBytes) {
-            // little endian
+            // big endian
             int numHashFunctions =
                     ((serializedBytes[0] << 24)
                             + (serializedBytes[1] << 16)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

should be big endian

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
