### PR TITLE
[spark] keep the rowId unchanged when updating the row tracking and deletion vectors table.

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/UpdatePaimonTableCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/UpdatePaimonTableCommand.scala
@@ -25,6 +25,7 @@ import org.apache.paimon.table.FileStoreTable
 import org.apache.paimon.table.sink.CommitMessage
 import org.apache.paimon.table.source.DataSplit
 import org.apache.paimon.types.RowKind
+
 import org.apache.spark.sql.{Column, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils.createDataset
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, If, Literal}
@@ -167,10 +168,7 @@ case class UpdatePaimonTableCommand(
   private def rowIdCol = col(ROW_ID_COLUMN)
 
   private def sequenceNumberCol(sparkSession: SparkSession) = toColumn(
-    optimizedIf(
-      condition,
-      Literal(null),
-      toExpression(sparkSession, col(SEQUENCE_NUMBER_COLUMN))))
+    optimizedIf(condition, Literal(null), toExpression(sparkSession, col(SEQUENCE_NUMBER_COLUMN))))
     .as(SEQUENCE_NUMBER_COLUMN)
 
   private def optimizedIf(

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
@@ -79,7 +79,8 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase {
       sql("DROP TABLE t")
 
       // enable row tracking and deletion vectors
-      sql("CREATE TABLE t (id INT, data INT) TBLPROPERTIES ('row-tracking.enabled' = 'true', 'deletion-vectors.enabled' = 'true')")
+      sql(
+        "CREATE TABLE t (id INT, data INT) TBLPROPERTIES ('row-tracking.enabled' = 'true', 'deletion-vectors.enabled' = 'true')")
       runAndCheckAnswer()
 
       def runAndCheckAnswer(): Unit = {
@@ -106,7 +107,8 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase {
       sql("DROP TABLE t")
 
       // enable row tracking and deletion vectors
-      sql("CREATE TABLE t (id INT, data INT) TBLPROPERTIES ('row-tracking.enabled' = 'true', 'deletion-vectors.enabled' = 'true')")
+      sql(
+        "CREATE TABLE t (id INT, data INT) TBLPROPERTIES ('row-tracking.enabled' = 'true', 'deletion-vectors.enabled' = 'true')")
       runAndCheckAnswer()
 
       def runAndCheckAnswer(): Unit = {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Fix the following issue: for the table with both row tracking and deletion vectors enabled, `_ROW_ID` was not written to new files during update operations, causing `_ROW_ID` to change when data is read.
This PR is following PR #6335 and commit 922ec95239a91ac98019819e881064c7d454ce1f
Linked issue: None

<!-- What is the purpose of the change -->

### Tests
org.apache.paimon.spark.sql.RowTrackingTestBase

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
