### PR TITLE
[python] Add table_type parameter support for list_tables API

### DIFF
--- a/paimon-python/pypaimon/api/rest_api.py
+++ b/paimon-python/pypaimon/api/rest_api.py
@@ -46,6 +46,7 @@ class RESTApi:
     PAGE_TOKEN = "pageToken"
     DATABASE_NAME_PATTERN = "databaseNamePattern"
     TABLE_NAME_PATTERN = "tableNamePattern"
+    TABLE_TYPE = "tableType"
     TOKEN_EXPIRATION_SAFE_TIME_MILLIS = 3_600_000
 
     def __init__(self, options: Union[Options, Dict[str, str]], config_required: bool = True):
@@ -228,6 +229,7 @@ class RESTApi:
             max_results: Optional[int] = None,
             page_token: Optional[str] = None,
             table_name_pattern: Optional[str] = None,
+            table_type: Optional[str] = None,
     ) -> PagedList[str]:
         if not database_name or not database_name.strip():
             raise ValueError("Database name cannot be empty")
@@ -235,7 +237,12 @@ class RESTApi:
         response = self.client.get_with_params(
             self.resource_paths.tables(database_name),
             self.__build_paged_query_params(
-                max_results, page_token, {self.TABLE_NAME_PATTERN: table_name_pattern}
+                max_results,
+                page_token,
+                {
+                    self.TABLE_NAME_PATTERN: table_name_pattern,
+                    self.TABLE_TYPE: table_type,
+                },
             ),
             ListTablesResponse,
             self.rest_auth_function,

--- a/paimon-python/pypaimon/catalog/rest/rest_catalog.py
+++ b/paimon-python/pypaimon/catalog/rest/rest_catalog.py
@@ -172,14 +172,16 @@ class RESTCatalog(Catalog):
             database_name: str,
             max_results: Optional[int] = None,
             page_token: Optional[str] = None,
-            table_name_pattern: Optional[str] = None
+            table_name_pattern: Optional[str] = None,
+            table_type: Optional[str] = None
     ) -> PagedList[str]:
         try:
             return self.rest_api.list_tables_paged(
                 database_name,
                 max_results,
                 page_token,
-                table_name_pattern
+                table_name_pattern,
+                table_type
             )
         except NoSuchResourceException as e:
             raise DatabaseNotExistException(database_name) from e


### PR DESCRIPTION
### Purpose
This PR adds support for filtering tables by type when listing tables through the REST API.

### Tests
`test_list_tables_paged_with_table_type_param` in `api_test.py`

### API and Format

- Added optional `table_type` parameter to `RESTApi.list_tables_paged()` method
- Added optional `table_type` parameter to `RESTCatalog.list_tables_paged()` method
- Added `TABLE_TYPE` constant to REST API parameter definitions