### PR TITLE
[core] Centralize partition statistics report in TableCommitImpl

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -57,6 +57,8 @@ import org.apache.paimon.utils.CatalogBranchManager;
 import org.apache.paimon.utils.ChangelogManager;
 import org.apache.paimon.utils.DVMetaCache;
 import org.apache.paimon.utils.FileSystemBranchManager;
+import org.apache.paimon.utils.InternalRowPartitionComputer;
+import org.apache.paimon.utils.PartitionStatisticsReporter;
 import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.SegmentsCache;
 import org.apache.paimon.utils.SimpleFileReader;
@@ -449,6 +451,13 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
     @Override
     public TableCommitImpl newCommit(String commitUser) {
         CoreOptions options = coreOptions();
+        InternalRowPartitionComputer partitionComputer =
+                new InternalRowPartitionComputer(
+                        options.partitionDefaultName(),
+                        schema().logicalPartitionType(),
+                        partitionKeys().toArray(new String[0]),
+                        options.legacyPartitionName());
+
         return new TableCommitImpl(
                 store().newCommit(commitUser, this),
                 newExpireRunnable(),
@@ -459,7 +468,25 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
                 options.snapshotExpireExecutionMode(),
                 name(),
                 options.forceCreatingSnapshot(),
-                options.fileOperationThreadNum());
+                options.fileOperationThreadNum(),
+                partitionStatisticsReporter(),
+                partitionComputer);
+    }
+
+    @Nullable
+    private PartitionStatisticsReporter partitionStatisticsReporter() {
+        CoreOptions options = coreOptions();
+        if (options.toConfiguration()
+                                .get(CoreOptions.PARTITION_IDLE_TIME_TO_REPORT_STATISTIC)
+                                .toMillis()
+                        <= 0
+                || partitionKeys().isEmpty()
+                || !options.partitionedTableInMetastore()
+                || catalogEnvironment().partitionHandler() == null) {
+            return null;
+        }
+
+        return new PartitionStatisticsReporter(this, catalogEnvironment().partitionHandler());
     }
 
     @Override


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Currently, the partition statistics report only enabled in spark writer. But for the compaction it will affect the partition statistics, especially for the partial-update. So this PR centralize partition statistics report in TableCommitImpl for the batch commit. 

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
