### PR TITLE
[core] Rollback 'COMPACT' commit for row-level operations

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/TableRollback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/TableRollback.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.catalog;
+
+import org.apache.paimon.table.Instant;
+
+import javax.annotation.Nullable;
+
+/** Rollback table to instant from snapshot. */
+public interface TableRollback {
+
+    void rollbackTo(Instant instant, @Nullable Long fromSnapshot);
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/commit/CommitRollback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/commit/CommitRollback.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.operation.commit;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.TableRollback;
+import org.apache.paimon.table.Instant;
+
+/** Commit rollback to rollback 'COMPACT' commits for resolving conflicts. */
+public class CommitRollback {
+
+    private final TableRollback tableRollback;
+
+    public CommitRollback(TableRollback tableRollback) {
+        this.tableRollback = tableRollback;
+    }
+
+    public boolean tryToRollback(Snapshot latestSnapshot) {
+        if (latestSnapshot.commitKind() == Snapshot.CommitKind.COMPACT) {
+            long latest = latestSnapshot.id();
+            try {
+                tableRollback.rollbackTo(Instant.snapshot(latest - 1), latest);
+                return true;
+            } catch (Exception ignored) {
+            }
+        }
+        return false;
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
@@ -929,6 +929,7 @@ public class FileDeletionTest {
                     null,
                     Collections.emptyMap(),
                     Snapshot.CommitKind.APPEND,
+                    false,
                     store.snapshotManager().latestSnapshot(),
                     true,
                     null);

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -1019,12 +1019,13 @@ public class FileStoreCommitTest {
                     null,
                     Collections.emptyMap(),
                     Snapshot.CommitKind.APPEND,
+                    false,
                     firstLatest,
                     true,
                     null);
             // Compact
             commit.tryCommitOnce(
-                    new RetryCommitResult(firstLatest, Collections.emptyList(), null),
+                    RetryCommitResult.forCommitFail(firstLatest, Collections.emptyList(), null),
                     Collections.emptyList(),
                     Collections.emptyList(),
                     Collections.emptyList(),
@@ -1032,6 +1033,7 @@ public class FileStoreCommitTest {
                     null,
                     Collections.emptyMap(),
                     Snapshot.CommitKind.COMPACT,
+                    false,
                     store.snapshotManager().latestSnapshot(),
                     true,
                     null);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
To prevent row-level operations (MERGE INTO /  DELETE / UPDATE) from failing, we can force a rollback of COMPACT commits that do not affect correctness.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

- `RESTCatalogTest.testConflictRollback`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
