### PR TITLE
[Python] Keep the variable names of Identifier consistent with Java

### DIFF
--- a/paimon-python/pypaimon/api/rest_api.py
+++ b/paimon-python/pypaimon/api/rest_api.py
@@ -219,15 +219,15 @@ class RESTApi:
     def create_table(self, identifier: Identifier, schema: Schema) -> None:
         request = CreateTableRequest(identifier, schema)
         return self.client.post(
-            self.resource_paths.tables(identifier.database_name),
+            self.resource_paths.tables(identifier.get_database_name()),
             request,
             self.rest_auth_function)
 
     def get_table(self, identifier: Identifier) -> GetTableResponse:
         return self.client.get(
             self.resource_paths.table(
-                identifier.database_name,
-                identifier.object_name),
+                identifier.get_database_name(),
+                identifier.get_object_name()),
             GetTableResponse,
             self.rest_auth_function,
         )
@@ -235,8 +235,8 @@ class RESTApi:
     def drop_table(self, identifier: Identifier) -> GetTableResponse:
         return self.client.delete(
             self.resource_paths.table(
-                identifier.database_name,
-                identifier.object_name),
+                identifier.get_database_name(),
+                identifier.get_object_name()),
             self.rest_auth_function,
         )
 
@@ -250,8 +250,8 @@ class RESTApi:
     def load_table_token(self, identifier: Identifier) -> GetTableTokenResponse:
         return self.client.get(
             self.resource_paths.table_token(
-                identifier.database_name,
-                identifier.object_name),
+                identifier.get_database_name(),
+                identifier.get_object_name()),
             GetTableTokenResponse,
             self.rest_auth_function,
         )
@@ -282,7 +282,7 @@ class RESTApi:
         request = CommitTableRequest(table_uuid, snapshot, statistics)
         response = self.client.post_with_response_type(
             self.resource_paths.commit_table(
-                identifier.database_name, identifier.object_name),
+                identifier.get_database_name(), identifier.get_object_name()),
             request,
             CommitTableResponse,
             self.rest_auth_function

--- a/paimon-python/pypaimon/common/identifier.py
+++ b/paimon-python/pypaimon/common/identifier.py
@@ -27,13 +27,13 @@ SYSTEM_BRANCH_PREFIX = 'branch-'
 @dataclass
 class Identifier:
 
-    database_name: str = json_field("database", default=None)
-    object_name: str = json_field("object", default=None)
-    branch_name: Optional[str] = json_field("branch", default=None)
+    database: str = json_field("database", default=None)
+    object: str = json_field("object", default=None)
+    branch: Optional[str] = json_field("branch", default=None)
 
     @classmethod
-    def create(cls, database_name: str, object_name: str) -> "Identifier":
-        return cls(database_name, object_name)
+    def create(cls, database: str, object: str) -> "Identifier":
+        return cls(database, object)
 
     @classmethod
     def from_string(cls, full_name: str) -> "Identifier":
@@ -46,21 +46,21 @@ class Identifier:
             raise ValueError("Invalid identifier format: {}".format(full_name))
 
     def get_full_name(self) -> str:
-        if self.branch_name:
-            return "{}.{}.{}".format(self.database_name, self.object_name, self.branch_name)
-        return "{}.{}".format(self.database_name, self.object_name)
+        if self.branch:
+            return "{}.{}.{}".format(self.database, self.object, self.branch)
+        return "{}.{}".format(self.database, self.object)
 
     def get_database_name(self) -> str:
-        return self.database_name
+        return self.database
 
     def get_table_name(self) -> str:
-        return self.object_name
+        return self.object
 
     def get_object_name(self) -> str:
-        return self.object_name
+        return self.object
 
     def get_branch_name(self) -> Optional[str]:
-        return self.branch_name
+        return self.branch
 
     def is_system_table(self) -> bool:
-        return self.object_name.startswith('$')
+        return self.object.startswith('$')

--- a/paimon-python/pypaimon/schema/data_types.py
+++ b/paimon-python/pypaimon/schema/data_types.py
@@ -73,10 +73,8 @@ class AtomicType(DataType):
         super().__init__(nullable)
         self.type = type
 
-    def to_dict(self) -> str:
-        if not self.nullable:
-            return self.type + " NOT NULL"
-        return self.type
+    def to_dict(self) -> Dict[str, Any]:
+        return {"type": self.type if self.nullable else self.type + " NOT NULL"}
 
     @classmethod
     def from_dict(cls, data: str) -> "AtomicType":

--- a/paimon-python/pypaimon/snapshot/catalog_snapshot_commit.py
+++ b/paimon-python/pypaimon/snapshot/catalog_snapshot_commit.py
@@ -57,9 +57,9 @@ class CatalogSnapshotCommit(SnapshotCommit):
             Exception: If commit fails
         """
         new_identifier = Identifier(
-            database_name=self.identifier.get_database_name(),
-            object_name=self.identifier.get_table_name(),
-            branch_name=branch
+            database=self.identifier.get_database_name(),
+            object=self.identifier.get_table_name(),
+            branch=branch
         )
 
         # Call catalog's commit_snapshot method


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Keep the variable names of Identifier consistent with Java

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
