### PR TITLE
[python] optimize file io retry

### DIFF
--- a/paimon-python/pypaimon/common/file_io.py
+++ b/paimon-python/pypaimon/common/file_io.py
@@ -70,22 +70,23 @@ class FileIO:
             connect_timeout: int = 60
     ) -> Dict[str, Any]:
         """
-        AwsStandardS3RetryStrategy is only available in PyArrow >= 8.0.0.
+        AwsStandardS3RetryStrategy and timeout parameters are only available
+        in PyArrow >= 8.0.0.
         """
-        config = {
-            'request_timeout': request_timeout,
-            'connect_timeout': connect_timeout
-        }
-
         if parse(pyarrow.__version__) >= parse("8.0.0"):
+            config = {
+                'request_timeout': request_timeout,
+                'connect_timeout': connect_timeout
+            }
             try:
                 from pyarrow.fs import AwsStandardS3RetryStrategy
                 retry_strategy = AwsStandardS3RetryStrategy(max_attempts=max_attempts)
                 config['retry_strategy'] = retry_strategy
             except ImportError:
                 pass
-
-        return config
+            return config
+        else:
+            return {}
 
     def _extract_oss_bucket(self, location) -> str:
         uri = urlparse(location)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
After reviewing AWS SDK's implementation of AwsStandardS3RetryStrategy, 3 attempts were found insufficient for complex production scenarios. 
Also Pyiceberg uses custom retry strategy instead of the default one too. So we suggest to increase the max attempts of file_io in pypaimon.
reference: https://github.com/aws/aws-sdk-cpp/blob/1.11.587/src/aws-cpp-sdk-core/source/client/RetryStrategy.cpp
                  https://github.com/apache/iceberg-python/blob/main/pyiceberg/io/pyarrow.py

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
