### PR TITLE
[spark] Fix spark write metrics with spark adaptive plan

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/PaimonV2Write.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/PaimonV2Write.scala
@@ -159,7 +159,7 @@ private case class PaimonBatchWrite(
     // todo: find a more suitable way to get metrics.
     val commitMetrics = metricRegistry.buildSparkCommitMetrics()
     val executionId = spark.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-    val executionMetrics = Compatibility.getExecutionMetrics(spark, executionId.toLong)
+    val executionMetrics = Compatibility.getExecutionMetrics(spark, executionId.toLong).distinct
     val metricUpdates = executionMetrics.flatMap {
       m =>
         commitMetrics.find(x => m.metricType.toLowerCase.contains(x.name.toLowerCase)) match {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

executionMetrics may have same ids which will make metrics multiply many times

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
