### PR TITLE
[core]update SingleFileWriter.outputBytes during close for writers with SupportsDirectWrite

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/io/SingleFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/SingleFileWriter.java
@@ -32,6 +32,7 @@ import org.apache.paimon.utils.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.function.Function;
@@ -189,6 +190,13 @@ public abstract class SingleFileWriter<T, R> implements FileWriter<T, R> {
                 outputBytes = out.getPos();
                 out.close();
                 out = null;
+            } else {
+                try {
+                    outputBytes = fileIO.getFileSize(path);
+                } catch (FileNotFoundException e) {
+                    LOG.warn("File " + path + " does not exist after close", e);
+                    outputBytes = 0;
+                }
             }
         } catch (IOException e) {
             LOG.warn("Exception occurs when closing file {}. Cleaning up.", path, e);


### PR DESCRIPTION
### Purpose

I found a suspected bug in `SingleFileWriter`.

If it is a writer that implements `SupportsDirectWrite` (currently only `LanceWriter`), then `outputBytes` will not be updated, ultimately causing the `file_size` in the manifest entry to always be `zero`.

I discovered this while testing PK Table & LanceFile & deletion-vectors. I found that no matter how I executed `DELETE`, the dv index was never generated as expected. Subsequently, I found that the `$files` system table showed `file_size_in_bytes` as `zero`, indicating that the `file_size` in the manifest is zero, but the actual data file ending with .lance is 1.5MB in size on the storage side.

After applying the fix in the PR, I found that the `$files` system table could display the actual file size normally, and the dv index could also be generated as expected.

### Tests

Not yet

### API and Format

No

### Documentation

No
