### PR TITLE
[spark] Introduce `source.split.target-size-with-column-pruning`

### DIFF
--- a/docs/layouts/shortcodes/generated/spark_connector_configuration.html
+++ b/docs/layouts/shortcodes/generated/spark_connector_configuration.html
@@ -75,6 +75,12 @@ under the License.
             <td>Whether to verify SparkSession is initialized with required configurations.</td>
         </tr>
         <tr>
+            <td><h5>source.split.target-size-with-column-pruning</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to adjust the target split size based on pruned (projected) columns. If enabled, split size estimation uses only the columns actually being read.</td>
+        </tr>
+        <tr>
             <td><h5>write.merge-schema</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
@@ -98,4 +98,12 @@ public class SparkConnectorOptions {
                     .defaultValue(true)
                     .withDescription(
                             "Whether to allow full scan when reading a partitioned table.");
+
+    public static final ConfigOption<Boolean> SOURCE_SPLIT_TARGET_SIZE_WITH_COLUMN_PRUNING =
+            key("source.split.target-size-with-column-pruning")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to adjust the target split size based on pruned (projected) columns. "
+                                    + "If enabled, split size estimation uses only the columns actually being read.");
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/scan/PaimonCopyOnWriteScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/scan/PaimonCopyOnWriteScan.scala
@@ -20,7 +20,6 @@ package org.apache.paimon.spark.scan
 
 import org.apache.paimon.partition.PartitionPredicate
 import org.apache.paimon.predicate.{Predicate, PredicateBuilder}
-import org.apache.paimon.spark.PaimonBatch
 import org.apache.paimon.spark.schema.PaimonMetadataColumn.FILE_PATH_COLUMN
 import org.apache.paimon.table.{FileStoreTable, InnerTable}
 import org.apache.paimon.table.source.{DataSplit, Split}
@@ -28,7 +27,7 @@ import org.apache.paimon.table.source.{DataSplit, Split}
 import org.apache.spark.sql.PaimonUtils
 import org.apache.spark.sql.connector.expressions.{Expressions, NamedReference}
 import org.apache.spark.sql.connector.expressions.filter.{Predicate => SparkPredicate}
-import org.apache.spark.sql.connector.read.{Batch, SupportsRuntimeV2Filtering}
+import org.apache.spark.sql.connector.read.SupportsRuntimeV2Filtering
 import org.apache.spark.sql.sources.{Filter, In}
 import org.apache.spark.sql.types.StructType
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/scan/PaimonStatistics.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/scan/PaimonStatistics.scala
@@ -68,7 +68,8 @@ case class PaimonStatistics(
     }
   }
 
-  lazy val readRowSizeRatio: Double = estimateRowSize(readRowType) / estimateRowSize(tableRowType)
+  lazy val readRowSizeRatio: Double =
+    estimateRowSize(readRowType).toDouble / estimateRowSize(tableRowType)
 
   private def estimateRowSize(rowType: RowType): Long = {
     rowType.getFields.asScala.map(estimateFieldSize).sum

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/OptionUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/OptionUtils.scala
@@ -111,6 +111,10 @@ object OptionUtils extends SQLConfHelper with Logging {
     getOptionString(SparkConnectorOptions.READ_ALLOW_FULL_SCAN).toBoolean
   }
 
+  def sourceSplitTargetSizeWithColumnPruning(): Boolean = {
+    getOptionString(SparkConnectorOptions.SOURCE_SPLIT_TARGET_SIZE_WITH_COLUMN_PRUNING).toBoolean
+  }
+
   private def mergeSQLConf(extraOptions: JMap[String, String]): JMap[String, String] = {
     val mergedOptions = new JHashMap[String, String](
       conf.getAllConfs


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

When reading a wide table (with many columns) but only selecting a subset of columns, the actual data processed by each task may be small. Having too many tasks can put excessive pressure on the driver. 

In such cases, can enable this configuration to calculate splits based on column pruning (i.e., considering only the actually read columns).

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
