### PR TITLE
[docs] Add missing executeFilter() call in Java API read examples

### DIFF
--- a/docs/content/program-api/java-api.md
+++ b/docs/content/program-api/java-api.md
@@ -192,6 +192,8 @@ public class ReadTable {
         // 3. Distribute these splits to different tasks
 
         // 4. Read a split in task
+        // You can use executeFilter to do filter per record.
+        // By default, only capable of performing coarse-grained filtering.
         TableRead read = readBuilder.newRead().executeFilter();
         RecordReader<InternalRow> reader = read.createReader(splits);
         reader.forEachRemaining(System.out::println);
@@ -304,6 +306,8 @@ public class StreamReadTable {
             // can be restored in scan.restore(state) after fail over
 
             // 3. Read a split in task
+            // You can use executeFilter to do filter per record.
+            // By default, only capable of performing coarse-grained filtering.
             TableRead read = readBuilder.newRead().executeFilter();
             RecordReader<InternalRow> reader = read.createReader(splits);
             reader.forEachRemaining(System.out::println);


### PR DESCRIPTION
### Purpose

Linked issue: close #2932

The current Java API documentation examples for Batch Read and Stream Read are missing the `executeFilter()` call after `newRead()`. Without calling `executeFilter()`, the filter conditions specified through `withFilter()` will not take effect when reading data.

This PR adds the missing `executeFilter()` call to both examples:
- Batch Read example (ReadTable.java)
- Stream Read example (StreamReadTable.java)

### Tests

This is a documentation-only change. No code tests are needed.

### API and Format

This change does not affect API or storage format. It only fixes the documentation examples.

### Documentation

This change fixes existing documentation. No new feature is introduced.