### PR TITLE
[core] Allow chain table to use non-deduplicate merge engines.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -661,9 +661,6 @@ public class SchemaValidation {
             Preconditions.checkArgument(
                     options.sequenceField() != null, "Sequence field is required for chain table.");
             Preconditions.checkArgument(
-                    options.mergeEngine() == MergeEngine.DEDUPLICATE,
-                    "Merge engine must be deduplicate for chain table.");
-            Preconditions.checkArgument(
                     changelogProducer == ChangelogProducer.NONE
                             || changelogProducer == ChangelogProducer.INPUT,
                     "Changelog producer must be none or input for chain table.");

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
@@ -176,4 +176,28 @@ class SchemaValidationTest {
         options.put("fields.f2.sequence-group", "f3");
         assertThatCode(() -> validateTableSchemaExec(options)).doesNotThrowAnyException();
     }
+
+    @Test
+    public void testChainTableAllowsNonDeduplicateMergeEngine() {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.CHAIN_TABLE_ENABLED.key(), "true");
+        options.put(CoreOptions.BUCKET.key(), "1");
+        options.put(CoreOptions.SEQUENCE_FIELD.key(), "f2");
+        options.put(CoreOptions.PARTITION_TIMESTAMP_PATTERN.key(), "$f0");
+        options.put(CoreOptions.PARTITION_TIMESTAMP_FORMATTER.key(), "yyyy-MM-dd");
+        options.put(CoreOptions.MERGE_ENGINE.key(), "partial-update");
+
+        List<DataField> fields =
+                Arrays.asList(
+                        new DataField(0, "f0", DataTypes.STRING()),
+                        new DataField(1, "f1", DataTypes.INT()),
+                        new DataField(2, "f2", DataTypes.BIGINT()),
+                        new DataField(3, "f3", DataTypes.STRING()));
+        List<String> partitionKeys = singletonList("f0");
+        List<String> primaryKeys = Arrays.asList("f0", "f1");
+        TableSchema schema =
+                new TableSchema(1, fields, 10, partitionKeys, primaryKeys, options, "");
+
+        assertThatNoException().isThrownBy(() -> validateTableSchema(schema));
+    }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->
Previously chain table was restricted to only use deduplicate merge engine.
This change removes that limitation, allowing chain table to work with other merge engines like partial-update.
### Tests

<!-- List UT and IT cases to verify this change -->
- Add unit test `testChainTableAllowsNonDeduplicateMergeEngine` to verify chain table can use partial-update merge engine
- Add integration test `testChainTableWithPartialUpdate` to verify chain table read/write with partial-update merge engine
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
