### PR TITLE
[cdc]Optimize SyncDatabaseActionBase:avoid blocking on listTables operation

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/SyncDatabaseActionBase.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.flink.action.cdc;
 
-import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.flink.action.Action;
 import org.apache.paimon.flink.action.MultiTablesSinkMode;
 import org.apache.paimon.flink.sink.TableFilter;
@@ -38,10 +37,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 import static org.apache.paimon.flink.action.MultiTablesSinkMode.COMBINED;
@@ -219,12 +216,6 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
                         tablePrefix,
                         tableSuffix,
                         tableMapping);
-        Set<String> createdTables;
-        try {
-            createdTables = new HashSet<>(catalog.listTables(database));
-        } catch (Catalog.DatabaseNotExistException e) {
-            throw new RuntimeException(e);
-        }
         return () ->
                 new RichCdcMultiplexRecordEventParser(
                         schemaBuilder,
@@ -232,8 +223,7 @@ public abstract class SyncDatabaseActionBase extends SynchronizationActionBase {
                         tblExcludingPattern,
                         dbIncludingPattern,
                         dbExcludingPattern,
-                        tableNameConverter,
-                        createdTables);
+                        tableNameConverter);
     }
 
     protected abstract boolean requirePrimaryKeys();

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcMultiplexRecordEventParser.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/RichCdcMultiplexRecordEventParser.java
@@ -50,8 +50,6 @@ public class RichCdcMultiplexRecordEventParser implements EventParser<RichCdcMul
     @Nullable private final Pattern dbIncludingPattern;
     @Nullable private final Pattern dbExcludingPattern;
     private final TableNameConverter tableNameConverter;
-    private final Set<String> createdTables;
-
     private final Map<String, RichEventParser> parsers = new HashMap<>();
     private final Set<String> includedTables = new HashSet<>();
     private final Set<String> excludedTables = new HashSet<>();
@@ -66,7 +64,7 @@ public class RichCdcMultiplexRecordEventParser implements EventParser<RichCdcMul
     private RichEventParser currentParser;
 
     public RichCdcMultiplexRecordEventParser(boolean caseSensitive) {
-        this(null, null, null, null, null, new TableNameConverter(caseSensitive), new HashSet<>());
+        this(null, null, null, null, null, new TableNameConverter(caseSensitive));
     }
 
     public RichCdcMultiplexRecordEventParser(
@@ -75,15 +73,13 @@ public class RichCdcMultiplexRecordEventParser implements EventParser<RichCdcMul
             @Nullable Pattern tblExcludingPattern,
             @Nullable Pattern dbIncludingPattern,
             @Nullable Pattern dbExcludingPattern,
-            TableNameConverter tableNameConverter,
-            Set<String> createdTables) {
+            TableNameConverter tableNameConverter) {
         this.schemaBuilder = schemaBuilder;
         this.tblIncludingPattern = tblIncludingPattern;
         this.tblExcludingPattern = tblExcludingPattern;
         this.dbIncludingPattern = dbIncludingPattern;
         this.dbExcludingPattern = dbExcludingPattern;
         this.tableNameConverter = tableNameConverter;
-        this.createdTables = createdTables;
     }
 
     @Override
@@ -201,8 +197,6 @@ public class RichCdcMultiplexRecordEventParser implements EventParser<RichCdcMul
     }
 
     private boolean shouldCreateCurrentTable() {
-        return shouldSynchronizeCurrentTable
-                && !record.cdcSchema().fields().isEmpty()
-                && createdTables.add(parseTableName());
+        return shouldSynchronizeCurrentTable && !record.cdcSchema().fields().isEmpty();
     }
 }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
@@ -524,7 +524,7 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
     }
 
     @Test
-    @Timeout(600)
+    @Timeout(2400)
     public void testCaseInsensitive() throws Exception {
         final String topic = "case-insensitive";
         createTestTopic(topic, 1, 1);

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaCanalSyncDatabaseActionITCase.java
@@ -524,7 +524,7 @@ public class KafkaCanalSyncDatabaseActionITCase extends KafkaActionITCaseBase {
     }
 
     @Test
-    @Timeout(60)
+    @Timeout(600)
     public void testCaseInsensitive() throws Exception {
         final String topic = "case-insensitive";
         createTestTopic(topic, 1, 1);

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaOggSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaOggSyncDatabaseActionITCase.java
@@ -73,7 +73,7 @@ public class KafkaOggSyncDatabaseActionITCase extends KafkaSyncDatabaseActionITC
     }
 
     @Test
-    @Timeout(600)
+    @Timeout(2400)
     public void testCaseInsensitive() throws Exception {
         testCaseInsensitive(OGG);
     }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaOggSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/kafka/KafkaOggSyncDatabaseActionITCase.java
@@ -73,7 +73,7 @@ public class KafkaOggSyncDatabaseActionITCase extends KafkaSyncDatabaseActionITC
     }
 
     @Test
-    @Timeout(60)
+    @Timeout(600)
     public void testCaseInsensitive() throws Exception {
         testCaseInsensitive(OGG);
     }

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionITCase.java
@@ -563,7 +563,7 @@ public class MySqlSyncDatabaseActionITCase extends MySqlActionITCaseBase {
     }
 
     @Test
-    @Timeout(600)
+    @Timeout(1200)
     public void testNewlyAddedTableSingleTable() throws Exception {
         testNewlyAddedTable(1, false, false, "paimon_sync_database_newly_added_tables_1");
     }


### PR DESCRIPTION
### Purpose
Linked issue: close #5955 

### What is the purpose of the change
Avoid blocking on listTables operation

### ChangeLog
remove SyncDatabaseActionBase.buildEventParserFactory() catalog.listTables(database). it will list all catalog tables, which will result in a lot of time consumption and cost
Consumes unnecessary memory to maintain the createdTables set
Performs redundant operations when tables are created lazily
### Tests
This optimization does not require additional test cases as the existing functionality is already covered by:
﻿
SyncDatabaseActionBaseTest.testSyncTablesWithoutDbLists() - validates table filtering logic
SyncDatabaseActionBaseTest.testSyncTablesWithDbList() - validates database filtering logic
SyncDatabaseActionBaseTest.testSycTablesCrossDB() - validates cross-database filtering scenarios
All these tests create and use RichCdcMultiplexRecordEventParser, ensuring the optimization doesn't break existing functionality.

When a table is lazily loaded, it will check for its existence, which will incur additional time consumption. Then waitJobRunning(client) method failure to obtain the Flink task status will result in test case errors. These test cases should add query timeout:
KafkaCanalSyncDatabaseActionITCase.testCaseInsensitive 
KafkaOggSyncDatabaseActionITCase.testCaseInsensitive 
MySqlSyncDatabaseActionITCase.testNewlyAddedTableSingleTable
