### PR TITLE
[core] Let short streaming job execute partition expire

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/PartitionExpire.java
@@ -79,8 +79,9 @@ public class PartitionExpire {
         // Avoid the execution time of stream jobs from being too short and preventing partition
         // expiration
         long rndSeconds = 0;
-        if (!checkInterval.isZero()) {
-            rndSeconds = ThreadLocalRandom.current().nextLong(checkInterval.toMillis() / 1000);
+        long checkIntervalSeconds = checkInterval.toMillis() / 1000;
+        if (checkIntervalSeconds > 0) {
+            rndSeconds = ThreadLocalRandom.current().nextLong(checkIntervalSeconds);
         }
         this.lastCheck = LocalDateTime.now().minusSeconds(rndSeconds);
         this.endInputCheckPartitionExpire = endInputCheckPartitionExpire;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Avoid the execution time of stream jobs from being too short and preventing partition expiration.
<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
