### PR TITLE
[python] Fix type conversion between avro timestamp and pyarrow timestamp

### DIFF
--- a/paimon-python/pypaimon/schema/data_types.py
+++ b/paimon-python/pypaimon/schema/data_types.py
@@ -614,16 +614,16 @@ class PyarrowFieldParser:
             unit = field_type.unit
             if field_type.tz is None:
                 if unit == 'ms':
-                    return {"type": "long", "logicalType": "timestamp-millis"}
+                    return {"type": "long", "logicalType": "local-timestamp-millis"}
                 elif unit == 'us':
-                    return {"type": "long", "logicalType": "timestamp-micros"}
+                    return {"type": "long", "logicalType": "local-timestamp-micros"}
                 else:
                     raise ValueError(f"Avro does not support pyarrow timestamp with unit {unit}.")
             else:
                 if unit == 'ms':
-                    return {"type": "long", "logicalType": "local-timestamp-millis"}
+                    return {"type": "long", "logicalType": "timestamp-millis"}
                 elif unit == 'us':
-                    return {"type": "long", "logicalType": "local-timestamp-micros"}
+                    return {"type": "long", "logicalType": "timestamp-micros"}
                 else:
                     raise ValueError(f"Avro does not support pyarrow timestamp with unit {unit}.")
         elif pyarrow.types.is_list(field_type) or pyarrow.types.is_large_list(field_type):

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -200,13 +200,9 @@ class JavaPyReadWriteTest(unittest.TestCase):
         read_builder = table.new_read_builder()
         table_scan = read_builder.new_scan()
         table_read = read_builder.new_read()
-        initial_result = table_read.to_pandas(table_scan.plan().splits())
-        print(f"Format: {file_format}, Result:\n{initial_result}")
-        self.assertEqual(len(initial_result), 6)
-        # Data order may vary due to partitioning/bucketing, so compare as sets
-        expected_names = {'Apple', 'Banana', 'Carrot', 'Broccoli', 'Chicken', 'Beef'}
-        actual_names = set(initial_result['name'].tolist())
-        self.assertEqual(actual_names, expected_names)
+        result = table_read.to_pandas(table_scan.plan().splits())
+        print(f"Format: {file_format}, Result:\n{result}")
+        self.assertEqual(initial_data.to_dict(), result.to_dict())
 
         from pypaimon.write.row_key_extractor import FixedBucketRowKeyExtractor
         expected_bucket_first_row = 2


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

avro's timestamp-millis corresponds to timestamps with time zones, and avro's local-timestamp-millis  corresponds to timestamps without time zones.

### Tests

JavaPyReadWriteTest.test_py_write_read_pk_table()

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
