### PR TITLE
[doc] fix typos in fileindex, manifest and rest-catalog related docs

### DIFF
--- a/docs/content/concepts/spec/fileindex.md
+++ b/docs/content/concepts/spec/fileindex.md
@@ -262,7 +262,7 @@ SELECT * FROM TABLE WHERE dt = '20250801' AND class_id = 1 AND score < 60 OR sco
 
 **Optimize the `TOPN` predicate:**
 
-For now, the `TOPN` predicate optimization can not using with other predicates, only support in Apache Spark.
+For now, the `TOPN` predicate optimization can not use with other predicates, only support in Apache Spark.
 ```sql
 SELECT * FROM TABLE WHERE dt = '20250801' ORDER BY score ASC LIMIT 10;
 

--- a/docs/content/concepts/spec/manifest.md
+++ b/docs/content/concepts/spec/manifest.md
@@ -33,7 +33,7 @@ under the License.
     └── manifest-list-51c16f7b-421c-4bc0-80a0-17677f343358-1
 ```
 
-Manifest List includes meta of several manifest files. Its name contains UUID, it is a avro file, the schema is:
+Manifest List includes meta of several manifest files. Its name contains UUID, it is an avro file, the schema is:
 
 1. _FILE_NAME: STRING, manifest file name.
 2. _FILE_SIZE: BIGINT, manifest file size.
@@ -131,5 +131,5 @@ objects.
 
 A Row has two part: Fixed-length part and variable-length part. Fixed-length part contains 1 byte header and null bit
 set and field values. Null bit set is used for null tracking and is aligned to 8-byte word boundaries. `Field values`
-holds fixed-length primitive types and variable-length values which can be stored in 8 bytes inside. If it do not fit
+holds fixed-length primitive types and variable-length values which can be stored in 8 bytes inside. If it does not fit
 the variable-length field, then store the length and offset of variable-length part.

--- a/docs/content/iceberg/rest-catalog.md
+++ b/docs/content/iceberg/rest-catalog.md
@@ -31,7 +31,7 @@ This option value will not only store Iceberg metadata like hadoop-catalog, but 
 This Paimon table can be accessed from Iceberg Rest catalog later.
 
 You need to provide information about Rest Catalog by setting options prefixed with `'metadata.iceberg.rest.'`, such as 
-`'metadata.iceberg.rest.uri' = 'https://localhost/'`. Paimon will try to use these options to initialize a iceberg rest catalog, 
+`'metadata.iceberg.rest.uri' = 'https://localhost/'`. Paimon will try to use these options to initialize an iceberg rest catalog, 
 and use this rest catalog to commit metadata.
 
 **Dependency:**
@@ -68,7 +68,7 @@ CREATE TABLE `paimon`.`default`.`T` (
 -- insert some data
 INSERT INTO `paimon`.`default`.`T` VALUES(1, 9, 90),(1, 10, 100),(1, 11, 110),(2, 20, 200);
 
--- create a iceberg rest catalog
+-- create an iceberg rest catalog
 CREATE CATALOG `iceberg` WITH (
   'type' = 'iceberg',
   'catalog-type' = 'rest',

--- a/docs/content/maintenance/filesystems.md
+++ b/docs/content/maintenance/filesystems.md
@@ -75,7 +75,7 @@ For HDFS, the most important thing is to be able to read your HDFS configuration
 
 {{< tab "Flink" >}}
 
-You may not have to do anything, if you are in a hadoop environment. Otherwise pick one of the following ways to
+You may not have to do anything, if you are in a hadoop environment. Otherwise, pick one of the following ways to
 configure your HDFS:
 
 1. Set environment variable `HADOOP_HOME` or `HADOOP_CONF_DIR`.
@@ -289,7 +289,7 @@ Please note that:
 {{< /tab >}}
 {{< /tabs >}}
 
-If you environment has jindo sdk dependencies, you can use Jindo Fs to connect OSS. Jindo has better read and write efficiency.
+If your environment has jindo sdk dependencies, you can use Jindo Fs to connect OSS. Jindo has better read and write efficiency.
 
 {{< stable >}}
 Download [paimon-jindo-{{< version >}}.jar](https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-jindo/{{< version >}}/paimon-jindo-{{< version >}}.jar).

--- a/docs/content/maintenance/manage-partitions.md
+++ b/docs/content/maintenance/manage-partitions.md
@@ -120,7 +120,7 @@ More options:
             <td><h5>partition.expiration-time</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
-            <td>The expiration interval of a partition. A partition will be expired if it‘s lifetime is over this value. Partition time is extracted from the partition value.</td>
+            <td>The expiration interval of a partition. A partition will be expired if it's lifetime is over this value. Partition time is extracted from the partition value.</td>
         </tr>
         <tr>
             <td><h5>partition.timestamp-formatter</h5></td>

--- a/docs/static/rest-catalog-open-api.yaml
+++ b/docs/static/rest-catalog-open-api.yaml
@@ -122,7 +122,7 @@ paths:
       tags:
         - database
       summary: Get Database
-      operationId: getDatabases
+      operationId: getDatabase
       parameters:
         - name: prefix
           in: path


### PR DESCRIPTION
### Purpose
fix typos in fileindex, manifest and rest-catalog related docs
