### PR TITLE
[core] Fix the serialization of JindoMultiPartUploadCommitter

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/BaseMultiPartUploadCommitter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/BaseMultiPartUploadCommitter.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.fs;
 
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.rest.RESTTokenFileIO;
 
 import org.slf4j.Logger;
@@ -32,7 +33,7 @@ public abstract class BaseMultiPartUploadCommitter<T, C> implements TwoPhaseOutp
 
     private static final Logger LOG = LoggerFactory.getLogger(BaseMultiPartUploadCommitter.class);
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     private final String uploadId;
     private final String objectName;
@@ -80,6 +81,11 @@ public abstract class BaseMultiPartUploadCommitter<T, C> implements TwoPhaseOutp
     @Override
     public Path targetPath() {
         return this.targetPath;
+    }
+
+    @VisibleForTesting
+    public List<T> uploadedParts() {
+        return uploadedParts;
     }
 
     @Override

--- a/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoMultiPartUploadCommitter.java
+++ b/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoMultiPartUploadCommitter.java
@@ -24,7 +24,6 @@ import org.apache.paimon.fs.MultiPartUploadStore;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.utils.Pair;
 
-import com.aliyun.jindodata.api.spec.protos.JdoObjectPart;
 import com.aliyun.jindodata.common.JindoHadoopSystem;
 
 import java.io.IOException;
@@ -32,10 +31,11 @@ import java.util.List;
 
 /** Jindo implementation of MultiPartUploadCommitter. */
 public class JindoMultiPartUploadCommitter
-        extends BaseMultiPartUploadCommitter<JdoObjectPart, String> {
+        extends BaseMultiPartUploadCommitter<SerializableJdoObjectPart, String> {
+
     public JindoMultiPartUploadCommitter(
             String uploadId,
-            List<JdoObjectPart> uploadedParts,
+            List<SerializableJdoObjectPart> uploadedParts,
             String objectName,
             long position,
             Path targetPath) {
@@ -43,7 +43,7 @@ public class JindoMultiPartUploadCommitter
     }
 
     @Override
-    protected MultiPartUploadStore<JdoObjectPart, String> multiPartUploadStore(
+    protected MultiPartUploadStore<SerializableJdoObjectPart, String> multiPartUploadStore(
             FileIO fileIO, Path targetPath) throws IOException {
         JindoFileIO jindoFileIO = (JindoFileIO) fileIO;
         org.apache.hadoop.fs.Path hadoopPath = jindoFileIO.path(targetPath);

--- a/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoTwoPhaseOutputStream.java
+++ b/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoTwoPhaseOutputStream.java
@@ -22,16 +22,14 @@ import org.apache.paimon.fs.MultiPartUploadStore;
 import org.apache.paimon.fs.MultiPartUploadTwoPhaseOutputStream;
 import org.apache.paimon.fs.Path;
 
-import com.aliyun.jindodata.api.spec.protos.JdoObjectPart;
-
 import java.io.IOException;
 
 /** Jindo implementation of TwoPhaseOutputStream using multipart upload. */
 public class JindoTwoPhaseOutputStream
-        extends MultiPartUploadTwoPhaseOutputStream<JdoObjectPart, String> {
+        extends MultiPartUploadTwoPhaseOutputStream<SerializableJdoObjectPart, String> {
 
     public JindoTwoPhaseOutputStream(
-            MultiPartUploadStore<JdoObjectPart, String> multiPartUploadStore,
+            MultiPartUploadStore<SerializableJdoObjectPart, String> multiPartUploadStore,
             org.apache.hadoop.fs.Path hadoopPath,
             Path targetPath)
             throws IOException {

--- a/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/SerializableJdoObjectPart.java
+++ b/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/SerializableJdoObjectPart.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.jindo;
+
+import com.aliyun.jindodata.api.spec.protos.JdoObjectPart;
+
+import java.io.Serializable;
+
+/** Serializable wrapper for JdoObjectPart. */
+public class SerializableJdoObjectPart implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final int partNum;
+    private final long size;
+    private final String eTag;
+
+    public SerializableJdoObjectPart(JdoObjectPart part) {
+        this.partNum = part.getPartNum();
+        this.size = part.getSize();
+        this.eTag = part.getETag();
+    }
+
+    public JdoObjectPart toJdoObjectPart() {
+        JdoObjectPart part = new JdoObjectPart();
+        part.setPartNum(this.partNum);
+        part.setSize(this.size);
+        part.setETag(this.eTag);
+        return part;
+    }
+
+    // Getters
+    public int getPartNum() {
+        return partNum;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public String getETag() {
+        return eTag;
+    }
+}

--- a/paimon-filesystems/paimon-jindo/src/test/java/org/apache/paimon/jindo/TestJindoMultiPartUploadCommitter.java
+++ b/paimon-filesystems/paimon-jindo/src/test/java/org/apache/paimon/jindo/TestJindoMultiPartUploadCommitter.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.jindo;
+
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.utils.InstantiationUtil;
+
+import com.aliyun.jindodata.api.spec.protos.JdoObjectPart;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for JindoMultiPartUploadCommitter. */
+public class TestJindoMultiPartUploadCommitter {
+
+    @Test
+    public void testSerializableJdoObjectPart() throws Exception {
+        // Test the SerializableJdoObjectPart wrapper directly
+        JdoObjectPart originalPart = new JdoObjectPart();
+        originalPart.setPartNum(5);
+        originalPart.setSize(2048L);
+        originalPart.setETag("test-etag-2");
+
+        SerializableJdoObjectPart wrapper = new SerializableJdoObjectPart(originalPart);
+
+        byte[] serialized = InstantiationUtil.serializeObject(wrapper);
+        SerializableJdoObjectPart deserialized =
+                InstantiationUtil.deserializeObject(serialized, getClass().getClassLoader());
+
+        assertThat(deserialized).isNotNull();
+        assertThat(deserialized.getPartNum()).isEqualTo(5);
+        assertThat(deserialized.getSize()).isEqualTo(2048L);
+        assertThat(deserialized.getETag()).isEqualTo("test-etag-2");
+
+        JdoObjectPart reconstructedPart = deserialized.toJdoObjectPart();
+        assertThat(reconstructedPart.getPartNum()).isEqualTo(5);
+        assertThat(reconstructedPart.getSize()).isEqualTo(2048L);
+        assertThat(reconstructedPart.getETag()).isEqualTo("test-etag-2");
+    }
+
+    @Test
+    public void testJindoMultiPartUploadCommitterSerialization() throws Exception {
+        String uploadId = "test-upload-id";
+        String objectName = "test-object-name";
+        long position = 1024L;
+        Path targetPath = new Path("/test/path/file.txt");
+        List<SerializableJdoObjectPart> uploadedParts = new ArrayList<>();
+        JdoObjectPart originalPart = new JdoObjectPart();
+        originalPart.setPartNum(5);
+        originalPart.setSize(2048L);
+        originalPart.setETag("test-etag-2");
+        uploadedParts.add(new SerializableJdoObjectPart(originalPart));
+
+        JindoMultiPartUploadCommitter committer =
+                new JindoMultiPartUploadCommitter(
+                        uploadId, uploadedParts, objectName, position, targetPath);
+
+        byte[] serialized = InstantiationUtil.serializeObject(committer);
+        JindoMultiPartUploadCommitter deserialized =
+                InstantiationUtil.deserializeObject(serialized, getClass().getClassLoader());
+
+        // Verify the deserialized object
+        assertThat(deserialized).isNotNull();
+        SerializableJdoObjectPart deserializedPart = deserialized.uploadedParts().get(0);
+        assertThat(deserializedPart.getPartNum()).isEqualTo(5);
+        assertThat(deserializedPart.getSize()).isEqualTo(2048L);
+        assertThat(deserializedPart.getETag()).isEqualTo("test-etag-2");
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

JdoObjectPart is not serializable

```
Caused by: org.apache.spark.SparkException: Job aborted due to stage failure: task 0.0 in stage 0.0 (TID 0) had a not serializable result: com.aliyun.jindodata.api.spec.protos.JdoObjectPart
Serialization stack:
	- object not serializable (class: com.aliyun.jindodata.api.spec.protos.JdoObjectPart, value: com.aliyun.jindodata.api.spec.protos.JdoObjectPart@7efd632)
	- writeObject data (class: java.util.ArrayList)
	- object (class java.util.ArrayList, [com.aliyun.jindodata.api.spec.protos.JdoObjectPart@7efd632])
	- field (class: org.apache.paimon.fs.BaseMultiPartUploadCommitter, name: uploadedParts, type: interface java.util.List)
	- object (class org.apache.paimon.jindo.JindoMultiPartUploadCommitter, org.apache.paimon.jindo.JindoMultiPartUploadCommitter@79aa3395)
	- field (class: org.apache.paimon.table.format.TwoPhaseCommitMessage, name: committer, type: interface org.apache.paimon.fs.TwoPhaseOutputStream$Committer)
	- object (class org.apache.paimon.table.format.TwoPhaseCommitMessage, org.apache.paimon.table.format.TwoPhaseCommitMessage@259631ac)
	- element of array (index: 0)
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
