### PR TITLE
[core] skip validate main branch before orphan files cleaning

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -108,7 +108,6 @@ public abstract class OrphanFilesClean implements Serializable {
 
     protected List<String> validBranches() {
         List<String> branches = table.branchManager().branches();
-        branches.add(DEFAULT_MAIN_BRANCH);
 
         List<String> abnormalBranches = new ArrayList<>();
         for (String branch : branches) {
@@ -124,6 +123,7 @@ public abstract class OrphanFilesClean implements Serializable {
                                     + "Please check these branches manually.",
                             abnormalBranches));
         }
+        branches.add(DEFAULT_MAIN_BRANCH);
         return branches;
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
skip validate main branch before doOrphanClean, since getTable is invoked before validate branches.
<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
