### PR TITLE
[cdc] support remained postgres cdc source options excluding chunkKeyColumns

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresActionUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresActionUtils.java
@@ -146,9 +146,6 @@ public class PostgresActionUtils {
                 .getOptional(PostgresSourceOptions.SCAN_SNAPSHOT_FETCH_SIZE)
                 .ifPresent(sourceBuilder::fetchSize);
         postgresConfig
-                .getOptional(PostgresSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN)
-                .ifPresent(sourceBuilder::chunkKeyColumn);
-        postgresConfig
                 .getOptional(PostgresSourceOptions.CHUNK_META_GROUP_SIZE)
                 .ifPresent(sourceBuilder::splitMetaGroupSize);
         postgresConfig


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close [#xxx](https://github.com/apache/paimon/issues/6887)

<!-- What is the purpose of the change -->
Support all postgres cdc options excluding chunkKeyColumn based on flink-cdc v3.5. While it is possible to provide chunk key columns for multiple tables using a semicolon (;) delimiter, we are excluding this option for now. This is because updates may not be reliably reflected if the column is not a Primary Key (PK).

The following options have been added for postgres cdc:
- `SCAN_SNAPSHOT_FETCH_SIZE`: Controls the number of rows fetched per batch during the snapshot phase.
- `CHUNK_META_GROUP_SIZE`: Specifies the size of metadata groups for chunks to optimize split management.
- `SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER / UPPER_BOUND`: Defines the bounds for split distribution to ensure even splitting based on the split key.
- `SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED`: Determines whether to prioritize the first unbounded chunk during incremental snapshots.
- `SCAN_NEWLY_ADDED_TABLE_ENABLED`: Enables the system to automatically scan and include tables that are added after the job has started.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
