### PR TITLE
[core] Fix the issue where aggregate function columns without defining sequenceGroup cause the table to be unavailable

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
@@ -151,4 +151,17 @@ class SchemaValidationTest {
         assertThatThrownBy(() -> validateBlobSchema(options, Collections.singletonList("f2")))
                 .hasMessage("The BLOB type column can not be part of partition keys.");
     }
+
+    @Test
+    public void testPartialUpdateTableAggregateFunctionWithoutSequenceGroup() {
+        Map<String, String> options = new HashMap<>(2);
+        options.put("merge-engine", "partial-update");
+        options.put("fields.f3.aggregate-function", "max");
+        assertThatThrownBy(() -> validateTableSchemaExec(options))
+                .hasMessageContaining(
+                        "Must use sequence group for aggregation functions but not found for field");
+
+        options.put("fields.f2.sequence-group", "f3");
+        assertThatCode(() -> validateTableSchemaExec(options)).doesNotThrowAnyException();
+    }
 }


### PR DESCRIPTION
Fix the issue where aggregate function columns without defining sequenceGroup cause the table to be unavailable
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close [#7045](https://github.com/apache/paimon/issues/7045)

<!-- What is the purpose of the change -->

### Tests
`testAggregateFunctionWithoutSequenceGroup`

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
