### PR TITLE
[core] Minor refactor the maintenance order in TableCommitImpl

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
@@ -372,19 +372,6 @@ public class TableCommitImpl implements InnerTableCommit {
     }
 
     private void maintain(long identifier, boolean doExpire) {
-        // expire consumer first to avoid preventing snapshot expiration
-        if (doExpire && consumerExpireTime != null) {
-            consumerManager.expire(LocalDateTime.now().minus(consumerExpireTime));
-        }
-
-        if (doExpire && expireSnapshots != null) {
-            expireSnapshots.run();
-        }
-
-        if (doExpire && partitionExpire != null) {
-            partitionExpire.expire(identifier);
-        }
-
         if (tagAutoManager != null) {
             TagAutoCreation tagAutoCreation = tagAutoManager.getTagAutoCreation();
             if (tagAutoCreation != null) {
@@ -395,6 +382,20 @@ public class TableCommitImpl implements InnerTableCommit {
             if (doExpire && tagTimeExpire != null) {
                 tagTimeExpire.expire();
             }
+        }
+
+        if (doExpire && partitionExpire != null) {
+            partitionExpire.expire(identifier);
+        }
+
+        // expire consumer first to avoid preventing snapshot expiration
+        if (doExpire && consumerExpireTime != null) {
+            consumerManager.expire(LocalDateTime.now().minus(consumerExpireTime));
+        }
+
+        // snapshot expiration usually take the most time, so put it at the end
+        if (doExpire && expireSnapshots != null) {
+            expireSnapshots.run();
         }
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The auto tag creation is time sensitive, for example, creating every day at 24:00. But currently the snapshot expiration and partition expiration are performed before auto tag creation, and they might take a long time.

So it's better to place the auto tag management to the first.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
