### PR TITLE
[test] Remove print test name in spark test

### DIFF
--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/PaimonSparkTestBase.scala
@@ -35,8 +35,6 @@ import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, Data
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.paimon.Utils
 import org.apache.spark.sql.test.SharedSparkSession
-import org.scalactic.source.Position
-import org.scalatest.Tag
 
 import java.io.File
 import java.util.{TimeZone, UUID}
@@ -152,14 +150,6 @@ class PaimonSparkTestBase
         case (key, None) => conf.unsetConf(key)
       }
     }
-  }
-
-  override def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit
-      pos: Position): Unit = {
-    super.test(testName, testTags: _*) {
-      println(testName)
-      testFun
-    }(pos)
   }
 
   def loadTable(tableName: String): FileStoreTable = {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Before
```
DDLWithHiveCatalogTest:
Paimon DDL with hive catalog: create database with location and comment
- Paimon DDL with hive catalog: create database with location and comment
Paimon DDL with hive catalog: drop partition for paimon table sparkCatalogName
- Paimon DDL with hive catalog: drop partition for paimon table sparkCatalogName
Paimon partition expire test with hive catalog: expire partition for paimon table sparkCatalogName
- Paimon partition expire test with hive catalog: expire partition for paimon table sparkCatalogName
Paimon DDL with hive catalog: create partition for paimon table sparkCatalogName
- Paimon DDL with hive catalog: create partition for paimon table sparkCatalogName
```

After
```
DDLWithHiveCatalogTest:
- Paimon DDL with hive catalog: create database with location and comment
- Paimon DDL with hive catalog: drop partition for paimon table sparkCatalogName
- Paimon partition expire test with hive catalog: expire partition for paimon table sparkCatalogName
- Paimon DDL with hive catalog: create partition for paimon table sparkCatalogName
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
