### PR TITLE
[variant] Refactor VariantAccessInfo to VariantExtraction

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/variant/PaimonShreddingUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/variant/PaimonShreddingUtils.java
@@ -581,7 +581,7 @@ public class PaimonShreddingUtils {
      * extract. If it is variant struct, return a list of fields matching the variant struct fields.
      */
     public static FieldToExtract[] getFieldsToExtract(
-            List<VariantAccessInfo.VariantField> variantFields, VariantSchema variantSchema) {
+            List<VariantExtraction.VariantField> variantFields, VariantSchema variantSchema) {
         if (variantFields != null) {
             return variantFields.stream()
                     .map(

--- a/paimon-common/src/main/java/org/apache/paimon/data/variant/VariantCastArgs.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/variant/VariantCastArgs.java
@@ -21,6 +21,7 @@ package org.apache.paimon.data.variant;
 import java.io.Serializable;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Objects;
 
 /** Several parameters used by `VariantGet.cast`. Packed together to simplify parameter passing. */
 public class VariantCastArgs implements Serializable {
@@ -50,5 +51,19 @@ public class VariantCastArgs implements Serializable {
     @Override
     public String toString() {
         return "VariantCastArgs{" + "failOnError=" + failOnError + ", zoneId=" + zoneId + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        VariantCastArgs that = (VariantCastArgs) o;
+        return failOnError == that.failOnError && Objects.equals(zoneId, that.zoneId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(failOnError, zoneId);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/data/variant/VariantExtraction.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/variant/VariantExtraction.java
@@ -18,28 +18,36 @@
 
 package org.apache.paimon.data.variant;
 
+import org.apache.paimon.annotation.Experimental;
 import org.apache.paimon.types.DataField;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
-/** Variant access information for a variant column. */
-public class VariantAccessInfo implements Serializable {
+/** Variant extraction information that describes fields extraction from a variant column. */
+@Experimental
+public class VariantExtraction implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    // The name of the variant column.
-    private final String columnName;
+    /**
+     * Returns the path to the variant column. For top-level variant columns, this is a single
+     * element array containing the column name. For nested variant columns within structs, this is
+     * an array representing the path (e.g., ["structCol", "innerStruct", "variantCol"]).
+     */
+    private final String[] columnName;
 
     // Extracted fields from the variant.
     private final List<VariantField> variantFields;
 
-    public VariantAccessInfo(String columnName, List<VariantField> variantFields) {
-        this.columnName = columnName;
+    public VariantExtraction(String columnName, List<VariantField> variantFields) {
+        this.columnName = new String[] {columnName};
         this.variantFields = variantFields;
     }
 
-    public String columnName() {
+    public String[] columnName() {
         return columnName;
     }
 
@@ -49,13 +57,27 @@ public class VariantAccessInfo implements Serializable {
 
     @Override
     public String toString() {
-        return "VariantAccessInfo{"
-                + "columnName='"
-                + columnName
-                + '\''
+        return "VariantExtraction{"
+                + "columnName="
+                + Arrays.toString(columnName)
                 + ", variantFields="
                 + variantFields
                 + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        VariantExtraction that = (VariantExtraction) o;
+        return Objects.deepEquals(columnName, that.columnName)
+                && Objects.equals(variantFields, that.variantFields);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(Arrays.hashCode(columnName), variantFields);
     }
 
     /** Variant field extracted from the variant. */
@@ -104,6 +126,22 @@ public class VariantAccessInfo implements Serializable {
                     + ", castArgs="
                     + castArgs
                     + '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            VariantField that = (VariantField) o;
+            return Objects.equals(dataField, that.dataField)
+                    && Objects.equals(path, that.path)
+                    && Objects.equals(castArgs, that.castArgs);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(dataField, path, castArgs);
         }
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/FileFormat.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.format;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.factories.FormatFactoryUtil;
 import org.apache.paimon.format.FileFormatFactory.FormatContext;
 import org.apache.paimon.options.Options;
@@ -67,8 +67,8 @@ public abstract class FileFormat {
             RowType dataSchemaRowType,
             RowType projectedRowType,
             @Nullable List<Predicate> filters,
-            @Nullable VariantAccessInfo[] variantAccess) {
-        if (variantAccess != null) {
+            @Nullable VariantExtraction[] variantExtractions) {
+        if (variantExtractions != null) {
             throw new UnsupportedOperationException();
         }
         return createReaderFactory(dataSchemaRowType, projectedRowType, filters);

--- a/paimon-core/src/main/java/org/apache/paimon/io/ChainKeyValueFileReaderFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/ChainKeyValueFileReaderFactory.java
@@ -20,7 +20,7 @@ package org.apache.paimon.io;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.deletionvectors.DeletionVector;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.predicate.Predicate;
@@ -120,10 +120,10 @@ public class ChainKeyValueFileReaderFactory extends KeyValueFileReaderFactory {
                 DeletionVector.Factory dvFactory,
                 boolean projectKeys,
                 @Nullable List<Predicate> filters,
-                @Nullable VariantAccessInfo[] variantAccess,
+                @Nullable VariantExtraction[] variantExtractions,
                 @Nullable ChainReadContext chainReadContext) {
             FormatReaderMapping.Builder builder =
-                    wrapped.formatReaderMappingBuilder(projectKeys, filters, variantAccess);
+                    wrapped.formatReaderMappingBuilder(projectKeys, filters, variantExtractions);
             return new ChainKeyValueFileReaderFactory(
                     wrapped.fileIO,
                     wrapped.schemaManager,

--- a/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/KeyValueFileReaderFactory.java
@@ -22,7 +22,7 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.deletionvectors.ApplyDeletionVectorReader;
 import org.apache.paimon.deletionvectors.DeletionVector;
 import org.apache.paimon.format.FileFormatDiscover;
@@ -271,9 +271,9 @@ public class KeyValueFileReaderFactory implements FileReaderFactory<KeyValue> {
                 DeletionVector.Factory dvFactory,
                 boolean projectKeys,
                 @Nullable List<Predicate> filters,
-                @Nullable VariantAccessInfo[] variantAccess) {
+                @Nullable VariantExtraction[] variantExtractions) {
             FormatReaderMapping.Builder builder =
-                    formatReaderMappingBuilder(projectKeys, filters, variantAccess);
+                    formatReaderMappingBuilder(projectKeys, filters, variantExtractions);
             return new KeyValueFileReaderFactory(
                     fileIO,
                     schemaManager,
@@ -290,7 +290,7 @@ public class KeyValueFileReaderFactory implements FileReaderFactory<KeyValue> {
         protected FormatReaderMapping.Builder formatReaderMappingBuilder(
                 boolean projectKeys,
                 @Nullable List<Predicate> filters,
-                @Nullable VariantAccessInfo[] variantAccess) {
+                @Nullable VariantExtraction[] variantExtractions) {
             RowType finalReadKeyType = projectKeys ? this.readKeyType : keyType;
             List<DataField> readTableFields =
                     KeyValue.createKeyValueFields(
@@ -308,7 +308,7 @@ public class KeyValueFileReaderFactory implements FileReaderFactory<KeyValue> {
                     filters,
                     null,
                     null,
-                    variantAccess);
+                    variantExtractions);
         }
 
         public FileIO fileIO() {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
@@ -22,7 +22,7 @@ import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.append.ForceSingleBatchReader;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.format.FileFormatDiscover;
 import org.apache.paimon.format.FormatKey;
@@ -89,7 +89,7 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
     private final FileStorePathFactory pathFactory;
     private final Map<FormatKey, FormatReaderMapping> formatReaderMappings;
     private final Function<Long, TableSchema> schemaFetcher;
-    @Nullable private VariantAccessInfo[] variantAccess;
+    @Nullable private VariantExtraction[] variantExtractions;
 
     protected RowType readRowType;
 
@@ -128,8 +128,8 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
     }
 
     @Override
-    public SplitRead<InternalRow> withVariantAccess(VariantAccessInfo[] variantAccess) {
-        this.variantAccess = variantAccess;
+    public SplitRead<InternalRow> withVariantExtractions(VariantExtraction[] variantExtractions) {
+        this.variantExtractions = variantExtractions;
         return this;
     }
 
@@ -172,7 +172,7 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
                         null,
                         null,
                         null,
-                        variantAccess);
+                        variantExtractions);
 
         List<List<DataFileMeta>> splitByRowId = mergeRangesAndSort(files);
         for (List<DataFileMeta> needMergeFiles : splitByRowId) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/RawFileSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/RawFileSplitRead.java
@@ -20,7 +20,7 @@ package org.apache.paimon.operation;
 
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.deletionvectors.ApplyDeletionVectorReader;
 import org.apache.paimon.deletionvectors.DeletionVector;
 import org.apache.paimon.disk.IOManager;
@@ -86,7 +86,7 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
     @Nullable private List<Predicate> filters;
     @Nullable private TopN topN;
     @Nullable private Integer limit;
-    @Nullable private VariantAccessInfo[] variantAccess;
+    @Nullable private VariantExtraction[] variantExtractions;
 
     public RawFileSplitRead(
             FileIO fileIO,
@@ -125,8 +125,8 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
     }
 
     @Override
-    public SplitRead<InternalRow> withVariantAccess(VariantAccessInfo[] variantAccess) {
-        this.variantAccess = variantAccess;
+    public SplitRead<InternalRow> withVariantExtractions(VariantExtraction[] variantExtractions) {
+        this.variantExtractions = variantExtractions;
         return this;
     }
 
@@ -193,7 +193,7 @@ public class RawFileSplitRead implements SplitRead<InternalRow> {
                         filters,
                         topN,
                         limit,
-                        variantAccess);
+                        variantExtractions);
 
         for (DataFileMeta file : files) {
             suppliers.add(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/SplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/SplitRead.java
@@ -18,7 +18,7 @@
 
 package org.apache.paimon.operation;
 
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.TopN;
@@ -44,7 +44,7 @@ public interface SplitRead<T> {
 
     SplitRead<T> withReadType(RowType readType);
 
-    SplitRead<T> withVariantAccess(VariantAccessInfo[] variantAccess);
+    SplitRead<T> withVariantExtractions(VariantExtraction[] variantExtractions);
 
     SplitRead<T> withFilter(@Nullable Predicate predicate);
 
@@ -81,8 +81,8 @@ public interface SplitRead<T> {
             }
 
             @Override
-            public SplitRead<R> withVariantAccess(VariantAccessInfo[] variantAccess) {
-                read.withVariantAccess(variantAccess);
+            public SplitRead<R> withVariantExtractions(VariantExtraction[] variantExtractions) {
+                read.withVariantExtractions(variantExtractions);
                 return this;
             }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatReadBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatReadBuilder.java
@@ -20,7 +20,7 @@ package org.apache.paimon.table.format;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.format.FileFormatDiscover;
 import org.apache.paimon.format.FormatReaderContext;
 import org.apache.paimon.format.FormatReaderFactory;
@@ -126,7 +126,7 @@ public class FormatReadBuilder implements ReadBuilder {
     }
 
     @Override
-    public ReadBuilder withVariantAccess(VariantAccessInfo[] variantAccessInfo) {
+    public ReadBuilder withVariantExtractions(VariantExtraction[] variantExtractions) {
         throw new UnsupportedOperationException();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
@@ -20,7 +20,7 @@ package org.apache.paimon.table.source;
 
 import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateProjectionConverter;
@@ -45,7 +45,7 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
 
     public abstract void applyReadType(RowType readType);
 
-    public abstract void applyVariantAccess(VariantAccessInfo[] variantAccess);
+    public abstract void applyVariantExtractions(VariantExtraction[] variantExtractions);
 
     public abstract RecordReader<InternalRow> reader(Split split) throws IOException;
 
@@ -84,8 +84,8 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     }
 
     @Override
-    public InnerTableRead withVariantAccess(VariantAccessInfo[] variantAccessInfo) {
-        applyVariantAccess(variantAccessInfo);
+    public InnerTableRead withVariantExtractions(VariantExtraction[] variantExtractions) {
+        applyVariantExtractions(variantExtractions);
         return this;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AppendTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AppendTableRead.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.table.source;
 
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.operation.MergeFileSplitRead;
 import org.apache.paimon.operation.SplitRead;
 import org.apache.paimon.predicate.Predicate;
@@ -49,7 +49,7 @@ public final class AppendTableRead extends AbstractDataTableRead {
     private Predicate predicate = null;
     private TopN topN = null;
     private Integer limit = null;
-    @Nullable private VariantAccessInfo[] variantAccess;
+    @Nullable private VariantExtraction[] variantExtractions;
 
     public AppendTableRead(
             List<Function<SplitReadConfig, SplitReadProvider>> providerFactories,
@@ -78,7 +78,7 @@ public final class AppendTableRead extends AbstractDataTableRead {
         read.withFilter(predicate);
         read.withTopN(topN);
         read.withLimit(limit);
-        read.withVariantAccess(variantAccess);
+        read.withVariantExtractions(variantExtractions);
     }
 
     @Override
@@ -88,9 +88,9 @@ public final class AppendTableRead extends AbstractDataTableRead {
     }
 
     @Override
-    public void applyVariantAccess(VariantAccessInfo[] variantAccess) {
-        initialized().forEach(r -> r.withVariantAccess(variantAccess));
-        this.variantAccess = variantAccess;
+    public void applyVariantExtractions(VariantExtraction[] variantExtractions) {
+        initialized().forEach(r -> r.withVariantExtractions(variantExtractions));
+        this.variantExtractions = variantExtractions;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableRead.java
@@ -18,7 +18,7 @@
 
 package org.apache.paimon.table.source;
 
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -52,7 +52,7 @@ public interface InnerTableRead extends TableRead {
         throw new UnsupportedOperationException();
     }
 
-    default InnerTableRead withVariantAccess(VariantAccessInfo[] variantAccessInfo) {
+    default InnerTableRead withVariantExtractions(VariantExtraction[] variantExtractions) {
         return this;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/KeyValueTableRead.java
@@ -21,7 +21,7 @@ package org.apache.paimon.table.source;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.operation.MergeFileSplitRead;
 import org.apache.paimon.operation.RawFileSplitRead;
@@ -58,7 +58,7 @@ public final class KeyValueTableRead extends AbstractDataTableRead {
     private IOManager ioManager = null;
     @Nullable private TopN topN = null;
     @Nullable private Integer limit = null;
-    @Nullable private VariantAccessInfo[] variantAccess = null;
+    @Nullable private VariantExtraction[] variantExtractions = null;
 
     public KeyValueTableRead(
             Supplier<MergeFileSplitRead> mergeReadSupplier,
@@ -97,8 +97,8 @@ public final class KeyValueTableRead extends AbstractDataTableRead {
         if (limit != null) {
             read = read.withLimit(limit);
         }
-        if (variantAccess != null) {
-            read = read.withVariantAccess(variantAccess);
+        if (variantExtractions != null) {
+            read = read.withVariantExtractions(variantExtractions);
         }
         read.withFilter(predicate).withIOManager(ioManager);
     }
@@ -110,9 +110,9 @@ public final class KeyValueTableRead extends AbstractDataTableRead {
     }
 
     @Override
-    public void applyVariantAccess(VariantAccessInfo[] variantAccess) {
-        initialized().forEach(r -> r.withVariantAccess(variantAccess));
-        this.variantAccess = variantAccess;
+    public void applyVariantExtractions(VariantExtraction[] variantExtractions) {
+        initialized().forEach(r -> r.withVariantExtractions(variantExtractions));
+        this.variantExtractions = variantExtractions;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
@@ -18,9 +18,10 @@
 
 package org.apache.paimon.table.source;
 
+import org.apache.paimon.annotation.Experimental;
 import org.apache.paimon.annotation.Public;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -128,12 +129,13 @@ public interface ReadBuilder extends Serializable {
     ReadBuilder withReadType(RowType readType);
 
     /**
-     * Push variant access to the reader.
+     * Push variant extraction to the reader.
      *
-     * @param variantAccessInfo variant access info
+     * @param variantExtractions variant extraction
      * @since 1.4.0
      */
-    ReadBuilder withVariantAccess(VariantAccessInfo[] variantAccessInfo);
+    @Experimental
+    ReadBuilder withVariantExtractions(VariantExtraction[] variantExtractions);
 
     /**
      * Apply projection to the reader, if you need nested row pruning, use {@link

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -19,8 +19,8 @@
 package org.apache.paimon.table.source;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.data.variant.VariantAccessInfo;
-import org.apache.paimon.data.variant.VariantAccessInfoUtils;
+import org.apache.paimon.data.variant.VariantExtraction;
+import org.apache.paimon.data.variant.VariantExtractionUtils;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -64,7 +64,7 @@ public class ReadBuilderImpl implements ReadBuilder {
     private Filter<Integer> bucketFilter;
 
     private @Nullable RowType readType;
-    private @Nullable VariantAccessInfo[] variantAccessInfo;
+    private @Nullable VariantExtraction[] variantExtractions;
     private @Nullable List<Range> rowRanges;
     private @Nullable VectorSearch vectorSearch;
 
@@ -84,10 +84,10 @@ public class ReadBuilderImpl implements ReadBuilder {
     @Override
     public RowType readType() {
         RowType finalReadType = readType != null ? readType : table.rowType();
-        // When variantAccessInfo is not null, replace the variant with the actual readType.
-        if (variantAccessInfo != null) {
+        // When variantExtraction is not null, replace the variant with the actual readType.
+        if (variantExtractions != null) {
             finalReadType =
-                    VariantAccessInfoUtils.buildReadRowType(finalReadType, variantAccessInfo);
+                    VariantExtractionUtils.buildReadRowType(finalReadType, variantExtractions);
         }
         return finalReadType;
     }
@@ -127,8 +127,8 @@ public class ReadBuilderImpl implements ReadBuilder {
     }
 
     @Override
-    public ReadBuilder withVariantAccess(VariantAccessInfo[] variantAccessInfo) {
-        this.variantAccessInfo = variantAccessInfo;
+    public ReadBuilder withVariantExtractions(VariantExtraction[] variantExtractions) {
+        this.variantExtractions = variantExtractions;
         return this;
     }
 
@@ -253,8 +253,8 @@ public class ReadBuilderImpl implements ReadBuilder {
         if (limit != null) {
             read.withLimit(limit);
         }
-        if (variantAccessInfo != null) {
-            read.withVariantAccess(variantAccessInfo);
+        if (variantExtractions != null) {
+            read.withVariantExtractions(variantExtractions);
         }
         return read;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
@@ -22,7 +22,7 @@ import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.data.serializer.InternalSerializers;
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.mergetree.MergeSorter;
 import org.apache.paimon.mergetree.compact.MergeFunctionWrapper;
@@ -80,8 +80,8 @@ public class IncrementalDiffSplitRead implements SplitRead<InternalRow> {
     }
 
     @Override
-    public SplitRead<InternalRow> withVariantAccess(VariantAccessInfo[] variantAccess) {
-        mergeRead.withVariantAccess(variantAccess);
+    public SplitRead<InternalRow> withVariantExtractions(VariantExtraction[] variantExtractions) {
+        mergeRead.withVariantExtractions(variantExtractions);
         return this;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/utils/FormatReaderMapping.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/FormatReaderMapping.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.utils;
 
 import org.apache.paimon.casting.CastFieldGetter;
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.format.FileFormatDiscover;
 import org.apache.paimon.format.FormatReaderFactory;
 import org.apache.paimon.partition.PartitionUtils;
@@ -159,7 +159,7 @@ public class FormatReaderMapping {
         @Nullable private final List<Predicate> filters;
         @Nullable private final TopN topN;
         @Nullable private final Integer limit;
-        @Nullable private final VariantAccessInfo[] variantAccess;
+        @Nullable private final VariantExtraction[] variantExtractions;
 
         public Builder(
                 FileFormatDiscover formatDiscover,
@@ -168,14 +168,14 @@ public class FormatReaderMapping {
                 @Nullable List<Predicate> filters,
                 @Nullable TopN topN,
                 @Nullable Integer limit,
-                @Nullable VariantAccessInfo[] variantAccess) {
+                @Nullable VariantExtraction[] variantExtractions) {
             this.formatDiscover = formatDiscover;
             this.readFields = readFields;
             this.fieldsExtractor = fieldsExtractor;
             this.filters = filters;
             this.topN = topN;
             this.limit = limit;
-            this.variantAccess = variantAccess;
+            this.variantExtractions = variantExtractions;
         }
 
         /**
@@ -238,7 +238,7 @@ public class FormatReaderMapping {
                                     new RowType(allDataFieldsInFile),
                                     actualReadRowType,
                                     readFilters,
-                                    variantAccess),
+                                    variantExtractions),
                     dataSchema,
                     readFilters,
                     systemFields,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupCompactDiffRead.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupCompactDiffRead.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.flink.lookup;
 
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.operation.MergeFileSplitRead;
 import org.apache.paimon.operation.SplitRead;
@@ -57,9 +57,9 @@ public class LookupCompactDiffRead extends AbstractDataTableRead {
     }
 
     @Override
-    public void applyVariantAccess(VariantAccessInfo[] variantAccess) {
-        fullPhaseMergeRead.withVariantAccess(variantAccess);
-        incrementalDiffRead.withVariantAccess(variantAccess);
+    public void applyVariantExtractions(VariantExtraction[] variantExtractions) {
+        fullPhaseMergeRead.withVariantExtractions(variantExtractions);
+        incrementalDiffRead.withVariantExtractions(variantExtractions);
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
@@ -19,7 +19,7 @@
 package org.apache.paimon.format.parquet;
 
 import org.apache.paimon.annotation.VisibleForTesting;
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.format.FileFormatFactory.FormatContext;
 import org.apache.paimon.format.FormatReaderFactory;
@@ -78,13 +78,13 @@ public class ParquetFileFormat extends FileFormat {
             RowType dataSchemaRowType,
             RowType projectedRowType,
             @Nullable List<Predicate> filters,
-            @Nullable VariantAccessInfo[] variantAccess) {
+            @Nullable VariantExtraction[] variantExtractions) {
         return new ParquetReaderFactory(
                 options,
                 projectedRowType,
                 readBatchSize,
                 ParquetFilters.convert(filters),
-                variantAccess);
+                variantExtractions);
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/VariantUtils.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/VariantUtils.java
@@ -20,7 +20,7 @@ package org.apache.paimon.format.parquet;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.variant.PaimonShreddingUtils;
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
@@ -39,6 +39,7 @@ import java.util.List;
 
 import static org.apache.paimon.data.variant.Variant.METADATA;
 import static org.apache.paimon.data.variant.Variant.VALUE;
+import static org.apache.paimon.utils.Preconditions.checkState;
 
 /** Utils for variant. */
 public class VariantUtils {
@@ -108,15 +109,17 @@ public class VariantUtils {
         return new RowType(rowType.isNullable(), newFields);
     }
 
-    public static List<List<VariantAccessInfo.VariantField>> buildVariantFields(
-            DataField[] readFields, @Nullable VariantAccessInfo[] variantAccess) {
-        HashMap<String, List<VariantAccessInfo.VariantField>> map = new HashMap<>();
-        if (variantAccess != null) {
-            for (VariantAccessInfo accessInfo : variantAccess) {
-                map.put(accessInfo.columnName(), accessInfo.variantFields());
+    public static List<List<VariantExtraction.VariantField>> buildVariantFields(
+            DataField[] readFields, @Nullable VariantExtraction[] variantExtractions) {
+        HashMap<String, List<VariantExtraction.VariantField>> map = new HashMap<>();
+        if (variantExtractions != null) {
+            for (VariantExtraction extraction : variantExtractions) {
+                checkState(extraction.columnName().length == 1);
+                // todo: support nested variant.
+                map.put(extraction.columnName()[0], extraction.variantFields());
             }
         }
-        List<List<VariantAccessInfo.VariantField>> variantFields = new ArrayList<>();
+        List<List<VariantExtraction.VariantField>> variantFields = new ArrayList<>();
         for (DataField readField : readFields) {
             variantFields.add(map.getOrDefault(readField.name(), null));
         }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetReaderUtil.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetReaderUtil.java
@@ -36,8 +36,8 @@ import org.apache.paimon.data.columnar.heap.HeapShortVector;
 import org.apache.paimon.data.columnar.heap.HeapTimestampVector;
 import org.apache.paimon.data.columnar.writable.WritableColumnVector;
 import org.apache.paimon.data.variant.Variant;
-import org.apache.paimon.data.variant.VariantAccessInfo;
-import org.apache.paimon.data.variant.VariantAccessInfoUtils;
+import org.apache.paimon.data.variant.VariantExtraction;
+import org.apache.paimon.data.variant.VariantExtractionUtils;
 import org.apache.paimon.format.parquet.ParquetSchemaConverter;
 import org.apache.paimon.format.parquet.type.ParquetField;
 import org.apache.paimon.format.parquet.type.ParquetGroupField;
@@ -80,7 +80,7 @@ public class ParquetReaderUtil {
     public static WritableColumnVector createWritableColumnVector(
             int batchSize,
             DataType fieldType,
-            @Nullable List<VariantAccessInfo.VariantField> variantFields) {
+            @Nullable List<VariantExtraction.VariantField> variantFields) {
         switch (fieldType.getTypeRoot()) {
             case BOOLEAN:
                 return new HeapBooleanVector(batchSize);
@@ -149,7 +149,7 @@ public class ParquetReaderUtil {
             case VARIANT:
                 if (variantFields != null) {
                     return createWritableColumnVector(
-                            batchSize, VariantAccessInfoUtils.actualReadType(variantFields));
+                            batchSize, VariantExtractionUtils.actualReadType(variantFields));
                 }
 
                 WritableColumnVector[] vectors = new WritableColumnVector[2];
@@ -233,7 +233,7 @@ public class ParquetReaderUtil {
             DataField[] readFields,
             MessageColumnIO columnIO,
             RowType[] shreddingSchemas,
-            List<List<VariantAccessInfo.VariantField>> variantFields) {
+            List<List<VariantExtraction.VariantField>> variantFields) {
         List<ParquetField> list = new ArrayList<>();
         for (int i = 0; i < readFields.length; i++) {
             list.add(
@@ -254,7 +254,7 @@ public class ParquetReaderUtil {
             DataField dataField,
             ColumnIO columnIO,
             @Nullable RowType shreddingSchema,
-            @Nullable List<VariantAccessInfo.VariantField> variantFields) {
+            @Nullable List<VariantExtraction.VariantField> variantFields) {
         boolean required = columnIO.getType().getRepetition() == REQUIRED;
         int repetitionLevel = columnIO.getRepetitionLevel();
         int definitionLevel = columnIO.getDefinitionLevel();
@@ -288,7 +288,7 @@ public class ParquetReaderUtil {
                 DataType clippedParquetType =
                         variantFields == null
                                 ? shreddingSchema
-                                : VariantAccessInfoUtils.clipVariantSchema(
+                                : VariantExtractionUtils.clipVariantSchema(
                                         shreddingSchema, variantFields);
                 ParquetGroupField parquetField =
                         (ParquetGroupField)
@@ -296,7 +296,7 @@ public class ParquetReaderUtil {
                 DataType readType =
                         variantFields == null
                                 ? variantType
-                                : VariantAccessInfoUtils.actualReadType(variantFields);
+                                : VariantExtractionUtils.actualReadType(variantFields);
                 return new ParquetGroupField(
                         readType,
                         parquetField.getRepetitionLevel(),

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/type/ParquetField.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/type/ParquetField.java
@@ -18,7 +18,7 @@
 
 package org.apache.paimon.format.parquet.type;
 
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.types.DataType;
 
 import javax.annotation.Nullable;
@@ -39,7 +39,7 @@ public abstract class ParquetField {
     // `variantFileType` describes the file schema of the Parquet variant field.
     @Nullable private final ParquetField variantFileType;
     // Represent the required variant fields.
-    @Nullable List<VariantAccessInfo.VariantField> variantFields;
+    @Nullable List<VariantExtraction.VariantField> variantFields;
 
     public ParquetField(
             DataType type,
@@ -57,7 +57,7 @@ public abstract class ParquetField {
             boolean required,
             String[] path,
             @Nullable ParquetField variantFileType,
-            @Nullable List<VariantAccessInfo.VariantField> variantFields) {
+            @Nullable List<VariantExtraction.VariantField> variantFields) {
         this.type = type;
         this.repetitionLevel = repetitionLevel;
         this.definitionLevel = definitionLevel;
@@ -92,7 +92,7 @@ public abstract class ParquetField {
     }
 
     @Nullable
-    public List<VariantAccessInfo.VariantField> variantFields() {
+    public List<VariantExtraction.VariantField> variantFields() {
         return variantFields;
     }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/type/ParquetGroupField.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/type/ParquetGroupField.java
@@ -18,7 +18,7 @@
 
 package org.apache.paimon.format.parquet.type;
 
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.types.DataType;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
@@ -52,7 +52,7 @@ public class ParquetGroupField extends ParquetField {
             List<ParquetField> children,
             String[] path,
             ParquetGroupField variantFileType,
-            @Nullable List<VariantAccessInfo.VariantField> variantFields) {
+            @Nullable List<VariantExtraction.VariantField> variantFields) {
         super(
                 type,
                 repetitionLevel,

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
@@ -23,7 +23,7 @@ import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.data.variant.GenericVariant;
-import org.apache.paimon.data.variant.VariantAccessInfo;
+import org.apache.paimon.data.variant.VariantExtraction;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.format.FileFormatFactory;
 import org.apache.paimon.format.FormatReadWriteTest;
@@ -141,18 +141,19 @@ public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
                 .isEqualTo("{\"age\":25,\"other\":\"Hello\"}");
 
         // read with typed col only
-        List<VariantAccessInfo.VariantField> variantFields2 = new ArrayList<>();
+        List<VariantExtraction.VariantField> variantFields2 = new ArrayList<>();
         variantFields2.add(
-                new VariantAccessInfo.VariantField(
+                new VariantExtraction.VariantField(
                         new DataField(0, "age", DataTypes.INT()), "$.age"));
-        VariantAccessInfo[] variantAccess2 = {new VariantAccessInfo("v", variantFields2)};
+        VariantExtraction[] variantExtraction2 = {new VariantExtraction("v", variantFields2)};
         RowType readStructType2 =
                 DataTypes.ROW(
                         DataTypes.FIELD(
                                 0, "v", DataTypes.ROW(DataTypes.FIELD(0, "age", DataTypes.INT()))));
         List<InternalRow> result2 = new ArrayList<>();
         try (RecordReader<InternalRow> reader =
-                format.createReaderFactory(writeType, writeType, new ArrayList<>(), variantAccess2)
+                format.createReaderFactory(
+                                writeType, writeType, new ArrayList<>(), variantExtraction2)
                         .createReader(
                                 new FormatReaderContext(fileIO, file, fileIO.getFileSize(file)))) {
             InternalRowSerializer serializer = new InternalRowSerializer(readStructType2);
@@ -162,14 +163,14 @@ public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
         assertThat(result2.get(1).equals(GenericRow.of(GenericRow.of(25)))).isTrue();
 
         // read with typed col and untyped col
-        List<VariantAccessInfo.VariantField> variantFields3 = new ArrayList<>();
+        List<VariantExtraction.VariantField> variantFields3 = new ArrayList<>();
         variantFields3.add(
-                new VariantAccessInfo.VariantField(
+                new VariantExtraction.VariantField(
                         new DataField(0, "age", DataTypes.INT()), "$.age"));
         variantFields3.add(
-                new VariantAccessInfo.VariantField(
+                new VariantExtraction.VariantField(
                         new DataField(1, "other", DataTypes.STRING()), "$.other"));
-        VariantAccessInfo[] variantAccess3 = {new VariantAccessInfo("v", variantFields3)};
+        VariantExtraction[] variantExtraction3 = {new VariantExtraction("v", variantFields3)};
         RowType readStructType3 =
                 DataTypes.ROW(
                         DataTypes.FIELD(
@@ -180,7 +181,8 @@ public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
                                         DataTypes.FIELD(1, "other", DataTypes.STRING()))));
         List<InternalRow> result3 = new ArrayList<>();
         try (RecordReader<InternalRow> reader =
-                format.createReaderFactory(writeType, writeType, new ArrayList<>(), variantAccess3)
+                format.createReaderFactory(
+                                writeType, writeType, new ArrayList<>(), variantExtraction3)
                         .createReader(
                                 new FormatReaderContext(fileIO, file, fileIO.getFileSize(file)))) {
             InternalRowSerializer serializer = new InternalRowSerializer(readStructType3);
@@ -196,11 +198,11 @@ public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
                 .isTrue();
 
         // read unexisted col
-        List<VariantAccessInfo.VariantField> variantFields4 = new ArrayList<>();
+        List<VariantExtraction.VariantField> variantFields4 = new ArrayList<>();
         variantFields4.add(
-                new VariantAccessInfo.VariantField(
+                new VariantExtraction.VariantField(
                         new DataField(0, "unexist_col", DataTypes.INT()), "$.unexist_col"));
-        VariantAccessInfo[] variantAccess4 = {new VariantAccessInfo("v", variantFields4)};
+        VariantExtraction[] variantExtraction4 = {new VariantExtraction("v", variantFields4)};
         RowType readStructType4 =
                 DataTypes.ROW(
                         DataTypes.FIELD(
@@ -209,7 +211,8 @@ public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
                                 DataTypes.ROW(DataTypes.FIELD(0, "unexist_col", DataTypes.INT()))));
         List<InternalRow> result4 = new ArrayList<>();
         try (RecordReader<InternalRow> reader =
-                format.createReaderFactory(writeType, writeType, new ArrayList<>(), variantAccess4)
+                format.createReaderFactory(
+                                writeType, writeType, new ArrayList<>(), variantExtraction4)
                         .createReader(
                                 new FormatReaderContext(fileIO, file, fileIO.getFileSize(file)))) {
             InternalRowSerializer serializer = new InternalRowSerializer(readStructType4);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Follow up [SPARK-54656](https://issues.apache.org/jira/browse/SPARK-54656):
1. Change `VariantAccessInfo` to `VariantExtraction`
2. Change `String columnName` in `VariantExtraction` to `String[] columnName` to support nested variant pushdown in the future.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
