### PR TITLE
[core] [docs] Fixing documentation about lookup change log producers

### DIFF
--- a/docs/content/primary-key-table/changelog-producer.md
+++ b/docs/content/primary-key-table/changelog-producer.md
@@ -61,8 +61,7 @@ By specifying `'changelog-producer' = 'input'`, Paimon writers rely on their inp
 If your input can’t produce a complete changelog but you still want to get rid of the costly normalized operator, you
 may consider using the `'lookup'` changelog producer.
 
-By specifying `'changelog-producer' = 'lookup'`, Paimon will generate changelog through `'lookup'` before committing
-the data writing (You can also enable [Async Compaction]({{< ref "primary-key-table/compaction#asynchronous-compaction" >}})).
+By specifying `'changelog-producer' = 'lookup'`, Paimon will generate changelog through `'lookup'` during compaction (You can also enable [Async Compaction]({{< ref "primary-key-table/compaction#asynchronous-compaction" >}})). By default, lookup compaction is performed before committing written data unless disabled by `write-only` property.
 
 {{< img src="/img/changelog-producer-lookup.png">}}
 

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -126,7 +126,7 @@ under the License.
             <td><h5>changelog-producer</h5></td>
             <td style="word-wrap: break-word;">none</td>
             <td><p>Enum</p></td>
-            <td>Whether to double write to a changelog file. This changelog file keeps the details of data changes, it can be read directly during stream reads. This can be applied to tables with primary keys. <br /><br />Possible values:<ul><li>"none": No changelog file.</li><li>"input": Double write to a changelog file when flushing memory table, the changelog is from input.</li><li>"full-compaction": Generate changelog files with each full compaction.</li><li>"lookup": Generate changelog files through 'lookup' before committing the data writing.</li></ul></td>
+            <td>Whether to double write to a changelog file. This changelog file keeps the details of data changes, it can be read directly during stream reads. This can be applied to tables with primary keys. <br /><br />Possible values:<ul><li>"none": No changelog file.</li><li>"input": Double write to a changelog file when flushing memory table, the changelog is from input.</li><li>"full-compaction": Generate changelog files with each full compaction.</li><li>"lookup": Generate changelog files through 'lookup' compaction.</li></ul></td>
         </tr>
         <tr>
             <td><h5>changelog-producer.row-deduplicate</h5></td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -3494,9 +3494,7 @@ public class CoreOptions implements Serializable {
 
         FULL_COMPACTION("full-compaction", "Generate changelog files with each full compaction."),
 
-        LOOKUP(
-                "lookup",
-                "Generate changelog files through 'lookup' before committing the data writing.");
+        LOOKUP("lookup", "Generate changelog files through 'lookup' compaction.");
 
         private final String value;
         private final String description;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

This PR improves the documentation by making lookup changelog producer dependency obvious on compaction.
Linked issue: https://github.com/apache/paimon/issues/6857


### Documentation

The documentation is updated. As this doesn't touch anything apart from docs, all the existing tests should be passing.