### PR TITLE
[python] update requirements.txt for pyarrow and pylance

### DIFF
--- a/paimon-python/dev/requirements.txt
+++ b/paimon-python/dev/requirements.txt
@@ -34,10 +34,11 @@ polars==0.9.12; python_version<"3.8"
 polars==1.8.0; python_version=="3.8"
 polars==1.32.0; python_version>"3.8"
 pyarrow==6.0.1; python_version < "3.8"
-pyarrow==16; python_version >= "3.8"
+pyarrow>=16,<19; python_version >= "3.8" and python_version < "3.13"
+pyarrow>=16,<19; python_version >= "3.13"
 ray==2.48.0
 readerwriterlock==1.0.9
 zstandard==0.19.0; python_version<"3.9"
 zstandard==0.24.0; python_version>="3.9"
-pylance==0.39.0; python_version>="3.9"
+pylance>=0.35,<0.40; python_version>="3.9"
 pylance==0.10.18; python_version>="3.8" and python_version<"3.9"


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

- pyarrow 16 is not avaliable in python 3.13, pypaimon install without `--no-deps` will fail if user python is 3.13.

- pylance  version from 0.35 to 0.39 should be supported

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
