### PR TITLE
[core] Fix testEmptyPartitionDirectories failure by making empty dir older

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
@@ -620,8 +620,8 @@ public class LocalOrphanFilesCleanTest {
 
         Path recentEmptyPath = new Path(tablePath, "part1=2");
         fileIO.mkdirs(recentEmptyPath);
-        LocalOrphanFilesClean cleanRecent =
-                new LocalOrphanFilesClean(table, System.currentTimeMillis() - 1, false);
+        long cutoffMs = System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(2);
+        LocalOrphanFilesClean cleanRecent = new LocalOrphanFilesClean(table, cutoffMs, false);
         cleanRecent.clean();
         assertThat(fileIO.exists(recentEmptyPath))
                 .as("Recent empty partition dir must not be deleted (age safeguard).")


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
