### PR TITLE
[core] Fix that cannot get partition info if all files are in level-0 when enable dv.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/system/PartitionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/PartitionsTable.java
@@ -182,7 +182,8 @@ public class PartitionsTable implements ReadonlyTable {
                 throw new IllegalArgumentException("Unsupported split: " + split.getClass());
             }
 
-            List<PartitionEntry> partitions = fileStoreTable.newScan().listPartitionEntries();
+            List<PartitionEntry> partitions =
+                    fileStoreTable.newScan().withLevelFilter(level -> true).listPartitionEntries();
 
             @SuppressWarnings("unchecked")
             CastExecutor<InternalRow, BinaryString> partitionCastExecutor =

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -1025,4 +1025,14 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
         sql("INSERT INTO test_table VALUES (1, 'A')");
         assertThat(sql("SELECT * FROM `test_table$files`")).isNotEmpty();
     }
+
+    @Test
+    public void testLevel0FileCanBeReadForPartitionsTable() {
+        sql(
+                "CREATE TABLE test_table (a int PRIMARY KEY NOT ENFORCED, b string, dt string) "
+                        + "PARTITIONED BY (dt)"
+                        + "WITH ('deletion-vectors.enabled' = 'true', 'write-only' = 'true');");
+        sql("INSERT INTO test_table VALUES (1, 'A', '2024-12-01')");
+        assertThat(sql("SELECT * FROM `test_table$partitions`")).isNotEmpty();
+    }
 }


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #6530

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
