### PR TITLE
[spark] fix drop partition when partition value is null or empty string

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonIncompatiblePHRRules.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonIncompatiblePHRRules.scala
@@ -40,7 +40,10 @@ case class PaimonIncompatiblePHRRules(session: SparkSession) extends Rule[Logica
             val field = schema.find(f => resolver(f.name, name)).getOrElse {
               throw new RuntimeException(s"$name is not a valid partition column in $schema.")
             }
-            (name -> ident.get(index, field.dataType).toString)
+
+            val partVal: String =
+              if (ident.isNullAt(index)) null else ident.get(index, field.dataType).toString
+            (name -> partVal)
         }.toMap
         PaimonTruncateTableCommand(table, partitionSpec)
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DeleteFromPaimonTableCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DeleteFromPaimonTableCommand.scala
@@ -76,12 +76,11 @@ case class DeleteFromPaimonTableCommand(
       ) {
         val matchedPartitions =
           table.newSnapshotReader().withPartitionFilter(partitionPredicate.get).partitions().asScala
-        val rowDataPartitionComputer = new InternalRowPartitionComputer(
-          table.coreOptions().partitionDefaultName(),
+        val rowDataPartitionComputer = InternalRowPartitionComputer.preserveNullOrEmptyValue(
           table.schema().logicalPartitionType(),
           table.partitionKeys.asScala.toArray,
-          table.coreOptions().legacyPartitionName()
-        )
+          table.coreOptions().legacyPartitionName())
+
         val dropPartitions = matchedPartitions.map {
           partition => rowDataPartitionComputer.generatePartValues(partition).asScala.asJava
         }

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkWriteITCase.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkWriteITCase.java
@@ -480,6 +480,18 @@ public class SparkWriteITCase {
     }
 
     @Test
+    public void testTruncatePartitionValueNull() {
+        spark.sql("CREATE TABLE t (pt STRING, data STRING) PARTITIONED BY (pt) ");
+
+        spark.sql("INSERT INTO t VALUES('1', 'a'), (null, 'b')");
+
+        spark.sql("TRUNCATE TABLE T PARTITION (pt = null)");
+
+        List<Row> rows = spark.sql("SELECT * FROM T ORDER BY pt").collectAsList();
+        assertThat(rows.toString()).isEqualTo("[[1,a]]");
+    }
+
+    @Test
     public void testWriteDynamicBucketPartitionedTable() {
         spark.sql(
                 "CREATE TABLE T (a INT, b INT, c STRING) PARTITIONED BY (a) TBLPROPERTIES"

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkWriteITCase.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkWriteITCase.java
@@ -481,9 +481,9 @@ public class SparkWriteITCase {
 
     @Test
     public void testTruncatePartitionValueNull() {
-        spark.sql("CREATE TABLE t (pt STRING, data STRING) PARTITIONED BY (pt) ");
+        spark.sql("CREATE TABLE T (pt STRING, data STRING) PARTITIONED BY (pt) ");
 
-        spark.sql("INSERT INTO t VALUES('1', 'a'), (null, 'b')");
+        spark.sql("INSERT INTO T VALUES('1', 'a'), (null, 'b')");
 
         spark.sql("TRUNCATE TABLE T PARTITION (pt = null)");
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DeleteFromTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DeleteFromTableTestBase.scala
@@ -471,4 +471,17 @@ abstract class DeleteFromTableTestBase extends PaimonSparkTestBase {
       assert(latestSnapshot.commitKind.equals(Snapshot.CommitKind.COMPACT))
     }
   }
+
+  test("Paimon delete: partition value is empty or null") {
+    withTable("t") {
+      sql(s"CREATE TABLE t (pt STRING, data STRING) PARTITIONED BY (pt)")
+      sql("INSERT INTO t VALUES('', 'a'), (null, 'b'), ('3', 'c')")
+
+      sql("DELETE FROM t WHERE pt = ''")
+      checkAnswer(sql("SELECT * FROM t ORDER BY data"), Seq(Row(null, "b"), Row("3", "c")))
+
+      sql("DELETE FROM t WHERE pt IS NULL")
+      checkAnswer(sql("SELECT * FROM t ORDER BY data"), Seq(Row("3", "c")))
+    }
+  }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DeleteFromTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DeleteFromTableTestBase.scala
@@ -473,15 +473,15 @@ abstract class DeleteFromTableTestBase extends PaimonSparkTestBase {
   }
 
   test("Paimon delete: partition value is empty or null") {
-    withTable("t") {
-      sql(s"CREATE TABLE t (pt STRING, data STRING) PARTITIONED BY (pt)")
-      sql("INSERT INTO t VALUES('', 'a'), (null, 'b'), ('3', 'c')")
+    withTable("T") {
+      sql(s"CREATE TABLE T (pt STRING, data STRING) PARTITIONED BY (pt)")
+      sql("INSERT INTO T VALUES('', 'a'), (null, 'b'), ('3', 'c')")
 
-      sql("DELETE FROM t WHERE pt = ''")
-      checkAnswer(sql("SELECT * FROM t ORDER BY data"), Seq(Row(null, "b"), Row("3", "c")))
+      sql("DELETE FROM T WHERE pt = ''")
+      checkAnswer(sql("SELECT * FROM T ORDER BY data"), Seq(Row(null, "b"), Row("3", "c")))
 
-      sql("DELETE FROM t WHERE pt IS NULL")
-      checkAnswer(sql("SELECT * FROM t ORDER BY data"), Seq(Row("3", "c")))
+      sql("DELETE FROM T WHERE pt IS NULL")
+      checkAnswer(sql("SELECT * FROM T ORDER BY data"), Seq(Row("3", "c")))
     }
   }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonPartitionManagementTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonPartitionManagementTest.scala
@@ -221,12 +221,12 @@ class PaimonPartitionManagementTest extends PaimonSparkTestBase {
                  |PARTITIONED BY (pt)
                  |""".stripMargin)
 
-    sql("INSERT INTO t VALUES('', 'a'), (null, 'b'), ('3', 'c')")
+    sql("INSERT INTO T VALUES('', 'a'), (null, 'b'), ('3', 'c')")
 
-    sql("ALTER TABLE t DROP PARTITION (pt = '')")
-    checkAnswer(sql("SELECT * FROM t ORDER BY data"), Seq(Row(null, "b"), Row("3", "c")))
+    sql("ALTER TABLE T DROP PARTITION (pt = '')")
+    checkAnswer(sql("SELECT * FROM T ORDER BY data"), Seq(Row(null, "b"), Row("3", "c")))
 
-    sql("ALTER TABLE t DROP PARTITION (pt = null)")
-    checkAnswer(sql("SELECT * FROM t ORDER BY data"), Seq(Row("3", "c")))
+    sql("ALTER TABLE T DROP PARTITION (pt = null)")
+    checkAnswer(sql("SELECT * FROM T ORDER BY data"), Seq(Row("3", "c")))
   }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonPartitionManagementTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonPartitionManagementTest.scala
@@ -214,4 +214,19 @@ class PaimonPartitionManagementTest extends PaimonSparkTestBase {
       Row("dt=20240601") :: Nil
     )
   }
+
+  test("Paimon Partition Management: partition values are null or empty string") {
+    spark.sql(s"""
+                 |CREATE TABLE T (pt STRING, data STRING)
+                 |PARTITIONED BY (pt)
+                 |""".stripMargin)
+
+    sql("INSERT INTO t VALUES('', 'a'), (null, 'b'), ('3', 'c')")
+
+    sql("ALTER TABLE t DROP PARTITION (pt = '')")
+    checkAnswer(sql("SELECT * FROM t ORDER BY data"), Seq(Row(null, "b"), Row("3", "c")))
+
+    sql("ALTER TABLE t DROP PARTITION (pt = null)")
+    checkAnswer(sql("SELECT * FROM t ORDER BY data"), Seq(Row("3", "c")))
+  }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Currently, when using Spark to delete Paimon partitions, deletion fails or incorrectly removes mismatched data if the partition value is NULL or an empty string. This issue occurs across `ALTER TABLE ... DROP PARTITION`, `DELETE FROM`, and `TRUNCATE PARTITION`

**ALTER TABLE T DROP PARTITION and DELETE FROM**
Dropping a partition with partitionField = '' erroneously deletes data where partitionField = null.

The root cause is that during deletion, Spark SQL passes partition values that are replaced by `InternalRowPartitionComputer` with the default partition value. However, the actual partition filter should use the original (real) partition values for matching, because the manifest files store the real partition values—not the default ones.

This PR resolves the issue by preserving the original partition values (instead of replacing them with the default partition value) when computing partitions for data deletion: `InternalRowPartitionComputer preserveNullOrEmptyValue`



**TRUNCATE PARTITION**
Throws a NullPointerException (NPE) when the partition value is null.

Fixed by safely handling null values.


### Tests

Added in the PR.

### API and Format

No.

### Documentation

No.
