### PR TITLE
[python] optimize schema validation and support binary/large_binary type conversion

### DIFF
--- a/paimon-python/pypaimon/tests/ray_data_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_test.py
@@ -117,125 +117,20 @@ class RayDataTest(unittest.TestCase):
         self.assertIsNotNone(ray_dataset, "Ray dataset should not be None")
         self.assertEqual(ray_dataset.count(), 5, "Should have 5 rows")
 
-    def test_ray_data_read_and_write_with_blob(self):
-        import time
-        pa_schema = pa.schema([
-            ('id', pa.int64()),
-            ('name', pa.string()),
-            ('data', pa.large_binary()),  # Table uses large_binary for blob
-        ])
+        # Test basic operations
+        sample_data = ray_dataset.take(3)
+        self.assertEqual(len(sample_data), 3, "Should have 3 sample rows")
 
-        schema = Schema.from_pyarrow_schema(
-            pa_schema,
-            options={
-                'row-tracking.enabled': 'true',
-                'data-evolution.enabled': 'true',
-                'blob-field': 'data',
-            }
-        )
-
-        table_name = f'default.test_ray_read_write_blob_{int(time.time() * 1000000)}'
-        self.catalog.create_table(table_name, schema, False)
-        table = self.catalog.get_table(table_name)
-
-        # Step 1: Write data to Paimon table using write_arrow (large_binary type)
-        initial_data = pa.Table.from_pydict({
-            'id': [1, 2, 3],
-            'name': ['Alice', 'Bob', 'Charlie'],
-            'data': [b'blob_data_1', b'blob_data_2', b'blob_data_3'],
-        }, schema=pa_schema)
-
-        write_builder = table.new_batch_write_builder()
-        writer = write_builder.new_write()
-        writer.write_arrow(initial_data)
-        commit_messages = writer.prepare_commit()
-        commit = write_builder.new_commit()
-        commit.commit(commit_messages)
-        writer.close()
-
-        # Step 2: Read from Paimon table using to_ray()
-        read_builder = table.new_read_builder()
-        table_read = read_builder.new_read()
-        table_scan = read_builder.new_scan()
-        splits = table_scan.plan().splits()
-
-        ray_dataset = table_read.to_ray(splits)
-
-        # Verify Ray blocks preserve large_binary type from Paimon
-        for batch in ray_dataset.iter_batches(batch_size=10, batch_format="pyarrow"):
-            ray_data_field = batch.schema.field('data')
-            self.assertTrue(
-                pa_types.is_large_binary(ray_data_field.type),
-                f"Ray block should preserve large_binary() from Paimon, but got {ray_data_field.type}"
-            )
-            break
-
-        # Verify Paimon table schema is large_binary (BLOB)
-        table_pa_schema = PyarrowFieldParser.from_paimon_schema(table.table_schema.fields)
-        self.assertTrue(
-            pa_types.is_large_binary(table_pa_schema.field('data').type),
-            f"Paimon table should have large_binary() for BLOB field"
-        )
-
-        # Step 3: Simulate user pipeline: map_batches returns Python dict,
-        # causing PyArrow to re-infer types (large_binary -> binary for bytes).
-        # This reproduces the real-world scenario where user code (e.g. DLFBlobParser)
-        # returns processed Python bytes and Ray/PyArrow downgrades the Arrow type.
-        def process_blob(batch):
-            return {
-                'id': batch['id'].to_pylist(),
-                'name': batch['name'].to_pylist(),
-                'data': batch['data'].to_pylist(),  # Python bytes -> binary
-            }
-
-        mapped_dataset = ray_dataset.map_batches(process_blob, batch_format="pyarrow")
-
-        # Verify map_batches caused type downgrade: large_binary -> binary
-        for batch in mapped_dataset.iter_batches(batch_size=10, batch_format="pyarrow"):
-            mapped_data_field = batch.schema.field('data')
-            self.assertTrue(
-                pa_types.is_binary(mapped_data_field.type),
-                f"After map_batches returning dict, data should be binary(), but got {mapped_data_field.type}"
-            )
-            break
-
-        # Step 4: Write mapped dataset back via write_ray().
-        # Without the fix in ray_datasink, this raises:
-        #   ValueError: Input schema isn't consistent with table schema
-        #   Input: binary, Table: large_binary
-        # With the fix, ray_datasink casts binary back to large_binary before writing.
-        write_builder2 = table.new_batch_write_builder()
-        writer2 = write_builder2.new_write()
-
-        writer2.write_ray(
-            mapped_dataset,
-            overwrite=False,
-            concurrency=1
-        )
-        writer2.close()
-
-        # Step 5: Verify the data was written correctly
-        read_builder2 = table.new_read_builder()
-        table_read2 = read_builder2.new_read()
-        result = table_read2.to_arrow(read_builder2.new_scan().plan().splits())
-
-        self.assertEqual(result.num_rows, 6, "Table should have 6 rows after roundtrip")
-
-        result_df = result.to_pandas()
-        result_df_sorted = result_df.sort_values(by='id').reset_index(drop=True)
-
-        self.assertEqual(list(result_df_sorted['id']), [1, 1, 2, 2, 3, 3], "ID column should match")
+        # Convert to pandas for verification
+        df = ray_dataset.to_pandas()
+        self.assertEqual(len(df), 5, "DataFrame should have 5 rows")
+        # Sort by id to ensure order-independent comparison
+        df_sorted = df.sort_values(by='id').reset_index(drop=True)
+        self.assertEqual(list(df_sorted['id']), [1, 2, 3, 4, 5], "ID column should match")
         self.assertEqual(
-            list(result_df_sorted['name']),
-            ['Alice', 'Alice', 'Bob', 'Bob', 'Charlie', 'Charlie'],
+            list(df_sorted['name']),
+            ['Alice', 'Bob', 'Charlie', 'David', 'Eve'],
             "Name column should match"
-        )
-
-        written_data_values = [bytes(d) if d is not None else None for d in result_df_sorted['data']]
-        self.assertEqual(
-            written_data_values,
-            [b'blob_data_1', b'blob_data_1', b'blob_data_2', b'blob_data_2', b'blob_data_3', b'blob_data_3'],
-            "Blob data column should match"
         )
 
     def test_basic_ray_data_write(self):
@@ -805,13 +700,6 @@ class RayDataTest(unittest.TestCase):
         self.assertIn("override_num_blocks must be at least 1", str(context.exception))
 
     def test_dict_return_loses_large_binary_type(self):
-        """Demonstrate that returning a dict from map_batches loses large_binary type.
-
-        This is the root cause of the binary/large_binary mismatch issue:
-        1. PyArrow table has large_binary column
-        2. Convert to dict (Python list[bytes]) — type info lost
-        3. Rebuild PyArrow table from dict — PyArrow infers bytes as binary
-        """
         # Original data with large_binary
         original = pa.table({
             'data': pa.array([b'hello', b'world'], type=pa.large_binary())
@@ -831,6 +719,120 @@ class RayDataTest(unittest.TestCase):
         self.assertFalse(
             pa_types.is_large_binary(rebuilt.schema.field('data').type),
             "large_binary type should be lost after dict roundtrip"
+        )
+
+    def test_ray_data_read_and_write_with_blob(self):
+        import time
+        pa_schema = pa.schema([
+            ('id', pa.int64()),
+            ('name', pa.string()),
+            ('data', pa.large_binary()),  # Table uses large_binary for blob
+        ])
+
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+                'blob-field': 'data',
+            }
+        )
+
+        table_name = f'default.test_ray_read_write_blob_{int(time.time() * 1000000)}'
+        self.catalog.create_table(table_name, schema, False)
+        table = self.catalog.get_table(table_name)
+
+        # Step 1: Write data to Paimon table using write_arrow (large_binary type)
+        initial_data = pa.Table.from_pydict({
+            'id': [1, 2, 3],
+            'name': ['Alice', 'Bob', 'Charlie'],
+            'data': [b'blob_data_1', b'blob_data_2', b'blob_data_3'],
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(initial_data)
+        commit_messages = writer.prepare_commit()
+        commit = write_builder.new_commit()
+        commit.commit(commit_messages)
+        writer.close()
+
+        # Step 2: Read from Paimon table using to_ray()
+        read_builder = table.new_read_builder()
+        table_read = read_builder.new_read()
+        table_scan = read_builder.new_scan()
+        splits = table_scan.plan().splits()
+
+        ray_dataset = table_read.to_ray(splits)
+
+        # Verify Ray blocks preserve large_binary type from Paimon
+        for batch in ray_dataset.iter_batches(batch_size=10, batch_format="pyarrow"):
+            ray_data_field = batch.schema.field('data')
+            self.assertTrue(
+                pa_types.is_large_binary(ray_data_field.type),
+                f"Ray block should preserve large_binary() from Paimon, but got {ray_data_field.type}"
+            )
+            break
+
+        # Verify Paimon table schema is large_binary (BLOB)
+        table_pa_schema = PyarrowFieldParser.from_paimon_schema(table.table_schema.fields)
+        self.assertTrue(
+            pa_types.is_large_binary(table_pa_schema.field('data').type),
+            "Paimon table should have large_binary() for BLOB field"
+        )
+
+        # Step 3: Simulate user pipeline: map_batches returns Python dict,
+        def process_blob(batch):
+            return {
+                'id': batch['id'].to_pylist(),
+                'name': batch['name'].to_pylist(),
+                'data': batch['data'].to_pylist(),  # Python bytes -> binary
+            }
+
+        mapped_dataset = ray_dataset.map_batches(process_blob, batch_format="pyarrow")
+
+        # Verify map_batches caused type downgrade: large_binary -> binary
+        for batch in mapped_dataset.iter_batches(batch_size=10, batch_format="pyarrow"):
+            mapped_data_field = batch.schema.field('data')
+            self.assertTrue(
+                pa_types.is_binary(mapped_data_field.type),
+                f"After map_batches returning dict, data should be binary(), but got {mapped_data_field.type}"
+            )
+            break
+
+        # Step 4: Write mapped dataset back via write_ray().
+        write_builder2 = table.new_batch_write_builder()
+        writer2 = write_builder2.new_write()
+
+        writer2.write_ray(
+            mapped_dataset,
+            overwrite=False,
+            concurrency=1
+        )
+        writer2.close()
+
+        # Step 5: Verify the data was written correctly
+        read_builder2 = table.new_read_builder()
+        table_read2 = read_builder2.new_read()
+        result = table_read2.to_arrow(read_builder2.new_scan().plan().splits())
+
+        self.assertEqual(result.num_rows, 6, "Table should have 6 rows after roundtrip")
+
+        result_df = result.to_pandas()
+        result_df_sorted = result_df.sort_values(by='id').reset_index(drop=True)
+
+        self.assertEqual(list(result_df_sorted['id']), [1, 1, 2, 2, 3, 3], "ID column should match")
+        self.assertEqual(
+            list(result_df_sorted['name']),
+            ['Alice', 'Alice', 'Bob', 'Bob', 'Charlie', 'Charlie'],
+            "Name column should match"
+        )
+
+        written_data_values = [bytes(d) if d is not None else None for d in result_df_sorted['data']]
+        self.assertEqual(
+            written_data_values,
+            [b'blob_data_1', b'blob_data_1', b'blob_data_2', b'blob_data_2', b'blob_data_3', b'blob_data_3'],
+            "Blob data column should match"
         )
 
 

--- a/paimon-python/pypaimon/tests/ray_data_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_test.py
@@ -22,10 +22,12 @@ import unittest
 import shutil
 
 import pyarrow as pa
+import pyarrow.types as pa_types
 import ray
 
 from pypaimon import CatalogFactory, Schema
 from pypaimon.common.options.core_options import CoreOptions
+from pypaimon.schema.data_types import PyarrowFieldParser
 
 
 class RayDataTest(unittest.TestCase):
@@ -115,20 +117,125 @@ class RayDataTest(unittest.TestCase):
         self.assertIsNotNone(ray_dataset, "Ray dataset should not be None")
         self.assertEqual(ray_dataset.count(), 5, "Should have 5 rows")
 
-        # Test basic operations
-        sample_data = ray_dataset.take(3)
-        self.assertEqual(len(sample_data), 3, "Should have 3 sample rows")
+    def test_ray_data_read_and_write_with_blob(self):
+        import time
+        pa_schema = pa.schema([
+            ('id', pa.int64()),
+            ('name', pa.string()),
+            ('data', pa.large_binary()),  # Table uses large_binary for blob
+        ])
 
-        # Convert to pandas for verification
-        df = ray_dataset.to_pandas()
-        self.assertEqual(len(df), 5, "DataFrame should have 5 rows")
-        # Sort by id to ensure order-independent comparison
-        df_sorted = df.sort_values(by='id').reset_index(drop=True)
-        self.assertEqual(list(df_sorted['id']), [1, 2, 3, 4, 5], "ID column should match")
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+                'blob-field': 'data',
+            }
+        )
+
+        table_name = f'default.test_ray_read_write_blob_{int(time.time() * 1000000)}'
+        self.catalog.create_table(table_name, schema, False)
+        table = self.catalog.get_table(table_name)
+
+        # Step 1: Write data to Paimon table using write_arrow (large_binary type)
+        initial_data = pa.Table.from_pydict({
+            'id': [1, 2, 3],
+            'name': ['Alice', 'Bob', 'Charlie'],
+            'data': [b'blob_data_1', b'blob_data_2', b'blob_data_3'],
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(initial_data)
+        commit_messages = writer.prepare_commit()
+        commit = write_builder.new_commit()
+        commit.commit(commit_messages)
+        writer.close()
+
+        # Step 2: Read from Paimon table using to_ray()
+        read_builder = table.new_read_builder()
+        table_read = read_builder.new_read()
+        table_scan = read_builder.new_scan()
+        splits = table_scan.plan().splits()
+
+        ray_dataset = table_read.to_ray(splits)
+
+        # Verify Ray blocks preserve large_binary type from Paimon
+        for batch in ray_dataset.iter_batches(batch_size=10, batch_format="pyarrow"):
+            ray_data_field = batch.schema.field('data')
+            self.assertTrue(
+                pa_types.is_large_binary(ray_data_field.type),
+                f"Ray block should preserve large_binary() from Paimon, but got {ray_data_field.type}"
+            )
+            break
+
+        # Verify Paimon table schema is large_binary (BLOB)
+        table_pa_schema = PyarrowFieldParser.from_paimon_schema(table.table_schema.fields)
+        self.assertTrue(
+            pa_types.is_large_binary(table_pa_schema.field('data').type),
+            f"Paimon table should have large_binary() for BLOB field"
+        )
+
+        # Step 3: Simulate user pipeline: map_batches returns Python dict,
+        # causing PyArrow to re-infer types (large_binary -> binary for bytes).
+        # This reproduces the real-world scenario where user code (e.g. DLFBlobParser)
+        # returns processed Python bytes and Ray/PyArrow downgrades the Arrow type.
+        def process_blob(batch):
+            return {
+                'id': batch['id'].to_pylist(),
+                'name': batch['name'].to_pylist(),
+                'data': batch['data'].to_pylist(),  # Python bytes -> binary
+            }
+
+        mapped_dataset = ray_dataset.map_batches(process_blob, batch_format="pyarrow")
+
+        # Verify map_batches caused type downgrade: large_binary -> binary
+        for batch in mapped_dataset.iter_batches(batch_size=10, batch_format="pyarrow"):
+            mapped_data_field = batch.schema.field('data')
+            self.assertTrue(
+                pa_types.is_binary(mapped_data_field.type),
+                f"After map_batches returning dict, data should be binary(), but got {mapped_data_field.type}"
+            )
+            break
+
+        # Step 4: Write mapped dataset back via write_ray().
+        # Without the fix in ray_datasink, this raises:
+        #   ValueError: Input schema isn't consistent with table schema
+        #   Input: binary, Table: large_binary
+        # With the fix, ray_datasink casts binary back to large_binary before writing.
+        write_builder2 = table.new_batch_write_builder()
+        writer2 = write_builder2.new_write()
+
+        writer2.write_ray(
+            mapped_dataset,
+            overwrite=False,
+            concurrency=1
+        )
+        writer2.close()
+
+        # Step 5: Verify the data was written correctly
+        read_builder2 = table.new_read_builder()
+        table_read2 = read_builder2.new_read()
+        result = table_read2.to_arrow(read_builder2.new_scan().plan().splits())
+
+        self.assertEqual(result.num_rows, 6, "Table should have 6 rows after roundtrip")
+
+        result_df = result.to_pandas()
+        result_df_sorted = result_df.sort_values(by='id').reset_index(drop=True)
+
+        self.assertEqual(list(result_df_sorted['id']), [1, 1, 2, 2, 3, 3], "ID column should match")
         self.assertEqual(
-            list(df_sorted['name']),
-            ['Alice', 'Bob', 'Charlie', 'David', 'Eve'],
+            list(result_df_sorted['name']),
+            ['Alice', 'Alice', 'Bob', 'Bob', 'Charlie', 'Charlie'],
             "Name column should match"
+        )
+
+        written_data_values = [bytes(d) if d is not None else None for d in result_df_sorted['data']]
+        self.assertEqual(
+            written_data_values,
+            [b'blob_data_1', b'blob_data_1', b'blob_data_2', b'blob_data_2', b'blob_data_3', b'blob_data_3'],
+            "Blob data column should match"
         )
 
     def test_basic_ray_data_write(self):
@@ -696,6 +803,36 @@ class RayDataTest(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             table_read.to_ray(splits, override_num_blocks=-10)
         self.assertIn("override_num_blocks must be at least 1", str(context.exception))
+
+    def test_dict_return_loses_large_binary_type(self):
+        """Demonstrate that returning a dict from map_batches loses large_binary type.
+
+        This is the root cause of the binary/large_binary mismatch issue:
+        1. PyArrow table has large_binary column
+        2. Convert to dict (Python list[bytes]) — type info lost
+        3. Rebuild PyArrow table from dict — PyArrow infers bytes as binary
+        """
+        # Original data with large_binary
+        original = pa.table({
+            'data': pa.array([b'hello', b'world'], type=pa.large_binary())
+        })
+        self.assertTrue(
+            pa_types.is_large_binary(original.schema.field('data').type),
+            "Original should be large_binary"
+        )
+
+        # Simulate map_batches returning dict: convert to Python list then rebuild
+        d = {'data': original['data'].to_pylist()}
+        rebuilt = pa.Table.from_pydict(d)
+        self.assertTrue(
+            pa_types.is_binary(rebuilt.schema.field('data').type),
+            f"Rebuilt from dict should be binary (PyArrow default), but got {rebuilt.schema.field('data').type}"
+        )
+        self.assertFalse(
+            pa_types.is_large_binary(rebuilt.schema.field('data').type),
+            "large_binary type should be lost after dict roundtrip"
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/paimon-python/pypaimon/write/ray_datasink.py
+++ b/paimon-python/pypaimon/write/ray_datasink.py
@@ -38,45 +38,26 @@ logger = logging.getLogger(__name__)
 
 
 def _cast_binary_to_table_schema(table: pa.Table, target_schema: pa.Schema) -> pa.Table:
-    """Cast binary columns to match the target table schema.
+    """Cast binary to large_binary for BLOB fields.
 
-    Ray map_batches may downgrade large_binary (BLOB) to binary when user code
-    returns Python dicts, because PyArrow infers bytes as binary by default.
-    This function casts such columns back to large_binary to match the Paimon
-    table schema before writing.
+    When map_batches returns Python dicts, PyArrow infers bytes as binary,
+    losing the original large_binary (BLOB) type. Cast back before writing.
     """
-    needs_cast = False
-    for field in table.schema:
-        try:
-            target_type = target_schema.field(field.name).type
-        except KeyError:
-            continue
-        if (pa.types.is_binary(field.type) and pa.types.is_large_binary(target_type)):
-            needs_cast = True
-            break
+    cast_indices = []
+    for i, field in enumerate(table.schema):
+        target_field = target_schema.field(field.name) if field.name in target_schema.names else None
+        if target_field and pa.types.is_binary(field.type) and pa.types.is_large_binary(target_field.type):
+            cast_indices.append(i)
 
-    if not needs_cast:
+    if not cast_indices:
         return table
 
-    new_columns = []
-    new_fields = []
-    for i, field in enumerate(table.schema):
-        col = table.column(i)
-        try:
-            target_type = target_schema.field(field.name).type
-        except KeyError:
-            new_columns.append(col)
-            new_fields.append(field)
-            continue
-
-        if pa.types.is_binary(field.type) and pa.types.is_large_binary(target_type):
-            col = col.cast(target_type)
-            new_fields.append(pa.field(field.name, target_type, nullable=field.nullable))
-        else:
-            new_fields.append(field)
-        new_columns.append(col)
-
-    return pa.table(new_columns, schema=pa.schema(new_fields))
+    columns = table.columns
+    for i in cast_indices:
+        columns[i] = columns[i].cast(pa.large_binary())
+    fields = [target_schema.field(f.name) if i in cast_indices else f
+              for i, f in enumerate(table.schema)]
+    return pa.table(columns, schema=pa.schema(fields))
 
 # Python 3.8 / Ray 2.10: Datasink is not subscriptable at runtime
 try:
@@ -142,8 +123,6 @@ class PaimonDatasink(_DatasinkBase):
                 if block_arrow.num_rows == 0:
                     continue
 
-                # Ray map_batches may downgrade large_binary to binary when
-                # returning Python dicts. Cast back to match the table schema.
                 block_arrow = _cast_binary_to_table_schema(block_arrow, target_pa_schema)
 
                 table_write.write_arrow(block_arrow)

--- a/paimon-python/pypaimon/write/ray_datasink.py
+++ b/paimon-python/pypaimon/write/ray_datasink.py
@@ -36,6 +36,48 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _cast_binary_to_table_schema(table: pa.Table, target_schema: pa.Schema) -> pa.Table:
+    """Cast binary columns to match the target table schema.
+
+    Ray map_batches may downgrade large_binary (BLOB) to binary when user code
+    returns Python dicts, because PyArrow infers bytes as binary by default.
+    This function casts such columns back to large_binary to match the Paimon
+    table schema before writing.
+    """
+    needs_cast = False
+    for field in table.schema:
+        try:
+            target_type = target_schema.field(field.name).type
+        except KeyError:
+            continue
+        if (pa.types.is_binary(field.type) and pa.types.is_large_binary(target_type)):
+            needs_cast = True
+            break
+
+    if not needs_cast:
+        return table
+
+    new_columns = []
+    new_fields = []
+    for i, field in enumerate(table.schema):
+        col = table.column(i)
+        try:
+            target_type = target_schema.field(field.name).type
+        except KeyError:
+            new_columns.append(col)
+            new_fields.append(field)
+            continue
+
+        if pa.types.is_binary(field.type) and pa.types.is_large_binary(target_type):
+            col = col.cast(target_type)
+            new_fields.append(pa.field(field.name, target_type, nullable=field.nullable))
+        else:
+            new_fields.append(field)
+        new_columns.append(col)
+
+    return pa.table(new_columns, schema=pa.schema(new_fields))
+
 # Python 3.8 / Ray 2.10: Datasink is not subscriptable at runtime
 try:
     _DatasinkBase = Datasink[List["CommitMessage"]]
@@ -90,11 +132,19 @@ class PaimonDatasink(_DatasinkBase):
             
             table_write = writer_builder.new_write()
 
+            table_schema = self.table.table_schema
+            from pypaimon.schema.data_types import PyarrowFieldParser
+            target_pa_schema = PyarrowFieldParser.from_paimon_schema(table_schema.fields)
+
             for block in blocks:
                 block_arrow: pa.Table = BlockAccessor.for_block(block).to_arrow()
 
                 if block_arrow.num_rows == 0:
                     continue
+
+                # Ray map_batches may downgrade large_binary to binary when
+                # returning Python dicts. Cast back to match the table schema.
+                block_arrow = _cast_binary_to_table_schema(block_arrow, target_pa_schema)
 
                 table_write.write_arrow(block_arrow)
 

--- a/paimon-python/pypaimon/write/table_write.py
+++ b/paimon-python/pypaimon/write/table_write.py
@@ -59,7 +59,7 @@ class TableWrite:
 
     def write_pandas(self, dataframe):
         pa_schema = PyarrowFieldParser.from_paimon_schema(self.table.table_schema.fields)
-        record_batch = pa.RecordBatch.from_pandas(dataframe, schema=pa_schema)
+        record_batch = pa.RecordBatch.from_pandas(dataframe, schema=pa_schema, preserve_index=False)
         return self.write_arrow_batch(record_batch)
 
     def with_write_type(self, write_cols: List[str]):
@@ -80,7 +80,7 @@ class TableWrite:
     ) -> None:
         """
         Write a Ray Dataset to Paimon table.
-        
+
         Args:
             dataset: Ray Dataset to write. This is a distributed data collection
                 from Ray Data (ray.data.Dataset).
@@ -102,31 +102,24 @@ class TableWrite:
         self.file_store_write.close()
 
     def _validate_pyarrow_schema(self, data_schema: pa.Schema):
-        if data_schema == self.table_pyarrow_schema:
-            return
-        if data_schema.names == self.file_store_write.write_cols:
-            return
-        # Allow compatible binary types: binary, fixed_size_binary[N] are interchangeable
-        if data_schema.names == self.table_pyarrow_schema.names:
-            compatible = True
-            for i in range(len(data_schema)):
-                input_type = data_schema.field(i).type
-                table_type = self.table_pyarrow_schema.field(i).type
-                if input_type != table_type:
-                    if self._is_binary_family(input_type) and self._is_binary_family(table_type):
-                        continue
-                    compatible = False
-                    break
-            if compatible:
-                return
-        raise ValueError(f"Input schema isn't consistent with table schema and write cols. "
-                         f"Input schema is: {data_schema} "
-                         f"Table schema is: {self.table_pyarrow_schema} "
-                         f"Write cols is: {self.file_store_write.write_cols}")
+        write_cols = self.file_store_write.write_cols
 
-    @staticmethod
-    def _is_binary_family(arrow_type) -> bool:
-        return pa.types.is_binary(arrow_type) or pa.types.is_fixed_size_binary(arrow_type)
+        if write_cols is None:
+            if data_schema != self.table_pyarrow_schema:
+                raise ValueError(
+                    f"Input schema isn't consistent with table schema and write cols. "
+                    f"Input schema is: {data_schema} "
+                    f"Table schema is: {self.table_pyarrow_schema} "
+                    f"Write cols is: {self.file_store_write.write_cols}"
+                )
+        else:
+            if list(data_schema.names) != write_cols:
+                raise ValueError(
+                    f"Input schema field names don't match write_cols. "
+                    f"Field names and order must match write_cols.\n"
+                    f"Input schema names: {list(data_schema.names)}\n"
+                    f"Write cols: {write_cols}"
+                )
 
 
 class BatchTableWrite(TableWrite):

--- a/paimon-python/pypaimon/write/table_write.py
+++ b/paimon-python/pypaimon/write/table_write.py
@@ -59,7 +59,7 @@ class TableWrite:
 
     def write_pandas(self, dataframe):
         pa_schema = PyarrowFieldParser.from_paimon_schema(self.table.table_schema.fields)
-        record_batch = pa.RecordBatch.from_pandas(dataframe, schema=pa_schema, preserve_index=False)
+        record_batch = pa.RecordBatch.from_pandas(dataframe, schema=pa_schema)
         return self.write_arrow_batch(record_batch)
 
     def with_write_type(self, write_cols: List[str]):
@@ -80,7 +80,7 @@ class TableWrite:
     ) -> None:
         """
         Write a Ray Dataset to Paimon table.
-
+        
         Args:
             dataset: Ray Dataset to write. This is a distributed data collection
                 from Ray Data (ray.data.Dataset).
@@ -102,24 +102,31 @@ class TableWrite:
         self.file_store_write.close()
 
     def _validate_pyarrow_schema(self, data_schema: pa.Schema):
-        write_cols = self.file_store_write.write_cols
+        if data_schema == self.table_pyarrow_schema:
+            return
+        if data_schema.names == self.file_store_write.write_cols:
+            return
+        # Allow compatible binary types: binary, fixed_size_binary[N] are interchangeable
+        if data_schema.names == self.table_pyarrow_schema.names:
+            compatible = True
+            for i in range(len(data_schema)):
+                input_type = data_schema.field(i).type
+                table_type = self.table_pyarrow_schema.field(i).type
+                if input_type != table_type:
+                    if self._is_binary_family(input_type) and self._is_binary_family(table_type):
+                        continue
+                    compatible = False
+                    break
+            if compatible:
+                return
+        raise ValueError(f"Input schema isn't consistent with table schema and write cols. "
+                         f"Input schema is: {data_schema} "
+                         f"Table schema is: {self.table_pyarrow_schema} "
+                         f"Write cols is: {self.file_store_write.write_cols}")
 
-        if write_cols is None:
-            if data_schema != self.table_pyarrow_schema:
-                raise ValueError(
-                    f"Input schema isn't consistent with table schema and write cols. "
-                    f"Input schema is: {data_schema} "
-                    f"Table schema is: {self.table_pyarrow_schema} "
-                    f"Write cols is: {self.file_store_write.write_cols}"
-                )
-        else:
-            if list(data_schema.names) != write_cols:
-                raise ValueError(
-                    f"Input schema field names don't match write_cols. "
-                    f"Field names and order must match write_cols.\n"
-                    f"Input schema names: {list(data_schema.names)}\n"
-                    f"Write cols: {write_cols}"
-                )
+    @staticmethod
+    def _is_binary_family(arrow_type) -> bool:
+        return pa.types.is_binary(arrow_type) or pa.types.is_fixed_size_binary(arrow_type)
 
 
 class BatchTableWrite(TableWrite):


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

- Optimize schema validation

  - Added `preserve_index=False` in `write_pandas()` to prevent pandas index from creating extra columns
  - support `write_cols=None` and optimize error message

- Binary/Large_Binary Type Compatibility
  - Ray Data converts `large_binary()` to `binary()` when reading from Paimon tables, make it compatibility by supporting binary/large_binary type conversion
  -  
<!-- What is the purpose of the change -->

### Tests
`ray_data_test.test_ray_data_read_with_blob`
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation
add note about ray data converts `large_binary()` to `binary()` when reading from Paimon tables in `python-api.md`
<!-- Does this change introduce a new feature -->
