### PR TITLE
[test] Fix flaky testDlfStSTokenPathAuth

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -3704,7 +3704,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
 
     protected void generateTokenAndWriteToFile(String tokenPath) throws IOException {
         File tokenFile = new File(tokenPath);
-        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC).plusMinutes(5);
         String expiration = now.format(TOKEN_DATE_FORMATTER);
         String secret = UUID.randomUUID().toString();
         DLFToken token = new DLFToken("accessKeyId", secret, "securityToken", expiration);


### PR DESCRIPTION
### Purpose

Fix the flaky test `testDlfStSTokenPathAuth` in `MockRESTCatalogTest`.

Setting the DLF test token expiration to 5 minutes in the future instead of ZonedDateTime.now(), preventing unnecessary token refresh retries that caused timestamp race conditions and intermittent NotAuthorizedException failures.

### Tests

- `MockRESTCatalogTest#testDlfStSTokenPathAuth`

### API and Format

Test-only fix.

### Documentation

No new features introduced.

### Generative AI tooling

No