### PR TITLE
[spark] Optimize compact for data-evolution table, commit multiple times to avoid out of memory

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -97,7 +97,6 @@ import java.util.stream.Collectors;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
-import static com.sun.org.apache.xml.internal.serializer.utils.Utils.messages;
 import static org.apache.paimon.CoreOptions.createCommitUser;
 import static org.apache.paimon.spark.utils.SparkProcedureUtils.readParallelism;
 import static org.apache.paimon.utils.Preconditions.checkArgument;


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
To avoid out-of-memory, we can commit multiple times in spark data-evolution table compact

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
