### PR TITLE
[spark] Fix SparkCatalog converts catalog option keys to lower case

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -128,7 +128,8 @@ public class SparkCatalog extends SparkBaseCatalog
         this.catalogName = name;
         CatalogContext catalogContext =
                 CatalogContext.create(
-                        Options.fromMap(options), sparkSession.sessionState().newHadoopConf());
+                        Options.fromMap(options.asCaseSensitiveMap()),
+                        sparkSession.sessionState().newHadoopConf());
         this.catalog = CatalogFactory.createCatalog(catalogContext);
         this.defaultDatabase =
                 options.getOrDefault(DEFAULT_DATABASE.key(), DEFAULT_DATABASE.defaultValue());


### PR DESCRIPTION
### What is the purpose of the change

This PR fixes issue #6535. 

`SparkCatalog::initialize` accepts a `CaseInsensitiveStringMap` as the input and `Options.fromMap(options)` creates an `Options` with lower case keys. This causes problems when catalog options should be case sensitive. For example, the `jdbc.socketFactory` option will be passed to the PostgreSQL JDBC driver and the driver only recognizes `socketFactory`, not `socketfactory`.

### Brief change log

- Use `options.asCaseSensitiveMap()` instead of directly passing `options` to `Options.fromMap()` in `SparkCatalog.initialize()` method to preserve case-sensitive option keys.

### Verifying this change

This change is already covered by existing tests and is consistent with the pattern used in `SparkGenericCatalog.autoFillConfigurations()` method.

### Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API: no
- The schema: no
- The default values of configurations: no
- The wire protocol: no
- The REST API: no

### Documentation

- Does this pull request introduce a new feature? no