### PR TITLE
[core] support null as the default value of map type

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/casting/StringToMapCastRule.java
+++ b/paimon-common/src/main/java/org/apache/paimon/casting/StringToMapCastRule.java
@@ -82,7 +82,13 @@ class StringToMapCastRule extends AbstractCastRule<BinaryString, InternalMap> {
             if ("{}".equals(str) || "MAP()".equalsIgnoreCase(str)) {
                 return new GenericMap(new HashMap<>());
             }
-            return new GenericMap(parseDefaultMap(str, keyCastExecutor, valueCastExecutor));
+            Map<Object, Object> defaultMapValue =
+                    parseDefaultMap(str, keyCastExecutor, valueCastExecutor);
+            if (defaultMapValue == null) {
+                return null;
+            } else {
+                return new GenericMap(defaultMapValue);
+            }
         } catch (Exception e) {
             throw new RuntimeException("Cannot parse '" + value + "' as MAP: " + e.getMessage(), e);
         }
@@ -104,7 +110,10 @@ class StringToMapCastRule extends AbstractCastRule<BinaryString, InternalMap> {
             CastExecutor<BinaryString, Object> keyCastExecutor,
             CastExecutor<BinaryString, Object> valueCastExecutor) {
 
-        Map<Object, Object> mapContent = Maps.newHashMap();
+        if (str.equalsIgnoreCase("NULL")) {
+            return null;
+        }
+
         Matcher bracketMatcher = BRACKET_MAP_PATTERN.matcher(str);
         if (bracketMatcher.matches()) {
             // Parse bracket format (arrow-separated entries)

--- a/paimon-common/src/test/java/org/apache/paimon/data/DefaultValueRowTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/DefaultValueRowTest.java
@@ -94,6 +94,33 @@ public class DefaultValueRowTest {
 
         InternalMap propertiesValue = wrappedRow.getMap(1);
         assertThat(propertiesValue).isNotNull();
+        assertThat(propertiesValue.size()).isEqualTo(2);
+    }
+
+    @Test
+    public void testDefaultValueRowWithNullMapType() {
+        // Test with Map default value
+        RowType rowType =
+                RowType.of(
+                        new DataField(0, "id", DataTypes.INT()),
+                        new DataField(
+                                1,
+                                "properties",
+                                DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING()),
+                                "Default properties",
+                                "null"));
+
+        DefaultValueRow defaultValueRow = DefaultValueRow.create(rowType);
+
+        GenericRow originalRow = new GenericRow(2);
+        originalRow.setField(0, 200);
+        originalRow.setField(1, null); // Use default properties
+
+        DefaultValueRow wrappedRow = defaultValueRow.replaceRow(originalRow);
+        InternalMap propertiesValue = wrappedRow.getMap(1);
+
+        assertThat(wrappedRow.getInt(0)).isEqualTo(200);
+        assertThat(propertiesValue).isNull();
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

When use `NULL` as the default value of map type like below, the exception will be thrown.

` col MAP<INT, DOUBLE> DEFAULT NULL`

<img width="2316" height="454" alt="image" src="https://github.com/user-attachments/assets/cd62e8c8-1486-4b29-a2ce-8c9e9a6738aa" />

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
