### PR TITLE
[core] Fix ChainSplit NPE after branch table cache invalidation

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
@@ -324,6 +324,13 @@ public class CachingCatalog extends DelegateCatalog {
         if (partitionCache != null) {
             partitionCache.invalidate(identifier);
         }
+        // clear all branches of this table
+        for (Identifier i : tableCache.asMap().keySet()) {
+            if (identifier.getTableName().equals(i.getTableName())
+                    && identifier.getDatabaseName().equals(i.getDatabaseName())) {
+                tableCache.invalidate(i);
+            }
+        }
     }
 
     // ================================== Cache Public API


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #7299

<!-- What is the purpose of the change -->

### Tests
SparkChainTableITCase.testChainTableCacheInvalidation
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
