### PR TITLE
[hive] Use latest schema when creating and updating Hive table

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitter.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitter.java
@@ -161,7 +161,7 @@ public class IcebergHiveMetadataCommitter implements IcebergMetadataCommitter {
 
         StorageDescriptor sd = hiveTable.getSd();
         sd.setCols(
-                table.schema().fields().stream()
+                table.copyWithLatestSchema().schema().fields().stream()
                         .map(this::convertToFieldSchema)
                         .collect(Collectors.toList()));
 
@@ -234,7 +234,7 @@ public class IcebergHiveMetadataCommitter implements IcebergMetadataCommitter {
         StorageDescriptor sd = hiveTable.getSd();
         sd.setLocation(metadataPath.getParent().getParent().toString());
         sd.setCols(
-                table.schema().fields().stream()
+                table.copyWithLatestSchema().schema().fields().stream()
                         .map(this::convertToFieldSchema)
                         .collect(Collectors.toList()));
         sd.setInputFormat("org.apache.hadoop.mapred.FileInputFormat");


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Linked issue: #6656 

<!-- What is the purpose of the change -->

When using AWS Glue client for Hive metastore, and added a new column to the source table, we noticed the new column was not added to the Glue table. This is similar to https://github.com/apache/paimon/pull/5701 but for the Hive metastore.