### PR TITLE
[core] Bump commons-lang3 to version 3.18.0 to avoid CVE-2025-48924

### DIFF
--- a/paimon-benchmark/paimon-micro-benchmarks/pom.xml
+++ b/paimon-benchmark/paimon-micro-benchmarks/pom.xml
@@ -134,7 +134,7 @@ under the License.
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.18.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/paimon-filesystems/paimon-azure-impl/src/main/resources/META-INF/NOTICE
+++ b/paimon-filesystems/paimon-azure-impl/src/main/resources/META-INF/NOTICE
@@ -28,7 +28,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-logging:commons-logging:1.1.3
 - org.apache.commons:commons-compress:1.21
 - org.apache.commons:commons-configuration2:2.1.1
-- org.apache.commons:commons-lang3:3.12.0
+- org.apache.commons:commons-lang3:3.18.0
 - org.apache.commons:commons-text:1.4
 - org.apache.hadoop:hadoop-annotations:3.3.4
 - org.apache.hadoop:hadoop-auth:3.3.4

--- a/paimon-filesystems/paimon-cosn-impl/src/main/resources/META-INF/NOTICE
+++ b/paimon-filesystems/paimon-cosn-impl/src/main/resources/META-INF/NOTICE
@@ -25,7 +25,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-logging:commons-logging:1.1.3
 - commons-beanutils:commons-beanutils:1.9.4
 - org.apache.commons:commons-configuration2:2.1.1
-- org.apache.commons:commons-lang3:3.12.0
+- org.apache.commons:commons-lang3:3.18.0
 - org.apache.commons:commons-text:1.4
 - org.apache.hadoop:hadoop-auth:3.3.4
 - org.apache.commons:commons-compress:1.21

--- a/paimon-filesystems/paimon-gs-impl/src/main/resources/META-INF/NOTICE
+++ b/paimon-filesystems/paimon-gs-impl/src/main/resources/META-INF/NOTICE
@@ -41,7 +41,7 @@ This project bundles the following dependencies under the Apache Software Licens
 -io.airlift:aircompressor:0.27
 -org.apache.commons:commons-compress:1.21
 -org.apache.commons:commons-configuration2:2.1.1
--org.apache.commons:commons-lang3:3.12.0
+-org.apache.commons:commons-lang3:3.18.0
 -org.apache.commons:commons-text:1.4
 -org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 -org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1

--- a/paimon-filesystems/paimon-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/paimon-filesystems/paimon-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -20,7 +20,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-logging:commons-logging:1.1.3
 - org.apache.commons:commons-compress:1.21
 - org.apache.commons:commons-configuration2:2.1.1
-- org.apache.commons:commons-lang3:3.12.0
+- org.apache.commons:commons-lang3:3.18.0
 - org.apache.commons:commons-text:1.4
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1

--- a/paimon-filesystems/paimon-obs-impl/src/main/resources/META-INF/NOTICE
+++ b/paimon-filesystems/paimon-obs-impl/src/main/resources/META-INF/NOTICE
@@ -21,7 +21,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-logging:commons-logging:1.1.3
 - org.apache.commons:commons-compress:1.21
 - org.apache.commons:commons-configuration2:2.1.1
-- org.apache.commons:commons-lang3:3.12.0
+- org.apache.commons:commons-lang3:3.18.0
 - org.apache.commons:commons-text:1.4
 - org.apache.hadoop:hadoop-annotations:3.3.4
 - org.apache.hadoop:hadoop-auth:3.3.4

--- a/paimon-filesystems/paimon-oss-impl/src/main/resources/META-INF/NOTICE
+++ b/paimon-filesystems/paimon-oss-impl/src/main/resources/META-INF/NOTICE
@@ -34,7 +34,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-collections:commons-collections:3.2.2
 - commons-beanutils:commons-beanutils:1.9.4
 - org.apache.commons:commons-configuration2:2.1.1
-- org.apache.commons:commons-lang3:3.12.0
+- org.apache.commons:commons-lang3:3.18.0
 - org.apache.commons:commons-text:1.4
 - org.apache.hadoop:hadoop-auth:3.3.4
 - org.apache.commons:commons-compress:1.21

--- a/paimon-filesystems/paimon-s3-impl/src/main/resources/META-INF/NOTICE
+++ b/paimon-filesystems/paimon-s3-impl/src/main/resources/META-INF/NOTICE
@@ -29,7 +29,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - joda-time:joda-time:2.8.1
 - org.apache.commons:commons-compress:1.21
 - org.apache.commons:commons-configuration2:2.1.1
-- org.apache.commons:commons-lang3:3.12.0
+- org.apache.commons:commons-lang3:3.18.0
 - org.apache.commons:commons-text:1.10.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1

--- a/paimon-format/pom.xml
+++ b/paimon-format/pom.xml
@@ -34,7 +34,7 @@ under the License.
     <properties>
         <joda-time.version>2.5</joda-time.version>
         <commons.pool.version>1.6</commons.pool.version>
-        <commons.lang3.version>3.12.0</commons.lang3.version>
+        <commons.lang3.version>3.18.0</commons.lang3.version>
         <storage-api.version>2.8.1</storage-api.version>
         <commons.io.version>2.16.1</commons.io.version>
     </properties>

--- a/paimon-format/src/main/resources/META-INF/NOTICE
+++ b/paimon-format/src/main/resources/META-INF/NOTICE
@@ -11,7 +11,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.hive:hive-storage-api:2.8.1
 - io.airlift:aircompressor:0.27
 - commons-lang:commons-lang:2.6
-- org.apache.commons:commons-lang3:3.12.0
+- org.apache.commons:commons-lang3:3.18.0
 
 - org.apache.avro:avro:1.11.4
 - com.fasterxml.jackson.core:jackson-core:2.14.2


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Bump commons-lang3 to version 3.18.0 to avoid [CVE-2025-48924](https://nvd.nist.gov/vuln/detail/CVE-2025-48924).

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
