### PR TITLE
[common] Unify hash function num calculation in BloomFilterFileIndex using bitwise operations

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bloomfilter/BloomFilterFileIndex.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bloomfilter/BloomFilterFileIndex.java
@@ -120,9 +120,9 @@ public class BloomFilterFileIndex implements FileIndexer {
             // big endian
             int numHashFunctions =
                     ((serializedBytes[0] << 24)
-                            + (serializedBytes[1] << 16)
-                            + (serializedBytes[2] << 8)
-                            + serializedBytes[3]);
+                            | (serializedBytes[1] << 16)
+                            | (serializedBytes[2] << 8)
+                            | serializedBytes[3]);
             BitSet bitSet = new BitSet(serializedBytes, 4);
             this.filter = new BloomFilter64(numHashFunctions, bitSet);
             this.hashFunction = FastHash.getHashFunction(type);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Unify hash function num calculation in BloomFilterFileIndex using bitwise operations

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
