### PR TITLE
[core] Fix default replication=1: delegate create()/getDefault() in HadoopSecuredFileSystem

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/hadoop/HadoopSecuredFileSystem.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/hadoop/HadoopSecuredFileSystem.java
@@ -89,6 +89,41 @@ public class HadoopSecuredFileSystem extends FileSystem {
     }
 
     @Override
+    public FSDataOutputStream create(Path path, boolean overwrite) throws IOException {
+        return runSecuredWithIOException(() -> fileSystem.create(path, overwrite));
+    }
+
+    @Override
+    public FSDataOutputStream create(
+            Path path, boolean overwrite, int bufferSize, short replication, long blockSize)
+            throws IOException {
+        return runSecuredWithIOException(
+                () -> fileSystem.create(path, overwrite, bufferSize, replication, blockSize));
+    }
+
+    @Override
+    public short getDefaultReplication(Path f) {
+        return runSecured(() -> fileSystem.getDefaultReplication(f));
+    }
+
+    @Deprecated
+    @Override
+    public short getDefaultReplication() {
+        return runSecured(() -> fileSystem.getDefaultReplication());
+    }
+
+    @Override
+    public long getDefaultBlockSize(Path f) {
+        return runSecured(() -> fileSystem.getDefaultBlockSize(f));
+    }
+
+    @Deprecated
+    @Override
+    public long getDefaultBlockSize() {
+        return runSecured(() -> fileSystem.getDefaultBlockSize());
+    }
+
+    @Override
     public boolean exists(Path f) throws IOException {
         return runSecuredWithIOException(() -> fileSystem.exists(f));
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close https://github.com/apache/paimon/issues/6587



<!-- What is the purpose of the change -->
- Override the following methods in HadoopSecuredFileSystem
- So they simply delegate to the underlying fileSystem (the real FS implementation such as DistributedFileSystem)


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
