### PR TITLE
[core] support btree indexed-scan in paimon-core and add some tests

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexParallelWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexParallelWriter.java
@@ -22,5 +22,14 @@ import javax.annotation.Nullable;
 
 /** Parallel Index writer for global index with relative row id (from 0 to rowCnt - 1). */
 public interface GlobalIndexParallelWriter extends GlobalIndexWriter {
+
+    /**
+     * Write the indexed key and its related localRowId to the index File. The input row id is
+     * "local" which means it is calculated by the original row id minus the start row id of current
+     * index range.
+     *
+     * @param key nullable index key
+     * @param relativeRowId local row id calculated by {@code rowId - rangeStart}.
+     */
     void write(@Nullable Object key, long relativeRowId);
 }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexer.java
@@ -34,18 +34,6 @@ public interface GlobalIndexer {
     GlobalIndexReader createReader(GlobalIndexFileReader fileReader, List<GlobalIndexIOMeta> files)
             throws IOException;
 
-    /**
-     * Describes whether the row ids stored in this global index are local row ids.
-     *
-     * <p>If this method returns {@code true}, the index stores row ids starting from {@code 0}
-     * within a fixed row-id range (e.g. the corresponding index shard range). Readers must
-     * translate them to global row ids by adding the corresponding base offset (e.g. {@code
-     * rangeStart}).
-     */
-    default boolean rowIdLocal() {
-        return true;
-    }
-
     static GlobalIndexer create(String type, DataField dataField, Options options) {
         GlobalIndexerFactory globalIndexerFactory = GlobalIndexerFactoryUtils.load(type);
         return globalIndexerFactory.create(dataField, options);

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeGlobalIndexer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeGlobalIndexer.java
@@ -95,9 +95,4 @@ public class BTreeGlobalIndexer implements GlobalIndexer {
             GlobalIndexFileReader fileReader, List<GlobalIndexIOMeta> files) throws IOException {
         return new LazyFilteredBTreeReader(files, keySerializer, fileReader, cacheManager.get());
     }
-
-    @Override
-    public boolean rowIdLocal() {
-        return false;
-    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/RowRangeGlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/RowRangeGlobalIndexScanner.java
@@ -135,13 +135,10 @@ public class RowRangeGlobalIndexScanner implements Closeable {
                                     .map(this::toGlobalMeta)
                                     .collect(Collectors.toList());
                     GlobalIndexReader innerReader =
-                            globalIndexer.rowIdLocal()
-                                    ? new OffsetGlobalIndexReader(
-                                            globalIndexer.createReader(
-                                                    indexFileReadWrite, globalMetas),
-                                            range.from,
-                                            range.to)
-                                    : globalIndexer.createReader(indexFileReadWrite, globalMetas);
+                            new OffsetGlobalIndexReader(
+                                    globalIndexer.createReader(indexFileReadWrite, globalMetas),
+                                    range.from,
+                                    range.to);
                     unionReader.add(innerReader);
                 }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/GlobalIndexTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/GlobalIndexTableTest.java
@@ -366,7 +366,7 @@ public class GlobalIndexTableTest extends DataEvolutionTestBase {
                     j < Math.min(currentOffset + targetFileSize, rows.size());
                     j++) {
                 InternalRow row = rows.get(j);
-                writer.write(row.getString(0), row.getLong(1));
+                writer.write(row.getString(0), row.getLong(1) - range.from);
             }
             currentOffset += targetFileSize;
 

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/btree/BTreeGlobalIndexBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/btree/BTreeGlobalIndexBuilder.java
@@ -118,7 +118,10 @@ public class BTreeGlobalIndexBuilder implements Serializable {
             if (currentWriter == null) {
                 currentWriter = createWriter();
             }
-            currentWriter.write(extractor.extractIndexField(row), extractor.extractRowId(row));
+
+            // convert the original rowId to local rowId
+            long localRowId = extractor.extractRowId(row) - rowRange.from;
+            currentWriter.write(extractor.extractIndexField(row), localRowId);
         }
 
         if (counter > 0) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This work is part of https://github.com/apache/paimon/issues/6834

This PR mainly contains two parts:
1. Introduce a `localRowId` method for `GlobalIndexer`, indicating whether the indexer stores original row ids (e.g. BTree index) or local row ids which are self-incremental from 0 (i.e. bitmap index and all vector indices). We should wrap an index reader by an  `OffsetIndexReader` only if the indexer has local row ids.
2. Split a GlobalIndexTest from DataEvolutionTableTest to avoid DataEvolutionTableTest growing too long.

<!-- What is the purpose of the change -->

### Tests
Please see `org.apache.paimon.table.GlobalIndexTableTest` for all global-index-related tests.
<!-- List UT and IT cases to verify this change -->

### API and Format
No public API modified.
<!-- Does this change affect API or storage format -->

### Documentation
No public doc need to be modified.
<!-- Does this change introduce a new feature -->
