### PR TITLE
[Core][Bug-fix] Fix wrong merge order of increment diff split read

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
@@ -206,10 +206,8 @@ public class IncrementalDiffSplitRead implements SplitRead<InternalRow> {
             } else if (kvs.size() == 2) {
                 KeyValue before = kvs.get(0);
                 KeyValue after = kvs.get(1);
-                if (after.level() == AFTER_LEVEL) {
-                    if (!valueAndRowKindEquals(before, after)) {
-                        toReturn = after;
-                    }
+                if (!valueAndRowKindEquals(before, after)) {
+                    toReturn = after.level() == AFTER_LEVEL ? after : before;
                 }
             } else {
                 throw new IllegalArgumentException("Illegal kv number: " + kvs.size());

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -1021,6 +1021,32 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testIncrementScanModeWithInsertOverwrite() throws Exception {
+
+        sql("CREATE TABLE test_scan_mode (id INT PRIMARY KEY NOT ENFORCED, v STRING)");
+
+        // snapshot 1
+        sql("INSERT OVERWRITE test_scan_mode VALUES (1, 'A'), (1, 'B'), (1, 'C')");
+        // snapshot 2
+        sql("INSERT OVERWRITE test_scan_mode VALUES (1, 'C'), (1, 'D')");
+
+        List<Row> result =
+                sql(
+                        "SELECT * FROM `test_scan_mode$audit_log` "
+                                + "/*+ OPTIONS('incremental-between'='1,2','incremental-between-scan-mode'='diff') */");
+        assertThat(result).containsExactlyInAnyOrder(Row.of("+I", 1, "D"));
+
+        // snapshot 3
+        sql("INSERT OVERWRITE test_scan_mode VALUES (1, 'D')");
+
+        result =
+                sql(
+                        "SELECT * FROM `test_scan_mode$audit_log` "
+                                + "/*+ OPTIONS('incremental-between'='2,2','incremental-between-scan-mode'='diff') */");
+        assertThat(result).isEmpty();
+    }
+
+    @Test
     public void testAuditLogTableWithComputedColumn() throws Exception {
         sql("CREATE TABLE test_table (a int, b int, c AS a + b);");
         String ddl = sql("SHOW CREATE TABLE `test_table$audit_log`").get(0).getFieldAs(0);


### PR DESCRIPTION
### Purpose

This pull request aims to fix an issue in the incremental scan where concurrent writes to the same key could finally return wrong merged result. Since records included in merging set are in non-deterministic sequence numbers  could result in unstable merge order, which the incremental scan heavily relies on, would lead to incorrect final results. The fix ensures the correct result by re-sorting the data in the getResult stage of the split diff read process.

### Tests

A new integration test, testIncrementScanModeWithInsertOverwrite, has been added to BatchFileStoreITCase.java. This test simulates the scenario with multiple INSERT OVERWRITE operations with different seq. number on the same key, and then verifies that the diff mode of incremental scan correctly identifies the changes, ensuring the fix is effective.

### API and Format

No API or format changes. This change only involves an internal logic correction and does not affect any external APIs, data storage formats, or configuration files.

### Documentation


This change is an internal bug fix and does not require updates to user-facing documentation.
