### PR TITLE
[core] Support ignore corrupt or lost files during read

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -1116,6 +1116,18 @@ This config option does not affect the default filesystem metastore.</td>
             <td>After configuring this time, only the data files created after this time will be read. It is independent of snapshots, but it is imprecise filtering (depending on whether or not compaction occurs).</td>
         </tr>
         <tr>
+            <td><h5>scan.ignore-corrupt-files</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Ignore corrupt files while scanning.</td>
+        </tr>
+        <tr>
+            <td><h5>scan.ignore-lost-files</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Ignore lost files while scanning.</td>
+        </tr>
+        <tr>
             <td><h5>scan.manifest.parallelism</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1040,6 +1040,18 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "The delay duration of stream read when scan incremental snapshots.");
 
+    public static final ConfigOption<Boolean> SCAN_IGNORE_CORRUPT_FILE =
+            key("scan.ignore-corrupt-files")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Ignore corrupt files while scanning.");
+
+    public static final ConfigOption<Boolean> SCAN_IGNORE_LOST_FILE =
+            key("scan.ignore-lost-files")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Ignore lost files while scanning.");
+
     public static final ConfigOption<Boolean> AUTO_CREATE =
             key("auto-create")
                     .booleanType()
@@ -2941,6 +2953,14 @@ public class CoreOptions implements Serializable {
 
     public String scanVersion() {
         return options.get(SCAN_VERSION);
+    }
+
+    public boolean scanIgnoreCorruptFile() {
+        return options.get(SCAN_IGNORE_CORRUPT_FILE);
+    }
+
+    public boolean scanIgnoreLostFile() {
+        return options.get(SCAN_IGNORE_LOST_FILE);
     }
 
     public Pair<String, String> incrementalBetween() {

--- a/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AppendOnlyFileStore.java
@@ -83,8 +83,7 @@ public class AppendOnlyFileStore extends AbstractFileStore<InternalRow> {
                 rowType,
                 FileFormatDiscover.of(options),
                 pathFactory(),
-                options.fileIndexReadEnabled(),
-                options.rowTrackingEnabled());
+                options);
     }
 
     public DataEvolutionSplitRead newDataEvolutionRead() {
@@ -93,12 +92,7 @@ public class AppendOnlyFileStore extends AbstractFileStore<InternalRow> {
                     "Field merge read is only supported when data-evolution.enabled is true.");
         }
         return new DataEvolutionSplitRead(
-                fileIO,
-                schemaManager,
-                schema,
-                rowType,
-                FileFormatDiscover.of(options),
-                pathFactory());
+                fileIO, schemaManager, schema, rowType, options, pathFactory());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -129,8 +129,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
                 valueType,
                 FileFormatDiscover.of(options),
                 pathFactory(),
-                options.fileIndexReadEnabled(),
-                false);
+                options);
     }
 
     public KeyValueFileReaderFactory.Builder newReaderFactoryBuilder() {

--- a/paimon-core/src/main/java/org/apache/paimon/io/ChainKeyValueFileReaderFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/ChainKeyValueFileReaderFactory.java
@@ -51,10 +51,10 @@ public class ChainKeyValueFileReaderFactory extends KeyValueFileReaderFactory {
             RowType valueType,
             FormatReaderMapping.Builder formatReaderMappingBuilder,
             DataFilePathFactory pathFactory,
-            long asyncThreshold,
             BinaryRow partition,
             DeletionVector.Factory dvFactory,
-            ChainReadContext chainReadContext) {
+            ChainReadContext chainReadContext,
+            CoreOptions coreOptions) {
         super(
                 fileIO,
                 schemaManager,
@@ -63,9 +63,9 @@ public class ChainKeyValueFileReaderFactory extends KeyValueFileReaderFactory {
                 valueType,
                 formatReaderMappingBuilder,
                 pathFactory,
-                asyncThreshold,
                 partition,
-                dvFactory);
+                dvFactory,
+                coreOptions);
         this.chainReadContext = chainReadContext;
         CoreOptions options = new CoreOptions(schema.options());
         this.currentBranch = options.branch();
@@ -130,10 +130,10 @@ public class ChainKeyValueFileReaderFactory extends KeyValueFileReaderFactory {
                     wrapped.readValueType,
                     builder,
                     wrapped.pathFactory.createChainReadDataFilePathFactory(chainReadContext),
-                    wrapped.options.fileReaderAsyncThreshold().getBytes(),
                     partition,
                     dvFactory,
-                    chainReadContext);
+                    chainReadContext,
+                    wrapped.options);
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatReadBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatReadBuilder.java
@@ -189,6 +189,8 @@ public class FormatReadBuilder implements ReadBuilder {
             return new DataFileRecordReader(
                     readType(),
                     reader,
+                    options.scanIgnoreCorruptFile(),
+                    options.scanIgnoreLostFile(),
                     null,
                     null,
                     PartitionUtils.create(partitionMapping, dataSplit.partition()),
@@ -196,7 +198,8 @@ public class FormatReadBuilder implements ReadBuilder {
                     null,
                     0,
                     Collections.emptyMap(),
-                    null);
+                    null,
+                    formatReaderContext.filePath());
         } catch (Exception e) {
             FileUtils.checkExists(formatReaderContext.fileIO(), formatReaderContext.filePath());
             throw e;

--- a/paimon-core/src/main/java/org/apache/paimon/utils/FileUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/FileUtils.java
@@ -109,15 +109,19 @@ public class FileUtils {
 
     public static void checkExists(FileIO fileIO, Path file) throws IOException {
         if (!fileIO.exists(file)) {
-            throw new FileNotFoundException(
-                    String.format(
-                            "File '%s' not found, Possible causes: "
-                                    + "1.snapshot expires too fast, you can configure 'snapshot.time-retained'"
-                                    + " option with a larger value. "
-                                    + "2.consumption is too slow, you can improve the performance of consumption"
-                                    + " (For example, increasing parallelism).",
-                            file));
+            throw newFileNotFoundException(file);
         }
+    }
+
+    public static FileNotFoundException newFileNotFoundException(Path file) {
+        return new FileNotFoundException(
+                String.format(
+                        "File '%s' not found, Possible causes: "
+                                + "1.snapshot expires too fast, you can configure 'snapshot.time-retained'"
+                                + " option with a larger value. "
+                                + "2.consumption is too slow, you can improve the performance of consumption"
+                                + " (For example, increasing parallelism).",
+                        file));
     }
 
     public static RecordReader<InternalRow> createFormatReader(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/TestChangelogDataReadWrite.java
@@ -141,6 +141,7 @@ public class TestChangelogDataReadWrite {
                                 pathFactory,
                                 EXTRACTOR,
                                 options));
+
         RawFileSplitRead rawFileRead =
                 new RawFileSplitRead(
                         LocalFileIO.create(),
@@ -149,8 +150,7 @@ public class TestChangelogDataReadWrite {
                         VALUE_TYPE,
                         FileFormatDiscover.of(options),
                         pathFactory,
-                        options.fileIndexReadEnabled(),
-                        false);
+                        options);
         return new KeyValueTableRead(() -> read, () -> rawFileRead, null);
     }
 


### PR DESCRIPTION

### Purpose

Introduce options `scan.ignore-corrupt-files` and `scan.ignore-lost-files` to skip data files with problems.

### Tests

- paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonQueryTest.scala

### API and Format

No

### Documentation

No
