### PR TITLE
[BUILD] Add `AGENTS.md`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# Apache Paimon
+
+This file provides context and guidelines for AI coding assistants working with the Apache Paimon codebase.
+
+## Syntax Requirements
+
+- Based on JDK 8 and Scala 2.12, higher version syntax features must not be used.
+
+## Build and Test
+
+Prefer the smallest possible build/test scope and use the local iteration speedup techniques below to keep feedback loops fast.
+
+### Build
+
+Prefer using Maven module selection to minimize the build scope.
+
+- Compile a single module: `mvn -pl <module> -DskipTests compile`
+- Compile multiple modules: `mvn -pl <module1>,<module2> -DskipTests compile`
+
+### Test
+
+Prefer running the narrowest tests.
+
+- Run test for a single method: `mvn -pl <module> -Dtest=TestClassName#methodName test`
+- Run test for a single class: `mvn -pl <module> -Dtest=TestClassName test`
+
+### Local Iteration Speedup
+
+#### Use Maven Skip Options
+
+Prefer these skip options for faster local iteration, but don't rely on them for final verification.
+
+```shell
+-Dcheckstyle.skip -Dspotless.check.skip -Denforcer.skip
+```
+
+For example:
+
+```shell
+mvn -pl <module> -Dcheckstyle.skip -Dspotless.check.skip -Denforcer.skip -Dtest=TestClassName#methodName test
+```
+
+#### Use -am (also-make)
+
+If your target module depends on other modules you've changed locally, prefer `-am` to rebuild them together in the same reactor.
+Also add `-DfailIfNoTests=false` to avoid failures for modules without tests.
+
+For example:
+
+```shell
+mvn -pl <module> -am -DfailIfNoTests=false -Dtest=TestClassName#methodName test
+```

--- a/pom.xml
+++ b/pom.xml
@@ -612,8 +612,7 @@ under the License.
                         <exclude>**/*.prefs</exclude>
                         <exclude>**/*.log</exclude>
                         <!-- Administrative files in the main trunk. -->
-                        <exclude>**/README.md</exclude>
-                        <exclude>**/CODE_OF_CONDUCT.md</exclude>
+                        <exclude>**/*.md</exclude>
                         <exclude>.github/**</exclude>
                         <!-- IDE files. -->
                         <exclude>**/*.iml</exclude>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

AI agents are already everywhere; it’s time to start writing `AGENTS.md` (Partly based on Apache Spark's  [AGENTS.md](https://github.com/apache/spark/blob/29fc5598005903e1e99a46f6065d2d2ed6b7285a/AGENTS.md?plain=1#L1)). 

### Tests

On my Mac, have the AI agent change a single line in a file under `paimon-api` module, then run the test, cost 4.999 s 

```bash
mvn test -Dcheckstyle.skip -Dspotless.check.skip -Denforcer.skip -DfailIfNoTests=false  \
-pl paimon-spark/paimon-spark-common -am \
-Dtest='CatalogUtilsTest'
```

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.999 s (Wall Clock)
[INFO] ------------------------------------------------------------------------
```

Without skip options, cost 15.075 s

```shell
mvn test -DfailIfNoTests=false  \
-pl paimon-spark/paimon-spark-common -am \
-Dtest='CatalogUtilsTest'
```

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  15.075 s (Wall Clock)
[INFO] ------------------------------------------------------------------------

```

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Generated-by: Qoder and gpt-5.2