### PR TITLE
[spark] Fix Scala version resolution for paimon-spark-4.0_2.13 in Spark 4 profile

### DIFF
--- a/paimon-hive/paimon-hive-catalog/pom.xml
+++ b/paimon-hive/paimon-hive-catalog/pom.xml
@@ -52,7 +52,6 @@ under the License.
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-hive-common</artifactId>
             <version>${project.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/paimon-hive/paimon-hive-catalog/pom.xml
+++ b/paimon-hive/paimon-hive-catalog/pom.xml
@@ -52,6 +52,7 @@ under the License.
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-hive-common</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/paimon-spark/paimon-spark-4.0/pom.xml
+++ b/paimon-spark/paimon-spark-4.0/pom.xml
@@ -33,6 +33,7 @@ under the License.
 
     <properties>
         <spark.version>4.0.1</spark.version>
+        <scala.binary.version>2.13</scala.binary.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #6682

<!-- What is the purpose of the change -->
`paimon-spark-4.0_2.13` is intended for Spark 4 + Scala 2.13, but its POM currently inherits
`scala.binary.version` from `paimon-parent`. Since the default value in the parent is `2.12`,
Maven may resolve `_2.12` Spark / Paimon Spark artifacts for this module when the `spark4`
profile is not explicitly activated (both in external projects and when running `mvn clean install`
under `paimon-spark-4.0`).

This PR makes the Scala version for `paimon-spark-4.0_2.13` explicit and local to the module
### Tests

<!-- List UT and IT cases to verify this change -->
```
mvn -pl paimon-spark/paimon-spark-4.0_2.13 -DskipTests clean install
```

From an external Spark 4 + Scala 2.13 project that depends on
org.apache.paimon:paimon-spark-4.0_2.13, verified with:
```
mvn dependency:tree -Dincludes=org.apache.paimon:paimon-spark-4.0_2.13
```
that only _2.13 Spark / Paimon Spark artifacts are resolved and no _2.12 artifacts are pulled in.
### API and Format

<!-- Does this change affect API or storage format -->
No API changes.
No storage format changes.

### Documentation

<!-- Does this change introduce a new feature -->
None