### PR TITLE
[core] Add min/max row id for manifest table

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ManifestsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ManifestsTable.java
@@ -87,7 +87,9 @@ public class ManifestsTable implements ReadonlyTable {
                             new DataField(
                                     6,
                                     "max_partition_stats",
-                                    SerializationUtils.newStringType(true))));
+                                    SerializationUtils.newStringType(true)),
+                            new DataField(7, "min_row_id", new BigIntType(true)),
+                            new DataField(8, "max_row_id", new BigIntType(true))));
 
     private final FileStoreTable dataTable;
 
@@ -224,7 +226,9 @@ public class ManifestsTable implements ReadonlyTable {
                     manifestFileMeta.numDeletedFiles(),
                     manifestFileMeta.schemaId(),
                     partitionCastExecutor.cast(manifestFileMeta.partitionStats().minValues()),
-                    partitionCastExecutor.cast(manifestFileMeta.partitionStats().maxValues()));
+                    partitionCastExecutor.cast(manifestFileMeta.partitionStats().maxValues()),
+                    manifestFileMeta.minRowId(),
+                    manifestFileMeta.maxRowId());
         }
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/ManifestsTableTest.java
@@ -237,7 +237,9 @@ public class ManifestsTableTest extends TableTestBase {
                                             manifestFileMeta
                                                     .partitionStats()
                                                     .maxValues()
-                                                    .getInt(0)))));
+                                                    .getInt(0))),
+                            manifestFileMeta.minRowId(),
+                            manifestFileMeta.maxRowId()));
         }
         return expectedRow;
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -248,6 +248,17 @@ public class CatalogTableITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testManifestsTableWihRowId() {
+        sql(
+                "CREATE TABLE T (a INT, b INT) WITH ('data-evolution.enabled'='true', 'row-tracking.enabled'='true')");
+        sql("INSERT INTO T VALUES (1, 2), (3, 4)");
+        sql("INSERT INTO T VALUES (5, 6), (7, 8)");
+
+        List<Row> result = sql("SELECT min_row_id, max_row_id FROM T$manifests");
+        assertThat(result).containsExactlyInAnyOrder(Row.of(0L, 1L), Row.of(2L, 3L));
+    }
+
+    @Test
     public void testSchemasTable() {
         sql(
                 "CREATE TABLE T(a INT, b INT, c STRING, PRIMARY KEY (a) NOT ENFORCED) with ('a.aa.aaa'='val1', 'b.bb.bbb'='val2')");


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Make manifest table show min/max row id

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
