### PR TITLE
[core] Unify conflict detect in FileStoreCommitImpl

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/commit/ConflictDetection.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/commit/ConflictDetection.java
@@ -532,21 +532,4 @@ public class ConflictDetection {
             return Objects.hash(partition, bucket, level);
         }
     }
-
-    /** Should do conflict check. */
-    public interface ConflictCheck {
-        boolean shouldCheck(long latestSnapshot);
-    }
-
-    public static ConflictCheck hasConflictChecked(@Nullable Long checkedLatestSnapshotId) {
-        return latestSnapshot -> !Objects.equals(latestSnapshot, checkedLatestSnapshotId);
-    }
-
-    public static ConflictCheck noConflictCheck() {
-        return latestSnapshot -> false;
-    }
-
-    public static ConflictCheck mustConflictCheck() {
-        return latestSnapshot -> true;
-    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/commit/ManifestEntryChanges.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/commit/ManifestEntryChanges.java
@@ -25,7 +25,6 @@ import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
-import org.apache.paimon.utils.ListUtils;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -164,15 +163,12 @@ public class ManifestEntryChanges {
     }
 
     public static List<BinaryRow> changedPartitions(
-            List<ManifestEntry> appendTableFiles,
-            List<ManifestEntry> compactTableFiles,
-            List<IndexManifestEntry> appendIndexFiles,
-            List<IndexManifestEntry> compactIndexFiles) {
+            List<ManifestEntry> dataFileChanges, List<IndexManifestEntry> indexFileChanges) {
         Set<BinaryRow> changedPartitions = new HashSet<>();
-        for (ManifestEntry file : ListUtils.union(appendTableFiles, compactTableFiles)) {
+        for (ManifestEntry file : dataFileChanges) {
             changedPartitions.add(file.partition());
         }
-        for (IndexManifestEntry file : ListUtils.union(appendIndexFiles, compactIndexFiles)) {
+        for (IndexManifestEntry file : indexFileChanges) {
             if (file.indexFile().indexType().equals(DELETION_VECTORS_INDEX)) {
                 changedPartitions.add(file.partition());
             }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
@@ -77,7 +77,6 @@ import static org.apache.paimon.operation.FileStoreTestUtils.assertPathExists;
 import static org.apache.paimon.operation.FileStoreTestUtils.assertPathNotExists;
 import static org.apache.paimon.operation.FileStoreTestUtils.commitData;
 import static org.apache.paimon.operation.FileStoreTestUtils.partitionedData;
-import static org.apache.paimon.operation.commit.ConflictDetection.mustConflictCheck;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -931,7 +930,7 @@ public class FileDeletionTest {
                     Collections.emptyMap(),
                     Snapshot.CommitKind.APPEND,
                     store.snapshotManager().latestSnapshot(),
-                    mustConflictCheck(),
+                    true,
                     null);
         }
     }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -84,7 +84,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.index.HashIndexFile.HASH_INDEX;
-import static org.apache.paimon.operation.commit.ConflictDetection.mustConflictCheck;
 import static org.apache.paimon.partition.PartitionPredicate.createPartitionPredicate;
 import static org.apache.paimon.stats.SimpleStats.EMPTY_STATS;
 import static org.apache.paimon.testutils.assertj.PaimonAssertions.anyCauseMatches;
@@ -1021,7 +1020,7 @@ public class FileStoreCommitTest {
                     Collections.emptyMap(),
                     Snapshot.CommitKind.APPEND,
                     firstLatest,
-                    mustConflictCheck(),
+                    true,
                     null);
             // Compact
             commit.tryCommitOnce(
@@ -1034,7 +1033,7 @@ public class FileStoreCommitTest {
                     Collections.emptyMap(),
                     Snapshot.CommitKind.COMPACT,
                     store.snapshotManager().latestSnapshot(),
-                    mustConflictCheck(),
+                    true,
                     null);
         }
         long id = store.snapshotManager().latestSnapshot().id();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
After https://github.com/apache/paimon/pull/3112

Reusing base files only works in recover case. But in recover case, we will discard COMPACT commit, no need to reuse base files. So this PR just simplify codes.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
