### PR TITLE
[core] fix the wrong parsing for map type with string sub type

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/casting/StringToMapCastRule.java
+++ b/paimon-common/src/main/java/org/apache/paimon/casting/StringToMapCastRule.java
@@ -176,7 +176,7 @@ class StringToMapCastRule extends AbstractCastRule<BinaryString, InternalMap> {
                 : castExecutor.cast(BinaryString.fromString(valueStr));
     }
 
-    private List<String> splitMapEntries(String content) {
+    public List<String> splitMapEntries(String content) {
         List<String> entries = new ArrayList<>();
         StringBuilder current = new StringBuilder();
         Stack<Character> bracketStack = new Stack<>();
@@ -186,10 +186,13 @@ class StringToMapCastRule extends AbstractCastRule<BinaryString, InternalMap> {
         for (char c : content.toCharArray()) {
             if (escaped) {
                 escaped = false;
+                continue;
             } else if (c == '\\') {
                 escaped = true;
+                continue;
             } else if (c == '"') {
                 inQuotes = !inQuotes;
+                continue;
             } else if (!inQuotes) {
                 if (StringUtils.isOpenBracket(c)) {
                     bracketStack.push(c);
@@ -209,7 +212,7 @@ class StringToMapCastRule extends AbstractCastRule<BinaryString, InternalMap> {
 
     private void addCurrentEntry(List<String> entries, StringBuilder current) {
         if (current.length() > 0) {
-            entries.add(current.toString());
+            entries.add(current.toString().trim());
             current.setLength(0);
         }
     }

--- a/paimon-common/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -52,6 +52,7 @@ import org.apache.paimon.utils.DecimalUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -896,6 +897,13 @@ public class CastExecutorTest {
                 CastExecutors.resolve(rowType, DataTypes.STRING()),
                 row,
                 BinaryString.fromString("{1, {2025-01-06, {1 -> [1, null, 2]}, null}}"));
+    }
+
+    @Test
+    public void testSplitMapEntriesWithQuotes() {
+        String content = "1, \"abc\"";
+        List<String> result = StringToMapCastRule.INSTANCE.splitMapEntries(content);
+        assertThat(result).containsExactly("1", "abc");
     }
 
     @SuppressWarnings("rawtypes")


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

`col MAP<BIGINT, STRING> DEFAULT map(9999, "hello")`

Without this pr, this value part of the default value is `"hello"`, but it should be `hello`. 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
