### PR TITLE
[spark] Fix rescale procedure to only read real buckets for postpone bucket table

### DIFF
--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -476,5 +476,18 @@ This section introduce all available spark procedures about paimon.
          CALL sys.copy(source_table => "t1", target_table => "t1_copy", where => "day = '2025-08-17'")<br/>
       </td>
    </tr>
+   <tr>
+      <td>rescale</td>
+      <td>
+         Rescale partitions of a table by changing the bucket number. Arguments:
+            <li>table: the target table identifier. Cannot be empty.</li>
+            <li>bucket_num: resulting bucket number after rescale. The default value is the current bucket number of the table. Cannot be empty for postpone bucket tables.</li>
+            <li>partitions: partition filter. Left empty for all partitions. (Can't be used together with "where")</li>
+            <li>where: partition predicate. Left empty for all partitions. (Can't be used together with "partitions")</li>
+      </td>
+      <td>
+         CALL sys.rescale(table => 'default.T', bucket_num => 16, partitions => 'dt=20250217,hh=08;dt=20250217,hh=09')<br/>
+      </td>
+   </tr>
    </tbody>
 </table>

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RescaleProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RescaleProcedure.java
@@ -162,7 +162,7 @@ public class RescaleProcedure extends BaseProcedure {
         if (partitionPredicate != null) {
             snapshotReader = snapshotReader.withPartitionFilter(partitionPredicate);
         }
-        List<DataSplit> dataSplits = snapshotReader.read().dataSplits();
+        List<DataSplit> dataSplits = snapshotReader.onlyReadRealBuckets().read().dataSplits();
 
         if (dataSplits.isEmpty()) {
             LOG.info("No data splits found for the specified partition. No need to rescale.");


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #7183

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
RescaleProcedureTest.test("Paimon Procedure: rescale postpone bucket table")
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
