### PR TITLE
[hive] Preserve default partition name when copying Hive tables

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/clone/HiveCloneUtils.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/clone/HiveCloneUtils.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import static org.apache.paimon.CoreOptions.PARTITION_DEFAULT_NAME;
 import static org.apache.paimon.hive.HiveTypeUtils.toPaimonType;
 
 /** Utils for cloning Hive table to Paimon table. */
@@ -151,6 +152,13 @@ public class HiveCloneUtils {
         List<FieldSchema> fields = extractor.extractSchema(client, hiveTable, database, table);
         List<String> partitionKeys = extractor.extractPartitionKeys(hiveTable);
         Map<String, String> options = extractor.extractOptions(hiveTable);
+        if (hiveTable.isSetPartitionKeys()) {
+            options.put(
+                    PARTITION_DEFAULT_NAME.key(),
+                    client.getConfigValue(
+                            "hive.exec.default.partition.name", "__HIVE_DEFAULT_PARTITION__"));
+        }
+
         Schema.Builder schemaBuilder =
                 Schema.newBuilder()
                         .comment(options.get("comment"))

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -170,7 +170,7 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
 
       spark.sql(
         s"""CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl$random',
-           |options => 'file.format=parquet,partition.default-name=__HIVE_DEFAULT_PARTITION__')
+           |options => 'file.format=orc')
            |""".stripMargin)
 
       checkAnswer(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

hive's default partition name is `__HIVE_DEFAULT_PARTITION__`, which is different from paimon, need to preserve it

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
