### PR TITLE
[core] SstFileReader supports range query

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/memory/MemorySliceInput.java
+++ b/paimon-common/src/main/java/org/apache/paimon/memory/MemorySliceInput.java
@@ -99,8 +99,4 @@ public class MemorySliceInput {
         position += length;
         return newSlice;
     }
-
-    public MemorySlice getSlice() {
-        return slice;
-    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/sst/BlockReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/BlockReader.java
@@ -86,11 +86,6 @@ public abstract class BlockReader {
         public int seekTo(int recordPosition) {
             return recordPosition * recordSize;
         }
-
-        @Override
-        public AlignedIterator detach() {
-            return new AlignedIterator(data.getSlice(), recordSize, comparator);
-        }
     }
 
     private static class UnalignedBlockReader extends BlockReader {
@@ -106,11 +101,6 @@ public abstract class BlockReader {
         @Override
         public int seekTo(int recordPosition) {
             return index.readInt(recordPosition * 4);
-        }
-
-        @Override
-        public UnalignedIterator detach() {
-            return new UnalignedIterator(data.getSlice(), index, comparator);
         }
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/sst/SstFileReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/SstFileReader.java
@@ -41,8 +41,7 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /**
  * An SST File Reader which serves point queries and range queries. Users can call {@code
- * createIterator} to create a file iterator and then use seek and read methods to complete range
- * queries.
+ * createIterator} to create a file iterator and then use seek and read methods to do range queries.
  *
  * <p>Note that this class is NOT thread-safe.
  */
@@ -112,8 +111,8 @@ public class SstFileReader implements Closeable {
         return null;
     }
 
-    public SstFileIterator createIterator() throws IOException {
-        return new SstFileIterator(indexBlockIterator.detach());
+    public SstFileIterator createIterator() {
+        return new SstFileIterator(indexBlock.iterator());
     }
 
     private BlockIterator getNextBlock(BlockIterator indexBlockIterator) {
@@ -201,7 +200,7 @@ public class SstFileReader implements Closeable {
          * Seek to the position of the record whose key is exactly equal to or greater than the
          * specified key.
          */
-        public void seekTo(byte[] key) throws IOException {
+        public void seekTo(byte[] key) {
             MemorySlice keySlice = MemorySlice.wrap(key);
 
             indexIterator.seekTo(keySlice);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This PR is the pre-step of https://github.com/apache/paimon/issues/6834, introducing a new access pattern for SstFileReader. Users can seek to specified key and start to iterate on remaining records. 
<!-- What is the purpose of the change -->

### Tests
Please see org.apache.paimon.sst.SstFileTest
<!-- List UT and IT cases to verify this change -->

### API and Format
No api modification
<!-- Does this change affect API or storage format -->

### Documentation
No related documentation
<!-- Does this change introduce a new feature -->
