### PR TITLE
[refactor] Make subclass of FallbackSplit public

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
@@ -254,7 +254,8 @@ public class FallbackReadFileStoreTable extends DelegatedFileStoreTable {
         Split wrapped();
     }
 
-    private static class FallbackSplitImpl implements FallbackSplit {
+    /** Other split (except DataSplit) fallback implementation. */
+    public static class FallbackSplitImpl implements FallbackSplit {
 
         private static final long serialVersionUID = 1L;
 
@@ -282,7 +283,8 @@ public class FallbackReadFileStoreTable extends DelegatedFileStoreTable {
         }
     }
 
-    private static class FallbackDataSplit extends DataSplit implements FallbackSplit {
+    /** DataSplit fallback implementation. */
+    public static class FallbackDataSplit extends DataSplit implements FallbackSplit {
 
         private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The key is that we need `FallbackDataSplit#deserialize` for development.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
