### PR TITLE
Optimize IndexFileMetaSerializer#rowArrayDataToDvMetas

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMetaSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/IndexFileMetaSerializer.java
@@ -85,10 +85,11 @@ public class IndexFileMetaSerializer extends ObjectSerializer<IndexFileMeta> {
         LinkedHashMap<String, DeletionVectorMeta> dvMetas = new LinkedHashMap<>(arrayData.size());
         for (int i = 0; i < arrayData.size(); i++) {
             InternalRow row = arrayData.getRow(i, DeletionVectorMeta.SCHEMA.getFieldCount());
+            String dataFileName = row.getString(0).toString();
             dvMetas.put(
-                    row.getString(0).toString(),
+                    dataFileName,
                     new DeletionVectorMeta(
-                            row.getString(0).toString(),
+                            dataFileName,
                             row.getInt(1),
                             row.getInt(2),
                             row.isNullAt(3) ? null : row.getLong(3)));


### PR DESCRIPTION
### Purpose

This PR optmizes `IndexFileMetaSerializer#rowArrayDataToDvMetas` by reusing the result of changing `BinaryString` to `String`.

### Tests

This is a simple optimization. No test is needed.

### API and Format

No format changes.

### Documentation

No new feature.
