### PR TITLE
[core] Exclude .class files from sources.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -341,6 +341,11 @@ under the License.
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
                         <version>3.2.1</version>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/*.class</exclude>
+                            </excludes>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>


### PR DESCRIPTION
### Purpose

Linked issue: close #6557

This PR fixes the issue where `.class` files were accidentally included in `sources.jar` during the 1.3.0 release. According to the [reproducible-central rebuild report](https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/paimon/README.md), the following 4 `.class` files were found in `paimon-core-1.3.0-sources.jar`:

- `org/apache/paimon/io/LRUCache$1.class`
- `org/apache/paimon/io/LRUCache$LRUList.class`
- `org/apache/paimon/io/LRUCache$Node.class`
- `org/apache/paimon/io/LRUCache.class`

This was caused by an unclean release manager environment. To prevent this from happening in future releases, this PR adds an `excludes` configuration to `maven-source-plugin` to exclude all `.class` files from `sources.jar`.

### Tests

- Manually verified that `.class` files placed in source directories are excluded from the generated `sources.jar`
- Verified that normal `.java` source files are still included in `sources.jar`
- Maven validation passed

### API and Format

No API or storage format changes.

### Documentation

No documentation changes needed.