### PR TITLE
[core] Append commit should check bucket number if latest commit user is different

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
@@ -36,6 +36,8 @@ public interface FileStoreCommit extends AutoCloseable {
 
     FileStoreCommit withPartitionExpire(PartitionExpire partitionExpire);
 
+    FileStoreCommit appendCommitCheckConflict(boolean appendCommitCheckConflict);
+
     /** Find out which committables need to be retried when recovering from the failure. */
     List<ManifestCommittable> filterCommitted(List<ManifestCommittable> committables);
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -154,6 +154,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
     private boolean ignoreEmptyCommit;
     private CommitMetrics commitMetrics;
+    private boolean appendCommitCheckConflict = false;
 
     public FileStoreCommitImpl(
             SnapshotCommit snapshotCommit,
@@ -247,6 +248,12 @@ public class FileStoreCommitImpl implements FileStoreCommit {
     }
 
     @Override
+    public FileStoreCommit appendCommitCheckConflict(boolean appendCommitCheckConflict) {
+        this.appendCommitCheckConflict = appendCommitCheckConflict;
+        return this;
+    }
+
+    @Override
     public List<ManifestCommittable> filterCommitted(List<ManifestCommittable> committables) {
         // nothing to filter, fast exit
         if (committables.isEmpty()) {
@@ -327,8 +334,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 if (containsFileDeletionOrDeletionVectors(appendSimpleEntries, appendIndexFiles)) {
                     commitKind = CommitKind.OVERWRITE;
                     conflictCheck = mustConflictCheck();
-                } else if (latestSnapshot != null
-                        && !latestSnapshot.commitUser().equals(commitUser)) {
+                } else if (latestSnapshot != null && appendCommitCheckConflict) {
                     conflictCheck = mustConflictCheck();
                 }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/BatchWriteBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/BatchWriteBuilderImpl.java
@@ -40,6 +40,7 @@ public class BatchWriteBuilderImpl implements BatchWriteBuilder {
     private final String commitUser;
 
     private Map<String, String> staticPartition;
+    private boolean appendCommitCheckConflict = false;
 
     public BatchWriteBuilderImpl(InnerTable table) {
         this.table = table;
@@ -81,7 +82,10 @@ public class BatchWriteBuilderImpl implements BatchWriteBuilder {
 
     @Override
     public BatchTableCommit newCommit() {
-        InnerTableCommit commit = table.newCommit(commitUser).withOverwrite(staticPartition);
+        InnerTableCommit commit =
+                table.newCommit(commitUser)
+                        .withOverwrite(staticPartition)
+                        .appendCommitCheckConflict(appendCommitCheckConflict);
         commit.ignoreEmptyCommit(
                 Options.fromMap(table.options())
                         .getOptional(CoreOptions.SNAPSHOT_IGNORE_EMPTY_COMMIT)
@@ -89,7 +93,12 @@ public class BatchWriteBuilderImpl implements BatchWriteBuilder {
         return commit;
     }
 
-    public BatchWriteBuilder copyWithNewTable(Table newTable) {
+    public BatchWriteBuilderImpl copyWithNewTable(Table newTable) {
         return new BatchWriteBuilderImpl((InnerTable) newTable, commitUser, staticPartition);
+    }
+
+    public BatchWriteBuilderImpl appendCommitCheckConflict(boolean appendCommitCheckConflict) {
+        this.appendCommitCheckConflict = appendCommitCheckConflict;
+        return this;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/InnerTableCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/InnerTableCommit.java
@@ -46,6 +46,8 @@ public interface InnerTableCommit extends StreamTableCommit, BatchTableCommit {
 
     InnerTableCommit expireForEmptyCommit(boolean expireForEmptyCommit);
 
+    InnerTableCommit appendCommitCheckConflict(boolean appendCommitCheckConflict);
+
     @Override
     InnerTableCommit withMetricRegistry(MetricRegistry registry);
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
@@ -159,6 +159,12 @@ public class TableCommitImpl implements InnerTableCommit {
     }
 
     @Override
+    public TableCommitImpl appendCommitCheckConflict(boolean appendCommitCheckConflict) {
+        commit.appendCommitCheckConflict(appendCommitCheckConflict);
+        return this;
+    }
+
+    @Override
     public InnerTableCommit withMetricRegistry(MetricRegistry registry) {
         commit.withMetrics(new CommitMetrics(registry, tableName));
         return this;

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -410,6 +410,8 @@ case class PaimonSparkWriter(
       writeBuilder
         .asInstanceOf[BatchWriteBuilderImpl]
         .copyWithNewTable(PostponeUtils.tableForCommit(table))
+        // Need to check conflict
+        .appendCommitCheckConflict(true)
     } else {
       writeBuilder
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

The case is, if user1 batch write the postpone table T, and user2 compact and rescale T. If they start the job at the same time and user2 commits first, the user1's append commit should also be checked because the bucket number might be changed.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
