### PR TITLE
[core] Infer parallelism uses the value of postpone.default-bucket-num in postpone bucket mode

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkTableSource.java
@@ -211,8 +211,11 @@ public abstract class FlinkTableSource
                 // In unaware bucket or dynamic bucket mode, we can't infer parallelism.
                 if (options.get(CoreOptions.BUCKET) == -1) {
                     return null;
-                } else if (options.get(CoreOptions.BUCKET) == -2){
-                    parallelism = Math.max(1, options.get(FlinkConnectorOptions.POSTPONE_DEFAULT_BUCKET_NUM));
+                } else if (options.get(CoreOptions.BUCKET) == -2) {
+                    parallelism =
+                            Math.max(
+                                    1,
+                                    options.get(FlinkConnectorOptions.POSTPONE_DEFAULT_BUCKET_NUM));
                 } else {
                     parallelism = Math.max(1, options.get(CoreOptions.BUCKET));
                 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Infer parallelism uses the value of postpone.default-bucket-num in postpone bucket mode.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
