### PR TITLE
[core] Optimize FileStoreCommitImpl#filterCommitted when commit strict mode is set

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -255,7 +255,15 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     "Committables must be sorted according to identifiers before filtering. This is unexpected.");
         }
 
-        Optional<Snapshot> latestSnapshot = snapshotManager.latestSnapshotOfUser(commitUser);
+        Optional<Snapshot> latestSnapshot =
+                options.commitStrictModeLastSafeSnapshot()
+                        .map(
+                                id ->
+                                        snapshotManager.latestSnapshotOfUser(
+                                                commitUser,
+                                                snapshotManager.latestSnapshotId(),
+                                                id + 1))
+                        .orElse(snapshotManager.latestSnapshotOfUser(commitUser));
         if (latestSnapshot.isPresent()) {
             List<ManifestCommittable> result = new ArrayList<>();
             for (ManifestCommittable committable : committables) {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/SnapshotManager.java
@@ -587,23 +587,26 @@ public class SnapshotManager implements Serializable {
     }
 
     public Optional<Snapshot> latestSnapshotOfUser(String user) {
-        return latestSnapshotOfUser(user, latestSnapshotId());
+        return latestSnapshotOfUser(user, latestSnapshotId(), null);
     }
 
     public Optional<Snapshot> latestSnapshotOfUserFromFilesystem(String user) {
-        return latestSnapshotOfUser(user, latestSnapshotIdFromFileSystem());
+        return latestSnapshotOfUser(user, latestSnapshotIdFromFileSystem(), null);
     }
 
-    private Optional<Snapshot> latestSnapshotOfUser(String user, Long latestId) {
+    public Optional<Snapshot> latestSnapshotOfUser(
+            String user, Long latestId, @Nullable Long earliestId) {
         if (latestId == null) {
             return Optional.empty();
         }
+        if (earliestId == null) {
+            earliestId =
+                    Preconditions.checkNotNull(
+                            earliestSnapshotId(),
+                            "Latest snapshot id is not null, but earliest snapshot id is null. "
+                                    + "This is unexpected.");
+        }
 
-        long earliestId =
-                Preconditions.checkNotNull(
-                        earliestSnapshotId(),
-                        "Latest snapshot id is not null, but earliest snapshot id is null. "
-                                + "This is unexpected.");
         for (long id = latestId; id >= earliestId; id--) {
             Snapshot snapshot;
             try {


### PR DESCRIPTION
### Purpose

It is costly to find the latest snapshot of user if there are many snapshots. This PR optimizes `FileStoreCommitImpl#filterCommitted` when commit strict mode is set: we only search until the safe snapshot ID.

### Tests

This is an optimization. Existing tests are enough.

### API and Format

No format changes.

### Documentation

No new feature.
