### PR TITLE
[lance] Remove oss and jindo dependency from paimon-lance

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/hadoop/HadoopFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/hadoop/HadoopFileIO.java
@@ -87,6 +87,10 @@ public class HadoopFileIO implements FileIO {
         return hadoopConf.get();
     }
 
+    public org.apache.paimon.options.Options hadoopOptions() {
+        return new org.apache.paimon.options.Options(hadoopConf.get());
+    }
+
     @Override
     public SeekableInputStream newInputStream(Path path) throws IOException {
         org.apache.hadoop.fs.Path hadoopPath = path(path);

--- a/paimon-lance/pom.xml
+++ b/paimon-lance/pom.xml
@@ -63,28 +63,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-oss</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-oss-impl</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-core</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-jindo</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Remove oss and jindo dependency from paimon-lance to speed up compile

```text
[INFO] Paimon : ........................................... SUCCESS [  0.714 s]
[INFO] Paimon : API ....................................... SUCCESS [  3.471 s]
[INFO] Paimon : Test utils ................................ SUCCESS [  0.987 s]
[INFO] Paimon : Common .................................... SUCCESS [  7.755 s]
[INFO] Paimon : Code Gen .................................. SUCCESS [  9.585 s]
[INFO] Paimon : Code Gen Loader ........................... SUCCESS [  0.823 s]
[INFO] Paimon : Arrow ..................................... SUCCESS [  0.372 s]
[INFO] Paimon : Format .................................... SUCCESS [  5.145 s]
[INFO] Paimon : Core ...................................... SUCCESS [  5.211 s]
[INFO] Paimon : Format : Lance ............................ SUCCESS [  0.448 s]

```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
