### PR TITLE
[core] Disable async write when blob type found

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -318,7 +318,10 @@ public class AppendOnlyWriter implements BatchRecordWriter, MemoryOwner {
                     statsCollectorFactories,
                     fileIndexOptions,
                     FileSource.APPEND,
-                    // blob write does not need async write
+                    // blob write does not need async write, cause blob write is I/O-intensive, not
+                    // CPU-intensive process.
+                    // Async write will cost 64MB more memory per write task, blob writes get low
+                    // benefit from async write, but cost a lot.
                     false,
                     statsDenseStore,
                     blobConsumer);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
As title, blob write stuck in io mostly, so there is no need to open async write

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
