### PR TITLE
[core] BucketedAppendCompactManager should use compactionFileSize instead of targetFileSize

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/BucketedAppendCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/BucketedAppendCompactManager.java
@@ -59,6 +59,7 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
     private final BucketedDvMaintainer dvMaintainer;
     private final PriorityQueue<DataFileMeta> toCompact;
     private final int minFileNum;
+    private final long targetFileSize;
     private final long compactionFileSize;
     private final boolean forceRewriteAllFiles;
     private final CompactRewriter rewriter;
@@ -72,6 +73,7 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
             List<DataFileMeta> restored,
             @Nullable BucketedDvMaintainer dvMaintainer,
             int minFileNum,
+            long targetFileSize,
             long compactionFileSize,
             boolean forceRewriteAllFiles,
             CompactRewriter rewriter,
@@ -81,6 +83,7 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
         this.toCompact = new PriorityQueue<>(Comparator.comparing(DataFileMeta::minSequenceNumber));
         this.toCompact.addAll(restored);
         this.minFileNum = minFileNum;
+        this.targetFileSize = targetFileSize;
         this.compactionFileSize = compactionFileSize;
         this.forceRewriteAllFiles = forceRewriteAllFiles;
         this.rewriter = rewriter;
@@ -214,7 +217,7 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
             fileNum++;
             if (fileNum >= minFileNum) {
                 return Optional.of(candidates);
-            } else if (totalFileSize >= compactionFileSize) {
+            } else if (totalFileSize >= targetFileSize * 2) {
                 // let pointer shift one pos to right
                 DataFileMeta removed = candidates.pollFirst();
                 assert removed != null;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/BucketedAppendFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/BucketedAppendFileStoreWrite.java
@@ -120,7 +120,7 @@ public class BucketedAppendFileStoreWrite extends BaseAppendFileStoreWrite {
                     restoredFiles,
                     dvMaintainer,
                     options.compactionMinFileNum(),
-                    options.targetFileSize(false),
+                    options.compactionFileSize(false),
                     options.forceRewriteAllFiles(),
                     files -> compactRewrite(partition, bucket, dvFactory, files),
                     compactionMetrics == null

--- a/paimon-core/src/main/java/org/apache/paimon/operation/BucketedAppendFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/BucketedAppendFileStoreWrite.java
@@ -120,6 +120,7 @@ public class BucketedAppendFileStoreWrite extends BaseAppendFileStoreWrite {
                     restoredFiles,
                     dvMaintainer,
                     options.compactionMinFileNum(),
+                    options.targetFileSize(false),
                     options.compactionFileSize(false),
                     options.forceRewriteAllFiles(),
                     files -> compactRewrite(partition, bucket, dvFactory, files),

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendCompactCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendCompactCoordinatorTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.deletionvectors.append.AppendDeleteFileMaintainer;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
@@ -40,10 +41,13 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.UUID;
 
 import static org.apache.paimon.CoreOptions.COMPACTION_MIN_FILE_NUM;
 import static org.apache.paimon.CoreOptions.DELETION_VECTORS_ENABLED;
 import static org.apache.paimon.io.DataFileTestUtils.newFile;
+import static org.apache.paimon.mergetree.compact.MergeTreeCompactManagerTest.row;
+import static org.apache.paimon.stats.StatsTestUtils.newSimpleStats;
 import static org.apache.paimon.testutils.assertj.PaimonAssertions.anyCauseMatches;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -239,5 +243,26 @@ public class AppendCompactCoordinatorTest {
             files.add(newFile(fileSize));
         }
         return files;
+    }
+
+    private DataFileMeta newFile(long fileSize) {
+        return DataFileMeta.create(
+                UUID.randomUUID().toString(),
+                fileSize,
+                100,
+                row(0),
+                row(0),
+                newSimpleStats(0, 1),
+                newSimpleStats(0, 1),
+                0,
+                0,
+                0,
+                0,
+                0L,
+                null,
+                FileSource.APPEND,
+                null,
+                null,
+                null);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendCompactCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendCompactCoordinatorTest.java
@@ -23,7 +23,6 @@ import org.apache.paimon.deletionvectors.append.AppendDeleteFileMaintainer;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.io.DataFileMeta;
-import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
@@ -41,12 +40,10 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.UUID;
 
 import static org.apache.paimon.CoreOptions.COMPACTION_MIN_FILE_NUM;
 import static org.apache.paimon.CoreOptions.DELETION_VECTORS_ENABLED;
-import static org.apache.paimon.mergetree.compact.MergeTreeCompactManagerTest.row;
-import static org.apache.paimon.stats.StatsTestUtils.newSimpleStats;
+import static org.apache.paimon.io.DataFileTestUtils.newFile;
 import static org.apache.paimon.testutils.assertj.PaimonAssertions.anyCauseMatches;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -242,26 +239,5 @@ public class AppendCompactCoordinatorTest {
             files.add(newFile(fileSize));
         }
         return files;
-    }
-
-    private DataFileMeta newFile(long fileSize) {
-        return DataFileMeta.create(
-                UUID.randomUUID().toString(),
-                fileSize,
-                100,
-                row(0),
-                row(0),
-                newSimpleStats(0, 1),
-                newSimpleStats(0, 1),
-                0,
-                0,
-                0,
-                0,
-                0L,
-                null,
-                FileSource.APPEND,
-                null,
-                null,
-                null);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/AppendOnlyWriterTest.java
@@ -675,6 +675,7 @@ public class AppendOnlyWriterTest {
                         null,
                         MIN_FILE_NUM,
                         targetFileSize,
+                        targetFileSize / 10 * 7,
                         false,
                         compactBefore -> {
                             latch.await();

--- a/paimon-core/src/test/java/org/apache/paimon/append/BucketedAppendCompactManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/BucketedAppendCompactManagerTest.java
@@ -45,31 +45,27 @@ public class BucketedAppendCompactManagerTest {
     public void testPickEmptyAndRelease() {
         // large file, release
         innerTest(
-                Collections.singletonList(newFile(1L, 1024L)),
+                Collections.singletonList(newFile(1L, 2048L)),
                 false,
                 Collections.emptyList(),
                 Collections.emptyList());
 
         // small file at last, release previous
         innerTest(
-                Arrays.asList(newFile(1L, 1024L), newFile(1025L, 2049L), newFile(2050L, 2100L)),
+                Arrays.asList(newFile(1L, 2048L), newFile(2049L, 2100L)),
                 false,
                 Collections.emptyList(),
-                Collections.singletonList(newFile(2050L, 2100L)));
+                Collections.singletonList(newFile(2049L, 2100L)));
         innerTest(
-                Arrays.asList(
-                        newFile(1L, 1024L),
-                        newFile(1025L, 2049L),
-                        newFile(2050L, 2100L),
-                        newFile(2101L, 2110L)),
+                Arrays.asList(newFile(1L, 2048L), newFile(2049L, 2100L), newFile(2101L, 2110L)),
                 false,
                 Collections.emptyList(),
-                Arrays.asList(newFile(2050L, 2100L), newFile(2101L, 2110L)));
+                Arrays.asList(newFile(2049L, 2100L), newFile(2101L, 2110L)));
         innerTest(
-                Arrays.asList(newFile(1L, 1024L), newFile(1025L, 2049L), newFile(2050L, 2500L)),
+                Arrays.asList(newFile(1L, 2048L), newFile(2049L, 4096L), newFile(4097L, 5000L)),
                 false,
                 Collections.emptyList(),
-                Collections.singletonList(newFile(2050L, 2500L)));
+                Collections.singletonList(newFile(4097L, 5000L)));
         innerTest(
                 Arrays.asList(
                         newFile(1L, 1024L),
@@ -81,29 +77,29 @@ public class BucketedAppendCompactManagerTest {
                         newFile(7001L, 7600L)),
                 false,
                 Collections.emptyList(),
-                Collections.singletonList(newFile(7001L, 7600L)));
+                Arrays.asList(newFile(6001L, 7000L), newFile(7001L, 7600L)));
 
         // ignore single small file (in the middle)
         innerTest(
                 Arrays.asList(
-                        newFile(1L, 1024L),
-                        newFile(1025L, 2049L),
-                        newFile(2050L, 2500L),
-                        newFile(2501L, 4096L)),
+                        newFile(1L, 2048L),
+                        newFile(2049L, 4096L),
+                        newFile(4097L, 4100L),
+                        newFile(4101L, 6150L)),
                 false,
                 Collections.emptyList(),
-                Collections.singletonList(newFile(2501L, 4096L)));
+                Collections.singletonList(newFile(4101L, 6150L)));
 
         innerTest(
                 Arrays.asList(
-                        newFile(1L, 1024L),
-                        newFile(1025L, 2049L),
-                        newFile(2050L, 2500L),
-                        newFile(2501L, 4096L),
-                        newFile(4097L, 6000L)),
+                        newFile(1L, 2048L),
+                        newFile(2049L, 4096L),
+                        newFile(4097L, 5000L),
+                        newFile(5001L, 6144L),
+                        newFile(6145L, 7048L)),
                 false,
                 Collections.emptyList(),
-                Collections.singletonList(newFile(4097L, 6000L)));
+                Collections.singletonList(newFile(6145L, 7048L)));
 
         // wait for more file
         innerTest(
@@ -113,16 +109,16 @@ public class BucketedAppendCompactManagerTest {
                 Arrays.asList(newFile(1L, 500L), newFile(501L, 1000L)));
 
         innerTest(
-                Arrays.asList(newFile(1L, 500L), newFile(501L, 1000L), newFile(1001L, 2026L)),
+                Arrays.asList(newFile(1L, 500L), newFile(501L, 1000L), newFile(1001L, 2048L)),
                 false,
                 Collections.emptyList(),
-                Arrays.asList(newFile(501L, 1000L), newFile(1001L, 2026L)));
+                Arrays.asList(newFile(501L, 1000L), newFile(1001L, 2048L)));
 
         innerTest(
-                Arrays.asList(newFile(1L, 2000L), newFile(2001L, 2005L), newFile(2006L, 2010L)),
+                Arrays.asList(newFile(1L, 2050L), newFile(2051L, 2100L), newFile(2101L, 2110L)),
                 false,
                 Collections.emptyList(),
-                Arrays.asList(newFile(2001L, 2005L), newFile(2006L, 2010L)));
+                Arrays.asList(newFile(2051L, 2100L), newFile(2101L, 2110L)));
     }
 
     @Disabled // TODO create new tests for min files only

--- a/paimon-core/src/test/java/org/apache/paimon/append/BucketedAppendCompactManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/BucketedAppendCompactManagerTest.java
@@ -207,6 +207,7 @@ public class BucketedAppendCompactManagerTest {
                         null,
                         minFileNum,
                         targetFileSize,
+                        targetFileSize / 10 * 7,
                         false,
                         null, // not used
                         null);

--- a/paimon-core/src/test/java/org/apache/paimon/append/FullCompactTaskTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/FullCompactTaskTest.java
@@ -71,6 +71,12 @@ public class FullCompactTaskTest {
                         newFile(3221, 3280)),
                 Collections.emptyList(),
                 Collections.emptyList());
+
+        // middle files are removed
+        innerTest(
+                Collections.singletonList(newFile(1L, 1024L / 10 * 8)),
+                Collections.emptyList(),
+                Collections.emptyList());
     }
 
     @Test
@@ -106,7 +112,7 @@ public class FullCompactTaskTest {
             List<DataFileMeta> expectBefore,
             List<DataFileMeta> expectAfter) {
         MockFullCompactTask task =
-                new MockFullCompactTask(compactFiles, TARGET_FILE_SIZE, rewriter());
+                new MockFullCompactTask(compactFiles, TARGET_FILE_SIZE / 10 * 7, rewriter());
         try {
             CompactResult actual = task.doCompact();
             assertThat(actual.before()).containsExactlyInAnyOrderElementsOf(expectBefore);

--- a/paimon-core/src/test/java/org/apache/paimon/io/DataFileTestUtils.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/DataFileTestUtils.java
@@ -111,6 +111,27 @@ public class DataFileTestUtils {
                 null);
     }
 
+    public static DataFileMeta newFile(long fileSize) {
+        return DataFileMeta.create(
+                "",
+                fileSize,
+                100,
+                row(0),
+                row(0),
+                EMPTY_STATS,
+                EMPTY_STATS,
+                0,
+                0,
+                0,
+                0,
+                0L,
+                null,
+                FileSource.APPEND,
+                null,
+                null,
+                null);
+    }
+
     public static BinaryRow row(int i) {
         BinaryRow row = new BinaryRow(1);
         BinaryRowWriter writer = new BinaryRowWriter(row);

--- a/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/KeyValueFileReadWriteTest.java
@@ -277,7 +277,7 @@ public class KeyValueFileReadWriteTest {
                         null,
                         0,
                         new BucketedAppendCompactManager(
-                                null, toCompact, null, 4, 10, false, null, null), // not used
+                                null, toCompact, null, 4, 10, 7, false, null, null), // not used
                         null,
                         false,
                         dataFilePathFactory,


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
See #1680 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
