### PR TITLE
[spark] Refactor DataSourceV2 fallback checks into reusable helper methods

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonDeleteTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonDeleteTable.scala
@@ -29,21 +29,6 @@ import org.apache.spark.sql.catalyst.rules.Rule
 
 object PaimonDeleteTable extends Rule[LogicalPlan] with RowLevelHelper {
 
-  /** Determines if DataSourceV2 delete is not supported for the given table. */
-  private def shouldFallbackToV1Delete(table: SparkTable, condition: Expression): Boolean = {
-    val baseTable = table.getTable
-    org.apache.spark.SPARK_VERSION < "3.5" ||
-    !baseTable.isInstanceOf[FileStoreTable] ||
-    !baseTable.primaryKeys().isEmpty ||
-    !table.useV2Write ||
-    table.coreOptions.deletionVectorsEnabled() ||
-    table.coreOptions.rowTrackingEnabled() ||
-    table.coreOptions.dataEvolutionEnabled() ||
-    OptimizeMetadataOnlyDeleteFromPaimonTable.isMetadataOnlyDelete(
-      baseTable.asInstanceOf[FileStoreTable],
-      condition)
-  }
-
   override val operation: RowLevelOp = Delete
 
   override def apply(plan: LogicalPlan): LogicalPlan = {


### PR DESCRIPTION
### Purpose

Refactor DataSourceV2 fallback checks into reusable helper methods

### Tests

CI
