### PR TITLE
[core] Introduce truncatedString for representations of large collections

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/utils/StringUtils.java
+++ b/paimon-api/src/main/java/org/apache/paimon/utils/StringUtils.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.utils;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -44,6 +45,9 @@ public class StringUtils {
 
     /** The empty String {@code ""}. */
     public static final String EMPTY = "";
+
+    /** Default maximum number of fields for truncated string representation. */
+    public static final int DEFAULT_MAX_FIELDS = 25;
 
     /**
      * Checks if the string is null, empty, or contains only whitespace characters. A whitespace
@@ -561,5 +565,47 @@ public class StringUtils {
 
     public static boolean isCloseBracket(char c) {
         return c == ']' || c == '}' || c == ')';
+    }
+
+    /**
+     * Converts a sequence to a string with truncation if it exceeds the maximum number of fields.
+     * This is useful for limiting the size of string representations of large collections.
+     *
+     * @param lst the collection to convert to string
+     * @param start the prefix string
+     * @param sep the separator between elements
+     * @param end the suffix string
+     * @param maxFields the maximum number of fields to include before truncation
+     * @return the truncated string representation
+     */
+    public static String truncatedString(
+            Collection<?> lst, String start, String sep, String end, int maxFields) {
+        boolean truncated = lst.size() > maxFields;
+        int numFields = truncated ? Math.max(0, maxFields - 1) : lst.size();
+
+        StringBuilder builder = new StringBuilder();
+        builder.append(start);
+
+        Iterator<?> iterator = lst.iterator();
+        for (int i = 0; i < numFields; i++) {
+            if (i > 0) {
+                builder.append(sep);
+            }
+            builder.append(iterator.next());
+        }
+
+        if (truncated) {
+            builder.append(sep)
+                    .append("... ")
+                    .append(lst.size() - numFields)
+                    .append(" more fields");
+        }
+
+        builder.append(end);
+        return builder.toString();
+    }
+
+    public static String truncatedString(Collection<?> lst, String start, String sep, String end) {
+        return truncatedString(lst, start, sep, end, DEFAULT_MAX_FIELDS);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/LeafPredicate.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/LeafPredicate.java
@@ -26,6 +26,7 @@ import org.apache.paimon.data.serializer.NullableSerializer;
 import org.apache.paimon.io.DataInputViewStreamWrapper;
 import org.apache.paimon.io.DataOutputViewStreamWrapper;
 import org.apache.paimon.types.DataType;
+import org.apache.paimon.utils.StringUtils;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -119,12 +120,13 @@ public class LeafPredicate extends TransformPredicate {
     @Override
     public String toString() {
         String literalsStr;
-        if (literals == null || literals.isEmpty()) {
+        int literalsSize = literals == null ? 0 : literals.size();
+        if (literalsSize == 0) {
             literalsStr = "";
-        } else if (literals.size() == 1) {
+        } else if (literalsSize == 1) {
             literalsStr = Objects.toString(literals.get(0));
         } else {
-            literalsStr = literals.toString();
+            literalsStr = StringUtils.truncatedString(literals, "[", ", ", "]");
         }
         return literalsStr.isEmpty()
                 ? function + "(" + fieldName() + ")"

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateBuilder.java
@@ -197,7 +197,7 @@ public class PredicateBuilder {
     public Predicate in(int idx, List<Object> literals) {
         // In the IN predicate, 20 literals are critical for performance.
         // If there are more than 20 literals, the performance will decrease.
-        if (literals.size() > 20 || literals.size() == 0) {
+        if (literals.size() > 20 || literals.isEmpty()) {
             DataField field = rowType.getFields().get(idx);
             return new LeafPredicate(In.INSTANCE, field.type(), idx, field.name(), literals);
         }

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
@@ -712,4 +712,17 @@ public class PredicateTest {
                 .isEqualTo(
                         "NotIn(f0, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])");
     }
+
+    @Test
+    public void testPredicateToStringWithManyFields() {
+        PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
+        List<Object> literals = new ArrayList<>();
+        for (int i = 1; i <= 100; i++) {
+            literals.add(i);
+        }
+        Predicate p = builder.in(0, literals);
+        assertThat(p.toString())
+                .isEqualTo(
+                        "In(f0, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, ... 76 more fields])");
+    }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/utils/StringUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/StringUtilsTest.java
@@ -412,6 +412,101 @@ class StringUtilsTest {
     }
 
     @Nested
+    class TruncatedStringTests {
+
+        @Test
+        void testTruncatedStringWithinMaxFields() {
+            List<String> items = Arrays.asList("a", "b", "c");
+            String result = StringUtils.truncatedString(items, "[", ", ", "]", 5);
+            assertThat(result).isEqualTo("[a, b, c]");
+        }
+
+        @Test
+        void testTruncatedStringExactlyMaxFields() {
+            List<String> items = Arrays.asList("a", "b", "c");
+            String result = StringUtils.truncatedString(items, "[", ", ", "]", 3);
+            assertThat(result).isEqualTo("[a, b, c]");
+        }
+
+        @Test
+        void testTruncatedStringExceedsMaxFields() {
+            List<String> items = Arrays.asList("a", "b", "c", "d", "e");
+            String result = StringUtils.truncatedString(items, "[", ", ", "]", 3);
+            assertThat(result).isEqualTo("[a, b, ... 3 more fields]");
+        }
+
+        @Test
+        void testTruncatedStringExceedsMaxFieldsWithSeparator() {
+            List<Integer> items = Arrays.asList(1, 2, 3, 4, 5, 6);
+            String result = StringUtils.truncatedString(items, "(", "-", ")", 4);
+            assertThat(result).isEqualTo("(1-2-3-... 3 more fields)");
+        }
+
+        @Test
+        void testTruncatedStringEmptyCollection() {
+            List<String> items = Arrays.asList();
+            String result = StringUtils.truncatedString(items, "[", ", ", "]", 3);
+            assertThat(result).isEqualTo("[]");
+        }
+
+        @Test
+        void testTruncatedStringSingleElement() {
+            List<String> items = Arrays.asList("only");
+            String result = StringUtils.truncatedString(items, "[", ", ", "]", 5);
+            assertThat(result).isEqualTo("[only]");
+        }
+
+        @Test
+        void testTruncatedStringMaxFieldsZero() {
+            List<String> items = Arrays.asList("a", "b", "c");
+            String result = StringUtils.truncatedString(items, "[", ", ", "]", 0);
+            assertThat(result).isEqualTo("[, ... 3 more fields]");
+        }
+
+        @Test
+        void testTruncatedStringMaxFieldsOne() {
+            List<String> items = Arrays.asList("a", "b", "c", "d");
+            String result = StringUtils.truncatedString(items, "[", ", ", "]", 1);
+            assertThat(result).isEqualTo("[, ... 4 more fields]");
+        }
+
+        @Test
+        void testTruncatedStringLargeCollection() {
+            List<Integer> items = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+            String result = StringUtils.truncatedString(items, "{", ", ", "}", 5);
+            assertThat(result).isEqualTo("{1, 2, 3, 4, ... 6 more fields}");
+        }
+
+        @Test
+        void testTruncatedStringWithEmptyStrings() {
+            List<String> items = Arrays.asList("", "a", "", "b", "");
+            String result = StringUtils.truncatedString(items, "[", "|", "]", 3);
+            assertThat(result).isEqualTo("[|a|... 3 more fields]");
+        }
+
+        @Test
+        void testTruncatedStringWithNullElements() {
+            List<String> items = Arrays.asList("a", null, "b", "c");
+            String result = StringUtils.truncatedString(items, "[", ", ", "]", 3);
+            assertThat(result).isEqualTo("[a, null, ... 2 more fields]");
+        }
+
+        @Test
+        void testTruncatedStringWithCustomDelimiters() {
+            List<String> items = Arrays.asList("apple", "banana", "cherry", "date");
+            String result = StringUtils.truncatedString(items, "<", " | ", ">", 3);
+            assertThat(result).isEqualTo("<apple | banana | ... 2 more fields>");
+        }
+
+        @Test
+        void testTruncatedStringWithEmptyDelimiters() {
+            List<String> items = Arrays.asList("a", "b", "c");
+            String result = StringUtils.truncatedString(items, "", "", "", 5);
+            assertThat(result).isEqualTo("abc");
+        }
+    }
+
+    @Nested
     class EdgeCaseTests {
 
         @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

- truncatedString is similar to Spark's truncatedString, and its default value also references Spark's default of 25.

```scala
  def truncatedString[T](
      seq: Seq[T],
      start: String,
      sep: String,
      end: String,
      maxFields: Int): String = {
    if (seq.length > maxFields) {
      if (truncationWarningPrinted.compareAndSet(false, true)) {
        logWarning(
          "Truncated the string representation of a plan since it was too large. This " +
            s"behavior can be adjusted by setting 'spark.sql.debug.maxToStringFields'.")
      }
      val numFields = math.max(0, maxFields - 1)
      seq.take(numFields).mkString(
        start, sep, sep + "... " + (seq.length - numFields) + " more fields" + end)
    } else {
      seq.mkString(start, sep, end)
    }
  }
```

- Use it in the toString of the IN predicate, as the IN predicates generated by DPP typically contain a large number of partition values.

<img width="359" height="659" alt="image" src="https://github.com/user-attachments/assets/c6ae4536-f724-4e09-8e58-890f4e7243bc" />


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
