### PR TITLE
[Core][BUG-FIX] Fix distinct collect agg bug of un-merged initial collect.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ReducerMergeFunctionWrapper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/ReducerMergeFunctionWrapper.java
@@ -53,6 +53,10 @@ public class ReducerMergeFunctionWrapper implements MergeFunctionWrapper<KeyValu
     public void add(KeyValue kv) {
         if (initialKv == null) {
             initialKv = kv;
+            if (kv.isAdd()) {
+                merge(initialKv);
+                isInitialized = true;
+            }
         } else {
             if (!isInitialized) {
                 merge(initialKv);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/aggregation/CollectAggregationITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/aggregation/CollectAggregationITCase.java
@@ -61,23 +61,27 @@ public class CollectAggregationITCase extends CatalogITCaseBase {
                 "INSERT INTO test_collect VALUES "
                         + "(1, CAST (NULL AS ARRAY<STRING>)), "
                         + "(2, ARRAY['A', 'B']), "
-                        + "(3, ARRAY['car', 'watch'])");
+                        + "(3, ARRAY['car', 'watch']), "
+                        + "(4, ARRAY['A', 'B', 'A'])");
 
         List<Row> result = queryAndSort("SELECT * FROM test_collect");
         checkOneRecord(result.get(0), 1);
         checkOneRecord(result.get(1), 2, "A", "B");
         checkOneRecord(result.get(2), 3, "car", "watch");
+        checkOneRecord(result.get(3), 4, "A", "B");
 
         sql(
                 "INSERT INTO test_collect VALUES "
                         + "(1, ARRAY['paimon', 'paimon']), "
                         + "(2, ARRAY['A', 'B', 'C']), "
-                        + "(3, CAST (NULL AS ARRAY<STRING>))");
+                        + "(3, CAST (NULL AS ARRAY<STRING>)), "
+                        + "(4, ARRAY['C', 'D', 'C'])");
 
         result = queryAndSort("SELECT * FROM test_collect");
         checkOneRecord(result.get(0), 1, "paimon");
         checkOneRecord(result.get(1), 2, "A", "B", "C");
         checkOneRecord(result.get(2), 3, "car", "watch");
+        checkOneRecord(result.get(3), 4, "A", "B", "C", "D");
     }
 
     @Test


### PR DESCRIPTION
### Purpose
        This PR aims to fix a bug in the aggregation merge engine where the collect aggregate function with distinct mode enabled handles unmerged initial data (initial collect) incorrectly. Specifically, when the first record (an ADD operation) enters the ReducerMergeFunctionWrapper, if it is not immediately merged and initialized, the subsequent aggregation result will incorrectly lose this initial value. This fix ensures that the first ADD record is merged immediately, thus guaranteeing the correctness of distinct collect aggregation in various scenarios.

### Tests
To verify the fix, this PR enhances the integration test case CollectAggregationITCase.java in the paimon-flink-common module.
- New Test Scenario: A new record with primary key 4 is added in the testAggWithDistinct test method.
- Initial Data: An INSERT statement inserts an array with duplicate elements: ARRAY['A', 'B', 'A'].
- Subsequent Merge: A second INSERT adds a new array ARRAY['C', 'D', 'C'] for the primary key 4.
- Key Assertions:
  - After the first query, the aggregation result for primary key 4 is asserted to be ['A', 'B'], verifying the deduplication logic on initial insertion.
  - After the second query, the aggregation result for primary key 4 is asserted to be ['A', 'B', 'C', 'D'], verifying the deduplication logic when merging with existing state.
This test case effectively covers the problematic scenario and ensures the correctness of the fix.
### API and Format
No API or format changes. This change only involves an internal logic correction and does not affect any external APIs, data storage formats, or configuration files.
### Documentation
This change is an internal bug fix and does not require updates to user-facing documentation.