### PR TITLE
[doc] Update postpone.default-bucket-num default value on Data distribution page

### DIFF
--- a/docs/content/primary-key-table/data-distribution.md
+++ b/docs/content/primary-key-table/data-distribution.md
@@ -78,7 +78,7 @@ To move the records into the correct bucket and make them readable,
 you need to run a compaction job.
 See `compact` [procedure]({{< ref "flink/procedures" >}}).
 The bucket number for the partitions compacted for the first time
-is configured by the option `postpone.default-bucket-num`, whose default value is `4`.
+is configured by the option `postpone.default-bucket-num`, whose default value is `1`.
 
 Finally, when you feel that the bucket number of some partition is too small,
 you can also run a rescale job.


### PR DESCRIPTION
### Purpose

Fix `postpone.default-bucket-num` default value on Data distribution page to align with actual code.

### Tests

### API and Format

### Documentation

