### PR TITLE
[spark] Allow format table and spark table options to recognize each other

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2368,6 +2368,8 @@ public class CoreOptions implements Serializable {
             return options.get(FILE_COMPRESSION.key());
         } else if (options.containsKey(FORMAT_TABLE_FILE_COMPRESSION.key())) {
             return options.get(FORMAT_TABLE_FILE_COMPRESSION.key());
+        } else if (options.containsKey("compression")) {
+            return options.get("compression");
         } else {
             String format = formatType();
             switch (format) {

--- a/paimon-format/src/main/java/org/apache/paimon/format/csv/CsvOptions.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/csv/CsvOptions.java
@@ -47,24 +47,28 @@ public class CsvOptions {
             ConfigOptions.key("csv.quote-character")
                     .stringType()
                     .defaultValue("\"")
+                    .withFallbackKeys("quote")
                     .withDescription("The quote character for CSV format");
 
     public static final ConfigOption<String> ESCAPE_CHARACTER =
             ConfigOptions.key("csv.escape-character")
                     .stringType()
                     .defaultValue("\\")
+                    .withFallbackKeys("escape")
                     .withDescription("The escape character for CSV format");
 
     public static final ConfigOption<Boolean> INCLUDE_HEADER =
             ConfigOptions.key("csv.include-header")
                     .booleanType()
                     .defaultValue(false)
+                    .withFallbackKeys("header")
                     .withDescription("Whether to include header in CSV files");
 
     public static final ConfigOption<String> NULL_LITERAL =
             ConfigOptions.key("csv.null-literal")
                     .stringType()
                     .defaultValue("")
+                    .withFallbackKeys("nullvalue")
                     .withDescription("The literal for null values in CSV format");
 
     public static final ConfigOption<Mode> MODE =

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/catalog/FormatTableCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/catalog/FormatTableCatalog.java
@@ -86,6 +86,15 @@ public interface FormatTableCatalog {
         CaseInsensitiveStringMap dsOptions = new CaseInsensitiveStringMap(options.toMap());
         if (formatTable.format() == FormatTable.Format.CSV) {
             options.set("sep", options.get(CsvOptions.FIELD_DELIMITER));
+            options.set("lineSep", options.get(CsvOptions.LINE_DELIMITER));
+            options.set("quote", options.get(CsvOptions.QUOTE_CHARACTER));
+            options.set("header", options.get(CsvOptions.INCLUDE_HEADER).toString());
+            options.set("escape", options.get(CsvOptions.ESCAPE_CHARACTER));
+            options.set("nullvalue", options.get(CsvOptions.NULL_LITERAL));
+            options.set("mode", options.get(CsvOptions.MODE).getValue());
+            if (options.contains(CoreOptions.FORMAT_TABLE_FILE_COMPRESSION)) {
+                options.set("compression", options.get(CoreOptions.FORMAT_TABLE_FILE_COMPRESSION));
+            }
             dsOptions = new CaseInsensitiveStringMap(options.toMap());
             return new PartitionedCSVTable(
                     ident.name(),


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Allow format table and spark table options to recognize each other, so that user can change the impl.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
