### PR TITLE
[core] format table: fix multi part two-phase stream flush bug

### DIFF
--- a/paimon-common/src/test/java/org/apache/paimon/fs/MultiPartUploadTwoPhaseOutputStreamTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/MultiPartUploadTwoPhaseOutputStreamTest.java
@@ -144,7 +144,7 @@ class MultiPartUploadTwoPhaseOutputStreamTest {
         stream.flush();
         assertThat(store.getUploadedParts())
                 .extracting(TestPart::getContent)
-                .containsExactly("abcab", "cdefg", "hij");
+                .containsExactly("abcab", "cdefg");
         TwoPhaseOutputStream.Committer committer = stream.closeForCommit();
         assertThat(store.getUploadedParts()).hasSize(3);
 
@@ -155,6 +155,39 @@ class MultiPartUploadTwoPhaseOutputStreamTest {
         assertThat(store.getCompletedParts()).containsExactlyElementsOf(store.getUploadedParts());
         assertThat(store.getCompletedBytes()).isEqualTo(stream.getPos());
         assertThat(store.getAbortedUploadId()).isNull();
+    }
+
+    @Test
+    void testFlushWhenBufferSizeIsSmallerThanThresholdDoesNotUpload() throws IOException {
+        TestMultiPartUploadTwoPhaseOutputStream stream =
+                new TestMultiPartUploadTwoPhaseOutputStream(store, objectPath, 10);
+
+        // Write 3 bytes, which is less than the threshold of 10
+        stream.write("abc".getBytes(StandardCharsets.UTF_8));
+        assertThat(store.getUploadedParts()).isEmpty();
+
+        // Flush should not trigger upload since buffer size (3) < threshold (10)
+        stream.flush();
+        assertThat(store.getUploadedParts()).isEmpty();
+        assertThat(stream.getPos()).isEqualTo(3);
+
+        // Write another 4 bytes, total buffer size is 7, still less than threshold
+        stream.write("defg".getBytes(StandardCharsets.UTF_8));
+        assertThat(store.getUploadedParts()).isEmpty();
+
+        // Flush again, should still not upload since buffer size (7) < threshold (10)
+        stream.flush();
+        assertThat(store.getUploadedParts()).isEmpty();
+        assertThat(stream.getPos()).isEqualTo(7);
+
+        // Only when closeForCommit is called, the remaining buffer should be uploaded
+        TwoPhaseOutputStream.Committer committer = stream.closeForCommit();
+        assertThat(store.getUploadedParts()).hasSize(1);
+        assertThat(store.getUploadedParts().get(0).getContent()).isEqualTo("abcdefg");
+        assertThat(store.getUploadedParts().get(0).getPartNumber()).isEqualTo(1);
+
+        committer.commit(fileIO);
+        assertThat(store.getCompletedBytes()).isEqualTo(7);
     }
 
     /** Fake store implementation for testing. */


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
format table: fix multi part two-phase stream flush bug. For object store, only the last part could be less than the threshold.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
- MultiPartUploadTwoPhaseOutputStreamTest.testFlushWhenBufferSizeIsSmallerThanThresholdDoesNotUpload
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
