### PR TITLE
[spark] Use copy to build new scanRelation in MergePaimonScalarSubqueries

### DIFF
--- a/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueries.scala
+++ b/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueries.scala
@@ -49,11 +49,8 @@ object MergePaimonScalarSubqueries extends MergePaimonScalarSubqueriesBase {
                   val cachedOutputNameMap = cachedRelation.output.map(a => a.name -> a).toMap
                   val mergedOutput =
                     mergedAttributes.map(a => cachedOutputNameMap.getOrElse(a.name, a))
-                  val newV2ScanRelation = DataSourceV2ScanRelation(
-                    cachedRelation,
-                    mergedScan,
-                    mergedOutput,
-                    cachedPartitioning)
+                  val newV2ScanRelation =
+                    cachedV2ScanRelation.copy(scan = mergedScan, output = mergedOutput)
 
                   val mergedOutputNameMap = mergedOutput.map(a => a.name -> a).toMap
                   val newOutputMap =

--- a/paimon-spark/paimon-spark-3.4/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueries.scala
+++ b/paimon-spark/paimon-spark-3.4/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueries.scala
@@ -60,11 +60,8 @@ object MergePaimonScalarSubqueries extends MergePaimonScalarSubqueriesBase {
                   val cachedOutputNameMap = cachedRelation.output.map(a => a.name -> a).toMap
                   val mergedOutput =
                     mergedAttributes.map(a => cachedOutputNameMap.getOrElse(a.name, a))
-                  val newV2ScanRelation = DataSourceV2ScanRelation(
-                    cachedRelation,
-                    mergedScan,
-                    mergedOutput,
-                    cachedPartitioning)
+                  val newV2ScanRelation =
+                    cachedV2ScanRelation.copy(scan = mergedScan, output = mergedOutput)
 
                   val mergedOutputNameMap = mergedOutput.map(a => a.name -> a).toMap
                   val newOutputMap =

--- a/paimon-spark/paimon-spark-3.5/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueries.scala
+++ b/paimon-spark/paimon-spark-3.5/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueries.scala
@@ -60,11 +60,8 @@ object MergePaimonScalarSubqueries extends MergePaimonScalarSubqueriesBase {
                   val cachedOutputNameMap = cachedRelation.output.map(a => a.name -> a).toMap
                   val mergedOutput =
                     mergedAttributes.map(a => cachedOutputNameMap.getOrElse(a.name, a))
-                  val newV2ScanRelation = DataSourceV2ScanRelation(
-                    cachedRelation,
-                    mergedScan,
-                    mergedOutput,
-                    cachedPartitioning)
+                  val newV2ScanRelation =
+                    cachedV2ScanRelation.copy(scan = mergedScan, output = mergedOutput)
 
                   val mergedOutputNameMap = mergedOutput.map(a => a.name -> a).toMap
                   val newOutputMap =
@@ -87,7 +84,6 @@ object MergePaimonScalarSubqueries extends MergePaimonScalarSubqueriesBase {
       outputAttrMap: AttributeMap[Attribute]): Boolean = {
     val mappedNewOrdering = newOrdering.map(_.map(mapAttributes(_, outputAttrMap)))
     mappedNewOrdering.map(_.map(_.canonicalized)) == cachedOrdering.map(_.map(_.canonicalized))
-
   }
 
   override protected def createScalarSubquery(plan: LogicalPlan, exprId: ExprId): ScalarSubquery = {

--- a/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueries.scala
+++ b/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueries.scala
@@ -60,11 +60,8 @@ object MergePaimonScalarSubqueries extends MergePaimonScalarSubqueriesBase {
                   val cachedOutputNameMap = cachedRelation.output.map(a => a.name -> a).toMap
                   val mergedOutput =
                     mergedAttributes.map(a => cachedOutputNameMap.getOrElse(a.name, a))
-                  val newV2ScanRelation = DataSourceV2ScanRelation(
-                    cachedRelation,
-                    mergedScan,
-                    mergedOutput,
-                    cachedPartitioning)
+                  val newV2ScanRelation =
+                    cachedV2ScanRelation.copy(scan = mergedScan, output = mergedOutput)
 
                   val mergedOutputNameMap = mergedOutput.map(a => a.name -> a).toMap
                   val newOutputMap =
@@ -87,7 +84,6 @@ object MergePaimonScalarSubqueries extends MergePaimonScalarSubqueriesBase {
       outputAttrMap: AttributeMap[Attribute]): Boolean = {
     val mappedNewOrdering = newOrdering.map(_.map(mapAttributes(_, outputAttrMap)))
     mappedNewOrdering.map(_.map(_.canonicalized)) == cachedOrdering.map(_.map(_.canonicalized))
-
   }
 
   override protected def createScalarSubquery(plan: LogicalPlan, exprId: ExprId): ScalarSubquery = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueriesBase.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/MergePaimonScalarSubqueriesBase.scala
@@ -272,19 +272,13 @@ trait MergePaimonScalarSubqueriesBase extends Rule[LogicalPlan] with PredicateHe
   }
 
   protected def mergePaimonScan(scan1: PaimonScan, scan2: PaimonScan): Option[PaimonScan] = {
-    if (
-      scan1.table == scan2.table &&
-      scan1.filters == scan2.filters &&
-      scan1.pushDownLimit == scan2.pushDownLimit
-    ) {
-
-      if (scan1.requiredSchema == scan2.requiredSchema) {
-        Some(scan2)
-      } else {
-        val mergedRequiredSchema = StructType(
-          (scan2.requiredSchema.fields.toSet ++ scan1.requiredSchema.fields.toSet).toArray)
-        Some(scan2.copy(requiredSchema = mergedRequiredSchema))
-      }
+    if (scan1 == scan2) {
+      Some(scan2)
+    } else if (scan1 == scan2.copy(requiredSchema = scan1.requiredSchema)) {
+      // Equals except `requiredSchema`
+      val mergedRequiredSchema = StructType(
+        (scan2.requiredSchema.fields.toSet ++ scan1.requiredSchema.fields.toSet).toArray)
+      Some(scan2.copy(requiredSchema = mergedRequiredSchema))
     } else {
       None
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

For spark3.4+, `DataSourceV2ScanRelation(cachedRelation,mergedScan,mergedOutput,cachedPartitioning)` will loss `ordering`, so use copy to build new scanRelation

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
