### PR TITLE
[spark] Correct the assignment of null to `currentResult` in `PaimonRecordReaderIterator#close`

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonRecordReaderIterator.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonRecordReaderIterator.scala
@@ -81,7 +81,7 @@ case class PaimonRecordReaderIterator(
     try {
       if (currentIterator != null) {
         currentIterator.releaseBatch()
-        currentResult == null
+        currentResult = null
       }
     } finally {
       reader.close()


### PR DESCRIPTION
### Purpose
From an intent perspective, the `PaimonRecordReaderIterator#close` method is supposed to assign `null` to `currentResult` when `currentIterator != null`. However, it was mistakenly written as `currentResult == null`. This  pr corrects this issue.

### Tests
Existing tests


### API and Format
No

### Documentation
No