### PR TITLE
[spark] Explicitly disable v2-write for row-level operation tests

### DIFF
--- a/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/DeleteFromTableTest.scala
+++ b/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/DeleteFromTableTest.scala
@@ -20,7 +20,11 @@ package org.apache.paimon.spark.sql
 
 import org.apache.spark.SparkConf
 
-class DeleteFromTableTest extends DeleteFromTableTestBase {}
+class DeleteFromTableTest extends DeleteFromTableTestBase {
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf.set("spark.paimon.write.use-v2-write", "false")
+  }
+}
 
 class V2DeleteFromTableTest extends DeleteFromTableTestBase {
   override protected def sparkConf: SparkConf = {

--- a/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTest.scala
+++ b/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTest.scala
@@ -20,26 +20,44 @@ package org.apache.paimon.spark.sql
 
 import org.apache.paimon.spark.{PaimonAppendBucketedTableTest, PaimonAppendNonBucketTableTest, PaimonPrimaryKeyBucketedTableTest, PaimonPrimaryKeyNonBucketTableTest}
 
+import org.apache.spark.SparkConf
+
 class MergeIntoPrimaryKeyBucketedTableTest
   extends MergeIntoTableTestBase
   with MergeIntoPrimaryKeyTableTest
   with MergeIntoNotMatchedBySourceTest
-  with PaimonPrimaryKeyBucketedTableTest {}
+  with PaimonPrimaryKeyBucketedTableTest {
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf.set("spark.paimon.write.use-v2-write", "false")
+  }
+}
 
 class MergeIntoPrimaryKeyNonBucketTableTest
   extends MergeIntoTableTestBase
   with MergeIntoPrimaryKeyTableTest
   with MergeIntoNotMatchedBySourceTest
-  with PaimonPrimaryKeyNonBucketTableTest {}
+  with PaimonPrimaryKeyNonBucketTableTest {
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf.set("spark.paimon.write.use-v2-write", "false")
+  }
+}
 
 class MergeIntoAppendBucketedTableTest
   extends MergeIntoTableTestBase
   with MergeIntoAppendTableTest
   with MergeIntoNotMatchedBySourceTest
-  with PaimonAppendBucketedTableTest {}
+  with PaimonAppendBucketedTableTest {
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf.set("spark.paimon.write.use-v2-write", "false")
+  }
+}
 
 class MergeIntoAppendNonBucketedTableTest
   extends MergeIntoTableTestBase
   with MergeIntoAppendTableTest
   with MergeIntoNotMatchedBySourceTest
-  with PaimonAppendNonBucketTableTest {}
+  with PaimonAppendNonBucketTableTest {
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf.set("spark.paimon.write.use-v2-write", "false")
+  }
+}

--- a/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/UpdateTableTest.scala
+++ b/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/UpdateTableTest.scala
@@ -18,4 +18,10 @@
 
 package org.apache.paimon.spark.sql
 
-class UpdateTableTest extends UpdateTableTestBase {}
+import org.apache.spark.SparkConf
+
+class UpdateTableTest extends UpdateTableTestBase {
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf.set("spark.paimon.write.use-v2-write", "false")
+  }
+}

--- a/paimon-spark/paimon-spark-4.0/src/test/scala/org/apache/paimon/spark/sql/DeleteFromTableTest.scala
+++ b/paimon-spark/paimon-spark-4.0/src/test/scala/org/apache/paimon/spark/sql/DeleteFromTableTest.scala
@@ -20,7 +20,11 @@ package org.apache.paimon.spark.sql
 
 import org.apache.spark.SparkConf
 
-class DeleteFromTableTest extends DeleteFromTableTestBase {}
+class DeleteFromTableTest extends DeleteFromTableTestBase {
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf.set("spark.paimon.write.use-v2-write", "false")
+  }
+}
 
 class V2DeleteFromTableTest extends DeleteFromTableTestBase {
   override protected def sparkConf: SparkConf = {

--- a/paimon-spark/paimon-spark-4.0/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTest.scala
+++ b/paimon-spark/paimon-spark-4.0/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTest.scala
@@ -20,26 +20,44 @@ package org.apache.paimon.spark.sql
 
 import org.apache.paimon.spark.{PaimonAppendBucketedTableTest, PaimonAppendNonBucketTableTest, PaimonPrimaryKeyBucketedTableTest, PaimonPrimaryKeyNonBucketTableTest}
 
+import org.apache.spark.SparkConf
+
 class MergeIntoPrimaryKeyBucketedTableTest
   extends MergeIntoTableTestBase
   with MergeIntoPrimaryKeyTableTest
   with MergeIntoNotMatchedBySourceTest
-  with PaimonPrimaryKeyBucketedTableTest {}
+  with PaimonPrimaryKeyBucketedTableTest {
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf.set("spark.paimon.write.use-v2-write", "false")
+  }
+}
 
 class MergeIntoPrimaryKeyNonBucketTableTest
   extends MergeIntoTableTestBase
   with MergeIntoPrimaryKeyTableTest
   with MergeIntoNotMatchedBySourceTest
-  with PaimonPrimaryKeyNonBucketTableTest {}
+  with PaimonPrimaryKeyNonBucketTableTest {
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf.set("spark.paimon.write.use-v2-write", "false")
+  }
+}
 
 class MergeIntoAppendBucketedTableTest
   extends MergeIntoTableTestBase
   with MergeIntoAppendTableTest
   with MergeIntoNotMatchedBySourceTest
-  with PaimonAppendBucketedTableTest {}
+  with PaimonAppendBucketedTableTest {
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf.set("spark.paimon.write.use-v2-write", "false")
+  }
+}
 
 class MergeIntoAppendNonBucketedTableTest
   extends MergeIntoTableTestBase
   with MergeIntoAppendTableTest
   with MergeIntoNotMatchedBySourceTest
-  with PaimonAppendNonBucketTableTest {}
+  with PaimonAppendNonBucketTableTest {
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf.set("spark.paimon.write.use-v2-write", "false")
+  }
+}

--- a/paimon-spark/paimon-spark-4.0/src/test/scala/org/apache/paimon/spark/sql/UpdateTableTest.scala
+++ b/paimon-spark/paimon-spark-4.0/src/test/scala/org/apache/paimon/spark/sql/UpdateTableTest.scala
@@ -18,4 +18,10 @@
 
 package org.apache.paimon.spark.sql
 
-class UpdateTableTest extends UpdateTableTestBase {}
+import org.apache.spark.SparkConf
+
+class UpdateTableTest extends UpdateTableTestBase {
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf.set("spark.paimon.write.use-v2-write", "false")
+  }
+}


### PR DESCRIPTION
### Purpose

Add V1 write path configuration for row-level operation tests

### Tests

CI
