### PR TITLE
[core][flink] Support parallelism snapshot expire

### DIFF
--- a/docs/content/maintenance/manage-snapshots.md
+++ b/docs/content/maintenance/manage-snapshots.md
@@ -263,6 +263,7 @@ Run the following command:
     --max_deletes <max-deletes> \
     --retain_max <retain-max> \
     --retain_min <retain-min> \
+    [--parallelism <parallelism>] \
     [--catalog_conf <paimon-catalog-conf> [--catalog_conf <paimon-catalog-conf> ...]]
 ```
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -136,10 +136,29 @@ public abstract class FileDeletionBase<T extends Snapshot> {
         if (!cleanEmptyDirectories || deletionBuckets.isEmpty()) {
             return;
         }
+        doCleanEmptyDirectories(deletionBuckets);
+        deletionBuckets.clear();
+    }
 
+    /**
+     * Try to delete data directories that may be empty after data file deletion.
+     *
+     * <p>This method uses externally provided buckets instead of internal deletionBuckets. Used in
+     * parallel expire mode where buckets are aggregated from multiple workers.
+     *
+     * @param aggregatedBuckets merged deletion buckets from all workers
+     */
+    public void cleanEmptyDirectories(Map<BinaryRow, Set<Integer>> aggregatedBuckets) {
+        if (!cleanEmptyDirectories || aggregatedBuckets.isEmpty()) {
+            return;
+        }
+        doCleanEmptyDirectories(aggregatedBuckets);
+    }
+
+    private void doCleanEmptyDirectories(Map<BinaryRow, Set<Integer>> buckets) {
         // All directory paths are deduplicated and sorted by hierarchy level
         Map<Integer, Set<Path>> deduplicate = new HashMap<>();
-        for (Map.Entry<BinaryRow, Set<Integer>> entry : deletionBuckets.entrySet()) {
+        for (Map.Entry<BinaryRow, Set<Integer>> entry : buckets.entrySet()) {
             List<Path> toDeleteEmptyDirectory = new ArrayList<>();
             // try to delete bucket directories
             for (Integer bucket : entry.getValue()) {
@@ -166,14 +185,29 @@ public abstract class FileDeletionBase<T extends Snapshot> {
         for (int hierarchy = deduplicate.size() - 1; hierarchy >= 0; hierarchy--) {
             deduplicate.get(hierarchy).forEach(this::tryDeleteEmptyDirectory);
         }
-
-        deletionBuckets.clear();
     }
 
     protected void recordDeletionBuckets(ExpireFileEntry entry) {
         deletionBuckets
                 .computeIfAbsent(entry.partition(), p -> new HashSet<>())
                 .add(entry.bucket());
+    }
+
+    /**
+     * Get and clear the deletion buckets.
+     *
+     * <p>This method is used in parallel expire to collect buckets for a single task without
+     * accumulating results from previous tasks processed by the same worker.
+     *
+     * @return a copy of the deletion buckets, the internal state is cleared after this call
+     */
+    public Map<BinaryRow, Set<Integer>> drainDeletionBuckets() {
+        Map<BinaryRow, Set<Integer>> result = new HashMap<>();
+        for (Map.Entry<BinaryRow, Set<Integer>> entry : deletionBuckets.entrySet()) {
+            result.put(entry.getKey(), new HashSet<>(entry.getValue()));
+        }
+        deletionBuckets.clear();
+        return result;
     }
 
     public void cleanUnusedDataFiles(String manifestList, Predicate<ExpireFileEntry> skipper) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
@@ -91,64 +91,14 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
     @Override
     public int expire() {
         snapshotDeletion.setChangelogDecoupled(expireConfig.isChangelogDecoupled());
-        int retainMax = expireConfig.getSnapshotRetainMax();
-        int retainMin = expireConfig.getSnapshotRetainMin();
-        int maxDeletes = expireConfig.getSnapshotMaxDeletes();
-        long olderThanMills =
-                System.currentTimeMillis() - expireConfig.getSnapshotTimeRetain().toMillis();
 
-        Long latestSnapshotId = snapshotManager.latestSnapshotId();
-        if (latestSnapshotId == null) {
-            // no snapshot, nothing to expire
+        ExpireRange range =
+                computeSnapshotExpireRange(expireConfig, snapshotManager, consumerManager);
+        if (range.isEmpty()) {
             return 0;
         }
 
-        Long earliest = snapshotManager.earliestSnapshotId();
-        if (earliest == null) {
-            return 0;
-        }
-
-        Preconditions.checkArgument(
-                retainMax >= retainMin,
-                String.format(
-                        "retainMax (%s) must not be less than retainMin (%s).",
-                        retainMax, retainMin));
-
-        // the min snapshot to retain from 'snapshot.num-retained.max'
-        // (the maximum number of snapshots to retain)
-        long min = Math.max(latestSnapshotId - retainMax + 1, earliest);
-
-        // the max exclusive snapshot to expire until
-        // protected by 'snapshot.num-retained.min'
-        // (the minimum number of completed snapshots to retain)
-        long maxExclusive = latestSnapshotId - retainMin + 1;
-
-        // the snapshot being read by the consumer cannot be deleted
-        if (!expireConfig.isConsumerChangelogOnly()) {
-            maxExclusive =
-                    Math.min(
-                            maxExclusive, consumerManager.minNextSnapshot().orElse(Long.MAX_VALUE));
-        }
-
-        // protected by 'snapshot.expire.limit'
-        // (the maximum number of snapshots allowed to expire at a time)
-        maxExclusive = Math.min(maxExclusive, earliest + maxDeletes);
-
-        for (long id = min; id < maxExclusive; id++) {
-            // Early exit the loop for 'snapshot.time-retained'
-            // (the maximum time of snapshots to retain)
-            try {
-                Snapshot snapshot = snapshotManager.tryGetSnapshot(id);
-                if (olderThanMills <= snapshot.timeMillis()) {
-                    return expireUntil(earliest, id);
-                }
-            } catch (FileNotFoundException e) {
-                // ignore
-                // snapshot may have been deleted by another process
-            }
-        }
-
-        return expireUntil(earliest, maxExclusive);
+        return expireUntil(range.earliestId, range.maxExclusive);
     }
 
     @VisibleForTesting
@@ -321,6 +271,95 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
     @VisibleForTesting
     public SnapshotDeletion snapshotDeletion() {
         return snapshotDeletion;
+    }
+
+    /** Range boundaries for snapshot expiration. */
+    public static class ExpireRange {
+        private static final ExpireRange EMPTY = new ExpireRange(0, 0);
+
+        public final long earliestId;
+        public final long maxExclusive;
+
+        public ExpireRange(long earliestId, long maxExclusive) {
+            this.earliestId = earliestId;
+            this.maxExclusive = maxExclusive;
+        }
+
+        public static ExpireRange empty() {
+            return EMPTY;
+        }
+
+        public boolean isEmpty() {
+            return maxExclusive <= earliestId;
+        }
+    }
+
+    /** Compute the snapshot expire range, or {@link ExpireRange#empty()} if nothing to expire. */
+    public static ExpireRange computeSnapshotExpireRange(
+            ExpireConfig expireConfig,
+            SnapshotManager snapshotManager,
+            ConsumerManager consumerManager) {
+        int retainMax = expireConfig.getSnapshotRetainMax();
+        int retainMin = expireConfig.getSnapshotRetainMin();
+        int maxDeletes = expireConfig.getSnapshotMaxDeletes();
+        long olderThanMills =
+                System.currentTimeMillis() - expireConfig.getSnapshotTimeRetain().toMillis();
+
+        Long latestSnapshotId = snapshotManager.latestSnapshotId();
+
+        if (latestSnapshotId == null) {
+            // no snapshot, nothing to expire
+            return ExpireRange.empty();
+        }
+
+        Long earliest = snapshotManager.earliestSnapshotId();
+
+        if (earliest == null) {
+            return ExpireRange.empty();
+        }
+
+        Preconditions.checkArgument(
+                retainMax >= retainMin,
+                String.format(
+                        "retainMax (%s) must not be less than retainMin (%s).",
+                        retainMax, retainMin));
+
+        // the min snapshot to retain from 'snapshot.num-retained.max'
+        // (the maximum number of snapshots to retain)
+        long min = Math.max(latestSnapshotId - retainMax + 1, earliest);
+
+        // the max exclusive snapshot to expire until
+        // protected by 'snapshot.num-retained.min'
+        // (the minimum number of completed snapshots to retain)
+        long maxExclusive = latestSnapshotId - retainMin + 1;
+
+        // the snapshot being read by the consumer cannot be deleted
+        if (!expireConfig.isConsumerChangelogOnly()) {
+            maxExclusive =
+                    Math.min(
+                            maxExclusive, consumerManager.minNextSnapshot().orElse(Long.MAX_VALUE));
+        }
+
+        // protected by 'snapshot.expire.limit'
+        // (the maximum number of snapshots allowed to expire at a time)
+        maxExclusive = Math.min(maxExclusive, earliest + maxDeletes);
+
+        for (long id = min; id < maxExclusive; id++) {
+            // Early exit the loop for 'snapshot.time-retained'
+            // (the maximum time of snapshots to retain)
+            try {
+                Snapshot snapshot = snapshotManager.tryGetSnapshot(id);
+                if (olderThanMills <= snapshot.timeMillis()) {
+                    maxExclusive = id;
+                    break;
+                }
+            } catch (FileNotFoundException e) {
+                // ignore
+                // snapshot may have been deleted by another process
+            }
+        }
+
+        return new ExpireRange(earliest, maxExclusive);
     }
 
     /** Find the skipping tags in sortedTags for range of [beginInclusive, endExclusive). */

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -64,7 +64,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
@@ -79,8 +78,8 @@ public class ExpireSnapshotsTest {
 
     protected final FileIO fileIO = new LocalFileIO();
     protected TestKeyValueGenerator gen;
-    @TempDir java.nio.file.Path tempDir;
-    @TempDir java.nio.file.Path tempExternalPath;
+    @TempDir protected java.nio.file.Path tempDir;
+    @TempDir protected java.nio.file.Path tempExternalPath;
     protected TestFileStore store;
     protected SnapshotManager snapshotManager;
     protected ChangelogManager changelogManager;
@@ -104,7 +103,12 @@ public class ExpireSnapshotsTest {
 
     @Test
     public void testExpireWithMissingFiles() throws Exception {
-        ExpireSnapshots expire = store.newExpire(1, 1, 1);
+        ExpireConfig config =
+                ExpireConfig.builder()
+                        .snapshotRetainMin(1)
+                        .snapshotRetainMax(1)
+                        .snapshotTimeRetain(Duration.ofMillis(1))
+                        .build();
 
         List<KeyValue> allData = new ArrayList<>();
         List<Integer> snapshotPositions = new ArrayList<>();
@@ -134,7 +138,7 @@ public class ExpireSnapshotsTest {
             fileIO.deleteQuietly(unusedFileList.get(i));
         }
 
-        expire.expire();
+        doExpire(config);
 
         for (int i = 1; i < latestSnapshotId; i++) {
             assertThat(snapshotManager.snapshotExists(i)).isFalse();
@@ -152,7 +156,12 @@ public class ExpireSnapshotsTest {
                 .set(
                         CoreOptions.DATA_FILE_EXTERNAL_PATHS_STRATEGY,
                         ExternalPathStrategy.ROUND_ROBIN);
-        ExpireSnapshots expire = store.newExpire(1, 1, 1);
+        ExpireConfig config =
+                ExpireConfig.builder()
+                        .snapshotRetainMin(1)
+                        .snapshotRetainMax(1)
+                        .snapshotTimeRetain(Duration.ofMillis(1))
+                        .build();
 
         List<KeyValue> allData = new ArrayList<>();
         List<Integer> snapshotPositions = new ArrayList<>();
@@ -195,7 +204,7 @@ public class ExpireSnapshotsTest {
             fileIO.deleteQuietly(unusedFileList.get(i));
         }
 
-        expire.expire();
+        doExpire(config);
 
         for (int i = 1; i < latestSnapshotId; i++) {
             assertThat(snapshotManager.snapshotExists(i)).isFalse();
@@ -228,7 +237,13 @@ public class ExpireSnapshotsTest {
         // randomly expire snapshots
         int expired = random.nextInt(latestSnapshotId / 2) + 1;
         int retained = latestSnapshotId - expired;
-        store.newExpire(retained, retained, Long.MAX_VALUE).expire();
+        ExpireConfig config =
+                ExpireConfig.builder()
+                        .snapshotRetainMin(retained)
+                        .snapshotRetainMax(retained)
+                        .snapshotTimeRetain(Duration.ofMillis(Long.MAX_VALUE))
+                        .build();
+        doExpire(config);
 
         // randomly delete tags
         for (int id = 1; id <= latestSnapshotId; id++) {
@@ -253,8 +268,6 @@ public class ExpireSnapshotsTest {
 
     @Test
     public void testExpireExtraFiles() throws IOException {
-        ExpireSnapshotsImpl expire = (ExpireSnapshotsImpl) store.newExpire(1, 3, Long.MAX_VALUE);
-
         // write test files
         BinaryRow partition = gen.getPartition(gen.next());
         Path bucketPath = store.pathFactory().bucketPath(partition, 0);
@@ -292,8 +305,8 @@ public class ExpireSnapshotsTest {
         ManifestEntry add = ManifestEntry.create(FileKind.ADD, partition, 0, 1, dataFile);
         ManifestEntry delete = ManifestEntry.create(FileKind.DELETE, partition, 0, 1, dataFile);
 
-        // expire
-        expire.snapshotDeletion()
+        // expire using SnapshotDeletion directly
+        store.newSnapshotDeletion()
                 .cleanUnusedDataFile(
                         Arrays.asList(ExpireFileEntry.from(add), ExpireFileEntry.from(delete)));
 
@@ -314,7 +327,7 @@ public class ExpireSnapshotsTest {
                 .set(
                         CoreOptions.DATA_FILE_EXTERNAL_PATHS_STRATEGY,
                         ExternalPathStrategy.ROUND_ROBIN);
-        ExpireSnapshotsImpl expire = (ExpireSnapshotsImpl) store.newExpire(1, 3, Long.MAX_VALUE);
+
         // write test files
         BinaryRow partition = gen.getPartition(gen.next());
 
@@ -355,8 +368,8 @@ public class ExpireSnapshotsTest {
         ManifestEntry add = ManifestEntry.create(FileKind.ADD, partition, 0, 1, dataFile);
         ManifestEntry delete = ManifestEntry.create(FileKind.DELETE, partition, 0, 1, dataFile);
 
-        // expire
-        expire.snapshotDeletion()
+        // expire using SnapshotDeletion directly
+        store.newSnapshotDeletion()
                 .cleanUnusedDataFile(
                         Arrays.asList(ExpireFileEntry.from(add), ExpireFileEntry.from(delete)));
 
@@ -369,9 +382,14 @@ public class ExpireSnapshotsTest {
     }
 
     @Test
-    public void testNoSnapshot() throws IOException {
-        ExpireSnapshots expire = store.newExpire(1, 3, Long.MAX_VALUE);
-        expire.expire();
+    public void testNoSnapshot() throws Exception {
+        ExpireConfig config =
+                ExpireConfig.builder()
+                        .snapshotRetainMin(1)
+                        .snapshotRetainMax(3)
+                        .snapshotTimeRetain(Duration.ofMillis(Long.MAX_VALUE))
+                        .build();
+        doExpire(config);
 
         assertThat(snapshotManager.latestSnapshotId()).isNull();
 
@@ -384,8 +402,13 @@ public class ExpireSnapshotsTest {
         List<Integer> snapshotPositions = new ArrayList<>();
         commit(2, allData, snapshotPositions);
         int latestSnapshotId = requireNonNull(snapshotManager.latestSnapshotId()).intValue();
-        ExpireSnapshots expire = store.newExpire(1, latestSnapshotId + 1, Long.MAX_VALUE);
-        expire.expire();
+        ExpireConfig config =
+                ExpireConfig.builder()
+                        .snapshotRetainMin(1)
+                        .snapshotRetainMax(latestSnapshotId + 1)
+                        .snapshotTimeRetain(Duration.ofMillis(Long.MAX_VALUE))
+                        .build();
+        doExpire(config);
 
         for (int i = 1; i <= latestSnapshotId; i++) {
             assertThat(snapshotManager.snapshotExists(i)).isTrue();
@@ -401,8 +424,13 @@ public class ExpireSnapshotsTest {
         List<Integer> snapshotPositions = new ArrayList<>();
         commit(5, allData, snapshotPositions);
         int latestSnapshotId = requireNonNull(snapshotManager.latestSnapshotId()).intValue();
-        ExpireSnapshots expire = store.newExpire(1, Integer.MAX_VALUE, Long.MAX_VALUE);
-        expire.expire();
+        ExpireConfig config =
+                ExpireConfig.builder()
+                        .snapshotRetainMin(1)
+                        .snapshotRetainMax(Integer.MAX_VALUE)
+                        .snapshotTimeRetain(Duration.ofMillis(Long.MAX_VALUE))
+                        .build();
+        doExpire(config);
 
         for (int i = 1; i <= latestSnapshotId; i++) {
             assertThat(snapshotManager.snapshotExists(i)).isTrue();
@@ -422,8 +450,13 @@ public class ExpireSnapshotsTest {
         commit(numRetainedMin + random.nextInt(5), allData, snapshotPositions);
         int latestSnapshotId = requireNonNull(snapshotManager.latestSnapshotId()).intValue();
         Thread.sleep(100);
-        ExpireSnapshots expire = store.newExpire(numRetainedMin, Integer.MAX_VALUE, 1);
-        expire.expire();
+        ExpireConfig config =
+                ExpireConfig.builder()
+                        .snapshotRetainMin(numRetainedMin)
+                        .snapshotRetainMax(Integer.MAX_VALUE)
+                        .snapshotTimeRetain(Duration.ofMillis(1))
+                        .build();
+        doExpire(config);
 
         for (int i = 1; i <= latestSnapshotId - numRetainedMin; i++) {
             assertThat(snapshotManager.snapshotExists(i)).isFalse();
@@ -438,31 +471,21 @@ public class ExpireSnapshotsTest {
 
     @Test
     public void testExpireEmptySnapshot() throws Exception {
-        Random random = new Random();
-
         List<KeyValue> allData = new ArrayList<>();
         List<Integer> snapshotPositions = new ArrayList<>();
         commit(100, allData, snapshotPositions);
-        int latestSnapshotId = requireNonNull(snapshotManager.latestSnapshotId()).intValue();
 
         List<Thread> s = new ArrayList<>();
-        s.add(
-                new Thread(
-                        () -> {
-                            final ExpireSnapshotsImpl expire =
-                                    (ExpireSnapshotsImpl) store.newExpire(1, Integer.MAX_VALUE, 1);
-                            expire.expireUntil(89, latestSnapshotId);
-                        }));
+        // Create multiple threads that concurrently expire snapshots
         for (int i = 0; i < 10; i++) {
-            final ExpireSnapshotsImpl expire =
-                    (ExpireSnapshotsImpl) store.newExpire(1, Integer.MAX_VALUE, 1);
-            s.add(
-                    new Thread(
-                            () -> {
-                                int start = random.nextInt(latestSnapshotId - 10);
-                                int end = start + random.nextInt(10);
-                                expire.expireUntil(start, end);
-                            }));
+            ExpireConfig config =
+                    ExpireConfig.builder()
+                            .snapshotRetainMin(1)
+                            .snapshotRetainMax(Integer.MAX_VALUE)
+                            .snapshotTimeRetain(Duration.ofMillis(1))
+                            .build();
+
+            s.add(new Thread(() -> doExpire(config)));
         }
 
         Assertions.assertThatCode(
@@ -482,13 +505,18 @@ public class ExpireSnapshotsTest {
 
     @Test
     public void testExpireWithNumber() throws Exception {
-        ExpireSnapshots expire = store.newExpire(1, 3, Long.MAX_VALUE);
+        ExpireConfig config =
+                ExpireConfig.builder()
+                        .snapshotRetainMin(1)
+                        .snapshotRetainMax(3)
+                        .snapshotTimeRetain(Duration.ofMillis(Long.MAX_VALUE))
+                        .build();
 
         List<KeyValue> allData = new ArrayList<>();
         List<Integer> snapshotPositions = new ArrayList<>();
         for (int i = 1; i <= 3; i++) {
             commit(ThreadLocalRandom.current().nextInt(5) + 1, allData, snapshotPositions);
-            expire.expire();
+            doExpire(config);
 
             int latestSnapshotId = requireNonNull(snapshotManager.latestSnapshotId()).intValue();
             for (int j = 1; j <= latestSnapshotId; j++) {
@@ -520,11 +548,12 @@ public class ExpireSnapshotsTest {
 
     @Test
     public void testExpireWithTime() throws Exception {
-        ExpireConfig.Builder builder = ExpireConfig.builder();
-        builder.snapshotRetainMin(1)
-                .snapshotRetainMax(Integer.MAX_VALUE)
-                .snapshotTimeRetain(Duration.ofMillis(1000));
-        ExpireSnapshots expire = store.newExpire(builder.build());
+        ExpireConfig config =
+                ExpireConfig.builder()
+                        .snapshotRetainMin(1)
+                        .snapshotRetainMax(Integer.MAX_VALUE)
+                        .snapshotTimeRetain(Duration.ofMillis(1000))
+                        .build();
 
         List<KeyValue> allData = new ArrayList<>();
         List<Integer> snapshotPositions = new ArrayList<>();
@@ -534,8 +563,8 @@ public class ExpireSnapshotsTest {
         long expireMillis = System.currentTimeMillis();
         // expire twice to check for idempotence
 
-        expire.config(builder.snapshotTimeRetain(Duration.ofMillis(1000)).build()).expire();
-        expire.config(builder.snapshotTimeRetain(Duration.ofMillis(1000)).build()).expire();
+        doExpire(config);
+        doExpire(config);
 
         int latestSnapshotId = requireNonNull(snapshotManager.latestSnapshotId()).intValue();
         for (int i = 1; i <= latestSnapshotId; i++) {
@@ -585,8 +614,13 @@ public class ExpireSnapshotsTest {
         FileStoreTestUtils.assertPathExists(fileIO, dataFilePath2);
 
         // the data file still exists after expire
-        ExpireSnapshots expire = store.newExpire(1, 1, Long.MAX_VALUE);
-        expire.expire();
+        ExpireConfig config =
+                ExpireConfig.builder()
+                        .snapshotRetainMin(1)
+                        .snapshotRetainMax(1)
+                        .snapshotTimeRetain(Duration.ofMillis(Long.MAX_VALUE))
+                        .build();
+        doExpire(config);
         FileStoreTestUtils.assertPathExists(fileIO, dataFilePath2);
 
         store.assertCleaned();
@@ -605,11 +639,11 @@ public class ExpireSnapshotsTest {
                         .changelogRetainMax(3)
                         .build();
 
-        ExpireSnapshots snapshot = store.newExpire(config);
+        doExpire(config);
         ExpireSnapshots changelog = store.newChangelogExpire(config);
         // expire twice to check for idempotence
-        snapshot.expire();
-        snapshot.expire();
+        doExpire(config);
+        doExpire(config);
 
         int latestSnapshotId = snapshotManager.latestSnapshotId().intValue();
         int earliestSnapshotId = snapshotManager.earliestSnapshotId().intValue();
@@ -657,7 +691,7 @@ public class ExpireSnapshotsTest {
                         .snapshotTimeRetain(Duration.ofMillis(Long.MAX_VALUE))
                         .build();
 
-        store.newExpire(config).expire();
+        doExpire(config);
 
         int latestSnapshotId = snapshotManager.latestSnapshotId().intValue();
         assertSnapshot(latestSnapshotId, allData, snapshotPositions);
@@ -774,5 +808,12 @@ public class ExpireSnapshotsTest {
         gen.sort(actualKvs);
         Map<BinaryRow, BinaryRow> actual = store.toKvMap(actualKvs);
         assertThat(actual).isEqualTo(expected);
+    }
+
+    // ==================== Expire Method (can be overridden by subclass) ====================
+
+    /** Subclass can override this method to test different expire implementations. */
+    protected int doExpire(ExpireConfig config) {
+        return store.newExpire(config).expire();
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireSnapshotsAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireSnapshotsAction.java
@@ -32,6 +32,8 @@ import org.apache.paimon.options.ExpireConfig;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.utils.ProcedureUtils;
 
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.slf4j.Logger;
@@ -49,10 +51,10 @@ import java.util.Map;
  * <p>This action supports both local and parallel execution modes:
  *
  * <ul>
- *   <li>Local mode: when {@code forceStartFlinkJob} is false and {@code parallelism <= 1}, executes
- *       locally via {@link #executeLocally()}
- *   <li>Parallel mode: when {@code forceStartFlinkJob} is true or {@code parallelism > 1}, uses
- *       Flink distributed execution for deletion
+ *   <li>Local mode: when {@code forceStartFlinkJob} is false, executes locally via {@link
+ *       #executeLocally()}
+ *   <li>Flink mode: when {@code forceStartFlinkJob} is true, uses Flink distributed execution for
+ *       deletion.
  * </ul>
  *
  * <p>In parallel mode:
@@ -108,12 +110,10 @@ public class ExpireSnapshotsAction extends ActionBase implements LocalAction {
 
     @Override
     public void run() throws Exception {
-        if (forceStartFlinkJob || parallelism > 1) {
-            // Parallel mode: build custom multi-parallelism Flink pipeline
+        if (forceStartFlinkJob) {
+            // Flink mode: always build and submit a Flink job
             build();
-            if (!env.getTransformations().isEmpty()) {
-                execute(this.getClass().getSimpleName());
-            }
+            execute(this.getClass().getSimpleName());
         } else {
             // Default: ActionBase handles LocalAction → executeLocally()
             super.run();
@@ -151,15 +151,14 @@ public class ExpireSnapshotsAction extends ActionBase implements LocalAction {
         // Plan the expiration
         ExpireSnapshotsPlan plan = planner.plan(expireConfig);
         if (plan.isEmpty()) {
-            LOG.info("No snapshots to expire, skipping Flink job submission.");
-            return;
+            LOG.info("No snapshots to expire.");
+        } else {
+            LOG.info(
+                    "Planning to expire {} snapshots, range=[{}, {})",
+                    plan.endExclusiveId() - plan.beginInclusiveId(),
+                    plan.beginInclusiveId(),
+                    plan.endExclusiveId());
         }
-
-        LOG.info(
-                "Planning to expire {} snapshots, range=[{}, {})",
-                plan.endExclusiveId() - plan.beginInclusiveId(),
-                plan.beginInclusiveId(),
-                plan.endExclusiveId());
 
         // Build worker phase
         DataStream<DeletionReport> reports = buildWorkerPhase(plan, identifier, expireConfig);
@@ -188,7 +187,10 @@ public class ExpireSnapshotsAction extends ActionBase implements LocalAction {
                 plan.partitionTasksBySnapshotRange(parallelism);
 
         DataStreamSource<List<SnapshotExpireTask>> source =
-                env.fromCollection(partitionedGroups).setParallelism(1);
+                env.fromCollection(
+                                partitionedGroups,
+                                TypeInformation.of(new TypeHint<List<SnapshotExpireTask>>() {}))
+                        .setParallelism(1);
 
         return source.rebalance()
                 .flatMap(
@@ -200,7 +202,6 @@ public class ExpireSnapshotsAction extends ActionBase implements LocalAction {
                                 expireConfig.isChangelogDecoupled()))
                 // Use JavaTypeInfo to ensure proper Java serialization of DeletionReport,
                 // avoiding Kryo's FieldSerializer which cannot handle BinaryRow correctly.
-                // This approach is compatible with both Flink 1.x and 2.x.
                 .returns(new JavaTypeInfo<>(DeletionReport.class))
                 .setParallelism(parallelism)
                 .name("RangePartitionedExpire");

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireSnapshotsAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireSnapshotsAction.java
@@ -18,30 +18,75 @@
 
 package org.apache.paimon.flink.action;
 
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.flink.expire.DeletionReport;
+import org.apache.paimon.flink.expire.ExpireSnapshotsPlan;
+import org.apache.paimon.flink.expire.ExpireSnapshotsPlanner;
+import org.apache.paimon.flink.expire.RangePartitionedExpireFunction;
+import org.apache.paimon.flink.expire.SnapshotExpireSink;
+import org.apache.paimon.flink.expire.SnapshotExpireTask;
 import org.apache.paimon.flink.procedure.ExpireSnapshotsProcedure;
+import org.apache.paimon.flink.utils.JavaTypeInfo;
+import org.apache.paimon.options.ExpireConfig;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.ProcedureUtils;
 
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-/** Expire snapshots action for Flink. */
+/**
+ * Expire snapshots action for Flink.
+ *
+ * <p>This action supports both local and parallel execution modes:
+ *
+ * <ul>
+ *   <li>Local mode: when {@code forceStartFlinkJob} is false and {@code parallelism <= 1}, executes
+ *       locally via {@link #executeLocally()}
+ *   <li>Parallel mode: when {@code forceStartFlinkJob} is true or {@code parallelism > 1}, uses
+ *       Flink distributed execution for deletion
+ * </ul>
+ *
+ * <p>In parallel mode:
+ *
+ * <ul>
+ *   <li>Worker phase (flatMap): deletes data files/changelog files in parallel
+ *   <li>Sink phase (commit): deletes manifests and snapshot metadata serially to avoid concurrent
+ *       deletion issues
+ * </ul>
+ */
 public class ExpireSnapshotsAction extends ActionBase implements LocalAction {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExpireSnapshotsAction.class);
 
     private final String database;
     private final String table;
+
     private final Integer retainMax;
     private final Integer retainMin;
     private final String olderThan;
     private final Integer maxDeletes;
     private final String options;
+    private final int parallelism;
 
     public ExpireSnapshotsAction(
             String database,
             String table,
             Map<String, String> catalogConfig,
-            Integer retainMax,
-            Integer retainMin,
-            String olderThan,
-            Integer maxDeletes,
-            String options) {
+            @Nullable Integer retainMax,
+            @Nullable Integer retainMin,
+            @Nullable String olderThan,
+            @Nullable Integer maxDeletes,
+            @Nullable String options,
+            @Nullable Integer parallelism) {
         super(catalogConfig);
         this.database = database;
         this.table = table;
@@ -50,12 +95,139 @@ public class ExpireSnapshotsAction extends ActionBase implements LocalAction {
         this.olderThan = olderThan;
         this.maxDeletes = maxDeletes;
         this.options = options;
+        this.parallelism = resolveParallelism(parallelism);
     }
 
+    private int resolveParallelism(Integer parallelism) {
+        if (parallelism != null) {
+            return parallelism;
+        }
+        int envParallelism = env.getParallelism();
+        return envParallelism > 0 ? envParallelism : 1;
+    }
+
+    @Override
+    public void run() throws Exception {
+        if (forceStartFlinkJob || parallelism > 1) {
+            // Parallel mode: build custom multi-parallelism Flink pipeline
+            build();
+            if (!env.getTransformations().isEmpty()) {
+                execute(this.getClass().getSimpleName());
+            }
+        } else {
+            // Default: ActionBase handles LocalAction → executeLocally()
+            super.run();
+        }
+    }
+
+    @Override
     public void executeLocally() throws Exception {
         ExpireSnapshotsProcedure expireSnapshotsProcedure = new ExpireSnapshotsProcedure();
         expireSnapshotsProcedure.withCatalog(catalog);
         expireSnapshotsProcedure.call(
                 null, database + "." + table, retainMax, retainMin, olderThan, maxDeletes, options);
+    }
+
+    @Override
+    public void build() throws Exception {
+        Identifier identifier = new Identifier(database, table);
+
+        // Prepare table with dynamic options
+        HashMap<String, String> dynamicOptions = new HashMap<>();
+        ProcedureUtils.putAllOptions(dynamicOptions, options);
+        FileStoreTable fileStoreTable =
+                (FileStoreTable) catalog.getTable(identifier).copy(dynamicOptions);
+
+        // Build expire config
+        CoreOptions tableOptions = fileStoreTable.store().options();
+        ExpireConfig expireConfig =
+                ProcedureUtils.fillInSnapshotOptions(
+                                tableOptions, retainMax, retainMin, olderThan, maxDeletes)
+                        .build();
+
+        // Create planner using factory method
+        ExpireSnapshotsPlanner planner = ExpireSnapshotsPlanner.create(fileStoreTable);
+
+        // Plan the expiration
+        ExpireSnapshotsPlan plan = planner.plan(expireConfig);
+        if (plan.isEmpty()) {
+            LOG.info("No snapshots to expire, skipping Flink job submission.");
+            return;
+        }
+
+        LOG.info(
+                "Planning to expire {} snapshots, range=[{}, {})",
+                plan.endExclusiveId() - plan.beginInclusiveId(),
+                plan.beginInclusiveId(),
+                plan.endExclusiveId());
+
+        // Build worker phase
+        DataStream<DeletionReport> reports = buildWorkerPhase(plan, identifier, expireConfig);
+
+        // Build sink phase
+        buildSinkPhase(reports, plan, identifier, expireConfig);
+    }
+
+    /**
+     * Build the worker phase of the Flink job.
+     *
+     * <p>Workers process data file and changelog file deletion tasks in parallel. Tasks are
+     * partitioned by snapshot range to ensure:
+     *
+     * <ul>
+     *   <li>Same snapshot range tasks are processed by the same worker
+     *   <li>Within each worker, data files are deleted before changelog files
+     *   <li>Cache locality is maximized (adjacent snapshots often share manifest files)
+     * </ul>
+     */
+    private DataStream<DeletionReport> buildWorkerPhase(
+            ExpireSnapshotsPlan plan, Identifier identifier, ExpireConfig expireConfig) {
+        // Partition by snapshot range: each worker gets a contiguous range of snapshots
+        // with dataFileTasks first, then changelogFileTasks
+        List<List<SnapshotExpireTask>> partitionedGroups =
+                plan.partitionTasksBySnapshotRange(parallelism);
+
+        DataStreamSource<List<SnapshotExpireTask>> source =
+                env.fromCollection(partitionedGroups).setParallelism(1);
+
+        return source.rebalance()
+                .flatMap(
+                        new RangePartitionedExpireFunction(
+                                catalogOptions.toMap(),
+                                identifier,
+                                plan.protectionSet().taggedSnapshots(),
+                                plan.snapshotCache(),
+                                expireConfig.isChangelogDecoupled()))
+                // Use JavaTypeInfo to ensure proper Java serialization of DeletionReport,
+                // avoiding Kryo's FieldSerializer which cannot handle BinaryRow correctly.
+                // This approach is compatible with both Flink 1.x and 2.x.
+                .returns(new JavaTypeInfo<>(DeletionReport.class))
+                .setParallelism(parallelism)
+                .name("RangePartitionedExpire");
+    }
+
+    /**
+     * Build the sink phase of the Flink job.
+     *
+     * <p>The sink collects deletion reports from workers, then serially deletes manifests and
+     * snapshot metadata files to avoid concurrent deletion issues.
+     */
+    private void buildSinkPhase(
+            DataStream<DeletionReport> reports,
+            ExpireSnapshotsPlan plan,
+            Identifier identifier,
+            ExpireConfig expireConfig) {
+        reports.sinkTo(
+                        new SnapshotExpireSink(
+                                catalogOptions.toMap(),
+                                identifier,
+                                plan.endExclusiveId(),
+                                plan.protectionSet().manifestSkippingSet(),
+                                plan.snapshotCache(),
+                                plan.manifestTasks(),
+                                plan.snapshotFileTasks(),
+                                expireConfig.isChangelogDecoupled()))
+                .setParallelism(1)
+                .name("SnapshotExpireCommit");
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireSnapshotsActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireSnapshotsActionFactory.java
@@ -32,6 +32,7 @@ public class ExpireSnapshotsActionFactory implements ActionFactory {
     private static final String OLDER_THAN = "older_than";
     private static final String MAX_DELETES = "max_deletes";
     private static final String OPTIONS = "options";
+    private static final String PARALLELISM = "parallelism";
 
     @Override
     public String identifier() {
@@ -48,6 +49,8 @@ public class ExpireSnapshotsActionFactory implements ActionFactory {
         Integer maxDeletes =
                 params.has(MAX_DELETES) ? Integer.parseInt(params.get(MAX_DELETES)) : null;
         String options = params.has(OPTIONS) ? params.get(OPTIONS) : null;
+        Integer parallelism =
+                params.has(PARALLELISM) ? Integer.parseInt(params.get(PARALLELISM)) : null;
 
         ExpireSnapshotsAction action =
                 new ExpireSnapshotsAction(
@@ -58,8 +61,8 @@ public class ExpireSnapshotsActionFactory implements ActionFactory {
                         retainMin,
                         olderThan,
                         maxDeletes,
-                        options);
-
+                        options,
+                        parallelism);
         return Optional.of(action);
     }
 
@@ -77,6 +80,7 @@ public class ExpireSnapshotsActionFactory implements ActionFactory {
                         + "--retain_max <max> \\\n"
                         + "--retain_min <min> \\\n"
                         + "--older_than <older_than> \\\n"
-                        + "--max_delete <max_delete>");
+                        + "--max_deletes <max_deletes> \\\n"
+                        + "[--parallelism <parallelism>]");
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/DeletionReport.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/DeletionReport.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.expire;
+
+import org.apache.paimon.data.BinaryRow;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/** Report of a single snapshot expiration task. */
+public class DeletionReport implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final long snapshotId;
+
+    /** Whether this task was skipped (e.g., snapshot already deleted). */
+    private boolean skipped;
+
+    /** Buckets that had files deleted (for empty directory cleanup in parallel phase). */
+    private Map<BinaryRow, Set<Integer>> deletionBuckets;
+
+    public DeletionReport(long snapshotId) {
+        this.snapshotId = snapshotId;
+        this.skipped = false;
+        this.deletionBuckets = new HashMap<>();
+    }
+
+    /**
+     * Create a skipped report for a snapshot that was already deleted.
+     *
+     * @param snapshotId the snapshot ID
+     * @return a skipped deletion report
+     */
+    public static DeletionReport skipped(long snapshotId) {
+        DeletionReport report = new DeletionReport(snapshotId);
+        report.skipped = true;
+        return report;
+    }
+
+    public long snapshotId() {
+        return snapshotId;
+    }
+
+    public boolean isSkipped() {
+        return skipped;
+    }
+
+    public void setDeletionBuckets(Map<BinaryRow, Set<Integer>> deletionBuckets) {
+        this.deletionBuckets = deletionBuckets;
+    }
+
+    public Map<BinaryRow, Set<Integer>> deletionBuckets() {
+        return deletionBuckets;
+    }
+
+    @Override
+    public String toString() {
+        return "DeletionReport{"
+                + "snapshotId="
+                + snapshotId
+                + ", skipped="
+                + skipped
+                + ", deletionBucketsCount="
+                + deletionBuckets.size()
+                + '}';
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/DeletionReport.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/DeletionReport.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.expire;
 
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.BinaryRow;
 
 import java.io.Serializable;
@@ -56,6 +57,7 @@ public class DeletionReport implements Serializable {
         return report;
     }
 
+    @VisibleForTesting
     public long snapshotId() {
         return snapshotId;
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/ExpireSnapshotsPlan.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/ExpireSnapshotsPlan.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.expire;
+
+import org.apache.paimon.Snapshot;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The plan for snapshot expiration, containing four groups of tasks organized by deletion phase.
+ *
+ * <p>The plan organizes tasks into four groups for correct deletion order:
+ *
+ * <ul>
+ *   <li>{@link #dataFileTasks()}: Phase 1a - Delete data files (can be parallelized)
+ *   <li>{@link #changelogFileTasks()}: Phase 1b - Delete changelog files (can be parallelized)
+ *   <li>{@link #manifestTasks()}: Phase 2a - Delete manifest files (serial)
+ *   <li>{@link #snapshotFileTasks()}: Phase 2b - Delete snapshot metadata files (serial)
+ * </ul>
+ */
+public class ExpireSnapshotsPlan implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final ExpireSnapshotsPlan EMPTY =
+            new ExpireSnapshotsPlan(
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    null,
+                    0,
+                    0,
+                    Collections.emptyMap());
+
+    private final List<SnapshotExpireTask> dataFileTasks;
+    private final List<SnapshotExpireTask> changelogFileTasks;
+    private final List<SnapshotExpireTask> manifestTasks;
+    private final List<SnapshotExpireTask> snapshotFileTasks;
+    private final ProtectionSet protectionSet;
+    private final long beginInclusiveId;
+    private final long endExclusiveId;
+
+    /** Pre-collected snapshot cache from planner to avoid redundant snapshot reads. */
+    private final Map<Long, Snapshot> snapshotCache;
+
+    public ExpireSnapshotsPlan(
+            List<SnapshotExpireTask> dataFileTasks,
+            List<SnapshotExpireTask> changelogFileTasks,
+            List<SnapshotExpireTask> manifestTasks,
+            List<SnapshotExpireTask> snapshotFileTasks,
+            ProtectionSet protectionSet,
+            long beginInclusiveId,
+            long endExclusiveId,
+            Map<Long, Snapshot> snapshotCache) {
+        this.dataFileTasks = dataFileTasks;
+        this.changelogFileTasks = changelogFileTasks;
+        this.manifestTasks = manifestTasks;
+        this.snapshotFileTasks = snapshotFileTasks;
+        this.protectionSet = protectionSet;
+        this.beginInclusiveId = beginInclusiveId;
+        this.endExclusiveId = endExclusiveId;
+        this.snapshotCache = snapshotCache;
+    }
+
+    public static ExpireSnapshotsPlan empty() {
+        return EMPTY;
+    }
+
+    public boolean isEmpty() {
+        return dataFileTasks.isEmpty()
+                && changelogFileTasks.isEmpty()
+                && manifestTasks.isEmpty()
+                && snapshotFileTasks.isEmpty();
+    }
+
+    /** Get data file deletion tasks (Phase 1a). These can be executed in parallel. */
+    public List<SnapshotExpireTask> dataFileTasks() {
+        return dataFileTasks;
+    }
+
+    /** Get changelog file deletion tasks (Phase 1b). These can be executed in parallel. */
+    public List<SnapshotExpireTask> changelogFileTasks() {
+        return changelogFileTasks;
+    }
+
+    /** Get manifest deletion tasks (Phase 2a). These should be executed serially. */
+    public List<SnapshotExpireTask> manifestTasks() {
+        return manifestTasks;
+    }
+
+    /** Get snapshot file deletion tasks (Phase 2b). These should be executed serially. */
+    public List<SnapshotExpireTask> snapshotFileTasks() {
+        return snapshotFileTasks;
+    }
+
+    /**
+     * Partition tasks into groups by snapshot ID range for parallel mode execution.
+     *
+     * <p>Each group contains tasks for a contiguous range of snapshots, with dataFileTasks first,
+     * then changelogFileTasks. This ensures:
+     *
+     * <ul>
+     *   <li>Same snapshot range tasks are processed by the same worker
+     *   <li>Within each worker, data files are deleted before changelog files
+     * </ul>
+     *
+     * <p>For example, with beginInclusiveId=1, endExclusiveId=11, parallelism=3:
+     *
+     * <ul>
+     *   <li>Worker 0 (snapshot 1-4): [dataTask(2,3,4), changelogTask(1,2,3,4)]
+     *   <li>Worker 1 (snapshot 5-8): [dataTask(5,6,7,8), changelogTask(5,6,7,8)]
+     *   <li>Worker 2 (snapshot 9-11): [dataTask(9,10,11), changelogTask(9,10)]
+     * </ul>
+     *
+     * @param parallelism target parallelism for distribution
+     * @return list of task groups, one per worker
+     */
+    public List<List<SnapshotExpireTask>> partitionTasksBySnapshotRange(int parallelism) {
+        if (dataFileTasks.isEmpty() && changelogFileTasks.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // Build maps for quick lookup: snapshotId -> task
+        Map<Long, SnapshotExpireTask> dataFileTaskMap = new HashMap<>();
+        for (SnapshotExpireTask task : dataFileTasks) {
+            dataFileTaskMap.put(task.snapshotId(), task);
+        }
+        Map<Long, SnapshotExpireTask> changelogFileTaskMap = new HashMap<>();
+        for (SnapshotExpireTask task : changelogFileTasks) {
+            changelogFileTaskMap.put(task.snapshotId(), task);
+        }
+
+        // Calculate snapshot ranges for each worker
+        // Total snapshot range is [beginInclusiveId, endExclusiveId]
+        long totalSnapshots = endExclusiveId - beginInclusiveId + 1;
+        int snapshotsPerWorker = (int) ((totalSnapshots + parallelism - 1) / parallelism);
+
+        List<List<SnapshotExpireTask>> result = new ArrayList<>(parallelism);
+        for (int i = 0; i < parallelism; i++) {
+            long rangeStart = beginInclusiveId + (long) i * snapshotsPerWorker;
+            long rangeEnd = Math.min(rangeStart + snapshotsPerWorker - 1, endExclusiveId);
+
+            if (rangeStart > endExclusiveId) {
+                break;
+            }
+
+            List<SnapshotExpireTask> workerTasks = new ArrayList<>();
+
+            // First pass: add all dataFileTasks in this range
+            for (long id = rangeStart; id <= rangeEnd; id++) {
+                SnapshotExpireTask task = dataFileTaskMap.get(id);
+                if (task != null) {
+                    workerTasks.add(task);
+                }
+            }
+
+            // Second pass: add all changelogFileTasks in this range
+            for (long id = rangeStart; id <= rangeEnd; id++) {
+                SnapshotExpireTask task = changelogFileTaskMap.get(id);
+                if (task != null) {
+                    workerTasks.add(task);
+                }
+            }
+
+            if (!workerTasks.isEmpty()) {
+                result.add(workerTasks);
+            }
+        }
+
+        return result;
+    }
+
+    public ProtectionSet protectionSet() {
+        return protectionSet;
+    }
+
+    public long beginInclusiveId() {
+        return beginInclusiveId;
+    }
+
+    public long endExclusiveId() {
+        return endExclusiveId;
+    }
+
+    public Map<Long, Snapshot> snapshotCache() {
+        return snapshotCache;
+    }
+
+    @Override
+    public String toString() {
+        return "ExpireSnapshotsPlan{"
+                + "dataFileTasks="
+                + dataFileTasks.size()
+                + ", changelogFileTasks="
+                + changelogFileTasks.size()
+                + ", manifestTasks="
+                + manifestTasks.size()
+                + ", snapshotFileTasks="
+                + snapshotFileTasks.size()
+                + ", beginInclusiveId="
+                + beginInclusiveId
+                + ", endExclusiveId="
+                + endExclusiveId
+                + ", hasProtectionSet="
+                + (protectionSet != null)
+                + '}';
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/ExpireSnapshotsPlan.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/ExpireSnapshotsPlan.java
@@ -33,8 +33,8 @@ import java.util.Map;
  * <p>The plan organizes tasks into four groups for correct deletion order:
  *
  * <ul>
- *   <li>{@link #dataFileTasks()}: Phase 1a - Delete data files (can be parallelized)
- *   <li>{@link #changelogFileTasks()}: Phase 1b - Delete changelog files (can be parallelized)
+ *   <li>Phase 1a - Delete data files (can be parallelized)
+ *   <li>Phase 1b - Delete changelog files (can be parallelized)
  *   <li>{@link #manifestTasks()}: Phase 2a - Delete manifest files (serial)
  *   <li>{@link #snapshotFileTasks()}: Phase 2b - Delete snapshot metadata files (serial)
  * </ul>
@@ -49,7 +49,7 @@ public class ExpireSnapshotsPlan implements Serializable {
                     Collections.emptyList(),
                     Collections.emptyList(),
                     Collections.emptyList(),
-                    null,
+                    new ProtectionSet(Collections.emptyList(), null),
                     0,
                     0,
                     Collections.emptyMap());
@@ -93,16 +93,6 @@ public class ExpireSnapshotsPlan implements Serializable {
                 && changelogFileTasks.isEmpty()
                 && manifestTasks.isEmpty()
                 && snapshotFileTasks.isEmpty();
-    }
-
-    /** Get data file deletion tasks (Phase 1a). These can be executed in parallel. */
-    public List<SnapshotExpireTask> dataFileTasks() {
-        return dataFileTasks;
-    }
-
-    /** Get changelog file deletion tasks (Phase 1b). These can be executed in parallel. */
-    public List<SnapshotExpireTask> changelogFileTasks() {
-        return changelogFileTasks;
     }
 
     /** Get manifest deletion tasks (Phase 2a). These should be executed serially. */

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/ExpireSnapshotsPlanner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/ExpireSnapshotsPlanner.java
@@ -19,12 +19,11 @@
 package org.apache.paimon.flink.expire;
 
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.operation.SnapshotDeletion;
 import org.apache.paimon.options.ExpireConfig;
+import org.apache.paimon.table.ExpireSnapshotsImpl;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
@@ -44,8 +43,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 
-import static org.apache.paimon.utils.SnapshotManager.findPreviousOrEqualSnapshot;
-import static org.apache.paimon.utils.SnapshotManager.findPreviousSnapshot;
+import static org.apache.paimon.table.ExpireSnapshotsImpl.findSkippingTags;
 
 /**
  * Planner for snapshot expiration. This class computes the expiration plan including:
@@ -100,78 +98,18 @@ public class ExpireSnapshotsPlanner {
      */
     public ExpireSnapshotsPlan plan(ExpireConfig config) {
         snapshotDeletion.setChangelogDecoupled(config.isChangelogDecoupled());
-        int retainMax = config.getSnapshotRetainMax();
-        int retainMin = config.getSnapshotRetainMin();
-        int maxDeletes = config.getSnapshotMaxDeletes();
-        long olderThanMills =
-                System.currentTimeMillis() - config.getSnapshotTimeRetain().toMillis();
 
-        // 1. Get snapshot range
-        Long latestSnapshotId = snapshotManager.latestSnapshotId();
-        if (latestSnapshotId == null) {
-            // no snapshot, nothing to expire
+        ExpireSnapshotsImpl.ExpireRange range =
+                ExpireSnapshotsImpl.computeSnapshotExpireRange(
+                        config, snapshotManager, consumerManager);
+        if (range.isEmpty()) {
             return ExpireSnapshotsPlan.empty();
         }
-
-        Long earliestId = snapshotManager.earliestSnapshotId();
-        if (earliestId == null) {
-            return ExpireSnapshotsPlan.empty();
-        }
-
-        Preconditions.checkArgument(
-                retainMax >= retainMin,
-                String.format(
-                        "retainMax (%s) must not be less than retainMin (%s).",
-                        retainMax, retainMin));
-
-        // the min snapshot to retain from 'snapshot.num-retained.max'
-        // (the maximum number of snapshots to retain)
-        long min = Math.max(latestSnapshotId - retainMax + 1, earliestId);
-
-        // the max exclusive snapshot to expire until
-        // protected by 'snapshot.num-retained.min'
-        // (the minimum number of completed snapshots to retain)
-        long endExclusiveId = latestSnapshotId - retainMin + 1;
-
-        // the snapshot being read by the consumer cannot be deleted
-        long consumerProtection = consumerManager.minNextSnapshot().orElse(Long.MAX_VALUE);
-        endExclusiveId = Math.min(endExclusiveId, consumerProtection);
-
-        // protected by 'snapshot.expire.limit'
-        // (the maximum number of snapshots allowed to expire at a time)
-        endExclusiveId = Math.min(endExclusiveId, earliestId + maxDeletes);
-
-        // collect all snapshots concurrently
-        Map<Long, Snapshot> snapshots = collectSnapshots(earliestId, endExclusiveId);
-
-        for (long id = min; id < endExclusiveId; id++) {
-            // Early exit the loop for 'snapshot.time-retained'
-            // (the maximum time of snapshots to retain)
-            Snapshot snapshot = snapshots.get(id);
-            if (snapshot != null && olderThanMills <= snapshot.timeMillis()) {
-                endExclusiveId = id;
-                break;
-            }
-        }
-
-        return plan(earliestId, endExclusiveId, config.isChangelogDecoupled(), snapshots);
-    }
-
-    @VisibleForTesting
-    public ExpireSnapshotsPlan plan(
-            long earliestId, long endExclusiveId, boolean changelogDecoupled) {
-        return plan(
-                earliestId,
-                endExclusiveId,
-                changelogDecoupled,
-                collectSnapshots(earliestId, endExclusiveId));
+        return plan(range.earliestId, range.maxExclusive, config.isChangelogDecoupled());
     }
 
     private ExpireSnapshotsPlan plan(
-            long earliestId,
-            long endExclusiveId,
-            boolean changelogDecoupled,
-            Map<Long, Snapshot> snapshots) {
+            long earliestId, long endExclusiveId, boolean changelogDecoupled) {
         // Boundary check
         if (endExclusiveId <= earliestId) {
             // No expire happens:
@@ -188,6 +126,7 @@ public class ExpireSnapshotsPlanner {
         }
 
         // find first snapshot to expire
+        Map<Long, Snapshot> snapshots = collectSnapshots(earliestId, endExclusiveId);
         long beginInclusiveId = earliestId;
         for (long id = endExclusiveId - 1; id >= earliestId; id--) {
             if (!snapshots.containsKey(id)) {
@@ -282,20 +221,6 @@ public class ExpireSnapshotsPlanner {
         }
 
         return new ProtectionSet(taggedSnapshots, manifestSkippingSet);
-    }
-
-    /** Find the skipping tags in sortedTags for range of [beginInclusive, endExclusive). */
-    public static List<Snapshot> findSkippingTags(
-            List<Snapshot> sortedTags, long beginInclusive, long endExclusive) {
-        List<Snapshot> overlappedSnapshots = new ArrayList<>();
-        int right = findPreviousSnapshot(sortedTags, endExclusive);
-        if (right >= 0) {
-            int left = Math.max(findPreviousOrEqualSnapshot(sortedTags, beginInclusive), 0);
-            for (int i = left; i <= right; i++) {
-                overlappedSnapshots.add(sortedTags.get(i));
-            }
-        }
-        return overlappedSnapshots;
     }
 
     /** Concurrently collect all snapshots in range [earliestId, endExclusiveId]. */

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/ExpireSnapshotsPlanner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/ExpireSnapshotsPlanner.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.expire;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.consumer.ConsumerManager;
+import org.apache.paimon.operation.SnapshotDeletion;
+import org.apache.paimon.options.ExpireConfig;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.Preconditions;
+import org.apache.paimon.utils.SnapshotManager;
+import org.apache.paimon.utils.TagManager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+
+import static org.apache.paimon.utils.SnapshotManager.findPreviousOrEqualSnapshot;
+import static org.apache.paimon.utils.SnapshotManager.findPreviousSnapshot;
+
+/**
+ * Planner for snapshot expiration. This class computes the expiration plan including:
+ *
+ * <ul>
+ *   <li>The range of snapshots to expire [beginInclusiveId, endExclusiveId)
+ *   <li>Protection set containing manifests that should not be deleted
+ *   <li>Four groups of tasks organized by deletion phase
+ * </ul>
+ *
+ * <p>Tag data files are loaded on-demand by workers using {@link
+ * SnapshotDeletion#createDataFileSkipperForTags}, which has internal caching to avoid repeated
+ * reads.
+ */
+public class ExpireSnapshotsPlanner {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExpireSnapshotsPlanner.class);
+
+    private final SnapshotManager snapshotManager;
+    private final ConsumerManager consumerManager;
+    private final SnapshotDeletion snapshotDeletion;
+    private final TagManager tagManager;
+
+    public ExpireSnapshotsPlanner(
+            SnapshotManager snapshotManager,
+            ConsumerManager consumerManager,
+            SnapshotDeletion snapshotDeletion,
+            TagManager tagManager) {
+        this.snapshotManager = snapshotManager;
+        this.consumerManager = consumerManager;
+        this.snapshotDeletion = snapshotDeletion;
+        this.tagManager = tagManager;
+    }
+
+    /** Creates an ExpireSnapshotsPlanner from a FileStoreTable. */
+    public static ExpireSnapshotsPlanner create(FileStoreTable table) {
+        SnapshotManager snapshotManager = table.snapshotManager();
+        ConsumerManager consumerManager =
+                new ConsumerManager(table.fileIO(), table.location(), snapshotManager.branch());
+        return new ExpireSnapshotsPlanner(
+                table.snapshotManager(),
+                consumerManager,
+                table.store().newSnapshotDeletion(),
+                table.tagManager());
+    }
+
+    /**
+     * Plan the snapshot expiration.
+     *
+     * @param config expiration configuration
+     * @return the expiration plan with three groups of tasks, or empty plan if nothing to expire
+     */
+    public ExpireSnapshotsPlan plan(ExpireConfig config) {
+        snapshotDeletion.setChangelogDecoupled(config.isChangelogDecoupled());
+        int retainMax = config.getSnapshotRetainMax();
+        int retainMin = config.getSnapshotRetainMin();
+        int maxDeletes = config.getSnapshotMaxDeletes();
+        long olderThanMills =
+                System.currentTimeMillis() - config.getSnapshotTimeRetain().toMillis();
+
+        // 1. Get snapshot range
+        Long latestSnapshotId = snapshotManager.latestSnapshotId();
+        if (latestSnapshotId == null) {
+            // no snapshot, nothing to expire
+            return ExpireSnapshotsPlan.empty();
+        }
+
+        Long earliestId = snapshotManager.earliestSnapshotId();
+        if (earliestId == null) {
+            return ExpireSnapshotsPlan.empty();
+        }
+
+        Preconditions.checkArgument(
+                retainMax >= retainMin,
+                String.format(
+                        "retainMax (%s) must not be less than retainMin (%s).",
+                        retainMax, retainMin));
+
+        // the min snapshot to retain from 'snapshot.num-retained.max'
+        // (the maximum number of snapshots to retain)
+        long min = Math.max(latestSnapshotId - retainMax + 1, earliestId);
+
+        // the max exclusive snapshot to expire until
+        // protected by 'snapshot.num-retained.min'
+        // (the minimum number of completed snapshots to retain)
+        long endExclusiveId = latestSnapshotId - retainMin + 1;
+
+        // the snapshot being read by the consumer cannot be deleted
+        long consumerProtection = consumerManager.minNextSnapshot().orElse(Long.MAX_VALUE);
+        endExclusiveId = Math.min(endExclusiveId, consumerProtection);
+
+        // protected by 'snapshot.expire.limit'
+        // (the maximum number of snapshots allowed to expire at a time)
+        endExclusiveId = Math.min(endExclusiveId, earliestId + maxDeletes);
+
+        // collect all snapshots concurrently
+        Map<Long, Snapshot> snapshots = collectSnapshots(earliestId, endExclusiveId);
+
+        for (long id = min; id < endExclusiveId; id++) {
+            // Early exit the loop for 'snapshot.time-retained'
+            // (the maximum time of snapshots to retain)
+            Snapshot snapshot = snapshots.get(id);
+            if (snapshot != null && olderThanMills <= snapshot.timeMillis()) {
+                endExclusiveId = id;
+                break;
+            }
+        }
+
+        return plan(earliestId, endExclusiveId, config.isChangelogDecoupled(), snapshots);
+    }
+
+    @VisibleForTesting
+    public ExpireSnapshotsPlan plan(
+            long earliestId, long endExclusiveId, boolean changelogDecoupled) {
+        return plan(
+                earliestId,
+                endExclusiveId,
+                changelogDecoupled,
+                collectSnapshots(earliestId, endExclusiveId));
+    }
+
+    private ExpireSnapshotsPlan plan(
+            long earliestId,
+            long endExclusiveId,
+            boolean changelogDecoupled,
+            Map<Long, Snapshot> snapshots) {
+        // Boundary check
+        if (endExclusiveId <= earliestId) {
+            // No expire happens:
+            // write the hint file in order to see the earliest snapshot directly next time
+            // should avoid duplicate writes when the file exists
+            if (snapshotManager.earliestFileNotExists()) {
+                try {
+                    snapshotManager.commitEarliestHint(earliestId);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+            return ExpireSnapshotsPlan.empty();
+        }
+
+        // find first snapshot to expire
+        long beginInclusiveId = earliestId;
+        for (long id = endExclusiveId - 1; id >= earliestId; id--) {
+            if (!snapshots.containsKey(id)) {
+                // only latest snapshots are retained, as we cannot find this snapshot, we can
+                // assume that all snapshots preceding it have been removed
+                beginInclusiveId = id + 1;
+                break;
+            }
+        }
+
+        // Get endSnapshot from cache
+        Snapshot cachedEndSnapshot = snapshots.get(endExclusiveId);
+        if (cachedEndSnapshot == null) {
+            // the end exclusive snapshot is gone
+            // there is no need to proceed
+            LOG.warn("End snapshot {} not found, abort expiration", endExclusiveId);
+            return ExpireSnapshotsPlan.empty();
+        }
+
+        // Build protection set
+        ProtectionSet protectionSet =
+                buildProtectionSet(beginInclusiveId, endExclusiveId, cachedEndSnapshot);
+
+        // Generate four groups of tasks
+        List<SnapshotExpireTask> dataFileTasks = new ArrayList<>();
+        List<SnapshotExpireTask> changelogFileTasks = new ArrayList<>();
+        List<SnapshotExpireTask> manifestTasks = new ArrayList<>();
+        List<SnapshotExpireTask> snapshotFileTasks = new ArrayList<>();
+
+        // Data file tasks: range is (beginInclusiveId, endExclusiveId]
+        // deleted merge tree files in a snapshot are not used by the next snapshot, so the range of
+        // id should be (beginInclusiveId, endExclusiveId]
+        for (long id = beginInclusiveId + 1; id <= endExclusiveId; id++) {
+            dataFileTasks.add(SnapshotExpireTask.forDataFiles(id));
+        }
+
+        // Changelog file tasks: range is [beginInclusiveId, endExclusiveId)
+        // Only when changelog is not decoupled
+        if (!changelogDecoupled) {
+            for (long id = beginInclusiveId; id < endExclusiveId; id++) {
+                changelogFileTasks.add(SnapshotExpireTask.forChangelogFiles(id));
+            }
+        }
+
+        // Manifest and snapshot file tasks: range is [beginInclusiveId, endExclusiveId)
+        for (long id = beginInclusiveId; id < endExclusiveId; id++) {
+            // Skip cleaning manifest files due to failed to build skipping set
+            if (protectionSet.manifestSkippingSet() != null) {
+                manifestTasks.add(SnapshotExpireTask.forManifests(id));
+            }
+            snapshotFileTasks.add(SnapshotExpireTask.forSnapshot(id, changelogDecoupled));
+        }
+
+        LOG.info(
+                "Planned expiration: range=[{}, {}), dataFileTasks={}, changelogFileTasks={}, manifestTasks={}, snapshotFileTasks={}",
+                beginInclusiveId,
+                endExclusiveId,
+                dataFileTasks.size(),
+                changelogFileTasks.size(),
+                manifestTasks.size(),
+                snapshotFileTasks.size());
+
+        return new ExpireSnapshotsPlan(
+                dataFileTasks,
+                changelogFileTasks,
+                manifestTasks,
+                snapshotFileTasks,
+                protectionSet,
+                beginInclusiveId,
+                endExclusiveId,
+                snapshots);
+    }
+
+    private ProtectionSet buildProtectionSet(
+            long beginInclusiveId, long endExclusiveId, Snapshot cachedEndSnapshot) {
+
+        List<Snapshot> taggedSnapshots = tagManager.taggedSnapshots();
+
+        // 1. Find skipping tags that overlap with expire range
+        List<Snapshot> skippingTags =
+                findSkippingTags(taggedSnapshots, beginInclusiveId, endExclusiveId);
+
+        // 2. Build manifest skipping set
+        List<Snapshot> manifestProtectedSnapshots = new ArrayList<>(skippingTags);
+        manifestProtectedSnapshots.add(cachedEndSnapshot);
+        Set<String> manifestSkippingSet = null;
+        try {
+            manifestSkippingSet =
+                    new HashSet<>(snapshotDeletion.manifestSkippingSet(manifestProtectedSnapshots));
+        } catch (Exception e) {
+            LOG.warn("Skip cleaning manifest files due to failed to build skipping set.", e);
+        }
+
+        return new ProtectionSet(taggedSnapshots, manifestSkippingSet);
+    }
+
+    /** Find the skipping tags in sortedTags for range of [beginInclusive, endExclusive). */
+    public static List<Snapshot> findSkippingTags(
+            List<Snapshot> sortedTags, long beginInclusive, long endExclusive) {
+        List<Snapshot> overlappedSnapshots = new ArrayList<>();
+        int right = findPreviousSnapshot(sortedTags, endExclusive);
+        if (right >= 0) {
+            int left = Math.max(findPreviousOrEqualSnapshot(sortedTags, beginInclusive), 0);
+            for (int i = left; i <= right; i++) {
+                overlappedSnapshots.add(sortedTags.get(i));
+            }
+        }
+        return overlappedSnapshots;
+    }
+
+    /** Concurrently collect all snapshots in range [earliestId, endExclusiveId]. */
+    private Map<Long, Snapshot> collectSnapshots(long earliestId, long endExclusiveId) {
+        Executor fileExecutor = snapshotDeletion.fileExecutor();
+        Map<Long, Snapshot> snapshots = new ConcurrentHashMap<>();
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (long id = earliestId; id <= endExclusiveId; id++) {
+            long snapshotId = id;
+            futures.add(
+                    CompletableFuture.runAsync(
+                            () -> {
+                                try {
+                                    Snapshot snapshot = snapshotManager.tryGetSnapshot(snapshotId);
+                                    snapshots.put(snapshotId, snapshot);
+                                } catch (FileNotFoundException ignored) {
+                                }
+                            },
+                            fileExecutor));
+        }
+        try {
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+        } catch (ExecutionException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        return snapshots;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/ProtectionSet.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/ProtectionSet.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.expire;
+
+import org.apache.paimon.Snapshot;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Immutable protection set for parallel expire snapshots. This class holds all the information
+ * needed to protect files that should not be deleted during expiration.
+ *
+ * <p>This class is broadcast to all workers and must be treated as read-only.
+ *
+ * <p>Note: Tag data files are loaded on-demand by workers using {@link
+ * org.apache.paimon.operation.SnapshotDeletion#createDataFileSkipperForTags}, which has internal
+ * caching to avoid repeated reads.
+ */
+public class ProtectionSet implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** All tagged snapshots, sorted by snapshot ID. */
+    private final List<Snapshot> taggedSnapshots;
+
+    /** Manifest file names that should be protected (from Tags and endSnapshot). */
+    private final Set<String> manifestSkippingSet;
+
+    public ProtectionSet(List<Snapshot> taggedSnapshots, Set<String> manifestSkippingSet) {
+        this.taggedSnapshots = Collections.unmodifiableList(taggedSnapshots);
+        this.manifestSkippingSet =
+                manifestSkippingSet == null
+                        ? null
+                        : Collections.unmodifiableSet(manifestSkippingSet);
+    }
+
+    public List<Snapshot> taggedSnapshots() {
+        return taggedSnapshots;
+    }
+
+    public Set<String> manifestSkippingSet() {
+        return manifestSkippingSet;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/RangePartitionedExpireFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/RangePartitionedExpireFunction.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.expire;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.flink.FlinkCatalogFactory;
+import org.apache.paimon.operation.SnapshotDeletion;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.FileStoreTable;
+
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.util.Collector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Flink flatMap function for range-partitioned snapshot expiration (worker phase).
+ *
+ * <p>This function processes a batch of {@link SnapshotExpireTask}s that belong to the same
+ * contiguous range. Each subtask receives a list of tasks (e.g., subtask 0 gets snap 1-4, subtask 1
+ * gets snap 5-8) and processes them sequentially in order.
+ *
+ * <p>Processing tasks in order within each subtask maximizes cache locality since adjacent
+ * snapshots often share manifest files.
+ *
+ * <p>In worker phase, this function only deletes data files and changelog data files. Manifest and
+ * snapshot metadata deletion is deferred to the sink phase to avoid concurrent deletion issues.
+ */
+public class RangePartitionedExpireFunction
+        extends RichFlatMapFunction<List<SnapshotExpireTask>, DeletionReport> {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LoggerFactory.getLogger(RangePartitionedExpireFunction.class);
+
+    private final Map<String, String> catalogConfig;
+    private final Identifier identifier;
+    private final List<Snapshot> taggedSnapshots;
+    private final Map<Long, Snapshot> snapshotCache;
+    private final boolean changelogDecoupled;
+
+    protected transient SnapshotExpireContext context;
+
+    public RangePartitionedExpireFunction(
+            Map<String, String> catalogConfig,
+            Identifier identifier,
+            List<Snapshot> taggedSnapshots,
+            Map<Long, Snapshot> snapshotCache,
+            boolean changelogDecoupled) {
+        this.catalogConfig = catalogConfig;
+        this.identifier = identifier;
+        this.taggedSnapshots = taggedSnapshots;
+        this.snapshotCache = snapshotCache;
+        this.changelogDecoupled = changelogDecoupled;
+    }
+
+    @Override
+    public void open(OpenContext openContext) throws Exception {
+        this.context = initContext();
+    }
+
+    /**
+     * Initializes and returns the context for processing expire tasks. Subclasses can override this
+     * method to provide a custom context for testing without catalog access.
+     */
+    protected SnapshotExpireContext initContext() throws Exception {
+        Options options = Options.fromMap(catalogConfig);
+        Catalog catalog = FlinkCatalogFactory.createPaimonCatalog(options);
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier);
+        SnapshotDeletion deletion = table.store().newSnapshotDeletion();
+        deletion.setChangelogDecoupled(changelogDecoupled);
+        return new SnapshotExpireContext(
+                table.snapshotManager(), deletion, null, taggedSnapshots, snapshotCache);
+    }
+
+    @Override
+    public void flatMap(List<SnapshotExpireTask> tasks, Collector<DeletionReport> out)
+            throws Exception {
+        LOG.info("Start processing {} expire tasks", tasks.size());
+        long start = System.currentTimeMillis();
+        for (int i = 0; i < tasks.size(); i++) {
+            SnapshotExpireTask task = tasks.get(i);
+            LOG.info("Processing expire task {}/{}, {}", i + 1, tasks.size(), task);
+            DeletionReport report = task.execute(context);
+            report.setDeletionBuckets(context.snapshotDeletion().drainDeletionBuckets());
+            out.collect(report);
+        }
+        LOG.info(
+                "End processing {} expire tasks, spend {} ms",
+                tasks.size(),
+                System.currentTimeMillis() - start);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/SnapshotExpireContext.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/SnapshotExpireContext.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.expire;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.operation.SnapshotDeletion;
+import org.apache.paimon.utils.ChangelogManager;
+import org.apache.paimon.utils.SnapshotManager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.FileNotFoundException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Context for snapshot expiration. Holds runtime dependencies and shared state used by both {@link
+ * SnapshotExpireTask} subclasses and {@link SnapshotExpireSink}.
+ */
+public class SnapshotExpireContext {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SnapshotExpireContext.class);
+
+    private final SnapshotManager snapshotManager;
+    private final SnapshotDeletion snapshotDeletion;
+    @Nullable private final ChangelogManager changelogManager;
+
+    /** Pre-collected snapshot cache from planner to avoid redundant reads. */
+    private final Map<Long, Snapshot> snapshotCache;
+
+    @Nullable private final List<Snapshot> taggedSnapshots;
+    @Nullable private Set<String> skippingSet;
+
+    public SnapshotExpireContext(
+            SnapshotManager snapshotManager,
+            SnapshotDeletion snapshotDeletion,
+            @Nullable ChangelogManager changelogManager,
+            @Nullable List<Snapshot> taggedSnapshots,
+            Map<Long, Snapshot> snapshotCache) {
+        this.snapshotManager = snapshotManager;
+        this.snapshotDeletion = snapshotDeletion;
+        this.changelogManager = changelogManager;
+        this.taggedSnapshots = taggedSnapshots;
+        this.snapshotCache = snapshotCache;
+    }
+
+    /**
+     * Load a snapshot by ID.
+     *
+     * @return the snapshot, or null if not found
+     */
+    @Nullable
+    public Snapshot loadSnapshot(long snapshotId) {
+        Snapshot snapshot = snapshotCache.get(snapshotId);
+        if (snapshot != null) {
+            return snapshot;
+        }
+        try {
+            return snapshotManager.tryGetSnapshot(snapshotId);
+        } catch (FileNotFoundException e) {
+            LOG.warn("Snapshot {} not found, skipping task", snapshotId);
+            return null;
+        }
+    }
+
+    public SnapshotManager snapshotManager() {
+        return snapshotManager;
+    }
+
+    public SnapshotDeletion snapshotDeletion() {
+        return snapshotDeletion;
+    }
+
+    @Nullable
+    public ChangelogManager changelogManager() {
+        return changelogManager;
+    }
+
+    @Nullable
+    public List<Snapshot> taggedSnapshots() {
+        return taggedSnapshots;
+    }
+
+    @Nullable
+    public Set<String> skippingSet() {
+        return skippingSet;
+    }
+
+    public void setSkippingSet(Set<String> skippingSet) {
+        this.skippingSet = skippingSet;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/SnapshotExpireSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/SnapshotExpireSink.java
@@ -179,10 +179,12 @@ public class SnapshotExpireSink implements Sink<DeletionReport> {
                 task.execute(context);
             }
 
-            try {
-                context.snapshotManager().commitEarliestHint(endExclusiveId);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
+            if (endExclusiveId > 0) {
+                try {
+                    context.snapshotManager().commitEarliestHint(endExclusiveId);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
             }
         }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/SnapshotExpireSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/SnapshotExpireSink.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.expire;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.flink.FlinkCatalogFactory;
+import org.apache.paimon.operation.SnapshotDeletion;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.FileStoreTable;
+
+import org.apache.flink.api.connector.sink2.InitContext;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Sink that collects deletion reports from parallel expire workers, aggregates the results, and
+ * performs the final commit operations.
+ *
+ * <p>In the sink phase (committer), this sink:
+ *
+ * <ul>
+ *   <li>Collects all deletion reports from workers
+ *   <li>Deletes manifest files serially in snapshot ID order (to avoid concurrent deletion issues)
+ *   <li>Deletes snapshot metadata files
+ *   <li>Commits changelogs (for changelogDecoupled mode)
+ *   <li>Cleans empty directories
+ *   <li>Updates earliest hint
+ * </ul>
+ */
+public class SnapshotExpireSink implements Sink<DeletionReport> {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(SnapshotExpireSink.class);
+
+    private final Map<String, String> catalogConfig;
+    private final Identifier identifier;
+    private final long endExclusiveId;
+    private final Set<String> manifestSkippingSet;
+    private final Map<Long, Snapshot> snapshotCache;
+    private final List<SnapshotExpireTask> manifestTasks;
+    private final List<SnapshotExpireTask> snapshotFileTasks;
+    private final boolean changelogDecoupled;
+
+    public SnapshotExpireSink(
+            Map<String, String> catalogConfig,
+            Identifier identifier,
+            long endExclusiveId,
+            Set<String> manifestSkippingSet,
+            Map<Long, Snapshot> snapshotCache,
+            List<SnapshotExpireTask> manifestTasks,
+            List<SnapshotExpireTask> snapshotFileTasks,
+            boolean changelogDecoupled) {
+        this.catalogConfig = catalogConfig;
+        this.identifier = identifier;
+        this.endExclusiveId = endExclusiveId;
+        this.manifestSkippingSet = manifestSkippingSet;
+        this.snapshotCache = snapshotCache;
+        this.manifestTasks = manifestTasks;
+        this.snapshotFileTasks = snapshotFileTasks;
+        this.changelogDecoupled = changelogDecoupled;
+    }
+
+    /**
+     * Do not annotate with <code>@override</code> here to maintain compatibility with Flink 2.0+.
+     */
+    public SinkWriter<DeletionReport> createWriter(InitContext initContext) throws IOException {
+        return new ExpireSinkWriter(initContext());
+    }
+
+    /**
+     * Do not annotate with <code>@Override</code> here to maintain compatibility with Flink 1.18-.
+     */
+    public SinkWriter<DeletionReport> createWriter(WriterInitContext initContext)
+            throws IOException {
+        return new ExpireSinkWriter(initContext());
+    }
+
+    /**
+     * Initializes and returns the context. Subclasses can override this method to provide a custom
+     * context for testing.
+     */
+    @VisibleForTesting
+    protected SnapshotExpireContext initContext() {
+        try {
+            Options options = Options.fromMap(catalogConfig);
+            Catalog catalog = FlinkCatalogFactory.createPaimonCatalog(options);
+            FileStoreTable table = (FileStoreTable) catalog.getTable(identifier);
+            SnapshotDeletion deletion = table.store().newSnapshotDeletion();
+            deletion.setChangelogDecoupled(changelogDecoupled);
+            return new SnapshotExpireContext(
+                    table.snapshotManager(),
+                    deletion,
+                    table.changelogManager(),
+                    null,
+                    snapshotCache);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to initialize context", e);
+        }
+    }
+
+    /** SinkWriter that collects reports and performs commit on flush. */
+    private class ExpireSinkWriter implements SinkWriter<DeletionReport> {
+
+        private final Map<BinaryRow, Set<Integer>> globalDeletionBuckets = new HashMap<>();
+        private final SnapshotExpireContext context;
+
+        ExpireSinkWriter(SnapshotExpireContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public void write(DeletionReport report, Context writeContext) {
+            if (!report.isSkipped()) {
+                report.deletionBuckets()
+                        .forEach(
+                                (partition, buckets) ->
+                                        globalDeletionBuckets
+                                                .computeIfAbsent(partition, k -> new HashSet<>())
+                                                .addAll(buckets));
+            }
+        }
+
+        @Override
+        public void flush(boolean endOfInput) {
+            if (!endOfInput) {
+                return;
+            }
+
+            LOG.info(
+                    "Expire sink received: {} manifest tasks, {} snapshot tasks",
+                    manifestTasks.size(),
+                    snapshotFileTasks.size());
+
+            // 1. Clean empty directories
+            context.snapshotDeletion().cleanEmptyDirectories(globalDeletionBuckets);
+
+            // 2. Execute manifest deletion tasks
+            if (manifestSkippingSet != null) {
+                context.setSkippingSet(new HashSet<>(manifestSkippingSet));
+                for (SnapshotExpireTask task : manifestTasks) {
+                    task.execute(context);
+                }
+            }
+
+            // 3. Execute snapshot file deletion tasks
+            for (SnapshotExpireTask task : snapshotFileTasks) {
+                task.execute(context);
+            }
+
+            try {
+                context.snapshotManager().commitEarliestHint(endExclusiveId);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/SnapshotExpireTask.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/expire/SnapshotExpireTask.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.expire;
+
+import org.apache.paimon.Changelog;
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.manifest.ExpireFileEntry;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.UncheckedIOException;
+import java.util.function.Predicate;
+
+import static org.apache.paimon.utils.Preconditions.checkNotNull;
+
+/**
+ * Abstract base class for snapshot expiration tasks. Each subclass represents a specific deletion
+ * operation:
+ *
+ * <ul>
+ *   <li>{@link DeleteDataFilesTask}: Delete data files
+ *   <li>{@link DeleteChangelogFilesTask}: Delete changelog files
+ *   <li>{@link DeleteManifestsTask}: Delete manifest files
+ *   <li>{@link DeleteSnapshotTask}: Delete snapshot metadata file
+ * </ul>
+ */
+public abstract class SnapshotExpireTask implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LoggerFactory.getLogger(SnapshotExpireTask.class);
+
+    protected final long snapshotId;
+
+    protected SnapshotExpireTask(long snapshotId) {
+        this.snapshotId = snapshotId;
+    }
+
+    public long snapshotId() {
+        return snapshotId;
+    }
+
+    /** Execute this task using the given context. */
+    public abstract DeletionReport execute(SnapshotExpireContext context);
+
+    // ==================== Factory Methods ====================
+
+    public static SnapshotExpireTask forDataFiles(long snapshotId) {
+        return new DeleteDataFilesTask(snapshotId);
+    }
+
+    public static SnapshotExpireTask forChangelogFiles(long snapshotId) {
+        return new DeleteChangelogFilesTask(snapshotId);
+    }
+
+    public static SnapshotExpireTask forManifests(long snapshotId) {
+        return new DeleteManifestsTask(snapshotId);
+    }
+
+    public static SnapshotExpireTask forSnapshot(long snapshotId, boolean changelogDecoupled) {
+        return new DeleteSnapshotTask(snapshotId, changelogDecoupled);
+    }
+
+    // ==================== Subclasses ====================
+
+    /** Task that deletes data files for a snapshot. */
+    public static class DeleteDataFilesTask extends SnapshotExpireTask {
+
+        private static final long serialVersionUID = 1L;
+
+        DeleteDataFilesTask(long snapshotId) {
+            super(snapshotId);
+        }
+
+        @Override
+        public DeletionReport execute(SnapshotExpireContext context) {
+            Snapshot snapshot = context.loadSnapshot(snapshotId);
+            if (snapshot == null) {
+                return DeletionReport.skipped(snapshotId);
+            }
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Ready to delete merge tree files not used by snapshot #{}", snapshotId);
+            }
+
+            Predicate<ExpireFileEntry> skipper = null;
+            try {
+                skipper =
+                        context.snapshotDeletion()
+                                .createDataFileSkipperForTags(
+                                        checkNotNull(context.taggedSnapshots()), snapshotId);
+            } catch (Exception e) {
+                LOG.warn(
+                        String.format(
+                                "Skip cleaning data files of snapshot '%s' due to failed to build skipping set.",
+                                snapshotId),
+                        e);
+                return DeletionReport.skipped(snapshotId);
+            }
+
+            if (skipper != null) {
+                context.snapshotDeletion().cleanUnusedDataFiles(snapshot, skipper);
+            }
+            return new DeletionReport(snapshotId);
+        }
+
+        @Override
+        public String toString() {
+            return "DeleteDataFiles{snapshotId=" + snapshotId + '}';
+        }
+    }
+
+    /** Task that deletes changelog files for a snapshot. */
+    public static class DeleteChangelogFilesTask extends SnapshotExpireTask {
+
+        private static final long serialVersionUID = 1L;
+
+        DeleteChangelogFilesTask(long snapshotId) {
+            super(snapshotId);
+        }
+
+        @Override
+        public DeletionReport execute(SnapshotExpireContext context) {
+            Snapshot snapshot = context.loadSnapshot(snapshotId);
+            if (snapshot == null) {
+                return DeletionReport.skipped(snapshotId);
+            }
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Ready to delete changelog files from snapshot #{}", snapshotId);
+            }
+
+            if (snapshot.changelogManifestList() != null) {
+                context.snapshotDeletion().deleteAddedDataFiles(snapshot.changelogManifestList());
+            }
+            return new DeletionReport(snapshotId);
+        }
+
+        @Override
+        public String toString() {
+            return "DeleteChangelogFiles{snapshotId=" + snapshotId + '}';
+        }
+    }
+
+    /** Task that deletes manifest files for a snapshot. */
+    public static class DeleteManifestsTask extends SnapshotExpireTask {
+
+        private static final long serialVersionUID = 1L;
+
+        DeleteManifestsTask(long snapshotId) {
+            super(snapshotId);
+        }
+
+        @Override
+        public DeletionReport execute(SnapshotExpireContext context) {
+            Snapshot snapshot = context.loadSnapshot(snapshotId);
+            if (snapshot == null) {
+                return DeletionReport.skipped(snapshotId);
+            }
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Ready to delete manifests in snapshot #{}", snapshotId);
+            }
+
+            context.snapshotDeletion()
+                    .cleanUnusedManifests(snapshot, checkNotNull(context.skippingSet()));
+            return new DeletionReport(snapshotId);
+        }
+
+        @Override
+        public String toString() {
+            return "DeleteManifests{snapshotId=" + snapshotId + '}';
+        }
+    }
+
+    /** Task that deletes snapshot metadata file. */
+    public static class DeleteSnapshotTask extends SnapshotExpireTask {
+
+        private static final long serialVersionUID = 1L;
+
+        private final boolean changelogDecoupled;
+
+        DeleteSnapshotTask(long snapshotId, boolean changelogDecoupled) {
+            super(snapshotId);
+            this.changelogDecoupled = changelogDecoupled;
+        }
+
+        @Override
+        public DeletionReport execute(SnapshotExpireContext context) {
+            Snapshot snapshot = context.loadSnapshot(snapshotId);
+            if (snapshot == null) {
+                return DeletionReport.skipped(snapshotId);
+            }
+
+            if (changelogDecoupled && context.changelogManager() != null) {
+                try {
+                    Changelog changelog = new Changelog(snapshot);
+                    context.changelogManager().commitChangelog(changelog, changelog.id());
+                    context.changelogManager().commitLongLivedChangelogLatestHint(changelog.id());
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+
+            context.snapshotManager().deleteSnapshot(snapshot.id());
+            return new DeletionReport(snapshotId);
+        }
+
+        @Override
+        public String toString() {
+            return "DeleteSnapshot{snapshotId="
+                    + snapshotId
+                    + ", changelogDecoupled="
+                    + changelogDecoupled
+                    + '}';
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ParallelExpireSnapshotsActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ParallelExpireSnapshotsActionITCase.java
@@ -37,6 +37,8 @@ import org.apache.paimon.operation.SnapshotDeletion;
 import org.apache.paimon.options.ExpireConfig;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
@@ -99,10 +101,6 @@ public class ParallelExpireSnapshotsActionITCase extends ExpireSnapshotsTest {
                         store.newTagManager());
         ExpireSnapshotsPlan plan = planner.plan(config);
 
-        if (plan.isEmpty()) {
-            return 0;
-        }
-
         List<Snapshot> taggedSnapshots = plan.protectionSet().taggedSnapshots();
         Map<Long, Snapshot> snapshotCache = plan.snapshotCache();
         contextSupplier =
@@ -126,7 +124,10 @@ public class ParallelExpireSnapshotsActionITCase extends ExpireSnapshotsTest {
                     plan.partitionTasksBySnapshotRange(TEST_PARALLELISM);
 
             DataStreamSource<List<SnapshotExpireTask>> source =
-                    env.fromCollection(partitionedGroups).setParallelism(1);
+                    env.fromCollection(
+                                    partitionedGroups,
+                                    TypeInformation.of(new TypeHint<List<SnapshotExpireTask>>() {}))
+                            .setParallelism(1);
 
             DataStream<DeletionReport> reports =
                     source.rebalance()
@@ -283,6 +284,36 @@ public class ParallelExpireSnapshotsActionITCase extends ExpireSnapshotsTest {
         }
         assertThat(snapshotManager.snapshotExists(latestSnapshotId)).isTrue();
         assertSnapshot(latestSnapshotId, allData, snapshotPositions);
+    }
+
+    /**
+     * Tests that when there are no snapshots to expire, the Flink job still starts and completes
+     * successfully with an empty plan.
+     */
+    @Test
+    public void testEmptyPlanFlinkJobCompletes() throws Exception {
+        // Create a table with snapshots, but configure retention to keep all of them
+        List<KeyValue> allData = new ArrayList<>();
+        List<Integer> snapshotPositions = new ArrayList<>();
+        commit(3, allData, snapshotPositions);
+
+        int latestSnapshotId = requireNonNull(snapshotManager.latestSnapshotId()).intValue();
+
+        // Configure to retain more snapshots than exist → empty plan
+        ExpireConfig config =
+                ExpireConfig.builder()
+                        .snapshotRetainMin(latestSnapshotId + 1)
+                        .snapshotRetainMax(latestSnapshotId + 1)
+                        .build();
+
+        // Should complete without error even with empty plan
+        int expired = doExpire(config);
+        assertThat(expired).isEqualTo(0);
+
+        // All snapshots should still exist
+        for (int i = 1; i <= latestSnapshotId; i++) {
+            assertThat(snapshotManager.snapshotExists(i)).isTrue();
+        }
     }
 
     // ==================== Disabled Tests ====================

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ParallelExpireSnapshotsActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/ParallelExpireSnapshotsActionITCase.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action;
+
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.consumer.ConsumerManager;
+import org.apache.paimon.flink.expire.DeletionReport;
+import org.apache.paimon.flink.expire.ExpireSnapshotsPlan;
+import org.apache.paimon.flink.expire.ExpireSnapshotsPlanner;
+import org.apache.paimon.flink.expire.RangePartitionedExpireFunction;
+import org.apache.paimon.flink.expire.SnapshotExpireContext;
+import org.apache.paimon.flink.expire.SnapshotExpireSink;
+import org.apache.paimon.flink.expire.SnapshotExpireTask;
+import org.apache.paimon.flink.util.MiniClusterWithClientExtension;
+import org.apache.paimon.flink.utils.JavaTypeInfo;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.operation.ExpireSnapshotsTest;
+import org.apache.paimon.operation.SnapshotDeletion;
+import org.apache.paimon.options.ExpireConfig;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.Collector;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * IT Case for parallel expire snapshots using Flink execution. This class extends {@link
+ * ExpireSnapshotsTest} and overrides {@link #doExpire} to test parallel execution mode with real
+ * Flink DataStream API.
+ *
+ * <p>This test validates that the Flink-based parallel expire logic produces the same results as
+ * the serial implementation. It extends the production {@link RangePartitionedExpireFunction} and
+ * {@link SnapshotExpireSink} classes, overriding {@code initContext} to inject test contexts.
+ */
+public class ParallelExpireSnapshotsActionITCase extends ExpireSnapshotsTest {
+
+    private static final int TEST_PARALLELISM = 2;
+
+    private static final Identifier TEST_IDENTIFIER = Identifier.create("default", "test_table");
+
+    @RegisterExtension
+    protected static final MiniClusterWithClientExtension MINI_CLUSTER_EXTENSION =
+            new MiniClusterWithClientExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(TEST_PARALLELISM)
+                            .build());
+
+    // Static supplier for test context (used by inner test classes)
+    private static volatile Supplier<SnapshotExpireContext> contextSupplier;
+
+    // Controls failure injection: when >= 0, TestExpireFunction throws after this many tasks.
+    private static volatile int failAfterTasks = -1;
+
+    @Override
+    protected int doExpire(ExpireConfig config) {
+        SnapshotDeletion snapshotDeletion = store.newSnapshotDeletion();
+        ExpireSnapshotsPlanner planner =
+                new ExpireSnapshotsPlanner(
+                        snapshotManager,
+                        new ConsumerManager(
+                                fileIO, new Path(tempDir.toUri()), snapshotManager.branch()),
+                        snapshotDeletion,
+                        store.newTagManager());
+        ExpireSnapshotsPlan plan = planner.plan(config);
+
+        if (plan.isEmpty()) {
+            return 0;
+        }
+
+        List<Snapshot> taggedSnapshots = plan.protectionSet().taggedSnapshots();
+        Map<Long, Snapshot> snapshotCache = plan.snapshotCache();
+        contextSupplier =
+                () -> {
+                    SnapshotDeletion deletion = store.newSnapshotDeletion();
+                    deletion.setChangelogDecoupled(config.isChangelogDecoupled());
+                    return new SnapshotExpireContext(
+                            snapshotManager,
+                            deletion,
+                            changelogManager,
+                            taggedSnapshots,
+                            snapshotCache);
+                };
+
+        try {
+            StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+            env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+            env.setParallelism(TEST_PARALLELISM);
+
+            List<List<SnapshotExpireTask>> partitionedGroups =
+                    plan.partitionTasksBySnapshotRange(TEST_PARALLELISM);
+
+            DataStreamSource<List<SnapshotExpireTask>> source =
+                    env.fromCollection(partitionedGroups).setParallelism(1);
+
+            DataStream<DeletionReport> reports =
+                    source.rebalance()
+                            .flatMap(
+                                    new TestExpireFunction(
+                                            Collections.emptyMap(),
+                                            TEST_IDENTIFIER,
+                                            plan.protectionSet().taggedSnapshots(),
+                                            plan.snapshotCache(),
+                                            config.isChangelogDecoupled()))
+                            .returns(new JavaTypeInfo<>(DeletionReport.class))
+                            .setParallelism(TEST_PARALLELISM)
+                            .name("RangePartitionedExpire");
+
+            reports.sinkTo(
+                            new TestExpireSink(
+                                    Collections.emptyMap(),
+                                    TEST_IDENTIFIER,
+                                    plan.endExclusiveId(),
+                                    plan.protectionSet().manifestSkippingSet(),
+                                    plan.snapshotCache(),
+                                    plan.manifestTasks(),
+                                    plan.snapshotFileTasks(),
+                                    config.isChangelogDecoupled()))
+                    .setParallelism(1)
+                    .name("SnapshotExpireCommit");
+
+            env.execute("ExpireSnapshotsFlinkTest");
+
+            return plan.snapshotFileTasks().size();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            contextSupplier = null;
+        }
+    }
+
+    // ==================== Test Subclasses ====================
+
+    /**
+     * Test subclass of {@link RangePartitionedExpireFunction} that overrides {@code initContext} to
+     * use the test context supplier, completely bypassing catalog access.
+     */
+    private static class TestExpireFunction extends RangePartitionedExpireFunction {
+
+        private static final long serialVersionUID = 1L;
+        private int processedCount = 0;
+
+        public TestExpireFunction(
+                Map<String, String> catalogConfig,
+                Identifier identifier,
+                List<Snapshot> taggedSnapshots,
+                Map<Long, Snapshot> snapshotCache,
+                boolean changelogDecoupled) {
+            super(catalogConfig, identifier, taggedSnapshots, snapshotCache, changelogDecoupled);
+        }
+
+        @Override
+        protected SnapshotExpireContext initContext() {
+            return contextSupplier.get();
+        }
+
+        @Override
+        public void flatMap(List<SnapshotExpireTask> tasks, Collector<DeletionReport> out)
+                throws Exception {
+            for (SnapshotExpireTask task : tasks) {
+                if (failAfterTasks >= 0 && processedCount++ >= failAfterTasks) {
+                    throw new RuntimeException(
+                            "Simulated failure after " + failAfterTasks + " tasks");
+                }
+                DeletionReport report = task.execute(context);
+                report.setDeletionBuckets(context.snapshotDeletion().drainDeletionBuckets());
+                out.collect(report);
+            }
+        }
+    }
+
+    /**
+     * Test subclass of {@link SnapshotExpireSink} that overrides {@code initContext} to use the
+     * test context supplier, completely bypassing catalog access.
+     */
+    private static class TestExpireSink extends SnapshotExpireSink {
+
+        private static final long serialVersionUID = 1L;
+
+        public TestExpireSink(
+                Map<String, String> catalogConfig,
+                Identifier identifier,
+                long endExclusiveId,
+                Set<String> manifestSkippingSet,
+                Map<Long, Snapshot> snapshotCache,
+                List<SnapshotExpireTask> manifestTasks,
+                List<SnapshotExpireTask> snapshotFileTasks,
+                boolean changelogDecoupled) {
+            super(
+                    catalogConfig,
+                    identifier,
+                    endExclusiveId,
+                    manifestSkippingSet,
+                    snapshotCache,
+                    manifestTasks,
+                    snapshotFileTasks,
+                    changelogDecoupled);
+        }
+
+        @Override
+        protected SnapshotExpireContext initContext() {
+            return contextSupplier.get();
+        }
+    }
+
+    // ==================== Additional Tests ====================
+
+    /**
+     * Tests that if the expired job fails midway (some data files deleted, but snapshot metadata
+     * intact), a subsequent expire run can still complete successfully.
+     */
+    @Test
+    public void testExpireRecoveryAfterPartialFailure() throws Exception {
+        List<KeyValue> allData = new ArrayList<>();
+        List<Integer> snapshotPositions = new ArrayList<>();
+        commit(6, allData, snapshotPositions);
+
+        ExpireConfig config =
+                ExpireConfig.builder()
+                        .snapshotRetainMin(1)
+                        .snapshotRetainMax(1)
+                        .snapshotTimeRetain(Duration.ofMillis(1))
+                        .build();
+
+        // First attempt: inject failure after processing 2 tasks
+        // Some data files are deleted, but sink phase never runs,
+        // so snapshot/manifest metadata remains intact
+        failAfterTasks = 2;
+        try {
+            assertThatThrownBy(() -> doExpire(config)).isInstanceOf(RuntimeException.class);
+        } finally {
+            failAfterTasks = -1;
+        }
+
+        // Snapshot metadata should still exist since sink phase didn't run
+        int latestSnapshotId = requireNonNull(snapshotManager.latestSnapshotId()).intValue();
+        for (int i = 1; i <= latestSnapshotId; i++) {
+            assertThat(snapshotManager.snapshotExists(i)).isTrue();
+        }
+
+        // Recovery: run expire again, should complete successfully
+        // despite some data files already being deleted
+        doExpire(config);
+
+        // Verify: only latest snapshot remains
+        for (int i = 1; i < latestSnapshotId; i++) {
+            assertThat(snapshotManager.snapshotExists(i)).isFalse();
+        }
+        assertThat(snapshotManager.snapshotExists(latestSnapshotId)).isTrue();
+        assertSnapshot(latestSnapshotId, allData, snapshotPositions);
+    }
+
+    // ==================== Disabled Tests ====================
+    // The following tests are disabled because they are not suitable for parallel Flink execution.
+
+    @Test
+    @Disabled("Tests SnapshotDeletion directly, not the full expire flow")
+    @Override
+    public void testExpireExtraFiles() {}
+
+    @Test
+    @Disabled("Tests SnapshotDeletion directly, not the full expire flow")
+    @Override
+    public void testExpireExtraFilesWithExternalPath() {}
+
+    @Test
+    @Disabled(
+            "This test runs 10 concurrent doExpire calls, each submitting a Flink job in this"
+                    + " subclass, which is not feasible in MiniCluster with limited slots")
+    @Override
+    public void testExpireEmptySnapshot() {}
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/expire/DeletionReportTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/expire/DeletionReportTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.expire;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.utils.InstantiationUtil;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link DeletionReport}. */
+public class DeletionReportTest {
+
+    @Test
+    public void testSerialization() throws IOException, ClassNotFoundException {
+        DeletionReport report = new DeletionReport(1L);
+
+        DeletionReport deserialized = InstantiationUtil.clone(report);
+        assertThat(deserialized.snapshotId()).isEqualTo(1L);
+        assertThat(deserialized.deletionBuckets()).isEmpty();
+    }
+
+    @Test
+    public void testSerializationWithBuckets() throws IOException, ClassNotFoundException {
+        DeletionReport report = new DeletionReport(2L);
+        Map<BinaryRow, Set<Integer>> buckets = new HashMap<>();
+
+        BinaryRow partition1 = createBinaryRow(10);
+        buckets.put(partition1, Collections.singleton(1));
+
+        report.setDeletionBuckets(buckets);
+
+        // BinaryRow supports standard Java serialization via BinarySection's
+        // writeObject/readObject.
+        // This test confirms that DeletionReport with BinaryRow keys can be serialized.
+        DeletionReport deserialized = InstantiationUtil.clone(report);
+        assertThat(deserialized.snapshotId()).isEqualTo(2L);
+        assertThat(deserialized.deletionBuckets()).hasSize(1);
+        Map.Entry<BinaryRow, Set<Integer>> entry =
+                deserialized.deletionBuckets().entrySet().iterator().next();
+        assertThat(entry.getKey()).isEqualTo(partition1);
+        assertThat(entry.getValue()).containsExactly(1);
+    }
+
+    private BinaryRow createBinaryRow(int i) {
+        BinaryRow row = new BinaryRow(1);
+        BinaryRowWriter writer = new BinaryRowWriter(row);
+        writer.writeInt(0, i);
+        writer.complete();
+        return row;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/expire/ExpireSnapshotsPlanTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/expire/ExpireSnapshotsPlanTest.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.expire;
+
+import org.apache.paimon.flink.expire.SnapshotExpireTask.DeleteChangelogFilesTask;
+import org.apache.paimon.flink.expire.SnapshotExpireTask.DeleteDataFilesTask;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ExpireSnapshotsPlan}. */
+public class ExpireSnapshotsPlanTest {
+
+    @Test
+    public void testPartitionTasksBySnapshotRange() {
+        // beginInclusiveId=1, endExclusiveId=11, parallelism=3
+        List<SnapshotExpireTask> dataFileTasks = new ArrayList<>();
+        for (long id = 2; id <= 11; id++) {
+            dataFileTasks.add(SnapshotExpireTask.forDataFiles(id));
+        }
+        List<SnapshotExpireTask> changelogFileTasks = new ArrayList<>();
+        for (long id = 1; id <= 10; id++) {
+            changelogFileTasks.add(SnapshotExpireTask.forChangelogFiles(id));
+        }
+
+        ExpireSnapshotsPlan plan =
+                new ExpireSnapshotsPlan(
+                        dataFileTasks,
+                        changelogFileTasks,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        null,
+                        1,
+                        11,
+                        Collections.emptyMap());
+
+        List<List<SnapshotExpireTask>> result = plan.partitionTasksBySnapshotRange(3);
+        assertThat(result).hasSize(3);
+
+        // Worker 0 (snapshot 1-4): [dataTask(2,3,4), changelogTask(1,2,3,4)]
+        assertWorker(
+                result.get(0),
+                new long[] {2, 3, 4, 1, 2, 3, 4},
+                new Class[] {
+                    DeleteDataFilesTask.class,
+                    DeleteDataFilesTask.class,
+                    DeleteDataFilesTask.class,
+                    DeleteChangelogFilesTask.class,
+                    DeleteChangelogFilesTask.class,
+                    DeleteChangelogFilesTask.class,
+                    DeleteChangelogFilesTask.class
+                });
+
+        // Worker 1 (snapshot 5-8): [dataTask(5,6,7,8), changelogTask(5,6,7,8)]
+        assertWorker(
+                result.get(1),
+                new long[] {5, 6, 7, 8, 5, 6, 7, 8},
+                new Class[] {
+                    DeleteDataFilesTask.class,
+                    DeleteDataFilesTask.class,
+                    DeleteDataFilesTask.class,
+                    DeleteDataFilesTask.class,
+                    DeleteChangelogFilesTask.class,
+                    DeleteChangelogFilesTask.class,
+                    DeleteChangelogFilesTask.class,
+                    DeleteChangelogFilesTask.class
+                });
+
+        // Worker 2 (snapshot 9-11): [dataTask(9,10,11), changelogTask(9,10)]
+        assertWorker(
+                result.get(2),
+                new long[] {9, 10, 11, 9, 10},
+                new Class[] {
+                    DeleteDataFilesTask.class,
+                    DeleteDataFilesTask.class,
+                    DeleteDataFilesTask.class,
+                    DeleteChangelogFilesTask.class,
+                    DeleteChangelogFilesTask.class
+                });
+    }
+
+    private void assertWorker(List<SnapshotExpireTask> tasks, long[] ids, Class<?>[] types) {
+        assertThat(tasks).extracting(SnapshotExpireTask::snapshotId).containsExactly(box(ids));
+        assertThat(tasks.stream().map(Object::getClass).collect(Collectors.toList()))
+                .isEqualTo(Arrays.asList(types));
+    }
+
+    @Test
+    public void testPartitionTasksWithLargeParallelism() {
+        // beginInclusiveId=1, endExclusiveId=4, parallelism=10
+        List<SnapshotExpireTask> dataFileTasks = new ArrayList<>();
+        for (long id = 2; id <= 4; id++) {
+            dataFileTasks.add(SnapshotExpireTask.forDataFiles(id));
+        }
+        List<SnapshotExpireTask> changelogFileTasks = new ArrayList<>();
+        for (long id = 1; id <= 3; id++) {
+            changelogFileTasks.add(SnapshotExpireTask.forChangelogFiles(id));
+        }
+
+        ExpireSnapshotsPlan plan =
+                new ExpireSnapshotsPlan(
+                        dataFileTasks,
+                        changelogFileTasks,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        null,
+                        1,
+                        4,
+                        Collections.emptyMap());
+
+        List<List<SnapshotExpireTask>> result = plan.partitionTasksBySnapshotRange(10);
+        // Parallelism is 10. Total snapshot range involved is [1, 4] (inclusive).
+        // ID 1: changelog only. ID 2,3: both. ID 4: data only (since data files are (begin, end]).
+        // Total 4 snapshots have tasks.
+        // snapshotsPerWorker = ceil(4 / 10) = 1.
+        // Workers 0, 1, 2, 3 should get tasks.
+        assertThat(result).hasSize(4);
+
+        // Worker 0 (snapshot 1): [changelogTask(1)]
+        assertWorker(result.get(0), new long[] {1}, new Class[] {DeleteChangelogFilesTask.class});
+
+        // Worker 1 (snapshot 2): [dataTask(2), changelogTask(2)]
+        assertWorker(
+                result.get(1),
+                new long[] {2, 2},
+                new Class[] {DeleteDataFilesTask.class, DeleteChangelogFilesTask.class});
+
+        // Worker 2 (snapshot 3): [dataTask(3), changelogTask(3)]
+        assertWorker(
+                result.get(2),
+                new long[] {3, 3},
+                new Class[] {DeleteDataFilesTask.class, DeleteChangelogFilesTask.class});
+
+        // Worker 3 (snapshot 4): [dataTask(4)]
+        assertWorker(result.get(3), new long[] {4}, new Class[] {DeleteDataFilesTask.class});
+    }
+
+    @Test
+    public void testPartitionTasksWithSingleSnapshot() {
+        // beginInclusiveId=1, endExclusiveId=2, parallelism=2
+        // Only snapshot 1 needs expire.
+        List<SnapshotExpireTask> dataFileTasks =
+                Collections.singletonList(SnapshotExpireTask.forDataFiles(2)); // usually id+1
+        List<SnapshotExpireTask> changelogFileTasks =
+                Collections.singletonList(SnapshotExpireTask.forChangelogFiles(1));
+
+        ExpireSnapshotsPlan plan =
+                new ExpireSnapshotsPlan(
+                        dataFileTasks,
+                        changelogFileTasks,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        null,
+                        1,
+                        2,
+                        Collections.emptyMap());
+
+        List<List<SnapshotExpireTask>> result = plan.partitionTasksBySnapshotRange(2);
+        // total = 2-1 = 1? or +1?
+        // If range is [1, 2). Snapshots are {1}. Count = 1.
+        // snapshotsPerWorker = 1.
+        // Worker 0: [1, 1].
+        // Worker 1: [2, 2]. > endExclusiveId?
+
+        assertThat(result).hasSize(2);
+        assertWorker(result.get(0), new long[] {1}, new Class[] {DeleteChangelogFilesTask.class});
+        assertWorker(result.get(1), new long[] {2}, new Class[] {DeleteDataFilesTask.class});
+    }
+
+    private Long[] box(long[] arr) {
+        Long[] result = new Long[arr.length];
+        for (int i = 0; i < arr.length; i++) {
+            result[i] = arr[i];
+        }
+        return result;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpireSnapshotsProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/ExpireSnapshotsProcedureITCase.java
@@ -28,7 +28,7 @@ import org.apache.paimon.utils.SnapshotManager;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.IOException;
 import java.sql.Timestamp;
@@ -81,8 +81,11 @@ public class ExpireSnapshotsProcedureITCase extends CatalogITCaseBase {
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {false, true})
-    public void testExpireSnapshotsAction(boolean forceStartFlinkJob) throws Exception {
+    @CsvSource(
+            value = {"false,", "true,", "true,1", "true,2", "false,2"},
+            nullValues = "")
+    public void testExpireSnapshotsAction(boolean forceStartFlinkJob, Integer parallelism)
+            throws Exception {
         sql(
                 "CREATE TABLE word_count ( word STRING PRIMARY KEY NOT ENFORCED, cnt INT)"
                         + " WITH ( 'num-sorted-run.compaction-trigger' = '9999',"
@@ -100,77 +103,38 @@ public class ExpireSnapshotsProcedureITCase extends CatalogITCaseBase {
         checkSnapshots(snapshotManager, 1, 6);
 
         // retain_max => 5, expected snapshots (2, 3, 4, 5, 6)
-        createAction(
-                        ExpireSnapshotsAction.class,
-                        "expire_snapshots",
-                        "--warehouse",
-                        path,
-                        "--database",
-                        "default",
-                        "--table",
-                        "word_count",
-                        "--retain_max",
-                        "5",
-                        "--force_start_flink_job",
-                        Boolean.toString(forceStartFlinkJob))
+        createExpireAction(forceStartFlinkJob, parallelism, "--retain_max", "5")
                 .withStreamExecutionEnvironment(env)
                 .run();
         checkSnapshots(snapshotManager, 2, 6);
 
         // older_than => timestamp of snapshot 6, max_deletes => 1, expected snapshots (3, 4, 5, 6)
         Timestamp ts6 = new Timestamp(snapshotManager.latestSnapshot().timeMillis());
-        createAction(
-                        ExpireSnapshotsAction.class,
-                        "expire_snapshots",
-                        "--warehouse",
-                        path,
-                        "--database",
-                        "default",
-                        "--table",
-                        "word_count",
+        createExpireAction(
+                        forceStartFlinkJob,
+                        parallelism,
                         "--older_than",
                         ts6.toString(),
                         "--max_deletes",
-                        "1",
-                        "--force_start_flink_job",
-                        Boolean.toString(forceStartFlinkJob))
+                        "1")
                 .withStreamExecutionEnvironment(env)
                 .run();
         checkSnapshots(snapshotManager, 3, 6);
 
-        createAction(
-                        ExpireSnapshotsAction.class,
-                        "expire_snapshots",
-                        "--warehouse",
-                        path,
-                        "--database",
-                        "default",
-                        "--table",
-                        "word_count",
+        // older_than => timestamp of snapshot 6, retain_min => 3, expected snapshots (4, 5, 6)
+        createExpireAction(
+                        forceStartFlinkJob,
+                        parallelism,
                         "--older_than",
                         ts6.toString(),
                         "--retain_min",
-                        "3",
-                        "--force_start_flink_job",
-                        Boolean.toString(forceStartFlinkJob))
+                        "3")
                 .withStreamExecutionEnvironment(env)
                 .run();
         checkSnapshots(snapshotManager, 4, 6);
 
         // older_than => timestamp of snapshot 6, expected snapshots (6)
-        createAction(
-                        ExpireSnapshotsAction.class,
-                        "expire_snapshots",
-                        "--warehouse",
-                        path,
-                        "--database",
-                        "default",
-                        "--table",
-                        "word_count",
-                        "--older_than",
-                        ts6.toString(),
-                        "--force_start_flink_job",
-                        Boolean.toString(forceStartFlinkJob))
+        createExpireAction(forceStartFlinkJob, parallelism, "--older_than", ts6.toString())
                 .withStreamExecutionEnvironment(env)
                 .run();
         checkSnapshots(snapshotManager, 6, 6);
@@ -216,5 +180,27 @@ public class ExpireSnapshotsProcedureITCase extends CatalogITCaseBase {
                 .filter(clazz::isInstance)
                 .map(clazz::cast)
                 .orElseThrow(() -> new RuntimeException("Failed to create action"));
+    }
+
+    private ExpireSnapshotsAction createExpireAction(
+            boolean forceStartFlinkJob, Integer parallelism, String... extraArgs) {
+        java.util.List<String> args = new java.util.ArrayList<>();
+        java.util.Collections.addAll(
+                args,
+                "expire_snapshots",
+                "--warehouse",
+                path,
+                "--database",
+                "default",
+                "--table",
+                "word_count",
+                "--force_start_flink_job",
+                Boolean.toString(forceStartFlinkJob));
+        if (parallelism != null) {
+            args.add("--parallelism");
+            args.add(String.valueOf(parallelism));
+        }
+        java.util.Collections.addAll(args, extraArgs);
+        return createAction(ExpireSnapshotsAction.class, args.toArray(new String[0]));
     }
 }


### PR DESCRIPTION
### Purpose

This PR implements parallel snapshot expiration using Flink distributed execution to improve the performance of large-scale cleanup operations.

**Motivation:**
- Serial file deletion becomes a performance bottleneck for tables with large amounts of data
- Current implementation cannot leverage Flink's distributed computing capabilities

**Architecture:**

The expire process is split into two phases:
- **Worker phase (parallel flatMap)**: Deletes data files and changelog files in parallel using `RangePartitionedExpireFunction`. Tasks are partitioned by snapshot ID range to maximize cache locality (adjacent snapshots share manifest files and tag data file skippers).
- **Sink phase (serial)**: Deletes manifests and snapshot metadata serially using `SnapshotExpireSink`, because `manifestSkippingSet` is global mutable state and snapshot deletion must be contiguous.

**Key classes:**
- `ExpireSnapshotsPlanner`: Computes expiration plan including snapshot range, four types of tasks, protection set, and snapshot cache
- `SnapshotExpireTask`: Abstract base with 4 polymorphic subclasses (`DeleteDataFilesTask`, `DeleteChangelogFilesTask`, `DeleteManifestsTask`, `DeleteSnapshotTask`)
- `ExpireContext`: Holds runtime dependencies (SnapshotManager, SnapshotDeletion, ChangelogManager) and shared state (taggedSnapshots, snapshotCache, skippingSet)
- `ExpireSnapshotsPlan`: Contains task lists, protection set, snapshot cache, and range-based task partitioning logic
- `DeletionReport`: Carries deletion bucket info from workers to sink for empty directory cleanup

**Execution modes:**
- Local mode: `forceStartFlinkJob=false` → executes locally via `ExpireSnapshotsProcedure`
- Flink mode: `forceStartFlinkJob=true`→ uses Flink distributed execution

**Other changes:**
- Moved planner/plan/task/report classes from paimon-core to paimon-flink (per reviewer suggestion)
- Planner pre-collects snapshots in parallel using `CompletableFuture` and caches them, serialized to both workers and sink to avoid redundant reads
- `ExpireSnapshotsImpl` (serial mode) reuses `ExpireSnapshotsPlanner` for planning, keeping serial execution path unchanged
- Added failure recovery test: verifies that if expire job fails midway (data files partially deleted but snapshot metadata intact), a subsequent run completes successfully

### Tests

**Unit Tests:**
- `ExpireSnapshotsPlanTest` - Tests range-based task partitioning logic
- `DeletionReportTest` - Tests deletion report serialization

**Integration Tests:**
- `ParallelExpireSnapshotsActionITCase` - Extends `ExpireSnapshotsTest` to validate parallel mode produces same results as serial mode, plus failure recovery test
- `ExpireSnapshotsProcedureITCase` - Tests both local and parallel modes via procedure

### API and Format

**New CLI parameter for `expire-snapshots` action:**
| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `--parallelism` | Integer | env parallelism | Parallelism for parallel expire workers |

**No storage format changes.**

**Backward compatible:** Default behavior (local mode) remains unchanged.

### Documentation

Yes, this introduces a new feature: parallel snapshot expiration.

Documentation should cover:
- New `--parallelism` parameter for `expire-snapshots` action
- `--force_start_flink_job` triggers flink mode