### PR TITLE
[core] Extract an SST File Format from LookupStore.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/io/cache/CacheKey.java
+++ b/paimon-common/src/main/java/org/apache/paimon/io/cache/CacheKey.java
@@ -18,14 +18,16 @@
 
 package org.apache.paimon.io.cache;
 
+import org.apache.paimon.fs.Path;
+
 import java.io.RandomAccessFile;
 import java.util.Objects;
 
 /** Key for cache manager. */
 public interface CacheKey {
 
-    static CacheKey forPosition(RandomAccessFile file, long position, int length, boolean isIndex) {
-        return new PositionCacheKey(file, position, length, isIndex);
+    static CacheKey forPosition(Path filePath, long position, int length, boolean isIndex) {
+        return new PositionCacheKey(filePath, position, length, isIndex);
     }
 
     static CacheKey forPageIndex(RandomAccessFile file, int pageSize, int pageIndex) {
@@ -35,17 +37,16 @@ public interface CacheKey {
     /** @return Whether this cache key is for index cache. */
     boolean isIndex();
 
-    /** Key for file position and length. */
+    /** Key for file position of a file path (could be remote) and length. */
     class PositionCacheKey implements CacheKey {
 
-        private final RandomAccessFile file;
+        private final Path filePath;
         private final long position;
         private final int length;
         private final boolean isIndex;
 
-        private PositionCacheKey(
-                RandomAccessFile file, long position, int length, boolean isIndex) {
-            this.file = file;
+        private PositionCacheKey(Path filePath, long position, int length, boolean isIndex) {
+            this.filePath = filePath;
             this.position = position;
             this.length = length;
             this.isIndex = isIndex;
@@ -63,12 +64,12 @@ public interface CacheKey {
             return position == that.position
                     && length == that.length
                     && isIndex == that.isIndex
-                    && Objects.equals(file, that.file);
+                    && Objects.equals(filePath, that.filePath);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(file, position, length, isIndex);
+            return Objects.hash(filePath, position, length, isIndex);
         }
 
         @Override

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/sort/SortLookupStoreFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/sort/SortLookupStoreFactory.java
@@ -52,7 +52,7 @@ public class SortLookupStoreFactory implements LookupStoreFactory {
 
     @Override
     public SortLookupStoreReader createReader(File file) throws IOException {
-        return new SortLookupStoreReader(comparator, file, blockSize, cacheManager);
+        return new SortLookupStoreReader(comparator, file, cacheManager);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/sort/SortLookupStoreReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/sort/SortLookupStoreReader.java
@@ -18,16 +18,14 @@
 
 package org.apache.paimon.lookup.sort;
 
-import org.apache.paimon.compression.BlockCompressionFactory;
-import org.apache.paimon.compression.BlockDecompressor;
-import org.apache.paimon.io.PageFileInput;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.io.cache.CacheManager;
 import org.apache.paimon.lookup.LookupStoreReader;
-import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.memory.MemorySlice;
-import org.apache.paimon.memory.MemorySliceInput;
-import org.apache.paimon.utils.FileBasedBloomFilter;
-import org.apache.paimon.utils.MurmurHashUtils;
+import org.apache.paimon.sst.SstFileReader;
 
 import javax.annotation.Nullable;
 
@@ -35,142 +33,34 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Comparator;
 
-import static org.apache.paimon.lookup.sort.SortLookupStoreUtils.crc32c;
-import static org.apache.paimon.utils.Preconditions.checkArgument;
-
-/** A {@link LookupStoreReader} for sort store. */
+/** A {@link LookupStoreReader} backed by an {@link SstFileReader}. */
 public class SortLookupStoreReader implements LookupStoreReader {
 
-    private final Comparator<MemorySlice> comparator;
-    private final String filePath;
-    private final long fileSize;
-
-    private final BlockIterator indexBlockIterator;
-    @Nullable private FileBasedBloomFilter bloomFilter;
-    private final BlockCache blockCache;
-    private final PageFileInput fileInput;
+    private final FileIO fileIO;
+    private final SeekableInputStream input;
+    private final SstFileReader sstFileReader;
 
     public SortLookupStoreReader(
-            Comparator<MemorySlice> comparator, File file, int blockSize, CacheManager cacheManager)
+            Comparator<MemorySlice> comparator, File file, CacheManager cacheManager)
             throws IOException {
-        this.comparator = comparator;
-        this.filePath = file.getAbsolutePath();
-        this.fileSize = file.length();
-
-        this.fileInput = PageFileInput.create(file, blockSize, null, fileSize, null);
-        this.blockCache = new BlockCache(fileInput.file(), cacheManager);
-        Footer footer = readFooter();
-        this.indexBlockIterator = readBlock(footer.getIndexBlockHandle(), true).iterator();
-        BloomFilterHandle handle = footer.getBloomFilterHandle();
-        if (handle != null) {
-            this.bloomFilter =
-                    new FileBasedBloomFilter(
-                            fileInput,
-                            cacheManager,
-                            handle.expectedEntries(),
-                            handle.offset(),
-                            handle.size());
-        }
-    }
-
-    private Footer readFooter() throws IOException {
-        MemorySegment footerData =
-                blockCache.getBlock(
-                        fileSize - Footer.ENCODED_LENGTH, Footer.ENCODED_LENGTH, b -> b, true);
-        return Footer.readFooter(MemorySlice.wrap(footerData).toInput());
+        final Path filePath = new Path(file.getAbsolutePath());
+        this.fileIO = LocalFileIO.create();
+        this.input = fileIO.newInputStream(filePath);
+        this.sstFileReader =
+                new SstFileReader(comparator, file.length(), filePath, input, cacheManager);
     }
 
     @Nullable
     @Override
     public byte[] lookup(byte[] key) throws IOException {
-        if (bloomFilter != null && !bloomFilter.testHash(MurmurHashUtils.hashBytes(key))) {
-            return null;
-        }
-
-        MemorySlice keySlice = MemorySlice.wrap(key);
-        // seek the index to the block containing the key
-        indexBlockIterator.seekTo(keySlice);
-
-        // if indexIterator does not have a next, it means the key does not exist in this iterator
-        if (indexBlockIterator.hasNext()) {
-            // seek the current iterator to the key
-            BlockIterator current = getNextBlock();
-            if (current.seekTo(keySlice)) {
-                return current.next().getValue().copyBytes();
-            }
-        }
-        return null;
-    }
-
-    private BlockIterator getNextBlock() {
-        // index block handle, point to the key, value position.
-        MemorySlice blockHandle = indexBlockIterator.next().getValue();
-        BlockReader dataBlock =
-                readBlock(BlockHandle.readBlockHandle(blockHandle.toInput()), false);
-        return dataBlock.iterator();
-    }
-
-    /**
-     * @param blockHandle The block handle.
-     * @param index Whether read the block as an index.
-     * @return The reader of the target block.
-     */
-    private BlockReader readBlock(BlockHandle blockHandle, boolean index) {
-        // read block trailer
-        MemorySegment trailerData =
-                blockCache.getBlock(
-                        blockHandle.offset() + blockHandle.size(),
-                        BlockTrailer.ENCODED_LENGTH,
-                        b -> b,
-                        true);
-        BlockTrailer blockTrailer =
-                BlockTrailer.readBlockTrailer(MemorySlice.wrap(trailerData).toInput());
-
-        MemorySegment unCompressedBlock =
-                blockCache.getBlock(
-                        blockHandle.offset(),
-                        blockHandle.size(),
-                        bytes -> decompressBlock(bytes, blockTrailer),
-                        index);
-        return new BlockReader(MemorySlice.wrap(unCompressedBlock), comparator);
-    }
-
-    private byte[] decompressBlock(byte[] compressedBytes, BlockTrailer blockTrailer) {
-        MemorySegment compressed = MemorySegment.wrap(compressedBytes);
-        int crc32cCode = crc32c(compressed, blockTrailer.getCompressionType());
-        checkArgument(
-                blockTrailer.getCrc32c() == crc32cCode,
-                String.format(
-                        "Expected CRC32C(%d) but found CRC32C(%d) for file(%s)",
-                        blockTrailer.getCrc32c(), crc32cCode, filePath));
-
-        // decompress data
-        BlockCompressionFactory compressionFactory =
-                BlockCompressionFactory.create(blockTrailer.getCompressionType());
-        if (compressionFactory == null) {
-            return compressedBytes;
-        } else {
-            MemorySliceInput compressedInput = MemorySlice.wrap(compressed).toInput();
-            byte[] uncompressed = new byte[compressedInput.readVarLenInt()];
-            BlockDecompressor decompressor = compressionFactory.getDecompressor();
-            int uncompressedLength =
-                    decompressor.decompress(
-                            compressed.getHeapMemory(),
-                            compressedInput.position(),
-                            compressedInput.available(),
-                            uncompressed,
-                            0);
-            checkArgument(uncompressedLength == uncompressed.length);
-            return uncompressed;
-        }
+        return sstFileReader.lookup(key);
     }
 
     @Override
     public void close() throws IOException {
-        if (bloomFilter != null) {
-            bloomFilter.close();
-        }
-        blockCache.close();
-        fileInput.close();
+        // be careful about the close order
+        sstFileReader.close();
+        input.close();
+        fileIO.close();
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/lookup/sort/SortLookupStoreWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/sort/SortLookupStoreWriter.java
@@ -19,185 +19,46 @@
 package org.apache.paimon.lookup.sort;
 
 import org.apache.paimon.compression.BlockCompressionFactory;
-import org.apache.paimon.compression.BlockCompressionType;
-import org.apache.paimon.compression.BlockCompressor;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.lookup.LookupStoreWriter;
-import org.apache.paimon.memory.MemorySegment;
-import org.apache.paimon.memory.MemorySlice;
-import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.sst.SstFileWriter;
 import org.apache.paimon.utils.BloomFilter;
-import org.apache.paimon.utils.MurmurHashUtils;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 
-import static org.apache.paimon.lookup.sort.BlockHandle.writeBlockHandle;
-import static org.apache.paimon.lookup.sort.SortLookupStoreUtils.crc32c;
-import static org.apache.paimon.memory.MemorySegmentUtils.allocateReuseBytes;
-import static org.apache.paimon.utils.VarLengthIntUtils.encodeInt;
-
-/** A {@link LookupStoreWriter} for sorting. */
+/** A {@link LookupStoreWriter} backed by an {@link SstFileWriter}. */
 public class SortLookupStoreWriter implements LookupStoreWriter {
+    private final SstFileWriter sstFileWriter;
+    private final FileIO fileIO;
+    private final PositionOutputStream out;
 
-    private static final Logger LOG =
-            LoggerFactory.getLogger(SortLookupStoreWriter.class.getName());
-
-    public static final int MAGIC_NUMBER = 1481571681;
-
-    private final BufferedOutputStream fileOutputStream;
-    private final int blockSize;
-    private final BlockWriter dataBlockWriter;
-    private final BlockWriter indexBlockWriter;
-    @Nullable private final BloomFilter.Builder bloomFilter;
-    private final BlockCompressionType compressionType;
-    @Nullable private final BlockCompressor blockCompressor;
-
-    private byte[] lastKey;
-    private long position;
-
-    private long recordCount;
-    private long totalUncompressedSize;
-    private long totalCompressedSize;
-
-    SortLookupStoreWriter(
+    public SortLookupStoreWriter(
             File file,
             int blockSize,
             @Nullable BloomFilter.Builder bloomFilter,
-            @Nullable BlockCompressionFactory compressionFactory)
+            BlockCompressionFactory compressionFactory)
             throws IOException {
-        this.fileOutputStream = new BufferedOutputStream(Files.newOutputStream(file.toPath()));
-        this.blockSize = blockSize;
-        this.dataBlockWriter = new BlockWriter((int) (blockSize * 1.1));
-        int expectedNumberOfBlocks = 1024;
-        this.indexBlockWriter =
-                new BlockWriter(BlockHandle.MAX_ENCODED_LENGTH * expectedNumberOfBlocks);
-        this.bloomFilter = bloomFilter;
-        if (compressionFactory == null) {
-            this.compressionType = BlockCompressionType.NONE;
-            this.blockCompressor = null;
-        } else {
-            this.compressionType = compressionFactory.getCompressionType();
-            this.blockCompressor = compressionFactory.getCompressor();
-        }
+        final Path filePath = new Path(file.getAbsolutePath());
+        this.fileIO = LocalFileIO.create();
+        this.out = fileIO.newOutputStream(filePath, true);
+        this.sstFileWriter = new SstFileWriter(out, blockSize, bloomFilter, compressionFactory);
     }
 
     @Override
     public void put(byte[] key, byte[] value) throws IOException {
-        dataBlockWriter.add(key, value);
-        if (bloomFilter != null) {
-            bloomFilter.addHash(MurmurHashUtils.hashBytes(key));
-        }
-
-        lastKey = key;
-
-        if (dataBlockWriter.memory() > blockSize) {
-            flush();
-        }
-
-        recordCount++;
-    }
-
-    private void flush() throws IOException {
-        if (dataBlockWriter.size() == 0) {
-            return;
-        }
-
-        BlockHandle blockHandle = writeBlock(dataBlockWriter);
-        MemorySlice handleEncoding = writeBlockHandle(blockHandle);
-        indexBlockWriter.add(lastKey, handleEncoding.copyBytes());
-    }
-
-    private BlockHandle writeBlock(BlockWriter blockWriter) throws IOException {
-        // close the block
-        MemorySlice block = blockWriter.finish();
-
-        totalUncompressedSize += block.length();
-
-        // attempt to compress the block
-        BlockCompressionType blockCompressionType = BlockCompressionType.NONE;
-        if (blockCompressor != null) {
-            int maxCompressedSize = blockCompressor.getMaxCompressedSize(block.length());
-            byte[] compressed = allocateReuseBytes(maxCompressedSize + 5);
-            int offset = encodeInt(compressed, 0, block.length());
-            int compressedSize =
-                    offset
-                            + blockCompressor.compress(
-                                    block.getHeapMemory(),
-                                    block.offset(),
-                                    block.length(),
-                                    compressed,
-                                    offset);
-
-            // Don't use the compressed data if compressed less than 12.5%,
-            if (compressedSize < block.length() - (block.length() / 8)) {
-                block = new MemorySlice(MemorySegment.wrap(compressed), 0, compressedSize);
-                blockCompressionType = this.compressionType;
-            }
-        }
-
-        totalCompressedSize += block.length();
-
-        // create block trailer
-        BlockTrailer blockTrailer =
-                new BlockTrailer(blockCompressionType, crc32c(block, blockCompressionType));
-        MemorySlice trailer = BlockTrailer.writeBlockTrailer(blockTrailer);
-
-        // create a handle to this block
-        BlockHandle blockHandle = new BlockHandle(position, block.length());
-
-        // write data
-        writeSlice(block);
-
-        // write trailer: 5 bytes
-        writeSlice(trailer);
-
-        // clean up state
-        blockWriter.reset();
-
-        return blockHandle;
+        sstFileWriter.put(key, value);
     }
 
     @Override
     public void close() throws IOException {
-        // flush current data block
-        flush();
-
-        LOG.info("Number of record: {}", recordCount);
-
-        // write bloom filter
-        @Nullable BloomFilterHandle bloomFilterHandle = null;
-        if (bloomFilter != null) {
-            MemorySegment buffer = bloomFilter.getBuffer();
-            bloomFilterHandle =
-                    new BloomFilterHandle(position, buffer.size(), bloomFilter.expectedEntries());
-            writeSlice(MemorySlice.wrap(buffer));
-            LOG.info("Bloom filter size: {} bytes", bloomFilter.getBuffer().size());
-        }
-
-        // write index block
-        BlockHandle indexBlockHandle = writeBlock(indexBlockWriter);
-
-        // write footer
-        Footer footer = new Footer(bloomFilterHandle, indexBlockHandle);
-        MemorySlice footerEncoding = Footer.writeFooter(footer);
-        writeSlice(footerEncoding);
-
-        // close file
-        fileOutputStream.close();
-
-        LOG.info("totalUncompressedSize: {}", MemorySize.ofBytes(totalUncompressedSize));
-        LOG.info("totalCompressedSize: {}", MemorySize.ofBytes(totalCompressedSize));
-    }
-
-    private void writeSlice(MemorySlice slice) throws IOException {
-        fileOutputStream.write(slice.getHeapMemory(), slice.offset(), slice.length());
-        position += slice.length();
+        sstFileWriter.close();
+        out.close();
+        fileIO.close();
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/sst/BlockAlignedType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/BlockAlignedType.java
@@ -16,20 +16,29 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.lookup.sort;
+package org.apache.paimon.sst;
 
-import org.apache.paimon.lookup.LookupStoreFactory.Context;
+/** Aligned type for block. */
+public enum BlockAlignedType {
+    ALIGNED((byte) 0),
+    UNALIGNED((byte) 1);
 
-/** A {@link Context} for sort store. */
-public class SortContext implements Context {
+    private final byte b;
 
-    private final long fileSize;
-
-    public SortContext(long fileSize) {
-        this.fileSize = fileSize;
+    BlockAlignedType(byte b) {
+        this.b = b;
     }
 
-    public long fileSize() {
-        return fileSize;
+    public byte toByte() {
+        return b;
+    }
+
+    public static BlockAlignedType fromByte(byte b) {
+        for (BlockAlignedType type : BlockAlignedType.values()) {
+            if (type.toByte() == b) {
+                return type;
+            }
+        }
+        throw new IllegalStateException("Illegal block aligned type: " + b);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/sst/BlockCache.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/BlockCache.java
@@ -16,18 +16,18 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.lookup.sort;
+package org.apache.paimon.sst;
 
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.SeekableInputStream;
 import org.apache.paimon.io.cache.CacheKey;
 import org.apache.paimon.io.cache.CacheManager;
 import org.apache.paimon.io.cache.CacheManager.SegmentContainer;
 import org.apache.paimon.memory.MemorySegment;
+import org.apache.paimon.utils.IOUtils;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -37,32 +37,29 @@ import java.util.function.Function;
 /** Cache for block reading. */
 public class BlockCache implements Closeable {
 
-    private final RandomAccessFile file;
-    private final FileChannel channel;
+    private final Path filePath;
+    private final SeekableInputStream input;
     private final CacheManager cacheManager;
     private final Map<CacheKey, SegmentContainer> blocks;
 
-    public BlockCache(RandomAccessFile file, CacheManager cacheManager) {
-        this.file = file;
-        this.channel = this.file.getChannel();
+    public BlockCache(Path filePath, SeekableInputStream input, CacheManager cacheManager) {
+        this.filePath = filePath;
+        this.input = input;
         this.cacheManager = cacheManager;
         this.blocks = new HashMap<>();
     }
 
     private byte[] readFrom(long offset, int length) throws IOException {
         byte[] buffer = new byte[length];
-        int read = channel.read(ByteBuffer.wrap(buffer), offset);
-
-        if (read != length) {
-            throw new IOException("Could not read all the data");
-        }
+        input.seek(offset);
+        IOUtils.readFully(input, buffer);
         return buffer;
     }
 
     public MemorySegment getBlock(
             long position, int length, Function<byte[], byte[]> decompressFunc, boolean isIndex) {
 
-        CacheKey cacheKey = CacheKey.forPosition(file, position, length, isIndex);
+        CacheKey cacheKey = CacheKey.forPosition(filePath, position, length, isIndex);
 
         SegmentContainer container = blocks.get(cacheKey);
         if (container == null || container.getAccessCount() == CacheManager.REFRESH_COUNT) {

--- a/paimon-common/src/main/java/org/apache/paimon/sst/BlockEntry.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/BlockEntry.java
@@ -16,35 +16,40 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.lookup.sort;
+package org.apache.paimon.sst;
 
-import java.util.Objects;
+import org.apache.paimon.memory.MemorySlice;
 
-/** Handle for bloom filter. */
-public class BloomFilterHandle {
+import java.util.Map.Entry;
 
-    public static final int MAX_ENCODED_LENGTH = 9 + 5 + 9;
+import static java.util.Objects.requireNonNull;
 
-    private final long offset;
-    private final int size;
-    private final long expectedEntries;
+/** Entry represents a key value. */
+public class BlockEntry implements Entry<MemorySlice, MemorySlice> {
 
-    BloomFilterHandle(long offset, int size, long expectedEntries) {
-        this.offset = offset;
-        this.size = size;
-        this.expectedEntries = expectedEntries;
+    private final MemorySlice key;
+    private final MemorySlice value;
+
+    public BlockEntry(MemorySlice key, MemorySlice value) {
+        requireNonNull(key, "key is null");
+        requireNonNull(value, "value is null");
+        this.key = key;
+        this.value = value;
     }
 
-    public long offset() {
-        return offset;
+    @Override
+    public MemorySlice getKey() {
+        return key;
     }
 
-    public int size() {
-        return size;
+    @Override
+    public MemorySlice getValue() {
+        return value;
     }
 
-    public long expectedEntries() {
-        return expectedEntries;
+    @Override
+    public final MemorySlice setValue(MemorySlice value) {
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -55,14 +60,19 @@ public class BloomFilterHandle {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        BloomFilterHandle that = (BloomFilterHandle) o;
-        return offset == that.offset
-                && size == that.size
-                && expectedEntries == that.expectedEntries;
+
+        BlockEntry entry = (BlockEntry) o;
+
+        if (!key.equals(entry.key)) {
+            return false;
+        }
+        return value.equals(entry.value);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(offset, size, expectedEntries);
+        int result = key.hashCode();
+        result = 31 * result + value.hashCode();
+        return result;
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/sst/BlockHandle.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/BlockHandle.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.lookup.sort;
+package org.apache.paimon.sst;
 
 import org.apache.paimon.memory.MemorySlice;
 import org.apache.paimon.memory.MemorySliceInput;

--- a/paimon-common/src/main/java/org/apache/paimon/sst/BlockIterator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/BlockIterator.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.lookup.sort;
+package org.apache.paimon.sst;
 
 import org.apache.paimon.memory.MemorySlice;
 import org.apache.paimon.memory.MemorySliceInput;

--- a/paimon-common/src/main/java/org/apache/paimon/sst/BlockReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/BlockReader.java
@@ -16,13 +16,13 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.lookup.sort;
+package org.apache.paimon.sst;
 
 import org.apache.paimon.memory.MemorySlice;
 
 import java.util.Comparator;
 
-import static org.apache.paimon.lookup.sort.BlockAlignedType.ALIGNED;
+import static org.apache.paimon.sst.BlockAlignedType.ALIGNED;
 
 /** Reader for a block. */
 public class BlockReader {

--- a/paimon-common/src/main/java/org/apache/paimon/sst/BlockTrailer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/BlockTrailer.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.lookup.sort;
+package org.apache.paimon.sst;
 
 import org.apache.paimon.compression.BlockCompressionType;
 import org.apache.paimon.memory.MemorySlice;

--- a/paimon-common/src/main/java/org/apache/paimon/sst/BlockWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/BlockWriter.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.lookup.sort;
+package org.apache.paimon.sst;
 
 import org.apache.paimon.memory.MemorySlice;
 import org.apache.paimon.memory.MemorySliceOutput;
@@ -24,10 +24,34 @@ import org.apache.paimon.utils.IntArrayList;
 
 import java.io.IOException;
 
-import static org.apache.paimon.lookup.sort.BlockAlignedType.ALIGNED;
-import static org.apache.paimon.lookup.sort.BlockAlignedType.UNALIGNED;
+import static org.apache.paimon.sst.BlockAlignedType.ALIGNED;
+import static org.apache.paimon.sst.BlockAlignedType.UNALIGNED;
 
-/** Writer to build a Block. */
+/**
+ * Writer to build a Block. A block is designed for storing and random-accessing k-v pairs. The
+ * layout is as below:
+ *
+ * <pre>
+ *     +---------------+
+ *     | Block Trailer |
+ *     +------------------------------------------------+
+ *     |       Block CRC23C      |     Compression      |
+ *     +------------------------------------------------+
+ *     +---------------+
+ *     |  Block Data   |
+ *     +---------------+--------------------------------+----+
+ *     | key len | key bytes | value len | value bytes  |    |
+ *     +------------------------------------------------+    |
+ *     | key len | key bytes | value len | value bytes  |    +-> Key-Value pairs
+ *     +------------------------------------------------+    |
+ *     |                  ... ...                       |    |
+ *     +------------------------------------------------+----+
+ *     | entry pos | entry pos |     ...    | entry pos |    +-> optional, for unaligned block
+ *     +------------------------------------------------+----+
+ *     |   entry num  /  entry size   |   aligned type  |
+ *     +------------------------------------------------+
+ * </pre>
+ */
 public class BlockWriter {
 
     private final IntArrayList positions;

--- a/paimon-common/src/main/java/org/apache/paimon/sst/BloomFilterHandle.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/BloomFilterHandle.java
@@ -16,40 +16,35 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.lookup.sort;
+package org.apache.paimon.sst;
 
-import org.apache.paimon.memory.MemorySlice;
+import java.util.Objects;
 
-import java.util.Map.Entry;
+/** Handle for bloom filter. */
+public class BloomFilterHandle {
 
-import static java.util.Objects.requireNonNull;
+    public static final int MAX_ENCODED_LENGTH = 9 + 5 + 9;
 
-/** Entry represents a key value. */
-public class BlockEntry implements Entry<MemorySlice, MemorySlice> {
+    private final long offset;
+    private final int size;
+    private final long expectedEntries;
 
-    private final MemorySlice key;
-    private final MemorySlice value;
-
-    public BlockEntry(MemorySlice key, MemorySlice value) {
-        requireNonNull(key, "key is null");
-        requireNonNull(value, "value is null");
-        this.key = key;
-        this.value = value;
+    BloomFilterHandle(long offset, int size, long expectedEntries) {
+        this.offset = offset;
+        this.size = size;
+        this.expectedEntries = expectedEntries;
     }
 
-    @Override
-    public MemorySlice getKey() {
-        return key;
+    public long offset() {
+        return offset;
     }
 
-    @Override
-    public MemorySlice getValue() {
-        return value;
+    public int size() {
+        return size;
     }
 
-    @Override
-    public final MemorySlice setValue(MemorySlice value) {
-        throw new UnsupportedOperationException();
+    public long expectedEntries() {
+        return expectedEntries;
     }
 
     @Override
@@ -60,19 +55,14 @@ public class BlockEntry implements Entry<MemorySlice, MemorySlice> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
-        BlockEntry entry = (BlockEntry) o;
-
-        if (!key.equals(entry.key)) {
-            return false;
-        }
-        return value.equals(entry.value);
+        BloomFilterHandle that = (BloomFilterHandle) o;
+        return offset == that.offset
+                && size == that.size
+                && expectedEntries == that.expectedEntries;
     }
 
     @Override
     public int hashCode() {
-        int result = key.hashCode();
-        result = 31 * result + value.hashCode();
-        return result;
+        return Objects.hash(offset, size, expectedEntries);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/sst/Footer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/Footer.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.lookup.sort;
+package org.apache.paimon.sst;
 
 import org.apache.paimon.memory.MemorySlice;
 import org.apache.paimon.memory.MemorySliceInput;
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 
-import static org.apache.paimon.lookup.sort.SortLookupStoreWriter.MAGIC_NUMBER;
+import static org.apache.paimon.sst.SstFileWriter.MAGIC_NUMBER;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Footer for a sorted file. */

--- a/paimon-common/src/main/java/org/apache/paimon/sst/SortContext.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/SortContext.java
@@ -16,27 +16,20 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.lookup.sort;
+package org.apache.paimon.sst;
 
-import org.apache.paimon.compression.BlockCompressionType;
-import org.apache.paimon.memory.MemorySegment;
-import org.apache.paimon.memory.MemorySlice;
+import org.apache.paimon.lookup.LookupStoreFactory.Context;
 
-import java.util.zip.CRC32;
+/** A {@link Context} for sort store. */
+public class SortContext implements Context {
 
-/** Utils for sort lookup store. */
-public class SortLookupStoreUtils {
-    public static int crc32c(MemorySlice data, BlockCompressionType type) {
-        CRC32 crc = new CRC32();
-        crc.update(data.getHeapMemory(), data.offset(), data.length());
-        crc.update(type.persistentId() & 0xFF);
-        return (int) crc.getValue();
+    private final long fileSize;
+
+    public SortContext(long fileSize) {
+        this.fileSize = fileSize;
     }
 
-    public static int crc32c(MemorySegment data, BlockCompressionType type) {
-        CRC32 crc = new CRC32();
-        crc.update(data.getHeapMemory(), 0, data.size());
-        crc.update(type.persistentId() & 0xFF);
-        return (int) crc.getValue();
+    public long fileSize() {
+        return fileSize;
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/sst/SstFileReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/SstFileReader.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.sst;
+
+import org.apache.paimon.compression.BlockCompressionFactory;
+import org.apache.paimon.compression.BlockDecompressor;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.io.cache.CacheManager;
+import org.apache.paimon.memory.MemorySegment;
+import org.apache.paimon.memory.MemorySlice;
+import org.apache.paimon.memory.MemorySliceInput;
+import org.apache.paimon.utils.FileBasedBloomFilter;
+import org.apache.paimon.utils.MurmurHashUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Comparator;
+
+import static org.apache.paimon.sst.SstFileUtils.crc32c;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/**
+ * An SST File Reader which only serves point queries now.
+ *
+ * <p>Note that this class is NOT thread-safe.
+ */
+public class SstFileReader implements Closeable {
+
+    private final Comparator<MemorySlice> comparator;
+    private final Path filePath;
+    private final long fileSize;
+
+    private final BlockIterator indexBlockIterator;
+    @Nullable private FileBasedBloomFilter bloomFilter;
+    private final BlockCache blockCache;
+
+    public SstFileReader(
+            Comparator<MemorySlice> comparator,
+            long fileSize,
+            Path filePath,
+            SeekableInputStream input,
+            CacheManager cacheManager)
+            throws IOException {
+        this.comparator = comparator;
+        this.filePath = filePath;
+        this.fileSize = fileSize;
+
+        this.blockCache = new BlockCache(filePath, input, cacheManager);
+        Footer footer = readFooter();
+        this.indexBlockIterator = readBlock(footer.getIndexBlockHandle(), true).iterator();
+        BloomFilterHandle handle = footer.getBloomFilterHandle();
+        if (handle != null) {
+            this.bloomFilter =
+                    new FileBasedBloomFilter(
+                            input,
+                            filePath,
+                            cacheManager,
+                            handle.expectedEntries(),
+                            handle.offset(),
+                            handle.size());
+        }
+    }
+
+    private Footer readFooter() throws IOException {
+        MemorySegment footerData =
+                blockCache.getBlock(
+                        fileSize - Footer.ENCODED_LENGTH, Footer.ENCODED_LENGTH, b -> b, true);
+        return Footer.readFooter(MemorySlice.wrap(footerData).toInput());
+    }
+
+    /**
+     * Lookup the specified key in the file.
+     *
+     * @param key serialized key
+     * @return corresponding serialized value, null if not found.
+     */
+    @Nullable
+    public byte[] lookup(byte[] key) throws IOException {
+        if (bloomFilter != null && !bloomFilter.testHash(MurmurHashUtils.hashBytes(key))) {
+            return null;
+        }
+
+        MemorySlice keySlice = MemorySlice.wrap(key);
+        // seek the index to the block containing the key
+        indexBlockIterator.seekTo(keySlice);
+
+        // if indexIterator does not have a next, it means the key does not exist in this iterator
+        if (indexBlockIterator.hasNext()) {
+            // seek the current iterator to the key
+            BlockIterator current = getNextBlock();
+            if (current.seekTo(keySlice)) {
+                return current.next().getValue().copyBytes();
+            }
+        }
+        return null;
+    }
+
+    private BlockIterator getNextBlock() {
+        // index block handle, point to the key, value position.
+        MemorySlice blockHandle = indexBlockIterator.next().getValue();
+        BlockReader dataBlock =
+                readBlock(BlockHandle.readBlockHandle(blockHandle.toInput()), false);
+        return dataBlock.iterator();
+    }
+
+    /**
+     * @param blockHandle The block handle.
+     * @param index Whether read the block as an index.
+     * @return The reader of the target block.
+     */
+    private BlockReader readBlock(BlockHandle blockHandle, boolean index) {
+        // read block trailer
+        MemorySegment trailerData =
+                blockCache.getBlock(
+                        blockHandle.offset() + blockHandle.size(),
+                        BlockTrailer.ENCODED_LENGTH,
+                        b -> b,
+                        true);
+        BlockTrailer blockTrailer =
+                BlockTrailer.readBlockTrailer(MemorySlice.wrap(trailerData).toInput());
+
+        MemorySegment unCompressedBlock =
+                blockCache.getBlock(
+                        blockHandle.offset(),
+                        blockHandle.size(),
+                        bytes -> decompressBlock(bytes, blockTrailer),
+                        index);
+        return new BlockReader(MemorySlice.wrap(unCompressedBlock), comparator);
+    }
+
+    private byte[] decompressBlock(byte[] compressedBytes, BlockTrailer blockTrailer) {
+        MemorySegment compressed = MemorySegment.wrap(compressedBytes);
+        int crc32cCode = crc32c(compressed, blockTrailer.getCompressionType());
+        checkArgument(
+                blockTrailer.getCrc32c() == crc32cCode,
+                String.format(
+                        "Expected CRC32C(%d) but found CRC32C(%d) for file(%s)",
+                        blockTrailer.getCrc32c(), crc32cCode, filePath));
+
+        // decompress data
+        BlockCompressionFactory compressionFactory =
+                BlockCompressionFactory.create(blockTrailer.getCompressionType());
+        if (compressionFactory == null) {
+            return compressedBytes;
+        } else {
+            MemorySliceInput compressedInput = MemorySlice.wrap(compressed).toInput();
+            byte[] uncompressed = new byte[compressedInput.readVarLenInt()];
+            BlockDecompressor decompressor = compressionFactory.getDecompressor();
+            int uncompressedLength =
+                    decompressor.decompress(
+                            compressed.getHeapMemory(),
+                            compressedInput.position(),
+                            compressedInput.available(),
+                            uncompressed,
+                            0);
+            checkArgument(uncompressedLength == uncompressed.length);
+            return uncompressed;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (bloomFilter != null) {
+            bloomFilter.close();
+        }
+        blockCache.close();
+        // do not need to close input, since it will be closed by outer classes
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/sst/SstFileUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/SstFileUtils.java
@@ -16,29 +16,27 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.lookup.sort;
+package org.apache.paimon.sst;
 
-/** Aligned type for block. */
-public enum BlockAlignedType {
-    ALIGNED((byte) 0),
-    UNALIGNED((byte) 1);
+import org.apache.paimon.compression.BlockCompressionType;
+import org.apache.paimon.memory.MemorySegment;
+import org.apache.paimon.memory.MemorySlice;
 
-    private final byte b;
+import java.util.zip.CRC32;
 
-    BlockAlignedType(byte b) {
-        this.b = b;
+/** Utils for sort lookup store. */
+public class SstFileUtils {
+    public static int crc32c(MemorySlice data, BlockCompressionType type) {
+        CRC32 crc = new CRC32();
+        crc.update(data.getHeapMemory(), data.offset(), data.length());
+        crc.update(type.persistentId() & 0xFF);
+        return (int) crc.getValue();
     }
 
-    public byte toByte() {
-        return b;
-    }
-
-    public static BlockAlignedType fromByte(byte b) {
-        for (BlockAlignedType type : BlockAlignedType.values()) {
-            if (type.toByte() == b) {
-                return type;
-            }
-        }
-        throw new IllegalStateException("Illegal block aligned type: " + b);
+    public static int crc32c(MemorySegment data, BlockCompressionType type) {
+        CRC32 crc = new CRC32();
+        crc.update(data.getHeapMemory(), 0, data.size());
+        crc.update(type.persistentId() & 0xFF);
+        return (int) crc.getValue();
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/sst/SstFileWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/SstFileWriter.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.sst;
+
+import org.apache.paimon.compression.BlockCompressionFactory;
+import org.apache.paimon.compression.BlockCompressionType;
+import org.apache.paimon.compression.BlockCompressor;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.memory.MemorySegment;
+import org.apache.paimon.memory.MemorySlice;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.utils.BloomFilter;
+import org.apache.paimon.utils.MurmurHashUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import static org.apache.paimon.memory.MemorySegmentUtils.allocateReuseBytes;
+import static org.apache.paimon.sst.BlockHandle.writeBlockHandle;
+import static org.apache.paimon.sst.SstFileUtils.crc32c;
+import static org.apache.paimon.utils.VarLengthIntUtils.encodeInt;
+
+/**
+ * The writer for writing SST Files. SST Files are row-oriented and designed to serve frequent point
+ * queries and range queries by key. The SST File layout is as below: (For layouts of each block
+ * type, please refer to corresponding classes)
+ *
+ * <pre>
+ *     +-----------------------------------+------+
+ *     |             Footer                |      |
+ *     +-----------------------------------+      |
+ *     |           Index Block             |      +--> Loaded on open
+ *     +-----------------------------------+      |
+ *     |        Bloom Filter Block         |      |
+ *     +-----------------------------------+------+
+ *     |            Data Block             |      |
+ *     +-----------------------------------+      |
+ *     |              ......               |      +--> Loaded on requested
+ *     +-----------------------------------+      |
+ *     |            Data Block             |      |
+ *     +-----------------------------------+------+
+ * </pre>
+ */
+public class SstFileWriter implements Closeable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SstFileWriter.class.getName());
+
+    public static final int MAGIC_NUMBER = 1481571681;
+
+    private final PositionOutputStream out;
+    private final int blockSize;
+    private final BlockWriter dataBlockWriter;
+    private final BlockWriter indexBlockWriter;
+    @Nullable private final BloomFilter.Builder bloomFilter;
+    private final BlockCompressionType compressionType;
+    @Nullable private final BlockCompressor blockCompressor;
+
+    private byte[] lastKey;
+    private long position;
+
+    private long recordCount;
+    private long totalUncompressedSize;
+    private long totalCompressedSize;
+
+    public SstFileWriter(
+            PositionOutputStream out,
+            int blockSize,
+            @Nullable BloomFilter.Builder bloomFilter,
+            @Nullable BlockCompressionFactory compressionFactory)
+            throws IOException {
+        this.out = out;
+        this.blockSize = blockSize;
+        this.dataBlockWriter = new BlockWriter((int) (blockSize * 1.1));
+        int expectedNumberOfBlocks = 1024;
+        this.indexBlockWriter =
+                new BlockWriter(BlockHandle.MAX_ENCODED_LENGTH * expectedNumberOfBlocks);
+        this.bloomFilter = bloomFilter;
+        if (compressionFactory == null) {
+            this.compressionType = BlockCompressionType.NONE;
+            this.blockCompressor = null;
+        } else {
+            this.compressionType = compressionFactory.getCompressionType();
+            this.blockCompressor = compressionFactory.getCompressor();
+        }
+    }
+
+    /**
+     * Put the serialized key and value into this SST File. The caller must guarantee that the input
+     * key is monotonically incremental according to {@link SstFileReader}'s comparator. Otherwise,
+     * the lookup and range query result will be undefined.
+     *
+     * @param key serialized key
+     * @param value serialized value
+     */
+    public void put(byte[] key, byte[] value) throws IOException {
+        dataBlockWriter.add(key, value);
+        if (bloomFilter != null) {
+            bloomFilter.addHash(MurmurHashUtils.hashBytes(key));
+        }
+
+        lastKey = key;
+
+        if (dataBlockWriter.memory() > blockSize) {
+            flush();
+        }
+
+        recordCount++;
+    }
+
+    private void flush() throws IOException {
+        if (dataBlockWriter.size() == 0) {
+            return;
+        }
+
+        BlockHandle blockHandle = writeBlock(dataBlockWriter);
+        MemorySlice handleEncoding = writeBlockHandle(blockHandle);
+        indexBlockWriter.add(lastKey, handleEncoding.copyBytes());
+    }
+
+    private BlockHandle writeBlock(BlockWriter blockWriter) throws IOException {
+        // close the block
+        MemorySlice block = blockWriter.finish();
+
+        totalUncompressedSize += block.length();
+
+        // attempt to compress the block
+        BlockCompressionType blockCompressionType = BlockCompressionType.NONE;
+        if (blockCompressor != null) {
+            int maxCompressedSize = blockCompressor.getMaxCompressedSize(block.length());
+            byte[] compressed = allocateReuseBytes(maxCompressedSize + 5);
+            int offset = encodeInt(compressed, 0, block.length());
+            int compressedSize =
+                    offset
+                            + blockCompressor.compress(
+                                    block.getHeapMemory(),
+                                    block.offset(),
+                                    block.length(),
+                                    compressed,
+                                    offset);
+
+            // Don't use the compressed data if compressed less than 12.5%,
+            if (compressedSize < block.length() - (block.length() / 8)) {
+                block = new MemorySlice(MemorySegment.wrap(compressed), 0, compressedSize);
+                blockCompressionType = this.compressionType;
+            }
+        }
+
+        totalCompressedSize += block.length();
+
+        // create block trailer
+        BlockTrailer blockTrailer =
+                new BlockTrailer(blockCompressionType, crc32c(block, blockCompressionType));
+        MemorySlice trailer = BlockTrailer.writeBlockTrailer(blockTrailer);
+
+        // create a handle to this block
+        BlockHandle blockHandle = new BlockHandle(position, block.length());
+
+        // write data
+        writeSlice(block);
+
+        // write trailer: 5 bytes
+        writeSlice(trailer);
+
+        // clean up state
+        blockWriter.reset();
+
+        return blockHandle;
+    }
+
+    @Override
+    public void close() throws IOException {
+        // flush current data block
+        flush();
+
+        LOG.info("Number of record: {}", recordCount);
+
+        // write bloom filter
+        @Nullable BloomFilterHandle bloomFilterHandle = null;
+        if (bloomFilter != null) {
+            MemorySegment buffer = bloomFilter.getBuffer();
+            bloomFilterHandle =
+                    new BloomFilterHandle(position, buffer.size(), bloomFilter.expectedEntries());
+            writeSlice(MemorySlice.wrap(buffer));
+            LOG.info("Bloom filter size: {} bytes", bloomFilter.getBuffer().size());
+        }
+
+        // write index block
+        BlockHandle indexBlockHandle = writeBlock(indexBlockWriter);
+
+        // write footer
+        Footer footer = new Footer(bloomFilterHandle, indexBlockHandle);
+        MemorySlice footerEncoding = Footer.writeFooter(footer);
+        writeSlice(footerEncoding);
+
+        // do not need to close outputStream, since it will be closed by outer classes
+
+        LOG.info("totalUncompressedSize: {}", MemorySize.ofBytes(totalUncompressedSize));
+        LOG.info("totalCompressedSize: {}", MemorySize.ofBytes(totalCompressedSize));
+    }
+
+    private void writeSlice(MemorySlice slice) throws IOException {
+        out.write(slice.getHeapMemory(), slice.offset(), slice.length());
+        position += slice.length();
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/sst/BlockIteratorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/sst/BlockIteratorTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.lookup.sort;
+package org.apache.paimon.sst;
 
 import org.apache.paimon.memory.MemorySlice;
 import org.apache.paimon.memory.MemorySliceOutput;

--- a/paimon-common/src/test/java/org/apache/paimon/sst/SstFileTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/sst/SstFileTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.sst;
+
+import org.apache.paimon.compression.BlockCompressionFactory;
+import org.apache.paimon.compression.CompressOptions;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.io.cache.CacheManager;
+import org.apache.paimon.memory.MemorySlice;
+import org.apache.paimon.memory.MemorySliceOutput;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.testutils.junit.parameterized.ParameterizedTestExtension;
+import org.apache.paimon.testutils.junit.parameterized.Parameters;
+import org.apache.paimon.utils.BloomFilter;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+/** Test for {@link SstFileReader} and {@link SstFileWriter}. */
+@ExtendWith(ParameterizedTestExtension.class)
+public class SstFileTest {
+    private static final Logger LOG = LoggerFactory.getLogger(SstFileTest.class);
+
+    // 256 records per block
+    private static final int BLOCK_SIZE = (10) * 256;
+    private static final CacheManager CACHE_MANAGER = new CacheManager(MemorySize.ofMebiBytes(10));
+    @TempDir java.nio.file.Path tempPath;
+
+    private final boolean bloomFilterEnabled;
+    private final CompressOptions compress;
+
+    private FileIO fileIO;
+    private Path file;
+    private Path parent;
+
+    public SstFileTest(List<Object> var) {
+        this.bloomFilterEnabled = (Boolean) var.get(0);
+        this.compress = new CompressOptions((String) var.get(1), 1);
+    }
+
+    @SuppressWarnings("unused")
+    @Parameters(name = "enableBf&compress-{0}")
+    public static List<List<Object>> getVarSeg() {
+        return Arrays.asList(
+                Arrays.asList(true, "none"),
+                Arrays.asList(false, "none"),
+                Arrays.asList(false, "lz4"),
+                Arrays.asList(true, "lz4"),
+                Arrays.asList(false, "zstd"),
+                Arrays.asList(true, "zstd"));
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        this.fileIO = LocalFileIO.create();
+        this.parent = new Path(tempPath.toUri());
+        this.file = new Path(new Path(tempPath.toUri()), UUID.randomUUID().toString());
+    }
+
+    @TestTemplate
+    public void testLookup() throws Exception {
+        writeData(5000, bloomFilterEnabled);
+        innerTestLookup();
+    }
+
+    private void innerTestLookup() throws Exception {
+        long fileSize = fileIO.getFileSize(file);
+        try (SeekableInputStream inputStream = fileIO.newInputStream(file);
+                SstFileReader reader =
+                        new SstFileReader(
+                                Comparator.comparingInt(slice -> slice.readInt(0)),
+                                fileSize,
+                                file,
+                                inputStream,
+                                CACHE_MANAGER); ) {
+            Random random = new Random();
+            MemorySliceOutput keyOut = new MemorySliceOutput(4);
+
+            // 1. lookup random existing keys
+            for (int i = 0; i < 100; i++) {
+                int key = random.nextInt(5000);
+                keyOut.reset();
+                keyOut.writeInt(key);
+                byte[] queried = reader.lookup(keyOut.toSlice().getHeapMemory());
+                Assertions.assertNotNull(queried);
+                Assertions.assertEquals(key, MemorySlice.wrap(queried).readInt(0));
+            }
+
+            // 2. lookup boundaries
+            keyOut.reset();
+            keyOut.writeInt(0);
+            byte[] queried = reader.lookup(keyOut.toSlice().getHeapMemory());
+            Assertions.assertNotNull(queried);
+            Assertions.assertEquals(0, MemorySlice.wrap(queried).readInt(0));
+
+            keyOut.reset();
+            keyOut.writeInt(511);
+            byte[] queried1 = reader.lookup(keyOut.toSlice().getHeapMemory());
+            Assertions.assertNotNull(queried1);
+            Assertions.assertEquals(511, MemorySlice.wrap(queried1).readInt(0));
+
+            keyOut.reset();
+            keyOut.writeInt(4999);
+            byte[] queried2 = reader.lookup(keyOut.toSlice().getHeapMemory());
+            Assertions.assertNotNull(queried2);
+            Assertions.assertEquals(4999, MemorySlice.wrap(queried2).readInt(0));
+
+            // 2. lookup key smaller than first key
+            for (int i = 0; i < 100; i++) {
+                keyOut.reset();
+                keyOut.writeInt(-10 - i);
+                Assertions.assertNull(reader.lookup(keyOut.toSlice().getHeapMemory()));
+            }
+
+            // 3. lookup key greater than last key
+            for (int i = 0; i < 100; i++) {
+                keyOut.reset();
+                keyOut.writeInt(10000 + i);
+                Assertions.assertNull(reader.lookup(keyOut.toSlice().getHeapMemory()));
+            }
+        }
+    }
+
+    private void writeData(int recordCount, boolean withBloomFilter) throws Exception {
+        BloomFilter.Builder bloomFilter = null;
+        if (withBloomFilter) {
+            bloomFilter = BloomFilter.builder(recordCount, 0.05);
+        }
+        BlockCompressionFactory compressionFactory = BlockCompressionFactory.create(compress);
+        try (PositionOutputStream outputStream = fileIO.newOutputStream(file, true);
+                SstFileWriter writer =
+                        new SstFileWriter(
+                                outputStream, BLOCK_SIZE, bloomFilter, compressionFactory); ) {
+            MemorySliceOutput keyOut = new MemorySliceOutput(4);
+            MemorySliceOutput valueOut = new MemorySliceOutput(4);
+            long start = System.currentTimeMillis();
+            for (int i = 0; i < recordCount; i++) {
+                keyOut.reset();
+                valueOut.reset();
+                keyOut.writeInt(i);
+                valueOut.writeInt(i);
+                writer.put(keyOut.toSlice().getHeapMemory(), valueOut.toSlice().getHeapMemory());
+            }
+            LOG.info("Write {} data cost {} ms", recordCount, System.currentTimeMillis() - start);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
This PR is a part of https://github.com/apache/paimon/issues/6734
<!-- Linking this pull request to the issue -->
This PR do **NOT** change any file structure, mainly moving classes under `paimon-common/lookup/sort` to `paimon-common/sst`.
Other changes can be summarized as below:
1. Rename previous `SortLookupStoreReader` and `SortLookupStoreWriter` to `SstFileReader` and `SstFileWriter`
2. Slightly change current `SstFileReader` and `SstFileWriter` to directly interact with `SeekableInputStream` and `PositionOutputStream`. Also modified related classes such as `BlockCache` and `FileBasedBloomFilter`.
3. Create new `SortLookupStoreReader` and `SortLookupStoreWriter` which just delegate reads and writes to inner Sst File
Reader/Writer

I'll try to modify SST File structure to make it more generalize in future PRs. i.e. support range query and sequential scan.

<!-- What is the purpose of the change -->

### Tests
Please see:
* `org.apache.paimon.lookup.sort.SortLookupStoreFactoryTest` for LookupStore Test
* `org.apache.paimon.sst.SstFileTest` for SST File Test
<!-- List UT and IT cases to verify this change -->

### API and Format
None
<!-- Does this change affect API or storage format -->

### Documentation
None for now
<!-- Does this change introduce a new feature -->
