### PR TITLE
[parquet] remove assertion when creating Range

### DIFF
--- a/paimon-format/src/main/java/org/apache/parquet/internal/filter2/columnindex/RowRanges.java
+++ b/paimon-format/src/main/java/org/apache/parquet/internal/filter2/columnindex/RowRanges.java
@@ -74,7 +74,6 @@ public class RowRanges {
 
         // Creates a range of [from, to] (from and to are inclusive; empty ranges are not valid)
         Range(long from, long to) {
-            assert from <= to;
             this.from = from;
             this.to = to;
         }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->
When the row count of a block in a parquet file is 0, creating a `Range` for that block will throw an AssertionError, which will cause data reading to fail if the JDK has the assertion mechanism enabled.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
