### PR TITLE
[spark] Wrap the corresponding table to ensure it guarantees its capabilities

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/BaseTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/BaseTable.scala
@@ -21,10 +21,11 @@ package org.apache.paimon.spark
 import org.apache.paimon.table.Table
 import org.apache.paimon.utils.StringUtils
 
+import org.apache.spark.sql.connector.catalog.TableCapability
 import org.apache.spark.sql.connector.expressions.{Expressions, Transform}
 import org.apache.spark.sql.types.StructType
 
-import java.util.{Map => JMap}
+import java.util.{Collections => JCollections, Map => JMap, Set => JSet}
 
 import scala.collection.JavaConverters._
 
@@ -34,6 +35,8 @@ abstract class BaseTable
 
   val table: Table
 
+  override def capabilities(): JSet[TableCapability] = JCollections.emptySet[TableCapability]()
+
   override def name: String = table.fullName
 
   override lazy val schema: StructType = SparkTypeUtils.fromPaimonRowType(table.rowType)
@@ -42,9 +45,7 @@ abstract class BaseTable
     table.partitionKeys().asScala.map(p => Expressions.identity(StringUtils.quote(p))).toArray
   }
 
-  override def properties: JMap[String, String] = {
-    table.options()
-  }
+  override def properties: JMap[String, String] = table.options()
 
   override def toString: String = {
     s"${table.getClass.getSimpleName}[${table.fullName()}]"

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkTable.scala
@@ -22,3 +22,9 @@ import org.apache.paimon.table.Table
 
 /** A spark [[org.apache.spark.sql.connector.catalog.Table]] for paimon. */
 case class SparkTable(override val table: Table) extends PaimonSparkTableBase(table) {}
+
+case class SparkIcebergTable(table: Table) extends BaseTable
+
+case class SparkLanceTable(table: Table) extends BaseTable
+
+case class SparkObjectTable(table: Table) extends BaseTable


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

 Iceberg, lance and object table should not support read and write yet, add wrap for them

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
