### PR TITLE
[core] Allow change ignore-delete/ignore-update-before from false to true

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -482,7 +482,6 @@ public class CoreOptions implements Serializable {
                     .defaultValue(MergeEngine.DEDUPLICATE)
                     .withDescription("Specify the merge engine for table with primary key.");
 
-    @Immutable
     public static final ConfigOption<Boolean> IGNORE_DELETE =
             key("ignore-delete")
                     .booleanType()
@@ -493,7 +492,6 @@ public class CoreOptions implements Serializable {
                             "partial-update.ignore-delete")
                     .withDescription("Whether to ignore delete records.");
 
-    @Immutable
     public static final ConfigOption<Boolean> IGNORE_UPDATE_BEFORE =
             key("ignore-update-before")
                     .booleanType()

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FirstRowMergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/FirstRowMergeFunction.java
@@ -54,7 +54,7 @@ public class FirstRowMergeFunction implements MergeFunction<KeyValue> {
             } else {
                 throw new IllegalArgumentException(
                         "By default, First row merge engine can not accept DELETE/UPDATE_BEFORE records.\n"
-                                + "You can config 'first-row.ignore-delete' to ignore the DELETE/UPDATE_BEFORE records.");
+                                + "You can config 'ignore-delete' to ignore the DELETE/UPDATE_BEFORE records.");
             }
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -82,7 +82,9 @@ import static org.apache.paimon.CoreOptions.DELETION_VECTORS_ENABLED;
 import static org.apache.paimon.CoreOptions.DELETION_VECTORS_MODIFIABLE;
 import static org.apache.paimon.CoreOptions.DISTINCT;
 import static org.apache.paimon.CoreOptions.FIELDS_PREFIX;
+import static org.apache.paimon.CoreOptions.IGNORE_DELETE;
 import static org.apache.paimon.CoreOptions.IGNORE_RETRACT;
+import static org.apache.paimon.CoreOptions.IGNORE_UPDATE_BEFORE;
 import static org.apache.paimon.CoreOptions.LIST_AGG_DELIMITER;
 import static org.apache.paimon.CoreOptions.NESTED_KEY;
 import static org.apache.paimon.CoreOptions.SEQUENCE_FIELD;
@@ -1118,6 +1120,32 @@ public class SchemaManager implements Serializable {
                                             + "If you are confident, you can set table option '%s' = 'true' to allow deletion vectors modification.",
                                     oldDv, newDv, DELETION_VECTORS_MODIFIABLE.key()));
                 }
+            }
+        }
+
+        if (IGNORE_DELETE.key().equals(key)) {
+            boolean oldIgnoreDelete =
+                    oldValue == null
+                            ? IGNORE_DELETE.defaultValue()
+                            : Boolean.parseBoolean(oldValue);
+            boolean newIgnoreDelete = Boolean.parseBoolean(newValue);
+            if (oldIgnoreDelete && !newIgnoreDelete) {
+                throw new UnsupportedOperationException(
+                        String.format("Cannot change %s from true to false.", IGNORE_DELETE.key()));
+            }
+        }
+
+        if (IGNORE_UPDATE_BEFORE.key().equals(key)) {
+            boolean oldIgnoreUpdateBefore =
+                    oldValue == null
+                            ? IGNORE_UPDATE_BEFORE.defaultValue()
+                            : Boolean.parseBoolean(oldValue);
+            boolean newIgnoreUpdateBefore = Boolean.parseBoolean(newValue);
+            if (oldIgnoreUpdateBefore && !newIgnoreUpdateBefore) {
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "Cannot change %s from true to false.",
+                                IGNORE_UPDATE_BEFORE.key()));
             }
         }
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
When users created a partial-update/aggregation table, they might not notice that some aggregate function cannot accept -D record, and if the `ignore-delete` option is not changeable, they have to recreate the table. This PR allow them to change the option to true from false.

Also change the `ignore-update-before`.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
