### PR TITLE
[core] Add listTableDetails method to Catalog interface

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
@@ -421,6 +421,28 @@ public class RESTApi {
     }
 
     /**
+     * List table details for a database.
+     *
+     * <p>Gets an array of table details for a database. There is no guarantee of a specific
+     * ordering of the elements in the array.
+     *
+     * @param databaseName name of database.
+     * @return a list of table details.
+     * @throws NoSuchResourceException Exception thrown on HTTP 404 means the database not exists
+     * @throws ForbiddenException Exception thrown on HTTP 403 means don't have the permission for
+     *     this database
+     */
+    public List<GetTableResponse> listTableDetails(String databaseName) {
+        return listDataFromPageApi(
+                queryParams ->
+                        client.get(
+                                resourcePaths.tableDetails(databaseName),
+                                queryParams,
+                                ListTableDetailsResponse.class,
+                                restAuthFunction));
+    }
+
+    /**
      * List table for a catalog.
      *
      * <p>Gets an array of table for a catalog. There is no guarantee of a specific ordering of the

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -331,6 +331,19 @@ public abstract class AbstractCatalog implements Catalog {
     }
 
     @Override
+    public List<Table> listTableDetails(String databaseName) throws DatabaseNotExistException {
+        List<Table> result = new ArrayList<>();
+        for (String tableName : listTables(databaseName)) {
+            try {
+                result.add(getTable(Identifier.create(databaseName, tableName)));
+            } catch (TableNotExistException e) {
+                // ignore
+            }
+        }
+        return result;
+    }
+
+    @Override
     public void dropTable(Identifier identifier, boolean ignoreIfNotExists)
             throws TableNotExistException {
         checkNotBranch(identifier, "dropTable");

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -233,6 +233,17 @@ public interface Catalog extends AutoCloseable {
             throws DatabaseNotExistException;
 
     /**
+     * Get list of table details under this database. An empty list is returned if none exists.
+     *
+     * <p>NOTE: System tables will not be listed.
+     *
+     * @param databaseName Name of the database to list table details.
+     * @return a list of the details of all tables in this database.
+     * @throws DatabaseNotExistException if the database does not exist
+     */
+    List<Table> listTableDetails(String databaseName) throws DatabaseNotExistException;
+
+    /**
      * Gets an array of tables for a catalog.
      *
      * <p>NOTE: System tables will not be listed.

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -127,6 +127,11 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
+    public List<Table> listTableDetails(String databaseName) throws DatabaseNotExistException {
+        return wrapped.listTableDetails(databaseName);
+    }
+
+    @Override
     public PagedList<Identifier> listTablesPagedGlobally(
             String databaseNamePattern,
             String tableNamePattern,

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -267,6 +267,16 @@ public class RESTCatalog implements Catalog {
     }
 
     @Override
+    public List<Table> listTableDetails(String databaseName) throws DatabaseNotExistException {
+        try {
+            List<GetTableResponse> tables = api.listTableDetails(databaseName);
+            return tables.stream().map(t -> toTable(databaseName, t)).collect(Collectors.toList());
+        } catch (NoSuchResourceException e) {
+            throw new DatabaseNotExistException(databaseName);
+        }
+    }
+
+    @Override
     public PagedList<Identifier> listTablesPagedGlobally(
             @Nullable String databaseNamePattern,
             @Nullable String tableNamePattern,

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -737,6 +737,32 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     }
 
     @Test
+    public void testListTableDetails() throws Exception {
+        // List table details returns an empty list when there are no tables in the database
+        String databaseName = "table_details_db";
+        catalog.createDatabase(databaseName, false);
+        List<Table> tableDetails = catalog.listTableDetails(databaseName);
+        assertThat(tableDetails).isEmpty();
+
+        String[] tableNames = {"table1", "table2", "table3", "abd", "def", "opr", "table_name"};
+        String[] expectedTableNames = Arrays.stream(tableNames).sorted().toArray(String[]::new);
+        for (String tableName : tableNames) {
+            catalog.createTable(
+                    Identifier.create(databaseName, tableName), DEFAULT_TABLE_SCHEMA, false);
+        }
+
+        tableDetails = catalog.listTableDetails(databaseName);
+        assertThat(tableDetails).hasSize(tableNames.length);
+        List<String> actualTableNames =
+                tableDetails.stream().map(Table::name).sorted().collect(Collectors.toList());
+        assertThat(actualTableNames).containsExactly(expectedTableNames);
+
+        // List table details throws DatabaseNotExistException when the database does not exist
+        assertThatExceptionOfType(Catalog.DatabaseNotExistException.class)
+                .isThrownBy(() -> catalog.listTableDetails("non_existing_db"));
+    }
+
+    @Test
     public void testListTablesPagedWithTableType() throws Exception {
         String databaseName = "tables_paged_table_type_db";
         catalog.createDatabase(databaseName, false);


### PR DESCRIPTION
### Purpose

This PR adds a `listTableDetails` method to the `Catalog` interface, for users to get all `Table` objects conveniently, especially from `RESTCatalog`.

### Tests

* `RESTCatalogTest#testListTableDetails`

### API and Format

No format changes.

### Documentation

No new feature.

### Generative AI tooling

Generated-by: qwen code 0.10.0

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
