### PR TITLE
[hotfix] Log channelWriterOutputView writeBytes after close

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/disk/ExternalBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/ExternalBuffer.java
@@ -162,11 +162,11 @@ public class ExternalBuffer implements RowBuffer {
                                 : segment.size();
                 channelWriterOutputView.write(segment, 0, bufferSize);
             }
+            channelWriterOutputView.close();
             LOG.info(
                     "here spill the reset buffer data with {} records {} bytes",
                     inMemoryBuffer.size(),
                     channelWriterOutputView.getWriteBytes());
-            channelWriterOutputView.close();
         } catch (IOException e) {
             channelWriterOutputView.closeAndDelete();
             throw e;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

before
```
here spill the reset buffer data with 16 records 0 bytes
here spill the reset buffer data with 16 records 0 bytes
here spill the reset buffer data with 16 records 0 bytes
here spill the reset buffer data with 16 records 0 bytes
here spill the reset buffer data with 16 records 0 bytes
```

after
```
here spill the reset buffer data with 16 records 3002 bytes
here spill the reset buffer data with 16 records 3023 bytes
here spill the reset buffer data with 16 records 2989 bytes
here spill the reset buffer data with 16 records 3019 bytes
here spill the reset buffer data with 16 records 3017 bytes
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
