### PR TITLE
[docs] Add missing PaimonSparkSessionExtensions to Spark configs

### DIFF
--- a/docs/content/maintenance/filesystems.md
+++ b/docs/content/maintenance/filesystems.md
@@ -242,9 +242,9 @@ Place `paimon-oss-{{< version >}}.jar` together with `paimon-spark-{{< version >
 
 ```shell
 spark-sql \
+  --conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions \
   --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
   --conf spark.sql.catalog.paimon.warehouse=oss://<bucket>/<path> \
-  --conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions \
   --conf spark.sql.catalog.paimon.fs.oss.endpoint=oss-cn-hangzhou.aliyuncs.com \
   --conf spark.sql.catalog.paimon.fs.oss.accessKeyId=xxx \
   --conf spark.sql.catalog.paimon.fs.oss.accessKeySecret=yyy
@@ -345,9 +345,9 @@ Place `paimon-s3-{{< version >}}.jar` together with `paimon-spark-{{< version >}
 
 ```shell
 spark-sql \
+  --conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions \
   --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
   --conf spark.sql.catalog.paimon.warehouse=s3://<bucket>/<path> \
-  --conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions \
   --conf spark.sql.catalog.paimon.s3.endpoint=your-endpoint-hostname \
   --conf spark.sql.catalog.paimon.s3.access-key=xxx \
   --conf spark.sql.catalog.paimon.s3.secret-key=yyy
@@ -500,9 +500,9 @@ Place `paimon-azure-{{< version >}}.jar` together with `paimon-spark-{{< version
 
 ```shell
 spark-sql \
+  --conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions \
   --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
   --conf spark.sql.catalog.paimon.warehouse=wasb://,<container>@<account>.blob.core.windows.net/<path> \
-  --conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions \
   --conf fs.azure.account.key.Account.blob.core.windows.net=yyy \
 ```
 
@@ -557,9 +557,9 @@ Place `paimon-obs-{{< version >}}.jar` together with `paimon-spark-{{< version >
 
 ```shell
 spark-sql \
+  --conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions \
   --conf spark.sql.catalog.paimon=org.apache.paimon.spark.SparkCatalog \
   --conf spark.sql.catalog.paimon.warehouse=obs://<bucket>/<path> \
-  --conf spark.sql.extensions=org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions \
   --conf spark.sql.catalog.paimon.fs.obs.endpoint=obs-endpoint-hostname \
   --conf spark.sql.catalog.paimon.fs.obs.access.key=xxx \
   --conf spark.sql.catalog.paimon.fs.obs.secret.key=yyy


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Add missing PaimonSparkSessionExtensions to Spark configs

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

<!-- Does this change affect API or storage format -->

### Documentation

docs/content/maintenance/filesystems.md

<!-- Does this change introduce a new feature -->
