### PR TITLE
[spark] paimon-spark supports row id push down

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -1038,6 +1038,12 @@ This config option does not affect the default filesystem metastore.</td>
             <td>Time field for record level expire. It supports the following types: `timestamps in seconds with INT`,`timestamps in seconds with BIGINT`, `timestamps in milliseconds with BIGINT` or `timestamp`.</td>
         </tr>
         <tr>
+            <td><h5>row-id-push-down.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to enable row id push down for scan. Currently, only the data evolution table supports row id push down.</td>
+        </tr>
+        <tr>
             <td><h5>row-tracking.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2146,6 +2146,14 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Whether to try upgrading the data files after overwriting a primary key table.");
 
+    public static final ConfigOption<Boolean> ROW_ID_PUSH_DOWN_ENABLED =
+            key("row-id-push-down.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to enable row id push down for scan."
+                                    + " Currently, only the data evolution table supports row id push down.");
+
     private final Options options;
 
     public CoreOptions(Map<String, String> options) {
@@ -3328,6 +3336,10 @@ public class CoreOptions implements Serializable {
 
     public boolean overwriteUpgrade() {
         return options.get(OVERWRITE_UPGRADE);
+    }
+
+    public boolean rowIdPushDownEnabled() {
+        return options.get(ROW_ID_PUSH_DOWN_ENABLED);
     }
 
     /** Specifies the merge engine for table with primary key. */

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/RowIdPredicateVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/RowIdPredicateVisitor.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.predicate;
+
+import org.apache.paimon.utils.Range;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.paimon.table.SpecialFields.ROW_ID;
+
+/**
+ * The {@link PredicateVisitor} to extract a list of row id ranges from predicates. The returned row
+ * id ranges can be pushed down to manifest readers and file readers to enable efficient random
+ * access.
+ *
+ * <p>Note that there is a significant distinction between returning {@code null} and returning an
+ * empty list:
+ *
+ * <ul>
+ *   <li>{@code null} indicates that the predicate cannot be converted into a random-access pattern,
+ *       meaning the filter is not consumable by this visitor.
+ *   <li>An empty list indicates that no rows satisfy the predicate (e.g. {@code WHERE _ROW_ID = 3
+ *       AND _ROW_ID IN (1, 2)}).
+ * </ul>
+ */
+public class RowIdPredicateVisitor implements PredicateVisitor<List<Range>> {
+
+    @Override
+    public List<Range> visit(LeafPredicate predicate) {
+        if (ROW_ID.name().equals(predicate.fieldName())) {
+            LeafFunction function = predicate.function();
+            if (function instanceof Equal || function instanceof In) {
+                ArrayList<Long> rowIds = new ArrayList<>();
+                for (Object literal : predicate.literals()) {
+                    rowIds.add((Long) literal);
+                }
+                // The list output by getRangesFromList is already sorted,
+                // and has no overlap
+                return Range.getRangesFromList(rowIds);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public List<Range> visit(CompoundPredicate predicate) {
+        CompoundPredicate.Function function = predicate.function();
+        List<Range> rowIds = null;
+        // `And` means we should get the intersection of all children.
+        if (function instanceof And) {
+            for (Predicate child : predicate.children()) {
+                List<Range> childList = child.visit(this);
+                if (childList == null) {
+                    continue;
+                }
+
+                if (rowIds == null) {
+                    rowIds = childList;
+                } else {
+                    rowIds = Range.and(rowIds, childList);
+                }
+
+                // shortcut for intersection
+                if (rowIds.isEmpty()) {
+                    return rowIds;
+                }
+            }
+        } else if (function instanceof Or) {
+            // `Or` means we should get the union of all children
+            rowIds = new ArrayList<>();
+            for (Predicate child : predicate.children()) {
+                List<Range> childList = child.visit(this);
+                if (childList == null) {
+                    return null;
+                }
+
+                rowIds.addAll(childList);
+                rowIds = Range.sortAndMergeOverlap(rowIds, true);
+            }
+        } else {
+            // unexpected function type, just return null
+            return null;
+        }
+        return rowIds;
+    }
+
+    @Override
+    public List<Range> visit(TransformPredicate predicate) {
+        // do not support transform predicate now.
+        return null;
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/Range.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/Range.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /** Range represents from (inclusive) and to (inclusive). */
 public class Range implements Serializable {
@@ -175,6 +176,34 @@ public class Range implements Serializable {
         result.add(current);
 
         return result;
+    }
+
+    public static List<Range> getRangesFromList(List<Long> origLongs) {
+        if (origLongs == null || origLongs.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Long> longs = origLongs.stream().distinct().sorted().collect(Collectors.toList());
+
+        ArrayList<Range> ranges = new ArrayList<>();
+        Long rangeStart = null;
+        Long rangeEnd = null;
+        for (Long cur : longs) {
+            if (rangeStart == null) {
+                rangeStart = cur;
+                rangeEnd = cur;
+            } else if (rangeEnd == cur - 1) {
+                rangeEnd = cur;
+            } else {
+                ranges.add(new Range(rangeStart, rangeEnd));
+                rangeStart = cur;
+                rangeEnd = cur;
+            }
+        }
+        if (rangeStart != null) {
+            ranges.add(new Range(rangeStart, rangeEnd));
+        }
+        return ranges;
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -653,6 +653,12 @@ public class SchemaValidation {
                     "Data evolution config must disabled with deletion-vectors.enabled");
         }
 
+        if (options.rowIdPushDownEnabled()) {
+            checkArgument(
+                    options.dataEvolutionEnabled(),
+                    "Row id push down config must enabled with data-evolution.enabled");
+        }
+
         List<String> blobNames =
                 BlobType.splitBlob(schema.logicalRowType()).getRight().getFieldNames();
         if (!blobNames.isEmpty()) {

--- a/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/sql/RowIdPushDownTest.scala
+++ b/paimon-spark/paimon-spark-3.2/src/test/scala/org/apache/paimon/spark/sql/RowIdPushDownTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+class RowIdPushDownTest extends RowIdPushDownTestBase {}

--- a/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/RowIdPushDownTest.scala
+++ b/paimon-spark/paimon-spark-3.3/src/test/scala/org/apache/paimon/spark/sql/RowIdPushDownTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+class RowIdPushDownTest extends RowIdPushDownTestBase {}

--- a/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/RowIdPushDownTest.scala
+++ b/paimon-spark/paimon-spark-3.4/src/test/scala/org/apache/paimon/spark/sql/RowIdPushDownTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+class RowIdPushDownTest extends RowIdPushDownTestBase {}

--- a/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/RowIdPushDownTest.scala
+++ b/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/RowIdPushDownTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+class RowIdPushDownTest extends RowIdPushDownTestBase {}

--- a/paimon-spark/paimon-spark-4.0/src/test/scala/org/apache/paimon/spark/sql/RowIdPushDownTest.scala
+++ b/paimon-spark/paimon-spark-4.0/src/test/scala/org/apache/paimon/spark/sql/RowIdPushDownTest.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+class RowIdPushDownTest extends RowIdPushDownTestBase {}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScanBuilder.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScanBuilder.scala
@@ -18,17 +18,19 @@
 
 package org.apache.paimon.spark
 
+import org.apache.paimon.CoreOptions
 import org.apache.paimon.partition.PartitionPredicate
 import org.apache.paimon.partition.PartitionPredicate.splitPartitionPredicatesAndDataPredicates
 import org.apache.paimon.predicate.{PartitionPredicateVisitor, Predicate, TopN}
-import org.apache.paimon.table.Table
-import org.apache.paimon.types.RowType
+import org.apache.paimon.table.{InnerTable, Table}
+import org.apache.paimon.table.SpecialFields.ROW_ID
+import org.apache.paimon.types.{DataField, DataTypes, RowType}
 
 import org.apache.spark.sql.connector.expressions.filter.{Predicate => SparkPredicate}
 import org.apache.spark.sql.connector.read.{SupportsPushDownLimit, SupportsPushDownRequiredColumns, SupportsPushDownV2Filters}
 import org.apache.spark.sql.types.StructType
 
-import java.util.{List => JList}
+import java.util.{ArrayList, List => JList}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -42,6 +44,7 @@ abstract class PaimonBaseScanBuilder
   val table: Table
   val partitionKeys: JList[String] = table.partitionKeys()
   val rowType: RowType = table.rowType()
+  val coreOptions: CoreOptions = CoreOptions.fromMap(table.options())
 
   private var pushedSparkPredicates = Array.empty[SparkPredicate]
   protected var hasPostScanPredicates = false
@@ -63,7 +66,14 @@ abstract class PaimonBaseScanBuilder
     val pushableDataFilters = mutable.ArrayBuffer.empty[Predicate]
     val postScan = mutable.ArrayBuffer.empty[SparkPredicate]
 
-    val converter = SparkV2FilterConverter(rowType)
+    var newRowType = rowType
+    if (table.isInstanceOf[InnerTable] && coreOptions.rowIdPushDownEnabled()) {
+      val dataFieldsWithRowId = new ArrayList[DataField](rowType.getFields)
+      dataFieldsWithRowId.add(
+        new DataField(rowType.getFieldCount, ROW_ID.name(), DataTypes.BIGINT()))
+      newRowType = rowType.copy(dataFieldsWithRowId)
+    }
+    val converter = SparkV2FilterConverter(newRowType)
     val partitionPredicateVisitor = new PartitionPredicateVisitor(partitionKeys)
     predicates.foreach {
       predicate =>

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowIdPushDownTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowIdPushDownTestBase.scala
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+import org.apache.paimon.spark.PaimonSparkTestBase
+import org.apache.paimon.table.source.ReadBuilderImpl
+import org.apache.paimon.utils.Range
+
+import org.apache.spark.sql.Row
+
+import scala.collection.JavaConverters._
+
+class RowIdPushDownTestBase extends PaimonSparkTestBase {
+
+  test("test paimon-spark row id push down") {
+    withTable("t") {
+      sql("CREATE TABLE t (a INT, b INT, c STRING) TBLPROPERTIES " +
+        "('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'row-id-push-down.enabled'='true')")
+      sql("INSERT INTO t VALUES (1, 1, '1'), (2, 2, '2'), (3, 3, '3'), (4, 4, '4')")
+
+      // 1.LeafPredicate
+      assertResult(Seq(new Range(0L, 0L)))(
+        getPaimonScan("SELECT * FROM t WHERE _ROW_ID = 0").readBuilder
+          .asInstanceOf[ReadBuilderImpl]
+          .rowRanges
+          .asScala)
+      checkAnswer(
+        sql("SELECT * FROM t WHERE _ROW_ID = 0"),
+        Seq(Row(1, 1, "1"))
+      )
+      assertResult(Seq(new Range(0L, 1L), new Range(3L, 3L)))(
+        getPaimonScan("SELECT * FROM t WHERE _ROW_ID IN (0, 1, 3)").readBuilder
+          .asInstanceOf[ReadBuilderImpl]
+          .rowRanges
+          .asScala)
+      checkAnswer(
+        sql("SELECT * FROM t WHERE _ROW_ID IN (0, 1, 3)"),
+        Seq(Row(1, 1, "1"), Row(2, 2, "2"), Row(4, 4, "4"))
+      )
+      assertResult(Seq(new Range(4L, 5L)))(
+        getPaimonScan("SELECT * FROM t WHERE _ROW_ID IN (4, 5)").readBuilder
+          .asInstanceOf[ReadBuilderImpl]
+          .rowRanges
+          .asScala)
+      checkAnswer(
+        sql("SELECT * FROM t WHERE _ROW_ID IN (4, 5)"),
+        Seq()
+      )
+
+      // 2.CompoundPredicate
+      assertResult(Seq(new Range(0, 0)))(
+        getPaimonScan("SELECT * FROM t WHERE _ROW_ID = 0 AND _ROW_ID IN (0, 1)").readBuilder
+          .asInstanceOf[ReadBuilderImpl]
+          .rowRanges
+          .asScala)
+      checkAnswer(
+        sql("SELECT * FROM t WHERE _ROW_ID = 0 AND _ROW_ID IN (0, 1)"),
+        Seq(Row(1, 1, "1"))
+      )
+      assertResult(Seq(new Range(0, 2)))(
+        getPaimonScan("SELECT * FROM t WHERE _ROW_ID = 0 OR _ROW_ID IN (1, 2)").readBuilder
+          .asInstanceOf[ReadBuilderImpl]
+          .rowRanges
+          .asScala)
+      checkAnswer(
+        sql("SELECT * FROM t WHERE _ROW_ID = 0 OR _ROW_ID IN (1, 2)"),
+        Seq(Row(1, 1, "1"), Row(2, 2, "2"), Row(3, 3, "3"))
+      )
+      assertResult(Seq())(
+        getPaimonScan("SELECT * FROM t WHERE _ROW_ID = 0 AND _ROW_ID IN (1, 2)").readBuilder
+          .asInstanceOf[ReadBuilderImpl]
+          .rowRanges
+          .asScala)
+      checkAnswer(
+        sql("SELECT * FROM t WHERE _ROW_ID = 0 AND _ROW_ID IN (1, 2)"),
+        Seq()
+      )
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

This PR is about to support row id push down for spark, following https://github.com/apache/paimon/pull/6483

Linked issue: None

### Tests

org.apache.paimon.spark.sql.RowIdPushDownTestBase

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
