### PR TITLE
[spark] Exclude dependencies from the test dependency paimon-spark-ut

### DIFF
--- a/.github/workflows/publish_snapshot-jdk17.yml
+++ b/.github/workflows/publish_snapshot-jdk17.yml
@@ -64,7 +64,7 @@ jobs:
           echo "</server></servers></settings>" >> $tmp_settings
         
           mvn --settings $tmp_settings clean install -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark4,flink1,paimon-lucene -pl org.apache.paimon:paimon-spark-4.0_2.13 -am
-          # skip deploy paimon-spark-common_2.13 and paimon-spark-ut_2.13, since they are already deployed in publish-snapshot.yml
-          mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark4,flink1,paimon-lucene -pl org.apache.paimon:paimon-spark4-common_2.13,org.apache.paimon:paimon-spark-4.0_2.13
+          # skip deploy paimon-spark-common_2.13 since they are already deployed in publish-snapshot.yml
+          mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark4,flink1,paimon-lucene -pl org.apache.paimon:paimon-spark4-common_2.13,org.apache.paimon:paimon-spark-ut_2.13,org.apache.paimon:paimon-spark-4.0_2.13
 
           rm $tmp_settings

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -67,6 +67,6 @@ jobs:
           
           mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark3,flink1 -pl '!paimon-faiss/paimon-faiss-jni,!paimon-faiss/paimon-faiss-index'
           # deploy for scala 2.13
-          mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark3,scala-2.13,flink1 -pl org.apache.paimon:paimon-spark-common_2.13,org.apache.paimon:paimon-spark3-common_2.13,org.apache.paimon:paimon-spark-ut_2.13,org.apache.paimon:paimon-spark-3.2_2.13,org.apache.paimon:paimon-spark-3.3_2.13,org.apache.paimon:paimon-spark-3.4_2.13,org.apache.paimon:paimon-spark-3.5_2.13
+          mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release,spark3,scala-2.13,flink1 -pl org.apache.paimon:paimon-spark-common_2.13,org.apache.paimon:paimon-spark3-common_2.13,org.apache.paimon:paimon-spark-3.2_2.13,org.apache.paimon:paimon-spark-3.3_2.13,org.apache.paimon:paimon-spark-3.4_2.13,org.apache.paimon:paimon-spark-3.5_2.13
 
           rm $tmp_settings

--- a/paimon-spark/paimon-spark-3.2/pom.xml
+++ b/paimon-spark/paimon-spark-3.2/pom.xml
@@ -79,6 +79,12 @@ under the License.
             <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/paimon-spark/paimon-spark-3.3/pom.xml
+++ b/paimon-spark/paimon-spark-3.3/pom.xml
@@ -79,6 +79,12 @@ under the License.
             <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/paimon-spark/paimon-spark-3.4/pom.xml
+++ b/paimon-spark/paimon-spark-3.4/pom.xml
@@ -79,6 +79,12 @@ under the License.
             <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/paimon-spark/paimon-spark-3.5/pom.xml
+++ b/paimon-spark/paimon-spark-3.5/pom.xml
@@ -79,6 +79,12 @@ under the License.
             <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/paimon-spark/paimon-spark-4.0/pom.xml
+++ b/paimon-spark/paimon-spark-4.0/pom.xml
@@ -85,6 +85,12 @@ under the License.
             <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Fix for local execution of `mvn test -pl paimon-spark/paimon-spark-4.0 -Pspark4 -DwildcardSuites='...'`

```text
*** RUN ABORTED ***
java.util.ServiceConfigurationError:org.apache.spark.sql.paimon.shims.SparkShim:org.apache.spark.sql.paimon.shims.Spark3Shim Unable to get public no-arg constructor
at java.base/java.util.ServiceLoader.fail（ServiceLoader.java:586）
at java.base/java.util.ServiceLoader .getConstructor（ServiceLoader.java:679）
at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService（ServiceLoader.java:1240）
at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext（ServiceLoader.java:1273）
at java.base/java.util.ServiceLoader$2.hasNext （ServiceLoader.java:1309）
at java.base/java.util.ServiceLoader$3.hasNext （ServiceLoader.java:1393）
at scala.collection.convert.JavaCollectionwrappers$JIteratorWrapper.hasNext （JavaCollectionwrappers.scala:46）
at scala.collection.IterableOnceOps.size（IterableOnce.scala:980）
at scala.collection.Iterable0nceOps.size$（IterableOnce.scala:975）
at scala.collection.AbstractIterable.size（Iterable.scala:935）
```

The most likely root cause is that `paimon-spark-ut_2.13` is being used by both `paimon-spark-3.x_2.13` and `paimon-spark-4.x_2.13`, and `paimon-spark-ut` itself depends on `paimon-sparkx-common`. This leads to dependency conflicts when running tests in the Spark 4 environment. Or there could be an issue with Maven handles profile activation failures.

Anyway, if we have to choose one, I prefer publishing `paimon-spark-ut_2.13` built under the Spark4 profile. Therefore, this PR makes the following changes:

- Publish `paimon-spark-ut_2.13` using the Spark 4 build profile.
- Exclude dependencies from the test dependency `paimon-spark-ut` — we only need its test classes, not its runtime dependencies. (Avoid maven handles profile activation bug)

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
