### PR TITLE
[core] Introduce 'file-io.atomic-rename.enabled' for atomic rename control

### DIFF
--- a/docs/generated/catalog_configuration.html
+++ b/docs/generated/catalog_configuration.html
@@ -81,6 +81,12 @@
             <td>Whether to allow static cache in file io implementation. If not allowed, this means that there may be a large number of FileIO instances generated, enabling caching can lead to resource leakage.</td>
         </tr>
         <tr>
+            <td><h5>file-io.atomic-rename.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to enable atomic rename for file overwrite operations. When enabled, Paimon attempts atomic rename via temp file, supported on HDFS (DistributedFileSystem, ViewFileSystem). Falls back to direct overwrite on object stores like S3/OSS. Set to false to skip atomic rename and avoid reflection/temp file overhead.</td>
+        </tr>
+        <tr>
             <td><h5>format-table.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/paimon-api/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -223,4 +223,14 @@ public class CatalogOptions {
                     .withDescription(
                             "Comma-separated list of file types to cache. "
                                     + "Supported values: meta, global-index, bucket-index, data, file-index.");
+
+    public static final ConfigOption<Boolean> FILE_IO_ATOMIC_RENAME_ENABLED =
+            ConfigOptions.key("file-io.atomic-rename.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to enable atomic rename for file overwrite operations. "
+                                    + "When enabled, Paimon attempts atomic rename via temp file, supported on HDFS (DistributedFileSystem, ViewFileSystem). "
+                                    + "Falls back to direct overwrite on object stores like S3/OSS. "
+                                    + "Set to false to skip atomic rename and avoid reflection/temp file overhead.");
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fs/hadoop/HadoopFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/hadoop/HadoopFileIO.java
@@ -28,6 +28,7 @@ import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.fs.RemoteIterator;
 import org.apache.paimon.fs.SeekableInputStream;
 import org.apache.paimon.hadoop.SerializableConfiguration;
+import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.utils.FileIOUtils;
 import org.apache.paimon.utils.FunctionWithException;
 import org.apache.paimon.utils.Pair;
@@ -59,6 +60,8 @@ public class HadoopFileIO implements FileIO, HadoopOptionsProvider {
 
     private org.apache.paimon.options.Options options;
 
+    private boolean atomicRenameEnabled = true;
+
     protected transient volatile Map<Pair<String, String>, FileSystem> fsMap;
 
     private final Path path;
@@ -82,6 +85,7 @@ public class HadoopFileIO implements FileIO, HadoopOptionsProvider {
     public void configure(CatalogContext context) {
         this.hadoopConf = new SerializableConfiguration(context.hadoopConf());
         this.options = context.options();
+        this.atomicRenameEnabled = options.get(CatalogOptions.FILE_IO_ATOMIC_RENAME_ENABLED);
     }
 
     public Configuration hadoopConf() {
@@ -178,8 +182,12 @@ public class HadoopFileIO implements FileIO, HadoopOptionsProvider {
 
     @Override
     public void overwriteFileUtf8(Path path, String content) throws IOException {
-        boolean success = tryAtomicOverwriteViaRename(path, content);
-        if (!success) {
+        if (atomicRenameEnabled) {
+            boolean success = tryAtomicOverwriteViaRename(path, content);
+            if (!success) {
+                FileIO.super.overwriteFileUtf8(path, content);
+            }
+        } else {
             FileIO.super.overwriteFileUtf8(path, content);
         }
     }

--- a/paimon-common/src/main/java/org/apache/paimon/fs/hadoop/HadoopFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/hadoop/HadoopFileIO.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Options;
 
 import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.io.OutputStreamWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -61,7 +60,7 @@ public class HadoopFileIO implements FileIO, HadoopOptionsProvider {
 
     private org.apache.paimon.options.Options options;
 
-    private boolean atomicRenameEnabled = true;
+    private Boolean atomicRenameEnabled;
 
     protected transient volatile Map<Pair<String, String>, FileSystem> fsMap;
 
@@ -87,13 +86,6 @@ public class HadoopFileIO implements FileIO, HadoopOptionsProvider {
         this.hadoopConf = new SerializableConfiguration(context.hadoopConf());
         this.options = context.options();
         this.atomicRenameEnabled = options.get(CatalogOptions.FILE_IO_ATOMIC_RENAME_ENABLED);
-    }
-
-    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-        // Default to true for instances serialized by older versions without this field;
-        // defaultReadObject only overwrites fields actually present in the stream.
-        this.atomicRenameEnabled = true;
-        in.defaultReadObject();
     }
 
     public Configuration hadoopConf() {
@@ -190,7 +182,7 @@ public class HadoopFileIO implements FileIO, HadoopOptionsProvider {
 
     @Override
     public void overwriteFileUtf8(Path path, String content) throws IOException {
-        if (atomicRenameEnabled) {
+        if (atomicRenameEnabled()) {
             boolean success = tryAtomicOverwriteViaRename(path, content);
             if (!success) {
                 FileIO.super.overwriteFileUtf8(path, content);
@@ -198,6 +190,13 @@ public class HadoopFileIO implements FileIO, HadoopOptionsProvider {
         } else {
             FileIO.super.overwriteFileUtf8(path, content);
         }
+    }
+
+    private boolean atomicRenameEnabled() {
+        // The field is null for instances created without configure() and, importantly, for
+        // instances deserialized from older versions that did not have this field. In both
+        // cases we default to true to preserve the legacy HDFS atomic overwrite behavior.
+        return atomicRenameEnabled == null || atomicRenameEnabled;
     }
 
     private org.apache.hadoop.fs.Path path(Path path) {

--- a/paimon-common/src/main/java/org/apache/paimon/fs/hadoop/HadoopFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/hadoop/HadoopFileIO.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Options;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.OutputStreamWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -86,6 +87,13 @@ public class HadoopFileIO implements FileIO, HadoopOptionsProvider {
         this.hadoopConf = new SerializableConfiguration(context.hadoopConf());
         this.options = context.options();
         this.atomicRenameEnabled = options.get(CatalogOptions.FILE_IO_ATOMIC_RENAME_ENABLED);
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        // Default to true for instances serialized by older versions without this field;
+        // defaultReadObject only overwrites fields actually present in the stream.
+        this.atomicRenameEnabled = true;
+        in.defaultReadObject();
     }
 
     public Configuration hadoopConf() {


### PR DESCRIPTION
### Purpose

Add a new configuration option `file-io.atomic-rename.enabled` to control whether to attempt atomic rename for file overwrite operations.

When enabled (default), Paimon attempts to use atomic rename (write to temp file then rename with OVERWRITE option) via reflection on the FileSystem's 3-parameter rename method. This is supported on distributed file systems like HDFS (DistributedFileSystem). On object storage systems like S3/OSS that don't implement this method, it automatically falls back to direct overwrite.

When disabled, Paimon skips the atomic rename attempt and always uses direct overwrite, which can avoid the overhead of reflection calls and temporary file operations, especially useful on object storage systems where atomic rename is not supported.

### Tests
<!-- List UT and IT cases to verify this change -->



### API and Format
<!-- Does this change affect API or storage format -->


### Documentation
<!-- Does this change introduce a new feature -->

