### PR TITLE
[python] Fix null handling when filter with or expression

### DIFF
--- a/paimon-python/pypaimon/common/predicate.py
+++ b/paimon-python/pypaimon/common/predicate.py
@@ -178,6 +178,8 @@ class Equal(Tester):
     name = 'equal'
 
     def test_by_value(self, val, literals) -> bool:
+        if val is None or not literals:
+            return False
         return val == literals[0]
 
     def test_by_stats(self, min_v, max_v, literals) -> bool:
@@ -191,6 +193,8 @@ class NotEqual(Tester):
     name = "notEqual"
 
     def test_by_value(self, val, literals) -> bool:
+        if val is None or not literals:
+            return False
         return val != literals[0]
 
     def test_by_stats(self, min_v, max_v, literals) -> bool:
@@ -204,6 +208,8 @@ class LessThan(Tester):
     name = "lessThan"
 
     def test_by_value(self, val, literals) -> bool:
+        if val is None or not literals:
+            return False
         return val < literals[0]
 
     def test_by_stats(self, min_v, max_v, literals) -> bool:
@@ -217,6 +223,8 @@ class LessOrEqual(Tester):
     name = "lessOrEqual"
 
     def test_by_value(self, val, literals) -> bool:
+        if val is None or not literals:
+            return False
         return val <= literals[0]
 
     def test_by_stats(self, min_v, max_v, literals) -> bool:
@@ -230,6 +238,8 @@ class GreaterThan(Tester):
     name = "greaterThan"
 
     def test_by_value(self, val, literals) -> bool:
+        if val is None or not literals:
+            return False
         return val > literals[0]
 
     def test_by_stats(self, min_v, max_v, literals) -> bool:
@@ -243,6 +253,8 @@ class GreaterOrEqual(Tester):
     name = "greaterOrEqual"
 
     def test_by_value(self, val, literals) -> bool:
+        if val is None or not literals:
+            return False
         return val >= literals[0]
 
     def test_by_stats(self, min_v, max_v, literals) -> bool:
@@ -256,6 +268,8 @@ class In(Tester):
     name = "in"
 
     def test_by_value(self, val, literals) -> bool:
+        if val is None:
+            return False
         return val in literals
 
     def test_by_stats(self, min_v, max_v, literals) -> bool:
@@ -269,6 +283,8 @@ class NotIn(Tester):
     name = "notIn"
 
     def test_by_value(self, val, literals) -> bool:
+        if val is None:
+            return False
         return val not in literals
 
     def test_by_stats(self, min_v, max_v, literals) -> bool:
@@ -282,6 +298,8 @@ class Between(Tester):
     name = "between"
 
     def test_by_value(self, val, literals) -> bool:
+        if val is None or not literals or len(literals) < 2:
+            return False
         return literals[0] <= val <= literals[1]
 
     def test_by_stats(self, min_v, max_v, literals) -> bool:
@@ -295,6 +313,8 @@ class StartsWith(Tester):
     name = "startsWith"
 
     def test_by_value(self, val, literals) -> bool:
+        if val is None or not literals:
+            return False
         return isinstance(val, str) and val.startswith(literals[0])
 
     def test_by_stats(self, min_v, max_v, literals) -> bool:
@@ -310,6 +330,8 @@ class EndsWith(Tester):
     name = "endsWith"
 
     def test_by_value(self, val, literals) -> bool:
+        if val is None or not literals:
+            return False
         return isinstance(val, str) and val.endswith(literals[0])
 
     def test_by_stats(self, min_v, max_v, literals) -> bool:
@@ -323,6 +345,8 @@ class Contains(Tester):
     name = "contains"
 
     def test_by_value(self, val, literals) -> bool:
+        if val is None or not literals:
+            return False
         return isinstance(val, str) and literals[0] in val
 
     def test_by_stats(self, min_v, max_v, literals) -> bool:

--- a/paimon-python/pypaimon/tests/predicates_test.py
+++ b/paimon-python/pypaimon/tests/predicates_test.py
@@ -342,7 +342,7 @@ class PredicateTest(unittest.TestCase):
         table = self.catalog.get_table('default.test_pk')
         predicate_builder = table.new_read_builder().new_predicate_builder()
         predicate = predicate_builder.is_not_in('f1', ['abc', 'abbc'])
-        _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[2:4])
+        _check_filtered_result(table.new_read_builder().with_filter(predicate), self.df.loc[[2, 3]])
 
     def test_between_append(self):
         table = self.catalog.get_table('default.test_append')
@@ -373,7 +373,7 @@ class PredicateTest(unittest.TestCase):
         _check_filtered_result(table.new_read_builder().with_filter(predicate),
                                self.df.loc[[0, 3, 4]])
 
-    def test_filter_null_or_comparison(self):
+    def test_filter_with_null_and_or(self):
         from pypaimon.common.predicate import Predicate
         from pypaimon.table.row.offset_row import OffsetRow
 
@@ -382,8 +382,7 @@ class PredicateTest(unittest.TestCase):
         predicate = Predicate(method='or', index=None, field=None, literals=[p_gt, p_null])
 
         record_null = OffsetRow([1, None], 0, 2)  # id=1, score=None
-        with self.assertRaises(TypeError):
-            predicate.test(record_null)
+        self.assertTrue(predicate.test(record_null))
 
         record_ok = OffsetRow([1, 15], 0, 2)
         self.assertTrue(predicate.test(record_ok))


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose/Problem
`OR(score > 10, score IS NULL)` on a row where score is null will raise TypeError instead of returning true now. 

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
