### PR TITLE
[spark] Refactor PaimonScan hierarchy to support flexible runtime filtering implementations

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -48,7 +48,8 @@ case class PaimonScan(
     filters,
     reservedFilters,
     pushDownLimit,
-    pushDownTopN)
+    pushDownTopN,
+    bucketedScanDisabled)
   with SupportsRuntimeV2Filtering {
   def disableBucketedScan(): PaimonScan = {
     copy(bucketedScanDisabled = true)


### PR DESCRIPTION
### Purpose

- Created `PaimonScanCommon` abstract class to extract common functionality
- Moved `PaimonScan` to extend `PaimonScanCommon` 
- Implemented `SupportsRuntimeV2Filtering` in `PaimonScan`
- This refactoring allows other classes to extend `PaimonScanCommon` and implement `SupportsRuntimeFiltering` interface independently
- Improves code reusability and extensibility for different runtime filtering strategies

This change enables better inheritance structure where multiple scan implementations can share common logic while having their own runtime filtering behavior.

### Tests

CI
