### PR TITLE
[variant] Extract only required columns when reading shredded variants

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/variant/VariantAccessInfo.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/variant/VariantAccessInfo.java
@@ -77,6 +77,10 @@ public class VariantAccessInfo implements Serializable {
             this.castArgs = castArgs;
         }
 
+        public VariantField(DataField dataField, String path) {
+            this(dataField, path, VariantCastArgs.defaultArgs());
+        }
+
         public DataField dataField() {
             return dataField;
         }

--- a/paimon-common/src/main/java/org/apache/paimon/data/variant/VariantCastArgs.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/variant/VariantCastArgs.java
@@ -20,6 +20,7 @@ package org.apache.paimon.data.variant;
 
 import java.io.Serializable;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 
 /** Several parameters used by `VariantGet.cast`. Packed together to simplify parameter passing. */
 public class VariantCastArgs implements Serializable {
@@ -40,6 +41,10 @@ public class VariantCastArgs implements Serializable {
 
     public ZoneId zoneId() {
         return zoneId;
+    }
+
+    public static VariantCastArgs defaultArgs() {
+        return new VariantCastArgs(true, ZoneOffset.UTC);
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetReaderUtil.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetReaderUtil.java
@@ -285,9 +285,14 @@ public class ParquetReaderUtil {
         if (type instanceof VariantType) {
             if (shreddingSchema != null) {
                 VariantType variantType = (VariantType) type;
+                DataType clippedParquetType =
+                        variantFields == null
+                                ? shreddingSchema
+                                : VariantAccessInfoUtils.clipVariantSchema(
+                                        shreddingSchema, variantFields);
                 ParquetGroupField parquetField =
                         (ParquetGroupField)
-                                constructField(dataField.newType(shreddingSchema), columnIO);
+                                constructField(dataField.newType(clippedParquetType), columnIO);
                 DataType readType =
                         variantFields == null
                                 ? variantType

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
@@ -18,13 +18,22 @@
 
 package org.apache.paimon.format.parquet;
 
+import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.data.variant.GenericVariant;
+import org.apache.paimon.data.variant.VariantAccessInfo;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.format.FileFormatFactory;
 import org.apache.paimon.format.FormatReadWriteTest;
+import org.apache.paimon.format.FormatReaderContext;
 import org.apache.paimon.format.FormatWriter;
+import org.apache.paimon.format.FormatWriterFactory;
 import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
@@ -34,11 +43,15 @@ import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** A parquet {@link FormatReadWriteTest}. */
 public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
@@ -87,5 +100,93 @@ public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
                 }
             }
         }
+    }
+
+    @Test
+    public void testReadShreddedVariant() throws Exception {
+        Options options = new Options();
+        options.set(
+                "parquet.variant.shreddingSchema",
+                "{\"type\":\"ROW\",\"fields\":[{\"name\":\"v\",\"type\":{\"type\":\"ROW\",\"fields\":[{\"name\":\"age\",\"type\":\"INT\"},{\"name\":\"city\",\"type\":\"STRING\"}]}}]}");
+        ParquetFileFormat format =
+                new ParquetFileFormat(new FileFormatFactory.FormatContext(options, 1024, 1024));
+
+        RowType writeType = DataTypes.ROW(DataTypes.FIELD(0, "v", DataTypes.VARIANT()));
+
+        FormatWriterFactory factory = format.createWriterFactory(writeType);
+        write(
+                factory,
+                file,
+                GenericRow.of(GenericVariant.fromJson("{\"age\":35,\"city\":\"Chicago\"}")),
+                GenericRow.of(GenericVariant.fromJson("{\"age\":25,\"other\":\"Hello\"}")));
+
+        // read without pruning
+        List<InternalRow> result1 = new ArrayList<>();
+        try (RecordReader<InternalRow> reader =
+                format.createReaderFactory(writeType, writeType, new ArrayList<>())
+                        .createReader(
+                                new FormatReaderContext(fileIO, file, fileIO.getFileSize(file)))) {
+            InternalRowSerializer serializer = new InternalRowSerializer(writeType);
+            reader.forEachRemaining(row -> result1.add(serializer.copy(row)));
+        }
+        assertThat(result1.get(0).getVariant(0).toJson())
+                .isEqualTo("{\"age\":35,\"city\":\"Chicago\"}");
+        assertThat(result1.get(1).getVariant(0).toJson())
+                .isEqualTo("{\"age\":25,\"other\":\"Hello\"}");
+
+        // read with typed col only
+        List<VariantAccessInfo.VariantField> variantFields2 = new ArrayList<>();
+        variantFields2.add(
+                new VariantAccessInfo.VariantField(
+                        new DataField(0, "age", DataTypes.INT()), "$.age"));
+        VariantAccessInfo[] variantAccess2 = {new VariantAccessInfo("v", variantFields2)};
+        RowType readStructType2 =
+                DataTypes.ROW(
+                        DataTypes.FIELD(
+                                0, "v", DataTypes.ROW(DataTypes.FIELD(0, "age", DataTypes.INT()))));
+        List<InternalRow> result2 = new ArrayList<>();
+        try (RecordReader<InternalRow> reader =
+                format.createReaderFactory(writeType, writeType, new ArrayList<>(), variantAccess2)
+                        .createReader(
+                                new FormatReaderContext(fileIO, file, fileIO.getFileSize(file)))) {
+            InternalRowSerializer serializer = new InternalRowSerializer(readStructType2);
+            reader.forEachRemaining(row -> result2.add(serializer.copy(row)));
+        }
+        assertThat(result2.get(0).equals(GenericRow.of(GenericRow.of(35)))).isTrue();
+        assertThat(result2.get(1).equals(GenericRow.of(GenericRow.of(25)))).isTrue();
+
+        // read with typed col and untyped col
+        List<VariantAccessInfo.VariantField> variantFields3 = new ArrayList<>();
+        variantFields3.add(
+                new VariantAccessInfo.VariantField(
+                        new DataField(0, "age", DataTypes.INT()), "$.age"));
+        variantFields3.add(
+                new VariantAccessInfo.VariantField(
+                        new DataField(1, "other", DataTypes.STRING()), "$.other"));
+        VariantAccessInfo[] variantAccess3 = {new VariantAccessInfo("v", variantFields3)};
+        RowType readStructType3 =
+                DataTypes.ROW(
+                        DataTypes.FIELD(
+                                0,
+                                "v",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD(0, "age", DataTypes.INT()),
+                                        DataTypes.FIELD(1, "other", DataTypes.STRING()))));
+        List<InternalRow> result3 = new ArrayList<>();
+        try (RecordReader<InternalRow> reader =
+                format.createReaderFactory(writeType, writeType, new ArrayList<>(), variantAccess3)
+                        .createReader(
+                                new FormatReaderContext(fileIO, file, fileIO.getFileSize(file)))) {
+            InternalRowSerializer serializer = new InternalRowSerializer(readStructType3);
+            reader.forEachRemaining(row -> result3.add(serializer.copy(row)));
+        }
+        assertThat(result3.get(0).equals(GenericRow.of(GenericRow.of(35, null)))).isTrue();
+        assertThat(
+                        result3.get(1)
+                                .equals(
+                                        GenericRow.of(
+                                                GenericRow.of(
+                                                        25, BinaryString.fromString("Hello")))))
+                .isTrue();
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Subtask of https://github.com/apache/paimon/issues/4471, we can read only the necessary fields when reading shredded variants

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
