### PR TITLE
[core] Introduce Flink 'CreateGlobalIndexProcedure'

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/ParameterUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ParameterUtils.java
@@ -18,10 +18,15 @@
 
 package org.apache.paimon.utils;
 
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypeJsonParser;
+import org.apache.paimon.types.RowType;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.JsonNode;
+
+import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -37,6 +42,23 @@ public class ParameterUtils {
             partitions.add(parseCommaSeparatedKeyValues(partition));
         }
         return partitions;
+    }
+
+    @Nullable
+    public static Predicate toPartitionPredicate(
+            List<Map<String, String>> partitionList,
+            RowType partitionType,
+            String partitionDefaultName) {
+        if (partitionList == null || partitionList.isEmpty()) {
+            return null;
+        }
+        return PredicateBuilder.or(
+                partitionList.stream()
+                        .map(
+                                p ->
+                                        PredicateBuilder.partition(
+                                                p, partitionType, partitionDefaultName))
+                        .toArray(Predicate[]::new));
     }
 
     public static Map<String, String> parseCommaSeparatedKeyValues(String keyValues) {

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/btree/BTreeGlobalIndexBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/btree/BTreeGlobalIndexBuilder.java
@@ -178,6 +178,14 @@ public class BTreeGlobalIndexBuilder implements Serializable {
         return result;
     }
 
+    public long recordsPerRange() {
+        return recordsPerRange;
+    }
+
+    public RowIdIndexFieldsExtractor extractor() {
+        return extractor;
+    }
+
     public List<CommitMessage> build(Range rowRange, Iterator<InternalRow> data)
             throws IOException {
         long counter = 0;
@@ -218,7 +226,7 @@ public class BTreeGlobalIndexBuilder implements Serializable {
         return commitMessages;
     }
 
-    private GlobalIndexParallelWriter createWriter() throws IOException {
+    public GlobalIndexParallelWriter createWriter() throws IOException {
         GlobalIndexParallelWriter currentWriter;
         GlobalIndexWriter indexWriter = createIndexWriter(table, indexType, indexField, options);
         if (!(indexWriter instanceof GlobalIndexParallelWriter)) {
@@ -230,7 +238,7 @@ public class BTreeGlobalIndexBuilder implements Serializable {
         return currentWriter;
     }
 
-    private CommitMessage flushIndex(
+    public CommitMessage flushIndex(
             Range rowRange, List<ResultEntry> resultEntries, BinaryRow partition)
             throws IOException {
         List<IndexFileMeta> indexFileMetas =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/SortCompactAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/SortCompactAction.java
@@ -127,7 +127,13 @@ public class SortCompactAction extends CompactAction {
                         .setRangeNumber(sinkParallelism * 10)
                         .build();
 
-        TableSorter sorter = TableSorter.getSorter(env, source, fileStoreTable, sortInfo);
+        TableSorter sorter =
+                TableSorter.getSorter(
+                        env,
+                        source,
+                        fileStoreTable.coreOptions(),
+                        fileStoreTable.rowType(),
+                        sortInfo);
 
         new SortCompactSinkBuilder(fileStoreTable)
                 .forCompact(true)

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/btree/BTreeIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/btree/BTreeIndexTopoBuilder.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.btree;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.flink.FlinkRowData;
+import org.apache.paimon.flink.FlinkRowWrapper;
+import org.apache.paimon.flink.LogicalTypeConversion;
+import org.apache.paimon.flink.sink.Committable;
+import org.apache.paimon.flink.sink.CommittableTypeInfo;
+import org.apache.paimon.flink.sink.CommitterOperatorFactory;
+import org.apache.paimon.flink.sink.NoopCommittableStateManager;
+import org.apache.paimon.flink.sink.StoreCommitter;
+import org.apache.paimon.flink.sorter.TableSortInfo;
+import org.apache.paimon.flink.sorter.TableSorter;
+import org.apache.paimon.flink.utils.BoundedOneInputOperator;
+import org.apache.paimon.flink.utils.JavaTypeInfo;
+import org.apache.paimon.globalindex.GlobalIndexParallelWriter;
+import org.apache.paimon.globalindex.RowIdIndexFieldsExtractor;
+import org.apache.paimon.globalindex.btree.BTreeGlobalIndexBuilder;
+import org.apache.paimon.globalindex.btree.BTreeIndexOptions;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.partition.PartitionPredicate;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.SpecialFields;
+import org.apache.paimon.table.sink.BatchWriteBuilder;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.Range;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.paimon.globalindex.btree.BTreeGlobalIndexBuilder.calcRowRange;
+
+/** The {@link BTreeIndexTopoBuilder} for BTree index in Flink. */
+public class BTreeIndexTopoBuilder {
+
+    public static void buildIndex(
+            StreamExecutionEnvironment env,
+            FileStoreTable table,
+            String indexColumn,
+            PartitionPredicate partitionPredicate,
+            Options userOptions)
+            throws Exception {
+        // 1. Create BTree index builder and scan splits
+        BTreeGlobalIndexBuilder indexBuilder =
+                new BTreeGlobalIndexBuilder(table)
+                        .withIndexType("btree")
+                        .withIndexField(indexColumn);
+        if (partitionPredicate != null) {
+            indexBuilder = indexBuilder.withPartitionPredicate(partitionPredicate);
+        }
+
+        List<DataSplit> splits = indexBuilder.scan();
+        Range range = calcRowRange(splits);
+        if (splits.isEmpty() || range == null) {
+            return;
+        }
+
+        // 2. Select necessary columns (partition keys + index field + ROW_ID)
+        List<String> selectedColumns = new ArrayList<>(table.partitionKeys());
+        selectedColumns.add(indexColumn);
+
+        RowType readType = SpecialFields.rowTypeWithRowId(table.rowType().project(selectedColumns));
+
+        // 3. Calculate parallelism and sort
+        long recordsPerRange = userOptions.get(BTreeIndexOptions.BTREE_INDEX_RECORDS_PER_RANGE);
+        int parallelism = Math.max((int) (range.count() / recordsPerRange), 1);
+        int maxParallelism = userOptions.get(BTreeIndexOptions.BTREE_INDEX_BUILD_MAX_PARALLELISM);
+        parallelism = Math.min(parallelism, maxParallelism);
+
+        // 4. Create source from splits and select columns
+        DataStream<DataSplit> sourceStream =
+                env.fromData(new JavaTypeInfo<>(DataSplit.class), splits.toArray(new DataSplit[0]))
+                        .name("Global Index Source")
+                        .setParallelism(1);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withReadType(readType);
+        DataStream<RowData> rowDataStream =
+                sourceStream
+                        .transform(
+                                "Read Data",
+                                InternalTypeInfo.of(LogicalTypeConversion.toLogicalType(readType)),
+                                new ReadDataOperator(readBuilder))
+                        .setParallelism(parallelism);
+
+        // 5. Sort data using TableSorter style
+        // Configure sort info similar to SortCompactAction
+        CoreOptions coreOptions = table.coreOptions();
+        TableSortInfo sortInfo =
+                new TableSortInfo.Builder()
+                        .setSortColumns(selectedColumns)
+                        .setSortStrategy(CoreOptions.OrderType.ORDER)
+                        .setSinkParallelism(parallelism)
+                        .setLocalSampleSize(parallelism * coreOptions.getLocalSampleMagnification())
+                        .setGlobalSampleSize(parallelism * 1000)
+                        .setRangeNumber(parallelism * 10)
+                        .build();
+
+        // Use TableSorter for sorting
+        TableSorter sorter =
+                TableSorter.getSorter(env, rowDataStream, coreOptions, readType, sortInfo);
+        DataStream<RowData> sortedStream = sorter.sort();
+
+        // 6. Build index for each partition
+        DataStream<Committable> commitMessages =
+                sortedStream
+                        .transform(
+                                "write-btree-index",
+                                new CommittableTypeInfo(),
+                                new WriteIndexOperator(range, indexBuilder))
+                        .setParallelism(parallelism);
+
+        // 7. Commit all commit messages
+        commit(table, commitMessages);
+
+        env.execute("Create btree global index for table: " + table.name());
+    }
+
+    private static void commit(FileStoreTable table, DataStream<Committable> written) {
+        OneInputStreamOperatorFactory<Committable, Committable> committerOperator =
+                new CommitterOperatorFactory<>(
+                        false,
+                        true,
+                        "BTreeIndexCommitter",
+                        context ->
+                                new StoreCommitter(
+                                        table, table.newCommit(context.commitUser()), context),
+                        new NoopCommittableStateManager());
+
+        written.transform("COMMIT OPERATOR", new CommittableTypeInfo(), committerOperator)
+                .setParallelism(1)
+                .setMaxParallelism(1);
+    }
+
+    /** Operator to read data from splits. */
+    private static class ReadDataOperator
+            extends org.apache.flink.table.runtime.operators.TableStreamOperator<RowData>
+            implements org.apache.flink.streaming.api.operators.OneInputStreamOperator<
+                    DataSplit, RowData> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final ReadBuilder readBuilder;
+
+        private transient TableRead tableRead;
+
+        public ReadDataOperator(ReadBuilder readBuilder) {
+            this.readBuilder = readBuilder;
+        }
+
+        @Override
+        public void open() throws Exception {
+            super.open();
+            this.tableRead = readBuilder.newRead();
+        }
+
+        @Override
+        public void processElement(StreamRecord<DataSplit> element) throws Exception {
+            DataSplit split = element.getValue();
+            try (RecordReader<InternalRow> reader = tableRead.createReader(split)) {
+                reader.forEachRemaining(
+                        row -> output.collect(new StreamRecord<>(new FlinkRowData(row))));
+            }
+        }
+    }
+
+    private static class WriteIndexOperator extends BoundedOneInputOperator<RowData, Committable> {
+
+        private final Range rowRange;
+        private final BTreeGlobalIndexBuilder builder;
+
+        private transient long counter;
+        private transient BinaryRow currentPart;
+        private transient GlobalIndexParallelWriter currentWriter;
+        private transient List<CommitMessage> commitMessages;
+
+        public WriteIndexOperator(Range rowRange, BTreeGlobalIndexBuilder builder) {
+            this.rowRange = rowRange;
+            this.builder = builder;
+        }
+
+        @Override
+        public void open() throws Exception {
+            super.open();
+            commitMessages = new ArrayList<>();
+        }
+
+        @Override
+        public void processElement(StreamRecord<RowData> element) throws IOException {
+            InternalRow row = new FlinkRowWrapper(element.getValue());
+
+            RowIdIndexFieldsExtractor extractor = builder.extractor();
+            BinaryRow partRow = extractor.extractPartition(row);
+
+            // the input is sorted by <partition, indexedField>
+            if (currentWriter != null) {
+                if (!Objects.equals(partRow, currentPart) || counter >= builder.recordsPerRange()) {
+                    commitMessages.add(
+                            builder.flushIndex(rowRange, currentWriter.finish(), currentPart));
+                    currentWriter = null;
+                    counter = 0;
+                }
+            }
+
+            // write <value, rowId> pair to index file
+            currentPart = partRow;
+            counter++;
+
+            if (currentWriter == null) {
+                currentWriter = builder.createWriter();
+            }
+
+            // convert the original rowId to local rowId
+            long localRowId = extractor.extractRowId(row) - rowRange.from;
+            currentWriter.write(extractor.extractIndexField(row), localRowId);
+        }
+
+        @Override
+        public void endInput() throws IOException {
+            if (counter > 0) {
+                commitMessages.add(
+                        builder.flushIndex(rowRange, currentWriter.finish(), currentPart));
+            }
+            for (CommitMessage message : commitMessages) {
+                output.collect(
+                        new StreamRecord<>(
+                                new Committable(BatchWriteBuilder.COMMIT_IDENTIFIER, message)));
+            }
+            commitMessages.clear();
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/IncrementalClusterCompact.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/IncrementalClusterCompact.java
@@ -146,7 +146,13 @@ public class IncrementalClusterCompact {
                         .setRangeNumber(sinkParallelism * 10)
                         .build();
         DataStream<RowData> sorted =
-                TableSorter.getSorter(env, sourcePair.getLeft(), table, sortInfo).sort();
+                TableSorter.getSorter(
+                                env,
+                                sourcePair.getLeft(),
+                                table.coreOptions(),
+                                table.rowType(),
+                                sortInfo)
+                        .sort();
 
         // 2.3 write and then reorganize the committable
         // set parallelism to null, and it'll forward parallelism when doWrite()

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.procedure;
+
+import org.apache.paimon.flink.btree.BTreeIndexTopoBuilder;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.partition.PartitionPredicate;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.ParameterUtils;
+
+import org.apache.flink.table.annotation.ArgumentHint;
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.ProcedureHint;
+import org.apache.flink.table.procedure.ProcedureContext;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.paimon.utils.ParameterUtils.getPartitions;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Procedure to create global index files via Flink. */
+public class CreateGlobalIndexProcedure extends ProcedureBase {
+
+    public static final String IDENTIFIER = "create_global_index";
+
+    @Override
+    public String identifier() {
+        return IDENTIFIER;
+    }
+
+    @ProcedureHint(
+            argument = {
+                @ArgumentHint(name = "table", type = @DataTypeHint("STRING")),
+                @ArgumentHint(name = "index_column", type = @DataTypeHint("STRING")),
+                @ArgumentHint(name = "index_type", type = @DataTypeHint("STRING")),
+                @ArgumentHint(
+                        name = "partitions",
+                        type = @DataTypeHint("STRING"),
+                        isOptional = true),
+                @ArgumentHint(name = "options", type = @DataTypeHint("STRING"), isOptional = true)
+            })
+    public String[] call(
+            ProcedureContext procedureContext,
+            String tableId,
+            String indexColumn,
+            String indexType,
+            String partitions,
+            String options)
+            throws Exception {
+
+        FileStoreTable table = (FileStoreTable) table(tableId);
+
+        // Validate table configuration
+        checkArgument(
+                table.coreOptions().rowTrackingEnabled(),
+                "Table '%s' must enable 'row-tracking.enabled=true' before creating global index.",
+                tableId);
+
+        RowType rowType = table.rowType();
+        checkArgument(
+                rowType.containsField(indexColumn),
+                "Column '%s' does not exist in table '%s'.",
+                indexColumn,
+                tableId);
+
+        // Parse partition predicate
+        PartitionPredicate partitionPredicate = parsePartitionPredicate(table, partitions);
+
+        // Parse options
+        Map<String, String> parsedOptions = optionalConfigMap(options);
+        Options userOptions = Options.fromMap(parsedOptions);
+
+        // Build global index based on index type
+        indexType = indexType.toLowerCase().trim();
+        if ("btree".equals(indexType)) {
+            BTreeIndexTopoBuilder.buildIndex(
+                    procedureContext.getExecutionEnvironment(),
+                    table,
+                    indexColumn,
+                    partitionPredicate,
+                    userOptions);
+            return new String[] {
+                "BTree global index created successfully for table: " + table.name()
+            };
+        } else {
+            throw new UnsupportedOperationException(
+                    "Unsupported index type: " + indexType + ". Supported types: btree, bitmap");
+        }
+    }
+
+    private PartitionPredicate parsePartitionPredicate(FileStoreTable table, String partitions) {
+        if (partitions == null || partitions.isEmpty()) {
+            return null;
+        }
+
+        List<Map<String, String>> partitionList = getPartitions(partitions.split(";"));
+        Predicate predicate =
+                ParameterUtils.toPartitionPredicate(
+                        partitionList,
+                        table.schema().logicalPartitionType(),
+                        table.coreOptions().partitionDefaultName());
+        return PartitionPredicate.fromPredicate(table.schema().logicalPartitionType(), predicate);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
@@ -337,7 +337,11 @@ public class FlinkSinkBuilder {
         if (tableSortInfo != null) {
             TableSorter sorter =
                     TableSorter.getSorter(
-                            input.getExecutionEnvironment(), input, table, tableSortInfo);
+                            input.getExecutionEnvironment(),
+                            input,
+                            table.coreOptions(),
+                            table.rowType(),
+                            tableSortInfo);
             return sorter.sort();
         }
         return input;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/SortUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/SortUtils.java
@@ -25,7 +25,6 @@ import org.apache.paimon.flink.FlinkRowData;
 import org.apache.paimon.flink.FlinkRowWrapper;
 import org.apache.paimon.flink.shuffle.RangeShuffle;
 import org.apache.paimon.flink.utils.InternalTypeInfo;
-import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.KeyProjectedRow;
@@ -68,7 +67,6 @@ public class SortUtils {
      * Sort the input stream by the key specified.
      *
      * @param inputStream the input data stream
-     * @param table the sorted file store table
      * @param sortKeyType we will use paimon `BinaryExternalSortBuffer` to local sort, so we need to
      *     specify the key type.
      * @param keyTypeInformation we will use range shuffle in global sort, so we need to range
@@ -83,16 +81,14 @@ public class SortUtils {
      */
     public static <KEY> DataStream<RowData> sortStreamByKey(
             final DataStream<RowData> inputStream,
-            final FileStoreTable table,
+            final CoreOptions options,
+            final RowType valueRowType,
             final RowType sortKeyType,
             final TypeInformation<KEY> keyTypeInformation,
             final SerializableSupplier<Comparator<KEY>> shuffleKeyComparator,
             final KeyAbstract<KEY> shuffleKeyAbstract,
             final ShuffleKeyConvertor<KEY> convertor,
             final TableSortInfo tableSortInfo) {
-
-        final RowType valueRowType = table.rowType();
-        CoreOptions options = table.coreOptions();
         final int sinkParallelism = tableSortInfo.getSinkParallelism();
         final int localSampleSize = tableSortInfo.getLocalSampleSize();
         final int globalSampleSize = tableSortInfo.getGlobalSampleSize();

--- a/paimon-flink/paimon-flink-common/src/main/resources/META-INF/services/org.apache.paimon.factories.Factory
+++ b/paimon-flink/paimon-flink-common/src/main/resources/META-INF/services/org.apache.paimon.factories.Factory
@@ -100,3 +100,4 @@ org.apache.paimon.flink.procedure.AlterColumnDefaultValueProcedure
 org.apache.paimon.flink.procedure.TriggerTagAutomaticCreationProcedure
 org.apache.paimon.flink.procedure.RemoveUnexistingManifestsProcedure
 org.apache.paimon.flink.procedure.DataEvolutionMergeIntoProcedure
+org.apache.paimon.flink.procedure.CreateGlobalIndexProcedure

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BTreeGlobalIndexITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BTreeGlobalIndexITCase.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.manifest.IndexManifestEntry;
+import org.apache.paimon.table.FileStoreTable;
+
+import org.apache.flink.types.Row;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test case for btree global index. */
+public class BTreeGlobalIndexITCase extends CatalogITCaseBase {
+
+    @Test
+    public void testBTreeIndex() throws Catalog.TableNotExistException {
+        sql(
+                "CREATE TABLE T (id INT, name STRING) WITH ("
+                        + "'global-index.enabled' = 'true', "
+                        + "'row-tracking.enabled' = 'true', "
+                        + "'data-evolution.enabled' = 'true'"
+                        + ")");
+        String values =
+                IntStream.range(0, 1_000)
+                        .mapToObj(i -> String.format("(%s, %s)", i, "'name_" + i + "'"))
+                        .collect(Collectors.joining(","));
+        sql("INSERT INTO T VALUES " + values);
+        sql(
+                "CALL sys.create_global_index(`table` => 'default.T', index_column => 'id', index_type => 'btree')");
+
+        // assert has btree index
+        FileStoreTable table = paimonTable("T");
+        List<IndexFileMeta> btreeEntries =
+                table.store().newIndexFileHandler().scanEntries().stream()
+                        .map(IndexManifestEntry::indexFile)
+                        .filter(f -> "btree".equals(f.indexType()))
+                        .collect(Collectors.toList());
+
+        long totalRowCount = btreeEntries.stream().mapToLong(IndexFileMeta::rowCount).sum();
+        assertThat(btreeEntries).hasSize(1);
+        assertThat(totalRowCount).isEqualTo(1000L);
+
+        // assert select with filter
+        assertThat(sql("SELECT * FROM T WHERE id = 100")).containsOnly(Row.of(100, "name_100"));
+    }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This Pull Request implements a BTree Global Index Builder for Flink in Apache Paimon, introducing the CreateGlobalIndexProcedure functionality.

Key Features

- Global Index Creation: Enables users to create global BTree indexes on Paimon tables using Flink
- BTree Index Support: Implements BTree-based indexing structure for efficient data lookup
- Flink Integration: Integrates the global index creation process with Flink's data processing pipeline
- Procedure API: Provides a SQL procedure interface (sys.create_global_index) for creating indexes
<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
The PR includes integration tests (BTreeGlobalIndexITCase).

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
