### PR TITLE
[doc] Fix DELETE statement example in Spark SQL Write documentation

### DIFF
--- a/docs/content/spark/sql-write.md
+++ b/docs/content/spark/sql-write.md
@@ -170,7 +170,7 @@ UPDATE t SET s.c2 = 'a_new' WHERE s.c1 = 1;
 Deletes the rows that match a predicate. When no predicate is provided, deletes all rows.
 
 ```sql
-DELETE FROM my_table WHERE currency = 'UNKNOWN';
+DELETE FROM my_table WHERE id = 1;
 ```
 
 ## Merge Into Table


### PR DESCRIPTION
### Purpose

- Updated the DELETE FROM example to use appropriate WHERE condition
- Changed `WHERE currency = 'UNKNOWN'` to `WHERE id = 1` to match the table schema shown in the example
- This fix ensures the documentation example is executable
