### PR TITLE
[core] rest catalog: support default create table options

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -96,6 +96,7 @@ public class RESTCatalog implements Catalog {
     private final RESTApi api;
     private final CatalogContext context;
     private final boolean dataTokenEnabled;
+    protected final Map<String, String> tableDefaultOptions;
 
     public RESTCatalog(CatalogContext context) {
         this(context, true);
@@ -110,6 +111,7 @@ public class RESTCatalog implements Catalog {
                         context.preferIO(),
                         context.fallbackIO());
         this.dataTokenEnabled = api.options().get(RESTTokenFileIO.DATA_TOKEN_ENABLED);
+        this.tableDefaultOptions = CatalogUtils.tableDefaultOptions(context.options().toMap());
     }
 
     @Override
@@ -448,6 +450,7 @@ public class RESTCatalog implements Catalog {
             checkNotSystemTable(identifier, "createTable");
             validateCreateTable(schema, dataTokenEnabled);
             createExternalTablePathIfNotExist(schema);
+            tableDefaultOptions.forEach(schema.options()::putIfAbsent);
             Schema newSchema = inferSchemaIfExternalPaimonTable(schema);
             api.createTable(identifier, newSchema);
         } catch (AlreadyExistsException e) {

--- a/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTCatalogTest.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.apache.paimon.catalog.Catalog.TABLE_DEFAULT_OPTION_PREFIX;
 import static org.apache.paimon.rest.RESTApi.HEADER_PREFIX;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -173,6 +174,17 @@ class MockRESTCatalogTest extends RESTCatalogTest {
         RESTCatalog restCatalog2 = restCatalog.catalogLoader().load();
         Map<String, String> headers2 = restCatalog2.api().authFunction().apply(restAuthParameter);
         assertEquals(headers2.get("User-Agent"), "test");
+    }
+
+    @Test
+    void testCreateTableDefaultOptions() throws Exception {
+        options.set(TABLE_DEFAULT_OPTION_PREFIX + "default-key", "default-value");
+        RESTCatalog restCatalog = initCatalog(false);
+        Identifier identifier = Identifier.create("db1", "new_table_default_options");
+        restCatalog.createDatabase(identifier.getDatabaseName(), true);
+        restCatalog.createTable(identifier, DEFAULT_TABLE_SCHEMA, true);
+        assertEquals(
+                restCatalog.getTable(identifier).options().get("default-key"), "default-value");
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->

rest catalog: support default create table options

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->
- MockRESTCatalogTest#testCreateTableDefaultOptions
### Documentation

<!-- Does this change introduce a new feature -->
