### PR TITLE
[format] Extend ParquetSimpleStats extractor to support nanosecond precision

### DIFF
--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetSimpleStatsExtractorTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetSimpleStatsExtractorTest.java
@@ -81,12 +81,6 @@ public class ParquetSimpleStatsExtractorTest extends SimpleColStatsExtractorTest
     @Override
     protected SimpleColStats regenerate(SimpleColStats stats, DataType type) {
         switch (type.getTypeRoot()) {
-            case TIMESTAMP_WITHOUT_TIME_ZONE:
-                TimestampType timestampType = (TimestampType) type;
-                if (timestampType.getPrecision() > 6) {
-                    return new SimpleColStats(null, null, stats.nullCount());
-                }
-                break;
             case ARRAY:
             case MAP:
             case MULTISET:


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->
Support nanosecond precision timestamp stats in parquet

### Tests

<!-- List UT and IT cases to verify this change -->
Uses existing SimpleColStatsExtractorTest to verify precision 9 (removed special test case handling)

### API and Format

<!-- Does this change affect API or storage format -->
Yes

### Documentation

<!-- Does this change introduce a new feature -->
Extends existing column stats to apply to nanosecond precision