### PR TITLE
[flink] Add descriptive operator names and enable parallel file listing in orphan files cleanup

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
@@ -318,12 +318,14 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                     for (Path emptyDir : emptyDirs) {
                                         try {
                                             if (fileIO.delete(emptyDir, false)) {
+                                                LOG.info("Clean empty dir: {}", emptyDir);
                                                 output.collect(
                                                         new StreamRecord<>(emptyDir.toString()));
                                                 // recursive cleaning
                                                 newEmptyDir.add(emptyDir.getParent());
                                             }
                                         } catch (IOException ignored) {
+                                            LOG.warn("Clean empty dir failed: {}", emptyDir);
                                         }
                                     }
                                     emptyDirs = newEmptyDir;


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #6957 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
