### PR TITLE
[variant] Fix reading empty shredded variant via variantAccess

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/variant/VariantAccessInfoUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/variant/VariantAccessInfoUtils.java
@@ -113,7 +113,9 @@ public class VariantAccessInfoUtils {
         if (!fieldsToRead.isEmpty()) {
             shreddingSchemaFields.add(shreddingSchema.getField(VARIANT_VALUE_FIELD_NAME));
         }
-        shreddingSchemaFields.add(typedValue.newType(new RowType(typedFieldsToRead)));
+        if (!typedFieldsToRead.isEmpty()) {
+            shreddingSchemaFields.add(typedValue.newType(new RowType(typedFieldsToRead)));
+        }
         return new RowType(shreddingSchemaFields);
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Fix reading empty shredded variant via variantAccess

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
