### PR TITLE
[flink] fix NPE when writing blob descriptors through flink connector mode

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTableFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTableFactory.java
@@ -50,7 +50,9 @@ public class FileStoreTableFactory {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-        return create(fileIO, context.options());
+        CatalogEnvironment catalogEnvironment =
+                new CatalogEnvironment(null, null, null, null, null, context, false);
+        return create(fileIO, context.options(), catalogEnvironment);
     }
 
     public static FileStoreTable create(FileIO fileIO, Path path) {
@@ -60,6 +62,11 @@ public class FileStoreTableFactory {
     }
 
     public static FileStoreTable create(FileIO fileIO, Options options) {
+        return create(fileIO, options, CatalogEnvironment.empty());
+    }
+
+    public static FileStoreTable create(
+            FileIO fileIO, Options options, CatalogEnvironment catalogEnvironment) {
         Path tablePath = CoreOptions.path(options);
         String branchName = CoreOptions.branch(options.toMap());
         TableSchema tableSchema =
@@ -72,7 +79,7 @@ public class FileStoreTableFactory {
                                                         + tablePath
                                                         + ". Please create table first."));
 
-        return create(fileIO, tablePath, tableSchema, options, CatalogEnvironment.empty());
+        return create(fileIO, tablePath, tableSchema, options, catalogEnvironment);
     }
 
     public static FileStoreTable create(FileIO fileIO, Path tablePath, TableSchema tableSchema) {


### PR DESCRIPTION
This PR tries to fix NPE when writing blobs with blob-as-descriptor = true and flink uses paimon as connector mode (not catalog mode)

The NPE happens in uriReaderFactory
https://github.com/apache/paimon/blob/7ec86cb99b46b3c8dbbd17aa73c75c6548e5a481/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowWrapper.java#L149-L153

This is because if flink use paimon in connector mode, the CatalogContext will be null:
https://github.com/apache/paimon/blob/7ec86cb99b46b3c8dbbd17aa73c75c6548e5a481/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/AbstractFlinkTableFactory.java#L157-L159

This PR just simply pass the context down(instead of creating an empty envrionment)

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: none

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
