### PR TITLE
[core] fix in predict when value is empty

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
@@ -197,7 +197,7 @@ public class PredicateBuilder {
     public Predicate in(int idx, List<Object> literals) {
         // In the IN predicate, 20 literals are critical for performance.
         // If there are more than 20 literals, the performance will decrease.
-        if (literals.size() > 20) {
+        if (literals.size() > 20 || literals.size() == 0) {
             DataField field = rowType.getFields().get(idx);
             return new LeafPredicate(In.INSTANCE, field.type(), idx, field.name(), literals);
         }

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateBuilderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateBuilderTest.java
@@ -25,6 +25,7 @@ import org.apache.paimon.types.RowType;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 
 import static org.apache.paimon.predicate.SimpleColStatsTestUtils.test;
@@ -106,5 +107,15 @@ public class PredicateBuilderTest {
                                 builder.isNull(4),
                                 builder.isNull(5),
                                 child3));
+    }
+
+    @Test
+    public void testIn() {
+        PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
+        Predicate predicate = builder.in(0, new ArrayList<>());
+        assertThat(predicate.test(GenericRow.of(1))).isEqualTo(false);
+        predicate = builder.in(0, Arrays.asList(1, 2));
+        assertThat(predicate.test(GenericRow.of(1))).isEqualTo(true);
+        assertThat(predicate.test(GenericRow.of(10))).isEqualTo(false);
     }
 }


### PR DESCRIPTION
core

### Purpose

<!-- Linking this pull request to the issue -->
https://github.com/apache/paimon/issues/6899

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
org.apache.paimon.predicate.PredicateBuilderTest#testIn

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
