### PR TITLE
[spark] Support AlwaysTrue and AlwaysFalse predicates in SparkV2FilterConverter

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/FalseFunction.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/FalseFunction.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.predicate;
+
+import org.apache.paimon.types.DataType;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.List;
+import java.util.Optional;
+
+/** A {@link LeafFunction} that always returns {@code false}. Used for AlwaysFalse predicates. */
+public class FalseFunction extends LeafFunction {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String NAME = "FALSE";
+
+    public static final FalseFunction INSTANCE = new FalseFunction();
+
+    @JsonCreator
+    private FalseFunction() {}
+
+    @Override
+    public boolean test(DataType type, Object field, List<Object> literals) {
+        return false;
+    }
+
+    @Override
+    public boolean test(
+            DataType type,
+            long rowCount,
+            Object min,
+            Object max,
+            Long nullCount,
+            List<Object> literals) {
+        return false;
+    }
+
+    @Override
+    public Optional<LeafFunction> negate() {
+        return Optional.of(TrueFunction.INSTANCE);
+    }
+
+    @Override
+    public <T> T visit(FunctionVisitor<T> visitor, FieldRef fieldRef, List<Object> literals) {
+        throw new UnsupportedOperationException(
+                "FalseFunction does not support field-based visitation.");
+    }
+
+    @Override
+    public String toJson() {
+        return NAME;
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/LeafFunction.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/LeafFunction.java
@@ -68,6 +68,8 @@ public abstract class LeafFunction implements Serializable {
             registry.put(NotIn.NAME, NotIn.INSTANCE);
             registry.put(Between.NAME, Between.INSTANCE);
             registry.put(NotBetween.NAME, NotBetween.INSTANCE);
+            registry.put(TrueFunction.NAME, TrueFunction.INSTANCE);
+            registry.put(FalseFunction.NAME, FalseFunction.INSTANCE);
             return Collections.unmodifiableMap(registry);
         }
     }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/LeafPredicate.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/LeafPredicate.java
@@ -143,6 +143,9 @@ public class LeafPredicate implements Predicate {
             long rowCount, InternalRow minValues, InternalRow maxValues, InternalArray nullCounts) {
         Optional<FieldRef> fieldRefOptional = fieldRefOptional();
         if (!fieldRefOptional.isPresent()) {
+            if (transform instanceof TrueTransform) {
+                return function.test(transform.outputType(), 0, null, null, null, literals);
+            }
             return true;
         }
         FieldRef fieldRef = fieldRefOptional.get();
@@ -165,6 +168,9 @@ public class LeafPredicate implements Predicate {
 
     @Override
     public Optional<Predicate> negate() {
+        if (transform instanceof TrueTransform) {
+            return function.negate().map(neg -> new LeafPredicate(transform, neg, literals));
+        }
         Optional<FieldRef> fieldRefOptional = fieldRefOptional();
         if (!fieldRefOptional.isPresent()) {
             return Optional.empty();

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PartitionPredicateVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PartitionPredicateVisitor.java
@@ -32,14 +32,16 @@ public class PartitionPredicateVisitor implements PredicateVisitor<Boolean> {
     @Override
     public Boolean visit(LeafPredicate predicate) {
         Transform transform = predicate.transform();
+        boolean hasFieldRef = false;
         for (Object input : transform.inputs()) {
             if (input instanceof FieldRef) {
+                hasFieldRef = true;
                 if (!partitionKeys.contains(((FieldRef) input).name())) {
                     return false;
                 }
             }
         }
-        return true;
+        return hasFieldRef;
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/Transform.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/Transform.java
@@ -38,7 +38,8 @@ import java.util.List;
     @JsonSubTypes.Type(value = ConcatTransform.class, name = ConcatTransform.NAME),
     @JsonSubTypes.Type(value = ConcatWsTransform.class, name = ConcatWsTransform.NAME),
     @JsonSubTypes.Type(value = UpperTransform.class, name = UpperTransform.NAME),
-    @JsonSubTypes.Type(value = LowerTransform.class, name = LowerTransform.NAME)
+    @JsonSubTypes.Type(value = LowerTransform.class, name = LowerTransform.NAME),
+    @JsonSubTypes.Type(value = TrueTransform.class, name = TrueTransform.NAME)
 })
 public interface Transform extends Serializable {
 

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/TrueFunction.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/TrueFunction.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.predicate;
+
+import org.apache.paimon.types.DataType;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.List;
+import java.util.Optional;
+
+/** A {@link LeafFunction} that always returns {@code true}. Used for AlwaysTrue predicates. */
+public class TrueFunction extends LeafFunction {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String NAME = "TRUE";
+
+    public static final TrueFunction INSTANCE = new TrueFunction();
+
+    @JsonCreator
+    private TrueFunction() {}
+
+    @Override
+    public boolean test(DataType type, Object field, List<Object> literals) {
+        return true;
+    }
+
+    @Override
+    public boolean test(
+            DataType type,
+            long rowCount,
+            Object min,
+            Object max,
+            Long nullCount,
+            List<Object> literals) {
+        return true;
+    }
+
+    @Override
+    public Optional<LeafFunction> negate() {
+        return Optional.of(FalseFunction.INSTANCE);
+    }
+
+    @Override
+    public <T> T visit(FunctionVisitor<T> visitor, FieldRef fieldRef, List<Object> literals) {
+        throw new UnsupportedOperationException(
+                "TrueFunction does not support field-based visitation.");
+    }
+
+    @Override
+    public String toJson() {
+        return NAME;
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/TrueTransform.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/TrueTransform.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.predicate;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Collections;
+import java.util.List;
+
+/** A {@link Transform} that always returns {@code true}. Used for constant predicates. */
+public class TrueTransform implements Transform {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String NAME = "TRUE";
+
+    public static final TrueTransform INSTANCE = new TrueTransform();
+
+    @JsonCreator
+    private TrueTransform() {}
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public List<Object> inputs() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public DataType outputType() {
+        return DataTypes.BOOLEAN();
+    }
+
+    @Override
+    public Object transform(InternalRow row) {
+        return true;
+    }
+
+    @Override
+    public Transform copyWithNewInputs(List<Object> inputs) {
+        return INSTANCE;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return NAME.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return NAME;
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateJsonSerdeTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateJsonSerdeTest.java
@@ -156,6 +156,24 @@ class PredicateJsonSerdeTest {
                         .expectJson(
                                 "{\"kind\":\"LEAF\",\"transform\":{\"name\":\"FIELD_REF\",\"fieldRef\":{\"index\":2,\"name\":\"f2\",\"type\":\"STRING\"}},\"function\":\"LIKE\",\"literals\":[\"%a%b%\"]}"),
 
+                // LeafPredicate - TrueTransform + TrueFunction (AlwaysTrue)
+                TestSpec.forPredicate(
+                                LeafPredicate.of(
+                                        TrueTransform.INSTANCE,
+                                        TrueFunction.INSTANCE,
+                                        Collections.emptyList()))
+                        .expectJson(
+                                "{\"kind\":\"LEAF\",\"transform\":{\"name\":\"TRUE\"},\"function\":\"TRUE\",\"literals\":[]}"),
+
+                // LeafPredicate - TrueTransform + FalseFunction (AlwaysFalse)
+                TestSpec.forPredicate(
+                                LeafPredicate.of(
+                                        TrueTransform.INSTANCE,
+                                        FalseFunction.INSTANCE,
+                                        Collections.emptyList()))
+                        .expectJson(
+                                "{\"kind\":\"LEAF\",\"transform\":{\"name\":\"TRUE\"},\"function\":\"FALSE\",\"literals\":[]}"),
+
                 // LeafPredicate - In with many values including nulls
                 TestSpec.forPredicate(
                                 builder.in(

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkV2FilterConverter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/SparkV2FilterConverter.scala
@@ -18,7 +18,7 @@
 
 package org.apache.paimon.spark
 
-import org.apache.paimon.predicate.{Predicate, PredicateBuilder, Transform}
+import org.apache.paimon.predicate.{FalseFunction, LeafPredicate, Predicate, PredicateBuilder, Transform, TrueFunction, TrueTransform}
 import org.apache.paimon.spark.util.SparkExpressionConverter.{toPaimonLiteral, toPaimonTransform}
 import org.apache.paimon.types.RowType
 
@@ -164,7 +164,18 @@ case class SparkV2FilterConverter(rowType: RowType) extends Logging {
             throw new UnsupportedOperationException(s"Convert $sparkPredicate is unsupported.")
         }
 
-      // TODO: AlwaysTrue, AlwaysFalse
+      case ALWAYS_TRUE =>
+        LeafPredicate.of(
+          TrueTransform.INSTANCE,
+          TrueFunction.INSTANCE,
+          java.util.Collections.emptyList())
+
+      case ALWAYS_FALSE =>
+        LeafPredicate.of(
+          TrueTransform.INSTANCE,
+          FalseFunction.INSTANCE,
+          java.util.Collections.emptyList())
+
       case _ => throw new UnsupportedOperationException(s"Convert $sparkPredicate is unsupported.")
     }
   }
@@ -228,5 +239,7 @@ object SparkV2FilterConverter extends Logging {
   private val STRING_START_WITH = "STARTS_WITH"
   private val STRING_END_WITH = "ENDS_WITH"
   private val STRING_CONTAINS = "CONTAINS"
+  private val ALWAYS_TRUE = "ALWAYS_TRUE"
+  private val ALWAYS_FALSE = "ALWAYS_FALSE"
 
 }


### PR DESCRIPTION
### Purpose

Support AlwaysTrue and AlwaysFalse predicates in SparkV2FilterConverter

### Tests

CI
