### PR TITLE
[fs] Replace AWS SDK v2 bundle with explicit module dependencies

### DIFF
--- a/paimon-filesystems/paimon-s3-impl/pom.xml
+++ b/paimon-filesystems/paimon-s3-impl/pom.xml
@@ -92,6 +92,10 @@
                     <artifactId>aws-java-sdk-bundle</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>bundle</artifactId>
+                </exclusion>
+                <exclusion>
                     <!-- Optional S3A analytics accelerator - only used with fs.s3a.input.stream.type=analytics -->
                     <groupId>software.amazon.s3.analyticsaccelerator</groupId>
                     <artifactId>analyticsaccelerator-s3</artifactId>
@@ -105,6 +109,68 @@
                     <artifactId>slf4j-reload4j</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <!-- AWS SDK v2 dependencies - only include necessary modules -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <version>${fs.s3.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <version>${fs.s3.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>crt-core</artifactId>
+            <version>${fs.s3.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-auth-aws-crt</artifactId>
+            <version>${fs.s3.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>iam</artifactId>
+            <version>${fs.s3.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sso</artifactId>
+            <version>${fs.s3.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>${fs.s3.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>kms</artifactId>
+            <version>${fs.s3.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>glue</artifactId>
+            <version>${fs.s3.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <version>${fs.s3.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>dynamodb</artifactId>
+            <version>${fs.s3.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>lakeformation</artifactId>
+            <version>${fs.s3.awssdk.version}</version>
         </dependency>
 
         <dependency>

--- a/paimon-filesystems/pom.xml
+++ b/paimon-filesystems/pom.xml
@@ -55,6 +55,7 @@
         <fs.hadoopshaded.version>3.3.4</fs.hadoopshaded.version>
         <fs.hadoopshaded-3.4.version>3.4.2</fs.hadoopshaded-3.4.version>
         <fs.s3.aws.version>1.12.319</fs.s3.aws.version>
+        <fs.s3.awssdk.version>2.29.52</fs.s3.awssdk.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
     </properties>
 


### PR DESCRIPTION
### Purpose

This PR significantly reduces the size of `paimon-s3` jar file by:

1.  Excluding the AWS SDK v2 Bundle (which contains 400+ AWS services) from the `hadoop-aws` dependency
2. Explicitly including only the 12 necessary AWS SDK v2 modules required for S3 functionality:

   - apache-client
   - auth
   - crt-core
   - http-auth-aws-crt
   - iam
   - sso
   - s3
   - kms
   - glue
   - sts
   - dynamodb
   - lakeformation

Result:
- `paimon-s3.jar`: 670MB → 91MB

### Tests
Existing Integration Tests:

- SparkS3ITCase

- HiveCatalogITCaseBase
