### PR TITLE
[python/rest] support dlf.oss-endpoint override endpoint in rest_token_file_io

### DIFF
--- a/paimon-python/pypaimon/catalog/rest/rest_token_file_io.py
+++ b/paimon-python/pypaimon/catalog/rest/rest_token_file_io.py
@@ -24,6 +24,7 @@ from pyarrow._fs import FileSystem
 
 from pypaimon.api.rest_api import RESTApi
 from pypaimon.catalog.rest.rest_token import RESTToken
+from pypaimon.common.config import CatalogOptions, OssOptions
 from pypaimon.common.file_io import FileIO
 from pypaimon.common.identifier import Identifier
 
@@ -57,8 +58,17 @@ class RESTTokenFileIO(FileIO):
 
     def _initialize_oss_fs(self, path) -> FileSystem:
         self.try_to_refresh_token()
-        self.properties.update(self.token.token)
+        merged_token = self._merge_token_with_catalog_options(self.token.token)
+        self.properties.update(merged_token)
         return super()._initialize_oss_fs(path)
+
+    def _merge_token_with_catalog_options(self, token: dict) -> dict:
+        """Merge token with catalog options, DLF OSS endpoint should override the standard OSS endpoint."""
+        merged_token = dict(token)
+        dlf_oss_endpoint = self.properties.get(CatalogOptions.DLF_OSS_ENDPOINT)
+        if dlf_oss_endpoint and dlf_oss_endpoint.strip():
+            merged_token[OssOptions.OSS_ENDPOINT] = dlf_oss_endpoint
+        return merged_token
 
     def new_output_stream(self, path: str):
         # Call parent class method to ensure path conversion and parent directory creation

--- a/paimon-python/pypaimon/common/config.py
+++ b/paimon-python/pypaimon/common/config.py
@@ -45,6 +45,7 @@ class CatalogOptions:
     DLF_TOKEN_LOADER = "dlf.token-loader"
     DLF_TOKEN_ECS_ROLE_NAME = "dlf.token-ecs-role-name"
     DLF_TOKEN_ECS_METADATA_URL = "dlf.token-ecs-metadata-url"
+    DLF_OSS_ENDPOINT = "dlf.oss-endpoint"
     PREFIX = 'prefix'
     HTTP_USER_AGENT_HEADER = 'header.HTTP_USER_AGENT'
     BLOB_FILE_IO_DEFAULT_CACHE_SIZE = 2**31 - 1


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
support dlf.oss-endpoint override endpoint in rest_token_file_io which follows rest token file io behivour in java
<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
