### PR TITLE
[core] Fix the ArrayIndexOutOfBoundsException when use data evolution…

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
@@ -374,7 +374,7 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
             readerSuppliers.add(
                     () ->
                             new DataFileRecordReader(
-                                    schema.logicalRowType(),
+                                    readRowType,
                                     formatReaderMapping.getReaderFactory(),
                                     formatReaderContext,
                                     formatReaderMapping.getIndexMapping(),
@@ -401,7 +401,7 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
                 new FormatReaderContext(
                         fileIO, dataFilePathFactory.toPath(file), file.fileSize(), selection);
         return new DataFileRecordReader(
-                schema.logicalRowType(),
+                readRowType,
                 formatReaderMapping.getReaderFactory(),
                 formatReaderContext,
                 formatReaderMapping.getIndexMapping(),

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
@@ -18,7 +18,9 @@
 
 package org.apache.paimon.spark.sql
 
+import org.apache.paimon.CoreOptions
 import org.apache.paimon.Snapshot.CommitKind
+import org.apache.paimon.format.FileFormat
 import org.apache.paimon.spark.PaimonSparkTestBase
 
 import org.apache.spark.sql.Row
@@ -295,26 +297,32 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase {
   }
 
   test("Data Evolution: merge into table with data-evolution") {
-    withTable("s", "t") {
-      sql("CREATE TABLE s (id INT, b INT)")
-      sql("INSERT INTO s VALUES (1, 11), (2, 22)")
+    Seq("parquet", "avro").foreach {
+      format =>
+        withTable("s", "t") {
+          sql("CREATE TABLE s (id INT, b INT)")
+          sql("INSERT INTO s VALUES (1, 11), (2, 22)")
 
-      sql(
-        "CREATE TABLE t (id INT, b INT, c INT) TBLPROPERTIES ('row-tracking.enabled' = 'true', 'data-evolution.enabled' = 'true')")
-      sql("INSERT INTO t SELECT /*+ REPARTITION(1) */ id, id AS b, id AS c FROM range(2, 4)")
+          sql(s"""CREATE TABLE t (id INT, b INT, c INT) TBLPROPERTIES
+                 |('row-tracking.enabled' = 'true',
+                 |'data-evolution.enabled' = 'true',
+                 |'file.format' = '$format'
+                 |)""".stripMargin)
+          sql("INSERT INTO t SELECT /*+ REPARTITION(1) */ id, id AS b, id AS c FROM range(2, 4)")
 
-      sql("""
-            |MERGE INTO t
-            |USING s
-            |ON t.id = s.id
-            |WHEN MATCHED THEN UPDATE SET t.b = s.b
-            |WHEN NOT MATCHED THEN INSERT (id, b, c) VALUES (id, b, 11)
-            |""".stripMargin)
-      checkAnswer(sql("SELECT count(*) FROM t"), Seq(Row(3)))
-      checkAnswer(
-        sql("SELECT *, _ROW_ID, _SEQUENCE_NUMBER FROM t ORDER BY id"),
-        Seq(Row(1, 11, 11, 2, 2), Row(2, 22, 2, 0, 2), Row(3, 3, 3, 1, 2))
-      )
+          sql("""
+                |MERGE INTO t
+                |USING s
+                |ON t.id = s.id
+                |WHEN MATCHED THEN UPDATE SET t.b = s.b
+                |WHEN NOT MATCHED THEN INSERT (id, b, c) VALUES (id, b, 11)
+                |""".stripMargin)
+          checkAnswer(sql("SELECT count(*) FROM t"), Seq(Row(3)))
+          checkAnswer(
+            sql("SELECT *, _ROW_ID, _SEQUENCE_NUMBER FROM t ORDER BY id"),
+            Seq(Row(1, 11, 11, 2, 2), Row(2, 22, 2, 0, 2), Row(3, 3, 3, 1, 2))
+          )
+        }
     }
   }
 


### PR DESCRIPTION
… with avro

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Fix the error

```
Job aborted due to stage failure: Task 0 in stage 32.0 failed 1 times, most recent failure: Lost task 0.0 in stage 32.0 (TID 38) (100.81.154.93 executor driver): java.lang.ArrayIndexOutOfBoundsException: Index 3 out of bounds for length 3
	at org.apache.paimon.io.DataFileRecordReader.readBatch(DataFileRecordReader.java:151)
	at org.apache.paimon.io.DataFileRecordReader.readBatch(DataFileRecordReader.java:45)
	at org.apache.paimon.mergetree.compact.ConcatRecordReader.readBatch(ConcatRecordReader.java:66)
	at org.apache.paimon.spark.PaimonRecordReaderIterator.readBatch(PaimonRecordReaderIterator.scala:95)
	at org.apache.paimon.spark.PaimonRecordReaderIterator.advanceIfNeeded(PaimonRecordReaderIterator.scala:140)
	at org.apache.paimon.spark.PaimonRecordReaderIterator.hasNext(PaimonRecordReaderIterator.scala:66)
	at org.apache.paimon.spark.PaimonPartitionReader.advanceIfNeeded(PaimonPartitionReader.scala:85)
	at org.apache.paimon.spark.PaimonPartitionReader.next(PaimonPartitionReader.scala:66)
	at org.apache.spark.sql.execution.datasources.v2.PartitionIterator.hasNext(DataSourceRDD.scala:120)
```
<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
