### PR TITLE
[tag] Force creating auto-tag even no data when calling trigger_tag_automatic_creation

### DIFF
--- a/docs/content/flink/procedures.md
+++ b/docs/content/flink/procedures.md
@@ -272,14 +272,21 @@ All available procedures are listed below.
    <tr>
       <td>trigger_tag_automatic_creation</td>
       <td>
+         -- Use named argument
+         CALL [catalog.]sys.trigger_tag_automatic_creation(`table` => 'identifier')
+         CALL [catalog.]sys.trigger_tag_automatic_creation(`table` => 'identifier', force => false)<br/><br/>
+         -- Use indexed argument
          CALL [catalog.]sys.trigger_tag_automatic_creation('identifier')
+         CALL [catalog.]sys.trigger_tag_automatic_creation('identifier', false)
       </td>
       <td>
          Trigger the tag automatic creation. Arguments:
             <li>table: the target table identifier. Cannot be empty.</li>
+            <li>force: force creating the auto-tag when it's after tag.creation-delay even no data exits. Default false.</li>
       </td>
       <td>
-         CALL sys.trigger_tag_automatic_creation(table => 'default.T')
+         CALL sys.trigger_tag_automatic_creation(table => 'default.T')<br/>
+         CALL sys.trigger_tag_automatic_creation(table => 'default.T', force => false)
       </td>
    </tr>
    <tr>

--- a/docs/content/spark/procedures.md
+++ b/docs/content/spark/procedures.md
@@ -166,9 +166,11 @@ This section introduce all available spark procedures about paimon.
       <td>
          Trigger the tag automatic creation. Arguments:
             <li>table: the target table identifier. Cannot be empty.</li>
+            <li>force: force creating the auto-tag when it's after tag.creation-delay even no data exits. Default false.</li>
       </td>
       <td>
-         CALL sys.trigger_tag_automatic_creation(table => 'default.T')
+         CALL sys.trigger_tag_automatic_creation(table => 'default.T')<br/><br/>
+         CALL sys.trigger_tag_automatic_creation(table => 'default.T', force => false)
       </td>
     </tr>
     <tr>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/TriggerTagAutomaticCreationProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/TriggerTagAutomaticCreationProcedure.java
@@ -18,14 +18,22 @@
 
 package org.apache.paimon.flink.procedure;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.TableCommitImpl;
+import org.apache.paimon.tag.TagAutoManager;
+import org.apache.paimon.tag.TagPeriodHandler;
 
 import org.apache.flink.table.annotation.ArgumentHint;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.annotation.ProcedureHint;
 import org.apache.flink.table.procedure.ProcedureContext;
 import org.apache.flink.types.Row;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
 
 /**
  * A procedure to trigger tag automatic creation for a table. Usage:
@@ -39,17 +47,52 @@ public class TriggerTagAutomaticCreationProcedure extends ProcedureBase {
 
     public static final String IDENTIFIER = "trigger_tag_automatic_creation";
 
-    @ProcedureHint(argument = {@ArgumentHint(name = "table", type = @DataTypeHint("STRING"))})
+    @ProcedureHint(
+            argument = {
+                @ArgumentHint(name = "table", type = @DataTypeHint("STRING")),
+                @ArgumentHint(name = "force", type = @DataTypeHint("BOOLEAN"), isOptional = true)
+            })
     public @DataTypeHint("ROW<result STRING>") Row[] call(
-            ProcedureContext procedureContext, String tableId) throws Exception {
-        ((FileStoreTable) catalog.getTable(Identifier.fromString(tableId)))
-                .newTagAutoManager()
-                .run();
+            ProcedureContext procedureContext, String tableId, Boolean force) throws Exception {
+        FileStoreTable fsTable =
+                ((FileStoreTable) catalog.getTable(Identifier.fromString(tableId)));
+        String commitUser = CoreOptions.fromMap(fsTable.options()).createCommitUser();
+
+        try (TableCommitImpl commit = fsTable.newCommit(commitUser)) {
+            TagAutoManager tam = fsTable.newTagAutoManager();
+            if (tam.getTagAutoCreation() != null) {
+                // Fist try
+                tam.run();
+
+                // If the expected tag not created, try again with an empty commit
+                if (force
+                        && !isAutoTagExits(fsTable)
+                        && tam.getTagAutoCreation().forceCreatingSnapshot()) {
+                    ManifestCommittable committable =
+                            new ManifestCommittable(Long.MAX_VALUE, null, Collections.emptyList());
+                    commit.ignoreEmptyCommit(false);
+                    commit.commit(committable);
+                    // Second try
+                    tam.run();
+                }
+            }
+        }
+
         return new Row[] {Row.of("Success")};
     }
 
     @Override
     public String identifier() {
         return IDENTIFIER;
+    }
+
+    private boolean isAutoTagExits(FileStoreTable table) {
+        TagPeriodHandler periodHandler =
+                TagPeriodHandler.create(CoreOptions.fromMap(table.options()));
+
+        // With forceCreatingSnapshot, the auto-tag should exist for "now"
+        LocalDateTime tagTime = periodHandler.normalizeToPreviousTag(LocalDateTime.now());
+        String tagName = periodHandler.timeToTag(tagTime);
+        return table.tagManager().tagExists(tagName);
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/TriggerTagAutomaticCreationProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/TriggerTagAutomaticCreationProcedure.java
@@ -18,7 +18,12 @@
 
 package org.apache.paimon.spark.procedure;
 
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.TableCommitImpl;
+import org.apache.paimon.tag.TagAutoManager;
+import org.apache.paimon.tag.TagPeriodHandler;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.Identifier;
@@ -28,13 +33,20 @@ import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import static org.apache.spark.sql.types.DataTypes.BooleanType;
 import static org.apache.spark.sql.types.DataTypes.StringType;
 
 /** A procedure to trigger the tag automatic creation for a table. */
 public class TriggerTagAutomaticCreationProcedure extends BaseProcedure {
 
     private static final ProcedureParameter[] PARAMETERS =
-            new ProcedureParameter[] {ProcedureParameter.required("table", StringType)};
+            new ProcedureParameter[] {
+                ProcedureParameter.required("table", StringType),
+                ProcedureParameter.optional("force", BooleanType)
+            };
 
     private static final StructType OUTPUT_TYPE =
             new StructType(
@@ -59,17 +71,48 @@ public class TriggerTagAutomaticCreationProcedure extends BaseProcedure {
     @Override
     public InternalRow[] call(InternalRow args) {
         Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
+        boolean force = !args.isNullAt(1) && args.getBoolean(1);
         return modifyPaimonTable(
                 tableIdent,
                 table -> {
-                    try {
-                        ((FileStoreTable) table).newTagAutoManager().run();
+                    FileStoreTable fsTable = ((FileStoreTable) table);
+                    String commitUser = CoreOptions.fromMap(table.options()).createCommitUser();
+
+                    try (TableCommitImpl commit = fsTable.newCommit(commitUser)) {
+                        TagAutoManager tam = fsTable.newTagAutoManager();
+                        if (tam.getTagAutoCreation() != null) {
+                            // Fist try
+                            tam.run();
+                            // If the expected tag not created, try again with an empty commit
+                            if (force
+                                    && !isAutoTagExits(fsTable)
+                                    && tam.getTagAutoCreation().forceCreatingSnapshot()) {
+                                ManifestCommittable committable =
+                                        new ManifestCommittable(
+                                                Long.MAX_VALUE, null, Collections.emptyList());
+                                commit.ignoreEmptyCommit(false);
+                                commit.commit(committable);
+                                // Second try
+                                tam.run();
+                            }
+                        }
+
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }
 
                     return new InternalRow[] {newInternalRow(true)};
                 });
+    }
+
+    private boolean isAutoTagExits(FileStoreTable table) {
+        TagPeriodHandler periodHandler =
+                TagPeriodHandler.create(CoreOptions.fromMap(table.options()));
+
+        // With forceCreatingSnapshot, the auto-tag should exist for "now"
+        LocalDateTime tagTime = periodHandler.normalizeToPreviousTag(LocalDateTime.now());
+        String tagName = periodHandler.timeToTag(tagTime);
+        return table.tagManager().tagExists(tagName);
     }
 
     public static ProcedureBuilder builder() {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- What is the purpose of the change -->
Make sure the auto-tag exists as expected even when no data is provided.

The former version of procedure `trigger_tag_automatic_creation` creates the tag only if it finds the right snapshot which is after `tag.creation-delay`. This is not always okay.

As we know, the auto-tag would be created within the Flink CDC job. But it would fail if the Flink job:
* crashes accidentally
* fails to create checkpoint
* is delayed in creating checkpoint

To meet the auto-tag expectation, I enhanced the `trigger_tag_automatic_creation` procedure by adding a new `force` parameter, defaulting to false. When it's true, and the auto-tag still does not exist after the first attempt at auto-creation, we make an empty commit to force the creation of the snapshot which could be used to create the auto-tag during the second run.

### Tests

<!-- List UT and IT cases to verify this change -->
Flink UT `TriggerTagAutomaticCreationProcedureITCase` and Spark UT `TriggerTagAutomaticCreationProcedureTest` were adapted.

### API and Format

<!-- Does this change affect API or storage format -->
NO

### Documentation

<!-- Does this change introduce a new feature -->
Doc provied for the new parameter.
