### PR TITLE
[spark] push down partition filter when compactUnAwareBucketTable

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -387,8 +387,12 @@ public class CompactProcedure extends BaseProcedure {
             compactionTasks = new ArrayList<>();
         }
         if (partitionIdleTime != null) {
+            SnapshotReader snapshotReader = table.newSnapshotReader();
+            if (partitionPredicate != null) {
+                snapshotReader.withPartitionFilter(partitionPredicate);
+            }
             Map<BinaryRow, Long> partitionInfo =
-                    table.newSnapshotReader().partitionEntries().stream()
+                    snapshotReader.partitionEntries().stream()
                             .collect(
                                     Collectors.toMap(
                                             PartitionEntry::partition,


### PR DESCRIPTION
### Purpose
push down partition filter to reduce partition merge during read `partitionEntries`

### Tests

Pass existing test `Paimon Procedure: compact unaware bucket append table with option`

### API and Format

No

### Documentation

No
