### PR TITLE
[flink] Fix that action/procedure cannot remove unexisting files from manifests when dv enabled.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/ListUnexistingFiles.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ListUnexistingFiles.java
@@ -27,6 +27,7 @@ import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.utils.FileOperationThreadPool;
 import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.ThreadPoolUtils;
 
 import java.io.IOException;
@@ -58,6 +59,7 @@ public class ListUnexistingFiles {
         Map<Integer, Map<String, DataFileMeta>> result = new HashMap<>();
         List<Split> splits =
                 table.newScan()
+                        .withLevelFilter(Filter.alwaysTrue())
                         .withPartitionFilter(Collections.singletonList(partition))
                         .plan()
                         .splits();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/RemoveUnexistingFilesActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/RemoveUnexistingFilesActionITCase.java
@@ -41,7 +41,7 @@ public class RemoveUnexistingFilesActionITCase extends ActionITCaseBase {
         int numFiles = 10;
         int[] numDeletes = new int[numPartitions];
         ListUnexistingFilesTest.prepareRandomlyDeletedTable(
-                warehouse, "mydb", "t", bucket, numFiles, numDeletes);
+                warehouse, "mydb", "t", bucket, numFiles, numDeletes, false);
 
         RemoveUnexistingFilesAction action =
                 createAction(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/RemoveUnexistingFilesProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/RemoveUnexistingFilesProcedureITCase.java
@@ -43,7 +43,7 @@ public class RemoveUnexistingFilesProcedureITCase extends AbstractTestBase {
         int numFiles = 10;
         int[] numDeletes = new int[numPartitions];
         ListUnexistingFilesTest.prepareRandomlyDeletedTable(
-                warehouse, "mydb", "t", bucket, numFiles, numDeletes);
+                warehouse, "mydb", "t", bucket, numFiles, numDeletes, false);
 
         TableEnvironment tEnv = tableEnvironmentBuilder().batchMode().build();
         tEnv.executeSql(

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RemoveUnexistingFilesProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RemoveUnexistingFilesProcedureTest.scala
@@ -46,7 +46,8 @@ class RemoveUnexistingFilesProcedureTest extends PaimonSparkTestBase {
       tableName,
       bucket,
       numFiles,
-      numDeletes)
+      numDeletes,
+      false)
 
     val actual = new Array[Int](numPartitions)
     val pattern = "pt=(\\d+?)/".r


### PR DESCRIPTION
… manifests when dv enabled.

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #6853 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
