### PR TITLE
[core] ConflictDetection should check delta files for OVERWRITE

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/manifest/FileEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/FileEntry.java
@@ -190,10 +190,12 @@ public interface FileEntry {
             Identifier identifier = entry.identifier();
             switch (entry.kind()) {
                 case ADD:
+                    T old = map.get(identifier);
                     checkState(
-                            !map.containsKey(identifier),
-                            "Trying to add file %s which is already added.",
-                            identifier);
+                            old == null,
+                            "Trying to add file %s which is already in the the map: %s",
+                            identifier,
+                            old);
                     map.put(identifier, entry);
                     break;
                 case DELETE:

--- a/paimon-core/src/main/java/org/apache/paimon/operation/commit/ConflictDetection.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/commit/ConflictDetection.java
@@ -137,6 +137,15 @@ public class ConflictDetection {
 
         Function<Throwable, RuntimeException> conflictException =
                 conflictException(baseCommitUser, baseEntries, deltaEntries);
+
+        try {
+            // check the delta, it is important not to delete and add the same file. Since scan
+            // relies on map for deduplication, this may result in the loss of this file
+            FileEntry.mergeEntries(deltaEntries);
+        } catch (Throwable e) {
+            throw conflictException.apply(e);
+        }
+
         Collection<SimpleFileEntry> mergedEntries;
         try {
             // merge manifest entries and also check if the files we want to delete are still there


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
See `AppendOnlySimpleTableTest.testOverwriteSameFiles`, commit twice will loose file.

We should check the delta, it is important not to delete and add the same file. Since scan relies on map for deduplication, this may result in the loss of this file

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
