### PR TITLE
[test] Fix unstable case in PaimonFormatTableTest

### DIFF
--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/table/PaimonFormatTableTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/table/PaimonFormatTableTest.scala
@@ -126,11 +126,10 @@ class PaimonFormatTableTest extends PaimonSparkTestWithRestCatalogBase {
           s"'format-table.implementation'='paimon') PARTITIONED BY (`ds`, `ds1`, `ds2`)")
       val table =
         paimonCatalog.getTable(Identifier.create("test_db", tableName)).asInstanceOf[FormatTable]
-      val partition = 20250920
       table.fileIO().mkdirs(new Path(table.location()))
       spark.sql(s"INSERT INTO $tableName  VALUES (5, 11, 12, 'ab', 13), (7, 11, 12, 'Larry', 13)")
       checkAnswer(
-        spark.sql(s"SELECT ds, age, ds1, name, ds2 FROM $tableName ORDER BY age"),
+        spark.sql(s"SELECT ds, age, ds1, name, ds2 FROM $tableName ORDER BY ds"),
         Row(5, 11, 12, "ab", 13) :: Row(7, 11, 12, "Larry", 13) :: Nil
       )
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

```
  == Results ==
  
  == Results ==
  !== Correct Answer - 2 ==   == Spark Answer - 2 ==
  !struct<>                   struct
  ![5,11,12,ab,13]            [7,11,12,Larry,13]
  ![7,11,12,Larry,13]         [5,11,12,ab,13] (QueryTest.scala:244)
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
