### PR TITLE
[python] Fix AtomicType.to_dict() inconsistency with java

### DIFF
--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -67,10 +67,10 @@ jobs:
           if [[ "${{ matrix.python-version }}" == "3.6.15" ]]; then
             python -m pip install --upgrade pip==21.3.1
             python --version
-            python -m pip install -q readerwriterlock==1.0.9 'fsspec==2021.10.1' 'cachetools==4.2.4' 'ossfs==2021.8.0' pyarrow==6.0.1 pandas==1.1.5 'polars==0.9.12' 'fastavro==1.4.7' zstandard==0.19.0 dataclasses==0.8.0 flake8 pytest py4j==0.10.9.9 requests 2>&1 >/dev/null
+            python -m pip install -q readerwriterlock==1.0.9 'fsspec==2021.10.1' 'cachetools==4.2.4' 'ossfs==2021.8.0' pyarrow==6.0.1 pandas==1.1.5 'polars==0.9.12' 'fastavro==1.4.7' zstandard==0.19.0 dataclasses==0.8.0 flake8 pytest py4j==0.10.9.9 requests parameterized==0.8.1 2>&1 >/dev/null
           else
             python -m pip install --upgrade pip
-            python -m pip install -q readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.48.0 fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests 2>&1 >/dev/null
+            python -m pip install -q readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.48.0 fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 2>&1 >/dev/null
           fi
       - name: Run lint-python.sh
         shell: bash

--- a/paimon-python/pypaimon/tests/data_types_test.py
+++ b/paimon-python/pypaimon/tests/data_types_test.py
@@ -1,0 +1,67 @@
+"""
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+from parameterized import parameterized
+
+from pypaimon.schema.data_types import DataField, AtomicType, ArrayType, MultisetType, MapType, RowType
+
+
+class DataTypesTest(unittest.TestCase):
+    def test_atomic_type(self):
+        self.assertEqual(str(AtomicType("BLOB")), "BLOB")
+        self.assertEqual(str(AtomicType("TINYINT", nullable=False)), "TINYINT NOT NULL")
+        self.assertEqual(str(AtomicType("BIGINT", nullable=False)), "BIGINT NOT NULL")
+        self.assertEqual(str(AtomicType("BOOLEAN", nullable=False)), "BOOLEAN NOT NULL")
+        self.assertEqual(str(AtomicType("DOUBLE")), "DOUBLE")
+        self.assertEqual(str(AtomicType("STRING")), "STRING")
+        self.assertEqual(str(AtomicType("BINARY(12)")), "BINARY(12)")
+        self.assertEqual(str(AtomicType("DECIMAL(10, 6)")), "DECIMAL(10, 6)")
+        self.assertEqual(str(AtomicType("BYTES")), "BYTES")
+        self.assertEqual(str(AtomicType("DATE")), "DATE")
+        self.assertEqual(str(AtomicType("TIME(0)")), "TIME(0)")
+        self.assertEqual(str(AtomicType("TIMESTAMP(0)")), "TIMESTAMP(0)")
+        self.assertEqual(str(AtomicType("SMALLINT", nullable=False)),
+                         str(AtomicType.from_dict(AtomicType("SMALLINT", nullable=False).to_dict())))
+        self.assertEqual(str(AtomicType("INT")),
+                         str(AtomicType.from_dict(AtomicType("INT").to_dict())))
+
+    @parameterized.expand([
+        (ArrayType, AtomicType("TIMESTAMP(6)"), "ARRAY<TIMESTAMP(6)>", "ARRAY<ARRAY<TIMESTAMP(6)>>"),
+        (MultisetType, AtomicType("TIMESTAMP(6)"), "MULTISET<TIMESTAMP(6)>", "MULTISET<MULTISET<TIMESTAMP(6)>>")
+    ])
+    def test_complex_types(self, data_type_class, element_type, expected1, expected2):
+        self.assertEqual(str(data_type_class(True, element_type)), expected1)
+        self.assertEqual(str(data_type_class(True, data_type_class(True, element_type))), expected2)
+        self.assertEqual(str(data_type_class(False, element_type)), expected1 + " NOT NULL")
+        self.assertEqual(str(data_type_class(False, element_type)),
+                         str(data_type_class.from_dict(data_type_class(False, element_type).to_dict())))
+        self.assertEqual(str(data_type_class(True, element_type)),
+                         str(data_type_class.from_dict(data_type_class(True, element_type).to_dict())))
+
+    def test_map_type(self):
+        self.assertEqual(str(MapType(True, AtomicType("STRING"), AtomicType("TIMESTAMP(6)"))),
+                         "MAP<STRING, TIMESTAMP(6)>")
+
+    def test_row_type(self):
+        self.assertEqual(str(RowType(True, [DataField(0, "a", AtomicType("STRING"), "Someone's desc."),
+                                            DataField(1, "b", AtomicType("TIMESTAMP(6)"),)])),
+                         "ROW<a: STRING COMMENT Someone's desc., b: TIMESTAMP(6)>")
+        row_data = RowType(True, [DataField(0, "a", AtomicType("STRING"), "Someone's desc."),
+                                  DataField(1, "b", AtomicType("TIMESTAMP(6)"),)])
+        self.assertEqual(str(row_data),
+                         str(RowType.from_dict(row_data.to_dict())))


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Fix AtomicType.to_dict() inconsistency with java caused by #6520
now: {'type': string}
Expected: string

<!-- What is the purpose of the change -->

### Tests
data_types_test.py
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
