### PR TITLE
[spark] Adding support for Iceberg compatibility options to be passed as tabl…

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergOptions.java
@@ -26,7 +26,10 @@ import org.apache.paimon.options.description.InlineElement;
 import org.apache.paimon.options.description.TextElement;
 import org.apache.paimon.utils.Preconditions;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.paimon.options.ConfigOptions.key;
@@ -254,5 +257,25 @@ public class IcebergOptions {
         public InlineElement getDescription() {
             return TextElement.text(description);
         }
+    }
+
+    /**
+     * Returns all ConfigOption fields defined in this class. This method uses reflection to
+     * dynamically discover all ConfigOption fields, ensuring that new options are automatically
+     * included without code changes.
+     */
+    public static List<ConfigOption<?>> getOptions() {
+        final Field[] fields = IcebergOptions.class.getFields();
+        final List<ConfigOption<?>> list = new ArrayList<>(fields.length);
+        for (Field field : fields) {
+            if (ConfigOption.class.isAssignableFrom(field.getType())) {
+                try {
+                    list.add((ConfigOption<?>) field.get(IcebergOptions.class));
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        return list;
     }
 }

--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/spark/sql/execution/shim/PaimonCreateTableAsSelectStrategy.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/spark/sql/execution/shim/PaimonCreateTableAsSelectStrategy.scala
@@ -19,6 +19,7 @@
 package org.apache.spark.sql.execution.shim
 
 import org.apache.paimon.CoreOptions
+import org.apache.paimon.iceberg.IcebergOptions
 import org.apache.paimon.spark.catalog.FormatTableCatalog
 
 import org.apache.spark.sql.{SparkSession, Strategy}
@@ -39,10 +40,16 @@ case class PaimonCreateTableAsSelectStrategy(spark: SparkSession) extends Strate
           throw new RuntimeException("Paimon can't extend StagingTableCatalog for now.")
         case _ =>
           val coreOptionKeys = CoreOptions.getOptions.asScala.map(_.key()).toSeq
-          val (coreOptions, writeOptions) = options.partition {
-            case (key, _) => coreOptionKeys.contains(key)
+
+          // Include Iceberg compatibility options in table properties (fix for DataFrame writer options)
+          val icebergOptionKeys = IcebergOptions.getOptions.asScala.map(_.key()).toSeq
+
+          val allTableOptionKeys = coreOptionKeys ++ icebergOptionKeys
+
+          val (tableOptions, writeOptions) = options.partition {
+            case (key, _) => allTableOptionKeys.contains(key)
           }
-          val newProps = CatalogV2Util.withDefaultOwnership(props) ++ coreOptions
+          val newProps = CatalogV2Util.withDefaultOwnership(props) ++ tableOptions
 
           val isPartitionedFormatTable = {
             catalog match {

--- a/paimon-spark/paimon-spark-3.4/src/main/scala/org/apache/spark/sql/execution/shim/PaimonCreateTableAsSelectStrategy.scala
+++ b/paimon-spark/paimon-spark-3.4/src/main/scala/org/apache/spark/sql/execution/shim/PaimonCreateTableAsSelectStrategy.scala
@@ -19,6 +19,7 @@
 package org.apache.spark.sql.execution.shim
 
 import org.apache.paimon.CoreOptions
+import org.apache.paimon.iceberg.IcebergOptions
 import org.apache.paimon.spark.SparkCatalog
 import org.apache.paimon.spark.catalog.FormatTableCatalog
 
@@ -53,10 +54,16 @@ case class PaimonCreateTableAsSelectStrategy(spark: SparkSession)
           throw new RuntimeException("Paimon can't extend StagingTableCatalog for now.")
         case _ =>
           val coreOptionKeys = CoreOptions.getOptions.asScala.map(_.key()).toSeq
-          val (coreOptions, writeOptions) = options.partition {
-            case (key, _) => coreOptionKeys.contains(key)
+
+          // Include Iceberg compatibility options in table properties (fix for DataFrame writer options)
+          val icebergOptionKeys = IcebergOptions.getOptions.asScala.map(_.key()).toSeq
+
+          val allTableOptionKeys = coreOptionKeys ++ icebergOptionKeys
+
+          val (tableOptions, writeOptions) = options.partition {
+            case (key, _) => allTableOptionKeys.contains(key)
           }
-          val newTableSpec = tableSpec.copy(properties = tableSpec.properties ++ coreOptions)
+          val newTableSpec = tableSpec.copy(properties = tableSpec.properties ++ tableOptions)
 
           val isPartitionedFormatTable = {
             catalog match {


### PR DESCRIPTION
…e properties with dataframe APIs

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #6793

<!-- What is the purpose of the change -->

### Tests

A unit test is added that covers this scenario.