### PR TITLE
[flink] Make toIdentifier an instance method of FlinkCatalog

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -1070,7 +1070,7 @@ public class FlinkCatalog extends AbstractCatalog {
         return columnOptions;
     }
 
-    public static Identifier toIdentifier(ObjectPath path) {
+    public Identifier toIdentifier(ObjectPath path) {
         return new Identifier(path.getDatabaseName(), path.getObjectName());
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkCatalogTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkCatalogTest.java
@@ -807,7 +807,7 @@ public class FlinkCatalogTest extends FlinkCatalogTestBase {
             Map<String, String> options =
                     ((FlinkCatalog) catalog)
                             .catalog()
-                            .getTable(FlinkCatalog.toIdentifier(path))
+                            .getTable(((FlinkCatalog) catalog).toIdentifier(path))
                             .options();
             tablePath = new Path(options.get(PATH.key()));
         } catch (org.apache.paimon.catalog.Catalog.TableNotExistException e) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

This PR makes `FlinkCatalog#toIdentifier` an instance method for better extensibility.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
