### PR TITLE
[core][spark] Support push down transform predicate

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/ConcatTransform.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/ConcatTransform.java
@@ -35,4 +35,9 @@ public class ConcatTransform extends StringTransform {
     public BinaryString transform(List<BinaryString> inputs) {
         return BinaryString.concat(inputs);
     }
+
+    @Override
+    public Transform withNewInputs(List<Object> inputs) {
+        return new ConcatTransform(inputs);
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/ConcatWsTransform.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/ConcatWsTransform.java
@@ -39,4 +39,9 @@ public class ConcatWsTransform extends StringTransform {
         BinaryString separator = inputs.get(0);
         return BinaryString.concatWs(separator, inputs.subList(1, inputs.size()));
     }
+
+    @Override
+    public Transform withNewInputs(List<Object> inputs) {
+        return new ConcatWsTransform(inputs);
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/FieldTransform.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/FieldTransform.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.predicate;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.types.DataType;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.paimon.utils.InternalRowUtils.get;
+
+/** Transform that extracts a field from a row. */
+public class FieldTransform implements Transform {
+
+    private final FieldRef fieldRef;
+
+    public FieldTransform(FieldRef fieldRef) {
+        this.fieldRef = fieldRef;
+    }
+
+    public FieldRef fieldRef() {
+        return fieldRef;
+    }
+
+    @Override
+    public List<Object> inputs() {
+        return Collections.singletonList(fieldRef);
+    }
+
+    @Override
+    public DataType outputType() {
+        return fieldRef.type();
+    }
+
+    @Override
+    public Object transform(InternalRow row) {
+        return get(row, fieldRef.index(), fieldRef.type());
+    }
+
+    @Override
+    public Transform withNewInputs(List<Object> inputs) {
+        assert inputs.size() == 1;
+        return new FieldTransform((FieldRef) inputs.get(0));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FieldTransform that = (FieldTransform) o;
+        return Objects.equals(fieldRef, that.fieldRef);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(fieldRef);
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/LeafPredicate.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/LeafPredicate.java
@@ -30,6 +30,7 @@ import org.apache.paimon.types.DataType;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -37,16 +38,9 @@ import java.util.Optional;
 import static org.apache.paimon.utils.InternalRowUtils.get;
 
 /** Leaf node of a {@link Predicate} tree. Compares a field in the row with literals. */
-public class LeafPredicate implements Predicate {
+public class LeafPredicate extends TransformPredicate {
 
     private static final long serialVersionUID = 1L;
-
-    private final LeafFunction function;
-    private final DataType type;
-    private final int fieldIndex;
-    private final String fieldName;
-
-    private transient List<Object> literals;
 
     public LeafPredicate(
             LeafFunction function,
@@ -54,11 +48,12 @@ public class LeafPredicate implements Predicate {
             int fieldIndex,
             String fieldName,
             List<Object> literals) {
-        this.function = function;
-        this.type = type;
-        this.fieldIndex = fieldIndex;
-        this.fieldName = fieldName;
-        this.literals = literals;
+        this(new FieldTransform(new FieldRef(fieldIndex, fieldName, type)), function, literals);
+    }
+
+    public LeafPredicate(
+            FieldTransform fieldTransform, LeafFunction function, List<Object> literals) {
+        super(fieldTransform, function, literals);
     }
 
     public LeafFunction function() {
@@ -66,19 +61,23 @@ public class LeafPredicate implements Predicate {
     }
 
     public DataType type() {
-        return type;
+        return fieldRef().type();
     }
 
     public int index() {
-        return fieldIndex;
+        return fieldRef().index();
     }
 
     public String fieldName() {
-        return fieldName;
+        return fieldRef().name();
+    }
+
+    public List<String> fieldNames() {
+        return Collections.singletonList(fieldRef().name());
     }
 
     public FieldRef fieldRef() {
-        return new FieldRef(fieldIndex, fieldName, type);
+        return ((FieldTransform) transform).fieldRef();
     }
 
     public List<Object> literals() {
@@ -86,20 +85,15 @@ public class LeafPredicate implements Predicate {
     }
 
     public LeafPredicate copyWithNewIndex(int fieldIndex) {
-        return new LeafPredicate(function, type, fieldIndex, fieldName, literals);
-    }
-
-    @Override
-    public boolean test(InternalRow row) {
-        return function.test(type, get(row, fieldIndex, type), literals);
+        return new LeafPredicate(function, type(), fieldIndex, fieldName(), literals);
     }
 
     @Override
     public boolean test(
             long rowCount, InternalRow minValues, InternalRow maxValues, InternalArray nullCounts) {
-        Object min = get(minValues, fieldIndex, type);
-        Object max = get(maxValues, fieldIndex, type);
-        Long nullCount = nullCounts.isNullAt(fieldIndex) ? null : nullCounts.getLong(fieldIndex);
+        Object min = get(minValues, index(), type());
+        Object max = get(maxValues, index(), type());
+        Long nullCount = nullCounts.isNullAt(index()) ? null : nullCounts.getLong(index());
         if (nullCount == null || rowCount != nullCount) {
             // not all null
             // min or max is null
@@ -108,39 +102,18 @@ public class LeafPredicate implements Predicate {
                 return true;
             }
         }
-        return function.test(type, rowCount, min, max, nullCount, literals);
+        return function.test(type(), rowCount, min, max, nullCount, literals);
     }
 
     @Override
     public Optional<Predicate> negate() {
         return function.negate()
-                .map(negate -> new LeafPredicate(negate, type, fieldIndex, fieldName, literals));
+                .map(negate -> new LeafPredicate(negate, type(), index(), fieldName(), literals));
     }
 
     @Override
     public <T> T visit(PredicateVisitor<T> visitor) {
         return visitor.visit(this);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        LeafPredicate that = (LeafPredicate) o;
-        return fieldIndex == that.fieldIndex
-                && Objects.equals(fieldName, that.fieldName)
-                && Objects.equals(function, that.function)
-                && Objects.equals(type, that.type)
-                && Objects.equals(literals, that.literals);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(function, type, fieldIndex, fieldName, literals);
     }
 
     @Override
@@ -154,13 +127,13 @@ public class LeafPredicate implements Predicate {
             literalsStr = literals.toString();
         }
         return literalsStr.isEmpty()
-                ? function + "(" + fieldName + ")"
-                : function + "(" + fieldName + ", " + literalsStr + ")";
+                ? function + "(" + fieldName() + ")"
+                : function + "(" + fieldName() + ", " + literalsStr + ")";
     }
 
     private ListSerializer<Object> objectsSerializer() {
         return new ListSerializer<>(
-                NullableSerializer.wrapIfNullIsNotSupported(InternalSerializers.create(type)));
+                NullableSerializer.wrapIfNullIsNotSupported(InternalSerializers.create(type())));
     }
 
     private void writeObject(ObjectOutputStream out) throws IOException {

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
@@ -77,55 +77,107 @@ public class PredicateBuilder {
         return leaf(Equal.INSTANCE, idx, literal);
     }
 
+    public Predicate equal(Transform transform, Object literal) {
+        return leaf(Equal.INSTANCE, transform, literal);
+    }
+
     public Predicate notEqual(int idx, Object literal) {
         return leaf(NotEqual.INSTANCE, idx, literal);
+    }
+
+    public Predicate notEqual(Transform transform, Object literal) {
+        return leaf(NotEqual.INSTANCE, transform, literal);
     }
 
     public Predicate lessThan(int idx, Object literal) {
         return leaf(LessThan.INSTANCE, idx, literal);
     }
 
+    public Predicate lessThan(Transform transform, Object literal) {
+        return leaf(LessThan.INSTANCE, transform, literal);
+    }
+
     public Predicate lessOrEqual(int idx, Object literal) {
         return leaf(LessOrEqual.INSTANCE, idx, literal);
+    }
+
+    public Predicate lessOrEqual(Transform transform, Object literal) {
+        return leaf(LessOrEqual.INSTANCE, transform, literal);
     }
 
     public Predicate greaterThan(int idx, Object literal) {
         return leaf(GreaterThan.INSTANCE, idx, literal);
     }
 
+    public Predicate greaterThan(Transform transform, Object literal) {
+        return leaf(GreaterThan.INSTANCE, transform, literal);
+    }
+
     public Predicate greaterOrEqual(int idx, Object literal) {
         return leaf(GreaterOrEqual.INSTANCE, idx, literal);
+    }
+
+    public Predicate greaterOrEqual(Transform transform, Object literal) {
+        return leaf(GreaterOrEqual.INSTANCE, transform, literal);
     }
 
     public Predicate isNull(int idx) {
         return leaf(IsNull.INSTANCE, idx);
     }
 
+    public Predicate isNull(Transform transform) {
+        return leaf(IsNull.INSTANCE, transform);
+    }
+
     public Predicate isNotNull(int idx) {
         return leaf(IsNotNull.INSTANCE, idx);
+    }
+
+    public Predicate isNotNull(Transform transform) {
+        return leaf(IsNotNull.INSTANCE, transform);
     }
 
     public Predicate startsWith(int idx, Object patternLiteral) {
         return leaf(StartsWith.INSTANCE, idx, patternLiteral);
     }
 
+    public Predicate startsWith(Transform transform, Object patternLiteral) {
+        return leaf(StartsWith.INSTANCE, transform, patternLiteral);
+    }
+
     public Predicate endsWith(int idx, Object patternLiteral) {
         return leaf(EndsWith.INSTANCE, idx, patternLiteral);
+    }
+
+    public Predicate endsWith(Transform transform, Object patternLiteral) {
+        return leaf(EndsWith.INSTANCE, transform, patternLiteral);
     }
 
     public Predicate contains(int idx, Object patternLiteral) {
         return leaf(Contains.INSTANCE, idx, patternLiteral);
     }
 
-    public Predicate leaf(NullFalseLeafBinaryFunction function, int idx, Object literal) {
+    public Predicate contains(Transform transform, Object patternLiteral) {
+        return leaf(Contains.INSTANCE, transform, patternLiteral);
+    }
+
+    private Predicate leaf(NullFalseLeafBinaryFunction function, int idx, Object literal) {
         DataField field = rowType.getFields().get(idx);
         return new LeafPredicate(function, field.type(), idx, field.name(), singletonList(literal));
     }
 
-    public Predicate leaf(LeafUnaryFunction function, int idx) {
+    private Predicate leaf(LeafFunction function, Transform transform, Object literal) {
+        return TransformPredicate.of(transform, function, singletonList(literal));
+    }
+
+    private Predicate leaf(LeafUnaryFunction function, int idx) {
         DataField field = rowType.getFields().get(idx);
         return new LeafPredicate(
                 function, field.type(), idx, field.name(), Collections.emptyList());
+    }
+
+    private Predicate leaf(LeafFunction function, Transform transform) {
+        return TransformPredicate.of(transform, function, Collections.emptyList());
     }
 
     public Predicate in(int idx, List<Object> literals) {
@@ -143,6 +195,20 @@ public class PredicateBuilder {
         return or(equals);
     }
 
+    public Predicate in(Transform transform, List<Object> literals) {
+        // In the IN predicate, 20 literals are critical for performance.
+        // If there are more than 20 literals, the performance will decrease.
+        if (literals.size() > 20) {
+            return TransformPredicate.of(transform, In.INSTANCE, literals);
+        }
+
+        List<Predicate> equals = new ArrayList<>(literals.size());
+        for (Object literal : literals) {
+            equals.add(equal(transform, literal));
+        }
+        return or(equals);
+    }
+
     public Predicate notIn(int idx, List<Object> literals) {
         return in(idx, literals).negate().get();
     }
@@ -153,6 +219,15 @@ public class PredicateBuilder {
                 Arrays.asList(
                         greaterOrEqual(idx, includedLowerBound),
                         lessOrEqual(idx, includedUpperBound)));
+    }
+
+    public Predicate between(
+            Transform transform, Object includedLowerBound, Object includedUpperBound) {
+        return new CompoundPredicate(
+                And.INSTANCE,
+                Arrays.asList(
+                        greaterOrEqual(transform, includedLowerBound),
+                        lessOrEqual(transform, includedUpperBound)));
     }
 
     public static Predicate and(Predicate... predicates) {
@@ -366,20 +441,26 @@ public class PredicateBuilder {
                 }
             }
             return Optional.of(new CompoundPredicate(compoundPredicate.function(), children));
-        } else {
-            LeafPredicate leafPredicate = (LeafPredicate) predicate;
-            int mapped = fieldIdxMapping[leafPredicate.index()];
-            if (mapped >= 0) {
-                return Optional.of(
-                        new LeafPredicate(
-                                leafPredicate.function(),
-                                leafPredicate.type(),
-                                mapped,
-                                leafPredicate.fieldName(),
-                                leafPredicate.literals()));
-            } else {
-                return Optional.empty();
+        } else if (predicate instanceof TransformPredicate) {
+            TransformPredicate transformPredicate = (TransformPredicate) predicate;
+            List<Object> inputs = transformPredicate.transform.inputs();
+            List<Object> newInputs = new ArrayList<>(inputs.size());
+            for (Object input : inputs) {
+                if (input instanceof FieldRef) {
+                    FieldRef fieldRef = (FieldRef) input;
+                    int mappedIndex = fieldIdxMapping[fieldRef.index()];
+                    if (mappedIndex >= 0) {
+                        newInputs.add(new FieldRef(mappedIndex, fieldRef.name(), fieldRef.type()));
+                    } else {
+                        return Optional.empty();
+                    }
+                } else {
+                    newInputs.add(input);
+                }
             }
+            return Optional.of(transformPredicate.withNewInputs(newInputs));
+        } else {
+            return Optional.empty();
         }
     }
 
@@ -392,8 +473,8 @@ public class PredicateBuilder {
             }
             return false;
         } else {
-            LeafPredicate leafPredicate = (LeafPredicate) predicate;
-            return fields.contains(leafPredicate.fieldName());
+            TransformPredicate transformPredicate = (TransformPredicate) predicate;
+            return fields.containsAll(transformPredicate.fieldNames());
         }
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/Transform.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/Transform.java
@@ -32,4 +32,6 @@ public interface Transform extends Serializable {
     DataType outputType();
 
     Object transform(InternalRow row);
+
+    Transform withNewInputs(List<Object> inputs);
 }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/TransformPredicate.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/TransformPredicate.java
@@ -29,6 +29,7 @@ import org.apache.paimon.io.DataOutputViewStreamWrapper;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -38,18 +39,41 @@ public class TransformPredicate implements Predicate {
 
     private static final long serialVersionUID = 1L;
 
-    private final Transform transform;
-    private final LeafFunction function;
-    private transient List<Object> literals;
+    protected final Transform transform;
+    protected final LeafFunction function;
+    protected transient List<Object> literals;
 
-    public TransformPredicate(Transform transform, LeafFunction function, List<Object> literals) {
+    protected TransformPredicate(
+            Transform transform, LeafFunction function, List<Object> literals) {
         this.transform = transform;
         this.function = function;
         this.literals = literals;
     }
 
+    public static TransformPredicate of(
+            Transform transform, LeafFunction function, List<Object> literals) {
+        if (transform instanceof FieldTransform) {
+            return new LeafPredicate((FieldTransform) transform, function, literals);
+        }
+        return new TransformPredicate(transform, function, literals);
+    }
+
     public Transform transform() {
         return transform;
+    }
+
+    public TransformPredicate withNewInputs(List<Object> newInputs) {
+        return TransformPredicate.of(transform.withNewInputs(newInputs), function, literals);
+    }
+
+    public List<String> fieldNames() {
+        List<String> names = new ArrayList<>();
+        for (Object input : transform.inputs()) {
+            if (input instanceof FieldRef) {
+                names.add(((FieldRef) input).name());
+            }
+        }
+        return names;
     }
 
     @Override

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/TransformPredicateTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/TransformPredicateTest.java
@@ -76,6 +76,6 @@ class TransformPredicateTest {
         ConcatTransform transform = new ConcatTransform(inputs);
         List<Object> literals = new ArrayList<>();
         literals.add(BinaryString.fromString("ha-he"));
-        return new TransformPredicate(transform, Equal.INSTANCE, literals);
+        return TransformPredicate.of(transform, Equal.INSTANCE, literals);
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBasePushDown.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBasePushDown.scala
@@ -23,7 +23,7 @@ import org.apache.paimon.types.RowType
 
 import org.apache.spark.sql.PaimonUtils
 import org.apache.spark.sql.connector.expressions.filter.{Predicate => SparkPredicate}
-import org.apache.spark.sql.connector.read.{SupportsPushDownLimit, SupportsPushDownRequiredColumns, SupportsPushDownV2Filters}
+import org.apache.spark.sql.connector.read.{SupportsPushDownLimit, SupportsPushDownV2Filters}
 import org.apache.spark.sql.sources.Filter
 
 import java.util.{List => JList}
@@ -56,7 +56,7 @@ trait PaimonBasePushDown extends SupportsPushDownV2Filters with SupportsPushDown
             pushable.append((predicate, paimonPredicate))
             if (paimonPredicate.visit(visitor)) {
               // We need to filter the stats using filter instead of predicate.
-              reserved.append(PaimonUtils.filterV2ToV1(predicate).get)
+              PaimonUtils.filterV2ToV1(predicate).map(reserved.append(_))
             } else {
               postScan.append(predicate)
             }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -27,8 +27,6 @@ import org.apache.paimon.spark.statistics.StatisticsHelper
 import org.apache.paimon.table.{DataTable, InnerTable}
 import org.apache.paimon.table.source.{InnerTableScan, Split}
 import org.apache.paimon.table.source.snapshot.TimeTravelUtil
-import org.apache.paimon.table.system.FilesTable
-import org.apache.paimon.utils.{SnapshotManager, TagManager}
 
 import org.apache.spark.sql.connector.metric.{CustomMetric, CustomTaskMetric}
 import org.apache.spark.sql.connector.read.{Batch, Scan, Statistics, SupportsReportStatistics}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -191,7 +191,8 @@ case class PaimonScan(
     val converter = SparkV2FilterConverter(table.rowType())
     val partitionKeys = table.partitionKeys().asScala.toSeq
     val partitionFilter = predicates.flatMap {
-      case p if SparkV2FilterConverter.isSupportedRuntimeFilter(p, partitionKeys) =>
+      case p
+          if SparkV2FilterConverter(table.rowType()).isSupportedRuntimeFilter(p, partitionKeys) =>
         converter.convert(p)
       case _ => None
     }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkV2FilterConverter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkV2FilterConverter.scala
@@ -18,21 +18,19 @@
 
 package org.apache.paimon.spark
 
-import org.apache.paimon.data.{BinaryString, Decimal, Timestamp}
-import org.apache.paimon.predicate.{Predicate, PredicateBuilder}
-import org.apache.paimon.spark.util.shim.TypeUtils.treatPaimonTimestampTypeAsSparkTimestampType
-import org.apache.paimon.types.{DataTypeRoot, DecimalType, RowType}
-import org.apache.paimon.types.DataTypeRoot._
+import org.apache.paimon.predicate.{FieldTransform, Predicate, PredicateBuilder, Transform}
+import org.apache.paimon.spark.util.SparkExpressionConverter.{toPaimonLiteral, toPaimonTransform}
+import org.apache.paimon.types.RowType
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.util.DateTimeUtils
-import org.apache.spark.sql.connector.expressions.{Literal, NamedReference}
+import org.apache.spark.sql.connector.expressions.Expression
+import org.apache.spark.sql.connector.expressions.Literal
 import org.apache.spark.sql.connector.expressions.filter.{And, Not, Or, Predicate => SparkPredicate}
 
 import scala.collection.JavaConverters._
 
 /** Conversion from [[SparkPredicate]] to [[Predicate]]. */
-case class SparkV2FilterConverter(rowType: RowType) {
+case class SparkV2FilterConverter(rowType: RowType) extends Logging {
 
   import org.apache.paimon.spark.SparkV2FilterConverter._
 
@@ -50,85 +48,78 @@ case class SparkV2FilterConverter(rowType: RowType) {
   private def convert(sparkPredicate: SparkPredicate): Predicate = {
     sparkPredicate.name() match {
       case EQUAL_TO =>
-        BinaryPredicate.unapply(sparkPredicate) match {
-          case Some((fieldName, literal)) =>
+        sparkPredicate match {
+          case BinaryPredicate(transform, literal) =>
             // TODO deal with isNaN
-            val index = fieldIndex(fieldName)
-            builder.equal(index, convertLiteral(index, literal))
+            builder.equal(transform, literal)
           case _ =>
             throw new UnsupportedOperationException(s"Convert $sparkPredicate is unsupported.")
         }
 
       case EQUAL_NULL_SAFE =>
-        BinaryPredicate.unapply(sparkPredicate) match {
-          case Some((fieldName, literal)) =>
-            val index = fieldIndex(fieldName)
+        sparkPredicate match {
+          case BinaryPredicate(transform, literal) =>
             if (literal == null) {
-              builder.isNull(index)
+              builder.isNull(transform)
             } else {
-              builder.equal(index, convertLiteral(index, literal))
+              builder.equal(transform, literal)
             }
           case _ =>
             throw new UnsupportedOperationException(s"Convert $sparkPredicate is unsupported.")
         }
 
       case GREATER_THAN =>
-        BinaryPredicate.unapply(sparkPredicate) match {
-          case Some((fieldName, literal)) =>
-            val index = fieldIndex(fieldName)
-            builder.greaterThan(index, convertLiteral(index, literal))
+        sparkPredicate match {
+          case BinaryPredicate(transform, literal) =>
+            builder.greaterThan(transform, literal)
           case _ =>
             throw new UnsupportedOperationException(s"Convert $sparkPredicate is unsupported.")
         }
 
       case GREATER_THAN_OR_EQUAL =>
-        BinaryPredicate.unapply(sparkPredicate) match {
-          case Some((fieldName, literal)) =>
-            val index = fieldIndex(fieldName)
-            builder.greaterOrEqual(index, convertLiteral(index, literal))
+        sparkPredicate match {
+          case BinaryPredicate((transform, literal)) =>
+            builder.greaterOrEqual(transform, literal)
           case _ =>
             throw new UnsupportedOperationException(s"Convert $sparkPredicate is unsupported.")
         }
 
       case LESS_THAN =>
-        BinaryPredicate.unapply(sparkPredicate) match {
-          case Some((fieldName, literal)) =>
-            val index = fieldIndex(fieldName)
-            builder.lessThan(index, convertLiteral(index, literal))
+        sparkPredicate match {
+          case BinaryPredicate(transform, literal) =>
+            builder.lessThan(transform, literal)
           case _ =>
             throw new UnsupportedOperationException(s"Convert $sparkPredicate is unsupported.")
         }
 
       case LESS_THAN_OR_EQUAL =>
-        BinaryPredicate.unapply(sparkPredicate) match {
-          case Some((fieldName, literal)) =>
-            val index = fieldIndex(fieldName)
-            builder.lessOrEqual(index, convertLiteral(index, literal))
+        sparkPredicate match {
+          case BinaryPredicate(transform, literal) =>
+            builder.lessOrEqual(transform, literal)
           case _ =>
             throw new UnsupportedOperationException(s"Convert $sparkPredicate is unsupported.")
         }
 
       case IN =>
-        MultiPredicate.unapply(sparkPredicate) match {
-          case Some((fieldName, literals)) =>
-            val index = fieldIndex(fieldName)
-            builder.in(index, literals.map(convertLiteral(index, _)).toList.asJava)
+        sparkPredicate match {
+          case MultiPredicate(transform, literals) =>
+            builder.in(transform, literals.toList.asJava)
           case _ =>
             throw new UnsupportedOperationException(s"Convert $sparkPredicate is unsupported.")
         }
 
       case IS_NULL =>
-        UnaryPredicate.unapply(sparkPredicate) match {
-          case Some(fieldName) =>
-            builder.isNull(fieldIndex(fieldName))
+        sparkPredicate match {
+          case UnaryPredicate(transform) =>
+            builder.isNull(transform)
           case _ =>
             throw new UnsupportedOperationException(s"Convert $sparkPredicate is unsupported.")
         }
 
       case IS_NOT_NULL =>
-        UnaryPredicate.unapply(sparkPredicate) match {
-          case Some(fieldName) =>
-            builder.isNotNull(fieldIndex(fieldName))
+        sparkPredicate match {
+          case UnaryPredicate(transform) =>
+            builder.isNotNull(transform)
           case _ =>
             throw new UnsupportedOperationException(s"Convert $sparkPredicate is unsupported.")
         }
@@ -151,28 +142,25 @@ case class SparkV2FilterConverter(rowType: RowType) {
         }
 
       case STRING_START_WITH =>
-        BinaryPredicate.unapply(sparkPredicate) match {
-          case Some((fieldName, literal)) =>
-            val index = fieldIndex(fieldName)
-            builder.startsWith(index, convertLiteral(index, literal))
+        sparkPredicate match {
+          case BinaryPredicate(transform, literal) =>
+            builder.startsWith(transform, literal)
           case _ =>
             throw new UnsupportedOperationException(s"Convert $sparkPredicate is unsupported.")
         }
 
       case STRING_END_WITH =>
-        BinaryPredicate.unapply(sparkPredicate) match {
-          case Some((fieldName, literal)) =>
-            val index = fieldIndex(fieldName)
-            builder.endsWith(index, convertLiteral(index, literal))
+        sparkPredicate match {
+          case BinaryPredicate(transform, literal) =>
+            builder.endsWith(transform, literal)
           case _ =>
             throw new UnsupportedOperationException(s"Convert $sparkPredicate is unsupported.")
         }
 
       case STRING_CONTAINS =>
-        BinaryPredicate.unapply(sparkPredicate) match {
-          case Some((fieldName, literal)) =>
-            val index = fieldIndex(fieldName)
-            builder.contains(index, convertLiteral(index, literal))
+        sparkPredicate match {
+          case BinaryPredicate(transform, literal) =>
+            builder.contains(transform, literal)
           case _ =>
             throw new UnsupportedOperationException(s"Convert $sparkPredicate is unsupported.")
         }
@@ -182,45 +170,60 @@ case class SparkV2FilterConverter(rowType: RowType) {
     }
   }
 
-  private def fieldIndex(fieldName: String): Int = {
-    val index = rowType.getFieldIndex(fieldName)
-    // TODO: support nested field
-    if (index == -1) {
-      throw new UnsupportedOperationException(s"Nested field '$fieldName' is unsupported.")
+  private object UnaryPredicate {
+    def unapply(sparkPredicate: SparkPredicate): Option[Transform] = {
+      sparkPredicate.children() match {
+        case Array(e: Expression) => toPaimonTransform(e, rowType)
+        case _ => None
+      }
     }
-    index
   }
 
-  private def convertLiteral(index: Int, value: Any): AnyRef = {
-    if (value == null) {
-      return null
+  private object BinaryPredicate {
+    def unapply(sparkPredicate: SparkPredicate): Option[(Transform, Object)] = {
+      sparkPredicate.children() match {
+        case Array(e: Expression, r: Literal[_]) =>
+          toPaimonTransform(e, rowType) match {
+            case Some(transform) => Some(transform, toPaimonLiteral(r))
+            case _ => None
+          }
+        case _ => None
+      }
     }
+  }
 
-    val dataType = rowType.getTypeAt(index)
-    dataType.getTypeRoot match {
-      case BOOLEAN | BIGINT | DOUBLE | TINYINT | SMALLINT | INTEGER | FLOAT | DATE =>
-        value.asInstanceOf[AnyRef]
-      case DataTypeRoot.VARCHAR =>
-        BinaryString.fromString(value.toString)
-      case DataTypeRoot.DECIMAL =>
-        val decimalType = dataType.asInstanceOf[DecimalType]
-        val precision = decimalType.getPrecision
-        val scale = decimalType.getScale
-        Decimal.fromBigDecimal(
-          value.asInstanceOf[org.apache.spark.sql.types.Decimal].toJavaBigDecimal,
-          precision,
-          scale)
-      case DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
-        Timestamp.fromMicros(value.asInstanceOf[Long])
-      case DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE =>
-        if (treatPaimonTimestampTypeAsSparkTimestampType()) {
-          Timestamp.fromSQLTimestamp(DateTimeUtils.toJavaTimestamp(value.asInstanceOf[Long]))
-        } else {
-          Timestamp.fromMicros(value.asInstanceOf[Long])
+  private object MultiPredicate {
+    def unapply(sparkPredicate: SparkPredicate): Option[(Transform, Seq[Object])] = {
+      sparkPredicate.children() match {
+        case Array(e: Expression, rest @ _*)
+            if rest.nonEmpty && rest.forall(_.isInstanceOf[Literal[_]]) =>
+          val literals = rest.map(_.asInstanceOf[Literal[_]])
+          if (literals.forall(_.dataType() == literals.head.dataType())) {
+            toPaimonTransform(e, rowType) match {
+              case Some(transform) => Some(transform, literals.map(toPaimonLiteral))
+              case _ => None
+            }
+          } else {
+            None
+          }
+        case _ => None
+      }
+    }
+  }
+
+  def isSupportedRuntimeFilter(
+      sparkPredicate: SparkPredicate,
+      partitionKeys: Seq[String]): Boolean = {
+    sparkPredicate.name() match {
+      case IN =>
+        sparkPredicate match {
+          case MultiPredicate(transform: FieldTransform, _) =>
+            partitionKeys.contains(transform.fieldRef().name())
+          case _ =>
+            logWarning(s"Convert $sparkPredicate is unsupported.")
+            false
         }
-      case _ =>
-        throw new UnsupportedOperationException(
-          s"Convert value: $value to datatype: $dataType is unsupported.")
+      case _ => false
     }
   }
 }
@@ -243,50 +246,4 @@ object SparkV2FilterConverter extends Logging {
   private val STRING_END_WITH = "ENDS_WITH"
   private val STRING_CONTAINS = "CONTAINS"
 
-  private object UnaryPredicate {
-    def unapply(sparkPredicate: SparkPredicate): Option[String] = {
-      sparkPredicate.children() match {
-        case Array(n: NamedReference) => Some(toFieldName(n))
-        case _ => None
-      }
-    }
-  }
-
-  private object BinaryPredicate {
-    def unapply(sparkPredicate: SparkPredicate): Option[(String, Any)] = {
-      sparkPredicate.children() match {
-        case Array(l: NamedReference, r: Literal[_]) => Some((toFieldName(l), r.value))
-        case Array(l: Literal[_], r: NamedReference) => Some((toFieldName(r), l.value))
-        case _ => None
-      }
-    }
-  }
-
-  private object MultiPredicate {
-    def unapply(sparkPredicate: SparkPredicate): Option[(String, Array[Any])] = {
-      sparkPredicate.children() match {
-        case Array(first: NamedReference, rest @ _*)
-            if rest.nonEmpty && rest.forall(_.isInstanceOf[Literal[_]]) =>
-          Some(toFieldName(first), rest.map(_.asInstanceOf[Literal[_]].value).toArray)
-        case _ => None
-      }
-    }
-  }
-
-  private def toFieldName(ref: NamedReference): String = ref.fieldNames().mkString(".")
-
-  def isSupportedRuntimeFilter(
-      sparkPredicate: SparkPredicate,
-      partitionKeys: Seq[String]): Boolean = {
-    sparkPredicate.name() match {
-      case IN =>
-        MultiPredicate.unapply(sparkPredicate) match {
-          case Some((fieldName, _)) => partitionKeys.contains(fieldName)
-          case _ =>
-            logWarning(s"Convert $sparkPredicate is unsupported.")
-            false
-        }
-      case _ => false
-    }
-  }
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/expressions/ExpressionHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/expressions/ExpressionHelper.scala
@@ -26,7 +26,6 @@ import org.apache.paimon.types.RowType
 
 import org.apache.spark.sql.{Column, SparkSession}
 import org.apache.spark.sql.PaimonUtils.{normalizeExprs, translateFilterV2}
-import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.expressions.{Alias, And, Attribute, Cast, Expression, GetStructField, Literal, PredicateHelper, SubqueryExpression}
 import org.apache.spark.sql.catalyst.optimizer.ConstantFolding

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/SparkExpressionConverter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/SparkExpressionConverter.scala
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.util
+
+import org.apache.paimon.data.{BinaryString, Decimal, Timestamp}
+import org.apache.paimon.predicate.{ConcatTransform, FieldRef, FieldTransform, Transform}
+import org.apache.paimon.spark.SparkTypeUtils
+import org.apache.paimon.spark.util.shim.TypeUtils.treatPaimonTimestampTypeAsSparkTimestampType
+import org.apache.paimon.types.{DecimalType, RowType}
+import org.apache.paimon.types.DataTypeRoot._
+
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.connector.expressions.{Expression, GeneralScalarExpression, Literal, NamedReference}
+
+import scala.collection.JavaConverters._
+
+object SparkExpressionConverter {
+
+  // Supported transform names
+  private val CONCAT = "CONCAT"
+
+  /** Convert Spark [[Expression]] to Paimon [[Transform]], return None if not supported. */
+  def toPaimonTransform(exp: Expression, rowType: RowType): Option[Transform] = {
+    exp match {
+      case n: NamedReference => Some(new FieldTransform(toPaimonFieldRef(n, rowType)))
+      case s: GeneralScalarExpression =>
+        s.name() match {
+          case CONCAT =>
+            val inputs = exp.children().map {
+              case n: NamedReference => toPaimonFieldRef(n, rowType)
+              case l: Literal[_] => toPaimonLiteral(l)
+              case _ => return None
+            }
+            Some(new ConcatTransform(inputs.toList.asJava))
+          case _ => None
+        }
+      case _ => None
+    }
+  }
+
+  /** Convert Spark [[Literal]] to Paimon literal. */
+  def toPaimonLiteral(literal: Literal[_]): Object = {
+    if (literal == null) {
+      return null
+    }
+
+    if (literal.children().nonEmpty) {
+      throw new UnsupportedOperationException(s"Convert value: $literal is unsupported.")
+    }
+
+    val dataType = SparkTypeUtils.toPaimonType(literal.dataType())
+    val value = literal.value()
+    dataType.getTypeRoot match {
+      case BOOLEAN | BIGINT | DOUBLE | TINYINT | SMALLINT | INTEGER | FLOAT | DATE =>
+        value.asInstanceOf[AnyRef]
+      case VARCHAR =>
+        BinaryString.fromString(value.toString)
+      case DECIMAL =>
+        val decimalType = dataType.asInstanceOf[DecimalType]
+        val precision = decimalType.getPrecision
+        val scale = decimalType.getScale
+        Decimal.fromBigDecimal(
+          value.asInstanceOf[org.apache.spark.sql.types.Decimal].toJavaBigDecimal,
+          precision,
+          scale)
+      case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
+        Timestamp.fromMicros(value.asInstanceOf[Long])
+      case TIMESTAMP_WITHOUT_TIME_ZONE =>
+        if (treatPaimonTimestampTypeAsSparkTimestampType()) {
+          Timestamp.fromSQLTimestamp(DateTimeUtils.toJavaTimestamp(value.asInstanceOf[Long]))
+        } else {
+          Timestamp.fromMicros(value.asInstanceOf[Long])
+        }
+      case _ =>
+        throw new UnsupportedOperationException(
+          s"Convert value: $value to datatype: $dataType is unsupported.")
+    }
+  }
+
+  private def toPaimonFieldRef(ref: NamedReference, rowType: RowType): FieldRef = {
+    val fieldName = toFieldName(ref)
+    val f = rowType.getField(fieldName)
+    // Note: here should use fieldIndex instead of fieldId
+    val index = rowType.getFieldIndex(fieldName)
+    if (index == -1) {
+      throw new UnsupportedOperationException(s"Nested field '$fieldName' is unsupported.")
+    }
+    new FieldRef(index, f.name(), f.`type`())
+  }
+
+  private def toFieldName(ref: NamedReference): String = ref.fieldNames().mkString(".")
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/connector/catalog/PaimonCatalogUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/connector/catalog/PaimonCatalogUtils.scala
@@ -20,9 +20,8 @@ package org.apache.spark.sql.connector.catalog
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{PaimonSparkSession, SparkSession}
+import org.apache.spark.sql.PaimonSparkSession
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalog
-import org.apache.spark.sql.connector.catalog.CatalogV2Util
 import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
 import org.apache.spark.sql.paimon.ReflectUtils
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonPushDownTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonPushDownTestBase.scala
@@ -87,6 +87,48 @@ abstract class PaimonPushDownTestBase extends PaimonSparkTestBase {
     checkAnswer(spark.sql(q), Row(1, "a", "p1") :: Row(2, "b", "p1") :: Row(3, "c", "p2") :: Nil)
   }
 
+  test(s"Paimon push down: apply CONCAT") {
+    // Spark support push down CONCAT since Spark 3.4.
+    if (gteqSpark3_4) {
+      withTable("t") {
+        sql(
+          """
+            |CREATE TABLE t (id int, value int, year STRING, month STRING, day STRING, hour STRING)
+            |using paimon
+            |PARTITIONED BY (year, month, day, hour)
+            |""".stripMargin)
+
+        sql("""
+              |INSERT INTO t values
+              |(1, 100, '2024', '07', '15', '21'),
+              |(2, 200, '2025', '07', '15', '21'),
+              |(3, 300, '2025', '07', '16', '22'),
+              |(4, 400, '2025', '07', '16', '23'),
+              |(5, 440, '2025', '07', '16', '23'),
+              |(6, 500, '2025', '07', '17', '00'),
+              |(7, 600, '2025', '07', '17', '02')
+              |""".stripMargin)
+
+        val q =
+          """
+            |SELECT * FROM t
+            |WHERE CONCAT(year,'-',month,'-',day,'-',hour) BETWEEN '2025-07-16-21' AND '2025-07-17-01'
+            |ORDER BY id
+            |""".stripMargin
+        assert(!checkFilterExists(q))
+
+        checkAnswer(
+          spark.sql(q),
+          Seq(
+            Row(3, 300, "2025", "07", "16", "22"),
+            Row(4, 400, "2025", "07", "16", "23"),
+            Row(5, 440, "2025", "07", "16", "23"),
+            Row(6, 500, "2025", "07", "17", "00"))
+        )
+      }
+    }
+  }
+
   test("Paimon pushDown: limit for append-only tables with deletion vector") {
     withTable("dv_test") {
       spark.sql(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

- Add spark push down transform predicate support (spark version >= 3.3)
- Enable concat pushdown (spark version >= 3.4)

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
