### PR TITLE
Also check row type if schema id not match in RemoteLookupFileManager

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -113,6 +113,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
     private final RowType keyType;
     private final RowType valueType;
     private final FileIO fileIO;
+    private final SchemaManager schemaManager;
     private final RowType partitionType;
     private final String commitUser;
     @Nullable private final RecordLevelExpire recordLevelExpire;
@@ -148,6 +149,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                 dvMaintainerFactory,
                 tableName);
         this.fileIO = fileIO;
+        this.schemaManager = schemaManager;
         this.partitionType = partitionType;
         this.keyType = keyType;
         this.valueType = valueType;
@@ -378,7 +380,8 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                                 fileIO,
                                 keyReaderFactory.pathFactory(),
                                 keyReaderFactory.schema(),
-                                lookupLevels);
+                                lookupLevels,
+                                schemaManager);
             }
             return new LookupMergeTreeCompactRewriter(
                     maxLevel,


### PR DESCRIPTION
### Purpose

This PR also reuse remote lookup file when schema id does not match, but row type matches. This can avoid invalidating remote lookup files when the user only changes some table options.

### Tests

<TODO>

### API and Format

No format changes.

### Documentation

No new feature.
