### PR TITLE
[core] format table: insert overwrite static partition when data is empty need init partition path

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableCommit.java
@@ -80,14 +80,21 @@ public class FormatTableCommit implements BatchTableCommit {
                                     + commitMessage.getClass().getName());
                 }
             }
-            if (overwrite && staticPartitions != null && !staticPartitions.isEmpty()) {
+
+            if (staticPartitions != null && !staticPartitions.isEmpty()) {
                 Path partitionPath =
                         buildPartitionPath(
                                 location,
                                 staticPartitions,
                                 formatTablePartitionOnlyValueInPath,
                                 partitionKeys);
-                deletePreviousDataFile(partitionPath);
+
+                if (overwrite) {
+                    deletePreviousDataFile(partitionPath);
+                }
+                if (!fileIO.exists(partitionPath)) {
+                    fileIO.mkdirs(partitionPath);
+                }
             } else if (overwrite) {
                 Set<Path> partitionPaths = new HashSet<>();
                 for (TwoPhaseOutputStream.Committer c : committers) {
@@ -97,6 +104,7 @@ public class FormatTableCommit implements BatchTableCommit {
                     deletePreviousDataFile(p);
                 }
             }
+
             for (TwoPhaseOutputStream.Committer committer : committers) {
                 committer.commit(this.fileIO);
             }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/format/PaimonFormatTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/format/PaimonFormatTable.scala
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.spark.format
 
-import org.apache.paimon.CoreOptions
 import org.apache.paimon.format.csv.CsvOptions
 import org.apache.paimon.spark.{BaseTable, FormatTableScanBuilder, SparkInternalRowWrapper}
 import org.apache.paimon.spark.write.BaseV2WriteBuilder


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->
format table: insert overwrite static partition when data is empty, need init partition path
### Tests
- test("PaimonFormatTable: partition path validate when insert overwrite empty data")

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
