### PR TITLE
[spark] ignore PaimonLambdaFunctionfunction_test.java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ metastore_db/
 paimon-python/dist/
 paimon-python/*.egg-info/
 paimon-python/dev/log
+paimon-spark/paimon-spark-ut/PaimonLambdaFunctionfunction_test.java
 
 ### Misc ###
 *.swp


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

When running some UT, it may generate the `PaimonLambdaFunctionfunction_test.java` file, and `mvn` may fail due to the check of `apache-rat-plugin`

org.apache.paimon.spark.JavaLambdaStringToMethodConverter#compileAndLoadMethod
```java
        File sourceFile = new File(getSourceFileName(functionName));
        try (FileWriter writer = new FileWriter(sourceFile)) {
            writer.write(javaCode);
        }
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
