### PR TITLE
[rest] Fix auth header generation order in HttpClient

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/rest/HttpClient.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/HttpClient.java
@@ -89,19 +89,14 @@ public class HttpClient implements RESTClient {
             RESTRequest body,
             Class<T> responseType,
             RESTAuthFunction restAuthFunction) {
-        try {
-            String bodyStr = RESTApi.toJson(body);
-            Header[] authHeaders = getHeaders(path, "POST", bodyStr, restAuthFunction);
-            HttpPost httpPost = new HttpPost(getRequestUrl(path, null));
-            httpPost.setHeaders(authHeaders);
-            String encodedBody = RESTUtil.encodedBody(body);
-            if (encodedBody != null) {
-                httpPost.setEntity(new StringEntity(encodedBody));
-            }
-            return exec(httpPost, responseType);
-        } catch (JsonProcessingException e) {
-            throw new RESTException(e, "build post request failed.");
+        HttpPost httpPost = new HttpPost(getRequestUrl(path, null));
+        String encodedBody = RESTUtil.encodedBody(body);
+        if (encodedBody != null) {
+            httpPost.setEntity(new StringEntity(encodedBody));
         }
+        Header[] authHeaders = getHeaders(path, "POST", encodedBody, restAuthFunction);
+        httpPost.setHeaders(authHeaders);
+        return exec(httpPost, responseType);
     }
 
     @Override
@@ -112,19 +107,14 @@ public class HttpClient implements RESTClient {
     @Override
     public <T extends RESTResponse> T delete(
             String path, RESTRequest body, RESTAuthFunction restAuthFunction) {
-        try {
-            String bodyStr = RESTApi.toJson(body);
-            Header[] authHeaders = getHeaders(path, "DELETE", bodyStr, restAuthFunction);
-            HttpDelete httpDelete = new HttpDelete(getRequestUrl(path, null));
-            httpDelete.setHeaders(authHeaders);
-            String encodedBody = RESTUtil.encodedBody(body);
-            if (encodedBody != null) {
-                httpDelete.setEntity(new StringEntity(encodedBody));
-            }
-            return exec(httpDelete, null);
-        } catch (JsonProcessingException e) {
-            throw new RESTException(e, "build delete request failed.");
+        HttpDelete httpDelete = new HttpDelete(getRequestUrl(path, null));
+        String encodedBody = RESTUtil.encodedBody(body);
+        if (encodedBody != null) {
+            httpDelete.setEntity(new StringEntity(encodedBody));
         }
+        Header[] authHeaders = getHeaders(path, "DELETE", encodedBody, restAuthFunction);
+        httpDelete.setHeaders(authHeaders);
+        return exec(httpDelete, null);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
### Purpose

Fix the order of authentication header generation in HttpClient to ensure proper request signing for authentication mechanisms that require complete request body information.

In the original implementation, authentication headers were generated before setting the request entity, which could cause issues for authentication mechanisms (like AlibabaCloud DLF ApiSigner) that need to sign the complete request including the body content.

This PR adjusts the execution order in `post()` and `delete()` methods to:
1. Set the encoded request entity first
2. Generate authentication headers with complete request information
3. Set the headers to the request

### Tests

- Existing unit tests for HttpClient should pass

### API and Format

No API or storage format changes. This is an internal implementation fix that maintains backward compatibility.

### Documentation

No new feature introduced. This is a bug fix for authentication header generation order.