### PR TITLE
[core] Add distinct parameter for FieldListaggAgg

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldListaggAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldListaggAgg.java
@@ -30,9 +30,12 @@ public class FieldListaggAgg extends FieldAggregator {
 
     private final String delimiter;
 
+    private final boolean distinct;
+
     public FieldListaggAgg(String name, VarCharType dataType, CoreOptions options, String field) {
         super(name, dataType);
         this.delimiter = options.fieldListAggDelimiter(field);
+        this.distinct = options.fieldCollectAggDistinct(field);
     }
 
     @Override
@@ -45,6 +48,12 @@ public class FieldListaggAgg extends FieldAggregator {
         // TODO: ensure not VARCHAR(n)
         BinaryString mergeFieldSD = (BinaryString) accumulator;
         BinaryString inFieldSD = (BinaryString) inputField;
+
+        if (distinct
+                && inFieldSD.getSizeInBytes() > 0
+                && mergeFieldSD.contains(inFieldSD)) {
+            return mergeFieldSD;
+        }
 
         return BinaryStringUtils.concat(
                 mergeFieldSD, BinaryString.fromString(delimiter), inFieldSD);

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -77,9 +77,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.apache.paimon.utils.ThetaSketch.sketchOf;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /** test whether {@link FieldAggregator}' subclasses behaviors are expected. */
 public class FieldAggregatorTest {
@@ -158,6 +161,30 @@ public class FieldAggregatorTest {
         BinaryString inputField = BinaryString.fromString("user2");
         assertThat(fieldListaggAgg.agg(accumulator, inputField).toString())
                 .isEqualTo("user1,user2");
+    }
+
+    @Test
+    public void testFieldListAggWithDefaultDelimiterAndDistinct() {
+        FieldListaggAgg fieldListaggAgg = new FieldListaggAggFactory()
+                .create(
+                        DataTypes.ARRAY(DataTypes.INT()),
+                        CoreOptions.fromMap(
+                                ImmutableMap.of("fields.fieldName.distinct", "true")),
+                        "fieldName");
+
+        BinaryString result = Stream
+                .of(
+                        BinaryString.fromString("user1"),
+                        BinaryString.fromString("user2"),
+                        BinaryString.fromString("user1"),
+                        BinaryString.fromString("user3")
+                )
+                .sequential()
+                .reduce((l, r) -> (BinaryString) fieldListaggAgg.agg(l, r))
+                .orElse(null);
+
+        assertNotNull(result);
+        assertEquals("user1,user2,user3", result.toString());
     }
 
     @Test


### PR DESCRIPTION
### Purpose

Add distinct support to FileListagg aggregate function.

- Reuses `fields.{fieldName}.distinct` option
- May significantly reduce computation overhead vs `array.collect.distinct`, `map.merge_map`

### Tests

org.apache.paimon.mergetree.compact.aggregate.FieldAggregatorTest#testFieldListAggWithDefaultDelimiterAndDistinct

### API and Format

- `fields.{fieldName}.distinct` option

### Documentation

