### PR TITLE
[spark] Fix wrong argument in procedure

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RemoveOrphanFilesProcedure.java
@@ -96,7 +96,7 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
         Preconditions.checkArgument(
                 tableId != null && !tableId.isEmpty(),
                 "Cannot handle an empty tableId for argument %s",
-                tableId);
+                PARAMETERS[0].name());
 
         if (tableId.endsWith(".*")) {
             identifier = org.apache.paimon.catalog.Identifier.fromString(tableId);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RemoveUnexistingFilesProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RemoveUnexistingFilesProcedure.java
@@ -42,7 +42,7 @@ import java.util.Arrays;
  *  CALL sys.remove_unexisting_files(`table` => 'mydb.myt')
  *
  *  -- only check what files will be removed, but not really remove them (dry run)
- *  CALL sys.remove_unexisting_files(`table` => 'mydb.myt', `dry_run` = true)
+ *  CALL sys.remove_unexisting_files(`table` => 'mydb.myt', `dry_run` => true)
  * </code></pre>
  *
  * <p>Note that user is on his own risk using this procedure, which may cause data loss when used
@@ -85,7 +85,7 @@ public class RemoveUnexistingFilesProcedure extends BaseProcedure {
         Preconditions.checkArgument(
                 tableId != null && !tableId.isEmpty(),
                 "Cannot handle an empty tableId for argument %s",
-                tableId);
+                PARAMETERS[0].name());
         org.apache.paimon.catalog.Identifier identifier =
                 org.apache.paimon.catalog.Identifier.fromString(
                         toIdentifier(args.getString(0), PARAMETERS[0].name()).toString());


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Fix wrong argument in procedure

**Before:**
```
26/01/17 00:35:09 ERROR [main] SparkSQLDriver: Failed in [CALL sys.remove_unexisting_files(`table` => '', `dry_run` => false)]
java.lang.IllegalArgumentException: Cannot handle an empty tableId for argument
```

**After:**
```
26/01/17 01:39:29 ERROR [main] SparkSQLDriver: Failed in [CALL sys.remove_unexisting_files(`table` => '', `dry_run` => false)]
java.lang.IllegalArgumentException: Cannot handle an empty tableId for argument table
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
