### PR TITLE
[spark] Fix changelog producer in Postpone Bucket table with batch write fixed bucket

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/PostponeUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PostponeUtils.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.paimon.CoreOptions.BUCKET;
-import static org.apache.paimon.CoreOptions.WRITE_ONLY;
 
 /** Utils for postpone table. */
 public class PostponeUtils {
@@ -56,7 +55,6 @@ public class PostponeUtils {
 
     public static FileStoreTable tableForFixBucketWrite(FileStoreTable table) {
         Map<String, String> batchWriteOptions = new HashMap<>();
-        batchWriteOptions.put(WRITE_ONLY.key(), "true");
         // It's just used to create merge tree writer for writing files to fixed bucket.
         // The real bucket number is determined at runtime.
         batchWriteOptions.put(BUCKET.key(), "1");


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #7165

<!-- What is the purpose of the change -->

### Tests
test("Postpone lookup bucket table: write fix bucket then write postpone bucket")

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
