### PR TITLE
[cdc] support remained mysql cdc source options excluding chunkKeyColumns 

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/mysql/MySqlActionUtils.java
@@ -183,6 +183,27 @@ public class MySqlActionUtils {
         mySqlConfig
                 .getOptional(MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP)
                 .ifPresent(sourceBuilder::skipSnapshotBackfill);
+        mySqlConfig
+                .getOptional(MySqlSourceOptions.SCAN_SNAPSHOT_FETCH_SIZE)
+                .ifPresent(sourceBuilder::fetchSize);
+        mySqlConfig
+                .getOptional(MySqlSourceOptions.CHUNK_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND)
+                .ifPresent(sourceBuilder::distributionFactorLower);
+        mySqlConfig
+                .getOptional(MySqlSourceOptions.CHUNK_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND)
+                .ifPresent(sourceBuilder::distributionFactorUpper);
+        mySqlConfig
+                .getOptional(MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST)
+                .ifPresent(sourceBuilder::assignUnboundedChunkFirst);
+        mySqlConfig
+                .getOptional(MySqlSourceOptions.CHUNK_META_GROUP_SIZE)
+                .ifPresent(sourceBuilder::splitMetaGroupSize);
+        mySqlConfig
+                .getOptional(MySqlSourceOptions.PARSE_ONLINE_SCHEMA_CHANGES)
+                .ifPresent(sourceBuilder::parseOnLineSchemaChanges);
+        mySqlConfig
+                .getOptional(MySqlSourceOptions.USE_LEGACY_JSON_FORMAT)
+                .ifPresent(sourceBuilder::useLegacyJsonFormat);
 
         String startupMode = mySqlConfig.get(MySqlSourceOptions.SCAN_STARTUP_MODE);
         // see


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close https://github.com/apache/paimon/issues/6885

<!-- What is the purpose of the change -->
Support all options excluding chunkKeyColumn based on flink-cdc v3.5. While it is possible to provide chunk key columns for multiple tables using a semicolon (;) delimiter, we are excluding this option for now. This is because updates may not be reliably reflected if the column is not a Primary Key (PK).

The following options have been added:
- `SCAN_SNAPSHOT_FETCH_SIZE`: Controls the number of rows fetched per batch during the snapshot phase.
- `CHUNK_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER / UPPER_BOUND`: Defines the bounds for chunk distribution to ensure even splitting based on the chunk key.
- `SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST`: Determines whether to prioritize the first unbounded chunk during incremental snapshots.
- `CHUNK_META_GROUP_SIZE`: Specifies the size of metadata groups for chunks to optimize split management.
- `PARSE_ONLINE_SCHEMA_CHANGES`: Enables parsing of real-time (online) schema changes (DDL).
- `USE_LEGACY_JSON_FORMAT`: Provides an option to use the legacy JSON format for backward compatibility.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
