### PR TITLE
[core][spark] Introduce lastScannedSnapshotId in ScanMetrics

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -300,6 +300,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
             scanMetrics.reportScan(
                     new ScanStats(
                             scanDuration,
+                            snapshot == null ? 0 : snapshot.id(),
                             manifests.size(),
                             allDataFiles - result.size(),
                             result.size()));

--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanMetrics.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanMetrics.java
@@ -30,6 +30,7 @@ public class ScanMetrics {
     public static final String GROUP_NAME = "scan";
     public static final String LAST_SCAN_DURATION = "lastScanDuration";
     public static final String SCAN_DURATION = "scanDuration";
+    public static final String LAST_SCANNED_SNAPSHOT_ID = "lastScannedSnapshotId";
     public static final String LAST_SCANNED_MANIFESTS = "lastScannedManifests";
     public static final String LAST_SCAN_SKIPPED_TABLE_FILES = "lastScanSkippedTableFiles";
     public static final String LAST_SCAN_RESULTED_TABLE_FILES = "lastScanResultedTableFiles";
@@ -52,6 +53,9 @@ public class ScanMetrics {
         durationHistogram = metricGroup.histogram(SCAN_DURATION, HISTOGRAM_WINDOW_SIZE);
         cacheMetrics = new CacheMetrics();
         dvMetaCacheMetrics = new CacheMetrics();
+        metricGroup.gauge(
+                LAST_SCANNED_SNAPSHOT_ID,
+                () -> latestScan == null ? 0L : latestScan.getScannedSnapshotId());
         metricGroup.gauge(
                 LAST_SCANNED_MANIFESTS,
                 () -> latestScan == null ? 0L : latestScan.getScannedManifests());

--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanStats.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/ScanStats.java
@@ -24,17 +24,27 @@ import org.apache.paimon.annotation.VisibleForTesting;
 public class ScanStats {
     // the unit is milliseconds
     private final long duration;
+    private final long scannedSnapshotId;
     private final long scannedManifests;
-
     private final long skippedTableFiles;
     private final long resultedTableFiles;
 
     public ScanStats(
-            long duration, long scannedManifests, long skippedTableFiles, long resultedTableFiles) {
+            long duration,
+            long scannedSnapshotId,
+            long scannedManifests,
+            long skippedTableFiles,
+            long resultedTableFiles) {
         this.duration = duration;
+        this.scannedSnapshotId = scannedSnapshotId;
         this.scannedManifests = scannedManifests;
         this.skippedTableFiles = skippedTableFiles;
         this.resultedTableFiles = resultedTableFiles;
+    }
+
+    @VisibleForTesting
+    protected long getScannedSnapshotId() {
+        return scannedSnapshotId;
     }
 
     @VisibleForTesting

--- a/paimon-core/src/test/java/org/apache/paimon/operation/metrics/ScanMetricsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/metrics/ScanMetricsTest.java
@@ -46,6 +46,7 @@ public class ScanMetricsTest {
                 .containsExactlyInAnyOrder(
                         ScanMetrics.LAST_SCAN_DURATION,
                         ScanMetrics.SCAN_DURATION,
+                        ScanMetrics.LAST_SCANNED_SNAPSHOT_ID,
                         ScanMetrics.LAST_SCANNED_MANIFESTS,
                         ScanMetrics.LAST_SCAN_SKIPPED_TABLE_FILES,
                         ScanMetrics.LAST_SCAN_RESULTED_TABLE_FILES,
@@ -66,6 +67,8 @@ public class ScanMetricsTest {
                 (Gauge<Long>) registeredGenericMetrics.get(ScanMetrics.LAST_SCAN_DURATION);
         Histogram scanDuration =
                 (Histogram) registeredGenericMetrics.get(ScanMetrics.SCAN_DURATION);
+        Gauge<Long> lastScannedSnapshotId =
+                (Gauge<Long>) registeredGenericMetrics.get(ScanMetrics.LAST_SCANNED_SNAPSHOT_ID);
         Gauge<Long> lastScannedManifests =
                 (Gauge<Long>) registeredGenericMetrics.get(ScanMetrics.LAST_SCANNED_MANIFESTS);
         Gauge<Long> lastScanSkippedTableFiles =
@@ -76,6 +79,7 @@ public class ScanMetricsTest {
                         registeredGenericMetrics.get(ScanMetrics.LAST_SCAN_RESULTED_TABLE_FILES);
 
         assertThat(lastScanDuration.getValue()).isEqualTo(0);
+        assertThat(lastScannedSnapshotId.getValue()).isEqualTo(0);
         assertThat(scanDuration.getCount()).isEqualTo(0);
         assertThat(scanDuration.getStatistics().size()).isEqualTo(0);
         assertThat(lastScannedManifests.getValue()).isEqualTo(0);
@@ -88,6 +92,7 @@ public class ScanMetricsTest {
         // generic metrics value updated
         assertThat(lastScanDuration.getValue()).isEqualTo(200);
         assertThat(scanDuration.getCount()).isEqualTo(1);
+        assertThat(lastScannedSnapshotId.getValue()).isEqualTo(1);
         assertThat(scanDuration.getStatistics().size()).isEqualTo(1);
         assertThat(scanDuration.getStatistics().getValues()[0]).isEqualTo(200L);
         assertThat(scanDuration.getStatistics().getMin()).isEqualTo(200);
@@ -105,6 +110,7 @@ public class ScanMetricsTest {
         // generic metrics value updated
         assertThat(lastScanDuration.getValue()).isEqualTo(500);
         assertThat(scanDuration.getCount()).isEqualTo(2);
+        assertThat(lastScannedSnapshotId.getValue()).isEqualTo(2L);
         assertThat(scanDuration.getStatistics().size()).isEqualTo(2);
         assertThat(scanDuration.getStatistics().getValues()[1]).isEqualTo(500L);
         assertThat(scanDuration.getStatistics().getMin()).isEqualTo(200);
@@ -118,12 +124,12 @@ public class ScanMetricsTest {
     }
 
     private void reportOnce(ScanMetrics scanMetrics) {
-        ScanStats scanStats = new ScanStats(200, 20, 25, 10);
+        ScanStats scanStats = new ScanStats(200, 1L, 20, 25, 10);
         scanMetrics.reportScan(scanStats);
     }
 
     private void reportAgain(ScanMetrics scanMetrics) {
-        ScanStats scanStats = new ScanStats(500, 22, 30, 8);
+        ScanStats scanStats = new ScanStats(500, 2L, 22, 30, 8);
         scanMetrics.reportScan(scanStats);
     }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonMetrics.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonMetrics.scala
@@ -29,6 +29,7 @@ object PaimonMetrics {
   val SPLIT_SIZE = "splitSize"
   val AVG_SPLIT_SIZE = "avgSplitSize"
   val PLANNING_DURATION = "planningDuration"
+  val SCANNED_SNAPSHOT_ID = "scannedSnapshotId"
   val SCANNED_MANIFESTS = "scannedManifests"
   val SKIPPED_TABLE_FILES = "skippedTableFiles"
   val RESULTED_TABLE_FILES = "resultedTableFiles"
@@ -138,6 +139,15 @@ case class PaimonPlanningDurationMetric() extends PaimonSumMetric {
 
 case class PaimonPlanningDurationTaskMetric(value: Long) extends PaimonTaskMetric {
   override def name(): String = PaimonMetrics.PLANNING_DURATION
+}
+
+case class PaimonScannedSnapshotIdMetric() extends PaimonSumMetric {
+  override def name(): String = PaimonMetrics.SCANNED_SNAPSHOT_ID
+  override def description(): String = "scanned snapshot id"
+}
+
+case class PaimonScannedSnapshotIdTaskMetric(value: Long) extends PaimonTaskMetric {
+  override def name(): String = PaimonMetrics.SCANNED_SNAPSHOT_ID
 }
 
 case class PaimonScannedManifestsMetric() extends PaimonSumMetric {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/metric/SparkMetricRegistry.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/metric/SparkMetricRegistry.scala
@@ -46,6 +46,8 @@ case class SparkMetricRegistry() extends MetricRegistry {
         val metrics = group.getMetrics
         Array(
           PaimonPlanningDurationTaskMetric(gauge[Long](metrics, ScanMetrics.LAST_SCAN_DURATION)),
+          PaimonScannedSnapshotIdTaskMetric(
+            gauge[Long](metrics, ScanMetrics.LAST_SCANNED_SNAPSHOT_ID)),
           PaimonScannedManifestsTaskMetric(
             gauge[Long](metrics, ScanMetrics.LAST_SCANNED_MANIFESTS)),
           PaimonSkippedTableFilesTaskMetric(

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonMetricTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonMetricTest.scala
@@ -19,7 +19,7 @@
 package org.apache.paimon.spark.sql
 
 import org.apache.paimon.spark.{PaimonSparkTestBase, PaimonSplitScan}
-import org.apache.paimon.spark.PaimonMetrics.{RESULTED_TABLE_FILES, SKIPPED_TABLE_FILES}
+import org.apache.paimon.spark.PaimonMetrics.{RESULTED_TABLE_FILES, SCANNED_SNAPSHOT_ID, SKIPPED_TABLE_FILES}
 import org.apache.paimon.spark.util.ScanPlanHelper
 import org.apache.paimon.table.source.DataSplit
 
@@ -45,24 +45,29 @@ class PaimonMetricTest extends PaimonSparkTestBase with ScanPlanHelper {
       sql(s"INSERT INTO T VALUES (3, 'c', 'p2'), (4, 'c', 'p3')")
       sql(s"INSERT INTO T VALUES (5, 'd', 'p2')")
 
-      def checkMetrics(s: String, skippedTableFiles: Long, resultedTableFiles: Long): Unit = {
+      def checkMetrics(
+          s: String,
+          scannedSnapshotId: Long,
+          skippedTableFiles: Long,
+          resultedTableFiles: Long): Unit = {
         val scan = getPaimonScan(s)
         // call getInputPartitions to trigger scan
         scan.lazyInputPartitions
         val metrics = scan.reportDriverMetrics()
+        Assertions.assertEquals(scannedSnapshotId, metric(metrics, SCANNED_SNAPSHOT_ID))
         Assertions.assertEquals(skippedTableFiles, metric(metrics, SKIPPED_TABLE_FILES))
         Assertions.assertEquals(resultedTableFiles, metric(metrics, RESULTED_TABLE_FILES))
       }
 
-      checkMetrics(s"SELECT * FROM T", 0, 5)
-      checkMetrics(s"SELECT * FROM T WHERE pt = 'p2'", 2, 3)
+      checkMetrics(s"SELECT * FROM T", 3, 0, 5)
+      checkMetrics(s"SELECT * FROM T WHERE pt = 'p2'", 3, 2, 3)
 
       sql(s"DELETE FROM T WHERE pt = 'p1'")
-      checkMetrics(s"SELECT * FROM T", 0, 4)
+      checkMetrics(s"SELECT * FROM T", 4, 0, 4)
 
       sql("CALL sys.compact(table => 'T', partitions => 'pt=\"p2\"')")
-      checkMetrics(s"SELECT * FROM T", 0, 2)
-      checkMetrics(s"SELECT * FROM T WHERE pt = 'p2'", 1, 1)
+      checkMetrics(s"SELECT * FROM T", 5, 0, 2)
+      checkMetrics(s"SELECT * FROM T WHERE pt = 'p2'", 5, 1, 1)
     }
   }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

The description method is invoked heavily during Spark execution, and calling latestSnapshot or currentSnapshot inside it would cause severe performance degradation.

Introduce lastScannedSnapshotId in ScanMetrics

<img width="262" height="240" alt="image" src="https://github.com/user-attachments/assets/919bb047-554c-4fa9-8194-f33a8e137cd4" />


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
