### PR TITLE
[Paimon-core] optimize read append table with limit

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreScan.java
@@ -92,6 +92,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
     private ScanMetrics scanMetrics = null;
     private boolean dropStats;
     @Nullable protected List<Range> rowRanges;
+    @Nullable protected Long limit;
 
     public AbstractFileStoreScan(
             ManifestsReader manifestsReader,
@@ -251,6 +252,12 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
         return this;
     }
 
+    @Override
+    public FileStoreScan withLimit(long limit) {
+        this.limit = limit;
+        return this;
+    }
+
     @Nullable
     @Override
     public Integer parallelism() {
@@ -379,7 +386,7 @@ public abstract class AbstractFileStoreScan implements FileStoreScan {
         return readManifestEntries(readManifests().filteredManifests, true);
     }
 
-    private Iterator<ManifestEntry> readManifestEntries(
+    protected Iterator<ManifestEntry> readManifestEntries(
             List<ManifestFileMeta> manifests, boolean useSequential) {
         return scanMode == ScanMode.ALL
                 ? readAndMergeFileEntries(manifests, Function.identity(), useSequential)

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreScan.java
@@ -95,6 +95,8 @@ public interface FileStoreScan {
 
     FileStoreScan withReadType(RowType readType);
 
+    FileStoreScan withLimit(long limit);
+
     @Nullable
     Integer parallelism();
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
@@ -79,6 +79,7 @@ public class DataTableBatchScan extends AbstractDataTableScan {
     @Override
     public InnerTableScan withLimit(int limit) {
         this.pushDownLimit = limit;
+        snapshotReader.withLimit(limit);
         return this;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReader.java
@@ -116,6 +116,8 @@ public interface SnapshotReader {
 
     SnapshotReader withReadType(RowType readType);
 
+    SnapshotReader withLimit(int limit);
+
     /** Get splits plan from snapshot. */
     Plan read();
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
@@ -323,6 +323,12 @@ public class SnapshotReaderImpl implements SnapshotReader {
     }
 
     @Override
+    public SnapshotReader withLimit(int limit) {
+        scan.withLimit(limit);
+        return this;
+    }
+
+    @Override
     public SnapshotReader dropStats() {
         scan.dropStats();
         return this;

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
@@ -439,6 +439,12 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
         }
 
         @Override
+        public SnapshotReader withLimit(int limit) {
+            wrapped.withLimit(limit);
+            return this;
+        }
+
+        @Override
         public Plan read() {
             return wrapped.read();
         }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/AppendTableITCase.java
@@ -737,4 +737,85 @@ public class AppendTableITCase extends CatalogITCaseBase {
             Thread.sleep(1000);
         }
     }
+
+    @Test
+    public void testLimitPushdownPerformanceOptimization() {
+        // Create a table with many files to test that limit optimization is applied
+        for (int i = 0; i < 50; i++) {
+            batchSql(String.format("INSERT INTO append_table VALUES (%d, 'data_%d')", i, i));
+        }
+
+        // Without limit, should read all data
+        List<Row> allRows = batchSql("SELECT * FROM append_table");
+        assertThat(allRows.size()).isEqualTo(50);
+
+        // With limit, optimization should be applied
+        List<Row> limitedRows = batchSql("SELECT * FROM append_table LIMIT 10");
+        assertThat(limitedRows.size()).isEqualTo(10);
+
+        // Test with limit 1
+        List<Row> limitedRows1 = batchSql("SELECT * FROM append_table LIMIT 1");
+        assertThat(limitedRows1.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void testLimitPushdownWithFilter() {
+        // Create a table with many files to test that limit optimization is applied
+        // when filter is present
+        for (int i = 0; i < 50; i++) {
+            batchSql(String.format("INSERT INTO append_table VALUES (%d, 'data_%d')", i, i));
+        }
+
+        // Without filter and without limit, should read all data
+        List<Row> allRows = batchSql("SELECT * FROM append_table");
+        assertThat(allRows.size()).isEqualTo(50);
+
+        // With filter (WHERE id > 20) and limit (10), optimization should be applied
+        // The early stop in LimitAwareManifestEntryIterator will now consider the filter's effect
+        // on row counts to ensure correctness.
+        List<Row> filteredAndLimitedRows =
+                batchSql("SELECT * FROM append_table WHERE id > 20 LIMIT 10");
+        assertThat(filteredAndLimitedRows.size()).isEqualTo(10);
+        // Verify all returned rows satisfy the filter
+        for (Row row : filteredAndLimitedRows) {
+            assertThat((Integer) row.getField(0)).isGreaterThan(20);
+        }
+
+        // Test with different filter
+        List<Row> filteredAndLimitedRows2 =
+                batchSql("SELECT * FROM append_table WHERE id < 30 LIMIT 5");
+        assertThat(filteredAndLimitedRows2.size()).isEqualTo(5);
+        // Verify all returned rows satisfy the filter
+        for (Row row : filteredAndLimitedRows2) {
+            assertThat((Integer) row.getField(0)).isLessThan(30);
+        }
+    }
+
+    @Test
+    public void testLimitPushdownWhenDataLessThanLimit() {
+        // Create a table with only 3 rows
+        for (int i = 0; i < 3; i++) {
+            batchSql(String.format("INSERT INTO append_table VALUES (%d, 'data_%d')", i, i));
+        }
+
+        // With limit 10, should return all 3 rows (less than limit)
+        List<Row> rows = batchSql("SELECT * FROM append_table LIMIT 10");
+        assertThat(rows.size()).isEqualTo(3);
+    }
+
+    @Test
+    public void testLimitPushdownWithFilterWhenDataLessThanLimit() {
+        // Create a table with 10 rows, rows 0-4 have id < 5, rows 5-9 have id >= 5
+        for (int i = 0; i < 10; i++) {
+            batchSql(String.format("INSERT INTO append_table VALUES (%d, 'data_%d')", i, i));
+        }
+
+        // With filter (id >= 5) and limit (10), should return all 5 matching rows
+        List<Row> rows = batchSql("SELECT * FROM append_table WHERE id >= 5 LIMIT 10");
+        assertThat(rows.size()).isEqualTo(5);
+        // Verify all returned rows satisfy the filter
+        for (Row row : rows) {
+            assertThat((Integer) row.getField(0)).isGreaterThanOrEqualTo(5);
+        }
+    }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

See https://github.com/apache/paimon/issues/6847

This pr is to support Append-only tables. 
After this PR is merged into the master branch, we will provide another PR to support the PK table.

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
