### PR TITLE
[blob] Add options blob-store-descriptor

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -63,6 +63,12 @@ under the License.
             <td>Specify the blob field.</td>
         </tr>
         <tr>
+            <td><h5>blob-store-descriptor</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Store blob field using blob descriptor rather than blob bytes.</td>
+        </tr>
+        <tr>
             <td><h5>blob.target-file-size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>MemorySize</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2036,6 +2036,13 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Write blob field using blob descriptor rather than blob bytes.");
 
+    public static final ConfigOption<Boolean> BLOB_STORE_DESCRIPTOR =
+            key("blob-store-descriptor")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Store blob field using blob descriptor rather than blob bytes.");
+
     public static final ConfigOption<Boolean> COMMIT_DISCARD_DUPLICATE_FILES =
             key("commit.discard-duplicate-files")
                     .booleanType()
@@ -3141,6 +3148,10 @@ public class CoreOptions implements Serializable {
 
     public boolean blobAsDescriptor() {
         return options.get(BLOB_AS_DESCRIPTOR);
+    }
+
+    public boolean blobStoreDescriptor() {
+        return options.get(BLOB_STORE_DESCRIPTOR);
     }
 
     /** Specifies the merge engine for table with primary key. */

--- a/paimon-core/src/main/java/org/apache/paimon/operation/BaseAppendFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/BaseAppendFileStoreWrite.java
@@ -140,7 +140,8 @@ public abstract class BaseAppendFileStoreWrite extends MemoryFileStoreWrite<Inte
                 options.writeBufferSpillDiskSize(),
                 fileIndexOptions,
                 options.asyncFileWrite(),
-                options.statsDenseStore());
+                options.statsDenseStore(),
+                options.blobStoreDescriptor());
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -710,6 +710,7 @@ public class AppendOnlyWriterTest {
                         MemorySize.MAX_VALUE,
                         new FileIndexOptions(),
                         true,
+                        false,
                         false);
         writer.setMemoryPool(
                 new HeapMemorySegmentPool(options.writeBufferSize(), options.pageSize()));

--- a/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/format/FileFormatSuffixTest.java
@@ -103,6 +103,7 @@ public class FileFormatSuffixTest extends KeyValueFileReadWriteTest {
                         MemorySize.MAX_VALUE,
                         new FileIndexOptions(),
                         true,
+                        false,
                         false);
         appendOnlyWriter.setMemoryPool(
                 new HeapMemorySegmentPool(options.writeBufferSize(), options.pageSize()));

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
@@ -116,7 +116,13 @@ public class ParquetReaderFactory implements FormatReaderFactory {
         List<ParquetField> fields = buildFieldsList(readFields, columnIO, shreddingSchemas);
 
         return new VectorizedParquetRecordReader(
-                context.filePath(), reader, fileSchema, fields, writableVectors, batchSize);
+                context.fileIO(),
+                context.filePath(),
+                reader,
+                fileSchema,
+                fields,
+                writableVectors,
+                batchSize);
     }
 
     private void setReadOptions(ParquetReadOptions.Builder builder) {

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetSchemaConverter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetSchemaConverter.java
@@ -90,6 +90,7 @@ public class ParquetSchemaConverter {
                         .withId(fieldId);
             case BINARY:
             case VARBINARY:
+            case BLOB:
                 return Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, repetition)
                         .named(name)
                         .withId(fieldId);

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ColumnarBatch.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ColumnarBatch.java
@@ -26,6 +26,7 @@ import org.apache.paimon.data.columnar.MapColumnVector;
 import org.apache.paimon.data.columnar.RowColumnVector;
 import org.apache.paimon.data.columnar.VectorizedColumnBatch;
 import org.apache.paimon.data.columnar.VectorizedRowIterator;
+import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.utils.LongIterator;
 
@@ -38,7 +39,7 @@ public class ColumnarBatch {
     protected final VectorizedColumnBatch vectorizedColumnBatch;
     protected final ColumnarRowIterator vectorizedRowIterator;
 
-    public ColumnarBatch(Path filePath, ColumnVector[] columns) {
+    public ColumnarBatch(FileIO fileIO, Path filePath, ColumnVector[] columns) {
         this.columns = columns;
         this.vectorizedColumnBatch = new VectorizedColumnBatch(columns);
         boolean containsNestedColumn =
@@ -49,6 +50,7 @@ public class ColumnarBatch {
                                                 || vector instanceof RowColumnVector
                                                 || vector instanceof ArrayColumnVector);
         ColumnarRow row = new ColumnarRow(vectorizedColumnBatch);
+        row.setFileIO(fileIO);
         this.vectorizedRowIterator =
                 containsNestedColumn
                         ? new ColumnarRowIterator(filePath, row, null)

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetReaderUtil.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetReaderUtil.java
@@ -92,6 +92,7 @@ public class ParquetReaderUtil {
             case VARBINARY:
                 return new HeapBytesVector(batchSize);
             case BINARY:
+            case BLOB:
                 return new HeapBytesVector(batchSize);
             case TIMESTAMP_WITHOUT_TIME_ZONE:
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetVectorUpdaterFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetVectorUpdaterFactory.java
@@ -218,7 +218,14 @@ public class ParquetVectorUpdaterFactory {
 
         @Override
         public UpdaterFactory visit(BlobType blobType) {
-            throw new RuntimeException("Blob type is not supported");
+            return c -> {
+                if (c.getPrimitiveType().getPrimitiveTypeName()
+                        == PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY) {
+                    return new FixedLenByteArrayUpdater(c.getPrimitiveType().getTypeLength());
+                } else {
+                    return new BinaryUpdater();
+                }
+            };
         }
 
         @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedParquetRecordReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedParquetRecordReader.java
@@ -29,6 +29,7 @@ import org.apache.paimon.data.columnar.heap.HeapRowVector;
 import org.apache.paimon.data.columnar.writable.WritableColumnVector;
 import org.apache.paimon.format.parquet.type.ParquetField;
 import org.apache.paimon.format.parquet.type.ParquetPrimitiveField;
+import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.reader.FileRecordIterator;
 import org.apache.paimon.reader.FileRecordReader;
@@ -86,6 +87,7 @@ public class VectorizedParquetRecordReader implements FileRecordReader<InternalR
 
     private ColumnarBatch columnarBatch;
 
+    private final FileIO fileIO;
     private final Path filePath;
     private final MessageType fileSchema;
     private final List<ParquetField> fields;
@@ -95,6 +97,7 @@ public class VectorizedParquetRecordReader implements FileRecordReader<InternalR
     private VersionParser.ParsedVersion writerVersion;
 
     public VectorizedParquetRecordReader(
+            FileIO fileIO,
             Path filePath,
             ParquetFileReader reader,
             MessageType fileSchema,
@@ -102,6 +105,7 @@ public class VectorizedParquetRecordReader implements FileRecordReader<InternalR
             WritableColumnVector[] vectors,
             int batchSize)
             throws IOException {
+        this.fileIO = fileIO;
         this.filePath = filePath;
         this.reader = reader;
         this.fileSchema = fileSchema;
@@ -127,6 +131,7 @@ public class VectorizedParquetRecordReader implements FileRecordReader<InternalR
     private void initBatch(WritableColumnVector[] vectors) {
         columnarBatch =
                 new ColumnarBatch(
+                        fileIO,
                         filePath,
                         createVectorizedColumnBatch(
                                 fields.stream()

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/ParquetRowDataWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/ParquetRowDataWriter.java
@@ -99,6 +99,7 @@ public class ParquetRowDataWriter {
                     return new BooleanWriter();
                 case BINARY:
                 case VARBINARY:
+                case BLOB:
                     return new BinaryWriter();
                 case DECIMAL:
                     DecimalType decimalType = (DecimalType) t;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Blob descriptor could be stored in parquet file.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
