### PR TITLE
[spark] Bump Spark 3.5.8

### DIFF
--- a/docs/content/ecosystem/overview.md
+++ b/docs/content/ecosystem/overview.md
@@ -58,7 +58,7 @@ implemented, but you must accept the mechanism of mini-batch.
 
 Spark Batch is the most widely used batch computing engine.
 
-Recommended version is Spark 3.5.7.
+Recommended version is Spark 3.5.8.
 
 ### Flink Batch
 

--- a/paimon-faiss/paimon-faiss-e2e-test/pom.xml
+++ b/paimon-faiss/paimon-faiss-e2e-test/pom.xml
@@ -34,7 +34,7 @@ under the License.
     <properties>
         <test.java.version>java8</test.java.version>
         <test.spark.main.version>3.5</test.spark.main.version>
-        <test.spark.version>3.5.7</test.spark.version>
+        <test.spark.version>3.5.8</test.spark.version>
     </properties>
 
     <dependencies>

--- a/paimon-spark/paimon-spark-3.5/pom.xml
+++ b/paimon-spark/paimon-spark-3.5/pom.xml
@@ -32,7 +32,7 @@ under the License.
     <name>Paimon : Spark : 3.5: ${scala.binary.version}</name>
 
     <properties>
-        <spark.version>3.5.7</spark.version>
+        <spark.version>3.5.8</spark.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ under the License.
 
         <!-- spark profile properties-->
         <paimon-sparkx-common>paimon-spark3-common_${scala.binary.version}</paimon-sparkx-common>
-        <paimon-spark-common.spark.version>3.5.7</paimon-spark-common.spark.version>
+        <paimon-spark-common.spark.version>3.5.8</paimon-spark-common.spark.version>
         <test.spark.main.version>3.3</test.spark.main.version>
         <test.spark.version>3.3.0</test.spark.version>
 
@@ -407,7 +407,7 @@ under the License.
             <properties>
                 <scala.binary.version>2.12</scala.binary.version>
                 <scala.version>${scala212.version}</scala.version>
-                <paimon-spark-common.spark.version>3.5.7</paimon-spark-common.spark.version>
+                <paimon-spark-common.spark.version>3.5.8</paimon-spark-common.spark.version>
                 <paimon-sparkx-common>paimon-spark3-common_${scala.binary.version}</paimon-sparkx-common>
                 <!-- todo: support the latest spark in paimon e2e test2 -->
                 <test.spark.main.version>3.3</test.spark.main.version>


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx

Spark 3.5.8 released (Jan 15, 2026)

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
