### PR TITLE
[core] Update lastFullCompaction in EarlyFullCompaction when triggering full compaction via size thresholds

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/EarlyFullCompaction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/EarlyFullCompaction.java
@@ -87,6 +87,7 @@ public class EarlyFullCompaction {
                 totalSize += run.run().totalSize();
             }
             if (totalSize < totalSizeThreshold) {
+                updateLastFullCompaction();
                 return Optional.of(CompactUnit.fromLevelRuns(maxLevel, runs));
             }
         }
@@ -98,6 +99,7 @@ public class EarlyFullCompaction {
                 }
             }
             if (incrementalSize > incrementalSizeThreshold) {
+                updateLastFullCompaction();
                 return Optional.of(CompactUnit.fromLevelRuns(maxLevel, runs));
             }
         }


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
In `EarlyFullCompaction`, update `lastFullCompaction` when full compaction is triggered by `totalSizeThreshold` or `incrementalSizeThreshold`. This prevents incorrect compaction triggering under the `fullCompactionInterval` policy.

<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->

### Tests
EarlyFullCompactionTest
<!-- List UT and IT cases to verify this change -->

