### PR TITLE
[doc] Fix paimon-website-javadoc profile to use its own maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -383,10 +383,10 @@ under the License.
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>3.1.1</version><!--$NO-MVN-MAN-VER$-->
-                        <configuration>
+                        <configuration combine.self="override">
                             <quiet>true</quiet>
                             <detectOfflineLinks>false</detectOfflineLinks>
-                            <additionalJOptions combine.children="append">
+                            <additionalJOptions>
                                 <additionalJOption>-Xdoclint:none</additionalJOption>
                             </additionalJOptions>
                         </configuration>


### PR DESCRIPTION
### Purpose
The Javadoc generation for the [Paimon website](https://paimon.apache.org/docs/master/api/java/) is currently broken — the API docs page cannot render properly.The CI build failure can be seen at: https://github.com/apache/paimon-website/actions/runs/22467456347/job/65076695360The error is:
plaintext
javadoc: error - invalid flag: --ignore-source-errors

Command line was: /opt/hostedtoolcache/jdk/8.0.482/x64/jre/../bin/javadoc
  "-Xdoclint:none --allow-script-in-comments" -Xdoclint:none
  --ignore-source-errors -Xdoclint:none @options @packages @argfile

The paimon-website-javadoc profile declares maven-javadoc-plugin version 3.1.1, but due to Maven's configuration merging, it inherits settings from pluginManagement (version 3.11.2), including --ignore-source-errors. This flag is only supported on JDK 11+ and causes the build to fail when the website CI runs with JDK 8.
