### PR TITLE
[core] Fix that get format table in rest catalog might throw permission exception

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -73,7 +73,6 @@ import org.apache.paimon.shade.org.apache.commons.lang3.StringUtils;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -772,8 +771,7 @@ public class RESTCatalog implements Catalog {
     @Override
     public void alterFunction(
             Identifier identifier, List<FunctionChange> changes, boolean ignoreIfNotExists)
-            throws FunctionNotExistException,
-                    DefinitionAlreadyExistException,
+            throws FunctionNotExistException, DefinitionAlreadyExistException,
                     DefinitionNotExistException {
         try {
             api.alterFunction(identifier, changes);


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In some cases we only need the format table object but won't access the data.

The exception stack is like:
```
Caused by: com.aliyun.oss.OSSException: Access denied by authorizer's policy.
xxx 
xxx
	at org.apache.paimon.fs.FileIO.checkAccess(FileIO.java:638) ~[?:?]
	at org.apache.paimon.fs.FileIO.get(FileIO.java:552) ~[?:?]
	at org.apache.paimon.rest.RESTCatalog.fileIOFromOptions(RESTCatalog.java:1130) ~[?:?]
	at org.apache.paimon.catalog.CatalogUtils.toFormatTable(CatalogUtils.java:407) ~[?:?]
	at org.apache.paimon.catalog.CatalogUtils.loadTable(CatalogUtils.java:255) ~[?:?]
	at org.apache.paimon.rest.RESTCatalog.getTable(RESTCatalog.java:297) ~[?:?]
```


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
