### PR TITLE
[core] Remote lookup file should overwrite old orphan file

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/lookup/RemoteLookupFileManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/lookup/RemoteLookupFileManager.java
@@ -75,7 +75,7 @@ public class RemoteLookupFileManager<T> implements RemoteFileDownloader {
         String remoteSstName = lookupLevels.newRemoteSst(file, length);
         Path sstFile = remoteSstPath(file, remoteSstName);
         try (FileInputStream is = new FileInputStream(lookupFile.localFile());
-                PositionOutputStream os = fileIO.newOutputStream(sstFile, false)) {
+                PositionOutputStream os = fileIO.newOutputStream(sstFile, true)) {
             IOUtils.copy(is, os);
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Upgrade may produce orphan file, we should overwrite it.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
