### PR TITLE
[core] Introduce 'lookup.remote-file.level-threshold' to let high levels use remote only

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -718,6 +718,12 @@ Mainly to resolve data skew on primary keys. We recommend starting with 64 mb wh
             <td>Whether to enable the remote file for lookup.</td>
         </tr>
         <tr>
+            <td><h5>lookup.remote-file.level-threshold</h5></td>
+            <td style="word-wrap: break-word;">-2147483648</td>
+            <td>Integer</td>
+            <td>Level threshold of lookup to generate remote lookup files. Level files below this threshold will not generate remote lookup files.</td>
+        </tr>
+        <tr>
             <td><h5>manifest.compression</h5></td>
             <td style="word-wrap: break-word;">"zstd"</td>
             <td>String</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1185,6 +1185,14 @@ public class CoreOptions implements Serializable {
                     .defaultValue(false)
                     .withDescription("Whether to enable the remote file for lookup.");
 
+    public static final ConfigOption<Integer> LOOKUP_REMOTE_LEVEL_THRESHOLD =
+            key("lookup.remote-file.level-threshold")
+                    .intType()
+                    .defaultValue(Integer.MIN_VALUE)
+                    .withDescription(
+                            "Level threshold of lookup to generate remote lookup files. "
+                                    + "Level files below this threshold will not generate remote lookup files.");
+
     public static final ConfigOption<Integer> READ_BATCH_SIZE =
             key("read.batch-size")
                     .intType()
@@ -2503,6 +2511,10 @@ public class CoreOptions implements Serializable {
 
     public boolean lookupRemoteFileEnabled() {
         return options.get(LOOKUP_REMOTE_FILE_ENABLED);
+    }
+
+    public int lookupRemoteLevelThreshold() {
+        return options.get(LOOKUP_REMOTE_LEVEL_THRESHOLD);
     }
 
     public double lookupCacheHighPrioPoolRatio() {

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/RemoteLookupFileManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/RemoteLookupFileManager.java
@@ -49,6 +49,7 @@ public class RemoteLookupFileManager<T> implements RemoteFileDownloader {
     private final DataFilePathFactory pathFactory;
     private final TableSchema schema;
     private final LookupLevels<T> lookupLevels;
+    private final int levelThreshold;
     private final SchemaManager schemaManager;
     private final Map<Long, RowType> schemaRowTypes;
 
@@ -57,17 +58,23 @@ public class RemoteLookupFileManager<T> implements RemoteFileDownloader {
             DataFilePathFactory pathFactory,
             TableSchema schema,
             LookupLevels<T> lookupLevels,
-            SchemaManager schemaManager) {
+            SchemaManager schemaManager,
+            int levelThreshold) {
         this.fileIO = fileIO;
         this.pathFactory = pathFactory;
         this.schema = schema;
         this.lookupLevels = lookupLevels;
+        this.levelThreshold = levelThreshold;
         this.lookupLevels.setRemoteFileDownloader(this);
         this.schemaManager = schemaManager;
         this.schemaRowTypes = new HashMap<>();
     }
 
     public DataFileMeta genRemoteLookupFile(DataFileMeta file) throws IOException {
+        if (file.level() < levelThreshold) {
+            return file;
+        }
+
         String remoteSstName = lookupLevels.remoteSstName(file.fileName());
         if (file.extraFiles().contains(remoteSstName)) {
             // ignore existed

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -381,7 +381,8 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                                 keyReaderFactory.pathFactory(),
                                 keyReaderFactory.schema(),
                                 lookupLevels,
-                                schemaManager);
+                                schemaManager,
+                                options.lookupRemoteLevelThreshold());
             }
             return new LookupMergeTreeCompactRewriter(
                     maxLevel,


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
