### PR TITLE
[python] Make the overwrite parameter of the write_file API take effect

### DIFF
--- a/paimon-python/pypaimon/common/file_io.py
+++ b/paimon-python/pypaimon/common/file_io.py
@@ -281,6 +281,9 @@ class FileIO:
             return success
 
     def write_file(self, path: str, content: str, overwrite: bool = False):
+        if not overwrite and self.exists(path):
+            raise FileExistsError(f"File {path} already exists and overwrite=False")
+
         with self.new_output_stream(path) as output_stream:
             output_stream.write(content.encode('utf-8'))
 

--- a/paimon-python/pypaimon/filesystem/pvfs.py
+++ b/paimon-python/pypaimon/filesystem/pvfs.py
@@ -158,7 +158,7 @@ class PaimonVirtualFileSystem(fsspec.AbstractFileSystem):
         return PROTOCOL_NAME
 
     def sign(self, path, expiration=None, **kwargs):
-        """We do not support to create a signed URL representing the given path in gvfs."""
+        """We do not support to create a signed URL representing the given path in pvfs."""
         raise Exception(
             "Sign is not implemented for Paimon Virtual FileSystem."
         )


### PR DESCRIPTION
### Purpose
Make the overwrite parameter of the write_file API take effect.

### Tests
file_io_test.test_write_file_with_overwrite_flag