### PR TITLE
[spark] Support native GlobalIndexTopologyBuilder

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/GlobalIndexTopologyBuilderUtils.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/GlobalIndexTopologyBuilderUtils.java
@@ -56,7 +56,8 @@ public class GlobalIndexTopologyBuilderUtils {
     }
 
     @Nullable
-    public static GlobalIndexTopologyBuilder createTopoBuilder(String indexType) {
-        return FACTORIES.get(indexType);
+    public static GlobalIndexTopologyBuilder createTopoBuilder(
+            String indexType, boolean useNative) {
+        return FACTORIES.get(indexType + (useNative ? "_native" : ""));
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
@@ -87,7 +87,8 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
                 ProcedureParameter.required("index_column", DataTypes.StringType),
                 ProcedureParameter.required("index_type", DataTypes.StringType),
                 ProcedureParameter.optional("partitions", StringType),
-                ProcedureParameter.optional("options", DataTypes.StringType)
+                ProcedureParameter.optional("options", DataTypes.StringType),
+                ProcedureParameter.optional("use_native", DataTypes.BooleanType)
             };
 
     private static final StructType OUTPUT_TYPE =
@@ -125,6 +126,7 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
                         ? null
                         : args.getString(3);
         String optionString = args.isNullAt(4) ? null : args.getString(4);
+        boolean useNative = args.isNullAt(5) ? false : args.getBoolean(5);
 
         String finalWhere = partitions != null ? SparkProcedureUtils.toWhere(partitions) : null;
 
@@ -170,7 +172,8 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
                         List<CommitMessage> indexResults;
                         // Step 1: build index by certain index system
                         GlobalIndexTopologyBuilder topoBuilder =
-                                GlobalIndexTopologyBuilderUtils.createTopoBuilder(indexType);
+                                GlobalIndexTopologyBuilderUtils.createTopoBuilder(
+                                        indexType, useNative);
 
                         if (topoBuilder != null) {
                             // do not need to prepare index shards for custom topo builder


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Parameter useNative indicate whether to use a TopologyBuilder with the "_native" suffix in IDENTIFIER to build the index.


### Tests


### API and Format


### Documentation

