### PR TITLE
[core] Fix parquet performance regression in reader init

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
@@ -36,6 +36,7 @@ import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Preconditions;
 
 import org.apache.parquet.ParquetReadOptions;
+import org.apache.parquet.conf.PlainParquetConfiguration;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.ParquetInputFormat;
@@ -101,7 +102,8 @@ public class ParquetReaderFactory implements FormatReaderFactory {
     public FileRecordReader<InternalRow> createReader(FormatReaderFactory.Context context)
             throws IOException {
         ParquetReadOptions.Builder builder =
-                ParquetReadOptions.builder().withRange(0, context.fileSize());
+                ParquetReadOptions.builder(new PlainParquetConfiguration())
+                        .withRange(0, context.fileSize());
         setReadOptions(builder);
 
         ParquetFileReader reader =

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetUtil.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetUtil.java
@@ -26,6 +26,7 @@ import org.apache.paimon.utils.Pair;
 
 import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.conf.PlainParquetConfiguration;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
@@ -83,7 +84,7 @@ public class ParquetUtil {
             throws IOException {
         return new ParquetFileReader(
                 ParquetInputFile.fromPath(fileIO, path, length),
-                ParquetReadOptions.builder().build(),
+                ParquetReadOptions.builder(new PlainParquetConfiguration()).build(),
                 null);
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Fix a query performance regression problem we found in trino when upgrading paimon-bundle from lower version. The flame graph is listed below.
[trino_profile.html](https://github.com/user-attachments/files/24101738/trino_profile.html)

This PR is the same as what Iceberg did in apache/iceberg#12305
<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
already covered

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
no