### PR TITLE
[spark]Handle NPE for pushdown aggregate when a datasplit has a null max/min value

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/aggregate/AggFuncEvaluator.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/aggregate/AggFuncEvaluator.scala
@@ -59,7 +59,9 @@ case class MinEvaluator(idx: Int, dataField: DataField, evolutions: SimpleStatsE
 
   override def update(dataSplit: DataSplit): Unit = {
     val other = dataSplit.minValue(idx, dataField, evolutions)
-    // if (_result == null || (other != null && CompareUtils.compareLiteral(dataField.`type`(), _result, other) > 0)) {
+    if (other == null) {
+      return
+    }
     if (_result == null || CompareUtils.compareLiteral(dataField.`type`(), _result, other) > 0) {
       _result = other;
     }
@@ -81,7 +83,10 @@ case class MaxEvaluator(idx: Int, dataField: DataField, evolutions: SimpleStatsE
 
   override def update(dataSplit: DataSplit): Unit = {
     val other = dataSplit.maxValue(idx, dataField, evolutions)
-    if (_result == null || (other != null && CompareUtils.compareLiteral(dataField.`type`(), _result, other) < 0)) {
+    if (other == null) {
+      return
+    }
+    if (_result == null || CompareUtils.compareLiteral(dataField.`type`(), _result, other) < 0) {
       _result = other
     }
   }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PushDownAggregatesTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PushDownAggregatesTest.scala
@@ -296,7 +296,7 @@ class PushDownAggregatesTest extends PaimonSparkTestBase with AdaptiveSparkPlanH
   }
 
   // https://github.com/apache/paimon/issues/6610
-  test("Push down aggregate - MIN/MAX of a column which in one partition is all null and the other is not") {
+  test("Push down aggregate: aggregate a column in one partition is all null and another is not") {
     withTable("T") {
       spark.sql("CREATE TABLE T (c1 INT, c2 LONG) PARTITIONED BY(day STRING)")
 


### PR DESCRIPTION
### Purpose

Linked issue: close #6610 

### Tests

An ut is added under PushDownAggregatesTest

### API and Format

No

### Documentation

No
