### PR TITLE
[core] Limit max parallelism for postpone batch write fixed bucket to avoid too many buckets

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -153,12 +153,6 @@ under the License.
             <td>Fields that are ignored for comparison while generating -U, +U changelog for the same record. This configuration is only valid for the changelog-producer.row-deduplicate is true.</td>
         </tr>
         <tr>
-            <td><h5>table-read.sequence-number.enabled</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Whether to include the _SEQUENCE_NUMBER field when reading the audit_log or binlog system tables. This is only valid for primary key tables.</td>
-        </tr>
-        <tr>
             <td><h5>changelog.num-retained.max</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
@@ -1032,6 +1026,12 @@ This config option does not affect the default filesystem metastore.</td>
             <td>Whether to write the data into fixed bucket for batch writing a postpone bucket table.</td>
         </tr>
         <tr>
+            <td><h5>postpone.batch-write-fixed-bucket.max-parallelism</h5></td>
+            <td style="word-wrap: break-word;">2048</td>
+            <td>Integer</td>
+            <td>The number of partitions for global index.</td>
+        </tr>
+        <tr>
             <td><h5>postpone.default-bucket-num</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>
@@ -1313,6 +1313,12 @@ If the data size allocated for the sorting task is uneven,which may lead to perf
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
             <td>The delay duration of stream read when scan incremental snapshots.</td>
+        </tr>
+        <tr>
+            <td><h5>table-read.sequence-number.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to include the _SEQUENCE_NUMBER field when reading the audit_log or binlog system tables. This is only valid for primary key tables.</td>
         </tr>
         <tr>
             <td><h5>tag.automatic-completion</h5></td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2164,6 +2164,12 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Whether to write the data into fixed bucket for batch writing a postpone bucket table.");
 
+    public static final ConfigOption<Integer> POSTPONE_BATCH_WRITE_FIXED_BUCKET_MAX_PARALLELISM =
+            key("postpone.batch-write-fixed-bucket.max-parallelism")
+                    .intType()
+                    .defaultValue(2048)
+                    .withDescription("The number of partitions for global index.");
+
     public static final ConfigOption<Integer> POSTPONE_DEFAULT_BUCKET_NUM =
             key("postpone.default-bucket-num")
                     .intType()
@@ -3399,6 +3405,10 @@ public class CoreOptions implements Serializable {
 
     public boolean postponeBatchWriteFixedBucket() {
         return options.get(POSTPONE_BATCH_WRITE_FIXED_BUCKET);
+    }
+
+    public int postponeBatchWriteFixedBucketMaxParallelism() {
+        return options.get(POSTPONE_BATCH_WRITE_FIXED_BUCKET_MAX_PARALLELISM);
     }
 
     public int postponeDefaultBucketNum() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/PostponeBatchWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/PostponeBatchWriteOperator.java
@@ -72,7 +72,11 @@ public class PostponeBatchWriteOperator extends StatelessRowDataStoreWriteOperat
         super.open();
 
         int sinkParallelism = RuntimeContextUtils.getNumberOfParallelSubtasks(getRuntimeContext());
-        this.defaultNumBuckets = sinkParallelism <= 0 ? 1 : sinkParallelism;
+        sinkParallelism = sinkParallelism <= 0 ? 1 : sinkParallelism;
+        this.defaultNumBuckets =
+                Math.min(
+                        sinkParallelism,
+                        table.coreOptions().postponeBatchWriteFixedBucketMaxParallelism());
 
         TableSchema schema = table.schema();
         this.partitionKeyExtractor = new RowPartitionKeyExtractor(schema);

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonSparkWriter.scala
@@ -123,7 +123,9 @@ case class PaimonSparkWriter(
     val postponePartitionBucketComputer: Option[BinaryRow => Integer] =
       if (postponeBatchWriteFixedBucket) {
         val knownNumBuckets = PostponeUtils.getKnownNumBuckets(table)
-        val defaultPostponeNumBuckets = withInitBucketCol.rdd.getNumPartitions
+        val defaultPostponeNumBuckets = Math.min(
+          withInitBucketCol.rdd.getNumPartitions,
+          table.coreOptions().postponeBatchWriteFixedBucketMaxParallelism)
         Some((p: BinaryRow) => knownNumBuckets.getOrDefault(p, defaultPostponeNumBuckets))
       } else {
         None

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkPostponeCompactProcedure.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkPostponeCompactProcedure.scala
@@ -62,12 +62,9 @@ case class SparkPostponeCompactProcedure(
   // Create bucket computer to determine bucket count for each partition
   private lazy val postponePartitionBucketComputer = {
     val knownNumBuckets = PostponeUtils.getKnownNumBuckets(table)
-    val defaultBucketNum =
-      if (table.coreOptions.toConfiguration.contains(CoreOptions.POSTPONE_DEFAULT_BUCKET_NUM)) {
-        table.coreOptions.postponeDefaultBucketNum
-      } else {
-        spark.sparkContext.defaultParallelism
-      }
+    val defaultBucketNum = Math.min(
+      spark.sparkContext.defaultParallelism,
+      table.coreOptions().postponeBatchWriteFixedBucketMaxParallelism)
     (p: BinaryRow) => knownNumBuckets.getOrDefault(p, defaultBucketNum)
   }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkPostponeCompactProcedure.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkPostponeCompactProcedure.scala
@@ -62,9 +62,12 @@ case class SparkPostponeCompactProcedure(
   // Create bucket computer to determine bucket count for each partition
   private lazy val postponePartitionBucketComputer = {
     val knownNumBuckets = PostponeUtils.getKnownNumBuckets(table)
-    val defaultBucketNum = Math.min(
-      spark.sparkContext.defaultParallelism,
-      table.coreOptions().postponeBatchWriteFixedBucketMaxParallelism)
+    val defaultBucketNum =
+      if (table.coreOptions.toConfiguration.contains(CoreOptions.POSTPONE_DEFAULT_BUCKET_NUM)) {
+        table.coreOptions.postponeDefaultBucketNum
+      } else {
+        spark.sparkContext.defaultParallelism
+      }
     (p: BinaryRow) => knownNumBuckets.getOrDefault(p, defaultBucketNum)
   }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
In our case, the spark written tens of thousands of buckets.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
