### PR TITLE
[core] Fix disk usage calculation in ExternalBuffer.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/disk/ExternalBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/ExternalBuffer.java
@@ -102,7 +102,8 @@ public class ExternalBuffer implements RowBuffer {
         }
     }
 
-    private long getDiskUsage() {
+    @VisibleForTesting
+    public long getDiskUsage() {
         long bytes = 0;
 
         for (ChannelWithMeta spillChannelID : spilledChannelIDs) {
@@ -164,7 +165,7 @@ public class ExternalBuffer implements RowBuffer {
             LOG.info(
                     "here spill the reset buffer data with {} records {} bytes",
                     inMemoryBuffer.size(),
-                    channelWriterOutputView.getNumBytes());
+                    channelWriterOutputView.getWriteBytes());
             channelWriterOutputView.close();
         } catch (IOException e) {
             channelWriterOutputView.closeAndDelete();
@@ -175,7 +176,7 @@ public class ExternalBuffer implements RowBuffer {
                 new ChannelWithMeta(
                         channel,
                         inMemoryBuffer.getNumRecordBuffers(),
-                        channelWriterOutputView.getNumBytes()));
+                        channelWriterOutputView.getWriteBytes()));
 
         inMemoryBuffer.reset();
     }

--- a/paimon-core/src/test/java/org/apache/paimon/disk/ExternalBufferTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/disk/ExternalBufferTest.java
@@ -32,7 +32,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -114,6 +116,20 @@ public class ExternalBufferTest {
         assertBuffer(expected, buffer);
         assertThat(buffer.getSpillChannels().size()).isGreaterThan(0);
         assertThat(buffer.flushMemory()).isFalse();
+
+        assertThat(buffer.getDiskUsage())
+                .isEqualTo(
+                        buffer.getSpillChannels().stream()
+                                .map(
+                                        c -> {
+                                            try {
+                                                return Files.size(
+                                                        Paths.get(c.getChannel().getPath()));
+                                            } catch (IOException e) {
+                                                throw new RuntimeException(e);
+                                            }
+                                        })
+                                .reduce(0L, Long::sum));
 
         // repeat read
         assertBuffer(expected, buffer);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #6679 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
