### PR TITLE
[flink] Set forceStartFlinkJob default to true for CompactAction

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactAction.java
@@ -104,6 +104,7 @@ public class CompactAction extends TableActionBase {
             Map<String, String> catalogConfig,
             Map<String, String> tableConf) {
         super(database, tableName, catalogConfig);
+        this.forceStartFlinkJob = true;
         if (!(table instanceof FileStoreTable)) {
             throw new UnsupportedOperationException(
                     String.format(
@@ -245,7 +246,7 @@ public class CompactAction extends TableActionBase {
                         table.coreOptions().legacyPartitionName());
 
         long perSubtaskDataSize = table.coreOptions().clusteringPerTaskDataSize().getBytes();
-        LOGGER.info("{} is {} bytes.", CLUSTERING_PER_TASK_DATA_SIZE, perSubtaskDataSize);
+        LOGGER.info("{} is {} bytes.", CLUSTERING_PER_TASK_DATA_SIZE.key(), perSubtaskDataSize);
 
         // 1. pick cluster files for each partition
         Map<BinaryRow, CompactUnit> compactUnits =


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
If no partition needs to be incrementally clustered, we can forcibly start a flink job instead of throwing "java.lang.IllegalStateException: No operators defined in streaming topology. Cannot execute."

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
