### PR TITLE
[core] Bump httpclient5 to version >5.4.3 to avoid CVE-2025-27820

### DIFF
--- a/paimon-core/src/main/resources/META-INF/NOTICE
+++ b/paimon-core/src/main/resources/META-INF/NOTICE
@@ -5,5 +5,5 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
-- org.apache.httpcomponents.core5:httpcore5:5.3.3
-- org.apache.httpcomponents.client5:httpclient5:5.4.2
+- org.apache.httpcomponents.core5:httpcore5:5.3.6
+- org.apache.httpcomponents.client5:httpclient5:5.5.1

--- a/pom.xml
+++ b/pom.xml
@@ -136,8 +136,8 @@ under the License.
         <mockito.version>3.4.6</mockito.version>
         <mockito-junit-jupiter.version>4.11.0</mockito-junit-jupiter.version>
         <okhttp.version>4.12.0</okhttp.version>
-        <apache.hc.core.version>5.3.3</apache.hc.core.version>
-        <apache.hc.client.version>5.4.2</apache.hc.client.version>
+        <apache.hc.core.version>5.3.6</apache.hc.core.version>
+        <apache.hc.client.version>5.5.1</apache.hc.client.version>
         <jaxb.api.version>2.3.1</jaxb.api.version>
         <findbugs.version>1.3.9</findbugs.version>
         <json-smart.version>2.5.2</json-smart.version>


### PR DESCRIPTION
### Purpose
Linked issue: close https://github.com/apache/paimon/issues/6580
Bump to > 5.4.3 to fix CVE-2025-27820

### Tests

### API and Format

### Documentation
