### PR TITLE
[core] Fix record comparator cache key for sort order

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/codegen/CodeGenUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/codegen/CodeGenUtils.java
@@ -80,6 +80,7 @@ public class CodeGenUtils {
                 RecordComparator.class,
                 inputTypes,
                 sortFields,
+                isAscendingOrder,
                 () ->
                         getCodeGenerator()
                                 .generateRecordComparator(
@@ -103,7 +104,16 @@ public class CodeGenUtils {
             List<DataType> fields,
             int[] fieldsIndex,
             Supplier<GeneratedClass<T>> supplier) {
-        ClassKey classKey = new ClassKey(classType, fields, fieldsIndex);
+        return generate(classType, fields, fieldsIndex, null, supplier);
+    }
+
+    private static <T> T generate(
+            Class<?> classType,
+            List<DataType> fields,
+            int[] fieldsIndex,
+            Object extraKey,
+            Supplier<GeneratedClass<T>> supplier) {
+        ClassKey classKey = new ClassKey(classType, fields, fieldsIndex, extraKey);
 
         try {
             Pair<Class<?>, Object[]> result =
@@ -153,10 +163,14 @@ public class CodeGenUtils {
 
         private final int[] fieldsIndex;
 
-        public ClassKey(Class<?> classType, List<DataType> fields, int[] fieldsIndex) {
+        private final Object extraKey;
+
+        public ClassKey(
+                Class<?> classType, List<DataType> fields, int[] fieldsIndex, Object extraKey) {
             this.classType = classType;
             this.fields = fields;
             this.fieldsIndex = fieldsIndex;
+            this.extraKey = extraKey;
         }
 
         @Override
@@ -170,12 +184,13 @@ public class CodeGenUtils {
             ClassKey classKey = (ClassKey) o;
             return Objects.equals(classType, classKey.classType)
                     && Objects.equals(fields, classKey.fields)
-                    && Arrays.equals(fieldsIndex, classKey.fieldsIndex);
+                    && Arrays.equals(fieldsIndex, classKey.fieldsIndex)
+                    && Objects.equals(extraKey, classKey.extraKey);
         }
 
         @Override
         public int hashCode() {
-            int result = Objects.hash(classType, fields);
+            int result = Objects.hash(classType, fields, extraKey);
             result = 31 * result + Arrays.hashCode(fieldsIndex);
             return result;
         }

--- a/paimon-core/src/test/java/org/apache/paimon/codegen/CodeGenUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/codegen/CodeGenUtilsTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.paimon.codegen;
 
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.types.RowType;
 
 import org.junit.jupiter.api.Test;
@@ -99,6 +102,21 @@ class CodeGenUtilsTest {
                 newRecordComparator(Arrays.asList(STRING(), INT()), new int[] {0, 1}, true),
                 newRecordComparator(
                         Arrays.asList(STRING(), INT(), DOUBLE()), new int[] {0, 1, 2}, true));
+    }
+
+    @Test
+    public void testRecordComparatorOrderCacheMiss() {
+        RecordComparator ascending =
+                newRecordComparator(Arrays.asList(STRING(), INT()), new int[] {0, 1}, true);
+        RecordComparator descending =
+                newRecordComparator(Arrays.asList(STRING(), INT()), new int[] {0, 1}, false);
+
+        InternalRow row1 = GenericRow.of(BinaryString.fromString("a"), 1);
+        InternalRow row2 = GenericRow.of(BinaryString.fromString("b"), 1);
+
+        assertThat(ascending.compare(row1, row2)).isLessThan(0);
+        assertThat(descending.compare(row1, row2)).isGreaterThan(0);
+        assertThat(ascending.getClass()).isNotEqualTo(descending.getClass());
     }
 
     @Test


### PR DESCRIPTION
## Problem
The cache key for `recordComparator` only considered the sort key types but ignored the sort order (ascending/descending). This caused comparators with different sort orders to share the same cached class, leading to incorrect sorting behavior.

## Solution
Include `SortOrder` in the cache key generation to ensure each unique sort order combination gets its own generated comparator class.

## Summary
- Include sort order in the codegen cache key for record comparators
- Add a regression test for ascending/descending comparator cache collisions

## Testing
```bash
mvn -pl paimon-core -Dtest=CodeGenUtilsTest test
```